### PR TITLE
[DI] Workaround bug in AsyncLocalStorage which would otherwise throw

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -31,7 +31,7 @@ jobs:
     uses: DataDog/system-tests/.github/workflows/compute-workflow-parameters.yml@main
     with:
       library: nodejs
-      scenarios_groups: essentials,appsec_rasp
+      scenarios_groups: tracer-release
 
   system-tests:
     runs-on: ${{ contains(fromJSON('["CROSSED_TRACING_LIBRARIES", "INTEGRATIONS"]'), matrix.scenario) && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -31,7 +31,7 @@ jobs:
     uses: DataDog/system-tests/.github/workflows/compute-workflow-parameters.yml@main
     with:
       library: nodejs
-      scenarios_groups: tracer-release
+      scenarios_groups: essentials,appsec_rasp,debugger
 
   system-tests:
     runs-on: ${{ contains(fromJSON('["CROSSED_TRACING_LIBRARIES", "INTEGRATIONS"]'), matrix.scenario) && 'ubuntu-latest-16-cores' || 'ubuntu-latest' }}

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -31,9 +31,9 @@ async function addBreakpoint (probe) {
   probe.nsBetweenSampling = BigInt(1 / snapshotsPerSecond * 1e9)
   probe.lastCaptureNs = 0n
 
-  // TODO: Inbetween `await session.post('Debugger.enable')` and here, the scripts are parsed and cached.
-  // Maybe there's a race condition here or maybe we're guraenteed that `await session.post('Debugger.enable')` will
-  // not continue untill all scripts have been parsed?
+  // Warning: The code below relies on undocumented behavior of the inspector!
+  // It expects that `await session.post('Debugger.enable')` will wait for all loaded scripts to be emitted as
+  // `Debugger.scriptParsed` events. If this ever changes, we will have a race condition!
   const script = findScriptFromPartialPath(file)
   if (!script) throw new Error(`No loaded script found for ${file} (probe: ${probe.id}, version: ${probe.version})`)
   const { url, scriptId, sourceMapURL, source } = script

--- a/packages/dd-trace/src/debugger/devtools_client/source-maps.js
+++ b/packages/dd-trace/src/debugger/devtools_client/source-maps.js
@@ -44,14 +44,15 @@ const self = module.exports = {
 //
 // Source: https://github.com/nodejs/node/blob/v18.20.6/lib/async_hooks.js#L312
 function cacheIt (key, value) {
-  if (Date.now() > cacheTimerLastSet + 1_000) {
+  const now = Date.now()
+  if (now > cacheTimerLastSet + 1_000) {
     clearTimeout(cacheTimer)
     cacheTimer = setTimeout(function () {
       // Optimize for app boot, where a lot of reads might happen
       // Clear cache a few seconds after it was last used
       cache.clear()
     }, 10_000).unref()
-    cacheTimerLastSet = Date.now()
+    cacheTimerLastSet = now
   }
   cache.set(key, value)
   return value

--- a/packages/dd-trace/src/debugger/devtools_client/source-maps.js
+++ b/packages/dd-trace/src/debugger/devtools_client/source-maps.js
@@ -7,6 +7,7 @@ const { SourceMapConsumer } = require('source-map')
 
 const cache = new Map()
 let cacheTimer = null
+let cacheTimerLastSet = 0
 
 const self = module.exports = {
   async loadSourceMap (dir, url) {
@@ -33,13 +34,25 @@ const self = module.exports = {
   }
 }
 
+// TODO: Remove if-statement around `setTimeout` below once it's safe to do so.
+//
+// This is a workaround for, what seems like a bug in Node.js core, that seems to trigger when, among other things, a
+// lot of timers are being created very rapidly. This makes the call to `setTimeout` throw an error from within
+// `AsyncLocalStorage._propagate` with the following error message:
+//
+//     TypeError: Cannot read properties of undefined (reading 'Symbol(kResourceStore)')
+//
+// Source: https://github.com/nodejs/node/blob/v18.20.6/lib/async_hooks.js#L312
 function cacheIt (key, value) {
-  clearTimeout(cacheTimer)
-  cacheTimer = setTimeout(function () {
-    // Optimize for app boot, where a lot of reads might happen
-    // Clear cache a few seconds after it was last used
-    cache.clear()
-  }, 10_000).unref()
+  if (Date.now() > cacheTimerLastSet + 1_000) {
+    clearTimeout(cacheTimer)
+    cacheTimer = setTimeout(function () {
+      // Optimize for app boot, where a lot of reads might happen
+      // Clear cache a few seconds after it was last used
+      cache.clear()
+    }, 10_000).unref()
+    cacheTimerLastSet = Date.now()
+  }
   cache.set(key, value)
   return value
 }

--- a/packages/dd-trace/test/debugger/devtools_client/source-maps.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/source-maps.spec.js
@@ -98,7 +98,9 @@ describe('source map utils', function () {
     let clock
 
     function setup () {
-      clock = sinon.useFakeTimers()
+      clock = sinon.useFakeTimers({
+        toFake: ['setTimeout']
+      })
       readFileSync = sinon.stub().returns(rawSourceMap)
       readFile = sinon.stub().resolves(rawSourceMap)
 


### PR DESCRIPTION
### What does this PR do?

This is a workaround for, what seems like a bug in Node.js core, that seems to trigger when, among other things, a lot of timers are being created very rapidly. This makes the call to `setTimeout` throw an error from within `AsyncLocalStorage._propagate` with the following TypeError:
    
    Cannot read properties of undefined (reading 'Symbol(kResourceStore)')

Source of the bug: https://github.com/nodejs/node/blob/v18.20.6/lib/async_hooks.js#L312

### Motivation

Don't crash customer applications.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


