### PR TITLE
handles _thenUnwrap for OpenAI's custom APIPromise class

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -329,7 +329,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
 }
 
 function handleUnwrappedAPIPromise (apiProm, ctx, stream, n) {
-  apiProm.then(([{ response, options }, body]) => {
+  return apiProm.then(([{ response, options }, body]) => {
     if (stream) {
       if (body.iterator) {
         shimmer.wrap(body, 'iterator', wrapStreamIterator(response, options, n, ctx))

--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -305,7 +305,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
               // the original response is wrapped in a promise, so we need to unwrap it
               .then(body => Promise.all([this.responsePromise, body]))
 
-            return handleUnwrappedAPIPromise(unwrappedPromise, ctx, stream, n)
+            return handleUnwrappedAPIPromise('_thenUnwrap', unwrappedPromise, ctx, stream, n)
           })
 
           // wrapping `parse` avoids problematic wrapping of `then` when trying to call
@@ -315,7 +315,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
               // the original response is wrapped in a promise, so we need to unwrap it
               .then(body => Promise.all([this.responsePromise, body]))
 
-            return handleUnwrappedAPIPromise(unwrappedPromise, ctx, stream, n)
+            return handleUnwrappedAPIPromise('parse', unwrappedPromise, ctx, stream, n)
           })
 
           ch.end.publish(ctx)
@@ -328,7 +328,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
   })
 }
 
-function handleUnwrappedAPIPromise (apiProm, ctx, stream, n) {
+function handleUnwrappedAPIPromise (name, apiProm, ctx, stream, n) {
   return apiProm.then(([{ response, options }, body]) => {
     if (stream) {
       if (body.iterator) {
@@ -359,7 +359,7 @@ function handleUnwrappedAPIPromise (apiProm, ctx, stream, n) {
     .finally(() => {
     // maybe we don't want to unwrap here in case the promise is re-used?
     // other hand: we want to avoid resource leakage
-      shimmer.unwrap(apiProm, 'parse')
+      shimmer.unwrap(apiProm, name)
     })
 }
 

--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -305,7 +305,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
               // the original response is wrapped in a promise, so we need to unwrap it
               .then(body => Promise.all([this.responsePromise, body]))
 
-            return handleWrappedPromise(unwrappedPromise, ctx, stream, n)
+            return handleUnwrappedAPIPromise(unwrappedPromise, ctx, stream, n)
           })
 
           // wrapping `parse` avoids problematic wrapping of `then` when trying to call
@@ -315,7 +315,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
               // the original response is wrapped in a promise, so we need to unwrap it
               .then(body => Promise.all([this.responsePromise, body]))
 
-            return handleWrappedPromise(unwrappedPromise, ctx, stream, n)
+            return handleUnwrappedAPIPromise(unwrappedPromise, ctx, stream, n)
           })
 
           ch.end.publish(ctx)
@@ -328,7 +328,7 @@ for (const shim of V4_PACKAGE_SHIMS) {
   })
 }
 
