### PR TITLE
fix(telemetry): only report configuration with known values

### DIFF
--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -338,7 +338,7 @@ function updateConfig (changes, config) {
   for (const change of changes) {
     const { origin, value } = change
     if (value === undefined) {
-      continue;
+      continue
     }
 
     const name = nameMapping[change.name] || change.name

--- a/packages/dd-trace/src/telemetry/index.js
+++ b/packages/dd-trace/src/telemetry/index.js
@@ -336,10 +336,14 @@ function updateConfig (changes, config) {
   const names = [] // list of config names whose values have been changed
 
   for (const change of changes) {
+    const { origin, value } = change
+    if (value === undefined) {
+      continue;
+    }
+
     const name = nameMapping[change.name] || change.name
 
     names.push(name)
-    const { origin, value } = change
     const entry = { name, value, origin }
 
     if (namesNeedFormatting.has(entry.name)) {
@@ -353,6 +357,7 @@ function updateConfig (changes, config) {
     } else if (Array.isArray(entry.value)) {
       entry.value = value.join(',')
     }
+
     configuration.push(entry)
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR ensures that telemetry configuration is only reported when it has valid values. Since the `value` field is mandatory for configuration entries (as specified in the [schema](https://github.com/DataDog/instrumentation-telemetry-api-docs/blob/main/GeneratedDocumentation/ApiDocs/v2/SchemaDocumentation/Schemas/conf_key_value.md)), reporting entries without values results in invalid payloads that our intake do not or entirely process.

### Motivation
To reduce the number of invalid payloads and ensure the tracer conforms to the expected schema.

### Plugin Checklist
I've done none of the thing below because I'm a clueless cpp engineer but feel free to take over.
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


