### PR TITLE
fix(openai): apply span char limit truncation to chat completion input tags

### DIFF
--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -795,7 +795,7 @@ function truncateApiKey (apiKey) {
 
 function tagChatCompletionRequestContent (contents, messageIdx, tags) {
   if (typeof contents === 'string') {
-    tags[`openai.request.messages.${messageIdx}.content`] = contents
+    tags[`openai.request.messages.${messageIdx}.content`] = normalize(contents)
   } else if (Array.isArray(contents)) {
     // content can also be an array of objects
     // which represent text input or image url


### PR DESCRIPTION
### What does this PR do?
Applies truncation/normalization logic to input/request tagging for the openai integration.

### Motivation
properly recognize `DD_OPENAI_SPAN_CHAR_LIMIT` in all relevant cases - this one was missed (I think has been missed since the creation of the integration).