### PR TITLE
change RASP addresses from persistent to ephemeral

### DIFF
--- a/packages/dd-trace/src/appsec/rasp/command_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/command_injection.js
@@ -31,20 +31,20 @@ function analyzeCommandInjection ({ file, fileArgs, shell, abortController }) {
   const req = store?.req
   if (!req) return
 
-  const persistent = {}
+  const ephemeral = {}
   const raspRule = { type: RULE_TYPES.COMMAND_INJECTION }
   const params = fileArgs ? [file, ...fileArgs] : file
 
   if (shell) {
-    persistent[addresses.SHELL_COMMAND] = params
+    ephemeral[addresses.SHELL_COMMAND] = params
     raspRule.variant = 'shell'
   } else {
     const commandParams = Array.isArray(params) ? params : [params]
-    persistent[addresses.EXEC_COMMAND] = commandParams
+    ephemeral[addresses.EXEC_COMMAND] = commandParams
     raspRule.variant = 'exec'
   }
 
-  const result = waf.run({ persistent }, req, raspRule)
+  const result = waf.run({ ephemeral }, req, raspRule)
 
   const res = store?.res
   handleResult(result, req, res, abortController, config)

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -54,13 +54,13 @@ function analyzeLfi (ctx) {
   if (!req || !fs) return
 
   getPaths(ctx, fs).forEach(path => {
-    const persistent = {
+    const ephemeral = {
       [FS_OPERATION_PATH]: path
     }
 
     const raspRule = { type: RULE_TYPES.LFI }
 
-    const result = waf.run({ persistent }, req, raspRule)
+    const result = waf.run({ ephemeral }, req, raspRule)
     handleResult(result, req, res, ctx.abortController, config)
   })
 }

--- a/packages/dd-trace/src/appsec/rasp/sql_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/sql_injection.js
@@ -67,14 +67,14 @@ function analyzeSqlInjection (query, dbSystem, abortController) {
   }
   executedQueries.add(query)
 
-  const persistent = {
+  const ephemeral = {
     [addresses.DB_STATEMENT]: query,
     [addresses.DB_SYSTEM]: dbSystem
   }
 
   const raspRule = { type: RULE_TYPES.SQL_INJECTION }
 
-  const result = waf.run({ persistent }, req, raspRule)
+  const result = waf.run({ ephemeral }, req, raspRule)
 
   handleResult(result, req, res, abortController, config)
 }

--- a/packages/dd-trace/src/appsec/rasp/ssrf.js
+++ b/packages/dd-trace/src/appsec/rasp/ssrf.js
@@ -25,13 +25,13 @@ function analyzeSsrf (ctx) {
 
   if (!req || !outgoingUrl) return
 
-  const persistent = {
+  const ephemeral = {
     [addresses.HTTP_OUTGOING_URL]: outgoingUrl
   }
 
   const raspRule = { type: RULE_TYPES.SSRF }
 
-  const result = waf.run({ persistent }, req, raspRule)
+  const result = waf.run({ ephemeral }, req, raspRule)
 
   const res = store?.res
   handleResult(result, req, res, ctx.abortController, config)

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -105,9 +105,9 @@ describe('RASP - command_injection.js', () => {
 
         start.publish(ctx)
 
-        const persistent = { [addresses.SHELL_COMMAND]: 'cmd' }
+        const ephemeral = { [addresses.SHELL_COMMAND]: 'cmd' }
         sinon.assert.calledOnceWithExactly(
-          waf.run, { persistent }, req, { type: 'command_injection', variant: 'shell' }
+          waf.run, { ephemeral }, req, { type: 'command_injection', variant: 'shell' }
         )
       })
 
@@ -122,9 +122,9 @@ describe('RASP - command_injection.js', () => {
 
         start.publish(ctx)
 
-        const persistent = { [addresses.SHELL_COMMAND]: ['cmd', 'arg0', 'arg1'] }
+        const ephemeral = { [addresses.SHELL_COMMAND]: ['cmd', 'arg0', 'arg1'] }
         sinon.assert.calledOnceWithExactly(
-          waf.run, { persistent }, req, { type: 'command_injection', variant: 'shell' }
+          waf.run, { ephemeral }, req, { type: 'command_injection', variant: 'shell' }
         )
       })
 
@@ -154,9 +154,9 @@ describe('RASP - command_injection.js', () => {
 
         start.publish(ctx)
 
-        const persistent = { [addresses.EXEC_COMMAND]: ['ls'] }
+        const ephemeral = { [addresses.EXEC_COMMAND]: ['ls'] }
         sinon.assert.calledOnceWithExactly(
-          waf.run, { persistent }, req, { type: 'command_injection', variant: 'exec' }
+          waf.run, { ephemeral }, req, { type: 'command_injection', variant: 'exec' }
         )
       })
 
@@ -171,9 +171,9 @@ describe('RASP - command_injection.js', () => {
 
         start.publish(ctx)
 
-        const persistent = { [addresses.EXEC_COMMAND]: ['ls', '-la', '/tmp'] }
+        const ephemeral = { [addresses.EXEC_COMMAND]: ['ls', '-la', '/tmp'] }
         sinon.assert.calledOnceWithExactly(
-          waf.run, { persistent }, req, { type: 'command_injection', variant: 'exec' }
+          waf.run, { ephemeral }, req, { type: 'command_injection', variant: 'exec' }
         )
       })
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -108,8 +108,8 @@ describe('RASP - lfi.js', () => {
 
       fsOperationStart.publish(ctx)
 
-      const persistent = { [FS_OPERATION_PATH]: path }
-      sinon.assert.calledOnceWithExactly(waf.run, { persistent }, req, { type: 'lfi' })
+      const ephemeral = { [FS_OPERATION_PATH]: path }
+      sinon.assert.calledOnceWithExactly(waf.run, { ephemeral }, req, { type: 'lfi' })
     })
 
     it('should NOT analyze lfi for child fs operations', () => {

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -51,11 +51,11 @@ describe('RASP - sql_injection', () => {
 
       pgQueryStart.publish(ctx)
 
-      const persistent = {
+      const ephemeral = {
         [addresses.DB_STATEMENT]: 'SELECT 1',
         [addresses.DB_SYSTEM]: 'postgresql'
       }
-      sinon.assert.calledOnceWithExactly(waf.run, { persistent }, req, { type: 'sql_injection' })
+      sinon.assert.calledOnceWithExactly(waf.run, { ephemeral }, req, { type: 'sql_injection' })
     })
 
     it('should not analyze sql injection if rasp is disabled', () => {
@@ -122,11 +122,11 @@ describe('RASP - sql_injection', () => {
 
       mysql2OuterQueryStart.publish(ctx)
 
-      const persistent = {
+      const ephemeral = {
         [addresses.DB_STATEMENT]: 'SELECT 1',
         [addresses.DB_SYSTEM]: 'mysql'
       }
-      sinon.assert.calledOnceWithExactly(waf.run, { persistent }, req, { type: 'sql_injection' })
+      sinon.assert.calledOnceWithExactly(waf.run, { ephemeral }, req, { type: 'sql_injection' })
     })
 
     it('should not analyze sql injection if rasp is disabled', () => {

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -51,8 +51,8 @@ describe('RASP - ssrf.js', () => {
 
       httpClientRequestStart.publish(ctx)
 
-      const persistent = { [addresses.HTTP_OUTGOING_URL]: 'http://example.com' }
-      sinon.assert.calledOnceWithExactly(waf.run, { persistent }, req, { type: 'ssrf' })
+      const ephemeral = { [addresses.HTTP_OUTGOING_URL]: 'http://example.com' }
+      sinon.assert.calledOnceWithExactly(waf.run, { ephemeral }, req, { type: 'ssrf' })
     })
 
     it('should not analyze ssrf if rasp is disabled', () => {


### PR DESCRIPTION
### What does this PR do?
Change all RASP WAF calls to ephemeral addresses.

### Motivation
According to a RFC we missed, all RASP addresses should be ephemeral.
This is to allow matching multiple times per request on RASP rules.
