### PR TITLE
ESLint: Run on the latest supported Node.js version

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       - run: yarn lint
 


### PR DESCRIPTION
### What does this PR do?

This changes the GitHub action CI workflow that runs the linter, to use the latest supported Node.js version instead of the oldest (currently version 22 instead of version 18).

### Motivation

The linting should produce the same result no matter which version it runs on, so there's no reason to use an older Node.js version for this.  If using a newer version, we might even get some benefits like faster runs or better error messages (thought I haven't verified this).

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


