### PR TITLE
ESLint: Require await inside async functions

### DIFF
--- a/benchmark/sirun/get-results.js
+++ b/benchmark/sirun/get-results.js
@@ -134,7 +134,7 @@ async function getResults (gitCommit) {
 async function main () {
   const ref = process.argv.length > 2 ? process.argv[2] : 'HEAD'
   const gitCommit = execSync(`git rev-parse ${ref}`).toString().trim()
-  console.log(JSON.stringify(getResults(gitCommit), null, 4))
+  console.log(JSON.stringify(await getResults(gitCommit), null, 4))
 }
 
 module.exports = {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -87,7 +87,8 @@ export default [
       'no-console': 'error',
       'no-prototype-builtins': 'off', // Override (turned on by @eslint/js/recommnded)
       'no-unused-expressions': 'off', // Override (turned on by standard)
-      'no-var': 'error' // Override (set to warn in standard)
+      'no-var': 'error', // Override (set to warn in standard)
+      'require-await': 'error'
     }
   },
   {
@@ -212,7 +213,8 @@ export default [
       'mocha/no-sibling-hooks': 'off',
       'mocha/no-skipped-tests': 'off',
       'mocha/no-top-level-hooks': 'off',
-      'n/handle-callback-err': 'off'
+      'n/handle-callback-err': 'off',
+      'require-await': 'off'
     }
   },
   {

--- a/packages/datadog-instrumentations/src/apollo-server-core.js
+++ b/packages/datadog-instrumentations/src/apollo-server-core.js
@@ -10,7 +10,7 @@ addHook({ name: 'apollo-server-core', file: 'dist/runHttpQuery.js', versions: ['
   const HttpQueryError = runHttpQueryModule.HttpQueryError
 
   shimmer.wrap(runHttpQueryModule, 'runHttpQuery', function wrapRunHttpQuery (originalRunHttpQuery) {
-    return async function runHttpQuery () {
+    return function runHttpQuery () {
       if (!requestChannel.start.hasSubscribers) {
         return originalRunHttpQuery.apply(this, arguments)
       }

--- a/packages/datadog-instrumentations/src/apollo-server-core.js
+++ b/packages/datadog-instrumentations/src/apollo-server-core.js
@@ -10,7 +10,6 @@ addHook({ name: 'apollo-server-core', file: 'dist/runHttpQuery.js', versions: ['
   const HttpQueryError = runHttpQueryModule.HttpQueryError
 
   shimmer.wrap(runHttpQueryModule, 'runHttpQuery', function wrapRunHttpQuery (originalRunHttpQuery) {
-    // The original function is async, but no need to mark it as such as long as it returns a promise
     return function runHttpQuery () {
       if (!requestChannel.start.hasSubscribers) {
         return originalRunHttpQuery.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/apollo-server-core.js
+++ b/packages/datadog-instrumentations/src/apollo-server-core.js
@@ -10,6 +10,7 @@ addHook({ name: 'apollo-server-core', file: 'dist/runHttpQuery.js', versions: ['
   const HttpQueryError = runHttpQueryModule.HttpQueryError
 
   shimmer.wrap(runHttpQueryModule, 'runHttpQuery', function wrapRunHttpQuery (originalRunHttpQuery) {
+    // The original function is async, but no need to mark it as such as long as it returns a promise
     return function runHttpQuery () {
       if (!requestChannel.start.hasSubscribers) {
         return originalRunHttpQuery.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/apollo-server.js
+++ b/packages/datadog-instrumentations/src/apollo-server.js
@@ -12,7 +12,7 @@ const requestChannel = dc.tracingChannel('datadog:apollo:request')
 let HeaderMap
 
 function wrapExecuteHTTPGraphQLRequest (originalExecuteHTTPGraphQLRequest) {
-  return async function executeHTTPGraphQLRequest () {
+  return function executeHTTPGraphQLRequest () {
     if (!HeaderMap || !requestChannel.start.hasSubscribers) {
       return originalExecuteHTTPGraphQLRequest.apply(this, arguments)
     }

--- a/packages/datadog-instrumentations/src/apollo-server.js
+++ b/packages/datadog-instrumentations/src/apollo-server.js
@@ -12,6 +12,7 @@ const requestChannel = dc.tracingChannel('datadog:apollo:request')
 let HeaderMap
 
 function wrapExecuteHTTPGraphQLRequest (originalExecuteHTTPGraphQLRequest) {
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   return function executeHTTPGraphQLRequest () {
     if (!HeaderMap || !requestChannel.start.hasSubscribers) {
       return originalExecuteHTTPGraphQLRequest.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/apollo-server.js
+++ b/packages/datadog-instrumentations/src/apollo-server.js
@@ -12,7 +12,6 @@ const requestChannel = dc.tracingChannel('datadog:apollo:request')
 let HeaderMap
 
 function wrapExecuteHTTPGraphQLRequest (originalExecuteHTTPGraphQLRequest) {
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   return function executeHTTPGraphQLRequest () {
     if (!HeaderMap || !requestChannel.start.hasSubscribers) {
       return originalExecuteHTTPGraphQLRequest.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -442,7 +442,7 @@ addHook({
 }, getTestEnvironment)
 
 function getWrappedScheduleTests (scheduleTests, frameworkVersion) {
-  return async function (tests) {
+  return function (tests) {
     if (!isSuitesSkippingEnabled || hasFilteredSkippableSuites) {
       return scheduleTests.apply(this, arguments)
     }
@@ -744,7 +744,7 @@ function coverageReporterWrapper (coverageReporter) {
    * This calculation adds no value, so we'll skip it, as long as the user has not manually opted in to code coverage,
    * in which case we'll leave it.
    */
-  shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => async function () {
+  shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => function () {
     // If the user has added coverage manually, they're willing to pay the price of this execution, so
     // we will not skip it.
     if (isSuitesSkippingEnabled && !isUserCodeCoverageEnabled) {
@@ -901,7 +901,7 @@ addHook({
 }, transformPackage => {
   const originalCreateScriptTransformer = transformPackage.createScriptTransformer
 
-  transformPackage.createScriptTransformer = async function (config) {
+  transformPackage.createScriptTransformer = function (config) {
     const { testEnvironmentOptions, ...restOfConfig } = config
     const {
       _ddTestModuleId,

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -442,7 +442,6 @@ addHook({
 }, getTestEnvironment)
 
 function getWrappedScheduleTests (scheduleTests, frameworkVersion) {
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   return function (tests) {
     if (!isSuitesSkippingEnabled || hasFilteredSkippableSuites) {
       return scheduleTests.apply(this, arguments)
@@ -745,7 +744,6 @@ function coverageReporterWrapper (coverageReporter) {
    * This calculation adds no value, so we'll skip it, as long as the user has not manually opted in to code coverage,
    * in which case we'll leave it.
    */
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => function () {
     // If the user has added coverage manually, they're willing to pay the price of this execution, so
     // we will not skip it.
@@ -903,7 +901,6 @@ addHook({
 }, transformPackage => {
   const originalCreateScriptTransformer = transformPackage.createScriptTransformer
 
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   transformPackage.createScriptTransformer = function (config) {
     const { testEnvironmentOptions, ...restOfConfig } = config
     const {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -442,6 +442,7 @@ addHook({
 }, getTestEnvironment)
 
 function getWrappedScheduleTests (scheduleTests, frameworkVersion) {
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   return function (tests) {
     if (!isSuitesSkippingEnabled || hasFilteredSkippableSuites) {
       return scheduleTests.apply(this, arguments)
@@ -744,6 +745,7 @@ function coverageReporterWrapper (coverageReporter) {
    * This calculation adds no value, so we'll skip it, as long as the user has not manually opted in to code coverage,
    * in which case we'll leave it.
    */
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => function () {
     // If the user has added coverage manually, they're willing to pay the price of this execution, so
     // we will not skip it.
@@ -901,6 +903,7 @@ addHook({
 }, transformPackage => {
   const originalCreateScriptTransformer = transformPackage.createScriptTransformer
 
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   transformPackage.createScriptTransformer = function (config) {
     const { testEnvironmentOptions, ...restOfConfig } = config
     const {

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -349,7 +349,6 @@ addHook({
   versions: ['>=5.2.0'],
   file: 'lib/cli/run-helpers.js'
 }, (run) => {
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(run, 'runMocha', runMocha => function () {
     if (!testStartCh.hasSubscribers) {
       return runMocha.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -349,6 +349,7 @@ addHook({
   versions: ['>=5.2.0'],
   file: 'lib/cli/run-helpers.js'
 }, (run) => {
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(run, 'runMocha', runMocha => function () {
     if (!testStartCh.hasSubscribers) {
       return runMocha.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -349,7 +349,7 @@ addHook({
   versions: ['>=5.2.0'],
   file: 'lib/cli/run-helpers.js'
 }, (run) => {
-  shimmer.wrap(run, 'runMocha', runMocha => async function () {
+  shimmer.wrap(run, 'runMocha', runMocha => function () {
     if (!testStartCh.hasSubscribers) {
       return runMocha.apply(this, arguments)
     }

--- a/packages/datadog-instrumentations/src/nyc.js
+++ b/packages/datadog-instrumentations/src/nyc.js
@@ -7,7 +7,7 @@ addHook({
   name: 'nyc',
   versions: ['>=17']
 }, (nycPackage) => {
-  shimmer.wrap(nycPackage.prototype, 'wrap', wrap => async function () {
+  shimmer.wrap(nycPackage.prototype, 'wrap', wrap => function () {
     // Only relevant if the config `all` is set to true
     try {
       if (JSON.parse(process.env.NYC_CONFIG).all) {

--- a/packages/datadog-instrumentations/src/nyc.js
+++ b/packages/datadog-instrumentations/src/nyc.js
@@ -7,7 +7,6 @@ addHook({
   name: 'nyc',
   versions: ['>=17']
 }, (nycPackage) => {
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(nycPackage.prototype, 'wrap', wrap => function () {
     // Only relevant if the config `all` is set to true
     try {

--- a/packages/datadog-instrumentations/src/nyc.js
+++ b/packages/datadog-instrumentations/src/nyc.js
@@ -7,6 +7,7 @@ addHook({
   name: 'nyc',
   versions: ['>=17']
 }, (nycPackage) => {
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(nycPackage.prototype, 'wrap', wrap => function () {
     // Only relevant if the config `all` is set to true
     try {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -329,7 +329,6 @@ addHook({
   const { VitestTestRunner } = vitestPackage
 
   // `onBeforeRunTask` is run before any repetition or attempt is run
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(VitestTestRunner.prototype, 'onBeforeRunTask', onBeforeRunTask => function (task) {
     const testName = getTestName(task)
 
@@ -362,7 +361,6 @@ addHook({
   })
 
   // `onAfterRunTask` is run after all repetitions or attempts are run
-  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(VitestTestRunner.prototype, 'onAfterRunTask', onAfterRunTask => function (task) {
     const { isEarlyFlakeDetectionEnabled, isQuarantinedTestsEnabled } = getProvidedContext()
 

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -329,7 +329,7 @@ addHook({
   const { VitestTestRunner } = vitestPackage
 
   // `onBeforeRunTask` is run before any repetition or attempt is run
-  shimmer.wrap(VitestTestRunner.prototype, 'onBeforeRunTask', onBeforeRunTask => async function (task) {
+  shimmer.wrap(VitestTestRunner.prototype, 'onBeforeRunTask', onBeforeRunTask => function (task) {
     const testName = getTestName(task)
 
     const {
@@ -361,7 +361,7 @@ addHook({
   })
 
   // `onAfterRunTask` is run after all repetitions or attempts are run
-  shimmer.wrap(VitestTestRunner.prototype, 'onAfterRunTask', onAfterRunTask => async function (task) {
+  shimmer.wrap(VitestTestRunner.prototype, 'onAfterRunTask', onAfterRunTask => function (task) {
     const { isEarlyFlakeDetectionEnabled, isQuarantinedTestsEnabled } = getProvidedContext()
 
     if (isEarlyFlakeDetectionEnabled && taskToStatuses.has(task)) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -329,6 +329,7 @@ addHook({
   const { VitestTestRunner } = vitestPackage
 
   // `onBeforeRunTask` is run before any repetition or attempt is run
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(VitestTestRunner.prototype, 'onBeforeRunTask', onBeforeRunTask => function (task) {
     const testName = getTestName(task)
 
@@ -361,6 +362,7 @@ addHook({
   })
 
   // `onAfterRunTask` is run after all repetitions or attempts are run
+  // The original function is async, but no need to mark it as such as long as it returns a promise
   shimmer.wrap(VitestTestRunner.prototype, 'onAfterRunTask', onAfterRunTask => function (task) {
     const { isEarlyFlakeDetectionEnabled, isQuarantinedTestsEnabled } = getProvidedContext()
 

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -76,12 +76,12 @@ async function removeBreakpoint ({ id }) {
   if (breakpoints.size === 0) return stop() // return instead of await to reduce number of promises created
 }
 
-async function start () {
+function start () {
   sessionStarted = true
   return session.post('Debugger.enable') // return instead of await to reduce number of promises created
 }
 
-async function stop () {
+function stop () {
   sessionStarted = false
   return session.post('Debugger.disable') // return instead of await to reduce number of promises created
 }

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
@@ -63,7 +63,7 @@ async function traverseGetPropertiesResult (props, opts, depth) {
   return props
 }
 
-async function getObjectProperties (subtype, objectId, opts, depth) {
+function getObjectProperties (subtype, objectId, opts, depth) {
   if (ITERABLE_SUBTYPES.has(subtype)) {
     return getIterable(objectId, opts, depth)
   } else if (subtype === 'promise') {

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -126,7 +126,7 @@ class Profiler extends EventEmitter {
     this._timeoutInterval = this._config.flushInterval
   }
 
-  async stop () {
+  stop () {
     if (!this._enabled) return
 
     // collect and export current profiles


### PR DESCRIPTION
### What does this PR do?

Enable the `require-await` ESLint rule. The rule isn't enabled in tests, where the extra created promises doesn't harm anyone.

### Motivation

If a function is marked as async, V8 will create a few extra promises behind the scenes when awaiting it. If the function doesn't itself contain any awaits, these extra promises just adds overhead that isn't needed.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes

Be aware: This might break some things that expect the function to return a promise. We'll have to go over each of the places where the PR removes the `async` keyword and check if the function returns something that should be a promise, but isn't.

There might be a few places, especially places were we use `shimmer.wrap` where we might actually want to keep the `async` keyword!