### PR TITLE
[test optimization] Fix wrong `log.error` if quarantined tests are empty

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -170,7 +170,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         try {
           const hasQuarantinedTests = !!quarantinedTests.jest
           this.quarantinedTestsForThisSuite = hasQuarantinedTests
-            ? this.getQuarantinedTestsForSuite(quarantinedTests.jest.suites[this.testSuite].tests)
+            ? this.getQuarantinedTestsForSuite(quarantinedTests.jest.suites?.[this.testSuite]?.tests)
             : this.getQuarantinedTestsForSuite(this.testEnvironmentOptions._ddQuarantinedTests)
         } catch (e) {
           log.error('Error parsing quarantined tests', e)
@@ -212,6 +212,9 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
     getQuarantinedTestsForSuite (quaratinedTests) {
       if (this.quarantinedTestsForThisSuite) {
         return this.quarantinedTestsForThisSuite
+      }
+      if (!quaratinedTests) {
+        return []
       }
       let quarantinedTestsForSuite = quaratinedTests
       // If jest is using workers, quarantined tests are serialized to json.

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -209,14 +209,14 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       return knownTestsForSuite
     }
 
-    getQuarantinedTestsForSuite (quaratinedTests) {
+    getQuarantinedTestsForSuite (quarantined) {
       if (this.quarantinedTestsForThisSuite) {
         return this.quarantinedTestsForThisSuite
       }
-      if (!quaratinedTests) {
+      if (!quarantined) {
         return []
       }
-      let quarantinedTestsForSuite = quaratinedTests
+      let quarantinedTestsForSuite = quarantined
       // If jest is using workers, quarantined tests are serialized to json.
       // If jest runs in band, they are not.
       if (typeof quarantinedTestsForSuite === 'string') {


### PR DESCRIPTION
### What does this PR do?

* Do not try to call `Object.entries(quarantinedTestsForSuite)` if the input is empty
* Fix typo 

### Motivation
If there are no quarantined tests, `quaratinedTests.jest` is empty, so we assume that we're running in a worker setup (parallel mode), and we fall back to `this.testEnvironmentOptions._ddQuarantinedTests`. This is wrong, so we're uselessly showing a `log.error` when in reality the quarantined tests should just be empty. 

### Plugin Checklist

Just make sure tests are still passing