### PR TITLE
datadog-plugin-mongoose test remove forgotten skip condition for versions >= 8.10.0

### DIFF
--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -12,8 +12,7 @@ describe('Plugin', () => {
   describe('mongoose', () => {
     withVersions('mongoose', ['mongoose'], (version) => {
       const specificVersion = require(`../../../versions/mongoose@${version}`).version()
-      if ((NODE_MAJOR === 14 && semver.satisfies(specificVersion, '>=8')) ||
-        semver.satisfies(specificVersion, '>=8.10.0')) return
+      if ((NODE_MAJOR === 14 && semver.satisfies(specificVersion, '>=8'))) return
 
       let mongoose
 

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -43,8 +43,8 @@ describe('Plugin', () => {
         await connect()
       })
 
-      after(() => {
-        return mongoose.disconnect()
+      after(async () => {
+        return await mongoose.disconnect()
       })
 
       after(() => {


### PR DESCRIPTION
### What does this PR do?
mongoose-plugin remove forgotten skip condition for versions >= 8.10.0

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


