### PR TITLE
Revert "Temporarily limit koa upstream tests to test against 2.15.3"

### DIFF
--- a/packages/datadog-plugin-koa/test/suite.js
+++ b/packages/datadog-plugin-koa/test/suite.js
@@ -1,10 +1,7 @@
 'use strict'
 const suiteTest = require('../../dd-trace/test/plugins/suite')
 
-// TODO: Temporarily limiting this to run against v2.15.3 instead of `latest`,
-// as it's currently failing on `latest` because that code hasn't been pushed to GitHub.
-// For details, see: https://github.com/koajs/koa/issues/1857
-suiteTest('koa', 'koajs/koa', '2.15.3')
+suiteTest('koa', 'koajs/koa', 'latest')
 
 // TODO enable this
 // suiteTest('@koa/router', 'koajs/router', 'latest')


### PR DESCRIPTION
### What does this PR do?

Revert #5248

### Motivation

We want to get CI back to testing the latest

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


