### PR TITLE
lazy load runtime metrics only when needed

### DIFF
--- a/packages/dd-trace/src/runtime_metrics/index.js
+++ b/packages/dd-trace/src/runtime_metrics/index.js
@@ -3,19 +3,19 @@
 let runtimeMetrics
 
 const noop = runtimeMetrics = {
-  start () {},
-  stop () {},
-  track () {},
-  boolean () {},
-  histogram () {},
-  count () {},
-  gauge () {},
-  increment () {},
-  decrement () {}
+  start: () => {},
+  stop: () => {},
+  track: () => {},
+  boolean: () => {},
+  histogram: () => {},
+  count: () => {},
+  gauge: () => {},
+  increment: () => {},
+  decrement: () => {}
 }
 
 module.exports = {
-  start (config) {
+  start: (config) => {
     if (!config?.runtimeMetrics) return
 
     runtimeMetrics = require('./runtime_metrics')

--- a/packages/dd-trace/src/runtime_metrics/index.js
+++ b/packages/dd-trace/src/runtime_metrics/index.js
@@ -1,0 +1,39 @@
+'use strict'
+
+let runtimeMetrics
+
+const noop = runtimeMetrics = {
+  start () {},
+  stop () {},
+  track () {},
+  boolean () {},
+  histogram () {},
+  count () {},
+  gauge () {},
+  increment () {},
+  decrement () {}
+}
+
+module.exports = {
+  start (config) {
+    if (!config?.runtimeMetrics) return
+
+    runtimeMetrics = require('./runtime_metrics')
+    runtimeMetrics.start(config)
+  },
+
+  stop: () => {
+    if (runtimeMetrics === noop) return
+
+    runtimeMetrics.stop()
+    runtimeMetrics = noop
+  },
+
+  track: (...args) => runtimeMetrics.track(...args),
+  boolean: (...args) => runtimeMetrics.boolean(...args),
+  histogram: (...args) => runtimeMetrics.histogram(...args),
+  count: (...args) => runtimeMetrics.count(...args),
+  gauge: (...args) => runtimeMetrics.gauge(...args),
+  increment: (...args) => runtimeMetrics.increment(...args),
+  decrement: (...args) => runtimeMetrics.decrement(...args)
+}

--- a/packages/dd-trace/src/runtime_metrics/index.js
+++ b/packages/dd-trace/src/runtime_metrics/index.js
@@ -3,19 +3,18 @@
 let runtimeMetrics
 
 const noop = runtimeMetrics = {
-  start: () => {},
-  stop: () => {},
-  track: () => {},
-  boolean: () => {},
-  histogram: () => {},
-  count: () => {},
-  gauge: () => {},
-  increment: () => {},
-  decrement: () => {}
+  stop () {},
+  track () {},
+  boolean () {},
+  histogram () {},
+  count () {},
+  gauge () {},
+  increment () {},
+  decrement () {}
 }
 
 module.exports = {
-  start: (config) => {
+  start (config) {
     if (!config?.runtimeMetrics) return
 
     runtimeMetrics = require('./runtime_metrics')
@@ -25,7 +24,7 @@ module.exports = {
     runtimeMetrics.start(config)
   },
 
-  stop: () => {
+  stop () {
     runtimeMetrics.stop()
 
     Object.setPrototypeOf(module.exports, runtimeMetrics = noop)

--- a/packages/dd-trace/src/runtime_metrics/index.js
+++ b/packages/dd-trace/src/runtime_metrics/index.js
@@ -19,21 +19,17 @@ module.exports = {
     if (!config?.runtimeMetrics) return
 
     runtimeMetrics = require('./runtime_metrics')
+
+    Object.setPrototypeOf(module.exports, runtimeMetrics)
+
     runtimeMetrics.start(config)
   },
 
   stop: () => {
-    if (runtimeMetrics === noop) return
-
     runtimeMetrics.stop()
-    runtimeMetrics = noop
-  },
 
-  track: (...args) => runtimeMetrics.track(...args),
-  boolean: (...args) => runtimeMetrics.boolean(...args),
-  histogram: (...args) => runtimeMetrics.histogram(...args),
-  count: (...args) => runtimeMetrics.count(...args),
-  gauge: (...args) => runtimeMetrics.gauge(...args),
-  increment: (...args) => runtimeMetrics.increment(...args),
-  decrement: (...args) => runtimeMetrics.decrement(...args)
+    Object.setPrototypeOf(module.exports, runtimeMetrics = noop)
+  }
 }
+
+Object.setPrototypeOf(module.exports, noop)

--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -4,12 +4,12 @@
 
 const v8 = require('v8')
 const os = require('os')
-const { DogStatsDClient } = require('./dogstatsd')
-const log = require('./log')
-const Histogram = require('./histogram')
+const { DogStatsDClient } = require('../dogstatsd')
+const log = require('../log')
+const Histogram = require('../histogram')
 const { performance, PerformanceObserver } = require('perf_hooks')
 
-const { NODE_MAJOR, NODE_MINOR } = require('../../../version')
+const { NODE_MAJOR, NODE_MINOR } = require('../../../../version')
 const INTERVAL = 10 * 1000
 
 // Node >=16 has PerformanceObserver with `gc` type, but <16.7 had a critical bug.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Lazy load runtime metrics only when needed.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now when runtime metrics are disabled, the code is still loaded which impacts startup time.