### PR TITLE
fix(openai): update openai instrumentation for newest release

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -97,6 +97,14 @@ const V4_PACKAGE_SHIMS = [
     targetClass: 'Translations',
     baseResource: 'audio.translations',
     methods: ['create']
+  },
+  {
+    file: 'resources/chat/completions/completions.js',
+    targetClass: 'Completions',
+    baseResource: 'chat.completions',
+    methods: ['create'],
+    streamedResponse: true,
+    versions: ['>=4.85.0']
   }
 ]
 


### PR DESCRIPTION
### What does this PR do?
The [4.85.0](https://github.com/openai/openai-node/releases/tag/v4.85.0) release of the OpenAI Node.js SDK changed the location of one of the files we traced. This PR fixes that for the newest version.

### Motivation
Fix OpenAI patching, unblock CI