### PR TITLE
Fix mongoose plugin tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
   mongo:
-    image: circleci/mongo:3.6
+    image: circleci/mongo:4.0
     platform: linux/amd64
     ports:
       - "127.0.0.1:27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
   mongo:
-    image: circleci/mongo:4.0
+    image: circleci/mongo:3.6
     platform: linux/amd64
     ports:
       - "127.0.0.1:27017:27017"

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -41,16 +41,6 @@ describe('Plugin', () => {
         mongoose = require(`../../../versions/mongoose@${version}`).get()
 
         connect()
-
-        withPeerService(
-          () => tracer,
-          'mongodb-core',
-          (done) => {
-            const PeerCat = mongoose.model('PeerCat', { name: String })
-            new PeerCat({ name: 'PeerCat' }).save().catch(done)
-            done()
-          },
-          'db', 'peer.service')
       })
 
       after(() => {
@@ -60,6 +50,16 @@ describe('Plugin', () => {
       after(() => {
         return agent.close({ ritmReset: false })
       })
+
+      withPeerService(
+        () => tracer,
+        'mongodb-core',
+        (done) => {
+          const PeerCat = mongoose.model('PeerCat', { name: String })
+          new PeerCat({ name: 'PeerCat' }).save().catch(done)
+          done()
+        },
+        'db', 'peer.service')
 
       it('should propagate context with write operations', () => {
         const Cat = mongoose.model('Cat1', { name: String })

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -57,7 +57,6 @@ describe('Plugin', () => {
         (done) => {
           const PeerCat = mongoose.model('PeerCat', { name: String })
           new PeerCat({ name: 'PeerCat' }).save().catch(done)
-          done()
         },
         'db', 'peer.service')
 

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -23,6 +23,7 @@ describe('Plugin', () => {
         // mongoose.connect('mongodb://username:password@host:port/database?options...');
         // actually the first part of the path is the dbName and not the collection
         return mongoose.connect(`mongodb://localhost:27017/${dbName}`, {
+          bufferCommands: false,
           useNewUrlParser: true,
           useUnifiedTopology: true
         })

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -19,10 +19,10 @@ describe('Plugin', () => {
       // This needs to be called synchronously right before each test to make
       // sure a connection is not already established and the request is added
       // to the queue.
-      function connect () {
+      async function connect () {
         // mongoose.connect('mongodb://username:password@host:port/database?options...');
         // actually the first part of the path is the dbName and not the collection
-        mongoose.connect(`mongodb://localhost:27017/${dbName}`, {
+        await mongoose.connect(`mongodb://localhost:27017/${dbName}`, {
           useNewUrlParser: true,
           useUnifiedTopology: true
         })

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -7,7 +7,7 @@ const id = require('../../dd-trace/src/id')
 
 describe('Plugin', () => {
   let tracer
-  const dbName = id().toString()
+  let dbName
 
   describe('mongoose', () => {
     withVersions('mongoose', ['mongoose'], (version) => {
@@ -37,6 +37,8 @@ describe('Plugin', () => {
 
         mongoose = require(`../../../versions/mongoose@${version}`).get()
 
+        dbName = id().toString()
+
         connect()
       })
 
@@ -55,7 +57,7 @@ describe('Plugin', () => {
           const PeerCat = mongoose.model('PeerCat', { name: String })
           new PeerCat({ name: 'PeerCat' }).save().catch(done)
         },
-        dbName, 'peer.service')
+        () => dbName, 'peer.service')
 
       it('should propagate context with write operations', () => {
         const Cat = mongoose.model('Cat1', { name: String })

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -22,7 +22,7 @@ describe('Plugin', () => {
       function connect () {
         // mongoose.connect('mongodb://username:password@host:port/database?options...');
         // actually the first part of the path is the dbName and not the collection
-        mongoose.connect(`mongodb://localhost:27017/${dbName}`, {
+        return mongoose.connect(`mongodb://localhost:27017/${dbName}`, {
           useNewUrlParser: true,
           useUnifiedTopology: true
         })
@@ -32,14 +32,14 @@ describe('Plugin', () => {
         return agent.load(['mongodb-core'])
       })
 
-      before(() => {
+      before(async () => {
         tracer = require('../../dd-trace')
 
         mongoose = require(`../../../versions/mongoose@${version}`).get()
 
         dbName = id().toString()
 
-        connect()
+        await connect()
       })
 
       after(() => {

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -131,7 +131,7 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
       agent
         .use(traces => {
           const span = traces[0][0]
-          expect(span.meta).to.have.property('peer.service', service)
+          expect(span.meta).to.have.property('peer.service', typeof service === 'function' ? service() : service)
           expect(span.meta).to.have.property('_dd.peer.service.source', serviceSource)
         })
         .then(done)


### PR DESCRIPTION
### What does this PR do?
- move `withPeerService` out of `before` block
- remove extra `done()` call
- change `peer.service` tag value. The test author set 'db' as the value but after fixing the test i checked 'peer.service' tag is set as the collection name used in the test.
- ensure mongo is connected setting `bufferCommands: false` and waiting

### Motivation
I believe the part of the test calling `withPeerService` was not entirely correct. 
As  `done()` was called by `spanGenerationFn` function

```javascript
(done) => {
  const PeerCat = mongoose.model('PeerCat', { name: String })
  new PeerCat({ name: 'PeerCat' }).save().catch(done)
  done()
}
```

the test ended before `'peer.service'` and `'_dd.peer.service.source'` expects were checked

```javascript
expect(span.meta).to.have.property('peer.service', typeof service === 'function' ? service() : service)
expect(span.meta).to.have.property('_dd.peer.service.source', serviceSource)
```

so this part of the test has never worked as it should.


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