-function handleWrappedPromise (apiProm, ctx, stream, n) {
+function handleUnwrappedAPIPromise (apiProm, ctx, stream, n) {
   apiProm.then(([{ response, options }, body]) => {
     if (stream) {
       if (body.iterator) {

--- a/packages/datadog-instrumentations/test/openai.spec.js
+++ b/packages/datadog-instrumentations/test/openai.spec.js
@@ -1,0 +1,124 @@
+'use strict'
+
+const { expect } = require('chai')
+const semver = require('semver')
+const agent = require('../../dd-trace/test/plugins/agent')
+const nock = require('nock')
+const dc = require('dc-polyfill')
+
+withVersions('openai', 'openai', version => {
+  if (!semver.intersects(version, '>=4')) return
+
+  let openai, start, finish, error, asyncFinish
+
+  const channel = dc.tracingChannel('apm:openai:request')
+
+  before(() => {
+    return agent.load('openai')
+  })
+
+  after(() => {
+    return agent.close({ ritmReset: false })
+  })
+
+  beforeEach(() => {
+    start = sinon.stub()
+    finish = sinon.stub()
+    error = sinon.stub()
+    asyncFinish = sinon.stub()
+
+    channel.subscribe({
+      start,
+      end: finish,
+      asyncEnd: asyncFinish,
+      error
+    })
+
+    const module = require(`../../../versions/openai@${version}`).get()
+    openai = new module.OpenAI({
+      apiKey: 'sk-DATADOG-INSTRUMENTATION-SPECS'
+    })
+  })
+
+  afterEach(() => {
+    channel.unsubscribe({
+      start,
+      end: finish,
+      asyncEnd: asyncFinish,
+      error
+    })
+
+    nock.cleanAll()
+  })
+
+  it('should end the channel when _thenUnwrap is used', async () => {
+    if (!semver.intersects(version, '>=4.59.0')) return
+    nock('https://api.openai.com:443')
+      .post('/v1/chat/completions')
+      .reply(200, {
+        id: 'chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN',
+        object: 'chat.completion',
+        created: 1684188020,
+        model: 'gpt-4o',
+        usage: {
+          prompt_tokens: 37,
+          completion_tokens: 10,
+          total_tokens: 47
+        },
+        choices: [{
+          message: {
+            role: 'assistant',
+            content: 'I am doing well, how about you?'
+          },
+          finish_reason: 'stop',
+          index: 0
+        }]
+      })
+
+    await openai.beta.chat.completions.parse({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
+      temperature: 0.5,
+      stream: false
+    })
+
+    expect(asyncFinish).to.have.been.calledOnce
+  })
+
+  it('should end the channel when .withResponse() is used for chat.completions.create', async () => {
+    nock('https://api.openai.com:443')
+      .post('/v1/chat/completions')
+      .reply(200, {
+        id: 'chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN',
+        object: 'chat.completion',
+        created: 1684188020,
+        model: 'gpt-4o',
+        usage: {
+          prompt_tokens: 37,
+          completion_tokens: 10,
+          total_tokens: 47
+        },
+        choices: [{
+          message: {
+            role: 'assistant',
+            content: 'I am doing well, how about you?'
+          },
+          finish_reason: 'stop',
+          index: 0
+        }]
+      })
+
+    const promise = openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
+      temperature: 0.5,
+      stream: false
+    })
+
+    expect(promise).to.have.property('withResponse').that.is.a('function')
+
+    await promise.withResponse()
+
+    expect(asyncFinish).to.have.been.calledOnce
+  })
+})

--- a/packages/datadog-instrumentations/test/openai.spec.js
+++ b/packages/datadog-instrumentations/test/openai.spec.js
@@ -7,118 +7,128 @@ const nock = require('nock')
 const dc = require('dc-polyfill')
 
 withVersions('openai', 'openai', version => {
-  if (!semver.intersects(version, '>=4')) return
+  describe('unwrap promises', () => {
+    if (!semver.intersects(version, '>=4')) return
 
-  let openai, start, finish, error, asyncFinish
+    let openai, start, finish, error, asyncFinish
 
-  const channel = dc.tracingChannel('apm:openai:request')
-
-  before(() => {
-    return agent.load('openai')
-  })
-
-  after(() => {
-    return agent.close({ ritmReset: false })
-  })
-
-  beforeEach(() => {
-    start = sinon.stub()
-    finish = sinon.stub()
-    error = sinon.stub()
-    asyncFinish = sinon.stub()
-
-    channel.subscribe({
-      start,
-      end: finish,
-      asyncEnd: asyncFinish,
-      error
-    })
-
-    const module = require(`../../../versions/openai@${version}`).get()
-    openai = new module.OpenAI({
-      apiKey: 'sk-DATADOG-INSTRUMENTATION-SPECS'
-    })
-  })
-
-  afterEach(() => {
-    channel.unsubscribe({
-      start,
-      end: finish,
-      asyncEnd: asyncFinish,
-      error
-    })
-
-    nock.cleanAll()
-  })
-
-  it('should end the channel when _thenUnwrap is used', async () => {
-    if (!semver.intersects(version, '>=4.59.0')) return
-    nock('https://api.openai.com:443')
-      .post('/v1/chat/completions')
-      .reply(200, {
-        id: 'chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN',
-        object: 'chat.completion',
-        created: 1684188020,
-        model: 'gpt-4o',
-        usage: {
-          prompt_tokens: 37,
-          completion_tokens: 10,
-          total_tokens: 47
-        },
-        choices: [{
+    const chatCompletionResponse = {
+      id: 'chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN',
+      object: 'chat.completion',
+      created: 1684188020,
+      model: 'gpt-4o',
+      usage: {
+        prompt_tokens: 37,
+        completion_tokens: 10,
+        total_tokens: 47,
+      },
+      choices: [
+        {
           message: {
             role: 'assistant',
-            content: 'I am doing well, how about you?'
+            content: 'I am doing well, how about you?',
           },
           finish_reason: 'stop',
-          index: 0
-        }]
-      })
-
-    await openai.beta.chat.completions.parse({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
-      temperature: 0.5,
-      stream: false
-    })
-
-    expect(asyncFinish).to.have.been.calledOnce
-  })
-
-  it('should end the channel when .withResponse() is used for chat.completions.create', async () => {
-    nock('https://api.openai.com:443')
-      .post('/v1/chat/completions')
-      .reply(200, {
-        id: 'chatcmpl-7GaWqyMTD9BLmkmy8SxyjUGX3KSRN',
-        object: 'chat.completion',
-        created: 1684188020,
-        model: 'gpt-4o',
-        usage: {
-          prompt_tokens: 37,
-          completion_tokens: 10,
-          total_tokens: 47
+          index: 0,
         },
-        choices: [{
-          message: {
-            role: 'assistant',
-            content: 'I am doing well, how about you?'
-          },
-          finish_reason: 'stop',
-          index: 0
-        }]
-      })
+      ],
+    }
 
-    const promise = openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
-      temperature: 0.5,
-      stream: false
+    const channel = dc.tracingChannel('apm:openai:request')
+
+    before(() => {
+      return agent.load('openai')
     })
 
-    expect(promise).to.have.property('withResponse').that.is.a('function')
+    after(() => {
+      return agent.close({ ritmReset: false })
+    })
 
-    await promise.withResponse()
+    beforeEach(() => {
+      start = sinon.stub()
+      finish = sinon.stub()
+      error = sinon.stub()
+      asyncFinish = sinon.stub()
 
-    expect(asyncFinish).to.have.been.calledOnce
+      channel.subscribe({
+        start,
+        end: finish,
+        asyncEnd: asyncFinish,
+        error
+      })
+
+      const module = require(`../../../versions/openai@${version}`).get()
+      openai = new module.OpenAI({
+        apiKey: 'sk-DATADOG-INSTRUMENTATION-SPECS'
+      })
+    })
+
+    afterEach(() => {
+      channel.unsubscribe({
+        start,
+        end: finish,
+        asyncEnd: asyncFinish,
+        error
+      })
+
+      nock.cleanAll()
+    })
+
+    it('should end the channel when a method returns with _thenUnwrap', async () => {
+      if (!semver.intersects(version, '>=4.59.0')) return
+      nock('https://api.openai.com:443')
+        .post('/v1/chat/completions')
+        .reply(200, chatCompletionResponse)
+
+      await openai.beta.chat.completions.parse({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
+        temperature: 0.5,
+        stream: false
+      })
+
+      expect(asyncFinish).to.have.been.calledOnce
+    })
+
+    it.only('should end the channel when _thenUnwrap is used on an instance of APIPromise', async () => {
+      if (!semver.intersects(version, '>=4.59.0')) return
+      nock('https://api.openai.com:443')
+        .post('/v1/chat/completions')
+        .reply(200, chatCompletionResponse)
+
+      const promise = openai.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [
+          { role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' },
+        ],
+        temperature: 0.5,
+        stream: false,
+      })
+
+      expect(promise).to.have.property('_thenUnwrap').that.is.a('function')
+
+      await promise._thenUnwrap((completion) => completion)
+
+      expect(asyncFinish).to.have.been.calledOnce
+    })
+
+    it('should end the channel when .withResponse() is used for chat.completions.create', async () => {
+      nock('https://api.openai.com:443')
+        .post('/v1/chat/completions')
+        .reply(200, chatCompletionResponse)
+
+      const promise = openai.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
+        temperature: 0.5,
+        stream: false
+      })
+
+      expect(promise).to.have.property('withResponse').that.is.a('function')
+
+      await promise.withResponse()
+
+      expect(asyncFinish).to.have.been.calledOnce
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Tracing is failing for requests that include a call to the OpenAI `this.client.beta.chat.completions.parse` method.  

This happens because OpenAI uses a custom promise class. The Datadog team is already aware of this issue, as it was previously addressed for the OpenAI `this.client.chat.completions.create` method. I'm reusing that logic to resolve the current issue.  

This PR implements the same unwrap logic and response handler that is used for the `parse` method, but for the `_thenUnwrap` method.

### Motivation  
When using the OpenAI Node SDK and calling `await this.client.beta.chat.completions.parse`, traces completely break.  

This happens because OpenAI uses a custom promise. This issue was previously fixed for `this.client.chat.completions.create` (the non-beta version). To address this, I abstracted that fix and applied it to `_thenUnwrap`.

The issue is reported here https://github.com/openai/openai-node/issues/1307 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


