### PR TITLE
Fix MongoDB DBM propagation issue where trace comments are not properly injected into commands

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -25,7 +25,7 @@ class MongodbCorePlugin extends DatabasePlugin {
         'out.port': options.port
       }
     })
-    ops = this.injectDbmCommand(span, ops, service)
+    ops.comment = this.injectDbmCommand(span, ops, service)
   }
 
   getPeerService (tags) {
@@ -44,21 +44,20 @@ class MongodbCorePlugin extends DatabasePlugin {
       return command
     }
 
-    // create a copy of the command to avoid mutating the original
-    const dbmTracedCommand = { ...command }
+    let { comment } = command
 
-    if (dbmTracedCommand.comment) {
+    if (comment) {
       // if the command already has a comment, append the dbm trace comment
-      if (typeof dbmTracedCommand.comment === 'string') {
-        dbmTracedCommand.comment += `,${dbmTraceComment}`
-      } else if (Array.isArray(dbmTracedCommand.comment)) {
-        dbmTracedCommand.comment.push(dbmTraceComment)
+      if (typeof comment === 'string') {
+        comment += `,${dbmTraceComment}`
+      } else if (Array.isArray(comment)) {
+        comment.push(dbmTraceComment)
       } // do nothing if the comment is not a string or an array
     } else {
-      dbmTracedCommand.comment = dbmTraceComment
+      comment = dbmTraceComment
     }
 
-    return dbmTracedCommand
+    return comment
   }
 }
 

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -25,7 +25,7 @@ class MongodbCorePlugin extends DatabasePlugin {
         'out.port': options.port
       }
     })
