### PR TITLE
Add missing decrement method to NoopDogStatsDClient

### DIFF
--- a/packages/dd-trace/src/noop/dogstatsd.js
+++ b/packages/dd-trace/src/noop/dogstatsd.js
@@ -1,6 +1,8 @@
 module.exports = class NoopDogStatsDClient {
   increment () { }
 
+  decrement () { }
+
   gauge () { }
 
   distribution () { }

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -75,6 +75,7 @@ describe('TracerProxy', () => {
 
     noopDogStatsDClient = {
       increment: sinon.spy(),
+      decrement: sinon.spy(),
       gauge: sinon.spy(),
       distribution: sinon.spy(),
       histogram: sinon.spy(),
@@ -676,6 +677,8 @@ describe('TracerProxy', () => {
       it('should not throw when calling noop methods', () => {
         proxy.dogstatsd.increment('inc')
         expect(noopDogStatsDClient.increment).to.have.been.calledWith('inc')
+        proxy.dogstatsd.increment('dec')
+        expect(noopDogStatsDClient.decrement).to.have.been.calledWith('dec')
         proxy.dogstatsd.distribution('dist')
         expect(noopDogStatsDClient.distribution).to.have.been.calledWith('dist')
         proxy.dogstatsd.histogram('hist')


### PR DESCRIPTION
### What does this PR do?

Adds the missing `decrement` method to the `NoopDogStatsDClient` class.

### Motivation

The `NoopDogStatsDClient` gets used in unit tests in consumers of this package.  However, it is missing the `decrement` method which causes those tests to fail because trying to call this method will throw an exception.

### Additional notes

I also manually tested that this works by applying the same change to the version of this package used by my project and confirmed that tests calling `tracer.dogstatsd.decrement` no longer threw exceptions.


