### PR TITLE
Do not expose internals

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -191,13 +191,12 @@ class CustomMetrics {
     const clientConfig = DogStatsDClient.generateClientConfig(config)
     this.dogstatsd = new DogStatsDClient(clientConfig)
 
-    this._boundFlush = this.flush.bind(this)
+    const flush = this.flush.bind(this)
 
     // TODO(bengl) this magic number should be configurable
-    this._flushInterval = setInterval(this._boundFlush, 10 * 1000)
-    this._flushInterval.unref()
+    setInterval(flush, 10 * 1000).unref()
 
-    process.once('beforeExit', this._boundFlush)
+    process.once('beforeExit', flush)
   }
 
   increment (stat, value = 1, tags) {


### PR DESCRIPTION
The timeout and the flush can be handled without any variables. This way nothing is added to the instance.
