### PR TITLE
[test optimization] Fix session fingerprint in playwright

### DIFF
--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -17,7 +17,8 @@ const {
   TEST_SOURCE_START,
   TEST_TYPE,
   TEST_SOURCE_FILE,
-  TEST_CONFIGURATION_BROWSER_NAME,
+  TEST_PARAMETERS,
+  TEST_BROWSER_NAME,
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
@@ -153,7 +154,12 @@ versions.forEach((version) => {
               assert.propertyVal(testEvent.content.meta, 'test.customtag', 'customvalue')
               assert.propertyVal(testEvent.content.meta, 'test.customtag2', 'customvalue2')
               // Adds the browser used
-              assert.propertyVal(testEvent.content.meta, TEST_CONFIGURATION_BROWSER_NAME, 'chromium')
+              assert.propertyVal(testEvent.content.meta, TEST_BROWSER_NAME, 'chromium')
+              assert.propertyVal(
+                testEvent.content.meta,
+                TEST_PARAMETERS,
+                JSON.stringify({ arguments: { browser: 'chromium' }, metadata: {} })
+              )
               assert.exists(testEvent.content.metrics[DD_HOST_CPU_COUNT])
             })
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -11,12 +11,13 @@ const {
   TEST_SOURCE_START,
   TEST_CODE_OWNERS,
   TEST_SOURCE_FILE,
-  TEST_CONFIGURATION_BROWSER_NAME,
+  TEST_PARAMETERS,
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
   TELEMETRY_TEST_SESSION,
-  TEST_RETRY_REASON
+  TEST_RETRY_REASON,
+  TEST_BROWSER_NAME
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -202,7 +203,9 @@ class PlaywrightPlugin extends CiPlugin {
       extraTags[TEST_SOURCE_FILE] = testSourceFile || testSuite
     }
     if (browserName) {
-      extraTags[TEST_CONFIGURATION_BROWSER_NAME] = browserName
+      // Added as parameter too because it should affect the test fingerprint
+      extraTags[TEST_PARAMETERS] = JSON.stringify({ arguments: { browser: browserName }, metadata: {} })
+      extraTags[TEST_BROWSER_NAME] = browserName
     }
 
     return super.startTestSpan(testName, testSuite, testSuiteSpan, extraTags)

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -52,8 +52,6 @@ const TEST_MODULE_ID = 'test_module_id'
 const TEST_SUITE_ID = 'test_suite_id'
 const TEST_TOOLCHAIN = 'test.toolchain'
 const TEST_SKIPPED_BY_ITR = 'test.skipped_by_itr'
-// Browser used in browser test. Namespaced by test.configuration because it affects the fingerprint
-const TEST_CONFIGURATION_BROWSER_NAME = 'test.configuration.browser_name'
 // Early flake detection
 const TEST_IS_NEW = 'test.is_new'
 const TEST_IS_RETRY = 'test.is_retry'
@@ -143,7 +141,6 @@ module.exports = {
   MOCHA_WORKER_TRACE_PAYLOAD_CODE,
   TEST_SOURCE_START,
   TEST_SKIPPED_BY_ITR,
-  TEST_CONFIGURATION_BROWSER_NAME,
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,


### PR DESCRIPTION
### What does this PR do?

* Remove `test.configuration.browser_name` from test events. 
* Add browser name as `test.parameter`
* Report browser name as `test.browser.name`

### Motivation

My initial intention with using `test.configuration.browser_name` was to make tests running in different browsers have a different fingerprint. This is a **problem** because `test.configuration.*` is part of the fingerprint both for session and events. Since `test.configuration.browser_name` is _not_ in the test session event (it wouldn't make sense, as there are multiple used browsers per session), the `test_session.fingerprint` calculated in the backend is different in test and session events. This makes correlating events impossible. 

By using `test.parameter` we still distinguish fingerprints for different browsers. Also, the browser name can be queried / filtered by using `test.browser.name`, so user functionality remains. 

### Plugin Checklist
Only manual tests possible, as the fingerprints are calculated in the backend. 
