### PR TITLE
dd-trace-api: remove runtime tests that should be test time

### DIFF
--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -48,14 +48,6 @@ module.exports = class DdTraceApiPlugin extends Plugin {
           self = objectMap.get(self)
         }
 
-        // `trace` returns the value that's returned from the original callback
-        // passed to it, so we need to detect that happening and bypass the check
-        // for a proxy, since a proxy isn't needed, since the object originates
-        // from the caller. In callbacks, we'll assign return values to this
-        // value, and bypass the proxy check if `ret.value` is exactly this
-        // value.
-        let passthroughRetVal
-
         for (let i = 0; i < args.length; i++) {
           if (objectMap.has(args[i])) {
             args[i] = objectMap.get(args[i])
@@ -71,8 +63,7 @@ module.exports = class DdTraceApiPlugin extends Plugin {
                 }
               }
               // TODO do we need to apply(this, ...) here?
-              passthroughRetVal = orig(...fnArgs)
-              return passthroughRetVal
+              return orig(...fnArgs)
             }
           }
         }
@@ -83,8 +74,6 @@ module.exports = class DdTraceApiPlugin extends Plugin {
             const proxyVal = proxy()
             objectMap.set(proxyVal, ret.value)
             ret.value = proxyVal
-          } else if (ret.value && typeof ret.value === 'object' && passthroughRetVal !== ret.value) {
-            throw new TypeError(`Objects need proxies when returned via API (${name})`)
           }
         } catch (e) {
           ret.error = e

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -220,20 +220,6 @@ describe('Plugin', () => {
     describeMethod('extract', null)
     describeMethod('getRumData', '')
     describeMethod('trace')
-
-    describe('trace with return value', () => {
-      it('should return the exact same value', () => {
-        const obj = { mustBeThis: 'value' }
-        tracer.trace.resetHistory() // clear previous call to `trace`
-        testChannel({
-          name: 'trace',
-          fn: tracer.trace,
-          ret: obj,
-          proxy: false,
-          args: ['foo', {}, () => obj]
-        })
-      })
-    })
     describeMethod('wrap')
     describeMethod('use', SELF)
     describeMethod('profilerStarted', Promise.resolve(false))


### PR DESCRIPTION
This was previously checking that objects returned by APIs are wrapped. This shouldn't be checked at run time, but at test time in dd-trace-api.


