### PR TITLE
tracing: fix http client synchronous errors causing spans to not finish

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -117,6 +117,11 @@ function patch (http, methodName) {
         } catch (e) {
           ctx.error = e
           errorChannel.publish(ctx)
+          // if the initial request failed, ctx.req will be unset, we must close the span here
+          // fix for: https://github.com/ndresselhaus/dd-trace-http-bug/tree/main
+          if (!ctx.req) {
+            finish()
+          }
           throw e
         } finally {
           endChannel.publish(ctx)

--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -118,7 +118,7 @@ function patch (http, methodName) {
           ctx.error = e
           errorChannel.publish(ctx)
           // if the initial request failed, ctx.req will be unset, we must close the span here
-          // fix for: https://github.com/ndresselhaus/dd-trace-http-bug/tree/main
+          // fix for: https://github.com/DataDog/dd-trace-js/issues/5016
           if (!ctx.req) {
             finish()
           }

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -102,7 +102,9 @@ class HttpClientPlugin extends ClientPlugin {
       addResponseHeaders(res, span, this.config)
     }
 
-    addRequestHeaders(req, span, this.config)
+    if (req) {
+      addRequestHeaders(req, span, this.config)
+    }
 
     this.config.hooks.request(span, req, res)
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -944,9 +944,13 @@ describe('Plugin', () => {
             .then(done)
             .catch(done)
 
-          http.request('https://httpbin.org/get', { headers: { BadHeader: 'a\nb' } }, res => {
-            res.on('data', () => { })
-          })
+          try {
+            http.request('http://httpbin.org/get', { headers: { BadHeader: 'a\nb' } }, res => {
+              res.on('data', () => { })
+            })
+          } catch {
+            // expected to throw error
+          }
         })
       })
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -934,6 +934,20 @@ describe('Plugin', () => {
             })
           })
         }
+
+        it('should record unfinished http requests as error spans', done => {
+          agent
+            .use(traces => {
+              expect(traces[0][0]).to.have.property('error', 1)
+              expect(traces[0][0].meta).to.not.have.property('http.status_code')
+            })
+            .then(done)
+            .catch(done)
+
+          http.request('https://httpbin.org/get', { headers: { BadHeader: 'a\nb' } }, res => {
+            res.on('data', () => { })
+          })
+        })
       })
 
       describe('with late plugin initialization and an external subscriber', () => {


### PR DESCRIPTION
Fixes #5016 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