-    ops.comment = this.injectDbmCommand(span, ops.comment, service)
+    ops.comment = this.injectDbmComment(span, ops.comment, service)
   }
 
   getPeerService (tags) {
@@ -37,7 +37,7 @@ class MongodbCorePlugin extends DatabasePlugin {
     return super.getPeerService(tags)
   }
 
-  injectDbmCommand (span, comment, serviceName) {
+  injectDbmComment (span, comment, serviceName) {
     const dbmTraceComment = this.createDbmComment(span, serviceName)
 
     if (!dbmTraceComment) {

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -25,7 +25,7 @@ class MongodbCorePlugin extends DatabasePlugin {
         'out.port': options.port
       }
     })
-    ops.comment = this.injectDbmCommand(span, ops, service)
+    ops.comment = this.injectDbmCommand(span, ops.comment, service)
   }
 
   getPeerService (tags) {
@@ -37,14 +37,12 @@ class MongodbCorePlugin extends DatabasePlugin {
     return super.getPeerService(tags)
   }
 
-  injectDbmCommand (span, command, serviceName) {
+  injectDbmCommand (span, comment, serviceName) {
     const dbmTraceComment = this.createDbmComment(span, serviceName)
 
     if (!dbmTraceComment) {
-      return command
+      return comment
     }
-
-    let { comment } = command
 
     if (comment) {
       // if the command already has a comment, append the dbm trace comment

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -33,7 +33,7 @@ describe('Plugin', () => {
   let id
   let tracer
   let collection
-  let injectDbmCommandSpy
+  let startSpy
 
   describe('mongodb-core (core)', () => {
     withTopologies(getServer => {
@@ -426,11 +426,11 @@ describe('Plugin', () => {
 
           server.connect()
 
-          injectDbmCommandSpy = sinon.spy(MongodbCorePlugin.prototype, 'injectDbmCommand')
+          startSpy = sinon.spy(MongodbCorePlugin.prototype, 'start')
         })
 
         afterEach(() => {
-          injectDbmCommandSpy?.restore()
+          startSpy?.restore()
         })
 
         it('DBM propagation should inject service mode as comment', done => {
@@ -438,8 +438,8 @@ describe('Plugin', () => {
             .use(traces => {
               const span = traces[0][0]
 
-              expect(injectDbmCommandSpy.called).to.be.true
-              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(startSpy.called).to.be.true
+              const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
@@ -461,8 +461,8 @@ describe('Plugin', () => {
             .use(traces => {
               const span = traces[0][0]
 
-              expect(injectDbmCommandSpy.called).to.be.true
-              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(startSpy.called).to.be.true
+              const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal(
                 'test comment,' +
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
@@ -491,8 +491,8 @@ describe('Plugin', () => {
             .use(traces => {
               const span = traces[0][0]
 
-              expect(injectDbmCommandSpy.called).to.be.true
-              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(startSpy.called).to.be.true
+              const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.deep.equal([
                 'test comment',
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
@@ -540,11 +540,11 @@ describe('Plugin', () => {
 
           server.connect()
 
-          injectDbmCommandSpy = sinon.spy(MongodbCorePlugin.prototype, 'injectDbmCommand')
+          startSpy = sinon.spy(MongodbCorePlugin.prototype, 'start')
         })
 
         afterEach(() => {
-          injectDbmCommandSpy?.restore()
+          startSpy?.restore()
         })
 
         it('DBM propagation should inject full mode with traceparent as comment', done => {
@@ -554,8 +554,8 @@ describe('Plugin', () => {
               const traceId = span.meta['_dd.p.tid'] + span.trace_id.toString(16).padStart(16, '0')
               const spanId = span.span_id.toString(16).padStart(16, '0')
 
-              expect(injectDbmCommandSpy.called).to.be.true
-              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(startSpy.called).to.be.true
+              const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -439,9 +439,8 @@ describe('Plugin', () => {
               const span = traces[0][0]
 
               expect(injectDbmCommandSpy.called).to.be.true
-              const instrumentedCommand = injectDbmCommandSpy.getCall(0).returnValue
-              expect(instrumentedCommand).to.have.property('comment')
-              expect(instrumentedCommand.comment).to.equal(
+              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
                 'dde=\'tester\',' +
@@ -463,9 +462,8 @@ describe('Plugin', () => {
               const span = traces[0][0]
 
               expect(injectDbmCommandSpy.called).to.be.true
-              const instrumentedCommand = injectDbmCommandSpy.getCall(0).returnValue
-              expect(instrumentedCommand).to.have.property('comment')
-              expect(instrumentedCommand.comment).to.equal(
+              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(comment).to.equal(
                 'test comment,' +
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
@@ -494,9 +492,8 @@ describe('Plugin', () => {
               const span = traces[0][0]
 
               expect(injectDbmCommandSpy.called).to.be.true
-              const instrumentedCommand = injectDbmCommandSpy.getCall(0).returnValue
-              expect(instrumentedCommand).to.have.property('comment')
-              expect(instrumentedCommand.comment).to.deep.equal([
+              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(comment).to.deep.equal([
                 'test comment',
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
@@ -558,9 +555,8 @@ describe('Plugin', () => {
               const spanId = span.span_id.toString(16).padStart(16, '0')
 
               expect(injectDbmCommandSpy.called).to.be.true
-              const instrumentedCommand = injectDbmCommandSpy.getCall(0).returnValue
-              expect(instrumentedCommand).to.have.property('comment')
-              expect(instrumentedCommand.comment).to.equal(
+              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
                 'dde=\'tester\',' +

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -388,9 +388,8 @@ describe('Plugin', () => {
               const span = traces[0][0]
 
               expect(injectDbmCommandSpy.called).to.be.true
-              const instrumentedCommand = injectDbmCommandSpy.getCall(0).returnValue
-              expect(instrumentedCommand).to.have.property('comment')
-              expect(instrumentedCommand.comment).to.equal(
+              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
                 'dde=\'tester\',' +
@@ -440,9 +439,8 @@ describe('Plugin', () => {
               const spanId = span.span_id.toString(16).padStart(16, '0')
 
               expect(injectDbmCommandSpy.called).to.be.true
-              const instrumentedCommand = injectDbmCommandSpy.getCall(0).returnValue
-              expect(instrumentedCommand).to.have.property('comment')
-              expect(instrumentedCommand.comment).to.equal(
+              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
                 'dde=\'tester\',' +

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -48,7 +48,7 @@ describe('Plugin', () => {
   let collection
   let db
   let BSON
-  let injectDbmCommandSpy
+  let startSpy
 
   describe('mongodb-core', () => {
     withTopologies(createClient => {
@@ -375,11 +375,11 @@ describe('Plugin', () => {
           db = client.db('test')
           collection = db.collection(collectionName)
 
-          injectDbmCommandSpy = sinon.spy(MongodbCorePlugin.prototype, 'injectDbmCommand')
+          startSpy = sinon.spy(MongodbCorePlugin.prototype, 'start')
         })
 
         afterEach(() => {
-          injectDbmCommandSpy?.restore()
+          startSpy?.restore()
         })
 
         it('DBM propagation should inject service mode as comment', done => {
@@ -387,8 +387,8 @@ describe('Plugin', () => {
             .use(traces => {
               const span = traces[0][0]
 
-              expect(injectDbmCommandSpy.called).to.be.true
-              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(startSpy.called).to.be.true
+              const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +
@@ -424,11 +424,11 @@ describe('Plugin', () => {
           db = client.db('test')
           collection = db.collection(collectionName)
 
-          injectDbmCommandSpy = sinon.spy(MongodbCorePlugin.prototype, 'injectDbmCommand')
+          startSpy = sinon.spy(MongodbCorePlugin.prototype, 'start')
         })
 
         afterEach(() => {
-          injectDbmCommandSpy?.restore()
+          startSpy?.restore()
         })
 
         it('DBM propagation should inject full mode with traceparent as comment', done => {
@@ -438,8 +438,8 @@ describe('Plugin', () => {
               const traceId = span.meta['_dd.p.tid'] + span.trace_id.toString(16).padStart(16, '0')
               const spanId = span.span_id.toString(16).padStart(16, '0')
 
-              expect(injectDbmCommandSpy.called).to.be.true
-              const comment = injectDbmCommandSpy.getCall(0).returnValue
+              expect(startSpy.called).to.be.true
+              const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal(
                 `dddb='${encodeURIComponent(span.meta['db.name'])}',` +
                 'dddbs=\'test-mongodb\',' +


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where MongoDB DBM trace comments were not properly injected into the command object. The root cause was that the modified comment was assigned to a new copied object `dbmTracedCommand = { ...command }`, which did not affect the original ops object outside of `start()`. This fix ensures that the comment is correctly assigned back to the original ops object to maintain proper DBM propagation.

### Motivation
Fix a bug where DBM trace comments were missing from MongoDB commands due to improper reassignment.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


