### PR TITLE
Temporarily limit koa upstream tests to test against 2.15.3

### DIFF
--- a/packages/datadog-plugin-koa/test/suite.js
+++ b/packages/datadog-plugin-koa/test/suite.js
@@ -1,7 +1,10 @@
 'use strict'
 const suiteTest = require('../../dd-trace/test/plugins/suite')
 
-suiteTest('koa', 'koajs/koa', 'latest')
+// TODO: Temporarily limiting this to run against v2.15.3 instead of `latest`,
+// as it's currently failing on `latest` because that code hasn't been pushed to GitHub.
+// For details, see: https://github.com/koajs/koa/issues/1857
+suiteTest('koa', 'koajs/koa', '2.15.3')
 
 // TODO enable this
 // suiteTest('@koa/router', 'koajs/router', 'latest')


### PR DESCRIPTION
### What does this PR do?

Ensure we test against koa v2.15.3 when running `PLUGINS=koa yarn test:plugins:upstream`.

### Motivation

Previously we would always test against `latest`. However, the source code for koa v2.15.4 [has not been pushed](https://github.com/koajs/koa/issues/1857) to GitHub, so this will fail for that version. Until that has been fixed, or a newer version of koa has been released, we need this workaround to ensure CI doesn't block everybody.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


