### PR TITLE
remove ability to propagate baggage on its own to avoid app crashes

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -598,7 +598,7 @@ class TextMapPropagator {
   }
 
   _extractBaggageItems (carrier, spanContext) {
-    if (!carrier) return
+    if (!spanContext) return
     const baggages = carrier.baggage.split(',')
     for (const keyValue of baggages) {
       if (!keyValue.includes('=')) {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -325,9 +325,7 @@ class TextMapPropagator {
       if (context === null) {
         context = extractedContext
         if (this._config.tracePropagationExtractFirst) {
-          if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
-            this._extractBaggageItems(carrier, context)
-          }
+          this._extractBaggageItems(carrier, context)
           return context
         }
       } else {
@@ -347,9 +345,7 @@ class TextMapPropagator {
       }
     }
 
-    if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
-      this._extractBaggageItems(carrier, context)
-    }
+    this._extractBaggageItems(carrier, context)
 
     return context || this._extractSqsdContext(carrier)
   }
@@ -598,6 +594,8 @@ class TextMapPropagator {
   }
 
   _extractBaggageItems (carrier, spanContext) {
+    if (!this._hasPropagationStyle('extract', 'baggage')) return
+    if (!carrier.baggage) return
     if (!spanContext) return
     const baggages = carrier.baggage.split(',')
     for (const keyValue of baggages) {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -325,6 +325,9 @@ class TextMapPropagator {
       if (context === null) {
         context = extractedContext
         if (this._config.tracePropagationExtractFirst) {
+          if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
+            if (context) this._extractBaggageItems(carrier, context)
+          }
           return context
         }
       } else {
@@ -345,8 +348,7 @@ class TextMapPropagator {
     }
 
     if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
-      context = context || new DatadogSpanContext()
-      this._extractBaggageItems(carrier, context)
+      if (context) this._extractBaggageItems(carrier, context)
     }
 
     return context || this._extractSqsdContext(carrier)

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -595,7 +595,7 @@ class TextMapPropagator {
 
   _extractBaggageItems (carrier, spanContext) {
     if (!this._hasPropagationStyle('extract', 'baggage')) return
-    if (!carrier.baggage) return
+    if (!carrier || !carrier.baggage) return
     if (!spanContext) return
     const baggages = carrier.baggage.split(',')
     for (const keyValue of baggages) {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -326,7 +326,7 @@ class TextMapPropagator {
         context = extractedContext
         if (this._config.tracePropagationExtractFirst) {
           if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
-            if (context) this._extractBaggageItems(carrier, context)
+            this._extractBaggageItems(carrier, context)
           }
           return context
         }
@@ -348,7 +348,7 @@ class TextMapPropagator {
     }
 
     if (this._hasPropagationStyle('extract', 'baggage') && carrier.baggage) {
-      if (context) this._extractBaggageItems(carrier, context)
+      this._extractBaggageItems(carrier, context)
     }
 
     return context || this._extractSqsdContext(carrier)
@@ -598,6 +598,7 @@ class TextMapPropagator {
   }
 
   _extractBaggageItems (carrier, spanContext) {
+    if (!carrier) return
     const baggages = carrier.baggage.split(',')
     for (const keyValue of baggages) {
       if (!keyValue.includes('=')) {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -451,20 +451,6 @@ describe('TextMapPropagator', () => {
       expect(spanContextD._baggageItems).to.deep.equal({})
     })
 
-    it('should extract baggage when it is the only propagation style', () => {
-      config = new Config({
-        tracePropagationStyle: {
-          extract: ['baggage']
-        }
-      })
-      propagator = new TextMapPropagator(config)
-      const carrier = {
-        baggage: 'foo=bar'
-      }
-      const spanContext = propagator.extract(carrier)
-      expect(spanContext._baggageItems).to.deep.equal({ foo: 'bar' })
-    })
-
     it('should convert signed IDs to unsigned', () => {
       textMap['x-datadog-trace-id'] = '-123'
       textMap['x-datadog-parent-id'] = '-456'

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -451,6 +451,7 @@ describe('TextMapPropagator', () => {
       expect(spanContextD._baggageItems).to.deep.equal({})
     })
 
+    // temporary test. On the contrary, it SHOULD extract baggage
     it('should not extract baggage when it is the only propagation style', () => {
       config = new Config({
         tracePropagationStyle: {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -451,6 +451,20 @@ describe('TextMapPropagator', () => {
       expect(spanContextD._baggageItems).to.deep.equal({})
     })
 
+    it('should not extract baggage when it is the only propagation style', () => {
+      config = new Config({
+        tracePropagationStyle: {
+          extract: ['baggage']
+        }
+      })
+      propagator = new TextMapPropagator(config)
+      const carrier = {
+        baggage: 'foo=bar'
+      }
+      const spanContext = propagator.extract(carrier)
+      expect(spanContext).to.be.null
+    })
+
     it('should convert signed IDs to unsigned', () => {
       textMap['x-datadog-trace-id'] = '-123'
       textMap['x-datadog-parent-id'] = '-456'


### PR DESCRIPTION
### What does this PR do?
Fixes this [issue](https://github.com/DataDog/dd-trace-js/issues/5111) at the expense of not allowing customers to propagate baggage on its own.
This is a quick fix for now to avoid crashing customer applications, we will add a more involved solution to provide customers with the full functionality of baggage in a later PR.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


