### PR TITLE
dd-trace-api: don't proxy objects returned from callbacks

### DIFF
--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -48,6 +48,14 @@ module.exports = class DdTraceApiPlugin extends Plugin {
           self = objectMap.get(self)
         }
 
+        // `trace` returns the value that's returned from the original callback
+        // passed to it, so we need to detect that happening and bypass the check
+        // for a proxy, since a proxy isn't needed, since the object originates
+        // from the caller. In callbacks, we'll assign return values to this
+        // value, and bypass the proxy check if `ret.value` is exactly this
+        // value.
+        let passthroughRetVal
+
         for (let i = 0; i < args.length; i++) {
           if (objectMap.has(args[i])) {
             args[i] = objectMap.get(args[i])
@@ -63,7 +71,8 @@ module.exports = class DdTraceApiPlugin extends Plugin {
                 }
               }
               // TODO do we need to apply(this, ...) here?
-              return orig(...fnArgs)
+              passthroughRetVal = orig(...fnArgs)
+              return passthroughRetVal
             }
           }
         }
@@ -74,7 +83,7 @@ module.exports = class DdTraceApiPlugin extends Plugin {
             const proxyVal = proxy()
             objectMap.set(proxyVal, ret.value)
             ret.value = proxyVal
-          } else if (ret.value && typeof ret.value === 'object') {
+          } else if (ret.value && typeof ret.value === 'object' && passthroughRetVal !== ret.value) {
             throw new TypeError(`Objects need proxies when returned via API (${name})`)
           }
         } catch (e) {


### PR DESCRIPTION
Some APIs (pretty much just trace) return whatever value is returned from a callback passed in. Without providing for this, this would trip up the check that returned objects are proxied. We don't want to proxy these objects since they come directly from the caller.


