### PR TITLE
Various improvements to profiling sample label generator

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -286,13 +286,22 @@ class NativeWallProfiler {
 
     const labels = { ...getThreadLabels() }
 
-    const { context: { ref }, timestamp } = context
-    const { spanId, rootSpanId, webTags, endpoint } = ref ?? {}
-
     if (this._timelineEnabled) {
       // Incoming timestamps are in microseconds, we emit nanos.
-      labels[END_TIMESTAMP_LABEL] = timestamp * 1000n
+      labels[END_TIMESTAMP_LABEL] = context.timestamp * 1000n
     }
+
+    const asyncId = context.asyncId
+    if (asyncId !== undefined && asyncId !== -1) {
+      labels['async id'] = asyncId
+    }
+
+    const ref = context.context?.ref
+    if (ref === undefined) {
+      return labels
+    }
+
+    const { spanId, rootSpanId, webTags, endpoint } = ref
 
     if (spanId !== undefined) {
       labels[SPAN_ID_LABEL] = spanId


### PR DESCRIPTION
### What does this PR do?
* Allows for `context.context` not being defined
* Bail out faster when it's not present
* Handle `context.asyncId`

### Motivation
A version of pprof-nodejs in the works streamlines few things. As a consequence,  `context.context` can sometimes be undefiined. also, `context.asyncId` will start appearing.

### Additional Notes
Jira: [PROF-11371]


