### PR TITLE
prevent usage of semver in code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,15 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const compat = new FlatCompat({ baseDirectory: __dirname })
 
+const SRC_FILES = [
+  '*.js',
+  '*.mjs',
+  'ext/**/*.js',
+  'ext/**/*.mjs',
+  'packages/*/src/**/*.js',
+  'packages/*/src/**/*.mjs'
+]
+
 const TEST_FILES = [
   'packages/*/test/**/*.js',
   'packages/*/test/**/*.mjs',
@@ -71,7 +80,7 @@ export default [
       '@stylistic/js/object-curly-newline': ['error', { multiline: true, consistent: true }],
       '@stylistic/js/object-curly-spacing': ['error', 'always'],
       'import/no-extraneous-dependencies': 'error',
-      'n/no-restricted-require': ['error', ['diagnostics_channel', 'semver']],
+      'n/no-restricted-require': ['error', ['diagnostics_channel']],
       'no-console': 'error',
       'no-prototype-builtins': 'off', // Override (turned on by @eslint/js/recommnded)
       'no-unused-expressions': 'off', // Override (turned on by standard)
@@ -82,6 +91,13 @@ export default [
     name: 'mocha/recommnded',
     ...mocha.configs.flat.recommended,
     files: TEST_FILES
+  },
+  {
+    name: 'dd-trace/src/all',
+    files: SRC_FILES,
+    rules: {
+      'n/no-restricted-require': ['error', ['semver']]
+    }
   },
   {
     name: 'dd-trace/tests/all',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,7 +71,7 @@ export default [
       '@stylistic/js/object-curly-newline': ['error', { multiline: true, consistent: true }],
       '@stylistic/js/object-curly-spacing': ['error', 'always'],
       'import/no-extraneous-dependencies': 'error',
-      'n/no-restricted-require': ['error', ['diagnostics_channel']],
+      'n/no-restricted-require': ['error', ['diagnostics_channel', 'semver']],
       'no-console': 'error',
       'no-prototype-builtins': 'off', // Override (turned on by @eslint/js/recommnded)
       'no-unused-expressions': 'off', // Override (turned on by standard)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,7 +96,16 @@ export default [
     name: 'dd-trace/src/all',
     files: SRC_FILES,
     rules: {
-      'n/no-restricted-require': ['error', ['diagnostics_channel', 'semver']]
+      'n/no-restricted-require': ['error', [
+        {
+          name: 'diagnostics_channel',
+          message: 'Please use dc-polyfill instead.'
+        },
+        {
+          name: 'semver',
+          message: 'Please use semifies instead.'
+        }
+      ]]
     }
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,7 +96,7 @@ export default [
     name: 'dd-trace/src/all',
     files: SRC_FILES,
     rules: {
-      'n/no-restricted-require': ['error', ['semver']]
+      'n/no-restricted-require': ['error', ['diagnostics_channel', 'semver']]
     }
   },
   {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Prevent usage of `semver` in code.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is a very large module and reintroducing its usage would cause a big regression for startup time.