### PR TITLE
Remove legacyStorage in favor of namespaced storages

### DIFF
--- a/packages/datadog-core/index.js
+++ b/packages/datadog-core/index.js
@@ -1,5 +1,5 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('./src/storage')
+const { storage } = require('./src/storage')
 
-module.exports = { storage, SPAN_NAMESPACE }
+module.exports = { storage }

--- a/packages/datadog-core/index.js
+++ b/packages/datadog-core/index.js
@@ -1,5 +1,5 @@
 'use strict'
 
-const storage = require('./src/storage')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('./src/storage')
 
-module.exports = { storage }
+module.exports = { storage, LEGACY_STORAGE_NAMESPACE }

--- a/packages/datadog-core/index.js
+++ b/packages/datadog-core/index.js
@@ -1,5 +1,5 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('./src/storage')
+const { storage, SPAN_NAMESPACE } = require('./src/storage')
 
-module.exports = { storage, LEGACY_STORAGE_NAMESPACE }
+module.exports = { storage, SPAN_NAMESPACE }

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -3,16 +3,6 @@
 const { AsyncLocalStorage } = require('async_hooks')
 
 /**
- * ⚠️THIS MAY NOT BE THE NAMESPACE YOU WANT!
- *
- * This mostly exists as a "default" namespace for storage and was added
- * retroactively throughout our codebase. There may be a better option for
- * different use cases
- * @type {string}
- */
-const SPAN_NAMESPACE = 'span'
-
-/**
  * This is exactly the same as AsyncLocalStorage, with the exception that it
  * uses a WeakMap to store the store object. This is because ALS stores the
  * store object as a property of the resource object, which causes all sorts
@@ -119,4 +109,4 @@ function storage (namespace) {
   return storages[namespace]
 }
 
-module.exports = { storage, SPAN_NAMESPACE }
+module.exports = { storage }

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -2,7 +2,15 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 
-const LEGACY_STORAGE_NAMESPACE = 'legacy'
+/**
+ * ⚠️THIS MAY NOT BE THE NAMESPACE YOU WANT!
+ *
+ * This mostly exists as a "default" namespace for storage and was added
+ * retroactively throughout our codebase. There may be a better option for
+ * different use cases
+ * @type {string}
+ */
+const SPAN_NAMESPACE = 'span'
 
 /**
  * This is exactly the same as AsyncLocalStorage, with the exception that it
@@ -36,7 +44,7 @@ class DatadogStorage extends AsyncLocalStorage {
    *
    * TODO: Refactor the Scope class to use a span-only store and remove this.
    *
-   * @returns {T}
+   * @returns {{}}
    */
   getHandle () {
     return super.getStore()
@@ -49,7 +57,7 @@ class DatadogStorage extends AsyncLocalStorage {
    * key. This is useful if you've stashed a handle somewhere and want to
    * retrieve the store with it.
    *
-   * @param handle {T | undefined}
+   * @param handle {{}}
    * @returns {T | undefined}
    */
   getStore (handle) {
@@ -111,4 +119,4 @@ function storage (namespace) {
   return storages[namespace]
 }
 
-module.exports = { storage, LEGACY_STORAGE_NAMESPACE }
+module.exports = { storage, SPAN_NAMESPACE }

--- a/packages/datadog-core/src/storage.js
+++ b/packages/datadog-core/src/storage.js
@@ -2,35 +2,56 @@
 
 const { AsyncLocalStorage } = require('async_hooks')
 
-/// This is exactly the same as AsyncLocalStorage, with the exception that it
-/// uses a WeakMap to store the store object. This is because ALS stores the
-/// store object as a property of the resource object, which causes all sorts
-/// of problems with logging and memory. We substitute the `store` object with
-/// a "handle" object, which is used as a key in a WeakMap, where the values
-/// are the real store objects.
+const LEGACY_STORAGE_NAMESPACE = 'legacy'
+
+/**
+ * This is exactly the same as AsyncLocalStorage, with the exception that it
+ * uses a WeakMap to store the store object. This is because ALS stores the
+ * store object as a property of the resource object, which causes all sorts
+ * of problems with logging and memory. We substitute the `store` object with
+ * a "handle" object, which is used as a key in a WeakMap, where the values
+ * are the real store objects.
+ *
+ * @template T
+ */
 class DatadogStorage extends AsyncLocalStorage {
+  /**
+   *
+   * @param store {DatadogStorage}
+   */
   enterWith (store) {
     const handle = {}
     stores.set(handle, store)
     super.enterWith(handle)
   }
 
-  // This is method is a passthrough to the real `getStore()`, so that, when we
-  // need it, we can use the handle rather than our mapped store.
-  // TODO: Refactor the Scope class to use a span-only store and remove this.
-  // It's only here because stores are currently used for a bunch of things,
-  // and we don't want to hold on to all of them in spans
-  // (see opentracing/span.js). Using a namespaced storage for spans would
-  // solve this.
+  /**
+   * This is method is a passthrough to the real `getStore()`, so that, when we
+   * need it, we can use the handle rather than our mapped store.
+   *
+   * It's only here because stores are currently used for a bunch of things,
+   * and we don't want to hold on to all of them in spans
+   * (see opentracing/span.js). Using a namespaced storage for spans would
+   * solve this.
+   *
+   * TODO: Refactor the Scope class to use a span-only store and remove this.
+   *
+   * @returns {T}
+   */
   getHandle () {
     return super.getStore()
   }
 
-  // Here, we replicate the behavior of the original `getStore()` method by
-  // passing in the handle, which we retrieve by calling it on super. Handles
-  // retrieved through `getHandle()` can also be passed in to be used as the
-  // key. This is useful if you've stashed a handle somewhere and want to
-  // retrieve the store with it.
+  /**
+   * Here, we replicate the behavior of the original `getStore()` method by
+   * passing in the handle, which we retrieve by calling it on super. Handles
+   * retrieved through `getHandle()` can also be passed in to be used as the
+   * key. This is useful if you've stashed a handle somewhere and want to
+   * retrieve the store with it.
+   *
+   * @param handle {T | undefined}
+   * @returns {T | undefined}
+   */
   getStore (handle) {
     if (!handle) {
       handle = super.getStore()
@@ -39,11 +60,19 @@ class DatadogStorage extends AsyncLocalStorage {
     return stores.get(handle)
   }
 
-  // Here, we replicate the behavior of the original `run()` method. We ensure
-  // that our `enterWith()` is called internally, so that the handle to the
-  // store is set. As an optimization, we use super for getStore and enterWith
-  // when dealing with the parent store, so that we don't have to access the
-  // WeakMap.
+  /**
+   * Here, we replicate the behavior of the original `run()` method. We ensure
+   * that our `enterWith()` is called internally, so that the handle to the
+   * store is set. As an optimization, we use super for getStore and enterWith
+   * when dealing with the parent store, so that we don't have to access the
+   * WeakMap.
+   * @template R
+   * @template TArgs extends any[]
+   * @param store {DatadogStorage}
+   * @param fn {() => R}
+   * @param args {TArgs}
+   * @returns {void}
+   */
   run (store, fn, ...args) {
     const prior = super.getStore()
     this.enterWith(store)
@@ -55,13 +84,26 @@ class DatadogStorage extends AsyncLocalStorage {
   }
 }
 
-// This is the map from handles to real stores, used in the class above.
+/**
+ * This is the map from handles to real stores, used in the class above.
+ * @template T
+ * @type {WeakMap<WeakKey, T>}
+ */
 const stores = new WeakMap()
 
-// For convenience, we use the `storage` function as a registry of namespaces
-// corresponding to DatadogStorage instances. This lets us have separate
-// storages for separate purposes.
+/**
+ * For convenience, we use the `storage` function as a registry of namespaces
+ * corresponding to DatadogStorage instances. This lets us have separate
+ * storages for separate purposes.
+ * @type {Map<string, DatadogStorage>}
+ */
 const storages = Object.create(null)
+
+/**
+ *
+ * @param namespace {string} the namespace to use
+ * @returns {DatadogStorage}
+ */
 function storage (namespace) {
   if (!storages[namespace]) {
     storages[namespace] = new DatadogStorage()
@@ -69,14 +111,4 @@ function storage (namespace) {
   return storages[namespace]
 }
 
-// Namespaces are a new concept, so for existing internal code that does not
-// use namespaces, we have a "legacy" storage object.
-const legacyStorage = new DatadogStorage()
-storage.disable = legacyStorage.disable.bind(legacyStorage)
-storage.enterWith = legacyStorage.enterWith.bind(legacyStorage)
-storage.exit = legacyStorage.exit.bind(legacyStorage)
-storage.getHandle = legacyStorage.getHandle.bind(legacyStorage)
-storage.getStore = legacyStorage.getStore.bind(legacyStorage)
-storage.run = legacyStorage.run.bind(legacyStorage)
-
-module.exports = storage
+module.exports = { storage, LEGACY_STORAGE_NAMESPACE }

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -16,17 +16,17 @@ describe('storage', () => {
   })
 
   afterEach(() => {
-    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith(undefined)
+    testStorage(SPAN_NAMESPACE).enterWith(undefined)
     testStorage2.enterWith(undefined)
   })
 
   it('should enter a store', done => {
     const store = 'foo'
 
-    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+    testStorage(SPAN_NAMESPACE).enterWith(store)
 
     setImmediate(() => {
-      expect(testStorage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+      expect(testStorage(SPAN_NAMESPACE).getStore()).to.equal(store)
       done()
     })
   })
@@ -35,11 +35,11 @@ describe('storage', () => {
     const store = 'foo'
     const store2 = 'bar'
 
-    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+    testStorage(SPAN_NAMESPACE).enterWith(store)
     testStorage2.enterWith(store2)
 
     setImmediate(() => {
-      expect(testStorage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+      expect(testStorage(SPAN_NAMESPACE).getStore()).to.equal(store)
       expect(testStorage2.getStore()).to.equal(store2)
       done()
     })
@@ -52,7 +52,7 @@ describe('storage', () => {
   it('should not have its store referenced by the underlying async resource', () => {
     const resource = executionAsyncResource()
 
-    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith({ internal: 'internal' })
+    testStorage(SPAN_NAMESPACE).enterWith({ internal: 'internal' })
 
     for (const sym of Object.getOwnPropertySymbols(resource)) {
       if (sym.toString() === 'Symbol(kResourceStore)' && resource[sym]) {

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -16,17 +16,17 @@ describe('storage', () => {
   })
 
   afterEach(() => {
-    testStorage.enterWith(undefined)
+    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith(undefined)
     testStorage2.enterWith(undefined)
   })
 
   it('should enter a store', done => {
     const store = 'foo'
 
-    testStorage.enterWith(store)
+    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
 
     setImmediate(() => {
-      expect(testStorage.getStore()).to.equal(store)
+      expect(testStorage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
       done()
     })
   })
@@ -35,11 +35,11 @@ describe('storage', () => {
     const store = 'foo'
     const store2 = 'bar'
 
-    testStorage.enterWith(store)
+    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
     testStorage2.enterWith(store2)
 
     setImmediate(() => {
-      expect(testStorage.getStore()).to.equal(store)
+      expect(testStorage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
       expect(testStorage2.getStore()).to.equal(store2)
       done()
     })
@@ -52,7 +52,7 @@ describe('storage', () => {
   it('should not have its store referenced by the underlying async resource', () => {
     const resource = executionAsyncResource()
 
-    testStorage.enterWith({ internal: 'internal' })
+    testStorage(LEGACY_STORAGE_NAMESPACE).enterWith({ internal: 'internal' })
 
     for (const sym of Object.getOwnPropertySymbols(resource)) {
       if (sym.toString() === 'Symbol(kResourceStore)' && resource[sym]) {

--- a/packages/datadog-core/test/storage.spec.js
+++ b/packages/datadog-core/test/storage.spec.js
@@ -16,17 +16,17 @@ describe('storage', () => {
   })
 
   afterEach(() => {
-    testStorage(SPAN_NAMESPACE).enterWith(undefined)
+    testStorage('legacy').enterWith(undefined)
     testStorage2.enterWith(undefined)
   })
 
   it('should enter a store', done => {
     const store = 'foo'
 
-    testStorage(SPAN_NAMESPACE).enterWith(store)
+    testStorage('legacy').enterWith(store)
 
     setImmediate(() => {
-      expect(testStorage(SPAN_NAMESPACE).getStore()).to.equal(store)
+      expect(testStorage('legacy').getStore()).to.equal(store)
       done()
     })
   })
@@ -35,11 +35,11 @@ describe('storage', () => {
     const store = 'foo'
     const store2 = 'bar'
 
-    testStorage(SPAN_NAMESPACE).enterWith(store)
+    testStorage('legacy').enterWith(store)
     testStorage2.enterWith(store2)
 
     setImmediate(() => {
-      expect(testStorage(SPAN_NAMESPACE).getStore()).to.equal(store)
+      expect(testStorage('legacy').getStore()).to.equal(store)
       expect(testStorage2.getStore()).to.equal(store2)
       done()
     })
@@ -52,7 +52,7 @@ describe('storage', () => {
   it('should not have its store referenced by the underlying async resource', () => {
     const resource = executionAsyncResource()
 
-    testStorage(SPAN_NAMESPACE).enterWith({ internal: 'internal' })
+    testStorage('legacy').enterWith({ internal: 'internal' })
 
     for (const sym of Object.getOwnPropertySymbols(resource)) {
       if (sym.toString() === 'Symbol(kResourceStore)' && resource[sym]) {

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -3,7 +3,7 @@
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 withVersions('body-parser', 'body-parser', version => {
   describe('body parser instrumentation', () => {
@@ -77,7 +77,7 @@ withVersions('body-parser', 'body-parser', version => {
       let payload
 
       function handler (data) {
-        store = storage(SPAN_NAMESPACE).getStore()
+        store = storage('legacy').getStore()
         payload = data
       }
       bodyParserReadCh.subscribe(handler)

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -3,7 +3,7 @@
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 withVersions('body-parser', 'body-parser', version => {
   describe('body parser instrumentation', () => {
@@ -77,7 +77,7 @@ withVersions('body-parser', 'body-parser', version => {
       let payload
 
       function handler (data) {
-        store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        store = storage(SPAN_NAMESPACE).getStore()
         payload = data
       }
       bodyParserReadCh.subscribe(handler)

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -3,7 +3,7 @@
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 withVersions('body-parser', 'body-parser', version => {
   describe('body parser instrumentation', () => {
@@ -77,7 +77,7 @@ withVersions('body-parser', 'body-parser', version => {
       let payload
 
       function handler (data) {
-        store = storage.getStore()
+        store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         payload = data
       }
       bodyParserReadCh.subscribe(handler)

--- a/packages/datadog-instrumentations/test/generic-pool.spec.js
+++ b/packages/datadog-instrumentations/test/generic-pool.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('..')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 describe('Instrumentation', () => {
   let genericPool
@@ -27,11 +27,11 @@ describe('Instrumentation', () => {
       it('should run the acquire() callback in context where acquire() was called', done => {
         const store = 'store'
 
-        storage.run(store, () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
           // eslint-disable-next-line n/handle-callback-err
           pool.acquire((err, resource) => {
             pool.release(resource)
-            expect(storage.getStore()).to.equal(store)
+            expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
             done()
           })
         })
@@ -56,20 +56,20 @@ describe('Instrumentation', () => {
         const store = 'store'
         const store2 = 'store2'
 
-        storage.run(store, () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
           pool.acquire()
             .then(resource => {
               pool.release(resource)
-              expect(storage.getStore()).to.equal(store)
+              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
             })
             .catch(done)
         })
 
-        storage.run(store2, () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run(store2, () => {
           pool.acquire()
             .then(resource => {
               pool.release(resource)
-              expect(storage.getStore()).to.equal(store2)
+              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store2)
               done()
             })
             .catch(done)

--- a/packages/datadog-instrumentations/test/generic-pool.spec.js
+++ b/packages/datadog-instrumentations/test/generic-pool.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('..')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 describe('Instrumentation', () => {
   let genericPool
@@ -27,11 +27,11 @@ describe('Instrumentation', () => {
       it('should run the acquire() callback in context where acquire() was called', done => {
         const store = 'store'
 
-        storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
+        storage(SPAN_NAMESPACE).run(store, () => {
           // eslint-disable-next-line n/handle-callback-err
           pool.acquire((err, resource) => {
             pool.release(resource)
-            expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+            expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
             done()
           })
         })
@@ -56,20 +56,20 @@ describe('Instrumentation', () => {
         const store = 'store'
         const store2 = 'store2'
 
-        storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
+        storage(SPAN_NAMESPACE).run(store, () => {
           pool.acquire()
             .then(resource => {
               pool.release(resource)
-              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
             })
             .catch(done)
         })
 
-        storage(LEGACY_STORAGE_NAMESPACE).run(store2, () => {
+        storage(SPAN_NAMESPACE).run(store2, () => {
           pool.acquire()
             .then(resource => {
               pool.release(resource)
-              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store2)
+              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store2)
               done()
             })
             .catch(done)

--- a/packages/datadog-instrumentations/test/generic-pool.spec.js
+++ b/packages/datadog-instrumentations/test/generic-pool.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('..')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 describe('Instrumentation', () => {
   let genericPool
@@ -27,11 +27,11 @@ describe('Instrumentation', () => {
       it('should run the acquire() callback in context where acquire() was called', done => {
         const store = 'store'
 
-        storage(SPAN_NAMESPACE).run(store, () => {
+        storage('legacy').run(store, () => {
           // eslint-disable-next-line n/handle-callback-err
           pool.acquire((err, resource) => {
             pool.release(resource)
-            expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+            expect(storage('legacy').getStore()).to.equal(store)
             done()
           })
         })
@@ -56,20 +56,20 @@ describe('Instrumentation', () => {
         const store = 'store'
         const store2 = 'store2'
 
-        storage(SPAN_NAMESPACE).run(store, () => {
+        storage('legacy').run(store, () => {
           pool.acquire()
             .then(resource => {
               pool.release(resource)
-              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+              expect(storage('legacy').getStore()).to.equal(store)
             })
             .catch(done)
         })
 
-        storage(SPAN_NAMESPACE).run(store2, () => {
+        storage('legacy').run(store2, () => {
           pool.acquire()
             .then(resource => {
               pool.release(resource)
-              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store2)
+              expect(storage('legacy').getStore()).to.equal(store2)
               done()
             })
             .catch(done)

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -4,18 +4,18 @@ require('../../../dd-trace/test/setup/tap')
 
 const { executionAsyncId } = require('async_hooks')
 const { expect } = require('chai')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const { AsyncResource } = require('../../src/helpers/instrument')
 
 describe('helpers/instrument', () => {
   describe('AsyncResource', () => {
     it('should bind statically', () => {
-      storage.run('test1', () => {
+      storage(LEGACY_STORAGE_NAMESPACE).run('test1', () => {
         const tested = AsyncResource.bind(() => {
-          expect(storage.getStore()).to.equal('test1')
+          expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal('test1')
         })
 
-        storage.run('test2', () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run('test2', () => {
           tested()
         })
       })
@@ -34,12 +34,12 @@ describe('helpers/instrument', () => {
     })
 
     it('should bind a specific instance', () => {
-      storage.run('test1', () => {
+      storage(LEGACY_STORAGE_NAMESPACE).run('test1', () => {
         const asyncResource = new AsyncResource('test')
 
-        storage.run('test2', () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run('test2', () => {
           const tested = asyncResource.bind((a, b, c) => {
-            expect(storage.getStore()).to.equal('test1')
+            expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal('test1')
             expect(test.asyncResource).to.equal(asyncResource)
             expect(test).to.have.length(3)
           })

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -4,18 +4,18 @@ require('../../../dd-trace/test/setup/tap')
 
 const { executionAsyncId } = require('async_hooks')
 const { expect } = require('chai')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const { AsyncResource } = require('../../src/helpers/instrument')
 
 describe('helpers/instrument', () => {
   describe('AsyncResource', () => {
     it('should bind statically', () => {
-      storage(SPAN_NAMESPACE).run('test1', () => {
+      storage('legacy').run('test1', () => {
         const tested = AsyncResource.bind(() => {
-          expect(storage(SPAN_NAMESPACE).getStore()).to.equal('test1')
+          expect(storage('legacy').getStore()).to.equal('test1')
         })
 
-        storage(SPAN_NAMESPACE).run('test2', () => {
+        storage('legacy').run('test2', () => {
           tested()
         })
       })
@@ -34,12 +34,12 @@ describe('helpers/instrument', () => {
     })
 
     it('should bind a specific instance', () => {
-      storage(SPAN_NAMESPACE).run('test1', () => {
+      storage('legacy').run('test1', () => {
         const asyncResource = new AsyncResource('test')
 
-        storage(SPAN_NAMESPACE).run('test2', () => {
+        storage('legacy').run('test2', () => {
           const tested = asyncResource.bind((a, b, c) => {
-            expect(storage(SPAN_NAMESPACE).getStore()).to.equal('test1')
+            expect(storage('legacy').getStore()).to.equal('test1')
             expect(test.asyncResource).to.equal(asyncResource)
             expect(test).to.have.length(3)
           })

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -4,18 +4,18 @@ require('../../../dd-trace/test/setup/tap')
 
 const { executionAsyncId } = require('async_hooks')
 const { expect } = require('chai')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const { AsyncResource } = require('../../src/helpers/instrument')
 
 describe('helpers/instrument', () => {
   describe('AsyncResource', () => {
     it('should bind statically', () => {
-      storage(LEGACY_STORAGE_NAMESPACE).run('test1', () => {
+      storage(SPAN_NAMESPACE).run('test1', () => {
         const tested = AsyncResource.bind(() => {
-          expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal('test1')
+          expect(storage(SPAN_NAMESPACE).getStore()).to.equal('test1')
         })
 
-        storage(LEGACY_STORAGE_NAMESPACE).run('test2', () => {
+        storage(SPAN_NAMESPACE).run('test2', () => {
           tested()
         })
       })
@@ -34,12 +34,12 @@ describe('helpers/instrument', () => {
     })
 
     it('should bind a specific instance', () => {
-      storage(LEGACY_STORAGE_NAMESPACE).run('test1', () => {
+      storage(SPAN_NAMESPACE).run('test1', () => {
         const asyncResource = new AsyncResource('test')
 
-        storage(LEGACY_STORAGE_NAMESPACE).run('test2', () => {
+        storage(SPAN_NAMESPACE).run('test2', () => {
           const tested = asyncResource.bind((a, b, c) => {
-            expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal('test1')
+            expect(storage(SPAN_NAMESPACE).getStore()).to.equal('test1')
             expect(test.asyncResource).to.equal(asyncResource)
             expect(test).to.have.length(3)
           })

--- a/packages/datadog-instrumentations/test/helpers/promise.js
+++ b/packages/datadog-instrumentations/test/helpers/promise.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai')
 const semver = require('semver')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const agent = require('../../../dd-trace/test/plugins/agent')
 
 module.exports = (name, factory, versionRange) => {
@@ -32,18 +32,18 @@ module.exports = (name, factory, versionRange) => {
 
           let promise = new Promise((resolve, reject) => {
             setImmediate(() => {
-              storage(LEGACY_STORAGE_NAMESPACE).run('promise', () => {
+              storage(SPAN_NAMESPACE).run('promise', () => {
                 resolve()
               })
             })
           })
 
-          storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
+          storage(SPAN_NAMESPACE).run(store, () => {
             for (let i = 0; i < promise.then.length; i++) {
               const args = new Array(i + 1)
 
               args[i] = () => {
-                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
               }
 
               promise = promise.then.apply(promise, args)
@@ -54,23 +54,23 @@ module.exports = (name, factory, versionRange) => {
         })
 
         it('should run the catch() callback in the context where catch() was called', () => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
 
           let promise = new Promise((resolve, reject) => {
             setImmediate(() => {
-              storage(LEGACY_STORAGE_NAMESPACE).run('promise', () => {
+              storage(SPAN_NAMESPACE).run('promise', () => {
                 reject(new Error())
               })
             })
           })
 
-          storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
+          storage(SPAN_NAMESPACE).run(store, () => {
             promise = promise
               .catch(err => {
                 throw err
               })
               .catch(() => {
-                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
               })
           })
 
@@ -78,7 +78,7 @@ module.exports = (name, factory, versionRange) => {
         })
 
         it('should allow to run without a scope if not available when calling then()', () => {
-          storage(LEGACY_STORAGE_NAMESPACE).run(null, () => {
+          storage(SPAN_NAMESPACE).run(null, () => {
             const promise = new Promise((resolve, reject) => {
               setImmediate(() => {
                 resolve()
@@ -87,7 +87,7 @@ module.exports = (name, factory, versionRange) => {
 
             return promise
               .then(() => {
-                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.be.null
+                expect(storage(SPAN_NAMESPACE).getStore()).to.be.null
               })
           })
         })

--- a/packages/datadog-instrumentations/test/helpers/promise.js
+++ b/packages/datadog-instrumentations/test/helpers/promise.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai')
 const semver = require('semver')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const agent = require('../../../dd-trace/test/plugins/agent')
 
 module.exports = (name, factory, versionRange) => {
@@ -32,18 +32,18 @@ module.exports = (name, factory, versionRange) => {
 
           let promise = new Promise((resolve, reject) => {
             setImmediate(() => {
-              storage(SPAN_NAMESPACE).run('promise', () => {
+              storage('legacy').run('promise', () => {
                 resolve()
               })
             })
           })
 
-          storage(SPAN_NAMESPACE).run(store, () => {
+          storage('legacy').run(store, () => {
             for (let i = 0; i < promise.then.length; i++) {
               const args = new Array(i + 1)
 
               args[i] = () => {
-                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+                expect(storage('legacy').getStore()).to.equal(store)
               }
 
               promise = promise.then.apply(promise, args)
@@ -54,23 +54,23 @@ module.exports = (name, factory, versionRange) => {
         })
 
         it('should run the catch() callback in the context where catch() was called', () => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
 
           let promise = new Promise((resolve, reject) => {
             setImmediate(() => {
-              storage(SPAN_NAMESPACE).run('promise', () => {
+              storage('legacy').run('promise', () => {
                 reject(new Error())
               })
             })
           })
 
-          storage(SPAN_NAMESPACE).run(store, () => {
+          storage('legacy').run(store, () => {
             promise = promise
               .catch(err => {
                 throw err
               })
               .catch(() => {
-                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+                expect(storage('legacy').getStore()).to.equal(store)
               })
           })
 
@@ -78,7 +78,7 @@ module.exports = (name, factory, versionRange) => {
         })
 
         it('should allow to run without a scope if not available when calling then()', () => {
-          storage(SPAN_NAMESPACE).run(null, () => {
+          storage('legacy').run(null, () => {
             const promise = new Promise((resolve, reject) => {
               setImmediate(() => {
                 resolve()
@@ -87,7 +87,7 @@ module.exports = (name, factory, versionRange) => {
 
             return promise
               .then(() => {
-                expect(storage(SPAN_NAMESPACE).getStore()).to.be.null
+                expect(storage('legacy').getStore()).to.be.null
               })
           })
         })

--- a/packages/datadog-instrumentations/test/helpers/promise.js
+++ b/packages/datadog-instrumentations/test/helpers/promise.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai')
 const semver = require('semver')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const agent = require('../../../dd-trace/test/plugins/agent')
 
 module.exports = (name, factory, versionRange) => {
@@ -32,18 +32,18 @@ module.exports = (name, factory, versionRange) => {
 
           let promise = new Promise((resolve, reject) => {
             setImmediate(() => {
-              storage.run('promise', () => {
+              storage(LEGACY_STORAGE_NAMESPACE).run('promise', () => {
                 resolve()
               })
             })
           })
 
-          storage.run(store, () => {
+          storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
             for (let i = 0; i < promise.then.length; i++) {
               const args = new Array(i + 1)
 
               args[i] = () => {
-                expect(storage.getStore()).to.equal(store)
+                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
               }
 
               promise = promise.then.apply(promise, args)
@@ -54,23 +54,23 @@ module.exports = (name, factory, versionRange) => {
         })
 
         it('should run the catch() callback in the context where catch() was called', () => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
           let promise = new Promise((resolve, reject) => {
             setImmediate(() => {
-              storage.run('promise', () => {
+              storage(LEGACY_STORAGE_NAMESPACE).run('promise', () => {
                 reject(new Error())
               })
             })
           })
 
-          storage.run(store, () => {
+          storage(LEGACY_STORAGE_NAMESPACE).run(store, () => {
             promise = promise
               .catch(err => {
                 throw err
               })
               .catch(() => {
-                expect(storage.getStore()).to.equal(store)
+                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
               })
           })
 
@@ -78,7 +78,7 @@ module.exports = (name, factory, versionRange) => {
         })
 
         it('should allow to run without a scope if not available when calling then()', () => {
-          storage.run(null, () => {
+          storage(LEGACY_STORAGE_NAMESPACE).run(null, () => {
             const promise = new Promise((resolve, reject) => {
               setImmediate(() => {
                 resolve()
@@ -87,7 +87,7 @@ module.exports = (name, factory, versionRange) => {
 
             return promise
               .then(() => {
-                expect(storage.getStore()).to.be.null
+                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.be.null
               })
           })
         })

--- a/packages/datadog-instrumentations/test/knex.spec.js
+++ b/packages/datadog-instrumentations/test/knex.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('../src/knex')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 describe('Instrumentation', () => {
   let knex
@@ -24,10 +24,10 @@ describe('Instrumentation', () => {
         afterEach(() => client.destroy())
 
         it('should propagate context', () =>
-          storage(LEGACY_STORAGE_NAMESPACE).run(store, () =>
+          storage(SPAN_NAMESPACE).run(store, () =>
             client.raw('PRAGMA user_version')
               .finally(() => {
-                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
               })
               .catch(() => {})
           )

--- a/packages/datadog-instrumentations/test/knex.spec.js
+++ b/packages/datadog-instrumentations/test/knex.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('../src/knex')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 describe('Instrumentation', () => {
   let knex
@@ -24,10 +24,10 @@ describe('Instrumentation', () => {
         afterEach(() => client.destroy())
 
         it('should propagate context', () =>
-          storage(SPAN_NAMESPACE).run(store, () =>
+          storage('legacy').run(store, () =>
             client.raw('PRAGMA user_version')
               .finally(() => {
-                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+                expect(storage('legacy').getStore()).to.equal(store)
               })
               .catch(() => {})
           )

--- a/packages/datadog-instrumentations/test/knex.spec.js
+++ b/packages/datadog-instrumentations/test/knex.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 require('../src/knex')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 describe('Instrumentation', () => {
   let knex
@@ -24,10 +24,10 @@ describe('Instrumentation', () => {
         afterEach(() => client.destroy())
 
         it('should propagate context', () =>
-          storage.run(store, () =>
+          storage(LEGACY_STORAGE_NAMESPACE).run(store, () =>
             client.raw('PRAGMA user_version')
               .finally(() => {
-                expect(storage.getStore()).to.equal(store)
+                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
               })
               .catch(() => {})
           )

--- a/packages/datadog-instrumentations/test/multer.spec.js
+++ b/packages/datadog-instrumentations/test/multer.spec.js
@@ -3,7 +3,7 @@
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 withVersions('multer', 'multer', version => {
   describe('multer parser instrumentation', () => {
@@ -86,7 +86,7 @@ withVersions('multer', 'multer', version => {
       let payload
 
       function handler (data) {
-        store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        store = storage(SPAN_NAMESPACE).getStore()
         payload = data
       }
       multerReadCh.subscribe(handler)

--- a/packages/datadog-instrumentations/test/multer.spec.js
+++ b/packages/datadog-instrumentations/test/multer.spec.js
@@ -3,7 +3,7 @@
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 withVersions('multer', 'multer', version => {
   describe('multer parser instrumentation', () => {
@@ -86,7 +86,7 @@ withVersions('multer', 'multer', version => {
       let payload
 
       function handler (data) {
-        store = storage.getStore()
+        store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         payload = data
       }
       multerReadCh.subscribe(handler)

--- a/packages/datadog-instrumentations/test/multer.spec.js
+++ b/packages/datadog-instrumentations/test/multer.spec.js
@@ -3,7 +3,7 @@
 const dc = require('dc-polyfill')
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 withVersions('multer', 'multer', version => {
   describe('multer parser instrumentation', () => {
@@ -86,7 +86,7 @@ withVersions('multer', 'multer', version => {
       let payload
 
       function handler (data) {
-        store = storage(SPAN_NAMESPACE).getStore()
+        store = storage('legacy').getStore()
         payload = data
       }
       multerReadCh.subscribe(handler)

--- a/packages/datadog-instrumentations/test/passport-http.spec.js
+++ b/packages/datadog-instrumentations/test/passport-http.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 withVersions('passport-http', 'passport-http', version => {
   describe('passport-http instrumentation', () => {
@@ -174,7 +174,7 @@ withVersions('passport-http', 'passport-http', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage(LEGACY_STORAGE_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
+        storage(SPAN_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport-http.spec.js
+++ b/packages/datadog-instrumentations/test/passport-http.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 withVersions('passport-http', 'passport-http', version => {
   describe('passport-http instrumentation', () => {
@@ -174,7 +174,7 @@ withVersions('passport-http', 'passport-http', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage(SPAN_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
+        storage('legacy').getStore().req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport-http.spec.js
+++ b/packages/datadog-instrumentations/test/passport-http.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 withVersions('passport-http', 'passport-http', version => {
   describe('passport-http instrumentation', () => {
@@ -174,7 +174,7 @@ withVersions('passport-http', 'passport-http', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage.getStore().req.res.writeHead(403).end('Blocked')
+        storage(LEGACY_STORAGE_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport-local.spec.js
+++ b/packages/datadog-instrumentations/test/passport-local.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 withVersions('passport-local', 'passport-local', version => {
   describe('passport-local instrumentation', () => {
@@ -154,7 +154,7 @@ withVersions('passport-local', 'passport-local', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage(LEGACY_STORAGE_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
+        storage(SPAN_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport-local.spec.js
+++ b/packages/datadog-instrumentations/test/passport-local.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 withVersions('passport-local', 'passport-local', version => {
   describe('passport-local instrumentation', () => {
@@ -154,7 +154,7 @@ withVersions('passport-local', 'passport-local', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage(SPAN_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
+        storage('legacy').getStore().req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport-local.spec.js
+++ b/packages/datadog-instrumentations/test/passport-local.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 withVersions('passport-local', 'passport-local', version => {
   describe('passport-local instrumentation', () => {
@@ -154,7 +154,7 @@ withVersions('passport-local', 'passport-local', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage.getStore().req.res.writeHead(403).end('Blocked')
+        storage(LEGACY_STORAGE_NAMESPACE).getStore().req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport.spec.js
+++ b/packages/datadog-instrumentations/test/passport.spec.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 const users = [
   {
@@ -145,7 +145,7 @@ withVersions('passport', 'passport', version => {
       const cookie = login.headers['set-cookie'][0]
 
       subscriberStub.callsFake(({ abortController }) => {
-        const res = storage(SPAN_NAMESPACE).getStore().req.res
+        const res = storage('legacy').getStore().req.res
         res.writeHead(403)
         res.constructor.prototype.end.call(res, 'Blocked')
         abortController.abort()

--- a/packages/datadog-instrumentations/test/passport.spec.js
+++ b/packages/datadog-instrumentations/test/passport.spec.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 const users = [
   {
@@ -145,7 +145,7 @@ withVersions('passport', 'passport', version => {
       const cookie = login.headers['set-cookie'][0]
 
       subscriberStub.callsFake(({ abortController }) => {
-        const res = storage.getStore().req.res
+        const res = storage(LEGACY_STORAGE_NAMESPACE).getStore().req.res
         res.writeHead(403)
         res.constructor.prototype.end.call(res, 'Blocked')
         abortController.abort()

--- a/packages/datadog-instrumentations/test/passport.spec.js
+++ b/packages/datadog-instrumentations/test/passport.spec.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios').create({ validateStatus: null })
 const dc = require('dc-polyfill')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 const users = [
   {
@@ -145,7 +145,7 @@ withVersions('passport', 'passport', version => {
       const cookie = login.headers['set-cookie'][0]
 
       subscriberStub.callsFake(({ abortController }) => {
-        const res = storage(LEGACY_STORAGE_NAMESPACE).getStore().req.res
+        const res = storage(SPAN_NAMESPACE).getStore().req.res
         res.writeHead(403)
         res.constructor.prototype.end.call(res, 'Blocked')
         abortController.abort()

--- a/packages/datadog-plugin-aerospike/src/index.js
+++ b/packages/datadog-plugin-aerospike/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 const AEROSPIKE_PEER_SERVICE = 'aerospike.namespace'
@@ -20,7 +20,7 @@ class AerospikePlugin extends DatabasePlugin {
   bindStart (ctx) {
     const { commandName, commandArgs } = ctx
     const resourceName = commandName.slice(0, commandName.indexOf('Command'))
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const childOf = store ? store.span : null
     const meta = getMeta(resourceName, commandArgs)
 

--- a/packages/datadog-plugin-aerospike/src/index.js
+++ b/packages/datadog-plugin-aerospike/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 const AEROSPIKE_PEER_SERVICE = 'aerospike.namespace'
@@ -20,7 +20,7 @@ class AerospikePlugin extends DatabasePlugin {
   bindStart (ctx) {
     const { commandName, commandArgs } = ctx
     const resourceName = commandName.slice(0, commandName.indexOf('Command'))
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const childOf = store ? store.span : null
     const meta = getMeta(resourceName, commandArgs)
 

--- a/packages/datadog-plugin-aerospike/src/index.js
+++ b/packages/datadog-plugin-aerospike/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 const AEROSPIKE_PEER_SERVICE = 'aerospike.namespace'
@@ -20,7 +20,7 @@ class AerospikePlugin extends DatabasePlugin {
   bindStart (ctx) {
     const { commandName, commandArgs } = ctx
     const resourceName = commandName.slice(0, commandName.indexOf('Command'))
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const childOf = store ? store.span : null
     const meta = getMeta(resourceName, commandArgs)
 

--- a/packages/datadog-plugin-apollo/src/gateway/fetch.js
+++ b/packages/datadog-plugin-apollo/src/gateway/fetch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
@@ -10,7 +10,7 @@ class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
   }
 
   bindStart (ctx) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const childOf = store ? store.span : null
 
     const spanData = {

--- a/packages/datadog-plugin-apollo/src/gateway/fetch.js
+++ b/packages/datadog-plugin-apollo/src/gateway/fetch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
@@ -10,7 +10,7 @@ class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
   }
 
   bindStart (ctx) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const childOf = store ? store.span : null
 
     const spanData = {

--- a/packages/datadog-plugin-apollo/src/gateway/fetch.js
+++ b/packages/datadog-plugin-apollo/src/gateway/fetch.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
@@ -10,7 +10,7 @@ class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
   }
 
   bindStart (ctx) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const childOf = store ? store.span : null
 
     const spanData = {

--- a/packages/datadog-plugin-apollo/src/gateway/index.js
+++ b/packages/datadog-plugin-apollo/src/gateway/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const CompositePlugin = require('../../../dd-trace/src/plugins/composite')
 const ApolloGatewayExecutePlugin = require('./execute')
 const ApolloGatewayPostProcessingPlugin = require('./postprocessing')
@@ -25,7 +25,7 @@ class ApolloGatewayPlugin extends CompositePlugin {
   constructor (...args) {
     super(...args)
     this.addSub('apm:apollo:gateway:general:error', (ctx) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
       if (!span) return
       span.setTag('error', ctx.error)

--- a/packages/datadog-plugin-apollo/src/gateway/index.js
+++ b/packages/datadog-plugin-apollo/src/gateway/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const CompositePlugin = require('../../../dd-trace/src/plugins/composite')
 const ApolloGatewayExecutePlugin = require('./execute')
 const ApolloGatewayPostProcessingPlugin = require('./postprocessing')
@@ -25,7 +25,7 @@ class ApolloGatewayPlugin extends CompositePlugin {
   constructor (...args) {
     super(...args)
     this.addSub('apm:apollo:gateway:general:error', (ctx) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
       if (!span) return
       span.setTag('error', ctx.error)

--- a/packages/datadog-plugin-apollo/src/gateway/index.js
+++ b/packages/datadog-plugin-apollo/src/gateway/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const CompositePlugin = require('../../../dd-trace/src/plugins/composite')
 const ApolloGatewayExecutePlugin = require('./execute')
 const ApolloGatewayPostProcessingPlugin = require('./postprocessing')
@@ -25,7 +25,7 @@ class ApolloGatewayPlugin extends CompositePlugin {
   constructor (...args) {
     super(...args)
     this.addSub('apm:apollo:gateway:general:error', (ctx) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
       if (!span) return
       span.setTag('error', ctx.error)

--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 let tools
@@ -15,7 +15,7 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
   }
 
   bindStart (ctx) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const childOf = store ? store.span : null
     const spanData = {
       childOf,

--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 let tools
@@ -15,7 +15,7 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
   }
 
   bindStart (ctx) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const childOf = store ? store.span : null
     const spanData = {
       childOf,

--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 let tools
@@ -15,7 +15,7 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
   }
 
   bindStart (ctx) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const childOf = store ? store.span : null
     const spanData = {
       childOf,

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -2,7 +2,7 @@
 
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const { isTrue } = require('../../dd-trace/src/util')
 const coalesce = require('koalas')
 const { tagsFromRequest, tagsFromResponse } = require('../../dd-trace/src/payload-tagging')
@@ -67,13 +67,13 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         span.addTags(requestTags)
       }
 
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
 
       this.enter(span, store)
     })
 
     this.addSub(`apm:aws:request:region:${this.serviceIdentifier}`, region => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (!store) return
       const { span } = store
       if (!span) return
@@ -82,7 +82,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     })
 
     this.addSub(`apm:aws:request:complete:${this.serviceIdentifier}`, ({ response, cbExists = false }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (!store) return
       const { span } = store
       if (!span) return

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -2,7 +2,7 @@
 
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const { isTrue } = require('../../dd-trace/src/util')
 const coalesce = require('koalas')
 const { tagsFromRequest, tagsFromResponse } = require('../../dd-trace/src/payload-tagging')
@@ -67,13 +67,13 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         span.addTags(requestTags)
       }
 
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
 
       this.enter(span, store)
     })
 
     this.addSub(`apm:aws:request:region:${this.serviceIdentifier}`, region => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       if (!store) return
       const { span } = store
       if (!span) return
@@ -82,7 +82,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     })
 
     this.addSub(`apm:aws:request:complete:${this.serviceIdentifier}`, ({ response, cbExists = false }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       if (!store) return
       const { span } = store
       if (!span) return

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -2,7 +2,7 @@
 
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const { isTrue } = require('../../dd-trace/src/util')
 const coalesce = require('koalas')
 const { tagsFromRequest, tagsFromResponse } = require('../../dd-trace/src/payload-tagging')
@@ -67,13 +67,13 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         span.addTags(requestTags)
       }
 
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
       this.enter(span, store)
     })
 
     this.addSub(`apm:aws:request:region:${this.serviceIdentifier}`, region => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (!store) return
       const { span } = store
       if (!span) return
@@ -82,7 +82,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     })
 
     this.addSub(`apm:aws:request:complete:${this.serviceIdentifier}`, ({ response, cbExists = false }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (!store) return
       const { span } = store
       if (!span) return

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -5,7 +5,7 @@ const {
 const { DsmPathwayCodec } = require('../../../dd-trace/src/datastreams/pathway')
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 
 class Kinesis extends BaseAwsSdkPlugin {
   static get id () { return 'kinesis' }
@@ -21,7 +21,7 @@ class Kinesis extends BaseAwsSdkPlugin {
 
     this.addSub('apm:aws:response:start:kinesis', obj => {
       const { request, response } = obj
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const plugin = this
 
       // if we have either of these operations, we want to store the streamName param
@@ -49,7 +49,7 @@ class Kinesis extends BaseAwsSdkPlugin {
         }
 
         // get the stream name that should have been stored previously
-        const { streamName } = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const { streamName } = storage(SPAN_NAMESPACE).getStore()
 
         // extract DSM context after as we might not have a parent-child but may have a DSM context
         this.responseExtractDSMContext(
@@ -59,7 +59,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:kinesis', err => {
-      const { span } = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const { span } = storage(SPAN_NAMESPACE).getStore()
       this.finish(span, null, err)
     })
   }
@@ -79,7 +79,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     if (!params || !params.StreamName) return
 
     const streamName = params.StreamName
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, streamName })
+    storage(SPAN_NAMESPACE).enterWith({ ...store, streamName })
   }
 
   responseExtract (params, operation, response) {

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -5,7 +5,7 @@ const {
 const { DsmPathwayCodec } = require('../../../dd-trace/src/datastreams/pathway')
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 
 class Kinesis extends BaseAwsSdkPlugin {
   static get id () { return 'kinesis' }
@@ -21,7 +21,7 @@ class Kinesis extends BaseAwsSdkPlugin {
 
     this.addSub('apm:aws:response:start:kinesis', obj => {
       const { request, response } = obj
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const plugin = this
 
       // if we have either of these operations, we want to store the streamName param
@@ -49,7 +49,7 @@ class Kinesis extends BaseAwsSdkPlugin {
         }
 
         // get the stream name that should have been stored previously
-        const { streamName } = storage.getStore()
+        const { streamName } = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
         // extract DSM context after as we might not have a parent-child but may have a DSM context
         this.responseExtractDSMContext(
@@ -59,7 +59,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:kinesis', err => {
-      const { span } = storage.getStore()
+      const { span } = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       this.finish(span, null, err)
     })
   }
@@ -79,7 +79,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     if (!params || !params.StreamName) return
 
     const streamName = params.StreamName
-    storage.enterWith({ ...store, streamName })
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, streamName })
   }
 
   responseExtract (params, operation, response) {

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -5,7 +5,7 @@ const {
 const { DsmPathwayCodec } = require('../../../dd-trace/src/datastreams/pathway')
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 
 class Kinesis extends BaseAwsSdkPlugin {
   static get id () { return 'kinesis' }
@@ -21,7 +21,7 @@ class Kinesis extends BaseAwsSdkPlugin {
 
     this.addSub('apm:aws:response:start:kinesis', obj => {
       const { request, response } = obj
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const plugin = this
 
       // if we have either of these operations, we want to store the streamName param
@@ -49,7 +49,7 @@ class Kinesis extends BaseAwsSdkPlugin {
         }
 
         // get the stream name that should have been stored previously
-        const { streamName } = storage(SPAN_NAMESPACE).getStore()
+        const { streamName } = storage('legacy').getStore()
 
         // extract DSM context after as we might not have a parent-child but may have a DSM context
         this.responseExtractDSMContext(
@@ -59,7 +59,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:kinesis', err => {
-      const { span } = storage(SPAN_NAMESPACE).getStore()
+      const { span } = storage('legacy').getStore()
       this.finish(span, null, err)
     })
   }
@@ -79,7 +79,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     if (!params || !params.StreamName) return
 
     const streamName = params.StreamName
-    storage(SPAN_NAMESPACE).enterWith({ ...store, streamName })
+    storage('legacy').enterWith({ ...store, streamName })
   }
 
   responseExtract (params, operation, response) {

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -2,7 +2,7 @@
 
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const { getHeadersSize } = require('../../../dd-trace/src/datastreams/processor')
 const { DsmPathwayCodec } = require('../../../dd-trace/src/datastreams/pathway')
 
@@ -20,7 +20,7 @@ class Sqs extends BaseAwsSdkPlugin {
 
     this.addSub('apm:aws:response:start:sqs', obj => {
       const { request, response } = obj
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const plugin = this
       const contextExtraction = this.responseExtract(request.params, request.operation, response)
       let span
@@ -47,7 +47,7 @@ class Sqs extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:sqs', err => {
-      const { span } = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const { span } = storage(SPAN_NAMESPACE).getStore()
       this.finish(span, null, err)
     })
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -2,7 +2,7 @@
 
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const { getHeadersSize } = require('../../../dd-trace/src/datastreams/processor')
 const { DsmPathwayCodec } = require('../../../dd-trace/src/datastreams/pathway')
 
@@ -20,7 +20,7 @@ class Sqs extends BaseAwsSdkPlugin {
 
     this.addSub('apm:aws:response:start:sqs', obj => {
       const { request, response } = obj
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const plugin = this
       const contextExtraction = this.responseExtract(request.params, request.operation, response)
       let span
@@ -47,7 +47,7 @@ class Sqs extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:sqs', err => {
-      const { span } = storage.getStore()
+      const { span } = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       this.finish(span, null, err)
     })
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -2,7 +2,7 @@
 
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const { getHeadersSize } = require('../../../dd-trace/src/datastreams/processor')
 const { DsmPathwayCodec } = require('../../../dd-trace/src/datastreams/pathway')
 
@@ -20,7 +20,7 @@ class Sqs extends BaseAwsSdkPlugin {
 
     this.addSub('apm:aws:response:start:sqs', obj => {
       const { request, response } = obj
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const plugin = this
       const contextExtraction = this.responseExtract(request.params, request.operation, response)
       let span
@@ -47,7 +47,7 @@ class Sqs extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:sqs', err => {
-      const { span } = storage(SPAN_NAMESPACE).getStore()
+      const { span } = storage('legacy').getStore()
       this.finish(span, null, err)
     })
   }

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const serverless = require('../../dd-trace/src/plugins/util/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -24,7 +24,7 @@ class AzureFunctionsPlugin extends TracingPlugin {
 
   bindStart (ctx) {
     const { functionName, methodName } = ctx
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     const span = this.startSpan(this.operationName(), {
       service: this.serviceName(),

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const serverless = require('../../dd-trace/src/plugins/util/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -24,7 +24,7 @@ class AzureFunctionsPlugin extends TracingPlugin {
 
   bindStart (ctx) {
     const { functionName, methodName } = ctx
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     const span = this.startSpan(this.operationName(), {
       service: this.serviceName(),

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const serverless = require('../../dd-trace/src/plugins/util/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -24,7 +24,7 @@ class AzureFunctionsPlugin extends TracingPlugin {
 
   bindStart (ctx) {
     const { functionName, methodName } = ctx
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     const span = this.startSpan(this.operationName(), {
       service: this.serviceName(),

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ChildProcessPlugin = require('../src')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
 const { NODE_MAJOR } = require('../../../version')
@@ -396,7 +396,7 @@ describe('Child process plugin', () => {
               parentSpan.finish()
               tracer.scope().activate(parentSpan, done)
             } else {
-              storage.enterWith({})
+              storage(LEGACY_STORAGE_NAMESPACE).enterWith({})
               done()
             }
           })
@@ -425,7 +425,7 @@ describe('Child process plugin', () => {
 
               it('should maintain previous span after the execution', (done) => {
                 const res = childProcess[methodName]('ls')
-                const span = storage.getStore()?.span
+                const span = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
                 expect(span).to.be.equals(parentSpan)
                 if (async) {
                   res.on('close', () => {
@@ -440,7 +440,7 @@ describe('Child process plugin', () => {
               if (async) {
                 it('should maintain previous span in the callback', (done) => {
                   childProcess[methodName]('ls', () => {
-                    const span = storage.getStore()?.span
+                    const span = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
                     expect(span).to.be.equals(parentSpan)
                     done()
                   })

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ChildProcessPlugin = require('../src')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
 const { NODE_MAJOR } = require('../../../version')
@@ -396,7 +396,7 @@ describe('Child process plugin', () => {
               parentSpan.finish()
               tracer.scope().activate(parentSpan, done)
             } else {
-              storage(LEGACY_STORAGE_NAMESPACE).enterWith({})
+              storage(SPAN_NAMESPACE).enterWith({})
               done()
             }
           })
@@ -425,7 +425,7 @@ describe('Child process plugin', () => {
 
               it('should maintain previous span after the execution', (done) => {
                 const res = childProcess[methodName]('ls')
-                const span = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
+                const span = storage(SPAN_NAMESPACE).getStore()?.span
                 expect(span).to.be.equals(parentSpan)
                 if (async) {
                   res.on('close', () => {
@@ -440,7 +440,7 @@ describe('Child process plugin', () => {
               if (async) {
                 it('should maintain previous span in the callback', (done) => {
                   childProcess[methodName]('ls', () => {
-                    const span = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
+                    const span = storage(SPAN_NAMESPACE).getStore()?.span
                     expect(span).to.be.equals(parentSpan)
                     done()
                   })

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -216,7 +216,7 @@ describe('Child process plugin', () => {
 
     describe('end', () => {
       it('should not call setTag if neither error nor result is passed', () => {
-        sinon.stub(storage, 'getStore').returns({ span: spanStub })
+        sinon.stub(storage('legacy'), 'getStore').returns({ span: spanStub })
         const shellPlugin = new ChildProcessPlugin(tracerStub, configStub)
 
         shellPlugin.end({})
@@ -226,7 +226,7 @@ describe('Child process plugin', () => {
       })
 
       it('should call setTag with proper code when result is a buffer', () => {
-        sinon.stub(storage, 'getStore').returns({ span: spanStub })
+        sinon.stub(storage('legacy'), 'getStore').returns({ span: spanStub })
         const shellPlugin = new ChildProcessPlugin(tracerStub, configStub)
 
         shellPlugin.end({ result: Buffer.from('test') })
@@ -236,7 +236,7 @@ describe('Child process plugin', () => {
       })
 
       it('should call setTag with proper code when result is a string', () => {
-        sinon.stub(storage, 'getStore').returns({ span: spanStub })
+        sinon.stub(storage('legacy'), 'getStore').returns({ span: spanStub })
         const shellPlugin = new ChildProcessPlugin(tracerStub, configStub)
 
         shellPlugin.end({ result: 'test' })
@@ -246,7 +246,7 @@ describe('Child process plugin', () => {
       })
 
       it('should call setTag with proper code when an error is thrown', () => {
-        sinon.stub(storage, 'getStore').returns({ span: spanStub })
+        sinon.stub(storage('legacy'), 'getStore').returns({ span: spanStub })
         const shellPlugin = new ChildProcessPlugin(tracerStub, configStub)
 
         shellPlugin.end({ error: { status: -1 } })
@@ -258,7 +258,7 @@ describe('Child process plugin', () => {
 
     describe('asyncEnd', () => {
       it('should call setTag with undefined code if neither error nor result is passed', () => {
-        sinon.stub(storage, 'getStore').returns({ span: spanStub })
+        sinon.stub(storage('legacy'), 'getStore').returns({ span: spanStub })
         const shellPlugin = new ChildProcessPlugin(tracerStub, configStub)
 
         shellPlugin.asyncEnd({})
@@ -268,7 +268,7 @@ describe('Child process plugin', () => {
       })
 
       it('should call setTag with proper code when a proper code is returned', () => {
-        sinon.stub(storage, 'getStore').returns({ span: spanStub })
+        sinon.stub(storage('legacy'), 'getStore').returns({ span: spanStub })
         const shellPlugin = new ChildProcessPlugin(tracerStub, configStub)
 
         shellPlugin.asyncEnd({ result: 0 })

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ChildProcessPlugin = require('../src')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
 const { NODE_MAJOR } = require('../../../version')
@@ -396,7 +396,7 @@ describe('Child process plugin', () => {
               parentSpan.finish()
               tracer.scope().activate(parentSpan, done)
             } else {
-              storage(SPAN_NAMESPACE).enterWith({})
+              storage('legacy').enterWith({})
               done()
             }
           })
@@ -425,7 +425,7 @@ describe('Child process plugin', () => {
 
               it('should maintain previous span after the execution', (done) => {
                 const res = childProcess[methodName]('ls')
-                const span = storage(SPAN_NAMESPACE).getStore()?.span
+                const span = storage('legacy').getStore()?.span
                 expect(span).to.be.equals(parentSpan)
                 if (async) {
                   res.on('close', () => {
@@ -440,7 +440,7 @@ describe('Child process plugin', () => {
               if (async) {
                 it('should maintain previous span in the callback', (done) => {
                   childProcess[methodName]('ls', () => {
-                    const span = storage(SPAN_NAMESPACE).getStore()?.span
+                    const span = storage('legacy').getStore()?.span
                     expect(span).to.be.equals(parentSpan)
                     done()
                   })

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -5,7 +5,6 @@ const http = require('http')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { AsyncLocalStorage } = require('async_hooks')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
-const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
@@ -463,12 +462,12 @@ describe('Plugin', () => {
           const store = {}
 
           app.use((req, res, next) => {
-            storage(SPAN_NAMESPACE).run(store, () => next())
+            storage.run(store, () => next())
           })
 
           app.use((req, res) => {
             try {
-              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+              expect(storage.getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -462,12 +462,12 @@ describe('Plugin', () => {
           const store = {}
 
           app.use((req, res, next) => {
-            storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
+            storage(SPAN_NAMESPACE).run(store, () => next())
           })
 
           app.use((req, res) => {
             try {
-              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -5,6 +5,7 @@ const http = require('http')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { AsyncLocalStorage } = require('async_hooks')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
+const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -462,12 +462,12 @@ describe('Plugin', () => {
           const store = {}
 
           app.use((req, res, next) => {
-            storage.run(store, () => next())
+            storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
           })
 
           app.use((req, res) => {
             try {
-              expect(storage.getStore()).to.equal(store)
+              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const StoragePlugin = require('../../dd-trace/src/plugins/storage')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 class CouchBasePlugin extends StoragePlugin {
   static get id () { return 'couchbase' }
@@ -42,7 +42,7 @@ class CouchBasePlugin extends StoragePlugin {
     super(...args)
 
     this.addSubs('query', ({ resource, bucket, seedNodes }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = this.startSpan(
         'query', {
           'span.type': 'sql',
@@ -64,7 +64,7 @@ class CouchBasePlugin extends StoragePlugin {
 
   _addCommandSubs (name) {
     this.addSubs(name, ({ bucket, collection, seedNodes }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = this.startSpan(name, {}, store, { bucket, collection, seedNodes })
       this.enter(span, store)
     })

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const StoragePlugin = require('../../dd-trace/src/plugins/storage')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 class CouchBasePlugin extends StoragePlugin {
   static get id () { return 'couchbase' }
@@ -42,7 +42,7 @@ class CouchBasePlugin extends StoragePlugin {
     super(...args)
 
     this.addSubs('query', ({ resource, bucket, seedNodes }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = this.startSpan(
         'query', {
           'span.type': 'sql',
@@ -64,7 +64,7 @@ class CouchBasePlugin extends StoragePlugin {
 
   _addCommandSubs (name) {
     this.addSubs(name, ({ bucket, collection, seedNodes }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = this.startSpan(name, {}, store, { bucket, collection, seedNodes })
       this.enter(span, store)
     })

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const StoragePlugin = require('../../dd-trace/src/plugins/storage')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 class CouchBasePlugin extends StoragePlugin {
   static get id () { return 'couchbase' }
@@ -42,7 +42,7 @@ class CouchBasePlugin extends StoragePlugin {
     super(...args)
 
     this.addSubs('query', ({ resource, bucket, seedNodes }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = this.startSpan(
         'query', {
           'span.type': 'sql',
@@ -64,7 +64,7 @@ class CouchBasePlugin extends StoragePlugin {
 
   _addCommandSubs (name) {
     this.addSubs(name, ({ bucket, collection, seedNodes }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = this.startSpan(name, {}, store, { bucket, collection, seedNodes })
       this.enter(span, store)
     })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 const {
   TEST_SKIP_REASON,
@@ -213,7 +213,7 @@ class CucumberPlugin extends CiPlugin {
       isParallel,
       promises
     }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
 
@@ -239,7 +239,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store.span
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
@@ -260,7 +260,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test-step:start', ({ resource }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const childOf = store ? store.span : store
       const span = this.tracer.startSpan('cucumber.step', {
         childOf,
@@ -313,7 +313,7 @@ class CucumberPlugin extends CiPlugin {
       isEfdRetry,
       isFlakyRetry
     }) => {
-      const span = storage(SPAN_NAMESPACE).getStore().span
+      const span = storage('legacy').getStore().span
       const statusTag = isStep ? 'step.status' : TEST_STATUS
 
       span.setTag(statusTag, status)
@@ -368,7 +368,7 @@ class CucumberPlugin extends CiPlugin {
 
     this.addSub('ci:cucumber:error', (err) => {
       if (err) {
-        const span = storage(SPAN_NAMESPACE).getStore().span
+        const span = storage('legacy').getStore().span
         span.setTag('error', err)
       }
     })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_SKIP_REASON,
@@ -213,7 +213,7 @@ class CucumberPlugin extends CiPlugin {
       isParallel,
       promises
     }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
 
@@ -239,7 +239,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store.span
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
@@ -260,7 +260,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test-step:start', ({ resource }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const childOf = store ? store.span : store
       const span = this.tracer.startSpan('cucumber.step', {
         childOf,
@@ -313,7 +313,7 @@ class CucumberPlugin extends CiPlugin {
       isEfdRetry,
       isFlakyRetry
     }) => {
-      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
+      const span = storage(SPAN_NAMESPACE).getStore().span
       const statusTag = isStep ? 'step.status' : TEST_STATUS
 
       span.setTag(statusTag, status)
@@ -368,7 +368,7 @@ class CucumberPlugin extends CiPlugin {
 
     this.addSub('ci:cucumber:error', (err) => {
       if (err) {
-        const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
+        const span = storage(SPAN_NAMESPACE).getStore().span
         span.setTag('error', err)
       }
     })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_SKIP_REASON,
@@ -213,7 +213,7 @@ class CucumberPlugin extends CiPlugin {
       isParallel,
       promises
     }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
 
@@ -239,7 +239,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store.span
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
@@ -260,7 +260,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test-step:start', ({ resource }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const childOf = store ? store.span : store
       const span = this.tracer.startSpan('cucumber.step', {
         childOf,
@@ -313,7 +313,7 @@ class CucumberPlugin extends CiPlugin {
       isEfdRetry,
       isFlakyRetry
     }) => {
-      const span = storage.getStore().span
+      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
       const statusTag = isStep ? 'step.status' : TEST_STATUS
 
       span.setTag(statusTag, status)
@@ -368,7 +368,7 @@ class CucumberPlugin extends CiPlugin {
 
     this.addSub('ci:cucumber:error', (err) => {
       if (err) {
-        const span = storage.getStore().span
+        const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
         span.setTag('error', err)
       }
     })

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -2,7 +2,7 @@
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { promisify } = require('util')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const { ERROR_TYPE, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
 
 const PLUGINS = ['dns', 'node:dns']
@@ -232,7 +232,7 @@ describe('Plugin', () => {
             clearTimeout(timer)
           })
 
-        storage.run({ noop: true }, () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, () => {
           resolver.resolve('lvh.me', () => {})
         })
       })

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -2,7 +2,7 @@
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { promisify } = require('util')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const { ERROR_TYPE, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
 
 const PLUGINS = ['dns', 'node:dns']
@@ -232,7 +232,7 @@ describe('Plugin', () => {
             clearTimeout(timer)
           })
 
-        storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, () => {
+        storage(SPAN_NAMESPACE).run({ noop: true }, () => {
           resolver.resolve('lvh.me', () => {})
         })
       })

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -2,7 +2,7 @@
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { promisify } = require('util')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const { ERROR_TYPE, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
 
 const PLUGINS = ['dns', 'node:dns']
@@ -232,7 +232,7 @@ describe('Plugin', () => {
             clearTimeout(timer)
           })
 
-        storage(SPAN_NAMESPACE).run({ noop: true }, () => {
+        storage('legacy').run({ noop: true }, () => {
           resolver.resolve('lvh.me', () => {})
         })
       })

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -6,6 +6,7 @@ const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
+const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1309,12 +1309,12 @@ describe('Plugin', () => {
           const store = {}
 
           app.use((req, res, next) => {
-            storage.run(store, () => next())
+            storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
           })
 
           app.get('/user', (req, res) => {
             try {
-              expect(storage.getStore()).to.equal(store)
+              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1309,12 +1309,12 @@ describe('Plugin', () => {
           const store = {}
 
           app.use((req, res, next) => {
-            storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
+            storage(SPAN_NAMESPACE).run(store, () => next())
           })
 
           app.get('/user', (req, res) => {
             try {
-              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -6,7 +6,6 @@ const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const plugin = require('../src')
-const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
@@ -1310,12 +1309,12 @@ describe('Plugin', () => {
           const store = {}
 
           app.use((req, res, next) => {
-            storage(SPAN_NAMESPACE).run(store, () => next())
+            storage.run(store, () => next())
           })
 
           app.get('/user', (req, res) => {
             try {
-              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+              expect(storage.getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -309,15 +309,15 @@ describe('Plugin', () => {
             const storage = new AsyncLocalStorage()
             const store = {}
 
-            global.getStore = () => storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            global.getStore = () => storage(SPAN_NAMESPACE).getStore()
 
             app.addHook('onRequest', (request, reply, next) => {
-              storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
+              storage(SPAN_NAMESPACE).run(store, () => next())
             })
 
             app.get('/user', (request, reply) => {
               try {
-                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
                 done()
               } catch (e) {
                 done(e)

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -6,7 +6,6 @@ const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { NODE_MAJOR } = require('../../../version')
-const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const host = 'localhost'
 
@@ -310,15 +309,15 @@ describe('Plugin', () => {
             const storage = new AsyncLocalStorage()
             const store = {}
 
-            global.getStore = () => storage(SPAN_NAMESPACE).getStore()
+            global.getStore = () => storage('legacy').getStore()
 
             app.addHook('onRequest', (request, reply, next) => {
-              storage(SPAN_NAMESPACE).run(store, () => next())
+              storage.run(store, () => next())
             })
 
             app.get('/user', (request, reply) => {
               try {
-                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+                expect(storage.getStore()).to.equal(store)
                 done()
               } catch (e) {
                 done(e)

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -6,6 +6,7 @@ const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { NODE_MAJOR } = require('../../../version')
+const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const host = 'localhost'
 

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -309,15 +309,15 @@ describe('Plugin', () => {
             const storage = new AsyncLocalStorage()
             const store = {}
 
-            global.getStore = () => storage.getStore()
+            global.getStore = () => storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
             app.addHook('onRequest', (request, reply, next) => {
-              storage.run(store, () => next())
+              storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
             })
 
             app.get('/user', (request, reply) => {
               try {
-                expect(storage.getStore()).to.equal(store)
+                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
                 done()
               } catch (e) {
                 done(e)

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { DD_MAJOR } = require('../../../version')
 const { rawExpectedSchema } = require('./naming')
@@ -338,13 +338,13 @@ describe('Plugin', function () {
               clearTimeout(timer)
             })
 
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
-          storage.enterWith({ noop: true })
+          storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
 
           fetch(`http://localhost:${port}/user`).catch(() => {})
 
-          storage.enterWith(store)
+          storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
         })
       })
     })

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { DD_MAJOR } = require('../../../version')
 const { rawExpectedSchema } = require('./naming')
@@ -338,13 +338,13 @@ describe('Plugin', function () {
               clearTimeout(timer)
             })
 
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
 
-          storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+          storage(SPAN_NAMESPACE).enterWith({ noop: true })
 
           fetch(`http://localhost:${port}/user`).catch(() => {})
 
-          storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+          storage(SPAN_NAMESPACE).enterWith(store)
         })
       })
     })

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -3,7 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { DD_MAJOR } = require('../../../version')
 const { rawExpectedSchema } = require('./naming')
@@ -338,13 +338,13 @@ describe('Plugin', function () {
               clearTimeout(timer)
             })
 
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
 
-          storage(SPAN_NAMESPACE).enterWith({ noop: true })
+          storage('legacy').enterWith({ noop: true })
 
           fetch(`http://localhost:${port}/user`).catch(() => {})
 
-          storage(SPAN_NAMESPACE).enterWith(store)
+          storage('legacy').enterWith(store)
         })
       })
     })

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -20,7 +20,7 @@ class GrpcClientPlugin extends ClientPlugin {
   }
 
   bindStart (message) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const { metadata, path, type } = message
     const metadataFilter = this.config.metadataFilter
     const method = getMethodMetadata(path, type)

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -20,7 +20,7 @@ class GrpcClientPlugin extends ClientPlugin {
   }
 
   bindStart (message) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const { metadata, path, type } = message
     const metadataFilter = this.config.metadataFilter
     const method = getMethodMetadata(path, type)

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -20,7 +20,7 @@ class GrpcClientPlugin extends ClientPlugin {
   }
 
   bindStart (message) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const { metadata, path, type } = message
     const metadataFilter = this.config.metadataFilter
     const method = getMethodMetadata(path, type)

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -27,7 +27,7 @@ class GrpcServerPlugin extends ServerPlugin {
   }
 
   bindStart (message) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const { name, metadata, type } = message
     const metadataFilter = this.config.metadataFilter
     const childOf = extract(this.tracer, metadata)

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -27,7 +27,7 @@ class GrpcServerPlugin extends ServerPlugin {
   }
 
   bindStart (message) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const { name, metadata, type } = message
     const metadataFilter = this.config.metadataFilter
     const childOf = extract(this.tracer, metadata)

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -27,7 +27,7 @@ class GrpcServerPlugin extends ServerPlugin {
   }
 
   bindStart (message) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const { name, metadata, type } = message
     const metadataFilter = this.config.metadataFilter
     const childOf = extract(this.tracer, metadata)

--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -15,7 +15,7 @@ class HapiPlugin extends RouterPlugin {
     this._requestSpans = new WeakMap()
 
     this.addSub('apm:hapi:request:handle', ({ req }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store && store.span
 
       this.setFramework(req, 'hapi', this.config)

--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -15,7 +15,7 @@ class HapiPlugin extends RouterPlugin {
     this._requestSpans = new WeakMap()
 
     this.addSub('apm:hapi:request:handle', ({ req }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store && store.span
 
       this.setFramework(req, 'hapi', this.config)

--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -15,7 +15,7 @@ class HapiPlugin extends RouterPlugin {
     this._requestSpans = new WeakMap()
 
     this.addSub('apm:hapi:request:handle', ({ req }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store && store.span
 
       this.setFramework(req, 'hapi', this.config)

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -351,11 +351,11 @@ describe('Plugin', () => {
       })
 
       it('should persist AsyncLocalStorage context', (done) => {
-        const als = new AsyncLocalStorage()
+        const storage = new AsyncLocalStorage()
         const path = '/path'
 
         server.ext('onRequest', (request, h) => {
-          als.enterWith({ path: request.path })
+          storage.enterWith({ path: request.path })
           return reply(request, h)
         })
 
@@ -363,7 +363,7 @@ describe('Plugin', () => {
           method: 'GET',
           path,
           handler: async (request, h) => {
-            expect(als.getStore()).to.deep.equal({ path })
+            expect(storage.getStore()).to.deep.equal({ path })
             done()
             return h.response ? h.response() : h()
           }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const tags = require('../../../ext/tags')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const formats = require('../../../ext/formats')
@@ -21,7 +21,7 @@ class HttpClientPlugin extends ClientPlugin {
 
   bindStart (message) {
     const { args, http = {} } = message
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const options = args.options
     const agent = options.agent || options._defaultAgent || http.globalAgent || {}
     const protocol = options.protocol || agent.protocol || 'http:'

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const tags = require('../../../ext/tags')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const formats = require('../../../ext/formats')
@@ -21,7 +21,7 @@ class HttpClientPlugin extends ClientPlugin {
 
   bindStart (message) {
     const { args, http = {} } = message
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const options = args.options
     const agent = options.agent || options._defaultAgent || http.globalAgent || {}
     const protocol = options.protocol || agent.protocol || 'http:'

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const tags = require('../../../ext/tags')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const formats = require('../../../ext/formats')
@@ -21,7 +21,7 @@ class HttpClientPlugin extends ClientPlugin {
 
   bindStart (message) {
     const { args, http = {} } = message
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const options = args.options
     const agent = options.agent || options._defaultAgent || http.globalAgent || {}
     const protocol = options.protocol || agent.protocol || 'http:'

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -22,7 +22,7 @@ class HttpServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res, abortController }) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const span = web.startSpan(
       this.tracer,
       {

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -22,7 +22,7 @@ class HttpServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res, abortController }) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const span = web.startSpan(
       this.tracer,
       {

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -22,7 +22,7 @@ class HttpServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res, abortController }) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const span = web.startSpan(
       this.tracer,
       {

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const key = fs.readFileSync(path.join(__dirname, './ssl/test.key'))
 const cert = fs.readFileSync(path.join(__dirname, './ssl/test.crt'))
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
@@ -922,15 +922,15 @@ describe('Plugin', () => {
               })
 
             appListener = server(app, port => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
-              storage.enterWith({ noop: true })
+              storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
               const req = http.request(tracer._tracer._url.href)
 
               req.on('error', () => {})
               req.end()
 
-              storage.enterWith(store)
+              storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
             })
           })
         }

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const key = fs.readFileSync(path.join(__dirname, './ssl/test.key'))
 const cert = fs.readFileSync(path.join(__dirname, './ssl/test.crt'))
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
@@ -922,15 +922,15 @@ describe('Plugin', () => {
               })
 
             appListener = server(app, port => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
 
-              storage(SPAN_NAMESPACE).enterWith({ noop: true })
+              storage('legacy').enterWith({ noop: true })
               const req = http.request(tracer._tracer._url.href)
 
               req.on('error', () => {})
               req.end()
 
-              storage(SPAN_NAMESPACE).enterWith(store)
+              storage('legacy').enterWith(store)
             })
           })
         }

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const key = fs.readFileSync(path.join(__dirname, './ssl/test.key'))
 const cert = fs.readFileSync(path.join(__dirname, './ssl/test.crt'))
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
@@ -922,15 +922,15 @@ describe('Plugin', () => {
               })
 
             appListener = server(app, port => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
 
-              storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+              storage(SPAN_NAMESPACE).enterWith({ noop: true })
               const req = http.request(tracer._tracer._url.href)
 
               req.on('error', () => {})
               req.end()
 
-              storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+              storage(SPAN_NAMESPACE).enterWith(store)
             })
           })
         }

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 const URL = require('url').URL
@@ -36,7 +36,7 @@ class Http2ClientPlugin extends ClientPlugin {
     const uri = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}${pathname}`
     const allowed = this.config.filter(uri)
 
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const childOf = store && allowed ? store.span : null
     const span = this.startSpan(this.operationName(), {
       childOf,
@@ -85,7 +85,7 @@ class Http2ClientPlugin extends ClientPlugin {
         return parentStore
     }
 
-    return storage(SPAN_NAMESPACE).getStore()
+    return storage('legacy').getStore()
   }
 
   configure (config) {
@@ -98,7 +98,7 @@ class Http2ClientPlugin extends ClientPlugin {
     store.span.setTag(HTTP_STATUS_CODE, status)
 
     if (!this.config.validateStatus(status)) {
-      storage(SPAN_NAMESPACE).run(store, () => this.addError())
+      storage('legacy').run(store, () => this.addError())
     }
 
     addHeaderTags(store.span, headers, HTTP_RESPONSE_HEADERS, this.config)

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 const URL = require('url').URL
@@ -36,7 +36,7 @@ class Http2ClientPlugin extends ClientPlugin {
     const uri = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}${pathname}`
     const allowed = this.config.filter(uri)
 
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const childOf = store && allowed ? store.span : null
     const span = this.startSpan(this.operationName(), {
       childOf,
@@ -85,7 +85,7 @@ class Http2ClientPlugin extends ClientPlugin {
         return parentStore
     }
 
-    return storage.getStore()
+    return storage(LEGACY_STORAGE_NAMESPACE).getStore()
   }
 
   configure (config) {
@@ -98,7 +98,7 @@ class Http2ClientPlugin extends ClientPlugin {
     store.span.setTag(HTTP_STATUS_CODE, status)
 
     if (!this.config.validateStatus(status)) {
-      storage.run(store, () => this.addError())
+      storage(LEGACY_STORAGE_NAMESPACE).run(store, () => this.addError())
     }
 
     addHeaderTags(store.span, headers, HTTP_RESPONSE_HEADERS, this.config)

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 const URL = require('url').URL
@@ -36,7 +36,7 @@ class Http2ClientPlugin extends ClientPlugin {
     const uri = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}${pathname}`
     const allowed = this.config.filter(uri)
 
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const childOf = store && allowed ? store.span : null
     const span = this.startSpan(this.operationName(), {
       childOf,
@@ -85,7 +85,7 @@ class Http2ClientPlugin extends ClientPlugin {
         return parentStore
     }
 
-    return storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    return storage(SPAN_NAMESPACE).getStore()
   }
 
   configure (config) {
@@ -98,7 +98,7 @@ class Http2ClientPlugin extends ClientPlugin {
     store.span.setTag(HTTP_STATUS_CODE, status)
 
     if (!this.config.validateStatus(status)) {
-      storage(LEGACY_STORAGE_NAMESPACE).run(store, () => this.addError())
+      storage(SPAN_NAMESPACE).run(store, () => this.addError())
     }
 
     addHeaderTags(store.span, headers, HTTP_RESPONSE_HEADERS, this.config)

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -3,7 +3,7 @@
 // Plugin temporarily disabled. See https://github.com/DataDog/dd-trace-js/issues/312
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
@@ -17,7 +17,7 @@ class Http2ServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res }) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const span = web.startSpan(
       this.tracer,
       {

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -3,7 +3,7 @@
 // Plugin temporarily disabled. See https://github.com/DataDog/dd-trace-js/issues/312
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
@@ -17,7 +17,7 @@ class Http2ServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res }) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const span = web.startSpan(
       this.tracer,
       {

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -3,7 +3,7 @@
 // Plugin temporarily disabled. See https://github.com/DataDog/dd-trace-js/issues/312
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
@@ -17,7 +17,7 @@ class Http2ServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res }) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const span = web.startSpan(
       this.tracer,
       {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -318,7 +318,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:test:start', (test) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = this.startTestSpan(test)
 
       this.enter(span, store)
@@ -326,7 +326,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:test:finish', ({ status, testStartLine }) => {
-      const span = storage.getStore().span
+      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
       span.setTag(TEST_STATUS, status)
       if (testStartLine) {
         span.setTag(TEST_SOURCE_START, testStartLine)
@@ -351,7 +351,7 @@ class JestPlugin extends CiPlugin {
 
     this.addSub('ci:jest:test:err', ({ error, shouldSetProbe, promises }) => {
       if (error) {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         if (store && store.span) {
           const span = store.span
           span.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -318,7 +318,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:test:start', (test) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = this.startTestSpan(test)
 
       this.enter(span, store)
@@ -326,7 +326,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:test:finish', ({ status, testStartLine }) => {
-      const span = storage(SPAN_NAMESPACE).getStore().span
+      const span = storage('legacy').getStore().span
       span.setTag(TEST_STATUS, status)
       if (testStartLine) {
         span.setTag(TEST_SOURCE_START, testStartLine)
@@ -351,7 +351,7 @@ class JestPlugin extends CiPlugin {
 
     this.addSub('ci:jest:test:err', ({ error, shouldSetProbe, promises }) => {
       if (error) {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         if (store && store.span) {
           const span = store.span
           span.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -318,7 +318,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:test:start', (test) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = this.startTestSpan(test)
 
       this.enter(span, store)
@@ -326,7 +326,7 @@ class JestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:jest:test:finish', ({ status, testStartLine }) => {
-      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
+      const span = storage(SPAN_NAMESPACE).getStore().span
       span.setTag(TEST_STATUS, status)
       if (testStartLine) {
         span.setTag(TEST_SOURCE_START, testStartLine)
@@ -351,7 +351,7 @@ class JestPlugin extends CiPlugin {
 
     this.addSub('ci:jest:test:err', ({ error, shouldSetProbe, promises }) => {
       if (error) {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         if (store && store.span) {
           const span = store.span
           span.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -5,7 +5,6 @@ const axios = require('axios')
 const semver = require('semver')
 const { ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
-const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
@@ -789,14 +788,14 @@ describe('Plugin', () => {
             const store = {}
 
             app.use((ctx, next) => {
-              return storage(SPAN_NAMESPACE).run(store, () => next())
+              return storage.run(store, () => next())
             })
 
             app.use(ctx => {
               ctx.body = ''
 
               try {
-                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+                expect(storage.getStore()).to.equal(store)
                 done()
               } catch (e) {
                 done(e)

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -788,14 +788,14 @@ describe('Plugin', () => {
             const store = {}
 
             app.use((ctx, next) => {
-              return storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
+              return storage(SPAN_NAMESPACE).run(store, () => next())
             })
 
             app.use(ctx => {
               ctx.body = ''
 
               try {
-                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+                expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
                 done()
               } catch (e) {
                 done(e)

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -5,6 +5,7 @@ const axios = require('axios')
 const semver = require('semver')
 const { ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
+const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -788,14 +788,14 @@ describe('Plugin', () => {
             const store = {}
 
             app.use((ctx, next) => {
-              return storage.run(store, () => next())
+              return storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
             })
 
             app.use(ctx => {
               ctx.body = ''
 
               try {
-                expect(storage.getStore()).to.equal(store)
+                expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
                 done()
               } catch (e) {
                 done(e)

--- a/packages/datadog-plugin-langchain/src/tracing.js
+++ b/packages/datadog-plugin-langchain/src/tracing.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { MEASURED } = require('../../../ext/tags')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
 const API_KEY = 'langchain.request.api_key'
@@ -61,7 +61,7 @@ class LangChainTracingPlugin extends TracingPlugin {
       }
     }, false)
 
-    const store = storage(SPAN_NAMESPACE).getStore() || {}
+    const store = storage('legacy').getStore() || {}
     ctx.currentStore = { ...store, span }
 
     return ctx.currentStore

--- a/packages/datadog-plugin-langchain/src/tracing.js
+++ b/packages/datadog-plugin-langchain/src/tracing.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { MEASURED } = require('../../../ext/tags')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
 const API_KEY = 'langchain.request.api_key'
@@ -61,7 +61,7 @@ class LangChainTracingPlugin extends TracingPlugin {
       }
     }, false)
 
-    const store = storage.getStore() || {}
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore() || {}
     ctx.currentStore = { ...store, span }
 
     return ctx.currentStore

--- a/packages/datadog-plugin-langchain/src/tracing.js
+++ b/packages/datadog-plugin-langchain/src/tracing.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { MEASURED } = require('../../../ext/tags')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
 const API_KEY = 'langchain.request.api_key'
@@ -61,7 +61,7 @@ class LangChainTracingPlugin extends TracingPlugin {
       }
     }, false)
 
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore() || {}
+    const store = storage(SPAN_NAMESPACE).getStore() || {}
     ctx.currentStore = { ...store, span }
 
     return ctx.currentStore

--- a/packages/datadog-plugin-limitd-client/test/index.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/index.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
 
 describe('Plugin', () => {
@@ -29,12 +29,12 @@ describe('Plugin', () => {
       it('should propagate context', done => {
         const span = {}
 
-        storage(SPAN_NAMESPACE).run(span, () => {
+        storage('legacy').run(span, () => {
           limitd.take('user', 'test', function (err, resp) {
             if (err) return done(err)
 
             try {
-              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(span)
+              expect(storage('legacy').getStore()).to.equal(span)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-limitd-client/test/index.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/index.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
 
 describe('Plugin', () => {
@@ -29,12 +29,12 @@ describe('Plugin', () => {
       it('should propagate context', done => {
         const span = {}
 
-        storage(LEGACY_STORAGE_NAMESPACE).run(span, () => {
+        storage(SPAN_NAMESPACE).run(span, () => {
           limitd.take('user', 'test', function (err, resp) {
             if (err) return done(err)
 
             try {
-              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(span)
+              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(span)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-limitd-client/test/index.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/index.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const agent = require('../../dd-trace/test/plugins/agent')
 
 describe('Plugin', () => {
@@ -29,12 +29,12 @@ describe('Plugin', () => {
       it('should propagate context', done => {
         const span = {}
 
-        storage.run(span, () => {
+        storage(LEGACY_STORAGE_NAMESPACE).run(span, () => {
           limitd.take('user', 'test', function (err, resp) {
             if (err) return done(err)
 
             try {
-              expect(storage.getStore()).to.equal(span)
+              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(span)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const MySQLPlugin = require('../../datadog-plugin-mysql/src')
 
 let skippedStore
@@ -13,12 +13,12 @@ class MariadbPlugin extends MySQLPlugin {
     super(...args)
 
     this.addSub(`apm:${this.component}:pool:skip`, () => {
-      skippedStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+      skippedStore = storage(SPAN_NAMESPACE).getStore()
+      storage(SPAN_NAMESPACE).enterWith({ noop: true })
     })
 
     this.addSub(`apm:${this.component}:pool:unskip`, () => {
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(skippedStore)
+      storage(SPAN_NAMESPACE).enterWith(skippedStore)
       skippedStore = undefined
     })
   }

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const MySQLPlugin = require('../../datadog-plugin-mysql/src')
 
 let skippedStore
@@ -13,12 +13,12 @@ class MariadbPlugin extends MySQLPlugin {
     super(...args)
 
     this.addSub(`apm:${this.component}:pool:skip`, () => {
-      skippedStore = storage(SPAN_NAMESPACE).getStore()
-      storage(SPAN_NAMESPACE).enterWith({ noop: true })
+      skippedStore = storage('legacy').getStore()
+      storage('legacy').enterWith({ noop: true })
     })
 
     this.addSub(`apm:${this.component}:pool:unskip`, () => {
-      storage(SPAN_NAMESPACE).enterWith(skippedStore)
+      storage('legacy').enterWith(skippedStore)
       skippedStore = undefined
     })
   }

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const MySQLPlugin = require('../../datadog-plugin-mysql/src')
 
 let skippedStore
@@ -13,12 +13,12 @@ class MariadbPlugin extends MySQLPlugin {
     super(...args)
 
     this.addSub(`apm:${this.component}:pool:skip`, () => {
-      skippedStore = storage.getStore()
-      storage.enterWith({ noop: true })
+      skippedStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
     })
 
     this.addSub(`apm:${this.component}:pool:unskip`, () => {
-      storage.enterWith(skippedStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(skippedStore)
       skippedStore = undefined
     })
   }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -155,13 +155,13 @@ class MochaPlugin extends CiPlugin {
       if (itrCorrelationId) {
         testSuiteSpan.setTag(ITR_CORRELATION_ID, itrCorrelationId)
       }
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       this.enter(testSuiteSpan, store)
       this._testSuites.set(testSuite, testSuiteSpan)
     })
 
     this.addSub('ci:mocha:test-suite:finish', (status) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       if (store && store.span) {
         const span = store.span
         // the test status of the suite may have been set in ci:mocha:test-suite:error already
@@ -174,7 +174,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test-suite:error', (err) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       if (store && store.span) {
         const span = store.span
         span.setTag('error', err)
@@ -183,7 +183,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:start', (testInfo) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = this.startTestSpan(testInfo)
 
       this.enter(span, store)
@@ -195,7 +195,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:finish', ({ status, hasBeenRetried, isLastRetry }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
 
       if (span) {
@@ -227,7 +227,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:skip', (testInfo) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       // skipped through it.skip, so the span is not created yet
       // for this test
       if (!store) {
@@ -237,7 +237,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:error', (err) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
       if (err && span) {
         if (err.constructor.name === 'Pending' && !this.forbidPending) {
@@ -250,7 +250,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:retry', ({ isFirstAttempt, willBeRetried, err, test }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -155,13 +155,13 @@ class MochaPlugin extends CiPlugin {
       if (itrCorrelationId) {
         testSuiteSpan.setTag(ITR_CORRELATION_ID, itrCorrelationId)
       }
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       this.enter(testSuiteSpan, store)
       this._testSuites.set(testSuite, testSuiteSpan)
     })
 
     this.addSub('ci:mocha:test-suite:finish', (status) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (store && store.span) {
         const span = store.span
         // the test status of the suite may have been set in ci:mocha:test-suite:error already
@@ -174,7 +174,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test-suite:error', (err) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (store && store.span) {
         const span = store.span
         span.setTag('error', err)
@@ -183,7 +183,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:start', (testInfo) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = this.startTestSpan(testInfo)
 
       this.enter(span, store)
@@ -195,7 +195,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:finish', ({ status, hasBeenRetried, isLastRetry }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
 
       if (span) {
@@ -227,7 +227,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:skip', (testInfo) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       // skipped through it.skip, so the span is not created yet
       // for this test
       if (!store) {
@@ -237,7 +237,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:error', (err) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
       if (err && span) {
         if (err.constructor.name === 'Pending' && !this.forbidPending) {
@@ -250,7 +250,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:retry', ({ isFirstAttempt, willBeRetried, err, test }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -155,13 +155,13 @@ class MochaPlugin extends CiPlugin {
       if (itrCorrelationId) {
         testSuiteSpan.setTag(ITR_CORRELATION_ID, itrCorrelationId)
       }
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       this.enter(testSuiteSpan, store)
       this._testSuites.set(testSuite, testSuiteSpan)
     })
 
     this.addSub('ci:mocha:test-suite:finish', (status) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (store && store.span) {
         const span = store.span
         // the test status of the suite may have been set in ci:mocha:test-suite:error already
@@ -174,7 +174,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test-suite:error', (err) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (store && store.span) {
         const span = store.span
         span.setTag('error', err)
@@ -183,7 +183,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:start', (testInfo) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = this.startTestSpan(testInfo)
 
       this.enter(span, store)
@@ -195,7 +195,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:finish', ({ status, hasBeenRetried, isLastRetry }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
 
       if (span) {
@@ -227,7 +227,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:skip', (testInfo) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       // skipped through it.skip, so the span is not created yet
       // for this test
       if (!store) {
@@ -237,7 +237,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:error', (err) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
       if (err && span) {
         if (err.constructor.name === 'Pending' && !this.forbidPending) {
@@ -250,7 +250,7 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addSub('ci:mocha:test:retry', ({ isFirstAttempt, willBeRetried, err, test }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, 'fail')

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
@@ -20,7 +20,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   bindStart ({ req, res }) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const childOf = store ? store.span : store
     const span = this.tracer.startSpan(this.operationName(), {
       childOf,
@@ -43,7 +43,7 @@ class NextPlugin extends ServerPlugin {
 
   error ({ span, error }) {
     if (!span) {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (!store) return
 
       span = store.span
@@ -53,7 +53,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   finish ({ req, res, nextRequest = {} }) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     if (!store) return
 
@@ -85,7 +85,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false }) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     if (!store) return
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
@@ -20,7 +20,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   bindStart ({ req, res }) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const childOf = store ? store.span : store
     const span = this.tracer.startSpan(this.operationName(), {
       childOf,
@@ -43,7 +43,7 @@ class NextPlugin extends ServerPlugin {
 
   error ({ span, error }) {
     if (!span) {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       if (!store) return
 
       span = store.span
@@ -53,7 +53,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   finish ({ req, res, nextRequest = {} }) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     if (!store) return
 
@@ -85,7 +85,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false }) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     if (!store) return
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const web = require('../../dd-trace/src/plugins/util/web')
@@ -20,7 +20,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   bindStart ({ req, res }) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const childOf = store ? store.span : store
     const span = this.tracer.startSpan(this.operationName(), {
       childOf,
@@ -43,7 +43,7 @@ class NextPlugin extends ServerPlugin {
 
   error ({ span, error }) {
     if (!span) {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (!store) return
 
       span = store.span
@@ -53,7 +53,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   finish ({ req, res, nextRequest = {} }) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     if (!store) return
 
@@ -85,7 +85,7 @@ class NextPlugin extends ServerPlugin {
   }
 
   pageLoad ({ page, isAppPath = false, isStatic = false }) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     if (!store) return
 

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const services = require('./services')
 const Sampler = require('../../dd-trace/src/sampler')
 const { MEASURED } = require('../../../ext/tags')
@@ -60,7 +60,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
   bindStart (ctx) {
     const { methodName, args, basePath, apiKey } = ctx
     const payload = normalizeRequestPayload(methodName, args)
-    const store = storage.getStore() || {}
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore() || {}
 
     const span = this.startSpan('openai.request', {
       service: this.config.service,

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const services = require('./services')
 const Sampler = require('../../dd-trace/src/sampler')
 const { MEASURED } = require('../../../ext/tags')
@@ -60,7 +60,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
   bindStart (ctx) {
     const { methodName, args, basePath, apiKey } = ctx
     const payload = normalizeRequestPayload(methodName, args)
-    const store = storage(SPAN_NAMESPACE).getStore() || {}
+    const store = storage('legacy').getStore() || {}
 
     const span = this.startSpan('openai.request', {
       service: this.config.service,

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -3,7 +3,7 @@
 const path = require('path')
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const services = require('./services')
 const Sampler = require('../../dd-trace/src/sampler')
 const { MEASURED } = require('../../../ext/tags')
@@ -60,7 +60,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
   bindStart (ctx) {
     const { methodName, args, basePath, apiKey } = ctx
     const payload = normalizeRequestPayload(methodName, args)
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore() || {}
+    const store = storage(SPAN_NAMESPACE).getStore() || {}
 
     const span = this.startSpan('openai.request', {
       service: this.config.service,

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 
 const {
@@ -68,7 +68,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test-suite:start', (testSuiteAbsolutePath) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
 
@@ -102,7 +102,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test-suite:finish', ({ status, error }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store && store.span
       if (!span) return
       if (error) {
@@ -121,7 +121,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine, browserName }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine, browserName)
@@ -129,7 +129,7 @@ class PlaywrightPlugin extends CiPlugin {
       this.enter(span, store)
     })
     this.addSub('ci:playwright:test:finish', ({ testStatus, steps, error, extraTags, isNew, isEfdRetry, isRetry }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store && store.span
       if (!span) return
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 
 const {
@@ -68,7 +68,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test-suite:start', (testSuiteAbsolutePath) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
 
@@ -102,7 +102,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test-suite:finish', ({ status, error }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store && store.span
       if (!span) return
       if (error) {
@@ -121,7 +121,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine, browserName }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine, browserName)
@@ -129,7 +129,7 @@ class PlaywrightPlugin extends CiPlugin {
       this.enter(span, store)
     })
     this.addSub('ci:playwright:test:finish', ({ testStatus, steps, error, extraTags, isNew, isEfdRetry, isRetry }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store && store.span
       if (!span) return
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 
 const {
@@ -68,7 +68,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test-suite:start', (testSuiteAbsolutePath) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
 
@@ -102,7 +102,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test-suite:finish', ({ status, error }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store && store.span
       if (!span) return
       if (error) {
@@ -121,7 +121,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test:start', ({ testName, testSuiteAbsolutePath, testSourceLine, browserName }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const span = this.startTestSpan(testName, testSuite, testSourceFile, testSourceLine, browserName)
@@ -129,7 +129,7 @@ class PlaywrightPlugin extends CiPlugin {
       this.enter(span, store)
     })
     this.addSub('ci:playwright:test:finish', ({ testStatus, steps, error, extraTags, isNew, isEfdRetry, isRetry }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store && store.span
       if (!span) return
 

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -5,7 +5,6 @@ const axios = require('axios')
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE } = require('../../dd-trace/src/constants')
-const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 describe('Plugin', () => {
   let tracer
@@ -226,12 +225,12 @@ describe('Plugin', () => {
           const store = {}
 
           server.use((req, res, next) => {
-            storage(SPAN_NAMESPACE).run(store, () => next())
+            storage.run(store, () => next())
           })
 
           server.get('/user', (req, res, next) => {
             try {
-              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
+              expect(storage.getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -5,6 +5,7 @@ const axios = require('axios')
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE } = require('../../dd-trace/src/constants')
+const {SPAN_NAMESPACE} = require("../../datadog-core");
 
 describe('Plugin', () => {
   let tracer

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -225,12 +225,12 @@ describe('Plugin', () => {
           const store = {}
 
           server.use((req, res, next) => {
-            storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
+            storage(SPAN_NAMESPACE).run(store, () => next())
           })
 
           server.get('/user', (req, res, next) => {
             try {
-              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
+              expect(storage(SPAN_NAMESPACE).getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -225,12 +225,12 @@ describe('Plugin', () => {
           const store = {}
 
           server.use((req, res, next) => {
-            storage.run(store, () => next())
+            storage(LEGACY_STORAGE_NAMESPACE).run(store, () => next())
           })
 
           server.get('/user', (req, res, next) => {
             try {
-              expect(storage.getStore()).to.equal(store)
+              expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.equal(store)
               done()
             } catch (e) {
               done(e)

--- a/packages/datadog-plugin-rhea/src/consumer.js
+++ b/packages/datadog-plugin-rhea/src/consumer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const { getAmqpMessageSize } = require('../../dd-trace/src/datastreams/processor')
 
 class RheaConsumerPlugin extends ConsumerPlugin {
@@ -11,7 +11,7 @@ class RheaConsumerPlugin extends ConsumerPlugin {
     super(...args)
 
     this.addTraceSub('dispatch', ({ state }) => {
-      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
+      const span = storage(SPAN_NAMESPACE).getStore().span
       span.setTag('amqp.delivery.state', state)
     })
   }

--- a/packages/datadog-plugin-rhea/src/consumer.js
+++ b/packages/datadog-plugin-rhea/src/consumer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const { getAmqpMessageSize } = require('../../dd-trace/src/datastreams/processor')
 
 class RheaConsumerPlugin extends ConsumerPlugin {
@@ -11,7 +11,7 @@ class RheaConsumerPlugin extends ConsumerPlugin {
     super(...args)
 
     this.addTraceSub('dispatch', ({ state }) => {
-      const span = storage(SPAN_NAMESPACE).getStore().span
+      const span = storage('legacy').getStore().span
       span.setTag('amqp.delivery.state', state)
     })
   }

--- a/packages/datadog-plugin-rhea/src/consumer.js
+++ b/packages/datadog-plugin-rhea/src/consumer.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const { getAmqpMessageSize } = require('../../dd-trace/src/datastreams/processor')
 
 class RheaConsumerPlugin extends ConsumerPlugin {
@@ -11,7 +11,7 @@ class RheaConsumerPlugin extends ConsumerPlugin {
     super(...args)
 
     this.addTraceSub('dispatch', ({ state }) => {
-      const span = storage.getStore().span
+      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore().span
       span.setTag('amqp.delivery.state', state)
     })
   }

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -3,7 +3,7 @@
 const web = require('../../dd-trace/src/plugins/util/web')
 const WebPlugin = require('../../datadog-plugin-web/src')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
 class RouterPlugin extends WebPlugin {
@@ -29,7 +29,7 @@ class RouterPlugin extends WebPlugin {
         context.middleware.push(span)
       }
 
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       this._storeStack.push(store)
       this.enter(span, store)
 
@@ -94,7 +94,7 @@ class RouterPlugin extends WebPlugin {
   }
 
   _getStoreSpan () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     return store && store.span
   }

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -3,7 +3,7 @@
 const web = require('../../dd-trace/src/plugins/util/web')
 const WebPlugin = require('../../datadog-plugin-web/src')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
 class RouterPlugin extends WebPlugin {
@@ -29,7 +29,7 @@ class RouterPlugin extends WebPlugin {
         context.middleware.push(span)
       }
 
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       this._storeStack.push(store)
       this.enter(span, store)
 
@@ -94,7 +94,7 @@ class RouterPlugin extends WebPlugin {
   }
 
   _getStoreSpan () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     return store && store.span
   }

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -3,7 +3,7 @@
 const web = require('../../dd-trace/src/plugins/util/web')
 const WebPlugin = require('../../datadog-plugin-web/src')
 const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
 class RouterPlugin extends WebPlugin {
@@ -29,7 +29,7 @@ class RouterPlugin extends WebPlugin {
         context.middleware.push(span)
       }
 
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       this._storeStack.push(store)
       this.enter(span, store)
 
@@ -94,7 +94,7 @@ class RouterPlugin extends WebPlugin {
   }
 
   _getStoreSpan () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     return store && store.span
   }

--- a/packages/datadog-plugin-selenium/src/index.js
+++ b/packages/datadog-plugin-selenium/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_IS_RUM_ACTIVE,
@@ -39,7 +39,7 @@ class SeleniumPlugin extends CiPlugin {
       browserVersion,
       isRumActive
     }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
       if (!span) {
         return

--- a/packages/datadog-plugin-selenium/src/index.js
+++ b/packages/datadog-plugin-selenium/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 const {
   TEST_IS_RUM_ACTIVE,
@@ -39,7 +39,7 @@ class SeleniumPlugin extends CiPlugin {
       browserVersion,
       isRumActive
     }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
       if (!span) {
         return

--- a/packages/datadog-plugin-selenium/src/index.js
+++ b/packages/datadog-plugin-selenium/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_IS_RUM_ACTIVE,
@@ -39,7 +39,7 @@ class SeleniumPlugin extends CiPlugin {
       browserVersion,
       isRumActive
     }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
       if (!span) {
         return

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -70,7 +70,7 @@ class VitestPlugin extends CiPlugin {
       isRetryReasonEfd
     }) => {
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
       const extraTags = {
         [TEST_SOURCE_FILE]: testSuite
@@ -102,7 +102,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:finish-time', ({ status, task }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
 
       // we store the finish time to finish at a later hook
@@ -114,7 +114,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:pass', ({ task }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
 
       if (span) {
@@ -128,7 +128,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:error', ({ duration, error, shouldSetProbe, promises }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
 
       if (span) {
@@ -221,13 +221,13 @@ class VitestPlugin extends CiPlugin {
         }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       this.enter(testSuiteSpan, store)
       this.testSuiteSpan = testSuiteSpan
     })
 
     this.addSub('ci:vitest:test-suite:finish', ({ status, onFinish }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, status)
@@ -243,7 +243,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test-suite:error', ({ error }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store?.span
       if (span && error) {
         span.setTag('error', error)

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -70,7 +70,7 @@ class VitestPlugin extends CiPlugin {
       isRetryReasonEfd
     }) => {
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
 
       const extraTags = {
         [TEST_SOURCE_FILE]: testSuite
@@ -102,7 +102,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:finish-time', ({ status, task }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
 
       // we store the finish time to finish at a later hook
@@ -114,7 +114,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:pass', ({ task }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
 
       if (span) {
@@ -128,7 +128,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:error', ({ duration, error, shouldSetProbe, promises }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
 
       if (span) {
@@ -221,13 +221,13 @@ class VitestPlugin extends CiPlugin {
         }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       this.enter(testSuiteSpan, store)
       this.testSuiteSpan = testSuiteSpan
     })
 
     this.addSub('ci:vitest:test-suite:finish', ({ status, onFinish }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, status)
@@ -243,7 +243,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test-suite:error', ({ error }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store?.span
       if (span && error) {
         span.setTag('error', error)

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -1,5 +1,5 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 const {
   TEST_STATUS,
@@ -70,7 +70,7 @@ class VitestPlugin extends CiPlugin {
       isRetryReasonEfd
     }) => {
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
 
       const extraTags = {
         [TEST_SOURCE_FILE]: testSuite
@@ -102,7 +102,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:finish-time', ({ status, task }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
 
       // we store the finish time to finish at a later hook
@@ -114,7 +114,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:pass', ({ task }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
 
       if (span) {
@@ -128,7 +128,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:error', ({ duration, error, shouldSetProbe, promises }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
 
       if (span) {
@@ -221,13 +221,13 @@ class VitestPlugin extends CiPlugin {
         }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       this.enter(testSuiteSpan, store)
       this.testSuiteSpan = testSuiteSpan
     })
 
     this.addSub('ci:vitest:test-suite:finish', ({ status, onFinish }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
       if (span) {
         span.setTag(TEST_STATUS, status)
@@ -243,7 +243,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test-suite:error', ({ error }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store?.span
       if (span && error) {
         span.setTag('error', error)

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const {
   addSpecificEndpoint,
   specificBlockingTypes,
@@ -30,7 +30,7 @@ function disable () {
 }
 
 function onGraphqlStartResolve ({ context, resolverInfo }) {
-  const req = storage.getStore()?.req
+  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
 
   if (!req) return
 
@@ -49,7 +49,7 @@ function onGraphqlStartResolve ({ context, resolverInfo }) {
 }
 
 function enterInApolloMiddleware (data) {
-  const req = data?.req || storage.getStore()?.req
+  const req = data?.req || storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -59,7 +59,7 @@ function enterInApolloMiddleware (data) {
 }
 
 function enterInApolloServerCoreRequest () {
-  const req = storage.getStore()?.req
+  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -69,13 +69,13 @@ function enterInApolloServerCoreRequest () {
 }
 
 function exitFromApolloMiddleware (data) {
-  const req = data?.req || storage.getStore()?.req
+  const req = data?.req || storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
   const requestData = graphqlRequestData.get(req)
   if (requestData) requestData.inApolloMiddleware = false
 }
 
 function enterInApolloRequest () {
-  const req = storage.getStore()?.req
+  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
 
   const requestData = graphqlRequestData.get(req)
   if (requestData?.inApolloMiddleware) {
@@ -85,7 +85,7 @@ function enterInApolloRequest () {
 }
 
 function beforeWriteApolloGraphqlResponse ({ abortController, abortData }) {
-  const req = storage.getStore()?.req
+  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
   if (!req) return
 
   const requestData = graphqlRequestData.get(req)

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const {
   addSpecificEndpoint,
   specificBlockingTypes,
@@ -30,7 +30,7 @@ function disable () {
 }
 
 function onGraphqlStartResolve ({ context, resolverInfo }) {
-  const req = storage(SPAN_NAMESPACE).getStore()?.req
+  const req = storage('legacy').getStore()?.req
 
   if (!req) return
 
@@ -49,7 +49,7 @@ function onGraphqlStartResolve ({ context, resolverInfo }) {
 }
 
 function enterInApolloMiddleware (data) {
-  const req = data?.req || storage(SPAN_NAMESPACE).getStore()?.req
+  const req = data?.req || storage('legacy').getStore()?.req
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -59,7 +59,7 @@ function enterInApolloMiddleware (data) {
 }
 
 function enterInApolloServerCoreRequest () {
-  const req = storage(SPAN_NAMESPACE).getStore()?.req
+  const req = storage('legacy').getStore()?.req
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -69,13 +69,13 @@ function enterInApolloServerCoreRequest () {
 }
 
 function exitFromApolloMiddleware (data) {
-  const req = data?.req || storage(SPAN_NAMESPACE).getStore()?.req
+  const req = data?.req || storage('legacy').getStore()?.req
   const requestData = graphqlRequestData.get(req)
   if (requestData) requestData.inApolloMiddleware = false
 }
 
 function enterInApolloRequest () {
-  const req = storage(SPAN_NAMESPACE).getStore()?.req
+  const req = storage('legacy').getStore()?.req
 
   const requestData = graphqlRequestData.get(req)
   if (requestData?.inApolloMiddleware) {
@@ -85,7 +85,7 @@ function enterInApolloRequest () {
 }
 
 function beforeWriteApolloGraphqlResponse ({ abortController, abortData }) {
-  const req = storage(SPAN_NAMESPACE).getStore()?.req
+  const req = storage('legacy').getStore()?.req
   if (!req) return
 
   const requestData = graphqlRequestData.get(req)

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const {
   addSpecificEndpoint,
   specificBlockingTypes,
@@ -30,7 +30,7 @@ function disable () {
 }
 
 function onGraphqlStartResolve ({ context, resolverInfo }) {
-  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = storage(SPAN_NAMESPACE).getStore()?.req
 
   if (!req) return
 
@@ -49,7 +49,7 @@ function onGraphqlStartResolve ({ context, resolverInfo }) {
 }
 
 function enterInApolloMiddleware (data) {
-  const req = data?.req || storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = data?.req || storage(SPAN_NAMESPACE).getStore()?.req
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -59,7 +59,7 @@ function enterInApolloMiddleware (data) {
 }
 
 function enterInApolloServerCoreRequest () {
-  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = storage(SPAN_NAMESPACE).getStore()?.req
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -69,13 +69,13 @@ function enterInApolloServerCoreRequest () {
 }
 
 function exitFromApolloMiddleware (data) {
-  const req = data?.req || storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = data?.req || storage(SPAN_NAMESPACE).getStore()?.req
   const requestData = graphqlRequestData.get(req)
   if (requestData) requestData.inApolloMiddleware = false
 }
 
 function enterInApolloRequest () {
-  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = storage(SPAN_NAMESPACE).getStore()?.req
 
   const requestData = graphqlRequestData.get(req)
   if (requestData?.inApolloMiddleware) {
@@ -85,7 +85,7 @@ function enterInApolloRequest () {
 }
 
 function beforeWriteApolloGraphqlResponse ({ abortController, abortData }) {
-  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = storage(SPAN_NAMESPACE).getStore()?.req
   if (!req) return
 
   const requestData = graphqlRequestData.get(req)

--- a/packages/dd-trace/src/appsec/iast/analyzers/code-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/code-injection-analyzer.js
@@ -3,7 +3,7 @@
 const InjectionAnalyzer = require('./injection-analyzer')
 const { CODE_INJECTION } = require('../vulnerabilities')
 const { INSTRUMENTED_SINK } = require('../telemetry/iast-metric')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const { getIastContext } = require('../iast-context')
 
 class CodeInjectionAnalyzer extends InjectionAnalyzer {
@@ -15,7 +15,7 @@ class CodeInjectionAnalyzer extends InjectionAnalyzer {
   onConfigure () {
     this.addSub('datadog:eval:call', ({ script }) => {
       if (!this.evalInstrumentedInc) {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         const iastContext = getIastContext(store)
         const tags = INSTRUMENTED_SINK.formatTags(CODE_INJECTION)
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/code-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/code-injection-analyzer.js
@@ -3,7 +3,7 @@
 const InjectionAnalyzer = require('./injection-analyzer')
 const { CODE_INJECTION } = require('../vulnerabilities')
 const { INSTRUMENTED_SINK } = require('../telemetry/iast-metric')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { getIastContext } = require('../iast-context')
 
 class CodeInjectionAnalyzer extends InjectionAnalyzer {
@@ -15,7 +15,7 @@ class CodeInjectionAnalyzer extends InjectionAnalyzer {
   onConfigure () {
     this.addSub('datadog:eval:call', ({ script }) => {
       if (!this.evalInstrumentedInc) {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         const iastContext = getIastContext(store)
         const tags = INSTRUMENTED_SINK.formatTags(CODE_INJECTION)
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/code-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/code-injection-analyzer.js
@@ -3,7 +3,7 @@
 const InjectionAnalyzer = require('./injection-analyzer')
 const { CODE_INJECTION } = require('../vulnerabilities')
 const { INSTRUMENTED_SINK } = require('../telemetry/iast-metric')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const { getIastContext } = require('../iast-context')
 
 class CodeInjectionAnalyzer extends InjectionAnalyzer {
@@ -15,7 +15,7 @@ class CodeInjectionAnalyzer extends InjectionAnalyzer {
   onConfigure () {
     this.addSub('datadog:eval:call', ({ script }) => {
       if (!this.evalInstrumentedInc) {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         const iastContext = getIastContext(store)
         const tags = INSTRUMENTED_SINK.formatTags(CODE_INJECTION)
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
@@ -5,7 +5,7 @@ const { NOSQL_MONGODB_INJECTION } = require('../vulnerabilities')
 const { getRanges, addSecureMark } = require('../taint-tracking/operations')
 const { getNodeModulesPaths } = require('../path-line')
 const { getNextSecureMark } = require('../taint-tracking/secure-marks-generator')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const { getIastContext } = require('../iast-context')
 const { HTTP_REQUEST_PARAMETER, HTTP_REQUEST_BODY } = require('../taint-tracking/source-types')
 
@@ -38,7 +38,7 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     this.configureSanitizers()
 
     const onStart = ({ filters }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (store && !store.nosqlAnalyzed && filters?.length) {
         filters.forEach(filter => {
           this.analyze({ filter }, store)
@@ -51,14 +51,14 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     const onStartAndEnterWithStore = (message) => {
       const store = onStart(message || {})
       if (store) {
-        storage.enterWith({ ...store, nosqlAnalyzed: true, nosqlParentStore: store })
+        storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, nosqlAnalyzed: true, nosqlParentStore: store })
       }
     }
 
     const onFinish = () => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (store?.nosqlParentStore) {
-        storage.enterWith(store.nosqlParentStore)
+        storage(LEGACY_STORAGE_NAMESPACE).enterWith(store.nosqlParentStore)
       }
     }
 
@@ -74,7 +74,7 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
 
   configureSanitizers () {
     this.addNotSinkSub('datadog:express-mongo-sanitize:filter:finish', ({ sanitizedProperties, req }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const iastContext = getIastContext(store)
 
       if (iastContext) { // do nothing if we are not in an iast request
@@ -100,7 +100,7 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     })
 
     this.addNotSinkSub('datadog:express-mongo-sanitize:sanitize:finish', ({ sanitizedObject }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const iastContext = getIastContext(store)
 
       if (iastContext) { // do nothing if we are not in an iast request

--- a/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.js
@@ -5,7 +5,7 @@ const { NOSQL_MONGODB_INJECTION } = require('../vulnerabilities')
 const { getRanges, addSecureMark } = require('../taint-tracking/operations')
 const { getNodeModulesPaths } = require('../path-line')
 const { getNextSecureMark } = require('../taint-tracking/secure-marks-generator')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { getIastContext } = require('../iast-context')
 const { HTTP_REQUEST_PARAMETER, HTTP_REQUEST_BODY } = require('../taint-tracking/source-types')
 
@@ -38,7 +38,7 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     this.configureSanitizers()
 
     const onStart = ({ filters }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (store && !store.nosqlAnalyzed && filters?.length) {
         filters.forEach(filter => {
           this.analyze({ filter }, store)
@@ -51,14 +51,14 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     const onStartAndEnterWithStore = (message) => {
       const store = onStart(message || {})
       if (store) {
-        storage(SPAN_NAMESPACE).enterWith({ ...store, nosqlAnalyzed: true, nosqlParentStore: store })
+        storage('legacy').enterWith({ ...store, nosqlAnalyzed: true, nosqlParentStore: store })
       }
     }
 
     const onFinish = () => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (store?.nosqlParentStore) {
-        storage(SPAN_NAMESPACE).enterWith(store.nosqlParentStore)
+        storage('legacy').enterWith(store.nosqlParentStore)
       }
     }
 
@@ -74,7 +74,7 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
 
   configureSanitizers () {
     this.addNotSinkSub('datadog:express-mongo-sanitize:filter:finish', ({ sanitizedProperties, req }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const iastContext = getIastContext(store)
 
       if (iastContext) { // do nothing if we are not in an iast request
@@ -100,7 +100,7 @@ class NosqlInjectionMongodbAnalyzer extends InjectionAnalyzer {
     })
 
     this.addNotSinkSub('datadog:express-mongo-sanitize:sanitize:finish', ({ sanitizedObject }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const iastContext = getIastContext(store)
 
       if (iastContext) { // do nothing if we are not in an iast request

--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const InjectionAnalyzer = require('./injection-analyzer')
 const { getIastContext } = require('../iast-context')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const { PATH_TRAVERSAL } = require('../vulnerabilities')
 
 const ignoredOperations = ['dir.close', 'close']
@@ -29,7 +29,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
 
   onConfigure () {
     this.addSub('apm:fs:operation:start', (obj) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const outOfReqOrChild = !store?.fs?.root
 
       // we could filter out all the nested fs.operations based on store.fs.root
@@ -84,7 +84,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
   }
 
   analyze (value) {
-    const iastContext = getIastContext(storage.getStore())
+    const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
     if (!iastContext) {
       return
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const InjectionAnalyzer = require('./injection-analyzer')
 const { getIastContext } = require('../iast-context')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const { PATH_TRAVERSAL } = require('../vulnerabilities')
 
 const ignoredOperations = ['dir.close', 'close']
@@ -29,7 +29,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
 
   onConfigure () {
     this.addSub('apm:fs:operation:start', (obj) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const outOfReqOrChild = !store?.fs?.root
 
       // we could filter out all the nested fs.operations based on store.fs.root
@@ -84,7 +84,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
   }
 
   analyze (value) {
-    const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+    const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
     if (!iastContext) {
       return
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const InjectionAnalyzer = require('./injection-analyzer')
 const { getIastContext } = require('../iast-context')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { PATH_TRAVERSAL } = require('../vulnerabilities')
 
 const ignoredOperations = ['dir.close', 'close']
@@ -29,7 +29,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
 
   onConfigure () {
     this.addSub('apm:fs:operation:start', (obj) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const outOfReqOrChild = !store?.fs?.root
 
       // we could filter out all the nested fs.operations based on store.fs.root
@@ -84,7 +84,7 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
   }
 
   analyze (value) {
-    const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+    const iastContext = getIastContext(storage('legacy').getStore())
     if (!iastContext) {
       return
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -3,7 +3,7 @@
 const InjectionAnalyzer = require('./injection-analyzer')
 const { SQL_INJECTION } = require('../vulnerabilities')
 const { getRanges } = require('../taint-tracking/operations')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const { getNodeModulesPaths } = require('../path-line')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('mysql', 'mysql2', 'sequelize', 'pg-pool', 'knex')
@@ -38,18 +38,18 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   getStoreAndAnalyze (query, dialect) {
-    const parentStore = storage.getStore()
+    const parentStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (parentStore) {
       this.analyze(query, parentStore, dialect)
 
-      storage.enterWith({ ...parentStore, sqlAnalyzed: true, sqlParentStore: parentStore })
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...parentStore, sqlAnalyzed: true, sqlParentStore: parentStore })
     }
   }
 
   returnToParentStore () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store && store.sqlParentStore) {
-      storage.enterWith(store.sqlParentStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(store.sqlParentStore)
     }
   }
 
@@ -59,7 +59,7 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   analyze (value, store, dialect) {
-    store = store || storage.getStore()
+    store = store || storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (!(store && store.sqlAnalyzed)) {
       super.analyze(value, store, dialect)
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -3,7 +3,7 @@
 const InjectionAnalyzer = require('./injection-analyzer')
 const { SQL_INJECTION } = require('../vulnerabilities')
 const { getRanges } = require('../taint-tracking/operations')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const { getNodeModulesPaths } = require('../path-line')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('mysql', 'mysql2', 'sequelize', 'pg-pool', 'knex')
@@ -38,18 +38,18 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   getStoreAndAnalyze (query, dialect) {
-    const parentStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const parentStore = storage(SPAN_NAMESPACE).getStore()
     if (parentStore) {
       this.analyze(query, parentStore, dialect)
 
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...parentStore, sqlAnalyzed: true, sqlParentStore: parentStore })
+      storage(SPAN_NAMESPACE).enterWith({ ...parentStore, sqlAnalyzed: true, sqlParentStore: parentStore })
     }
   }
 
   returnToParentStore () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store && store.sqlParentStore) {
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(store.sqlParentStore)
+      storage(SPAN_NAMESPACE).enterWith(store.sqlParentStore)
     }
   }
 
@@ -59,7 +59,7 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   analyze (value, store, dialect) {
-    store = store || storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    store = store || storage(SPAN_NAMESPACE).getStore()
     if (!(store && store.sqlAnalyzed)) {
       super.analyze(value, store, dialect)
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -3,7 +3,7 @@
 const InjectionAnalyzer = require('./injection-analyzer')
 const { SQL_INJECTION } = require('../vulnerabilities')
 const { getRanges } = require('../taint-tracking/operations')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { getNodeModulesPaths } = require('../path-line')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('mysql', 'mysql2', 'sequelize', 'pg-pool', 'knex')
@@ -38,18 +38,18 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   getStoreAndAnalyze (query, dialect) {
-    const parentStore = storage(SPAN_NAMESPACE).getStore()
+    const parentStore = storage('legacy').getStore()
     if (parentStore) {
       this.analyze(query, parentStore, dialect)
 
-      storage(SPAN_NAMESPACE).enterWith({ ...parentStore, sqlAnalyzed: true, sqlParentStore: parentStore })
+      storage('legacy').enterWith({ ...parentStore, sqlAnalyzed: true, sqlParentStore: parentStore })
     }
   }
 
   returnToParentStore () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store && store.sqlParentStore) {
-      storage(SPAN_NAMESPACE).enterWith(store.sqlParentStore)
+      storage('legacy').enterWith(store.sqlParentStore)
     }
   }
 
@@ -59,7 +59,7 @@ class SqlInjectionAnalyzer extends InjectionAnalyzer {
   }
 
   analyze (value, store, dialect) {
-    store = store || storage(SPAN_NAMESPACE).getStore()
+    store = store || storage('legacy').getStore()
     if (!(store && store.sqlAnalyzed)) {
       super.analyze(value, store, dialect)
     }

--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { getNonDDCallSiteFrames } = require('../path-line')
 const { getIastContext, getIastStackTraceId } = require('../iast-context')
 const overheadController = require('../overhead-controller')
@@ -91,7 +91,7 @@ class Analyzer extends SinkIastPlugin {
     return store && !iastContext
   }
 
-  analyze (value, store = storage(SPAN_NAMESPACE).getStore(), meta) {
+  analyze (value, store = storage('legacy').getStore(), meta) {
     const iastContext = getIastContext(store)
     if (this._isInvalidContext(store, iastContext)) return
 
@@ -99,7 +99,7 @@ class Analyzer extends SinkIastPlugin {
   }
 
   analyzeAll (...values) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const iastContext = getIastContext(store)
     if (this._isInvalidContext(store, iastContext)) return
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const { getNonDDCallSiteFrames } = require('../path-line')
 const { getIastContext, getIastStackTraceId } = require('../iast-context')
 const overheadController = require('../overhead-controller')
@@ -91,7 +91,7 @@ class Analyzer extends SinkIastPlugin {
     return store && !iastContext
   }
 
-  analyze (value, store = storage(LEGACY_STORAGE_NAMESPACE).getStore(), meta) {
+  analyze (value, store = storage(SPAN_NAMESPACE).getStore(), meta) {
     const iastContext = getIastContext(store)
     if (this._isInvalidContext(store, iastContext)) return
 
@@ -99,7 +99,7 @@ class Analyzer extends SinkIastPlugin {
   }
 
   analyzeAll (...values) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const iastContext = getIastContext(store)
     if (this._isInvalidContext(store, iastContext)) return
 

--- a/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/vulnerability-analyzer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const { getNonDDCallSiteFrames } = require('../path-line')
 const { getIastContext, getIastStackTraceId } = require('../iast-context')
 const overheadController = require('../overhead-controller')
@@ -91,7 +91,7 @@ class Analyzer extends SinkIastPlugin {
     return store && !iastContext
   }
 
-  analyze (value, store = storage.getStore(), meta) {
+  analyze (value, store = storage(LEGACY_STORAGE_NAMESPACE).getStore(), meta) {
     const iastContext = getIastContext(store)
     if (this._isInvalidContext(store, iastContext)) return
 
@@ -99,7 +99,7 @@ class Analyzer extends SinkIastPlugin {
   }
 
   analyzeAll (...values) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const iastContext = getIastContext(store)
     if (this._isInvalidContext(store, iastContext)) return
 

--- a/packages/dd-trace/src/appsec/iast/context/context-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/context/context-plugin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
 const overheadController = require('../overhead-controller')
 const { IastPlugin } = require('../iast-plugin')
@@ -48,7 +48,7 @@ class IastContextPlugin extends IastPlugin {
     let isRequestAcquired = false
     let iastContext
 
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store) {
       const topContext = this.getTopContext()
       const rootSpan = this.getRootSpan(store)
@@ -70,7 +70,7 @@ class IastContextPlugin extends IastPlugin {
   }
 
   finishContext () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store) {
       const topContext = this.getTopContext()
       const iastContext = iastContextFunctions.getIastContext(store, topContext)

--- a/packages/dd-trace/src/appsec/iast/context/context-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/context/context-plugin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
 const overheadController = require('../overhead-controller')
 const { IastPlugin } = require('../iast-plugin')
@@ -48,7 +48,7 @@ class IastContextPlugin extends IastPlugin {
     let isRequestAcquired = false
     let iastContext
 
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store) {
       const topContext = this.getTopContext()
       const rootSpan = this.getRootSpan(store)
@@ -70,7 +70,7 @@ class IastContextPlugin extends IastPlugin {
   }
 
   finishContext () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store) {
       const topContext = this.getTopContext()
       const iastContext = iastContextFunctions.getIastContext(store, topContext)

--- a/packages/dd-trace/src/appsec/iast/context/context-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/context/context-plugin.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
 const overheadController = require('../overhead-controller')
 const { IastPlugin } = require('../iast-plugin')
@@ -48,7 +48,7 @@ class IastContextPlugin extends IastPlugin {
     let isRequestAcquired = false
     let iastContext
 
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store) {
       const topContext = this.getTopContext()
       const rootSpan = this.getRootSpan(store)
@@ -70,7 +70,7 @@ class IastContextPlugin extends IastPlugin {
   }
 
   finishContext () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store) {
       const topContext = this.getTopContext()
       const iastContext = iastContextFunctions.getIastContext(store, topContext)

--- a/packages/dd-trace/src/appsec/iast/iast-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/iast-plugin.js
@@ -6,7 +6,7 @@ const Plugin = require('../../plugins/plugin')
 const iastTelemetry = require('./telemetry')
 const { getInstrumentedMetric, getExecutedMetric, TagKey, EXECUTED_SOURCE, formatTags } =
   require('./telemetry/iast-metric')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const { getIastContext } = require('./iast-context')
 const instrumentations = require('../../../../datadog-instrumentations/src/helpers/instrumentations')
 const log = require('../../log')
@@ -62,12 +62,12 @@ class IastPlugin extends Plugin {
 
   _getTelemetryHandler (iastSub) {
     return () => {
-      const iastContext = getIastContext(storage.getStore())
+      const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
       iastSub.increaseExecuted(iastContext)
     }
   }
 
-  _execHandlerAndIncMetric ({ handler, metric, tags, iastContext = getIastContext(storage.getStore()) }) {
+  _execHandlerAndIncMetric ({ handler, metric, tags, iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore()) }) {
     try {
       const result = handler()
       if (iastTelemetry.isEnabled()) {

--- a/packages/dd-trace/src/appsec/iast/iast-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/iast-plugin.js
@@ -6,7 +6,7 @@ const Plugin = require('../../plugins/plugin')
 const iastTelemetry = require('./telemetry')
 const { getInstrumentedMetric, getExecutedMetric, TagKey, EXECUTED_SOURCE, formatTags } =
   require('./telemetry/iast-metric')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const { getIastContext } = require('./iast-context')
 const instrumentations = require('../../../../datadog-instrumentations/src/helpers/instrumentations')
 const log = require('../../log')
@@ -62,12 +62,12 @@ class IastPlugin extends Plugin {
 
   _getTelemetryHandler (iastSub) {
     return () => {
-      const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+      const iastContext = getIastContext(storage('legacy').getStore())
       iastSub.increaseExecuted(iastContext)
     }
   }
 
-  _execHandlerAndIncMetric ({ handler, metric, tags, iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore()) }) {
+  _execHandlerAndIncMetric ({ handler, metric, tags, iastContext = getIastContext(storage('legacy').getStore()) }) {
     try {
       const result = handler()
       if (iastTelemetry.isEnabled()) {

--- a/packages/dd-trace/src/appsec/iast/iast-plugin.js
+++ b/packages/dd-trace/src/appsec/iast/iast-plugin.js
@@ -6,7 +6,7 @@ const Plugin = require('../../plugins/plugin')
 const iastTelemetry = require('./telemetry')
 const { getInstrumentedMetric, getExecutedMetric, TagKey, EXECUTED_SOURCE, formatTags } =
   require('./telemetry/iast-metric')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const { getIastContext } = require('./iast-context')
 const instrumentations = require('../../../../datadog-instrumentations/src/helpers/instrumentations')
 const log = require('../../log')
@@ -62,12 +62,12 @@ class IastPlugin extends Plugin {
 
   _getTelemetryHandler (iastSub) {
     return () => {
-      const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+      const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
       iastSub.increaseExecuted(iastContext)
     }
   }
 
-  _execHandlerAndIncMetric ({ handler, metric, tags, iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore()) }) {
+  _execHandlerAndIncMetric ({ handler, metric, tags, iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore()) }) {
     try {
       const result = handler()
       if (iastTelemetry.isEnabled()) {

--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -1,7 +1,7 @@
 const vulnerabilityReporter = require('./vulnerability-reporter')
 const { enableAllAnalyzers, disableAllAnalyzers } = require('./analyzers')
 const web = require('../../plugins/util/web')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const overheadController = require('./overhead-controller')
 const dc = require('dc-polyfill')
 const iastContextFunctions = require('./iast-context')
@@ -57,7 +57,7 @@ function disable () {
 
 function onIncomingHttpRequestStart (data) {
   if (data?.req) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store) {
       const topContext = web.getContext(data.req)
       if (topContext) {
@@ -82,7 +82,7 @@ function onIncomingHttpRequestStart (data) {
 
 function onIncomingHttpRequestEnd (data) {
   if (data?.req) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const topContext = web.getContext(data.req)
     const iastContext = iastContextFunctions.getIastContext(store, topContext)
     if (iastContext?.rootSpan) {

--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -1,7 +1,7 @@
 const vulnerabilityReporter = require('./vulnerability-reporter')
 const { enableAllAnalyzers, disableAllAnalyzers } = require('./analyzers')
 const web = require('../../plugins/util/web')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const overheadController = require('./overhead-controller')
 const dc = require('dc-polyfill')
 const iastContextFunctions = require('./iast-context')
@@ -57,7 +57,7 @@ function disable () {
 
 function onIncomingHttpRequestStart (data) {
   if (data?.req) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store) {
       const topContext = web.getContext(data.req)
       if (topContext) {
@@ -82,7 +82,7 @@ function onIncomingHttpRequestStart (data) {
 
 function onIncomingHttpRequestEnd (data) {
   if (data?.req) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const topContext = web.getContext(data.req)
     const iastContext = iastContextFunctions.getIastContext(store, topContext)
     if (iastContext?.rootSpan) {

--- a/packages/dd-trace/src/appsec/iast/index.js
+++ b/packages/dd-trace/src/appsec/iast/index.js
@@ -1,7 +1,7 @@
 const vulnerabilityReporter = require('./vulnerability-reporter')
 const { enableAllAnalyzers, disableAllAnalyzers } = require('./analyzers')
 const web = require('../../plugins/util/web')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const overheadController = require('./overhead-controller')
 const dc = require('dc-polyfill')
 const iastContextFunctions = require('./iast-context')
@@ -57,7 +57,7 @@ function disable () {
 
 function onIncomingHttpRequestStart (data) {
   if (data?.req) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store) {
       const topContext = web.getContext(data.req)
       if (topContext) {
@@ -82,7 +82,7 @@ function onIncomingHttpRequestStart (data) {
 
 function onIncomingHttpRequestEnd (data) {
   if (data?.req) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const topContext = web.getContext(data.req)
     const iastContext = iastContextFunctions.getIastContext(store, topContext)
     if (iastContext?.rootSpan) {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -2,7 +2,7 @@
 
 const { SourceIastPlugin } = require('../iast-plugin')
 const { getIastContext } = require('../iast-context')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { taintObject, newTaintedString, getRanges } = require('./operations')
 const {
   HTTP_REQUEST_BODY,
@@ -39,7 +39,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
 
   onConfigure () {
     const onRequestBody = ({ req }) => {
-      const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+      const iastContext = getIastContext(storage('legacy').getStore())
       if (iastContext && iastContext.body !== req.body) {
         this._taintTrackingHandler(HTTP_REQUEST_BODY, req, 'body', iastContext)
         iastContext.body = req.body
@@ -70,7 +70,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
       { channelName: 'apm:express:middleware:next', tag: HTTP_REQUEST_BODY },
       ({ req }) => {
         if (req && req.body !== null && typeof req.body === 'object') {
-          const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+          const iastContext = getIastContext(storage('legacy').getStore())
           if (iastContext && iastContext.body !== req.body) {
             this._taintTrackingHandler(HTTP_REQUEST_BODY, req, 'body', iastContext)
             iastContext.body = req.body
@@ -115,7 +115,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.addSub(
       { channelName: 'apm:graphql:resolve:start', tag: HTTP_REQUEST_BODY },
       (data) => {
-        const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+        const iastContext = getIastContext(storage('legacy').getStore())
         const source = data.context?.source
         const ranges = source && getRanges(iastContext, source)
         if (ranges?.length) {
@@ -128,7 +128,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.addSub(
       { channelName: 'datadog:url:parse:finish' },
       ({ input, base, parsed, isURL }) => {
-        const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+        const iastContext = getIastContext(storage('legacy').getStore())
         let ranges
 
         if (base) {
@@ -157,7 +157,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
         const origRange = this._taintedURLs.get(context.urlObject)
         if (!origRange) return
 
-        const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+        const iastContext = getIastContext(storage('legacy').getStore())
         if (!iastContext) return
 
         context.result =
@@ -168,7 +168,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.addInstrumentedSource('http', [HTTP_REQUEST_HEADER_VALUE, HTTP_REQUEST_HEADER_NAME])
   }
 
-  _taintTrackingHandler (type, target, property, iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())) {
+  _taintTrackingHandler (type, target, property, iastContext = getIastContext(storage('legacy').getStore())) {
     if (!property) {
       taintObject(iastContext, target, type)
     } else if (target[property]) {
@@ -177,7 +177,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
   }
 
   _cookiesTaintTrackingHandler (target) {
-    const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+    const iastContext = getIastContext(storage('legacy').getStore())
     // Prevent tainting cookie names since it leads to taint literal string with same value.
     taintObject(iastContext, target, HTTP_REQUEST_COOKIE_VALUE)
   }
@@ -206,7 +206,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.taintUrl(req, iastContext)
   }
 
-  _taintDatabaseResult (result, dbOrigin, iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore()), name) {
+  _taintDatabaseResult (result, dbOrigin, iastContext = getIastContext(storage('legacy').getStore()), name) {
     if (!iastContext) return result
 
     if (this._rowsToTaint === 0) return result

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugin.js
@@ -2,7 +2,7 @@
 
 const { SourceIastPlugin } = require('../iast-plugin')
 const { getIastContext } = require('../iast-context')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const { taintObject, newTaintedString, getRanges } = require('./operations')
 const {
   HTTP_REQUEST_BODY,
@@ -39,7 +39,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
 
   onConfigure () {
     const onRequestBody = ({ req }) => {
-      const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+      const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
       if (iastContext && iastContext.body !== req.body) {
         this._taintTrackingHandler(HTTP_REQUEST_BODY, req, 'body', iastContext)
         iastContext.body = req.body
@@ -70,7 +70,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
       { channelName: 'apm:express:middleware:next', tag: HTTP_REQUEST_BODY },
       ({ req }) => {
         if (req && req.body !== null && typeof req.body === 'object') {
-          const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+          const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
           if (iastContext && iastContext.body !== req.body) {
             this._taintTrackingHandler(HTTP_REQUEST_BODY, req, 'body', iastContext)
             iastContext.body = req.body
@@ -115,7 +115,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.addSub(
       { channelName: 'apm:graphql:resolve:start', tag: HTTP_REQUEST_BODY },
       (data) => {
-        const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+        const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
         const source = data.context?.source
         const ranges = source && getRanges(iastContext, source)
         if (ranges?.length) {
@@ -128,7 +128,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.addSub(
       { channelName: 'datadog:url:parse:finish' },
       ({ input, base, parsed, isURL }) => {
-        const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+        const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
         let ranges
 
         if (base) {
@@ -157,7 +157,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
         const origRange = this._taintedURLs.get(context.urlObject)
         if (!origRange) return
 
-        const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+        const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
         if (!iastContext) return
 
         context.result =
@@ -168,7 +168,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.addInstrumentedSource('http', [HTTP_REQUEST_HEADER_VALUE, HTTP_REQUEST_HEADER_NAME])
   }
 
-  _taintTrackingHandler (type, target, property, iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())) {
+  _taintTrackingHandler (type, target, property, iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())) {
     if (!property) {
       taintObject(iastContext, target, type)
     } else if (target[property]) {
@@ -177,7 +177,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
   }
 
   _cookiesTaintTrackingHandler (target) {
-    const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+    const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
     // Prevent tainting cookie names since it leads to taint literal string with same value.
     taintObject(iastContext, target, HTTP_REQUEST_COOKIE_VALUE)
   }
@@ -206,7 +206,7 @@ class TaintTrackingPlugin extends SourceIastPlugin {
     this.taintUrl(req, iastContext)
   }
 
-  _taintDatabaseResult (result, dbOrigin, iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore()), name) {
+  _taintDatabaseResult (result, dbOrigin, iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore()), name) {
     if (!iastContext) return result
 
     if (this._rowsToTaint === 0) return result

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const shimmer = require('../../../../../../datadog-shimmer')
-const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage } = require('../../../../../../datadog-core')
 const { getIastContext } = require('../../iast-context')
 const { KAFKA_MESSAGE_KEY, KAFKA_MESSAGE_VALUE } = require('../source-types')
 const { newTaintedObject, newTaintedString } = require('../operations')
@@ -22,7 +22,7 @@ class KafkaConsumerIastPlugin extends SourceIastPlugin {
   }
 
   taintKafkaMessage (message) {
-    const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
+    const iastContext = getIastContext(storage('legacy').getStore())
 
     if (iastContext && message) {
       const { key, value } = message

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const shimmer = require('../../../../../../datadog-shimmer')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
 const { getIastContext } = require('../../iast-context')
 const { KAFKA_MESSAGE_KEY, KAFKA_MESSAGE_VALUE } = require('../source-types')
 const { newTaintedObject, newTaintedString } = require('../operations')
@@ -22,7 +22,7 @@ class KafkaConsumerIastPlugin extends SourceIastPlugin {
   }
 
   taintKafkaMessage (message) {
-    const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
+    const iastContext = getIastContext(storage(SPAN_NAMESPACE).getStore())
 
     if (iastContext && message) {
       const { key, value } = message

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const shimmer = require('../../../../../../datadog-shimmer')
-const { storage } = require('../../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
 const { getIastContext } = require('../../iast-context')
 const { KAFKA_MESSAGE_KEY, KAFKA_MESSAGE_VALUE } = require('../source-types')
 const { newTaintedObject, newTaintedString } = require('../operations')
@@ -22,7 +22,7 @@ class KafkaConsumerIastPlugin extends SourceIastPlugin {
   }
 
   taintKafkaMessage (message) {
-    const iastContext = getIastContext(storage.getStore())
+    const iastContext = getIastContext(storage(LEGACY_STORAGE_NAMESPACE).getStore())
 
     if (iastContext && message) {
       const { key, value } = message

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -2,7 +2,7 @@
 
 const dc = require('dc-polyfill')
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
 const { EXECUTED_PROPAGATION } = require('../telemetry/iast-metric')
 const { isDebugAllowed } = require('../telemetry/verbosity')
@@ -39,7 +39,7 @@ function getTransactionId (iastContext) {
 }
 
 function getContextDefault () {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   return iastContextFunctions.getIastContext(store)
 }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -2,7 +2,7 @@
 
 const dc = require('dc-polyfill')
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
 const { EXECUTED_PROPAGATION } = require('../telemetry/iast-metric')
 const { isDebugAllowed } = require('../telemetry/verbosity')
@@ -39,7 +39,7 @@ function getTransactionId (iastContext) {
 }
 
 function getContextDefault () {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   return iastContextFunctions.getIastContext(store)
 }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -2,7 +2,7 @@
 
 const dc = require('dc-polyfill')
 const TaintedUtils = require('@datadog/native-iast-taint-tracking')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../iast-context')
 const { EXECUTED_PROPAGATION } = require('../telemetry/iast-metric')
 const { isDebugAllowed } = require('../telemetry/verbosity')
@@ -39,7 +39,7 @@ function getTransactionId (iastContext) {
 }
 
 function getContextDefault () {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   return iastContextFunctions.getIastContext(store)
 }
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -30,7 +30,7 @@ const { extractIp } = require('../plugins/util/ip_extractor')
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
 const { isBlocked, block, setTemplates, getBlockingAction } = require('./blocking')
 const UserTracking = require('./user_tracking')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const graphql = require('./graphql')
 const rasp = require('./rasp')
 
@@ -91,7 +91,7 @@ function onRequestBodyParsed ({ req, res, body, abortController }) {
   if (body === undefined || body === null) return
 
   if (!req) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     req = store?.req
   }
 
@@ -186,7 +186,7 @@ function incomingHttpEndTranslator ({ req, res }) {
 }
 
 function onPassportVerify ({ framework, login, user, success, abortController }) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   const rootSpan = store?.req && web.root(store.req)
 
   if (!rootSpan) {
@@ -200,7 +200,7 @@ function onPassportVerify ({ framework, login, user, success, abortController })
 }
 
 function onPassportDeserializeUser ({ user, abortController }) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   const rootSpan = store?.req && web.root(store.req)
 
   if (!rootSpan) {
@@ -217,7 +217,7 @@ function onRequestQueryParsed ({ req, res, query, abortController }) {
   if (!query || typeof query !== 'object') return
 
   if (!req) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     req = store?.req
   }
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -30,7 +30,7 @@ const { extractIp } = require('../plugins/util/ip_extractor')
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
 const { isBlocked, block, setTemplates, getBlockingAction } = require('./blocking')
 const UserTracking = require('./user_tracking')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const graphql = require('./graphql')
 const rasp = require('./rasp')
 
@@ -91,7 +91,7 @@ function onRequestBodyParsed ({ req, res, body, abortController }) {
   if (body === undefined || body === null) return
 
   if (!req) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     req = store?.req
   }
 
@@ -186,7 +186,7 @@ function incomingHttpEndTranslator ({ req, res }) {
 }
 
 function onPassportVerify ({ framework, login, user, success, abortController }) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   const rootSpan = store?.req && web.root(store.req)
 
   if (!rootSpan) {
@@ -200,7 +200,7 @@ function onPassportVerify ({ framework, login, user, success, abortController })
 }
 
 function onPassportDeserializeUser ({ user, abortController }) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   const rootSpan = store?.req && web.root(store.req)
 
   if (!rootSpan) {
@@ -217,7 +217,7 @@ function onRequestQueryParsed ({ req, res, query, abortController }) {
   if (!query || typeof query !== 'object') return
 
   if (!req) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     req = store?.req
   }
 

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -30,7 +30,7 @@ const { extractIp } = require('../plugins/util/ip_extractor')
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
 const { isBlocked, block, setTemplates, getBlockingAction } = require('./blocking')
 const UserTracking = require('./user_tracking')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const graphql = require('./graphql')
 const rasp = require('./rasp')
 
@@ -91,7 +91,7 @@ function onRequestBodyParsed ({ req, res, body, abortController }) {
   if (body === undefined || body === null) return
 
   if (!req) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     req = store?.req
   }
 
@@ -186,7 +186,7 @@ function incomingHttpEndTranslator ({ req, res }) {
 }
 
 function onPassportVerify ({ framework, login, user, success, abortController }) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   const rootSpan = store?.req && web.root(store.req)
 
   if (!rootSpan) {
@@ -200,7 +200,7 @@ function onPassportVerify ({ framework, login, user, success, abortController })
 }
 
 function onPassportDeserializeUser ({ user, abortController }) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   const rootSpan = store?.req && web.root(store.req)
 
   if (!rootSpan) {
@@ -217,7 +217,7 @@ function onRequestQueryParsed ({ req, res, query, abortController }) {
   if (!query || typeof query !== 'object') return
 
   if (!req) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     req = store?.req
   }
 

--- a/packages/dd-trace/src/appsec/rasp/command_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/command_injection.js
@@ -2,7 +2,7 @@
 
 const { childProcessExecutionTracingChannel } = require('../channels')
 const { RULE_TYPES, handleResult } = require('./utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 
@@ -27,7 +27,7 @@ function disable () {
 function analyzeCommandInjection ({ file, fileArgs, shell, abortController }) {
   if (!file) return
 
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   const req = store?.req
   if (!req) return
 

--- a/packages/dd-trace/src/appsec/rasp/command_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/command_injection.js
@@ -2,7 +2,7 @@
 
 const { childProcessExecutionTracingChannel } = require('../channels')
 const { RULE_TYPES, handleResult } = require('./utils')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 
@@ -27,7 +27,7 @@ function disable () {
 function analyzeCommandInjection ({ file, fileArgs, shell, abortController }) {
   if (!file) return
 
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   const req = store?.req
   if (!req) return
 

--- a/packages/dd-trace/src/appsec/rasp/command_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/command_injection.js
@@ -2,7 +2,7 @@
 
 const { childProcessExecutionTracingChannel } = require('../channels')
 const { RULE_TYPES, handleResult } = require('./utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 
@@ -27,7 +27,7 @@ function disable () {
 function analyzeCommandInjection ({ file, fileArgs, shell, abortController }) {
   if (!file) return
 
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   const req = store?.req
   if (!req) return
 

--- a/packages/dd-trace/src/appsec/rasp/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/rasp/fs-plugin.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Plugin = require('../../plugins/plugin')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const RASP_MODULE = 'rasp'
@@ -14,9 +14,9 @@ const enabledFor = {
 
 let fsPlugin
 
-function enterWith (fsProps, store = storage(SPAN_NAMESPACE).getStore()) {
+function enterWith (fsProps, store = storage('legacy').getStore()) {
   if (store && !store.fs?.opExcluded) {
-    storage(SPAN_NAMESPACE).enterWith({
+    storage('legacy').enterWith({
       ...store,
       fs: {
         ...store.fs,
@@ -42,7 +42,7 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationStart () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store) {
       enterWith({ root: store.fs?.root === undefined }, store)
     }
@@ -53,9 +53,9 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationFinishOrRenderEnd () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store?.fs?.parentStore) {
-      storage(SPAN_NAMESPACE).enterWith(store.fs.parentStore)
+      storage('legacy').enterWith(store.fs.parentStore)
     }
   }
 }

--- a/packages/dd-trace/src/appsec/rasp/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/rasp/fs-plugin.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Plugin = require('../../plugins/plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const RASP_MODULE = 'rasp'
@@ -14,9 +14,9 @@ const enabledFor = {
 
 let fsPlugin
 
-function enterWith (fsProps, store = storage(LEGACY_STORAGE_NAMESPACE).getStore()) {
+function enterWith (fsProps, store = storage(SPAN_NAMESPACE).getStore()) {
   if (store && !store.fs?.opExcluded) {
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith({
+    storage(SPAN_NAMESPACE).enterWith({
       ...store,
       fs: {
         ...store.fs,
@@ -42,7 +42,7 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationStart () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store) {
       enterWith({ root: store.fs?.root === undefined }, store)
     }
@@ -53,9 +53,9 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationFinishOrRenderEnd () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store?.fs?.parentStore) {
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(store.fs.parentStore)
+      storage(SPAN_NAMESPACE).enterWith(store.fs.parentStore)
     }
   }
 }

--- a/packages/dd-trace/src/appsec/rasp/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/rasp/fs-plugin.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Plugin = require('../../plugins/plugin')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const RASP_MODULE = 'rasp'
@@ -14,9 +14,9 @@ const enabledFor = {
 
 let fsPlugin
 
-function enterWith (fsProps, store = storage.getStore()) {
+function enterWith (fsProps, store = storage(LEGACY_STORAGE_NAMESPACE).getStore()) {
   if (store && !store.fs?.opExcluded) {
-    storage.enterWith({
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith({
       ...store,
       fs: {
         ...store.fs,
@@ -42,7 +42,7 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationStart () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store) {
       enterWith({ root: store.fs?.root === undefined }, store)
     }
@@ -53,9 +53,9 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationFinishOrRenderEnd () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store?.fs?.parentStore) {
-      storage.enterWith(store.fs.parentStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(store.fs.parentStore)
     }
   }
 }

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { fsOperationStart, incomingHttpRequestStart } = require('../channels')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const { enable: enableFsPlugin, disable: disableFsPlugin, RASP_MODULE } = require('./fs-plugin')
 const { FS_OPERATION_PATH } = require('../addresses')
 const waf = require('../waf')
@@ -47,7 +47,7 @@ function onFirstReceivedRequest () {
 }
 
 function analyzeLfi (ctx) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   if (!store) return
 
   const { req, fs, res } = store

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { fsOperationStart, incomingHttpRequestStart } = require('../channels')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const { enable: enableFsPlugin, disable: disableFsPlugin, RASP_MODULE } = require('./fs-plugin')
 const { FS_OPERATION_PATH } = require('../addresses')
 const waf = require('../waf')
@@ -47,7 +47,7 @@ function onFirstReceivedRequest () {
 }
 
 function analyzeLfi (ctx) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   if (!store) return
 
   const { req, fs, res } = store

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { fsOperationStart, incomingHttpRequestStart } = require('../channels')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const { enable: enableFsPlugin, disable: disableFsPlugin, RASP_MODULE } = require('./fs-plugin')
 const { FS_OPERATION_PATH } = require('../addresses')
 const waf = require('../waf')
@@ -47,7 +47,7 @@ function onFirstReceivedRequest () {
 }
 
 function analyzeLfi (ctx) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   if (!store) return
 
   const { req, fs, res } = store

--- a/packages/dd-trace/src/appsec/rasp/sql_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/sql_injection.js
@@ -6,7 +6,7 @@ const {
   wafRunFinished,
   mysql2OuterQueryStart
 } = require('../channels')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -49,7 +49,7 @@ function analyzePgSqlInjection (ctx) {
 }
 
 function analyzeSqlInjection (query, dbSystem, abortController) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   if (!store) return
 
   const { req, res } = store
@@ -91,7 +91,7 @@ function hasAddressesObjectInputAddress (addressesObject) {
 function clearQuerySet ({ payload }) {
   if (!payload) return
 
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   if (!store) return
 
   const { req } = store

--- a/packages/dd-trace/src/appsec/rasp/sql_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/sql_injection.js
@@ -6,7 +6,7 @@ const {
   wafRunFinished,
   mysql2OuterQueryStart
 } = require('../channels')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -49,7 +49,7 @@ function analyzePgSqlInjection (ctx) {
 }
 
 function analyzeSqlInjection (query, dbSystem, abortController) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   if (!store) return
 
   const { req, res } = store
@@ -91,7 +91,7 @@ function hasAddressesObjectInputAddress (addressesObject) {
 function clearQuerySet ({ payload }) {
   if (!payload) return
 
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   if (!store) return
 
   const { req } = store

--- a/packages/dd-trace/src/appsec/rasp/sql_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/sql_injection.js
@@ -6,7 +6,7 @@ const {
   wafRunFinished,
   mysql2OuterQueryStart
 } = require('../channels')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -49,7 +49,7 @@ function analyzePgSqlInjection (ctx) {
 }
 
 function analyzeSqlInjection (query, dbSystem, abortController) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   if (!store) return
 
   const { req, res } = store
@@ -91,7 +91,7 @@ function hasAddressesObjectInputAddress (addressesObject) {
 function clearQuerySet ({ payload }) {
   if (!payload) return
 
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   if (!store) return
 
   const { req } = store

--- a/packages/dd-trace/src/appsec/rasp/ssrf.js
+++ b/packages/dd-trace/src/appsec/rasp/ssrf.js
@@ -2,7 +2,7 @@
 
 const { format } = require('url')
 const { httpClientRequestStart } = require('../channels')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -19,7 +19,7 @@ function disable () {
 }
 
 function analyzeSsrf (ctx) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   const req = store?.req
   const outgoingUrl = (ctx.args.options?.uri && format(ctx.args.options.uri)) ?? ctx.args.uri
 

--- a/packages/dd-trace/src/appsec/rasp/ssrf.js
+++ b/packages/dd-trace/src/appsec/rasp/ssrf.js
@@ -2,7 +2,7 @@
 
 const { format } = require('url')
 const { httpClientRequestStart } = require('../channels')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -19,7 +19,7 @@ function disable () {
 }
 
 function analyzeSsrf (ctx) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   const req = store?.req
   const outgoingUrl = (ctx.args.options?.uri && format(ctx.args.options.uri)) ?? ctx.args.uri
 

--- a/packages/dd-trace/src/appsec/rasp/ssrf.js
+++ b/packages/dd-trace/src/appsec/rasp/ssrf.js
@@ -2,7 +2,7 @@
 
 const { format } = require('url')
 const { httpClientRequestStart } = require('../channels')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const addresses = require('../addresses')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -19,7 +19,7 @@ function disable () {
 }
 
 function analyzeSsrf (ctx) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   const req = store?.req
   const outgoingUrl = (ctx.args.options?.uri && format(ctx.args.options.uri)) ?? ctx.args.uri
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Limiter = require('../rate_limiter')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const web = require('../plugins/util/web')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const {
@@ -102,7 +102,7 @@ function reportWafInit (wafVersion, rulesVersion, diagnosticsRules = {}) {
 }
 
 function reportMetrics (metrics, raspRule) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   const rootSpan = store?.req && web.root(store.req)
   if (!rootSpan) return
 
@@ -117,7 +117,7 @@ function reportMetrics (metrics, raspRule) {
 }
 
 function reportAttack (attackData) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   const req = store?.req
   const rootSpan = web.root(req)
   if (!rootSpan) return
@@ -162,7 +162,7 @@ function isFingerprintDerivative (derivative) {
 function reportDerivatives (derivatives) {
   if (!derivatives) return
 
-  const req = storage(SPAN_NAMESPACE).getStore()?.req
+  const req = storage('legacy').getStore()?.req
   const rootSpan = web.root(req)
 
   if (!rootSpan) return

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Limiter = require('../rate_limiter')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const web = require('../plugins/util/web')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const {
@@ -102,7 +102,7 @@ function reportWafInit (wafVersion, rulesVersion, diagnosticsRules = {}) {
 }
 
 function reportMetrics (metrics, raspRule) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   const rootSpan = store?.req && web.root(store.req)
   if (!rootSpan) return
 
@@ -117,7 +117,7 @@ function reportMetrics (metrics, raspRule) {
 }
 
 function reportAttack (attackData) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   const req = store?.req
   const rootSpan = web.root(req)
   if (!rootSpan) return
@@ -162,7 +162,7 @@ function isFingerprintDerivative (derivative) {
 function reportDerivatives (derivatives) {
   if (!derivatives) return
 
-  const req = storage.getStore()?.req
+  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
   const rootSpan = web.root(req)
 
   if (!rootSpan) return

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Limiter = require('../rate_limiter')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const web = require('../plugins/util/web')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const {
@@ -102,7 +102,7 @@ function reportWafInit (wafVersion, rulesVersion, diagnosticsRules = {}) {
 }
 
 function reportMetrics (metrics, raspRule) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   const rootSpan = store?.req && web.root(store.req)
   if (!rootSpan) return
 
@@ -117,7 +117,7 @@ function reportMetrics (metrics, raspRule) {
 }
 
 function reportAttack (attackData) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   const req = store?.req
   const rootSpan = web.root(req)
   if (!rootSpan) return
@@ -162,7 +162,7 @@ function isFingerprintDerivative (derivative) {
 function reportDerivatives (derivatives) {
   if (!derivatives) return
 
-  const req = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.req
+  const req = storage(SPAN_NAMESPACE).getStore()?.req
   const rootSpan = web.root(req)
 
   if (!rootSpan) return

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -4,7 +4,7 @@ const { USER_ID } = require('../addresses')
 const waf = require('../waf')
 const { getRootSpan } = require('./utils')
 const { block, getBlockingAction } = require('../blocking')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const { setUserTags } = require('./set_user')
 const log = require('../../log')
 
@@ -34,7 +34,7 @@ function checkUserAndSetUser (tracer, user) {
 
 function blockRequest (tracer, req, res) {
   if (!req || !res) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store) {
       req = req || store.req
       res = res || store.res

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -4,7 +4,7 @@ const { USER_ID } = require('../addresses')
 const waf = require('../waf')
 const { getRootSpan } = require('./utils')
 const { block, getBlockingAction } = require('../blocking')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const { setUserTags } = require('./set_user')
 const log = require('../../log')
 
@@ -34,7 +34,7 @@ function checkUserAndSetUser (tracer, user) {
 
 function blockRequest (tracer, req, res) {
   if (!req || !res) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store) {
       req = req || store.req
       res = res || store.res

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -4,7 +4,7 @@ const { USER_ID } = require('../addresses')
 const waf = require('../waf')
 const { getRootSpan } = require('./utils')
 const { block, getBlockingAction } = require('../blocking')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const { setUserTags } = require('./set_user')
 const log = require('../../log')
 
@@ -34,7 +34,7 @@ function checkUserAndSetUser (tracer, user) {
 
 function blockRequest (tracer, req, res) {
   if (!req || !res) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store) {
       req = req || store.req
       res = res || store.res

--- a/packages/dd-trace/src/appsec/waf/index.js
+++ b/packages/dd-trace/src/appsec/waf/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const waf = {
@@ -48,7 +48,7 @@ function update (newRules) {
 
 function run (data, req, raspRule) {
   if (!req) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (!store || !store.req) {
       log.warn('[ASM] Request object not available in waf.run')
       return

--- a/packages/dd-trace/src/appsec/waf/index.js
+++ b/packages/dd-trace/src/appsec/waf/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const waf = {
@@ -48,7 +48,7 @@ function update (newRules) {
 
 function run (data, req, raspRule) {
   if (!req) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (!store || !store.req) {
       log.warn('[ASM] Request object not available in waf.run')
       return

--- a/packages/dd-trace/src/appsec/waf/index.js
+++ b/packages/dd-trace/src/appsec/waf/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const waf = {
@@ -48,7 +48,7 @@ function update (newRules) {
 
 function run (data, req, raspRule) {
   if (!req) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (!store || !store.req) {
       log.warn('[ASM] Request object not available in waf.run')
       return

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -4,7 +4,7 @@ const {
   finishAllTraceSpans,
   getTestSuitePath
 } = require('../../plugins/util/test')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 
 class TestApiManualPlugin extends CiPlugin {
   static get id () {
@@ -17,13 +17,13 @@ class TestApiManualPlugin extends CiPlugin {
     this.sourceRoot = process.cwd()
 
     this.unconfiguredAddSub('dd-trace:ci:manual:test:start', ({ testName, testSuite }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const testSuiteRelative = getTestSuitePath(testSuite, this.sourceRoot)
       const testSpan = this.startTestSpan(testName, testSuiteRelative)
       this.enter(testSpan, store)
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:finish', ({ status, error }) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.setTag(TEST_STATUS, status)
@@ -35,7 +35,7 @@ class TestApiManualPlugin extends CiPlugin {
       }
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:addTags', (tags) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.addTags(tags)

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -4,7 +4,7 @@ const {
   finishAllTraceSpans,
   getTestSuitePath
 } = require('../../plugins/util/test')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 
 class TestApiManualPlugin extends CiPlugin {
   static get id () {
@@ -17,13 +17,13 @@ class TestApiManualPlugin extends CiPlugin {
     this.sourceRoot = process.cwd()
 
     this.unconfiguredAddSub('dd-trace:ci:manual:test:start', ({ testName, testSuite }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const testSuiteRelative = getTestSuitePath(testSuite, this.sourceRoot)
       const testSpan = this.startTestSpan(testName, testSuiteRelative)
       this.enter(testSpan, store)
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:finish', ({ status, error }) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.setTag(TEST_STATUS, status)
@@ -35,7 +35,7 @@ class TestApiManualPlugin extends CiPlugin {
       }
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:addTags', (tags) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.addTags(tags)

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -4,7 +4,7 @@ const {
   finishAllTraceSpans,
   getTestSuitePath
 } = require('../../plugins/util/test')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 
 class TestApiManualPlugin extends CiPlugin {
   static get id () {
@@ -17,13 +17,13 @@ class TestApiManualPlugin extends CiPlugin {
     this.sourceRoot = process.cwd()
 
     this.unconfiguredAddSub('dd-trace:ci:manual:test:start', ({ testName, testSuite }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const testSuiteRelative = getTestSuitePath(testSuite, this.sourceRoot)
       const testSpan = this.startTestSpan(testName, testSuiteRelative)
       this.enter(testSpan, store)
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:finish', ({ status, error }) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.setTag(TEST_STATUS, status)
@@ -35,7 +35,7 @@ class TestApiManualPlugin extends CiPlugin {
       }
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:addTags', (tags) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.addTags(tags)

--- a/packages/dd-trace/src/data_streams_context.js
+++ b/packages/dd-trace/src/data_streams_context.js
@@ -1,15 +1,15 @@
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 const log = require('./log')
 
 function getDataStreamsContext () {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   return (store && store.dataStreamsContext) || null
 }
 
 function setDataStreamsContext (dataStreamsContext) {
   log.debug(() => `Setting new DSM Context: ${JSON.stringify(dataStreamsContext)}.`)
 
-  if (dataStreamsContext) storage.enterWith({ ...(storage.getStore()), dataStreamsContext })
+  if (dataStreamsContext) storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...(storage(LEGACY_STORAGE_NAMESPACE).getStore()), dataStreamsContext })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/data_streams_context.js
+++ b/packages/dd-trace/src/data_streams_context.js
@@ -1,15 +1,15 @@
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 const log = require('./log')
 
 function getDataStreamsContext () {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   return (store && store.dataStreamsContext) || null
 }
 
 function setDataStreamsContext (dataStreamsContext) {
   log.debug(() => `Setting new DSM Context: ${JSON.stringify(dataStreamsContext)}.`)
 
-  if (dataStreamsContext) storage(SPAN_NAMESPACE).enterWith({ ...(storage(SPAN_NAMESPACE).getStore()), dataStreamsContext })
+  if (dataStreamsContext) storage('legacy').enterWith({ ...(storage('legacy').getStore()), dataStreamsContext })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/data_streams_context.js
+++ b/packages/dd-trace/src/data_streams_context.js
@@ -1,15 +1,15 @@
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 const log = require('./log')
 
 function getDataStreamsContext () {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   return (store && store.dataStreamsContext) || null
 }
 
 function setDataStreamsContext (dataStreamsContext) {
   log.debug(() => `Setting new DSM Context: ${JSON.stringify(dataStreamsContext)}.`)
 
-  if (dataStreamsContext) storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...(storage(LEGACY_STORAGE_NAMESPACE).getStore()), dataStreamsContext })
+  if (dataStreamsContext) storage(SPAN_NAMESPACE).enterWith({ ...(storage(SPAN_NAMESPACE).getStore()), dataStreamsContext })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -2,7 +2,7 @@
 
 const http = require('http')
 const https = require('https')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 
 const keepAlive = true
 const maxSockets = 1
@@ -26,7 +26,7 @@ function createAgentClass (BaseAgent) {
     }
 
     _noop (callback) {
-      return storage.run({ noop: true }, callback)
+      return storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, callback)
     }
   }
 

--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -2,7 +2,7 @@
 
 const http = require('http')
 const https = require('https')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 
 const keepAlive = true
 const maxSockets = 1
@@ -26,7 +26,7 @@ function createAgentClass (BaseAgent) {
     }
 
     _noop (callback) {
-      return storage(SPAN_NAMESPACE).run({ noop: true }, callback)
+      return storage('legacy').run({ noop: true }, callback)
     }
   }
 

--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -2,7 +2,7 @@
 
 const http = require('http')
 const https = require('https')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 
 const keepAlive = true
 const maxSockets = 1
@@ -26,7 +26,7 @@ function createAgentClass (BaseAgent) {
     }
 
     _noop (callback) {
-      return storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, callback)
+      return storage(SPAN_NAMESPACE).run({ noop: true }, callback)
     }
   }
 

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -11,7 +11,7 @@ const zlib = require('zlib')
 const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const maxActiveRequests = 8
@@ -126,9 +126,9 @@ function request (data, options, callback) {
 
     activeRequests++
 
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
-    storage.enterWith({ noop: true })
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
 
     const req = client.request(options, onResponse)
 
@@ -146,7 +146,7 @@ function request (data, options, callback) {
       req.end()
     }
 
-    storage.enterWith(store)
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
   }
 
   // TODO: Figure out why setTimeout is needed to avoid losing the async context

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -11,7 +11,7 @@ const zlib = require('zlib')
 const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const maxActiveRequests = 8
@@ -126,9 +126,9 @@ function request (data, options, callback) {
 
     activeRequests++
 
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
-    storage(SPAN_NAMESPACE).enterWith({ noop: true })
+    storage('legacy').enterWith({ noop: true })
 
     const req = client.request(options, onResponse)
 
@@ -146,7 +146,7 @@ function request (data, options, callback) {
       req.end()
     }
 
-    storage(SPAN_NAMESPACE).enterWith(store)
+    storage('legacy').enterWith(store)
   }
 
   // TODO: Figure out why setTimeout is needed to avoid losing the async context

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -11,7 +11,7 @@ const zlib = require('zlib')
 const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const maxActiveRequests = 8
@@ -126,9 +126,9 @@ function request (data, options, callback) {
 
     activeRequests++
 
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+    storage(SPAN_NAMESPACE).enterWith({ noop: true })
 
     const req = client.request(options, onResponse)
 
@@ -146,7 +146,7 @@ function request (data, options, callback) {
       req.end()
     }
 
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+    storage(SPAN_NAMESPACE).enterWith(store)
   }
 
   // TODO: Figure out why setTimeout is needed to avoid losing the async context

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -63,7 +63,7 @@ function disable () {
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propogate the parent id.
 function handleLLMObsParentIdInjection ({ carrier }) {
-  const parent = storage(SPAN_NAMESPACE).getStore()?.span
+  const parent = storage.getStore()?.span
   if (!parent) return
 
   const parentId = parent?.context().toSpanId()

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -63,7 +63,7 @@ function disable () {
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propogate the parent id.
 function handleLLMObsParentIdInjection ({ carrier }) {
-  const parent = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
+  const parent = storage(SPAN_NAMESPACE).getStore()?.span
   if (!parent) return
 
   const parentId = parent?.context().toSpanId()

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -63,7 +63,7 @@ function disable () {
 // since LLMObs traces can extend between services and be the same trace,
 // we need to propogate the parent id.
 function handleLLMObsParentIdInjection ({ carrier }) {
-  const parent = storage.getStore()?.span
+  const parent = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
   if (!parent) return
 
   const parentId = parent?.context().toSpanId()

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -37,7 +37,7 @@ class LLMObsPlugin extends TracingPlugin {
     // ie OpenAI fine tuning jobs, file jobs, etc.
     if (registerOptions) {
       ctx.llmobs = {} // initialize context-based namespace
-      llmobsStorage(LEGACY_STORAGE_NAMESPACE).enterWith({ span })
+      llmobsStorage(SPAN_NAMESPACE).enterWith({ span })
       ctx.llmobs.parent = parent
 
       this._tagger.registerLLMObsSpan(span, { parent, ...registerOptions })
@@ -54,7 +54,7 @@ class LLMObsPlugin extends TracingPlugin {
     if (!LLMObsTagger.tagMap.has(span)) return
 
     const parent = ctx.llmobs.parent
-    llmobsStorage(LEGACY_STORAGE_NAMESPACE).enterWith({ span: parent })
+    llmobsStorage(SPAN_NAMESPACE).enterWith({ span: parent })
   }
 
   asyncEnd (ctx) {
@@ -86,7 +86,7 @@ class LLMObsPlugin extends TracingPlugin {
   }
 
   getLLMObsParent () {
-    const store = llmobsStorage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = llmobsStorage(SPAN_NAMESPACE).getStore()
     return store?.span
   }
 }

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -37,7 +37,7 @@ class LLMObsPlugin extends TracingPlugin {
     // ie OpenAI fine tuning jobs, file jobs, etc.
     if (registerOptions) {
       ctx.llmobs = {} // initialize context-based namespace
-      llmobsStorage(SPAN_NAMESPACE).enterWith({ span })
+      llmobsStorage.enterWith({ span })
       ctx.llmobs.parent = parent
 
       this._tagger.registerLLMObsSpan(span, { parent, ...registerOptions })
@@ -54,7 +54,7 @@ class LLMObsPlugin extends TracingPlugin {
     if (!LLMObsTagger.tagMap.has(span)) return
 
     const parent = ctx.llmobs.parent
-    llmobsStorage(SPAN_NAMESPACE).enterWith({ span: parent })
+    llmobsStorage.enterWith({ span: parent })
   }
 
   asyncEnd (ctx) {
@@ -86,7 +86,7 @@ class LLMObsPlugin extends TracingPlugin {
   }
 
   getLLMObsParent () {
-    const store = llmobsStorage(SPAN_NAMESPACE).getStore()
+    const store = llmobsStorage.getStore()
     return store?.span
   }
 }

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -37,7 +37,7 @@ class LLMObsPlugin extends TracingPlugin {
     // ie OpenAI fine tuning jobs, file jobs, etc.
     if (registerOptions) {
       ctx.llmobs = {} // initialize context-based namespace
-      llmobsStorage.enterWith({ span })
+      llmobsStorage(LEGACY_STORAGE_NAMESPACE).enterWith({ span })
       ctx.llmobs.parent = parent
 
       this._tagger.registerLLMObsSpan(span, { parent, ...registerOptions })
@@ -54,7 +54,7 @@ class LLMObsPlugin extends TracingPlugin {
     if (!LLMObsTagger.tagMap.has(span)) return
 
     const parent = ctx.llmobs.parent
-    llmobsStorage.enterWith({ span: parent })
+    llmobsStorage(LEGACY_STORAGE_NAMESPACE).enterWith({ span: parent })
   }
 
   asyncEnd (ctx) {
@@ -86,7 +86,7 @@ class LLMObsPlugin extends TracingPlugin {
   }
 
   getLLMObsParent () {
-    const store = llmobsStorage.getStore()
+    const store = llmobsStorage(LEGACY_STORAGE_NAMESPACE).getStore()
     return store?.span
   }
 }

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -29,7 +29,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       if (modelName.includes('embed')) {
         return
       }
-      const span = storage.getStore()?.span
+      const span = storage('legacy').getStore()?.span
       this.setLLMObsTags({ request, span, response, modelProvider, modelName })
     })
 

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -1,5 +1,5 @@
 const BaseLLMObsPlugin = require('./base')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const llmobsStore = storage('llmobs')
 
 const {
@@ -29,7 +29,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       if (modelName.includes('embed')) {
         return
       }
-      const span = storage(SPAN_NAMESPACE).getStore()?.span
+      const span = storage.getStore()?.span
       this.setLLMObsTags({ request, span, response, modelProvider, modelName })
     })
 

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -1,5 +1,5 @@
 const BaseLLMObsPlugin = require('./base')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const llmobsStore = storage('llmobs')
 
 const {
@@ -29,7 +29,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       if (modelName.includes('embed')) {
         return
       }
-      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
+      const span = storage(SPAN_NAMESPACE).getStore()?.span
       this.setLLMObsTags({ request, span, response, modelProvider, modelName })
     })
 

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -1,5 +1,5 @@
 const BaseLLMObsPlugin = require('./base')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const llmobsStore = storage('llmobs')
 
 const {
@@ -29,7 +29,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       if (modelName.includes('embed')) {
         return
       }
-      const span = storage.getStore()?.span
+      const span = storage(LEGACY_STORAGE_NAMESPACE).getStore()?.span
       this.setLLMObsTags({ request, span, response, modelProvider, modelName })
     })
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -381,13 +381,13 @@ class LLMObs extends NoopLLMObs {
   }
 
   _active () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     return store?.span
   }
 
   _activate (span, options, fn) {
     const parent = this._active()
-    if (this.enabled) storage(LEGACY_STORAGE_NAMESPACE).enterWith({ span })
+    if (this.enabled) storage(SPAN_NAMESPACE).enterWith({ span })
 
     if (options) {
       this._tagger.registerLLMObsSpan(span, {
@@ -399,7 +399,7 @@ class LLMObs extends NoopLLMObs {
     try {
       return fn()
     } finally {
-      if (this.enabled) storage(LEGACY_STORAGE_NAMESPACE).enterWith({ span: parent })
+      if (this.enabled) storage(SPAN_NAMESPACE).enterWith({ span: parent })
     }
   }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -381,13 +381,13 @@ class LLMObs extends NoopLLMObs {
   }
 
   _active () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     return store?.span
   }
 
   _activate (span, options, fn) {
     const parent = this._active()
-    if (this.enabled) storage.enterWith({ span })
+    if (this.enabled) storage(LEGACY_STORAGE_NAMESPACE).enterWith({ span })
 
     if (options) {
       this._tagger.registerLLMObsSpan(span, {
@@ -399,7 +399,7 @@ class LLMObs extends NoopLLMObs {
     try {
       return fn()
     } finally {
-      if (this.enabled) storage.enterWith({ span: parent })
+      if (this.enabled) storage(LEGACY_STORAGE_NAMESPACE).enterWith({ span: parent })
     }
   }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -381,13 +381,13 @@ class LLMObs extends NoopLLMObs {
   }
 
   _active () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage.getStore()
     return store?.span
   }
 
   _activate (span, options, fn) {
     const parent = this._active()
-    if (this.enabled) storage(SPAN_NAMESPACE).enterWith({ span })
+    if (this.enabled) storage.enterWith({ span })
 
     if (options) {
       this._tagger.registerLLMObsSpan(span, {
@@ -399,7 +399,7 @@ class LLMObs extends NoopLLMObs {
     try {
       return fn()
     } finally {
-      if (this.enabled) storage(SPAN_NAMESPACE).enterWith({ span: parent })
+      if (this.enabled) storage.enterWith({ span: parent })
     }
   }
 

--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const { LogChannel } = require('./channels')
 const { Log } = require('./log')
 const defaultLogger = {
@@ -15,11 +15,11 @@ let logger = defaultLogger
 let logChannel = new LogChannel()
 
 function withNoop (fn) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
 
-  storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+  storage(SPAN_NAMESPACE).enterWith({ noop: true })
   fn()
-  storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+  storage(SPAN_NAMESPACE).enterWith(store)
 }
 
 function unsubscribeAll () {

--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const { LogChannel } = require('./channels')
 const { Log } = require('./log')
 const defaultLogger = {
@@ -15,11 +15,11 @@ let logger = defaultLogger
 let logChannel = new LogChannel()
 
 function withNoop (fn) {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
 
-  storage(SPAN_NAMESPACE).enterWith({ noop: true })
+  storage('legacy').enterWith({ noop: true })
   fn()
-  storage(SPAN_NAMESPACE).enterWith(store)
+  storage('legacy').enterWith(store)
 }
 
 function unsubscribeAll () {

--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const { LogChannel } = require('./channels')
 const { Log } = require('./log')
 const defaultLogger = {
@@ -15,11 +15,11 @@ let logger = defaultLogger
 let logChannel = new LogChannel()
 
 function withNoop (fn) {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
-  storage.enterWith({ noop: true })
+  storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
   fn()
-  storage.enterWith(store)
+  storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
 }
 
 function unsubscribeAll () {

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -2,11 +2,11 @@
 
 const NoopSpanContext = require('./span_context')
 const id = require('../id')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core') // TODO: noop storage?
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core') // TODO: noop storage?
 
 class NoopSpan {
   constructor (tracer, parent) {
-    this._store = storage(LEGACY_STORAGE_NAMESPACE).getHandle()
+    this._store = storage(SPAN_NAMESPACE).getHandle()
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -2,11 +2,11 @@
 
 const NoopSpanContext = require('./span_context')
 const id = require('../id')
-const { storage } = require('../../../datadog-core') // TODO: noop storage?
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core') // TODO: noop storage?
 
 class NoopSpan {
   constructor (tracer, parent) {
-    this._store = storage.getHandle()
+    this._store = storage(LEGACY_STORAGE_NAMESPACE).getHandle()
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -2,11 +2,11 @@
 
 const NoopSpanContext = require('./span_context')
 const id = require('../id')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core') // TODO: noop storage?
+const { storage } = require('../../../datadog-core') // TODO: noop storage?
 
 class NoopSpan {
   constructor (tracer, parent) {
-    this._store = storage(SPAN_NAMESPACE).getHandle()
+    this._store = storage('legacy').getHandle()
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const DataDogSpanContext = require('../opentracing/span_context')
 

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const DataDogSpanContext = require('../opentracing/span_context')
 

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const DataDogSpanContext = require('../opentracing/span_context')
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -10,7 +10,7 @@ const id = require('../id')
 const tagger = require('../tagger')
 const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
 const { channel } = require('dc-polyfill')
 const spanleak = require('../spanleak')
@@ -65,7 +65,7 @@ class DatadogSpan {
     this._debug = debug
     this._processor = processor
     this._prioritySampler = prioritySampler
-    this._store = storage.getHandle()
+    this._store = storage(LEGACY_STORAGE_NAMESPACE).getHandle()
     this._duration = undefined
 
     this._events = []

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -10,7 +10,7 @@ const id = require('../id')
 const tagger = require('../tagger')
 const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
 const { channel } = require('dc-polyfill')
 const spanleak = require('../spanleak')
@@ -65,7 +65,7 @@ class DatadogSpan {
     this._debug = debug
     this._processor = processor
     this._prioritySampler = prioritySampler
-    this._store = storage(LEGACY_STORAGE_NAMESPACE).getHandle()
+    this._store = storage(SPAN_NAMESPACE).getHandle()
     this._duration = undefined
 
     this._events = []

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -10,7 +10,7 @@ const id = require('../id')
 const tagger = require('../tagger')
 const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
 const { channel } = require('dc-polyfill')
 const spanleak = require('../spanleak')
@@ -65,7 +65,7 @@ class DatadogSpan {
     this._debug = debug
     this._processor = processor
     this._prioritySampler = prioritySampler
-    this._store = storage(SPAN_NAMESPACE).getHandle()
+    this._store = storage('legacy').getHandle()
     this._duration = undefined
 
     this._events = []

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -1,5 +1,5 @@
 const TracingPlugin = require('./tracing')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 
 class ApolloBasePlugin extends TracingPlugin {
   static get id () { return 'apollo.gateway' }
@@ -7,7 +7,7 @@ class ApolloBasePlugin extends TracingPlugin {
   static get kind () { return 'server' }
 
   bindStart (ctx) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const childOf = store ? store.span : null
 
     const span = this.startSpan(this.getOperationName(), {

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -1,5 +1,5 @@
 const TracingPlugin = require('./tracing')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 
 class ApolloBasePlugin extends TracingPlugin {
   static get id () { return 'apollo.gateway' }
@@ -7,7 +7,7 @@ class ApolloBasePlugin extends TracingPlugin {
   static get kind () { return 'server' }
 
   bindStart (ctx) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const childOf = store ? store.span : null
 
     const span = this.startSpan(this.getOperationName(), {

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -1,5 +1,5 @@
 const TracingPlugin = require('./tracing')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 
 class ApolloBasePlugin extends TracingPlugin {
   static get id () { return 'apollo.gateway' }
@@ -7,7 +7,7 @@ class ApolloBasePlugin extends TracingPlugin {
   static get kind () { return 'server' }
 
   bindStart (ctx) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const childOf = store ? store.span : null
 
     const span = this.startSpan(this.getOperationName(), {

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -2,7 +2,7 @@
 
 const { LOG } = require('../../../../ext/formats')
 const Plugin = require('./plugin')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 
 const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 
@@ -40,7 +40,7 @@ module.exports = class LogPlugin extends Plugin {
     super(...args)
 
     this.addSub(`apm:${this.constructor.id}:log`, (arg) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const span = store && store.span
 
       // NOTE: This needs to run whether or not there is a span

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -2,7 +2,7 @@
 
 const { LOG } = require('../../../../ext/formats')
 const Plugin = require('./plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 
 const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 
@@ -40,7 +40,7 @@ module.exports = class LogPlugin extends Plugin {
     super(...args)
 
     this.addSub(`apm:${this.constructor.id}:log`, (arg) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const span = store && store.span
 
       // NOTE: This needs to run whether or not there is a span

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -2,7 +2,7 @@
 
 const { LOG } = require('../../../../ext/formats')
 const Plugin = require('./plugin')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 
 const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
 
@@ -40,7 +40,7 @@ module.exports = class LogPlugin extends Plugin {
     super(...args)
 
     this.addSub(`apm:${this.constructor.id}:log`, (arg) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const span = store && store.span
 
       // NOTE: This needs to run whether or not there is a span

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -4,13 +4,13 @@
 
 const dc = require('dc-polyfill')
 const logger = require('../log')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 
 class Subscription {
   constructor (event, handler) {
     this._channel = dc.channel(event)
     this._handler = (message, name) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       if (!store || !store.noop) {
         handler(message, name)
       }
@@ -30,7 +30,7 @@ class StoreBinding {
   constructor (event, transform) {
     this._channel = dc.channel(event)
     this._transform = data => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
 
       return !store || !store.noop
         ? transform(data)
@@ -62,14 +62,14 @@ module.exports = class Plugin {
   }
 
   enter (span, store) {
-    store = store || storage(LEGACY_STORAGE_NAMESPACE).getStore()
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, span })
+    store = store || storage(SPAN_NAMESPACE).getStore()
+    storage(SPAN_NAMESPACE).enterWith({ ...store, span })
   }
 
   // TODO: Implement filters on resource name for all plugins.
   /** Prevents creation of spans here and for all async descendants. */
   skip () {
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+    storage(SPAN_NAMESPACE).enterWith({ noop: true })
   }
 
   addSub (channelName, handler) {
@@ -91,7 +91,7 @@ module.exports = class Plugin {
   }
 
   addError (error) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     if (!store || !store.span) return
 

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -4,13 +4,13 @@
 
 const dc = require('dc-polyfill')
 const logger = require('../log')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 
 class Subscription {
   constructor (event, handler) {
     this._channel = dc.channel(event)
     this._handler = (message, name) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       if (!store || !store.noop) {
         handler(message, name)
       }
@@ -30,7 +30,7 @@ class StoreBinding {
   constructor (event, transform) {
     this._channel = dc.channel(event)
     this._transform = data => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
       return !store || !store.noop
         ? transform(data)
@@ -62,14 +62,14 @@ module.exports = class Plugin {
   }
 
   enter (span, store) {
-    store = store || storage.getStore()
-    storage.enterWith({ ...store, span })
+    store = store || storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, span })
   }
 
   // TODO: Implement filters on resource name for all plugins.
   /** Prevents creation of spans here and for all async descendants. */
   skip () {
-    storage.enterWith({ noop: true })
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
   }
 
   addSub (channelName, handler) {
@@ -91,7 +91,7 @@ module.exports = class Plugin {
   }
 
   addError (error) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     if (!store || !store.span) return
 

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -39,11 +39,11 @@ class StoreBinding {
   }
 
   enable () {
-    this._channel.bindStore(storage, this._transform)
+    this._channel.bindStore(storage(SPAN_NAMESPACE), this._transform)
   }
 
   disable () {
-    this._channel.unbindStore(storage, this._transform)
+    this._channel.unbindStore(storage(SPAN_NAMESPACE))
   }
 }
 

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -4,13 +4,13 @@
 
 const dc = require('dc-polyfill')
 const logger = require('../log')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 
 class Subscription {
   constructor (event, handler) {
     this._channel = dc.channel(event)
     this._handler = (message, name) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       if (!store || !store.noop) {
         handler(message, name)
       }
@@ -30,7 +30,7 @@ class StoreBinding {
   constructor (event, transform) {
     this._channel = dc.channel(event)
     this._transform = data => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
 
       return !store || !store.noop
         ? transform(data)
@@ -39,11 +39,11 @@ class StoreBinding {
   }
 
   enable () {
-    this._channel.bindStore(storage(SPAN_NAMESPACE), this._transform)
+    this._channel.bindStore(storage('legacy'), this._transform)
   }
 
   disable () {
-    this._channel.unbindStore(storage(SPAN_NAMESPACE))
+    this._channel.unbindStore(storage('legacy'))
   }
 }
 
@@ -62,14 +62,14 @@ module.exports = class Plugin {
   }
 
   enter (span, store) {
-    store = store || storage(SPAN_NAMESPACE).getStore()
-    storage(SPAN_NAMESPACE).enterWith({ ...store, span })
+    store = store || storage('legacy').getStore()
+    storage('legacy').enterWith({ ...store, span })
   }
 
   // TODO: Implement filters on resource name for all plugins.
   /** Prevents creation of spans here and for all async descendants. */
   skip () {
-    storage(SPAN_NAMESPACE).enterWith({ noop: true })
+    storage('legacy').enterWith({ noop: true })
   }
 
   addSub (channelName, handler) {
@@ -91,7 +91,7 @@ module.exports = class Plugin {
   }
 
   addError (error) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     if (!store || !store.span) return
 

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Plugin = require('./plugin')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const analyticsSampler = require('../analytics_sampler')
 const { COMPONENT } = require('../constants')
 
@@ -16,7 +16,7 @@ class TracingPlugin extends Plugin {
   }
 
   get activeSpan () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     return store && store.span
   }
@@ -102,7 +102,7 @@ class TracingPlugin extends Plugin {
   }
 
   startSpan (name, { childOf, kind, meta, metrics, service, resource, type } = {}, enter = true) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     if (store && childOf === undefined) {
       childOf = store.span
     }
@@ -126,7 +126,7 @@ class TracingPlugin extends Plugin {
 
     // TODO: Remove this after migration to TracingChannel is done.
     if (enter) {
-      storage(SPAN_NAMESPACE).enterWith({ ...store, span })
+      storage('legacy').enterWith({ ...store, span })
     }
 
     return span

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Plugin = require('./plugin')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const analyticsSampler = require('../analytics_sampler')
 const { COMPONENT } = require('../constants')
 
@@ -16,7 +16,7 @@ class TracingPlugin extends Plugin {
   }
 
   get activeSpan () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     return store && store.span
   }
@@ -102,7 +102,7 @@ class TracingPlugin extends Plugin {
   }
 
   startSpan (name, { childOf, kind, meta, metrics, service, resource, type } = {}, enter = true) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     if (store && childOf === undefined) {
       childOf = store.span
     }
@@ -126,7 +126,7 @@ class TracingPlugin extends Plugin {
 
     // TODO: Remove this after migration to TracingChannel is done.
     if (enter) {
-      storage.enterWith({ ...store, span })
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, span })
     }
 
     return span

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Plugin = require('./plugin')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const analyticsSampler = require('../analytics_sampler')
 const { COMPONENT } = require('../constants')
 
@@ -16,7 +16,7 @@ class TracingPlugin extends Plugin {
   }
 
   get activeSpan () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     return store && store.span
   }
@@ -102,7 +102,7 @@ class TracingPlugin extends Plugin {
   }
 
   startSpan (name, { childOf, kind, meta, metrics, service, resource, type } = {}, enter = true) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     if (store && childOf === undefined) {
       childOf = store.span
     }
@@ -126,7 +126,7 @@ class TracingPlugin extends Plugin {
 
     // TODO: Remove this after migration to TracingChannel is done.
     if (enter) {
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...store, span })
+      storage(SPAN_NAMESPACE).enterWith({ ...store, span })
     }
 
     return span

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -26,7 +26,7 @@ const {
   TELEMETRY_GIT_COMMAND_ERRORS
 } = require('../../ci-visibility/telemetry')
 const { filterSensitiveInfoFromRepository } = require('./url')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 
 const GIT_REV_LIST_MAX_BUFFER = 12 * 1024 * 1024 // 12MB
 
@@ -37,8 +37,8 @@ function sanitizedExec (
   durationMetric,
   errorMetric
 ) {
-  const store = storage.getStore()
-  storage.enterWith({ noop: true })
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
 
   let startTime
   if (operationMetric) {
@@ -64,7 +64,7 @@ function sanitizedExec (
     log.error('Git plugin error executing command', err)
     return ''
   } finally {
-    storage.enterWith(store)
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -26,7 +26,7 @@ const {
   TELEMETRY_GIT_COMMAND_ERRORS
 } = require('../../ci-visibility/telemetry')
 const { filterSensitiveInfoFromRepository } = require('./url')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 
 const GIT_REV_LIST_MAX_BUFFER = 12 * 1024 * 1024 // 12MB
 
@@ -37,8 +37,8 @@ function sanitizedExec (
   durationMetric,
   errorMetric
 ) {
-  const store = storage(SPAN_NAMESPACE).getStore()
-  storage(SPAN_NAMESPACE).enterWith({ noop: true })
+  const store = storage('legacy').getStore()
+  storage('legacy').enterWith({ noop: true })
 
   let startTime
   if (operationMetric) {
@@ -64,7 +64,7 @@ function sanitizedExec (
     log.error('Git plugin error executing command', err)
     return ''
   } finally {
-    storage(SPAN_NAMESPACE).enterWith(store)
+    storage('legacy').enterWith(store)
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -26,7 +26,7 @@ const {
   TELEMETRY_GIT_COMMAND_ERRORS
 } = require('../../ci-visibility/telemetry')
 const { filterSensitiveInfoFromRepository } = require('./url')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 
 const GIT_REV_LIST_MAX_BUFFER = 12 * 1024 * 1024 // 12MB
 
@@ -37,8 +37,8 @@ function sanitizedExec (
   durationMetric,
   errorMetric
 ) {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
-  storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+  const store = storage(SPAN_NAMESPACE).getStore()
+  storage(SPAN_NAMESPACE).enterWith({ noop: true })
 
   let startTime
   if (operationMetric) {
@@ -64,7 +64,7 @@ function sanitizedExec (
     log.error('Git plugin error executing command', err)
     return ''
   } finally {
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+    storage(SPAN_NAMESPACE).enterWith(store)
   }
 }
 

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -8,7 +8,7 @@ const { EventSerializer } = require('./event_serializer')
 // TODO: avoid using dd-trace internals. Make this a separate module?
 const docker = require('../../exporters/common/docker')
 const FormData = require('../../exporters/common/form-data')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const version = require('../../../../../package.json').version
 const { urlToHttpOptions } = require('url')
 const perf = require('perf_hooks').performance
@@ -40,8 +40,8 @@ function countStatusCode (statusCode) {
 function sendRequest (options, form, callback) {
   const request = options.protocol === 'https:' ? httpsRequest : httpRequest
 
-  const store = storage(SPAN_NAMESPACE).getStore()
-  storage(SPAN_NAMESPACE).enterWith({ noop: true })
+  const store = storage('legacy').getStore()
+  storage('legacy').enterWith({ noop: true })
   requestCounter.inc()
   const start = perf.now()
   const req = request(options, res => {
@@ -65,7 +65,7 @@ function sendRequest (options, form, callback) {
     sizeDistribution.track(form.size())
     form.pipe(req)
   }
-  storage(SPAN_NAMESPACE).enterWith(store)
+  storage('legacy').enterWith(store)
 }
 
 function getBody (stream, callback) {

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -8,7 +8,7 @@ const { EventSerializer } = require('./event_serializer')
 // TODO: avoid using dd-trace internals. Make this a separate module?
 const docker = require('../../exporters/common/docker')
 const FormData = require('../../exporters/common/form-data')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const version = require('../../../../../package.json').version
 const { urlToHttpOptions } = require('url')
 const perf = require('perf_hooks').performance
@@ -40,8 +40,8 @@ function countStatusCode (statusCode) {
 function sendRequest (options, form, callback) {
   const request = options.protocol === 'https:' ? httpsRequest : httpRequest
 
-  const store = storage.getStore()
-  storage.enterWith({ noop: true })
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
   requestCounter.inc()
   const start = perf.now()
   const req = request(options, res => {
@@ -65,7 +65,7 @@ function sendRequest (options, form, callback) {
     sizeDistribution.track(form.size())
     form.pipe(req)
   }
-  storage.enterWith(store)
+  storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
 }
 
 function getBody (stream, callback) {

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -8,7 +8,7 @@ const { EventSerializer } = require('./event_serializer')
 // TODO: avoid using dd-trace internals. Make this a separate module?
 const docker = require('../../exporters/common/docker')
 const FormData = require('../../exporters/common/form-data')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const version = require('../../../../../package.json').version
 const { urlToHttpOptions } = require('url')
 const perf = require('perf_hooks').performance
@@ -40,8 +40,8 @@ function countStatusCode (statusCode) {
 function sendRequest (options, form, callback) {
   const request = options.protocol === 'https:' ? httpsRequest : httpRequest
 
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
-  storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+  const store = storage(SPAN_NAMESPACE).getStore()
+  storage(SPAN_NAMESPACE).enterWith({ noop: true })
   requestCounter.inc()
   const start = perf.now()
   const req = request(options, res => {
@@ -65,7 +65,7 @@ function sendRequest (options, form, callback) {
     sizeDistribution.track(form.size())
     form.pipe(req)
   }
-  storage(LEGACY_STORAGE_NAMESPACE).enterWith(store)
+  storage(SPAN_NAMESPACE).enterWith(store)
 }
 
 function getBody (stream, callback) {

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -1,4 +1,4 @@
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const TracingPlugin = require('../../../plugins/tracing')
 const { performance } = require('perf_hooks')
 

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -1,4 +1,4 @@
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const TracingPlugin = require('../../../plugins/tracing')
 const { performance } = require('perf_hooks')
 

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -1,4 +1,4 @@
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const TracingPlugin = require('../../../plugins/tracing')
 const { performance } = require('perf_hooks')
 

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 
 const dc = require('dc-polyfill')
 const runtimeMetrics = require('../../runtime_metrics')
@@ -25,7 +25,7 @@ const ProfilingContext = Symbol('NativeWallProfiler.ProfilingContext')
 let kSampleCount
 
 function getActiveSpan () {
-  const store = storage.getStore()
+  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
   return store && store.span
 }
 

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 
 const dc = require('dc-polyfill')
 const runtimeMetrics = require('../../runtime_metrics')
@@ -25,7 +25,7 @@ const ProfilingContext = Symbol('NativeWallProfiler.ProfilingContext')
 let kSampleCount
 
 function getActiveSpan () {
-  const store = storage(SPAN_NAMESPACE).getStore()
+  const store = storage('legacy').getStore()
   return store && store.span
 }
 

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 
 const dc = require('dc-polyfill')
 const runtimeMetrics = require('../../runtime_metrics')
@@ -25,7 +25,7 @@ const ProfilingContext = Symbol('NativeWallProfiler.ProfilingContext')
 let kSampleCount
 
 function getActiveSpan () {
-  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+  const store = storage(SPAN_NAMESPACE).getStore()
   return store && store.span
 }
 

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 // TODO: refactor bind to use shimmer once the new internal tracer lands
 
@@ -8,7 +8,7 @@ const originals = new WeakMap()
 
 class Scope {
   active () {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
 
     return (store && store.span) || null
   }
@@ -16,10 +16,10 @@ class Scope {
   activate (span, callback) {
     if (typeof callback !== 'function') return callback
 
-    const oldStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
-    const newStore = span ? storage(LEGACY_STORAGE_NAMESPACE).getStore(span._store) : oldStore
+    const oldStore = storage(SPAN_NAMESPACE).getStore()
+    const newStore = span ? storage(SPAN_NAMESPACE).getStore(span._store) : oldStore
 
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...newStore, span })
+    storage(SPAN_NAMESPACE).enterWith({ ...newStore, span })
 
     try {
       return callback()
@@ -30,7 +30,7 @@ class Scope {
 
       throw e
     } finally {
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(oldStore)
+      storage(SPAN_NAMESPACE).enterWith(oldStore)
     }
   }
 

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 // TODO: refactor bind to use shimmer once the new internal tracer lands
 
@@ -8,7 +8,7 @@ const originals = new WeakMap()
 
 class Scope {
   active () {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
 
     return (store && store.span) || null
   }
@@ -16,10 +16,10 @@ class Scope {
   activate (span, callback) {
     if (typeof callback !== 'function') return callback
 
-    const oldStore = storage(SPAN_NAMESPACE).getStore()
-    const newStore = span ? storage(SPAN_NAMESPACE).getStore(span._store) : oldStore
+    const oldStore = storage('legacy').getStore()
+    const newStore = span ? storage('legacy').getStore(span._store) : oldStore
 
-    storage(SPAN_NAMESPACE).enterWith({ ...newStore, span })
+    storage('legacy').enterWith({ ...newStore, span })
 
     try {
       return callback()
@@ -30,7 +30,7 @@ class Scope {
 
       throw e
     } finally {
-      storage(SPAN_NAMESPACE).enterWith(oldStore)
+      storage('legacy').enterWith(oldStore)
     }
   }
 

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 // TODO: refactor bind to use shimmer once the new internal tracer lands
 
@@ -8,7 +8,7 @@ const originals = new WeakMap()
 
 class Scope {
   active () {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
     return (store && store.span) || null
   }
@@ -16,10 +16,10 @@ class Scope {
   activate (span, callback) {
     if (typeof callback !== 'function') return callback
 
-    const oldStore = storage.getStore()
-    const newStore = span ? storage.getStore(span._store) : oldStore
+    const oldStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const newStore = span ? storage(LEGACY_STORAGE_NAMESPACE).getStore(span._store) : oldStore
 
-    storage.enterWith({ ...newStore, span })
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith({ ...newStore, span })
 
     try {
       return callback()
@@ -30,7 +30,7 @@ class Scope {
 
       throw e
     } finally {
-      storage.enterWith(oldStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(oldStore)
     }
   }
 

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire')
 const waf = require('../../src/appsec/waf')
 const web = require('../../src/plugins/util/web')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const addresses = require('../../src/appsec/addresses')
 
 const {
@@ -131,7 +131,7 @@ describe('GraphQL', () => {
         user: [{ id: '1234' }]
       }
 
-      storage(LEGACY_STORAGE_NAMESPACE).getStore().req = undefined
+      storage(SPAN_NAMESPACE).getStore().req = undefined
 
       startGraphqlResolve.publish({ context, resolverInfo })
 

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire')
 const waf = require('../../src/appsec/waf')
 const web = require('../../src/plugins/util/web')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const addresses = require('../../src/appsec/addresses')
 
 const {
@@ -131,7 +131,7 @@ describe('GraphQL', () => {
         user: [{ id: '1234' }]
       }
 
-      storage(SPAN_NAMESPACE).getStore().req = undefined
+      storage('legacy').getStore().req = undefined
 
       startGraphqlResolve.publish({ context, resolverInfo })
 

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -95,7 +95,7 @@ describe('GraphQL', () => {
   describe('onGraphqlStartResolve', () => {
     beforeEach(() => {
       sinon.stub(waf, 'run').returns([''])
-      sinon.stub(storage, 'getStore').returns({ req: {} })
+      sinon.stub(storage('legacy'), 'getStore').returns({ req: {} })
       sinon.stub(web, 'root').returns({})
       graphql.enable()
     })
@@ -160,7 +160,7 @@ describe('GraphQL', () => {
     const res = {}
 
     beforeEach(() => {
-      sinon.stub(storage, 'getStore').returns({ req, res })
+      sinon.stub(storage('legacy'), 'getStore').returns({ req, res })
 
       graphql.enable()
       graphqlMiddlewareChannel.start.publish({ req, res })

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire')
 const waf = require('../../src/appsec/waf')
 const web = require('../../src/plugins/util/web')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const addresses = require('../../src/appsec/addresses')
 
 const {
@@ -131,7 +131,7 @@ describe('GraphQL', () => {
         user: [{ id: '1234' }]
       }
 
-      storage.getStore().req = undefined
+      storage(LEGACY_STORAGE_NAMESPACE).getStore().req = undefined
 
       startGraphqlResolve.publish({ context, resolverInfo })
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/code-injection-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/code-injection-analyzer.express.plugin.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 
 describe('Code injection vulnerability', () => {
@@ -49,7 +49,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -110,7 +110,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -149,7 +149,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -188,7 +188,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -228,7 +228,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -269,7 +269,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                const store = storage(SPAN_NAMESPACE).getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -311,7 +311,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                const store = storage(SPAN_NAMESPACE).getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -353,7 +353,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                const store = storage(SPAN_NAMESPACE).getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/code-injection-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/code-injection-analyzer.express.plugin.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 
 describe('Code injection vulnerability', () => {
@@ -49,7 +49,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -110,7 +110,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -149,7 +149,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -188,7 +188,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -228,7 +228,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -269,7 +269,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage(SPAN_NAMESPACE).getStore()
+                const store = storage('legacy').getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -311,7 +311,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage(SPAN_NAMESPACE).getStore()
+                const store = storage('legacy').getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -353,7 +353,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage(SPAN_NAMESPACE).getStore()
+                const store = storage('legacy').getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/code-injection-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/code-injection-analyzer.express.plugin.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 
 describe('Code injection vulnerability', () => {
@@ -49,7 +49,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -110,7 +110,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -149,7 +149,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -188,7 +188,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -228,7 +228,7 @@ describe('Code injection vulnerability', () => {
           testThatRequestHasVulnerability({
             fn: (req, res) => {
               const source = '1 + 2'
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -269,7 +269,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage.getStore()
+                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -311,7 +311,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage.getStore()
+                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 
@@ -353,7 +353,7 @@ describe('Code injection vulnerability', () => {
             testThatRequestHasVulnerability({
               fn: (req, res) => {
                 const source = '1 + 2'
-                const store = storage.getStore()
+                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                 const iastContext = iastContextFunctions.getIastContext(store)
                 const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -9,7 +9,7 @@ describe('command injection analyzer', () => {
   prepareTestServerForIast('command injection analyzer',
     (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       testThatRequestHasVulnerability(() => {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const command = newTaintedString(iastContext, 'ls -la', 'param', 'Request')
         const childProcess = require('child_process')

--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -9,7 +9,7 @@ describe('command injection analyzer', () => {
   prepareTestServerForIast('command injection analyzer',
     (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       testThatRequestHasVulnerability(() => {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const command = newTaintedString(iastContext, 'ls -la', 'param', 'Request')
         const childProcess = require('child_process')

--- a/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/command-injection-analyzer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -9,7 +9,7 @@ describe('command injection analyzer', () => {
   prepareTestServerForIast('command injection analyzer',
     (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       testThatRequestHasVulnerability(() => {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const command = newTaintedString(iastContext, 'ls -la', 'param', 'Request')
         const childProcess = require('child_process')

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -47,7 +47,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -84,7 +84,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('context is not null after search end event', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -95,7 +95,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                 return reject(err)
               }
               searchRes.on('end', () => {
-                const storeEnd = storage(SPAN_NAMESPACE).getStore()
+                const storeEnd = storage('legacy').getStore()
                 const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
                 expect(iastCtxEnd).to.not.be.undefined
 
@@ -109,7 +109,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('remove listener should work as expected', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -144,7 +144,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
               if (err) {
                 reject(err)
               } else {
-                const store = storage(SPAN_NAMESPACE).getStore()
+                const store = storage('legacy').getStore()
                 const iastCtx = iastContextFunctions.getIastContext(store)
 
                 let filter = '(objectClass=*)'
@@ -155,7 +155,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                     return reject(err)
                   }
                   searchRes.on('end', () => {
-                    const storeEnd = storage(SPAN_NAMESPACE).getStore()
+                    const storeEnd = storage('legacy').getStore()
                     const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
                     expect(iastCtxEnd).to.not.be.undefined
 
@@ -199,7 +199,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
 
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
 
           let filter = '(objectClass=*)'

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -47,7 +47,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -84,7 +84,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('context is not null after search end event', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -95,7 +95,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                 return reject(err)
               }
               searchRes.on('end', () => {
-                const storeEnd = storage.getStore()
+                const storeEnd = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                 const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
                 expect(iastCtxEnd).to.not.be.undefined
 
@@ -109,7 +109,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('remove listener should work as expected', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -144,7 +144,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
               if (err) {
                 reject(err)
               } else {
-                const store = storage.getStore()
+                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                 const iastCtx = iastContextFunctions.getIastContext(store)
 
                 let filter = '(objectClass=*)'
@@ -155,7 +155,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                     return reject(err)
                   }
                   searchRes.on('end', () => {
-                    const storeEnd = storage.getStore()
+                    const storeEnd = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                     const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
                     expect(iastCtxEnd).to.not.be.undefined
 
@@ -199,7 +199,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
 
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
 
           let filter = '(objectClass=*)'

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.ldapjs.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -47,7 +47,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -84,7 +84,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('context is not null after search end event', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -95,7 +95,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                 return reject(err)
               }
               searchRes.on('end', () => {
-                const storeEnd = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                const storeEnd = storage(SPAN_NAMESPACE).getStore()
                 const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
                 expect(iastCtxEnd).to.not.be.undefined
 
@@ -109,7 +109,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
       describe('remove listener should work as expected', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let filter = '(objectClass=*)'
@@ -144,7 +144,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
               if (err) {
                 reject(err)
               } else {
-                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                const store = storage(SPAN_NAMESPACE).getStore()
                 const iastCtx = iastContextFunctions.getIastContext(store)
 
                 let filter = '(objectClass=*)'
@@ -155,7 +155,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
                     return reject(err)
                   }
                   searchRes.on('end', () => {
-                    const storeEnd = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                    const storeEnd = storage(SPAN_NAMESPACE).getStore()
                     const iastCtxEnd = iastContextFunctions.getIastContext(storeEnd)
                     expect(iastCtxEnd).to.not.be.undefined
 
@@ -199,7 +199,7 @@ describe('ldap-injection-analyzer with ldapjs', () => {
 
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
 
           let filter = '(objectClass=*)'

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.spec.js
@@ -93,8 +93,16 @@ describe('ldap-injection-analyzer', () => {
     const getStore = sinon.stub().returns(store)
     const getIastContext = sinon.stub().returns(iastContext)
 
+    const datadogCore = {
+      storage: () => {
+        return {
+          getStore: getStore
+        }
+      }
+    }
+
     const iastPlugin = proxyquire('../../../../src/appsec/iast/iast-plugin', {
-      '../../../../datadog-core': { storage: { getStore } },
+      '../../../../datadog-core': datadogCore,
       './iast-context': { getIastContext }
     })
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ldap-injection-analyzer.spec.js
@@ -96,7 +96,7 @@ describe('ldap-injection-analyzer', () => {
     const datadogCore = {
       storage: () => {
         return {
-          getStore: getStore
+          getStore
         }
       }
     }

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -2,7 +2,7 @@
 
 const os = require('os')
 const path = require('path')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const expect = require('chai').expect
 const sinon = require('sinon')
@@ -186,7 +186,7 @@ prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, t
     describe(description, () => {
       describe('vulnerable', () => {
         testThatRequestHasVulnerability(function () {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const callArgs = [...args]
           if (vulnerableIndex > -1) {

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -2,7 +2,7 @@
 
 const os = require('os')
 const path = require('path')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const expect = require('chai').expect
 const sinon = require('sinon')
@@ -186,7 +186,7 @@ prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, t
     describe(description, () => {
       describe('vulnerable', () => {
         testThatRequestHasVulnerability(function () {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const callArgs = [...args]
           if (vulnerableIndex > -1) {

--- a/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/path-traversal-analyzer.spec.js
@@ -2,7 +2,7 @@
 
 const os = require('os')
 const path = require('path')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const expect = require('chai').expect
 const sinon = require('sinon')
@@ -186,7 +186,7 @@ prepareTestServerForIast('integration test', (testThatRequestHasVulnerability, t
     describe(description, () => {
       describe('vulnerable', () => {
         testThatRequestHasVulnerability(function () {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const callArgs = [...args]
           if (vulnerableIndex > -1) {

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -48,7 +48,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('simple raw query', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let sql = 'SELECT 1'
@@ -70,7 +70,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -90,7 +90,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query - onRejected as then argument', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -110,7 +110,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query - with catch', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -131,7 +131,7 @@ describe('sql-injection-analyzer with knex', () => {
           describe('nested raw query - asCallback', () => {
             testThatRequestHasVulnerability(() => {
               return new Promise((resolve, reject) => {
-                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                const store = storage(SPAN_NAMESPACE).getStore()
                 const iastCtx = iastContextFunctions.getIastContext(store)
 
                 let taintedSql = 'SELECT 1'

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -48,7 +48,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('simple raw query', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let sql = 'SELECT 1'
@@ -70,7 +70,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -90,7 +90,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query - onRejected as then argument', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -110,7 +110,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query - with catch', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -131,7 +131,7 @@ describe('sql-injection-analyzer with knex', () => {
           describe('nested raw query - asCallback', () => {
             testThatRequestHasVulnerability(() => {
               return new Promise((resolve, reject) => {
-                const store = storage(SPAN_NAMESPACE).getStore()
+                const store = storage('legacy').getStore()
                 const iastCtx = iastContextFunctions.getIastContext(store)
 
                 let taintedSql = 'SELECT 1'

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -48,7 +48,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('simple raw query', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let sql = 'SELECT 1'
@@ -70,7 +70,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -90,7 +90,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query - onRejected as then argument', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -110,7 +110,7 @@ describe('sql-injection-analyzer with knex', () => {
 
           describe('nested raw query - with catch', () => {
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
 
               let taintedSql = 'SELECT 1'
@@ -131,7 +131,7 @@ describe('sql-injection-analyzer with knex', () => {
           describe('nested raw query - asCallback', () => {
             testThatRequestHasVulnerability(() => {
               return new Promise((resolve, reject) => {
-                const store = storage.getStore()
+                const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                 const iastCtx = iastContextFunctions.getIastContext(store)
 
                 let taintedSql = 'SELECT 1'

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql.plugin.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -47,7 +47,7 @@ describe('sql-injection-analyzer with mysql', () => {
 
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -97,7 +97,7 @@ describe('sql-injection-analyzer with mysql', () => {
 
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql.plugin.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -47,7 +47,7 @@ describe('sql-injection-analyzer with mysql', () => {
 
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -97,7 +97,7 @@ describe('sql-injection-analyzer with mysql', () => {
 
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql.plugin.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -47,7 +47,7 @@ describe('sql-injection-analyzer with mysql', () => {
 
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -97,7 +97,7 @@ describe('sql-injection-analyzer with mysql', () => {
 
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -29,7 +29,7 @@ describe('sql-injection-analyzer with mysql2', () => {
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -29,7 +29,7 @@ describe('sql-injection-analyzer with mysql2', () => {
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -29,7 +29,7 @@ describe('sql-injection-analyzer with mysql2', () => {
       describe('has vulnerability', () => {
         testThatRequestHasVulnerability(() => {
           return new Promise((resolve, reject) => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
             let sql = 'SELECT 1'
             sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -60,7 +60,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -95,7 +95,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -107,7 +107,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -60,7 +60,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -95,7 +95,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -107,7 +107,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.pg.plugin.spec.js
@@ -5,7 +5,7 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -60,7 +60,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -95,7 +95,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')
@@ -107,7 +107,7 @@ describe('sql-injection-analyzer with pg', () => {
             })
 
             testThatRequestHasVulnerability(() => {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastCtx = iastContextFunctions.getIastContext(store)
               let sql = 'SELECT 1'
               sql = newTaintedString(iastCtx, sql, 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -34,7 +34,7 @@ describe('sql-injection-analyzer with sequelize', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let sql = 'SELECT 1'
@@ -53,7 +53,7 @@ module.exports = function (sequelize, sql) {
             const filepath = path.join(os.tmpdir(), 'test-sequelize-sqli.js')
             fs.writeFileSync(filepath, externalFileContent)
 
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let sql = 'SELECT 1'

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -34,7 +34,7 @@ describe('sql-injection-analyzer with sequelize', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let sql = 'SELECT 1'
@@ -53,7 +53,7 @@ module.exports = function (sequelize, sql) {
             const filepath = path.join(os.tmpdir(), 'test-sequelize-sqli.js')
             fs.writeFileSync(filepath, externalFileContent)
 
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let sql = 'SELECT 1'

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.sequelize.plugin.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const semver = require('semver')
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -34,7 +34,7 @@ describe('sql-injection-analyzer with sequelize', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let sql = 'SELECT 1'
@@ -53,7 +53,7 @@ module.exports = function (sequelize, sql) {
             const filepath = path.join(os.tmpdir(), 'test-sequelize-sqli.js')
             fs.writeFileSync(filepath, externalFileContent)
 
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastCtx = iastContextFunctions.getIastContext(store)
 
             let sql = 'SELECT 1'

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
@@ -136,7 +136,7 @@ describe('sql-injection-analyzer', () => {
       const datadogCore = {
         storage: () => {
           return {
-            getStore: getStore
+            getStore
           }
         }
       }

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
@@ -133,8 +133,16 @@ describe('sql-injection-analyzer', () => {
       const getStore = sinon.stub().returns(store)
       const getIastContext = sinon.stub().returns(iastContext)
 
+      const datadogCore = {
+        storage: () => {
+          return {
+            getStore: getStore
+          }
+        }
+      }
+
       const iastPlugin = proxyquire('../../../../src/appsec/iast/iast-plugin', {
-        '../../../../datadog-core': { storage: { getStore } },
+        '../../../../datadog-core': datadogCore,
         './iast-context': { getIastContext }
       })
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -79,7 +79,7 @@ describe('ssrf analyzer', () => {
             describe(requestMethodData.httpMethodName, () => {
               describe('with url', () => {
                 testThatRequestHasVulnerability(() => {
-                  const store = storage.getStore()
+                  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                   const iastContext = iastContextFunctions.getIastContext(store)
 
                   const url = newTaintedString(iastContext, pluginName + '://www.google.com', 'param', 'Request')
@@ -97,7 +97,7 @@ describe('ssrf analyzer', () => {
 
               describe('with options', () => {
                 testThatRequestHasVulnerability(() => {
-                  const store = storage.getStore()
+                  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
                   const iastContext = iastContextFunctions.getIastContext(store)
 
                   const host = newTaintedString(iastContext, 'www.google.com', 'param', 'Request')
@@ -126,7 +126,7 @@ describe('ssrf analyzer', () => {
 
       describe('http2', () => {
         testThatRequestHasVulnerability(() => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastContext = iastContextFunctions.getIastContext(store)
 
           const url = newTaintedString(iastContext, 'http://www.datadoghq.com', 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -79,7 +79,7 @@ describe('ssrf analyzer', () => {
             describe(requestMethodData.httpMethodName, () => {
               describe('with url', () => {
                 testThatRequestHasVulnerability(() => {
-                  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                  const store = storage(SPAN_NAMESPACE).getStore()
                   const iastContext = iastContextFunctions.getIastContext(store)
 
                   const url = newTaintedString(iastContext, pluginName + '://www.google.com', 'param', 'Request')
@@ -97,7 +97,7 @@ describe('ssrf analyzer', () => {
 
               describe('with options', () => {
                 testThatRequestHasVulnerability(() => {
-                  const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+                  const store = storage(SPAN_NAMESPACE).getStore()
                   const iastContext = iastContextFunctions.getIastContext(store)
 
                   const host = newTaintedString(iastContext, 'www.google.com', 'param', 'Request')
@@ -126,7 +126,7 @@ describe('ssrf analyzer', () => {
 
       describe('http2', () => {
         testThatRequestHasVulnerability(() => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastContext = iastContextFunctions.getIastContext(store)
 
           const url = newTaintedString(iastContext, 'http://www.datadoghq.com', 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -79,7 +79,7 @@ describe('ssrf analyzer', () => {
             describe(requestMethodData.httpMethodName, () => {
               describe('with url', () => {
                 testThatRequestHasVulnerability(() => {
-                  const store = storage(SPAN_NAMESPACE).getStore()
+                  const store = storage('legacy').getStore()
                   const iastContext = iastContextFunctions.getIastContext(store)
 
                   const url = newTaintedString(iastContext, pluginName + '://www.google.com', 'param', 'Request')
@@ -97,7 +97,7 @@ describe('ssrf analyzer', () => {
 
               describe('with options', () => {
                 testThatRequestHasVulnerability(() => {
-                  const store = storage(SPAN_NAMESPACE).getStore()
+                  const store = storage('legacy').getStore()
                   const iastContext = iastContextFunctions.getIastContext(store)
 
                   const host = newTaintedString(iastContext, 'www.google.com', 'param', 'Request')
@@ -126,7 +126,7 @@ describe('ssrf analyzer', () => {
 
       describe('http2', () => {
         testThatRequestHasVulnerability(() => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastContext = iastContextFunctions.getIastContext(store)
 
           const url = newTaintedString(iastContext, 'http://www.datadoghq.com', 'param', 'Request')

--- a/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.handlebars.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.handlebars.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
@@ -22,14 +22,14 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compile(template)
@@ -51,14 +51,14 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.precompile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.precompile(template)
@@ -80,7 +80,7 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const partial = newTaintedString(iastContext, source, 'param', 'Request')
 
@@ -88,7 +88,7 @@ describe('template-injection-analyzer with handlebars', () => {
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const partial = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.handlebars.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.handlebars.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
@@ -22,14 +22,14 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compile(template)
@@ -51,14 +51,14 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.precompile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.precompile(template)
@@ -80,7 +80,7 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const partial = newTaintedString(iastContext, source, 'param', 'Request')
 
@@ -88,7 +88,7 @@ describe('template-injection-analyzer with handlebars', () => {
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const partial = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.handlebars.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.handlebars.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
@@ -22,14 +22,14 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compile(template)
@@ -51,14 +51,14 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.precompile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.precompile(template)
@@ -80,7 +80,7 @@ describe('template-injection-analyzer with handlebars', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const partial = newTaintedString(iastContext, source, 'param', 'Request')
 
@@ -88,7 +88,7 @@ describe('template-injection-analyzer with handlebars', () => {
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const partial = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.pug.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.pug.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
@@ -22,14 +22,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compile(template)
@@ -52,14 +52,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compileClient(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compileClient(template)
@@ -81,14 +81,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compileClientWithDependenciesTracked(template, {})
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compileClientWithDependenciesTracked(template, {})
@@ -110,14 +110,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, source, 'param', 'Request')
             lib.render(str)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.render(str)

--- a/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.pug.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.pug.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
@@ -22,14 +22,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compile(template)
@@ -52,14 +52,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compileClient(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compileClient(template)
@@ -81,14 +81,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compileClientWithDependenciesTracked(template, {})
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compileClientWithDependenciesTracked(template, {})
@@ -110,14 +110,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, source, 'param', 'Request')
             lib.render(str)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.render(str)

--- a/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.pug.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/template-injection-analyzer.pug.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { SQL_ROW_VALUE } = require('../../../../src/appsec/iast/taint-tracking/source-types')
@@ -22,14 +22,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compile(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compile(template)
@@ -52,14 +52,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compileClient(template)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compileClient(template)
@@ -81,14 +81,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', 'Request')
             lib.compileClientWithDependenciesTracked(template, {})
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const template = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.compileClientWithDependenciesTracked(template, {})
@@ -110,14 +110,14 @@ describe('template-injection-analyzer with pug', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, source, 'param', 'Request')
             lib.render(str)
           }, 'TEMPLATE_INJECTION')
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, source, 'param', SQL_ROW_VALUE)
             lib.render(str)

--- a/packages/dd-trace/test/appsec/iast/analyzers/untrusted-deserialization-analyzer.node-serialize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/untrusted-deserialization-analyzer.node-serialize.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -21,7 +21,7 @@ describe('untrusted-deserialization-analyzer with node-serialize', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(SPAN_NAMESPACE).getStore()
+            const store = storage('legacy').getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, obj, 'query', 'Request')
             lib.unserialize(str)

--- a/packages/dd-trace/test/appsec/iast/analyzers/untrusted-deserialization-analyzer.node-serialize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/untrusted-deserialization-analyzer.node-serialize.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -21,7 +21,7 @@ describe('untrusted-deserialization-analyzer with node-serialize', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage.getStore()
+            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, obj, 'query', 'Request')
             lib.unserialize(str)

--- a/packages/dd-trace/test/appsec/iast/analyzers/untrusted-deserialization-analyzer.node-serialize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/untrusted-deserialization-analyzer.node-serialize.plugin.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { prepareTestServerForIast } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -21,7 +21,7 @@ describe('untrusted-deserialization-analyzer with node-serialize', () => {
           })
 
           testThatRequestHasVulnerability(() => {
-            const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+            const store = storage(SPAN_NAMESPACE).getStore()
             const iastContext = iastContextFunctions.getIastContext(store)
             const str = newTaintedString(iastContext, obj, 'query', 'Request')
             lib.unserialize(str)

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -28,7 +28,7 @@ describe('Unvalidated Redirect vulnerability', () => {
     prepareTestServerForIastInExpress('in express', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)
@@ -41,7 +41,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
           redirectFunctions.insecureWithResRedirectMethod(location, res)
@@ -54,7 +54,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
           redirectFunctions.insecureWithResLocationMethod(location, res)
@@ -67,7 +67,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasNoVulnerability((req, res) => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'pathParam', 'Request')
           res.header('X-test', location)

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -28,7 +28,7 @@ describe('Unvalidated Redirect vulnerability', () => {
     prepareTestServerForIastInExpress('in express', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)
@@ -41,7 +41,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
           redirectFunctions.insecureWithResRedirectMethod(location, res)
@@ -54,7 +54,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
           redirectFunctions.insecureWithResLocationMethod(location, res)
@@ -67,7 +67,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasNoVulnerability((req, res) => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'pathParam', 'Request')
           res.header('X-test', location)

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -28,7 +28,7 @@ describe('Unvalidated Redirect vulnerability', () => {
     prepareTestServerForIastInExpress('in express', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)
@@ -41,7 +41,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
           redirectFunctions.insecureWithResRedirectMethod(location, res)
@@ -54,7 +54,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
           redirectFunctions.insecureWithResLocationMethod(location, res)
@@ -67,7 +67,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         })
 
         testThatRequestHasNoVulnerability((req, res) => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'http://user@app.com/', 'pathParam', 'Request')
           res.header('X-test', location)

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -45,7 +45,7 @@ describe('Vulnerability Analyzer plugin', () => {
     prepareTestServerForIastInExpress('should find original source line minified or not', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectMinFunctions.insecureWithResHeaderMethod('location', location, res)
@@ -58,7 +58,7 @@ describe('Vulnerability Analyzer plugin', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -45,7 +45,7 @@ describe('Vulnerability Analyzer plugin', () => {
     prepareTestServerForIastInExpress('should find original source line minified or not', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectMinFunctions.insecureWithResHeaderMethod('location', location, res)
@@ -58,7 +58,7 @@ describe('Vulnerability Analyzer plugin', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
 
@@ -45,7 +45,7 @@ describe('Vulnerability Analyzer plugin', () => {
     prepareTestServerForIastInExpress('should find original source line minified or not', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectMinFunctions.insecureWithResHeaderMethod('location', location, res)
@@ -58,7 +58,7 @@ describe('Vulnerability Analyzer plugin', () => {
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           const iastCtx = iastContextFunctions.getIastContext(store)
           const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)

--- a/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
@@ -120,7 +120,7 @@ describe('IastContextPlugin', () => {
     let getStore
 
     beforeEach(() => {
-      getStore = sinon.stub(storage, 'getStore')
+      getStore = sinon.stub(storage('legacy'), 'getStore')
       getStore.returns(store)
     })
 
@@ -203,7 +203,7 @@ describe('IastContextPlugin', () => {
     const store = {}
 
     beforeEach(() => {
-      sinon.stub(storage, 'getStore').returns(store)
+      sinon.stub(storage('legacy'), 'getStore').returns(store)
     })
 
     it('should send the vulnerabilities if any', () => {

--- a/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
@@ -3,7 +3,7 @@
 const proxyquire = require('proxyquire')
 const { IastPlugin } = require('../../../../src/appsec/iast/iast-plugin')
 const { TagKey } = require('../../../../src/appsec/iast/telemetry/iast-metric')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const { IAST_ENABLED_TAG_KEY } = require('../../../../src/appsec/iast/tags')
 
 describe('IastContextPlugin', () => {

--- a/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
@@ -3,7 +3,7 @@
 const proxyquire = require('proxyquire')
 const { IastPlugin } = require('../../../../src/appsec/iast/iast-plugin')
 const { TagKey } = require('../../../../src/appsec/iast/telemetry/iast-metric')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const { IAST_ENABLED_TAG_KEY } = require('../../../../src/appsec/iast/tags')
 
 describe('IastContextPlugin', () => {

--- a/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/context/context-plugin.spec.js
@@ -3,7 +3,7 @@
 const proxyquire = require('proxyquire')
 const { IastPlugin } = require('../../../../src/appsec/iast/iast-plugin')
 const { TagKey } = require('../../../../src/appsec/iast/telemetry/iast-metric')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const { IAST_ENABLED_TAG_KEY } = require('../../../../src/appsec/iast/tags')
 
 describe('IastContextPlugin', () => {

--- a/packages/dd-trace/test/appsec/iast/iast-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-plugin.spec.js
@@ -12,7 +12,7 @@ const SOURCE_TYPE = TagKey.SOURCE_TYPE
 describe('IAST Plugin', () => {
   const loadChannel = channel('dd-trace:instrumentation:load')
 
-  let logError, addSubMock, getIastContext, configureMock, datadogCore
+  let logError, addSubMock, getIastContext, configureMock, legacyStorage
 
   const handler = () => {
     throw new Error('handler error')
@@ -44,12 +44,8 @@ describe('IAST Plugin', () => {
         }
       }
 
-      datadogCore = {
-        storage: () => {
-          return {
-            getStore: () => sinon.stub()
-          }
-        }
+      legacyStorage = {
+        getStore: () => sinon.stub()
       }
 
       const iastPluginMod = proxyquire('../../../src/appsec/iast/iast-plugin', {
@@ -64,7 +60,7 @@ describe('IAST Plugin', () => {
           isEnabled: () => false
         },
         './telemetry/metrics': {},
-        '../../../../datadog-core': datadogCore
+        '../../../../datadog-core': { storage: () => legacyStorage }
       })
       iastPlugin = new iastPluginMod.IastPlugin()
     })

--- a/packages/dd-trace/test/appsec/iast/iast-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-plugin.spec.js
@@ -45,8 +45,10 @@ describe('IAST Plugin', () => {
       }
 
       datadogCore = {
-        storage: {
-          getStore: sinon.stub()
+        storage: () => {
+          return {
+            getStore: () => sinon.stub()
+          }
         }
       }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.spec.js
@@ -27,8 +27,10 @@ describe('IAST Taint tracking plugin', () => {
   const store = {}
 
   const datadogCore = {
-    storage: {
-      getStore: () => store
+    storage: () => {
+      return {
+        getStore: () => store
+      }
     }
   }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
@@ -2,7 +2,7 @@
 
 const axios = require('axios')
 const Config = require('../../../../../src/config')
-const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -16,7 +16,7 @@ describe('Cookies sourcing with cookies', () => {
   let cookie
   withVersions('cookie', 'cookie', version => {
     function app () {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const rawCookies = 'cookie=value'

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
@@ -2,7 +2,7 @@
 
 const axios = require('axios')
 const Config = require('../../../../../src/config')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -16,7 +16,7 @@ describe('Cookies sourcing with cookies', () => {
   let cookie
   withVersions('cookie', 'cookie', version => {
     function app () {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const rawCookies = 'cookie=value'

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.cookie.plugin.spec.js
@@ -2,7 +2,7 @@
 
 const axios = require('axios')
 const Config = require('../../../../../src/config')
-const { storage } = require('../../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -16,7 +16,7 @@ describe('Cookies sourcing with cookies', () => {
   let cookie
   withVersions('cookie', 'cookie', version => {
     function app () {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const rawCookies = 'cookie=value'

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -4,7 +4,7 @@ const axios = require('axios')
 const semver = require('semver')
 const agent = require('../../../../plugins/agent')
 const Config = require('../../../../../src/config')
-const { storage } = require('../../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -50,7 +50,7 @@ describe('URI sourcing with express', () => {
       const app = express()
       const pathPattern = semver.intersects(version, '>=5.0.0') ? '/path/*splat' : '/path/*'
       app.get(pathPattern, (req, res) => {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const isPathTainted = isTainted(iastContext, req.url)
         expect(isPathTainted).to.be.true
@@ -78,7 +78,7 @@ describe('Path params sourcing with express', () => {
 
   withVersions('express', 'express', version => {
     const checkParamIsTaintedAndNext = (req, res, next, param, name) => {
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const pathParamValue = name ? req.params[name] : req.params
@@ -123,7 +123,7 @@ describe('Path params sourcing with express', () => {
     it('should taint path params', function (done) {
       const app = express()
       app.get('/:parameter1/:parameter2', (req, res) => {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         for (const pathParamName of ['parameter1', 'parameter2']) {
@@ -156,7 +156,7 @@ describe('Path params sourcing with express', () => {
       const nestedRouter = express.Router({ mergeParams: true })
 
       nestedRouter.get('/:parameterChild', (req, res) => {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         for (const pathParamName of ['parameterParent', 'parameterChild']) {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -4,7 +4,7 @@ const axios = require('axios')
 const semver = require('semver')
 const agent = require('../../../../plugins/agent')
 const Config = require('../../../../../src/config')
-const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -50,7 +50,7 @@ describe('URI sourcing with express', () => {
       const app = express()
       const pathPattern = semver.intersects(version, '>=5.0.0') ? '/path/*splat' : '/path/*'
       app.get(pathPattern, (req, res) => {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const isPathTainted = isTainted(iastContext, req.url)
         expect(isPathTainted).to.be.true
@@ -78,7 +78,7 @@ describe('Path params sourcing with express', () => {
 
   withVersions('express', 'express', version => {
     const checkParamIsTaintedAndNext = (req, res, next, param, name) => {
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const pathParamValue = name ? req.params[name] : req.params
@@ -123,7 +123,7 @@ describe('Path params sourcing with express', () => {
     it('should taint path params', function (done) {
       const app = express()
       app.get('/:parameter1/:parameter2', (req, res) => {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         for (const pathParamName of ['parameter1', 'parameter2']) {
@@ -156,7 +156,7 @@ describe('Path params sourcing with express', () => {
       const nestedRouter = express.Router({ mergeParams: true })
 
       nestedRouter.get('/:parameterChild', (req, res) => {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         for (const pathParamName of ['parameterParent', 'parameterChild']) {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.express.plugin.spec.js
@@ -4,7 +4,7 @@ const axios = require('axios')
 const semver = require('semver')
 const agent = require('../../../../plugins/agent')
 const Config = require('../../../../../src/config')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -50,7 +50,7 @@ describe('URI sourcing with express', () => {
       const app = express()
       const pathPattern = semver.intersects(version, '>=5.0.0') ? '/path/*splat' : '/path/*'
       app.get(pathPattern, (req, res) => {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
         const isPathTainted = isTainted(iastContext, req.url)
         expect(isPathTainted).to.be.true
@@ -78,7 +78,7 @@ describe('Path params sourcing with express', () => {
 
   withVersions('express', 'express', version => {
     const checkParamIsTaintedAndNext = (req, res, next, param, name) => {
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
 
       const pathParamValue = name ? req.params[name] : req.params
@@ -123,7 +123,7 @@ describe('Path params sourcing with express', () => {
     it('should taint path params', function (done) {
       const app = express()
       app.get('/:parameter1/:parameter2', (req, res) => {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         for (const pathParamName of ['parameter1', 'parameter2']) {
@@ -156,7 +156,7 @@ describe('Path params sourcing with express', () => {
       const nestedRouter = express.Router({ mergeParams: true })
 
       nestedRouter.get('/:parameterChild', (req, res) => {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         for (const pathParamName of ['parameterParent', 'parameterChild']) {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.headers.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.headers.spec.js
@@ -2,7 +2,7 @@
 
 const axios = require('axios')
 const Config = require('../../../../../src/config')
-const { storage } = require('../../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -11,7 +11,7 @@ const { testInRequest } = require('../../utils')
 
 describe('Headers sourcing', () => {
   function app (req) {
-    const store = storage.getStore()
+    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
     const iastContext = iastContextFunctions.getIastContext(store)
 
     Object.keys(req.headers).forEach(headerName => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.headers.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.headers.spec.js
@@ -2,7 +2,7 @@
 
 const axios = require('axios')
 const Config = require('../../../../../src/config')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -11,7 +11,7 @@ const { testInRequest } = require('../../utils')
 
 describe('Headers sourcing', () => {
   function app (req) {
-    const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+    const store = storage(SPAN_NAMESPACE).getStore()
     const iastContext = iastContextFunctions.getIastContext(store)
 
     Object.keys(req.headers).forEach(headerName => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.headers.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.headers.spec.js
@@ -2,7 +2,7 @@
 
 const axios = require('axios')
 const Config = require('../../../../../src/config')
-const { storage, SPAN_NAMESPACE } = require('../../../../../../datadog-core')
+const { storage } = require('../../../../../../datadog-core')
 const iast = require('../../../../../src/appsec/iast')
 const iastContextFunctions = require('../../../../../src/appsec/iast/iast-context')
 const { isTainted, getRanges } = require('../../../../../src/appsec/iast/taint-tracking/operations')
@@ -11,7 +11,7 @@ const { testInRequest } = require('../../utils')
 
 describe('Headers sourcing', () => {
   function app (req) {
-    const store = storage(SPAN_NAMESPACE).getStore()
+    const store = storage('legacy').getStore()
     const iastContext = iastContextFunctions.getIastContext(store)
 
     Object.keys(req.headers).forEach(headerName => {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString, isTainted, getRanges } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -66,7 +66,7 @@ describe('TaintTracking', () => {
         commands.forEach((command) => {
           describe(`with command: '${command}'`, () => {
             testThatRequestHasVulnerability(function () {
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
@@ -93,7 +93,7 @@ describe('TaintTracking', () => {
 
     describe('using JSON.parse', () => {
       testThatRequestHasVulnerability(function () {
-        const store = storage(SPAN_NAMESPACE).getStore()
+        const store = storage('legacy').getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         const json = '{"command":"ls -la"}'

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString, isTainted, getRanges } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -66,7 +66,7 @@ describe('TaintTracking', () => {
         commands.forEach((command) => {
           describe(`with command: '${command}'`, () => {
             testThatRequestHasVulnerability(function () {
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
@@ -93,7 +93,7 @@ describe('TaintTracking', () => {
 
     describe('using JSON.parse', () => {
       testThatRequestHasVulnerability(function () {
-        const store = storage.getStore()
+        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         const json = '{"command":"ls -la"}'

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-impl.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString, isTainted, getRanges } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -66,7 +66,7 @@ describe('TaintTracking', () => {
         commands.forEach((command) => {
           describe(`with command: '${command}'`, () => {
             testThatRequestHasVulnerability(function () {
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
@@ -93,7 +93,7 @@ describe('TaintTracking', () => {
 
     describe('using JSON.parse', () => {
       testThatRequestHasVulnerability(function () {
-        const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+        const store = storage(SPAN_NAMESPACE).getStore()
         const iastContext = iastContextFunctions.getIastContext(store)
 
         const json = '{"command":"ls -la"}'

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -45,8 +45,10 @@ describe('IAST TaintTracking Operations', () => {
   const store = {}
 
   const datadogCore = {
-    storage: {
-      getStore: () => store
+    storage: () => {
+      return {
+        getStore: () => store
+      }
     }
   }
 
@@ -531,8 +533,10 @@ describe('IAST TaintTracking Operations', () => {
 
     it('Should not call taintedUtils.trim method if an Error happens', () => {
       const datadogCoreErr = {
-        storage: {
-          getStore: () => { throw new Error() }
+        storage: () => {
+          return {
+            getStore: () => { throw new Error() }
+          }
         }
       }
       const taintTrackingImpl = proxyquire('../../../../src/appsec/iast/taint-tracking/taint-tracking-impl', {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking-operations.spec.js
@@ -44,12 +44,8 @@ describe('IAST TaintTracking Operations', () => {
 
   const store = {}
 
-  const datadogCore = {
-    storage: () => {
-      return {
-        getStore: () => store
-      }
-    }
+  const legacyStorage = {
+    getStore: () => store
   }
 
   beforeEach(() => {
@@ -60,11 +56,11 @@ describe('IAST TaintTracking Operations', () => {
     taintTrackingImpl = proxyquire('../../../../src/appsec/iast/taint-tracking/taint-tracking-impl', {
       '@datadog/native-iast-taint-tracking': taintedUtilsMock,
       './operations-taint-object': operationsTaintObject,
-      '../../../../../datadog-core': datadogCore
+      '../../../../../datadog-core': { storage: () => legacyStorage }
     })
     taintTrackingOperations = proxyquire('../../../../src/appsec/iast/taint-tracking/operations', {
       '@datadog/native-iast-taint-tracking': taintedUtilsMock,
-      '../../../../../datadog-core': datadogCore,
+      '../../../../../datadog-core': { storage: () => legacyStorage },
       './taint-tracking-impl': taintTrackingImpl,
       './operations-taint-object': operationsTaintObject,
       '../telemetry': iastTelemetry
@@ -181,7 +177,7 @@ describe('IAST TaintTracking Operations', () => {
         '../../../log': logSpy
       })
       const taintTrackingOperations = proxyquire('../../../../src/appsec/iast/taint-tracking/operations', {
-        '../../../../../datadog-core': datadogCore,
+        '../../../../../datadog-core': { storage: () => legacyStorage },
         './taint-tracking-impl': taintTrackingImpl,
         './operations-taint-object': operationsTaintObject
       })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString, isTainted } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -53,7 +53,7 @@ describe('TaintTracking lodash', () => {
           describe(`with command: '${command}'`, () => {
             testThatRequestHasVulnerability(function () {
               const _ = require('../../../../../../versions/lodash').get()
-              const store = storage.getStore()
+              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
@@ -82,7 +82,7 @@ describe('TaintTracking lodash', () => {
   describe('lodash method with no taint tracking', () => {
     it('should return the original result', () => {
       const _ = require('../../../../../../versions/lodash').get()
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
       const taintedValue = newTaintedString(iastContext, 'tainted', 'param', 'Request')
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
-const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
+const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString, isTainted } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -53,7 +53,7 @@ describe('TaintTracking lodash', () => {
           describe(`with command: '${command}'`, () => {
             testThatRequestHasVulnerability(function () {
               const _ = require('../../../../../../versions/lodash').get()
-              const store = storage(SPAN_NAMESPACE).getStore()
+              const store = storage('legacy').getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
@@ -82,7 +82,7 @@ describe('TaintTracking lodash', () => {
   describe('lodash method with no taint tracking', () => {
     it('should return the original result', () => {
       const _ = require('../../../../../../versions/lodash').get()
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
       const taintedValue = newTaintedString(iastContext, 'tainted', 'param', 'Request')
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/taint-tracking.lodash.plugin.spec.js
@@ -4,7 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { prepareTestServerForIast, copyFileToTmp } = require('../utils')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
 const { newTaintedString, isTainted } = require('../../../../src/appsec/iast/taint-tracking/operations')
 const { clearCache } = require('../../../../src/appsec/iast/vulnerability-reporter')
@@ -53,7 +53,7 @@ describe('TaintTracking lodash', () => {
           describe(`with command: '${command}'`, () => {
             testThatRequestHasVulnerability(function () {
               const _ = require('../../../../../../versions/lodash').get()
-              const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+              const store = storage(SPAN_NAMESPACE).getStore()
               const iastContext = iastContextFunctions.getIastContext(store)
               const commandTainted = newTaintedString(iastContext, command, 'param', 'Request')
 
@@ -82,7 +82,7 @@ describe('TaintTracking lodash', () => {
   describe('lodash method with no taint tracking', () => {
     it('should return the original result', () => {
       const _ = require('../../../../../../versions/lodash').get()
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
       const iastContext = iastContextFunctions.getIastContext(store)
       const taintedValue = newTaintedString(iastContext, 'tainted', 'param', 'Request')
 

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -820,7 +820,7 @@ describe('AppSec Index', function () {
     describe('onPassportVerify', () => {
       beforeEach(() => {
         web.root.resetHistory()
-        sinon.stub(storage, 'getStore').returns({ req })
+        sinon.stub(storage('legacy'), 'getStore').returns({ req })
       })
 
       it('should block when UserTracking.trackLogin() returns action', () => {
@@ -902,7 +902,7 @@ describe('AppSec Index', function () {
     describe('onPassportDeserializeUser', () => {
       beforeEach(() => {
         web.root.resetHistory()
-        sinon.stub(storage, 'getStore').returns({ req })
+        sinon.stub(storage('legacy'), 'getStore').returns({ req })
       })
 
       it('should block when UserTracking.trackUser() returns action', () => {

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -26,7 +26,7 @@ const agent = require('../plugins/agent')
 const Config = require('../../src/config')
 const axios = require('axios')
 const blockedTemplate = require('../../src/appsec/blocked_templates')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../../src/telemetry/metrics')
 const addresses = require('../../src/appsec/addresses')
 
@@ -837,7 +837,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackLogin).to.have.been.calledOnceWithExactly(
           payload.framework,
@@ -864,7 +864,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackLogin).to.have.been.calledOnceWithExactly(
           payload.framework,
@@ -878,7 +878,7 @@ describe('AppSec Index', function () {
       })
 
       it('should not block and call log if no rootSpan is found', () => {
-        storage(SPAN_NAMESPACE).getStore.returns(undefined)
+        storage('legacy').getStore.returns(undefined)
 
         const abortController = new AbortController()
         const payload = {
@@ -891,7 +891,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportVerify')
         expect(UserTracking.trackLogin).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false
@@ -916,7 +916,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
           payload.user,
@@ -937,7 +937,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
           payload.user,
@@ -948,7 +948,7 @@ describe('AppSec Index', function () {
       })
 
       it('should not block and call log if no rootSpan is found', () => {
-        storage(SPAN_NAMESPACE).getStore.returns(undefined)
+        storage('legacy').getStore.returns(undefined)
 
         const abortController = new AbortController()
         const payload = {
@@ -958,7 +958,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportDeserializeUser')
         expect(UserTracking.trackUser).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -26,7 +26,7 @@ const agent = require('../plugins/agent')
 const Config = require('../../src/config')
 const axios = require('axios')
 const blockedTemplate = require('../../src/appsec/blocked_templates')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const telemetryMetrics = require('../../src/telemetry/metrics')
 const addresses = require('../../src/appsec/addresses')
 
@@ -837,7 +837,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackLogin).to.have.been.calledOnceWithExactly(
           payload.framework,
@@ -864,7 +864,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackLogin).to.have.been.calledOnceWithExactly(
           payload.framework,
@@ -878,7 +878,7 @@ describe('AppSec Index', function () {
       })
 
       it('should not block and call log if no rootSpan is found', () => {
-        storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+        storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
         const abortController = new AbortController()
         const payload = {
@@ -891,7 +891,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportVerify')
         expect(UserTracking.trackLogin).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false
@@ -916,7 +916,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
           payload.user,
@@ -937,7 +937,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
           payload.user,
@@ -948,7 +948,7 @@ describe('AppSec Index', function () {
       })
 
       it('should not block and call log if no rootSpan is found', () => {
-        storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+        storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
         const abortController = new AbortController()
         const payload = {
@@ -958,7 +958,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportDeserializeUser')
         expect(UserTracking.trackUser).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -26,7 +26,7 @@ const agent = require('../plugins/agent')
 const Config = require('../../src/config')
 const axios = require('axios')
 const blockedTemplate = require('../../src/appsec/blocked_templates')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const telemetryMetrics = require('../../src/telemetry/metrics')
 const addresses = require('../../src/appsec/addresses')
 
@@ -837,7 +837,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackLogin).to.have.been.calledOnceWithExactly(
           payload.framework,
@@ -864,7 +864,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackLogin).to.have.been.calledOnceWithExactly(
           payload.framework,
@@ -878,7 +878,7 @@ describe('AppSec Index', function () {
       })
 
       it('should not block and call log if no rootSpan is found', () => {
-        storage.getStore.returns(undefined)
+        storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
         const abortController = new AbortController()
         const payload = {
@@ -891,7 +891,7 @@ describe('AppSec Index', function () {
 
         passportVerify.publish(payload)
 
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportVerify')
         expect(UserTracking.trackLogin).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false
@@ -916,7 +916,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
           payload.user,
@@ -937,7 +937,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(web.root).to.have.been.calledOnceWithExactly(req)
         expect(UserTracking.trackUser).to.have.been.calledOnceWithExactly(
           payload.user,
@@ -948,7 +948,7 @@ describe('AppSec Index', function () {
       })
 
       it('should not block and call log if no rootSpan is found', () => {
-        storage.getStore.returns(undefined)
+        storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
         const abortController = new AbortController()
         const payload = {
@@ -958,7 +958,7 @@ describe('AppSec Index', function () {
 
         passportUser.publish(payload)
 
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] No rootSpan found in onPassportDeserializeUser')
         expect(UserTracking.trackUser).to.not.have.been.called
         expect(abortController.signal.aborted).to.be.false

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -55,7 +55,7 @@ describe('RASP - command_injection.js', () => {
         file: 'cmd'
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -66,7 +66,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage.getStore.returns(undefined)
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
       start.publish(ctx)
 
@@ -77,7 +77,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       start.publish(ctx)
 
@@ -89,7 +89,7 @@ describe('RASP - command_injection.js', () => {
         fileArgs: ['arg0']
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -103,7 +103,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage.getStore.returns({ req })
+        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -120,7 +120,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage.getStore.returns({ req })
+        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -137,7 +137,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage.getStore.returns({ req, res })
+        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, res })
 
         start.publish(ctx)
 
@@ -152,7 +152,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage.getStore.returns({ req })
+        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -169,7 +169,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage.getStore.returns({ req })
+        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -186,7 +186,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage.getStore.returns({ req, res })
+        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, res })
 
         start.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -3,7 +3,6 @@
 const proxyquire = require('proxyquire')
 const addresses = require('../../../src/appsec/addresses')
 const { childProcessExecutionTracingChannel } = require('../../../src/appsec/channels')
-const { SPAN_NAMESPACE } = require("../../../../datadog-core");
 
 const { start } = childProcessExecutionTracingChannel
 
@@ -58,7 +57,7 @@ describe('RASP - command_injection.js', () => {
         file: 'cmd'
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -69,7 +68,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage('legacy').getStore.returns(undefined)
 
       start.publish(ctx)
 
@@ -80,7 +79,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       start.publish(ctx)
 
@@ -92,7 +91,7 @@ describe('RASP - command_injection.js', () => {
         fileArgs: ['arg0']
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -106,7 +105,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage('legacy').getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -123,7 +122,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage('legacy').getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -140,7 +139,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, res })
+        datadogCore.storage('legacy').getStore.returns({ req, res })
 
         start.publish(ctx)
 
@@ -155,7 +154,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage('legacy').getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -172,7 +171,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage('legacy').getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -189,7 +188,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, res })
+        datadogCore.storage('legacy').getStore.returns({ req, res })
 
         start.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -55,7 +55,7 @@ describe('RASP - command_injection.js', () => {
         file: 'cmd'
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -66,7 +66,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
       start.publish(ctx)
 
@@ -77,7 +77,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       start.publish(ctx)
 
@@ -89,7 +89,7 @@ describe('RASP - command_injection.js', () => {
         fileArgs: ['arg0']
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -103,7 +103,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -120,7 +120,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -137,7 +137,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, res })
+        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, res })
 
         start.publish(ctx)
 
@@ -152,7 +152,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -169,7 +169,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -186,7 +186,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, res })
+        datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, res })
 
         start.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -3,6 +3,7 @@
 const proxyquire = require('proxyquire')
 const addresses = require('../../../src/appsec/addresses')
 const { childProcessExecutionTracingChannel } = require('../../../src/appsec/channels')
+const { SPAN_NAMESPACE } = require("../../../../datadog-core");
 
 const { start } = childProcessExecutionTracingChannel
 
@@ -11,8 +12,10 @@ describe('RASP - command_injection.js', () => {
 
   beforeEach(() => {
     datadogCore = {
-      storage: {
-        getStore: sinon.stub()
+      storage: () => {
+        return {
+          getStore: sinon.stub()
+        }
       }
     }
 

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -7,15 +7,11 @@ const { childProcessExecutionTracingChannel } = require('../../../src/appsec/cha
 const { start } = childProcessExecutionTracingChannel
 
 describe('RASP - command_injection.js', () => {
-  let waf, datadogCore, commandInjection, utils, config
+  let waf, legacyStorage, commandInjection, utils, config
 
   beforeEach(() => {
-    datadogCore = {
-      storage: () => {
-        return {
-          getStore: sinon.stub()
-        }
-      }
+    legacyStorage = {
+      getStore: sinon.stub()
     }
 
     waf = {
@@ -27,7 +23,7 @@ describe('RASP - command_injection.js', () => {
     }
 
     commandInjection = proxyquire('../../../src/appsec/rasp/command_injection', {
-      '../../../../datadog-core': datadogCore,
+      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf,
       './utils': utils
     })
@@ -57,7 +53,7 @@ describe('RASP - command_injection.js', () => {
         file: 'cmd'
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -68,7 +64,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage('legacy').getStore.returns(undefined)
+      legacyStorage.getStore.returns(undefined)
 
       start.publish(ctx)
 
@@ -79,7 +75,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd'
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       start.publish(ctx)
 
@@ -91,7 +87,7 @@ describe('RASP - command_injection.js', () => {
         fileArgs: ['arg0']
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       start.publish(ctx)
 
@@ -105,7 +101,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage('legacy').getStore.returns({ req })
+        legacyStorage.getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -122,7 +118,7 @@ describe('RASP - command_injection.js', () => {
           shell: true
         }
         const req = {}
-        datadogCore.storage('legacy').getStore.returns({ req })
+        legacyStorage.getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -139,7 +135,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage('legacy').getStore.returns({ req, res })
+        legacyStorage.getStore.returns({ req, res })
 
         start.publish(ctx)
 
@@ -154,7 +150,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage('legacy').getStore.returns({ req })
+        legacyStorage.getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -171,7 +167,7 @@ describe('RASP - command_injection.js', () => {
           shell: false
         }
         const req = {}
-        datadogCore.storage('legacy').getStore.returns({ req })
+        legacyStorage.getStore.returns({ req })
 
         start.publish(ctx)
 
@@ -188,7 +184,7 @@ describe('RASP - command_injection.js', () => {
         const req = { req: 'req' }
         const res = { res: 'res' }
         waf.run.returns(wafResult)
-        datadogCore.storage('legacy').getStore.returns({ req, res })
+        legacyStorage.getStore.returns({ req, res })
 
         start.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire')
 const { assert } = require('chai')
 const path = require('path')
 const dc = require('dc-polyfill')
-const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
+const { storage } = require('../../../../datadog-core')
 const { AppsecFsPlugin } = require('../../../src/appsec/rasp/fs-plugin')
 const agent = require('../../plugins/agent')
 
@@ -95,36 +95,36 @@ describe('AppsecFsPlugin', () => {
   describe('_onFsOperationStart', () => {
     it('should mark fs root', () => {
       const origStore = {}
-      storage(SPAN_NAMESPACE).enterWith(origStore)
+      storage('legacy').enterWith(origStore)
 
       appsecFsPlugin._onFsOperationStart()
 
-      let store = storage(SPAN_NAMESPACE).getStore()
+      let store = storage('legacy').getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', origStore)
       assert.propertyVal(store.fs, 'root', true)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage(SPAN_NAMESPACE).getStore()
+      store = storage('legacy').getStore()
       assert.equal(store, origStore)
       assert.notProperty(store, 'fs')
     })
 
     it('should mark fs children', () => {
       const origStore = { orig: true }
-      storage(SPAN_NAMESPACE).enterWith(origStore)
+      storage('legacy').enterWith(origStore)
 
       appsecFsPlugin._onFsOperationStart()
 
-      const rootStore = storage(SPAN_NAMESPACE).getStore()
+      const rootStore = storage('legacy').getStore()
       assert.property(rootStore, 'fs')
       assert.propertyVal(rootStore.fs, 'parentStore', origStore)
       assert.propertyVal(rootStore.fs, 'root', true)
 
       appsecFsPlugin._onFsOperationStart()
 
-      let store = storage(SPAN_NAMESPACE).getStore()
+      let store = storage('legacy').getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', rootStore)
       assert.propertyVal(store.fs, 'root', false)
@@ -132,11 +132,11 @@ describe('AppsecFsPlugin', () => {
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage(SPAN_NAMESPACE).getStore()
+      store = storage('legacy').getStore()
       assert.equal(store, rootStore)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
-      store = storage(SPAN_NAMESPACE).getStore()
+      store = storage('legacy').getStore()
       assert.equal(store, origStore)
     })
   })
@@ -146,18 +146,18 @@ describe('AppsecFsPlugin', () => {
       appsecFsPlugin.enable()
 
       const origStore = {}
-      storage(SPAN_NAMESPACE).enterWith(origStore)
+      storage('legacy').enterWith(origStore)
 
       appsecFsPlugin._onResponseRenderStart()
 
-      let store = storage(SPAN_NAMESPACE).getStore()
+      let store = storage('legacy').getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', origStore)
       assert.propertyVal(store.fs, 'opExcluded', true)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage(SPAN_NAMESPACE).getStore()
+      store = storage('legacy').getStore()
       assert.equal(store, origStore)
       assert.notProperty(store, 'fs')
     })
@@ -176,7 +176,7 @@ describe('AppsecFsPlugin', () => {
       it('should mark root operations', () => {
         let count = 0
         const onStart = () => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           assert.isNotNull(store.fs)
 
           count++
@@ -185,7 +185,7 @@ describe('AppsecFsPlugin', () => {
 
         try {
           const origStore = {}
-          storage(SPAN_NAMESPACE).enterWith(origStore)
+          storage('legacy').enterWith(origStore)
 
           opStartCh.subscribe(onStart)
 
@@ -200,7 +200,7 @@ describe('AppsecFsPlugin', () => {
       it('should mark root even if op is excluded', () => {
         let count = 0
         const onStart = () => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           assert.isNotNull(store.fs)
 
           count++
@@ -211,7 +211,7 @@ describe('AppsecFsPlugin', () => {
           const origStore = {
             fs: { opExcluded: true }
           }
-          storage(SPAN_NAMESPACE).enterWith(origStore)
+          storage('legacy').enterWith(origStore)
 
           opStartCh.subscribe(onStart)
 
@@ -226,7 +226,7 @@ describe('AppsecFsPlugin', () => {
       it('should clean up store when finishing op', () => {
         let count = 4
         const onFinish = () => {
-          const store = storage(SPAN_NAMESPACE).getStore()
+          const store = storage('legacy').getStore()
           count--
 
           if (count === 0) {
@@ -235,7 +235,7 @@ describe('AppsecFsPlugin', () => {
         }
         try {
           const origStore = {}
-          storage(SPAN_NAMESPACE).enterWith(origStore)
+          storage('legacy').enterWith(origStore)
 
           opFinishCh.subscribe(onFinish)
 

--- a/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire')
 const { assert } = require('chai')
 const path = require('path')
 const dc = require('dc-polyfill')
-const { storage } = require('../../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
 const { AppsecFsPlugin } = require('../../../src/appsec/rasp/fs-plugin')
 const agent = require('../../plugins/agent')
 
@@ -95,36 +95,36 @@ describe('AppsecFsPlugin', () => {
   describe('_onFsOperationStart', () => {
     it('should mark fs root', () => {
       const origStore = {}
-      storage.enterWith(origStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
 
       appsecFsPlugin._onFsOperationStart()
 
-      let store = storage.getStore()
+      let store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', origStore)
       assert.propertyVal(store.fs, 'root', true)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage.getStore()
+      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.equal(store, origStore)
       assert.notProperty(store, 'fs')
     })
 
     it('should mark fs children', () => {
       const origStore = { orig: true }
-      storage.enterWith(origStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
 
       appsecFsPlugin._onFsOperationStart()
 
-      const rootStore = storage.getStore()
+      const rootStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.property(rootStore, 'fs')
       assert.propertyVal(rootStore.fs, 'parentStore', origStore)
       assert.propertyVal(rootStore.fs, 'root', true)
 
       appsecFsPlugin._onFsOperationStart()
 
-      let store = storage.getStore()
+      let store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', rootStore)
       assert.propertyVal(store.fs, 'root', false)
@@ -132,11 +132,11 @@ describe('AppsecFsPlugin', () => {
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage.getStore()
+      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.equal(store, rootStore)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
-      store = storage.getStore()
+      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.equal(store, origStore)
     })
   })
@@ -146,18 +146,18 @@ describe('AppsecFsPlugin', () => {
       appsecFsPlugin.enable()
 
       const origStore = {}
-      storage.enterWith(origStore)
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
 
       appsecFsPlugin._onResponseRenderStart()
 
-      let store = storage.getStore()
+      let store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', origStore)
       assert.propertyVal(store.fs, 'opExcluded', true)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage.getStore()
+      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
       assert.equal(store, origStore)
       assert.notProperty(store, 'fs')
     })
@@ -176,7 +176,7 @@ describe('AppsecFsPlugin', () => {
       it('should mark root operations', () => {
         let count = 0
         const onStart = () => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           assert.isNotNull(store.fs)
 
           count++
@@ -185,7 +185,7 @@ describe('AppsecFsPlugin', () => {
 
         try {
           const origStore = {}
-          storage.enterWith(origStore)
+          storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
 
           opStartCh.subscribe(onStart)
 
@@ -200,7 +200,7 @@ describe('AppsecFsPlugin', () => {
       it('should mark root even if op is excluded', () => {
         let count = 0
         const onStart = () => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           assert.isNotNull(store.fs)
 
           count++
@@ -211,7 +211,7 @@ describe('AppsecFsPlugin', () => {
           const origStore = {
             fs: { opExcluded: true }
           }
-          storage.enterWith(origStore)
+          storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
 
           opStartCh.subscribe(onStart)
 
@@ -226,7 +226,7 @@ describe('AppsecFsPlugin', () => {
       it('should clean up store when finishing op', () => {
         let count = 4
         const onFinish = () => {
-          const store = storage.getStore()
+          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
           count--
 
           if (count === 0) {
@@ -235,7 +235,7 @@ describe('AppsecFsPlugin', () => {
         }
         try {
           const origStore = {}
-          storage.enterWith(origStore)
+          storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
 
           opFinishCh.subscribe(onFinish)
 

--- a/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
@@ -4,7 +4,7 @@ const proxyquire = require('proxyquire')
 const { assert } = require('chai')
 const path = require('path')
 const dc = require('dc-polyfill')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../../datadog-core')
 const { AppsecFsPlugin } = require('../../../src/appsec/rasp/fs-plugin')
 const agent = require('../../plugins/agent')
 
@@ -95,36 +95,36 @@ describe('AppsecFsPlugin', () => {
   describe('_onFsOperationStart', () => {
     it('should mark fs root', () => {
       const origStore = {}
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
+      storage(SPAN_NAMESPACE).enterWith(origStore)
 
       appsecFsPlugin._onFsOperationStart()
 
-      let store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      let store = storage(SPAN_NAMESPACE).getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', origStore)
       assert.propertyVal(store.fs, 'root', true)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      store = storage(SPAN_NAMESPACE).getStore()
       assert.equal(store, origStore)
       assert.notProperty(store, 'fs')
     })
 
     it('should mark fs children', () => {
       const origStore = { orig: true }
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
+      storage(SPAN_NAMESPACE).enterWith(origStore)
 
       appsecFsPlugin._onFsOperationStart()
 
-      const rootStore = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const rootStore = storage(SPAN_NAMESPACE).getStore()
       assert.property(rootStore, 'fs')
       assert.propertyVal(rootStore.fs, 'parentStore', origStore)
       assert.propertyVal(rootStore.fs, 'root', true)
 
       appsecFsPlugin._onFsOperationStart()
 
-      let store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      let store = storage(SPAN_NAMESPACE).getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', rootStore)
       assert.propertyVal(store.fs, 'root', false)
@@ -132,11 +132,11 @@ describe('AppsecFsPlugin', () => {
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      store = storage(SPAN_NAMESPACE).getStore()
       assert.equal(store, rootStore)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
-      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      store = storage(SPAN_NAMESPACE).getStore()
       assert.equal(store, origStore)
     })
   })
@@ -146,18 +146,18 @@ describe('AppsecFsPlugin', () => {
       appsecFsPlugin.enable()
 
       const origStore = {}
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
+      storage(SPAN_NAMESPACE).enterWith(origStore)
 
       appsecFsPlugin._onResponseRenderStart()
 
-      let store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      let store = storage(SPAN_NAMESPACE).getStore()
       assert.property(store, 'fs')
       assert.propertyVal(store.fs, 'parentStore', origStore)
       assert.propertyVal(store.fs, 'opExcluded', true)
 
       appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      store = storage(SPAN_NAMESPACE).getStore()
       assert.equal(store, origStore)
       assert.notProperty(store, 'fs')
     })
@@ -176,7 +176,7 @@ describe('AppsecFsPlugin', () => {
       it('should mark root operations', () => {
         let count = 0
         const onStart = () => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           assert.isNotNull(store.fs)
 
           count++
@@ -185,7 +185,7 @@ describe('AppsecFsPlugin', () => {
 
         try {
           const origStore = {}
-          storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
+          storage(SPAN_NAMESPACE).enterWith(origStore)
 
           opStartCh.subscribe(onStart)
 
@@ -200,7 +200,7 @@ describe('AppsecFsPlugin', () => {
       it('should mark root even if op is excluded', () => {
         let count = 0
         const onStart = () => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           assert.isNotNull(store.fs)
 
           count++
@@ -211,7 +211,7 @@ describe('AppsecFsPlugin', () => {
           const origStore = {
             fs: { opExcluded: true }
           }
-          storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
+          storage(SPAN_NAMESPACE).enterWith(origStore)
 
           opStartCh.subscribe(onStart)
 
@@ -226,7 +226,7 @@ describe('AppsecFsPlugin', () => {
       it('should clean up store when finishing op', () => {
         let count = 4
         const onFinish = () => {
-          const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+          const store = storage(SPAN_NAMESPACE).getStore()
           count--
 
           if (count === 0) {
@@ -235,7 +235,7 @@ describe('AppsecFsPlugin', () => {
         }
         try {
           const origStore = {}
-          storage(LEGACY_STORAGE_NAMESPACE).enterWith(origStore)
+          storage(SPAN_NAMESPACE).enterWith(origStore)
 
           opFinishCh.subscribe(onFinish)
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -106,7 +106,7 @@ describe('RASP - lfi.js', () => {
 
     it('should analyze lfi for root fs operations', () => {
       const fs = { root: true }
-      datadogCore.storage.getStore.returns({ req, fs })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -116,7 +116,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for child fs operations', () => {
       const fs = {}
-      datadogCore.storage.getStore.returns({ req, fs })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -125,7 +125,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for undefined fs (AppsecFsPlugin disabled)', () => {
       const fs = undefined
-      datadogCore.storage.getStore.returns({ req, fs })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -134,7 +134,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for excluded operations', () => {
       const fs = { opExcluded: true, root: true }
-      datadogCore.storage.getStore.returns({ req, fs })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -5,14 +5,17 @@ const { assert } = require('chai')
 const { fsOperationStart, incomingHttpRequestStart } = require('../../../src/appsec/channels')
 const { FS_OPERATION_PATH } = require('../../../src/appsec/addresses')
 const { RASP_MODULE } = require('../../../src/appsec/rasp/fs-plugin')
+const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 describe('RASP - lfi.js', () => {
   let waf, datadogCore, lfi, web, blocking, appsecFsPlugin, config
 
   beforeEach(() => {
     datadogCore = {
-      storage: {
-        getStore: sinon.stub()
+      storage: () => {
+        return {
+          getStore: sinon.stub()
+        }
       }
     }
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -106,7 +106,7 @@ describe('RASP - lfi.js', () => {
 
     it('should analyze lfi for root fs operations', () => {
       const fs = { root: true }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -116,7 +116,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for child fs operations', () => {
       const fs = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -125,7 +125,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for undefined fs (AppsecFsPlugin disabled)', () => {
       const fs = undefined
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -134,7 +134,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for excluded operations', () => {
       const fs = { opExcluded: true, root: true }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -5,7 +5,6 @@ const { assert } = require('chai')
 const { fsOperationStart, incomingHttpRequestStart } = require('../../../src/appsec/channels')
 const { FS_OPERATION_PATH } = require('../../../src/appsec/addresses')
 const { RASP_MODULE } = require('../../../src/appsec/rasp/fs-plugin')
-const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 describe('RASP - lfi.js', () => {
   let waf, datadogCore, lfi, web, blocking, appsecFsPlugin, config
@@ -109,7 +108,7 @@ describe('RASP - lfi.js', () => {
 
     it('should analyze lfi for root fs operations', () => {
       const fs = { root: true }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage('legacy').getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -119,7 +118,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for child fs operations', () => {
       const fs = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage('legacy').getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -128,7 +127,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for undefined fs (AppsecFsPlugin disabled)', () => {
       const fs = undefined
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage('legacy').getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 
@@ -137,7 +136,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for excluded operations', () => {
       const fs = { opExcluded: true, root: true }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req, fs })
+      datadogCore.storage('legacy').getStore.returns({ req, fs })
 
       fsOperationStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -3,14 +3,17 @@
 const { pgQueryStart, mysql2OuterQueryStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
 const proxyquire = require('proxyquire')
+const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 describe('RASP - sql_injection', () => {
   let waf, datadogCore, sqli
 
   beforeEach(() => {
     datadogCore = {
-      storage: {
-        getStore: sinon.stub()
+      storage: () => {
+        return {
+          getStore: sinon.stub()
+        }
       }
     }
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -5,15 +5,11 @@ const addresses = require('../../../src/appsec/addresses')
 const proxyquire = require('proxyquire')
 
 describe('RASP - sql_injection', () => {
-  let waf, datadogCore, sqli
+  let waf, legacyStorage, sqli
 
   beforeEach(() => {
-    datadogCore = {
-      storage: () => {
-        return {
-          getStore: sinon.stub()
-        }
-      }
+    legacyStorage = {
+      getStore: sinon.stub()
     }
 
     waf = {
@@ -21,7 +17,7 @@ describe('RASP - sql_injection', () => {
     }
 
     sqli = proxyquire('../../../src/appsec/rasp/sql_injection', {
-      '../../../../datadog-core': datadogCore,
+      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf
     })
 
@@ -51,7 +47,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -71,7 +67,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -84,7 +80,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage('legacy').getStore.returns(undefined)
+      legacyStorage.getStore.returns(undefined)
 
       pgQueryStart.publish(ctx)
 
@@ -97,7 +93,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -108,7 +104,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         query: {}
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -122,7 +118,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -140,7 +136,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -151,7 +147,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage('legacy').getStore.returns(undefined)
+      legacyStorage.getStore.returns(undefined)
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -162,7 +158,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -173,7 +169,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -49,7 +49,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -69,7 +69,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -82,7 +82,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage.getStore.returns(undefined)
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
       pgQueryStart.publish(ctx)
 
@@ -95,7 +95,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -106,7 +106,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         query: {}
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -120,7 +120,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -138,7 +138,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -149,7 +149,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage.getStore.returns(undefined)
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -160,7 +160,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -171,7 +171,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -3,7 +3,6 @@
 const { pgQueryStart, mysql2OuterQueryStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
 const proxyquire = require('proxyquire')
-const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 describe('RASP - sql_injection', () => {
   let waf, datadogCore, sqli
@@ -52,7 +51,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -72,7 +71,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -85,7 +84,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage('legacy').getStore.returns(undefined)
 
       pgQueryStart.publish(ctx)
 
@@ -98,7 +97,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -109,7 +108,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         query: {}
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -123,7 +122,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -141,7 +140,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -152,7 +151,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage('legacy').getStore.returns(undefined)
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -163,7 +162,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -174,7 +173,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -49,7 +49,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -69,7 +69,7 @@ describe('RASP - sql_injection', () => {
         }
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       pgQueryStart.publish(ctx)
 
@@ -82,7 +82,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
       pgQueryStart.publish(ctx)
 
@@ -95,7 +95,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1'
         }
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -106,7 +106,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         query: {}
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       pgQueryStart.publish(ctx)
 
@@ -120,7 +120,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -138,7 +138,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1'
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -149,7 +149,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -160,7 +160,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -171,7 +171,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1'
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       mysql2OuterQueryStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -5,15 +5,11 @@ const { httpClientRequestStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
 
 describe('RASP - ssrf.js', () => {
-  let waf, datadogCore, ssrf
+  let waf, legacyStorage, ssrf
 
   beforeEach(() => {
-    datadogCore = {
-      storage: () => {
-        return {
-          getStore: sinon.stub()
-        }
-      }
+    legacyStorage = {
+      getStore: sinon.stub()
     }
 
     waf = {
@@ -21,7 +17,7 @@ describe('RASP - ssrf.js', () => {
     }
 
     ssrf = proxyquire('../../../src/appsec/rasp/ssrf', {
-      '../../../../datadog-core': datadogCore,
+      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf
     })
 
@@ -51,7 +47,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -67,7 +63,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage('legacy').getStore.returns({ req })
+      legacyStorage.getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -80,7 +76,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage('legacy').getStore.returns(undefined)
+      legacyStorage.getStore.returns(undefined)
 
       httpClientRequestStart.publish(ctx)
 
@@ -93,7 +89,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 
@@ -104,7 +100,7 @@ describe('RASP - ssrf.js', () => {
       const ctx = {
         args: {}
       }
-      datadogCore.storage('legacy').getStore.returns({})
+      legacyStorage.getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -3,14 +3,17 @@
 const proxyquire = require('proxyquire')
 const { httpClientRequestStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
+const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 describe('RASP - ssrf.js', () => {
   let waf, datadogCore, ssrf
 
   beforeEach(() => {
     datadogCore = {
-      storage: {
-        getStore: sinon.stub()
+      storage: () => {
+        return {
+          getStore: sinon.stub()
+        }
       }
     }
 

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -3,7 +3,6 @@
 const proxyquire = require('proxyquire')
 const { httpClientRequestStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
-const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 describe('RASP - ssrf.js', () => {
   let waf, datadogCore, ssrf
@@ -52,7 +51,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -68,7 +67,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage('legacy').getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -81,7 +80,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage('legacy').getStore.returns(undefined)
 
       httpClientRequestStart.publish(ctx)
 
@@ -94,7 +93,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 
@@ -105,7 +104,7 @@ describe('RASP - ssrf.js', () => {
       const ctx = {
         args: {}
       }
-      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
+      datadogCore.storage('legacy').getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -49,7 +49,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -65,7 +65,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage.getStore.returns({ req })
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -78,7 +78,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage.getStore.returns(undefined)
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
       httpClientRequestStart.publish(ctx)
 
@@ -91,7 +91,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 
@@ -102,7 +102,7 @@ describe('RASP - ssrf.js', () => {
       const ctx = {
         args: {}
       }
-      datadogCore.storage.getStore.returns({})
+      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -49,7 +49,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -65,7 +65,7 @@ describe('RASP - ssrf.js', () => {
         }
       }
       const req = {}
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({ req })
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({ req })
 
       httpClientRequestStart.publish(ctx)
 
@@ -78,7 +78,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
       httpClientRequestStart.publish(ctx)
 
@@ -91,7 +91,7 @@ describe('RASP - ssrf.js', () => {
           uri: 'http://example.com'
         }
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 
@@ -102,7 +102,7 @@ describe('RASP - ssrf.js', () => {
       const ctx = {
         args: {}
       }
-      datadogCore.storage(LEGACY_STORAGE_NAMESPACE).getStore.returns({})
+      datadogCore.storage(SPAN_NAMESPACE).getStore.returns({})
 
       httpClientRequestStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const zlib = require('zlib')
 const { SAMPLING_MECHANISM_APPSEC } = require('../../src/constants')
 const { USER_KEEP } = require('../../../../ext/priority')
@@ -141,11 +141,11 @@ describe('reporter', () => {
 
     beforeEach(() => {
       req = {}
-      storage.enterWith({ req })
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ req })
     })
 
     afterEach(() => {
-      storage.disable()
+      storage(LEGACY_STORAGE_NAMESPACE).disable()
     })
 
     it('should do nothing when passed incomplete objects', () => {
@@ -184,7 +184,7 @@ describe('reporter', () => {
 
     it('should call updateWafRequestsMetricTags', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
       Reporter.reportMetrics(metrics)
 
@@ -194,7 +194,7 @@ describe('reporter', () => {
 
     it('should call updateRaspRequestsMetricTags when raspRule is provided', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage.getStore()
+      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
 
       const raspRule = { type: 'rule_type', variant: 'rule_variant' }
 
@@ -218,11 +218,11 @@ describe('reporter', () => {
           'user-agent': 'arachni'
         }
       }
-      storage.enterWith({ req })
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ req })
     })
 
     afterEach(() => {
-      storage.disable()
+      storage(LEGACY_STORAGE_NAMESPACE).disable()
     })
 
     it('should add tags to request span when socket is not there', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const zlib = require('zlib')
 const { SAMPLING_MECHANISM_APPSEC } = require('../../src/constants')
 const { USER_KEEP } = require('../../../../ext/priority')
@@ -141,11 +141,11 @@ describe('reporter', () => {
 
     beforeEach(() => {
       req = {}
-      storage(SPAN_NAMESPACE).enterWith({ req })
+      storage('legacy').enterWith({ req })
     })
 
     afterEach(() => {
-      storage(SPAN_NAMESPACE).disable()
+      storage('legacy').disable()
     })
 
     it('should do nothing when passed incomplete objects', () => {
@@ -184,7 +184,7 @@ describe('reporter', () => {
 
     it('should call updateWafRequestsMetricTags', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
 
       Reporter.reportMetrics(metrics)
 
@@ -194,7 +194,7 @@ describe('reporter', () => {
 
     it('should call updateRaspRequestsMetricTags when raspRule is provided', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage(SPAN_NAMESPACE).getStore()
+      const store = storage('legacy').getStore()
 
       const raspRule = { type: 'rule_type', variant: 'rule_variant' }
 
@@ -218,11 +218,11 @@ describe('reporter', () => {
           'user-agent': 'arachni'
         }
       }
-      storage(SPAN_NAMESPACE).enterWith({ req })
+      storage('legacy').enterWith({ req })
     })
 
     afterEach(() => {
-      storage(SPAN_NAMESPACE).disable()
+      storage('legacy').disable()
     })
 
     it('should add tags to request span when socket is not there', () => {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const zlib = require('zlib')
 const { SAMPLING_MECHANISM_APPSEC } = require('../../src/constants')
 const { USER_KEEP } = require('../../../../ext/priority')
@@ -141,11 +141,11 @@ describe('reporter', () => {
 
     beforeEach(() => {
       req = {}
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ req })
+      storage(SPAN_NAMESPACE).enterWith({ req })
     })
 
     afterEach(() => {
-      storage(LEGACY_STORAGE_NAMESPACE).disable()
+      storage(SPAN_NAMESPACE).disable()
     })
 
     it('should do nothing when passed incomplete objects', () => {
@@ -184,7 +184,7 @@ describe('reporter', () => {
 
     it('should call updateWafRequestsMetricTags', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
 
       Reporter.reportMetrics(metrics)
 
@@ -194,7 +194,7 @@ describe('reporter', () => {
 
     it('should call updateRaspRequestsMetricTags when raspRule is provided', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage(LEGACY_STORAGE_NAMESPACE).getStore()
+      const store = storage(SPAN_NAMESPACE).getStore()
 
       const raspRule = { type: 'rule_type', variant: 'rule_variant' }
 
@@ -218,11 +218,11 @@ describe('reporter', () => {
           'user-agent': 'arachni'
         }
       }
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ req })
+      storage(SPAN_NAMESPACE).enterWith({ req })
     })
 
     afterEach(() => {
-      storage(LEGACY_STORAGE_NAMESPACE).disable()
+      storage(SPAN_NAMESPACE).disable()
     })
 
     it('should add tags to request span when socket is not there', () => {

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -10,6 +10,7 @@ const path = require('path')
 const waf = require('../../../src/appsec/waf')
 const { USER_ID } = require('../../../src/appsec/addresses')
 const blocking = require('../../../src/appsec/blocking')
+const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 const resultActions = {
   block_request: {
@@ -44,8 +45,10 @@ describe('user_blocking', () => {
 
       block = sinon.stub()
 
-      storage = {
-        getStore: sinon.stub().returns({ req, res })
+      storage = () => {
+        return {
+          getStore: sinon.stub().returns({ req, res })
+        }
       }
 
       log = {

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -10,7 +10,6 @@ const path = require('path')
 const waf = require('../../../src/appsec/waf')
 const { USER_ID } = require('../../../src/appsec/addresses')
 const blocking = require('../../../src/appsec/blocking')
-const {SPAN_NAMESPACE} = require("../../../../datadog-core");
 
 const resultActions = {
   block_request: {
@@ -117,16 +116,16 @@ describe('user_blocking', () => {
       it('should get req and res from local storage when they are not passed', () => {
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.true
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(block).to.be.calledOnceWithExactly(req, res, rootSpan)
       })
 
       it('should log warning when req or res is not available', () => {
-        storage(SPAN_NAMESPACE).getStore.returns(undefined)
+        storage('legacy').getStore.returns(undefined)
 
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.false
-        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage('legacy').getStore).to.have.been.calledOnce
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Requests or response object not available in blockRequest')
         expect(block).to.not.have.been.called

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -114,16 +114,16 @@ describe('user_blocking', () => {
       it('should get req and res from local storage when they are not passed', () => {
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.true
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(block).to.be.calledOnceWithExactly(req, res, rootSpan)
       })
 
       it('should log warning when req or res is not available', () => {
-        storage.getStore.returns(undefined)
+        storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
 
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.false
-        expect(storage.getStore).to.have.been.calledOnce
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Requests or response object not available in blockRequest')
         expect(block).to.not.have.been.called

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -25,7 +25,7 @@ describe('user_blocking', () => {
     const res = { headersSent: false }
     const tracer = {}
 
-    let rootSpan, getRootSpan, block, legacyStorage, datadogCore, log, userBlocking
+    let rootSpan, getRootSpan, block, legacyStorage, log, userBlocking
 
     before(() => {
       const runStub = sinon.stub(waf, 'run')

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -25,7 +25,7 @@ describe('user_blocking', () => {
     const res = { headersSent: false }
     const tracer = {}
 
-    let rootSpan, getRootSpan, block, storage, log, userBlocking
+    let rootSpan, getRootSpan, block, storage, datadogCore, log, userBlocking
 
     before(() => {
       const runStub = sinon.stub(waf, 'run')
@@ -44,10 +44,11 @@ describe('user_blocking', () => {
 
       block = sinon.stub()
 
-      storage = () => {
-        return {
-          getStore: sinon.stub().returns({ req, res })
-        }
+      storage = {
+        getStore: sinon.stub().returns({ req, res })
+      }
+      datadogCore = {
+        storage: () => storage
       }
 
       log = {
@@ -57,7 +58,7 @@ describe('user_blocking', () => {
       userBlocking = proxyquire('../../../src/appsec/sdk/user_blocking', {
         './utils': { getRootSpan },
         '../blocking': { block },
-        '../../../../datadog-core': storage,
+        '../../../../datadog-core': datadogCore,
         '../../log': log
       })
     })
@@ -116,16 +117,16 @@ describe('user_blocking', () => {
       it('should get req and res from local storage when they are not passed', () => {
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.true
-        expect(storage('legacy').getStore).to.have.been.calledOnce
+        expect(datadogCore('legacy').getStore).to.have.been.calledOnce
         expect(block).to.be.calledOnceWithExactly(req, res, rootSpan)
       })
 
       it('should log warning when req or res is not available', () => {
-        storage('legacy').getStore.returns(undefined)
+        datadogCore('legacy').getStore.returns(undefined)
 
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.false
-        expect(storage('legacy').getStore).to.have.been.calledOnce
+        expect(datadogCore('legacy').getStore).to.have.been.calledOnce
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Requests or response object not available in blockRequest')
         expect(block).to.not.have.been.called

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -57,7 +57,7 @@ describe('user_blocking', () => {
       userBlocking = proxyquire('../../../src/appsec/sdk/user_blocking', {
         './utils': { getRootSpan },
         '../blocking': { block },
-        '../../../../datadog-core': { storage },
+        '../../../../datadog-core': storage,
         '../../log': log
       })
     })

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -114,16 +114,16 @@ describe('user_blocking', () => {
       it('should get req and res from local storage when they are not passed', () => {
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.true
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(block).to.be.calledOnceWithExactly(req, res, rootSpan)
       })
 
       it('should log warning when req or res is not available', () => {
-        storage(LEGACY_STORAGE_NAMESPACE).getStore.returns(undefined)
+        storage(SPAN_NAMESPACE).getStore.returns(undefined)
 
         const ret = userBlocking.blockRequest(tracer)
         expect(ret).to.be.false
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore).to.have.been.calledOnce
+        expect(storage(SPAN_NAMESPACE).getStore).to.have.been.calledOnce
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Requests or response object not available in blockRequest')
         expect(block).to.not.have.been.called

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -3,7 +3,7 @@
 require('./setup/tap')
 
 const { expect } = require('chai')
-const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
+const { storage } = require('../../datadog-core')
 
 /* eslint-disable no-console */
 
@@ -119,7 +119,7 @@ describe('log', () => {
 
     it('should call the logger in a noop context', () => {
       logger.debug = () => {
-        expect(storage(SPAN_NAMESPACE).getStore()).to.have.property('noop', true)
+        expect(storage('legacy').getStore()).to.have.property('noop', true)
       }
 
       log.use(logger).debug('debug')

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -3,7 +3,7 @@
 require('./setup/tap')
 
 const { expect } = require('chai')
-const { storage } = require('../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
 
 /* eslint-disable no-console */
 
@@ -119,7 +119,7 @@ describe('log', () => {
 
     it('should call the logger in a noop context', () => {
       logger.debug = () => {
-        expect(storage.getStore()).to.have.property('noop', true)
+        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.have.property('noop', true)
       }
 
       log.use(logger).debug('debug')

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -3,7 +3,7 @@
 require('./setup/tap')
 
 const { expect } = require('chai')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../datadog-core')
 
 /* eslint-disable no-console */
 
@@ -119,7 +119,7 @@ describe('log', () => {
 
     it('should call the logger in a noop context', () => {
       logger.debug = () => {
-        expect(storage(LEGACY_STORAGE_NAMESPACE).getStore()).to.have.property('noop', true)
+        expect(storage(SPAN_NAMESPACE).getStore()).to.have.property('noop', true)
       }
 
       log.use(logger).debug('debug')

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -6,7 +6,7 @@ const msgpack = require('@msgpack/msgpack')
 const express = require('express')
 const path = require('path')
 const ritm = require('../../src/ritm')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 
 const traceHandlers = new Set()
 const statsHandlers = new Set()
@@ -325,7 +325,7 @@ module.exports = {
     const emit = server.emit
 
     server.emit = function () {
-      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
+      storage(SPAN_NAMESPACE).enterWith({ noop: true })
       return emit.apply(this, arguments)
     }
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -6,7 +6,7 @@ const msgpack = require('@msgpack/msgpack')
 const express = require('express')
 const path = require('path')
 const ritm = require('../../src/ritm')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 
 const traceHandlers = new Set()
 const statsHandlers = new Set()
@@ -325,7 +325,7 @@ module.exports = {
     const emit = server.emit
 
     server.emit = function () {
-      storage(SPAN_NAMESPACE).enterWith({ noop: true })
+      storage('legacy').enterWith({ noop: true })
       return emit.apply(this, arguments)
     }
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -6,7 +6,7 @@ const msgpack = require('@msgpack/msgpack')
 const express = require('express')
 const path = require('path')
 const ritm = require('../../src/ritm')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 
 const traceHandlers = new Set()
 const statsHandlers = new Set()
@@ -325,7 +325,7 @@ module.exports = {
     const emit = server.emit
 
     server.emit = function () {
-      storage.enterWith({ noop: true })
+      storage(LEGACY_STORAGE_NAMESPACE).enterWith({ noop: true })
       return emit.apply(this, arguments)
     }
 

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -9,7 +9,7 @@ const externals = require('../plugins/externals.json')
 const runtimeMetrics = require('../../src/runtime_metrics')
 const agent = require('../plugins/agent')
 const Nomenclature = require('../../src/service-naming')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const { schemaDefinitions } = require('../../src/service-naming/schemas')
 const { getInstrumentation } = require('./helpers/load-inst')
 
@@ -252,6 +252,6 @@ exports.mochaHooks = {
   afterEach () {
     agent.reset()
     runtimeMetrics.stop()
-    storage.enterWith(undefined)
+    storage(LEGACY_STORAGE_NAMESPACE).enterWith(undefined)
   }
 }

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -9,7 +9,7 @@ const externals = require('../plugins/externals.json')
 const runtimeMetrics = require('../../src/runtime_metrics')
 const agent = require('../plugins/agent')
 const Nomenclature = require('../../src/service-naming')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const { schemaDefinitions } = require('../../src/service-naming/schemas')
 const { getInstrumentation } = require('./helpers/load-inst')
 
@@ -252,6 +252,6 @@ exports.mochaHooks = {
   afterEach () {
     agent.reset()
     runtimeMetrics.stop()
-    storage(LEGACY_STORAGE_NAMESPACE).enterWith(undefined)
+    storage(SPAN_NAMESPACE).enterWith(undefined)
   }
 }

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -9,7 +9,7 @@ const externals = require('../plugins/externals.json')
 const runtimeMetrics = require('../../src/runtime_metrics')
 const agent = require('../plugins/agent')
 const Nomenclature = require('../../src/service-naming')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const { schemaDefinitions } = require('../../src/service-naming/schemas')
 const { getInstrumentation } = require('./helpers/load-inst')
 
@@ -252,6 +252,6 @@ exports.mochaHooks = {
   afterEach () {
     agent.reset()
     runtimeMetrics.stop()
-    storage(SPAN_NAMESPACE).enterWith(undefined)
+    storage('legacy').enterWith(undefined)
   }
 }

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -6,7 +6,7 @@ const tracerVersion = require('../../../../package.json').version
 const proxyquire = require('proxyquire').noPreserveCache()
 const http = require('http')
 const { once } = require('events')
-const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
+const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
 const os = require('os')
 const sinon = require('sinon')
 
@@ -24,7 +24,7 @@ describe('telemetry', () => {
     // If we don't no-op the server inside it, it will trace it, which will
     // screw up this test file entirely. -- bengl
 
-    storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, () => {
+    storage(SPAN_NAMESPACE).run({ noop: true }, () => {
       traceAgent = http.createServer(async (req, res) => {
         const chunks = []
         for await (const chunk of req) {
@@ -832,7 +832,7 @@ describe('AVM OSS', () => {
         before((done) => {
           clock = sinon.useFakeTimers()
 
-          storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, () => {
+          storage(SPAN_NAMESPACE).run({ noop: true }, () => {
             traceAgent = http.createServer(async (req, res) => {
               const chunks = []
               for await (const chunk of req) {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -6,7 +6,7 @@ const tracerVersion = require('../../../../package.json').version
 const proxyquire = require('proxyquire').noPreserveCache()
 const http = require('http')
 const { once } = require('events')
-const { storage, SPAN_NAMESPACE } = require('../../../datadog-core')
+const { storage } = require('../../../datadog-core')
 const os = require('os')
 const sinon = require('sinon')
 
@@ -24,7 +24,7 @@ describe('telemetry', () => {
     // If we don't no-op the server inside it, it will trace it, which will
     // screw up this test file entirely. -- bengl
 
-    storage(SPAN_NAMESPACE).run({ noop: true }, () => {
+    storage('legacy').run({ noop: true }, () => {
       traceAgent = http.createServer(async (req, res) => {
         const chunks = []
         for await (const chunk of req) {
@@ -832,7 +832,7 @@ describe('AVM OSS', () => {
         before((done) => {
           clock = sinon.useFakeTimers()
 
-          storage(SPAN_NAMESPACE).run({ noop: true }, () => {
+          storage('legacy').run({ noop: true }, () => {
             traceAgent = http.createServer(async (req, res) => {
               const chunks = []
               for await (const chunk of req) {

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -6,7 +6,7 @@ const tracerVersion = require('../../../../package.json').version
 const proxyquire = require('proxyquire').noPreserveCache()
 const http = require('http')
 const { once } = require('events')
-const { storage } = require('../../../datadog-core')
+const { storage, LEGACY_STORAGE_NAMESPACE } = require('../../../datadog-core')
 const os = require('os')
 const sinon = require('sinon')
 
@@ -24,7 +24,7 @@ describe('telemetry', () => {
     // If we don't no-op the server inside it, it will trace it, which will
     // screw up this test file entirely. -- bengl
 
-    storage.run({ noop: true }, () => {
+    storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, () => {
       traceAgent = http.createServer(async (req, res) => {
         const chunks = []
         for await (const chunk of req) {
@@ -832,7 +832,7 @@ describe('AVM OSS', () => {
         before((done) => {
           clock = sinon.useFakeTimers()
 
-          storage.run({ noop: true }, () => {
+          storage(LEGACY_STORAGE_NAMESPACE).run({ noop: true }, () => {
             traceAgent = http.createServer(async (req, res) => {
               const chunks = []
               for await (const chunk of req) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
- Removes `legacyStorage` in favor of a namespaced `'legacy'` storage
- Adds JSDoc comments to `storage.js` so my IDE knows how to code for me

### Motivation
<!-- What inspired you to submit this pull request? -->
This gets us one step closer to getting rid of `getHandle` as we are now fully converted to namespaced storages

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


