### PR TITLE
only load fetch plugin when fetch is used

### DIFF
--- a/packages/datadog-instrumentations/src/fetch.js
+++ b/packages/datadog-instrumentations/src/fetch.js
@@ -1,12 +1,14 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
-const { tracingChannel } = require('dc-polyfill')
+const { channel, tracingChannel } = require('dc-polyfill')
 const { createWrapFetch } = require('./helpers/fetch')
 
 if (globalThis.fetch) {
   const ch = tracingChannel('apm:fetch:request')
-  const wrapFetch = createWrapFetch(globalThis.Request, ch)
+  const wrapFetch = createWrapFetch(globalThis.Request, ch, () => {
+    channel('dd-trace:instrumentation:load').publish({ name: 'fetch' })
+  })
 
   globalThis.fetch = shimmer.wrapFunction(fetch, fetch => wrapFetch(fetch))
 }

--- a/packages/datadog-instrumentations/src/helpers/fetch.js
+++ b/packages/datadog-instrumentations/src/helpers/fetch.js
@@ -1,10 +1,19 @@
 'use strict'
 
+const { channel } = require('dc-polyfill')
+
 exports.createWrapFetch = function createWrapFetch (Request, ch) {
+  let loaded = false
+
   return function wrapFetch (fetch) {
     if (typeof fetch !== 'function') return fetch
 
     return function (input, init) {
+      if (!loaded) {
+        channel('dd-trace:instrumentation:load').publish({ name: 'fetch' })
+        loaded = true
+      }
+
       if (!ch.start.hasSubscribers) return fetch.apply(this, arguments)
 
       if (input instanceof Request) {

--- a/packages/datadog-instrumentations/src/helpers/fetch.js
+++ b/packages/datadog-instrumentations/src/helpers/fetch.js
@@ -1,17 +1,13 @@
 'use strict'
 
-const { channel } = require('dc-polyfill')
-
-exports.createWrapFetch = function createWrapFetch (Request, ch) {
-  let loaded = false
-
+exports.createWrapFetch = function createWrapFetch (Request, ch, onLoad) {
   return function wrapFetch (fetch) {
     if (typeof fetch !== 'function') return fetch
 
     return function (input, init) {
-      if (!loaded) {
-        channel('dd-trace:instrumentation:load').publish({ name: 'fetch' })
-        loaded = true
+      if (onLoad) {
+        onLoad()
+        onLoad = undefined
       }
 
       if (!ch.start.hasSubscribers) return fetch.apply(this, arguments)

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -103,7 +103,7 @@ module.exports = class PluginManager {
     this._tracerConfig = config
     this._tracer._nomenclature.configure(config)
 
-    if (!config._isInServerlessEnvironment()) {
+    if (!config._isInServerlessEnvironment?.()) {
       maybeEnable(require('../../datadog-plugin-fetch/src'))
     }
 

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -28,9 +28,6 @@ loadChannel.subscribe(({ name }) => {
   maybeEnable(plugins[name])
 })
 
-// Globals
-maybeEnable(require('../../datadog-plugin-fetch/src'))
-
 // Always enabled
 maybeEnable(require('../../datadog-plugin-dd-trace-api/src'))
 

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -103,6 +103,10 @@ module.exports = class PluginManager {
     this._tracerConfig = config
     this._tracer._nomenclature.configure(config)
 
+    if (!config._isInServerlessEnvironment()) {
+      maybeEnable(require('../../datadog-plugin-fetch/src'))
+    }
+
     for (const name in pluginClasses) {
       this.loadPlugin(name)
     }

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -38,6 +38,7 @@ module.exports = {
   get elasticsearch () { return require('../../../datadog-plugin-elasticsearch/src') },
   get express () { return require('../../../datadog-plugin-express/src') },
   get fastify () { return require('../../../datadog-plugin-fastify/src') },
+  get fetch () { return require('../../../datadog-plugin-fetch/src') },
   get 'find-my-way' () { return require('../../../datadog-plugin-find-my-way/src') },
   get graphql () { return require('../../../datadog-plugin-graphql/src') },
   get grpc () { return require('../../../datadog-plugin-grpc/src') },

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -38,7 +38,6 @@ module.exports = {
   get elasticsearch () { return require('../../../datadog-plugin-elasticsearch/src') },
   get express () { return require('../../../datadog-plugin-express/src') },
   get fastify () { return require('../../../datadog-plugin-fastify/src') },
-  get fetch () { return require('../../../datadog-plugin-fetch/src') },
   get 'find-my-way' () { return require('../../../datadog-plugin-find-my-way/src') },
   get graphql () { return require('../../../datadog-plugin-graphql/src') },
   get grpc () { return require('../../../datadog-plugin-grpc/src') },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Only load `fetch` plugin when fetch is used.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now it's always loaded regardless of whether it's used, which impacts startup time.