### PR TITLE
Add bot to manage stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          debug-only: true #
           days-before-issue-stale: -1 # disabled for issues
 
           days-before-pr-stale: 90 # 3 months

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,6 @@ name: 'Stale PR Bot'
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch: # allow manual trigger
-  pull_request: # manual trigger
 
 permissions:
   pull-requests: write
@@ -22,10 +20,7 @@ jobs:
           stale-pr-label: "stale"
           exempt-pr-labels: "keep-open"
           stale-pr-message: |
-            This pull request has been marked as stale due to inactivity. 
-            If this is still relevant, please update or comment to keep it open. 
-            Otherwise, it will be automatically closed after additional time.
-
-            If you need assistance or have any questions, feel free to reach out.
-
-            Thank you for your contribution! 🚀
+            This pull request has been marked as stale due to 60 days of inactivity.
+            If this is still relevant, please update or comment to keep it open.
+            If this should be kept open indefinitely, please apply the label `keep-open`.
+            Otherwise, it will be automatically closed after 14 days.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: # allow manual trigger
 
+permissions:
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
           exempt-pr-labels: "keep-open"
           exempt-draft-pr: true
           stale-pr-message: |
-            This pull request has been marked as stale due to 60 days of inactivity.
+            This pull request has been marked as stale due to 90 days of inactivity.
             If this is still relevant, please update or comment to keep it open.
             If this should be kept open indefinitely, please apply the label `keep-open`.
             Otherwise, it will be automatically closed after 14 days.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Stale PR Bot'
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 4 * * *'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch: # allow manual trigger
+  pull_request: # manual trigger
 
 permissions:
   pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
           days-before-pr-close: 14 # 2 weeks
           stale-pr-label: "stale"
           exempt-pr-labels: "keep-open"
+          exempt-draft-pr: true
           stale-pr-message: |
             This pull request has been marked as stale due to 60 days of inactivity.
             If this is still relevant, please update or comment to keep it open.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: 'Stale PR Bot'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          debug-only: true #
+          days-before-issue-stale: -1 # disabled for issues
+
+          days-before-pr-stale: 90 # 3 months
+          days-before-pr-close: 14 # 2 weeks
+          stale-pr-label: "stale"
+          exempt-pr-labels: "keep-open"
+          stale-pr-message: |
+            This pull request has been marked as stale due to inactivity. 
+            If this is still relevant, please update or comment to keep it open. 
+            Otherwise, it will be automatically closed after additional time.
+
+            If you need assistance or have any questions, feel free to reach out.
+
+            Thank you for your contribution! 🚀

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -169,11 +169,16 @@ const IGNORED_WORKFLOWS = {
     'release-latest.yml',
     'release-proposal.yml',
     'codeql-analysis.yml',
-    'pr-labels.yml',
+    'pr-labels.yml'
   ],
-  trigger_pull_request: [],
-  trigger_push: ['package-size.yml'],
-  trigger_schedule: [],
+  trigger_pull_request: [
+    'stale.yml'
+  ],
+  trigger_push: [
+    'package-size.yml',
+    'stale.yml'
+  ],
+  trigger_schedule: []
 }
 
 const workflows = fs.readdirSync(path.join(__dirname, '..', '.github', 'workflows'))
