### PR TITLE
[test optimization] Lighter init in worker thread

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const tracer = require('../packages/dd-trace')
-const { isTrue } = require('../packages/dd-trace/src/util')
+const { isTrue, isFalse } = require('../packages/dd-trace/src/util')
 const log = require('../packages/dd-trace/src/log')
 
 const isJestWorker = !!process.env.JEST_WORKER_ID
@@ -23,7 +23,7 @@ const options = {
   flushInterval: isJestWorker ? 0 : 5000
 }
 
-let shouldInit = true
+let shouldInit = !isFalse(process.env.DD_CIVISIBILITY_ENABLED)
 
 if (isPackageManager()) {
   log.debug('dd-trace is not initialized in a package manager.')

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -69,8 +69,12 @@ class TestVisDynamicInstrumentation {
         // To avoid infinite initialization loops, we're disabling DI and tracing in the worker.
         env: {
           ...process.env,
+          DD_CIVISIBILITY_ENABLED: 0,
           DD_TRACE_ENABLED: 0,
-          DD_TEST_FAILED_TEST_REPLAY_ENABLED: 0
+          DD_TEST_FAILED_TEST_REPLAY_ENABLED: 0,
+          DD_CIVISIBILITY_MANUAL_API_ENABLED: 0,
+          DD_TRACING_ENABLED: 0,
+          DD_TRACE_TELEMETRY_ENABLED: 0
         },
         workerData: {
           config: config.serialize(),


### PR DESCRIPTION
### What does this PR do?
Pass disable flags to the worker thread. 

### Motivation
Have a lighter initialization in the worker thread to prevent memory issues now that the worker thread is not lazily loaded. 

### Plugin Checklist
Just make sure that the tests still pass