### PR TITLE
only load the naming schema version that is used

### DIFF
--- a/packages/dd-trace/src/service-naming/index.js
+++ b/packages/dd-trace/src/service-naming/index.js
@@ -29,12 +29,14 @@ class SchemaManager {
   }
 
   configure (config = {}) {
-    switch (config.spanAttributeSchema) {
-      case 'v1':
-        this.schemas.v1 = this.schemas.v1 || require('./schemas/v1')
-        break
-      default:
-        this.schemas.v0 = this.schemas.v0 || require('./schemas/v0')
+    const { spanAttributeSchema, spanRemoveIntegrationFromService } = config
+
+    if (!this.schemas.v0 && spanAttributeSchema === 'v0') {
+      this.schemas.v0 = require('./schemas/v0')
+    }
+
+    if (!this.schemas.v1 && (spanAttributeSchema === 'v1' || spanRemoveIntegrationFromService)) {
+      this.schemas.v1 = require('./schemas/v1')
     }
 
     this.config = config

--- a/packages/dd-trace/src/service-naming/index.js
+++ b/packages/dd-trace/src/service-naming/index.js
@@ -1,9 +1,7 @@
-const { schemaDefinitions } = require('./schemas')
-
 class SchemaManager {
   constructor () {
-    this.schemas = schemaDefinitions
-    this.config = { spanAttributeSchema: 'v0', spanRemoveIntegrationFromService: false }
+    this.schemas = {}
+    this.configure({ spanAttributeSchema: 'v0', spanRemoveIntegrationFromService: false })
   }
 
   get schema () {
@@ -31,6 +29,14 @@ class SchemaManager {
   }
 
   configure (config = {}) {
+    switch (config.spanAttributeSchema) {
+      case 'v1':
+        this.schemas.v1 = require('./schemas/v1')
+        break
+      default:
+        this.schemas.v0 = require('./schemas/v0')
+    }
+
     this.config = config
   }
 }

--- a/packages/dd-trace/src/service-naming/index.js
+++ b/packages/dd-trace/src/service-naming/index.js
@@ -31,10 +31,10 @@ class SchemaManager {
   configure (config = {}) {
     switch (config.spanAttributeSchema) {
       case 'v1':
-        this.schemas.v1 = require('./schemas/v1')
+        this.schemas.v1 = this.schemas.v1 || require('./schemas/v1')
         break
       default:
-        this.schemas.v0 = require('./schemas/v0')
+        this.schemas.v0 = this.schemas.v0 || require('./schemas/v0')
     }
 
     this.config = config

--- a/packages/dd-trace/src/service-naming/schemas/index.js
+++ b/packages/dd-trace/src/service-naming/schemas/index.js
@@ -1,6 +1,0 @@
-const v0 = require('./v0')
-const v1 = require('./v1')
-
-module.exports = {
-  schemaDefinitions: { v0, v1 }
-}

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -10,7 +10,6 @@ const runtimeMetrics = require('../../src/runtime_metrics')
 const agent = require('../plugins/agent')
 const Nomenclature = require('../../src/service-naming')
 const { storage } = require('../../../datadog-core')
-const { schemaDefinitions } = require('../../src/service-naming/schemas')
 const { getInstrumentation } = require('./helpers/load-inst')
 
 global.withVersions = withVersions
@@ -35,7 +34,7 @@ function withNamingSchema (
   const testTitle = 'service and operation naming' + (desc !== '' ? ` (${desc})` : '')
 
   describe(testTitle, () => {
-    Object.keys(schemaDefinitions).forEach(versionName => {
+    ['v0', 'v1'].forEach(versionName => {
       describe(`in version ${versionName}`, () => {
         before(() => {
           fullConfig = Nomenclature.config


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Only load the naming schema version that is used.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise all schema versions are unnecessarily loaded, thus impacting startup time.