@@ -190,16 +195,16 @@ for (const workflow of workflows) {
   const yamlPath = path.join(__dirname, '..', '.github', 'workflows', workflow)
   const yamlContent = yaml.parse(fs.readFileSync(yamlPath, 'utf8'))
   const triggers = yamlContent.on
-  if (!IGNORED_WORKFLOWS.trigger_pull_request.includes(workflow)
-      && triggers?.pull_request !== null) {
+  if (!IGNORED_WORKFLOWS.trigger_pull_request.includes(workflow) &&
+      triggers?.pull_request !== null) {
     triggersError(workflow, 'The `pull_request` trigger should be blank')
   }
-  if (!IGNORED_WORKFLOWS.trigger_push.includes(workflow)
-      && triggers?.push?.branches?.[0] !== 'master') {
+  if (!IGNORED_WORKFLOWS.trigger_push.includes(workflow) &&
+      triggers?.push?.branches?.[0] !== 'master') {
     triggersError(workflow, 'The `push` trigger should run on master')
   }
-  if (!IGNORED_WORKFLOWS.trigger_schedule.includes(workflow)
-      && triggers?.schedule?.[0]?.cron !== '0 4 * * *') {
+  if (!IGNORED_WORKFLOWS.trigger_schedule.includes(workflow) &&
+      triggers?.schedule?.[0]?.cron !== '0 4 * * *') {
     triggersError(workflow, 'The `cron` trigger should be \'0 4 * * *\'')
   }
 }

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -159,9 +159,26 @@ checkPlugins(path.join(__dirname, '..', '.github', 'workflows', 'appsec.yml'))
 /// / Verifying that tests run on correct triggers
 /// /
 
+const IGNORED_WORKFLOWS = {
+  all: [
+    'prepare-release-proposal.yml',
+    'rebase-release-proposal.yml',
+    'release-3.yml',
+    'release-4.yml',
+    'release-dev.yml',
+    'release-latest.yml',
+    'release-proposal.yml',
+    'codeql-analysis.yml',
+    'pr-labels.yml',
+  ],
+  trigger_pull_request: [],
+  trigger_push: ['package-size.yml'],
+  trigger_schedule: [],
+}
+
 const workflows = fs.readdirSync(path.join(__dirname, '..', '.github', 'workflows'))
   .filter(file =>
-    !['release', 'codeql', 'pr-labels']
+    !IGNORED_WORKFLOWS.all
       .reduce((contained, name) => contained || file.includes(name), false)
   )
 
@@ -173,13 +190,16 @@ for (const workflow of workflows) {
   const yamlPath = path.join(__dirname, '..', '.github', 'workflows', workflow)
   const yamlContent = yaml.parse(fs.readFileSync(yamlPath, 'utf8'))
   const triggers = yamlContent.on
-  if (triggers?.pull_request !== null) {
+  if (!IGNORED_WORKFLOWS.trigger_pull_request.includes(workflow)
+      && triggers?.pull_request !== null) {
     triggersError(workflow, 'The `pull_request` trigger should be blank')
   }
-  if (workflow !== 'package-size.yml' && triggers?.push?.branches?.[0] !== 'master') {
+  if (!IGNORED_WORKFLOWS.trigger_push.includes(workflow)
+      && triggers?.push?.branches?.[0] !== 'master') {
     triggersError(workflow, 'The `push` trigger should run on master')
   }
-  if (triggers?.schedule?.[0]?.cron !== '0 4 * * *') {
+  if (!IGNORED_WORKFLOWS.trigger_schedule.includes(workflow)
+      && triggers?.schedule?.[0]?.cron !== '0 4 * * *') {
     triggersError(workflow, 'The `cron` trigger should be \'0 4 * * *\'')
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a [GHA bot](https://github.com/actions/stale) (written by Github) that will 
- Comment on and label stale PRs as `stale` after 60 days of inactivity
  - This resets after any update, including comments, edits, pushes, etc
- Close PRs that are marked as `stale` without any action taken after 14 additional days
  - The branch will not be deleted so these can be easily re-opened

Provides the use of another label `keep-open` to avoid the bot check

Example output (excerpt below): https://github.com/DataDog/dd-trace-js/actions/runs/13418709485/job/37485897173?pr=5300


<details><summary>Recent PR</summary>

```
  [#5300] Pull request #5300
  [#5300] Found this pull request last updated at: 2025-02-19T17:30:47Z
  [#5300] The option only-labels (​[https://github.com/actions/stale#only-labels​)](https://github.com/actions/stale#only-labels%E2%80%8B)) was not specified
  [#5300] └── Continuing the process for this pull request
  [#5300] Days before pull request stale: 90
  [#5300] The pull request is not closed nor locked. Trying to remove the close label...
  [#5300] ├── The close-pr-label (​[https://github.com/actions/stale#close-pr-label​)](https://github.com/actions/stale#close-pr-label%E2%80%8B)) option was not set
  [#5300] └── Skipping the removal of the close label
  [#5300] This pull request does not include a stale label
  [#5300] The option any-of-labels (​[https://github.com/actions/stale#any-of-labels​)](https://github.com/actions/stale#any-of-labels%E2%80%8B)) was not specified
  [#5300] └── Continuing the process for this pull request
  [#5300] This pull request has no milestone
  [#5300] └── Skip the milestones checks
  [#5300] This pull request has no assignee
  [#5300] └── Skip the assignees checks
  [#5300] This pull request is not stale
  [#5300] The option ignore-updates (​https://github.com/actions/stale#ignore-updates​) is disabled. The stale counter will take into account updates and comments on this pull request to avoid to stale when there is some update
  [#5300] This pull request should not be stale based on the last update date the 19-02-2025 (2025-02-19T17:30:[47](https://github.com/DataDog/dd-trace-js/actions/runs/13418709485/job/37485897173?pr=5300#step:2:48)Z)
```

</details>

<details><summary>Old Issue</summary>

```
  [#4814] Issue #4814
  [#4814] Found this issue last updated at: 2024-10-23T11:06:05Z
  [#4814] The option only-labels (​[https://github.com/actions/stale#only-labels​)](https://github.com/actions/stale#only-labels%E2%80%8B)) was not specified
  [#4814] └── Continuing the process for this issue
  [#4814] Days before issue stale: -1
  [#4814] The issue is not closed nor locked. Trying to remove the close label...
  [#4814] ├── The close-issue-label (​[https://github.com/actions/stale#close-issue-label​)](https://github.com/actions/stale#close-issue-label%E2%80%8B)) option was not set
  [#4814] └── Skipping the removal of the close label
  [#4814] This issue does not include a stale label
  [#4814] The option any-of-labels (​[https://github.com/actions/stale#any-of-labels​)](https://github.com/actions/stale#any-of-labels%E2%80%8B)) was not specified
  [#4814] └── Continuing the process for this issue
  [#4814] This issue has no milestone
  [#4814] └── Skip the milestones checks
  [#4814] This issue has no assignee
  [#4814] └── Skip the assignees checks
  [#4814] This issue is not stale
  [#4814] The option ignore-updates (​[https://github.com/actions/stale#ignore-updates​)](https://github.com/actions/stale#ignore-updates%E2%80%8B)) is disabled. The stale counter will take into account updates and comments on this issue to avoid to stale when there is some update
  [#4814] This issue should be stale based on the last update date the 23-10-2024 (2024-10-23T11:06:05Z)
  [#4814] This issue should not be marked as stale based on the option days-before-issue-stale (​[https://github.com/actions/stale#days-before-issue-stale​)](https://github.com/actions/stale#days-before-issue-stale%E2%80%8B)) (-1)
```

</details>

<details><summary>Old PR</summary>

```
  [#4819] Pull request #4819
  [#4819] Found this pull request last updated at: 2024-10-24T13:28:11Z
  [#4819] The option only-labels (​[https://github.com/actions/stale#only-labels​)](https://github.com/actions/stale#only-labels%E2%80%8B)) was not specified
  [#4819] └── Continuing the process for this pull request
  [#4819] Days before pull request stale: 90
  [#4819] The pull request is not closed nor locked. Trying to remove the close label...
  [#4819] ├── The close-pr-label (​[https://github.com/actions/stale#close-pr-label​)](https://github.com/actions/stale#close-pr-label%E2%80%8B)) option was not set
  [#4819] └── Skipping the removal of the close label
  [#4819] This pull request does not include a stale label
  [#4819] The option any-of-labels (​[https://github.com/actions/stale#any-of-labels​)](https://github.com/actions/stale#any-of-labels%E2%80%8B)) was not specified
  [#4819] └── Continuing the process for this pull request
  [#4819] This pull request has no milestone
  [#4819] └── Skip the milestones checks
  [#4819] This pull request has no assignee
  [#4819] └── Skip the assignees checks
  [#4819] This pull request is not stale
  [#4819] The option ignore-updates (​[https://github.com/actions/stale#ignore-updates​)](https://github.com/actions/stale#ignore-updates%E2%80%8B)) is disabled. The stale counter will take into account updates and comments on this pull request to avoid to stale when there is some update
  [#4819] This pull request should be stale based on the last update date the 24-10-2024 (2024-10-24T13:28:11Z)
  [#4819] This pull request should be marked as stale based on the option days-before-pr-stale (​[https://github.com/actions/stale#days-before-pr-stale​)](https://github.com/actions/stale#days-before-pr-stale%E2%80%8B)) (90)
  [#4819] Marking this pull request as stale
  [#4819] This pull request is now stale
  [#4819] This pull request is already stale
  [#4819] Checking for label on this pull request
  [#4819] Pull request marked stale on: Wed Feb 19 2025 17:31:27 GMT+0000 (Coordinated Universal Time)
  [#4819] Checking for comments on pull request since: Wed Feb 19 2025 17:31:27 GMT+0000 (Coordinated Universal Time)
  [#4819] Comments that are not the stale comment or another bot: 0
  [#4819] Pull request has been commented on: false
  [#4819] Days before pull request close: 14
  [#4819] The option remove-stale-when-updated (​[https://github.com/actions/stale#remove-stale-when-updated​)](https://github.com/actions/stale#remove-stale-when-updated%E2%80%8B)) is: true
  [#4819] The stale label should not be removed
  [#4819] marked stale this run, so don't check for updates
  [#4819] Pull request has been updated since it was marked stale: false
  [#4819] Pull request has been updated in the last 14 days: true
  [#4819] Stale pull request is not old enough to close yet (hasComments? false, hasUpdate? true)
  [#4819] 4 operations consumed for this pull request
```

</details>

### Motivation
<!-- What inspired you to submit this pull request? -->
Discussed with @BridgeAR and the Node.js group at Datadog and this would be helpful

In the future, this should be expanded to other DD OSS repos

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


