### PR TITLE
CI: Clean up Node.js installation in GitHub actions

### DIFF
--- a/.github/actions/node/14/action.yml
+++ b/.github/actions/node/14/action.yml
@@ -1,8 +1,0 @@
-name: Node 14
-description: Install Node 14
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '14'

--- a/.github/actions/node/16/action.yml
+++ b/.github/actions/node/16/action.yml
@@ -1,8 +1,0 @@
-name: Node 16
-description: Install Node 16
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '16'

--- a/.github/actions/node/18/action.yml
+++ b/.github/actions/node/18/action.yml
@@ -1,8 +1,0 @@
-name: Node 18
-description: Install Node 18
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '18'

--- a/.github/actions/node/20/action.yml
+++ b/.github/actions/node/20/action.yml
@@ -1,8 +1,0 @@
-name: Node 20
-description: Install Node 20
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '20'

--- a/.github/actions/node/active-lts/action.yml
+++ b/.github/actions/node/active-lts/action.yml
@@ -1,0 +1,9 @@
+name: Node.js Active LTS
+description: Install the current Active LTS version of Node.js
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        cache: yarn
+        node-version: '22'

--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -1,8 +1,0 @@
-name: Node Latest
-description: Install the latest Node.js version
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '22' # Update this line to the latest Node.js version

--- a/.github/actions/node/newest-maintenance-lts/action.yml
+++ b/.github/actions/node/newest-maintenance-lts/action.yml
@@ -1,0 +1,9 @@
+name: Node.js Newst Maintenance LTS
+description: Install the newest Maintenance LTS version of Node.js
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        cache: yarn
+        node-version: '20'

--- a/.github/actions/node/oldest-maintenance-lts/action.yml
+++ b/.github/actions/node/oldest-maintenance-lts/action.yml
@@ -1,5 +1,5 @@
-name: Node Setup
-description: Install Node.js
+name: Node.js Oldest Maintenance LTS
+description: Install the oldest Maintenance LTS version of Node.js
 runs:
   using: composite
   steps:

--- a/.github/actions/node/oldest/action.yml
+++ b/.github/actions/node/oldest/action.yml
@@ -1,8 +1,0 @@
-name: Node 18
-description: Install Oldest Supported Node.js version
-runs:
-  using: composite
-  steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '18'

--- a/.github/actions/plugins/test-and-upstream/action.yml
+++ b/.github/actions/plugins/test-and-upstream/action.yml
@@ -4,14 +4,13 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/testagent/start
-    - uses: ./.github/actions/node/setup
+    - uses: ./.github/actions/node/oldest-maintenance-lts
     - uses: ./.github/actions/install
-    - uses: ./.github/actions/node/oldest
     - run: yarn test:plugins:ci
       shell: bash
     - run: yarn test:plugins:upstream
       shell: bash
-    - uses: ./.github/actions/node/latest
+    - uses: ./.github/actions/node/active-lts
     - run: yarn test:plugins:ci
       shell: bash
     - run: yarn test:plugins:upstream

--- a/.github/actions/plugins/test/action.yml
+++ b/.github/actions/plugins/test/action.yml
@@ -4,12 +4,11 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/testagent/start
-    - uses: ./.github/actions/node/setup
+    - uses: ./.github/actions/node/oldest-maintenance-lts
     - uses: ./.github/actions/install
-    - uses: ./.github/actions/node/oldest
     - run: yarn test:plugins:ci
       shell: bash
-    - uses: ./.github/actions/node/latest
+    - uses: ./.github/actions/node/active-lts
     - run: yarn test:plugins:ci
       shell: bash
     - uses: codecov/codecov-action@v5

--- a/.github/actions/plugins/upstream/action.yml
+++ b/.github/actions/plugins/upstream/action.yml
@@ -4,12 +4,11 @@ runs:
   using: composite
   steps:
     - uses: ./.github/actions/testagent/start
-    - uses: ./.github/actions/node/setup
+    - uses: ./.github/actions/node/oldest-maintenance-lts
     - uses: ./.github/actions/install
-    - uses: ./.github/actions/node/oldest
     - run: yarn test:plugins:upstream
       shell: bash
-    - uses: ./.github/actions/node/latest
+    - uses: ./.github/actions/node/active-lts
     - run: yarn test:plugins:upstream
       shell: bash
     - uses: codecov/codecov-action@v5

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       # NOTE: Ok this next bit seems unnecessary, right? The problem is that
       # this repo is currently incompatible with npm, at least with the
       # devDependencies. While this is intended to be corrected, it hasn't yet,

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:appsec:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -27,13 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:appsec:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -41,9 +40,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: '18'
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:appsec:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -65,11 +62,10 @@ jobs:
           LDAP_PASSWORDS: 'password1,password2'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -88,13 +84,10 @@ jobs:
       SERVICES: postgres
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/18
-      - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -113,11 +106,10 @@ jobs:
       SERVICES: mysql
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -127,11 +119,10 @@ jobs:
       PLUGINS: express|body-parser|cookie-parser|multer
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -141,11 +132,10 @@ jobs:
       PLUGINS: apollo-server|apollo-server-express|apollo-server-fastify|apollo-server-core
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -161,11 +151,10 @@ jobs:
       SERVICES: mongo
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -181,11 +170,10 @@ jobs:
       SERVICES: mongo
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -195,13 +183,12 @@ jobs:
       PLUGINS: cookie
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -255,11 +242,10 @@ jobs:
       PLUGINS: lodash
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -268,9 +254,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: yarn install
-      - uses: ./.github/actions/node/oldest
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - run: yarn test:integration:appsec
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:integration:appsec
 
   passport:
@@ -279,11 +265,10 @@ jobs:
       PLUGINS: passport-local|passport-http
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -293,11 +278,10 @@ jobs:
       PLUGINS: handlebars|pug
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -307,10 +291,9 @@ jobs:
       PLUGINS: node-serialize
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:appsec:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1

--- a/.github/workflows/ci-visibility-performance.yml
+++ b/.github/workflows/ci-visibility-performance.yml
@@ -22,6 +22,6 @@ jobs:
       ROBOT_CI_GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.ROBOT_CI_GITHUB_PERSONAL_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/18
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - name: CI Visibility Performance Overhead Test
         run: yarn bench:e2e:ci-visibility

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -18,10 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:shimmer:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:shimmer:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -19,15 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:debugger:ci
       - run: yarn test:integration:debugger
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:debugger:ci
       - run: yarn test:integration:debugger
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:debugger:ci
       - run: yarn test:integration:debugger
       - if: always()

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -19,13 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:lambda:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:lambda:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:lambda:ci
       - if: always()
         uses: ./.github/actions/testagent/logs

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -19,13 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:llmobs:sdk:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:llmobs:sdk:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:llmobs:sdk:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -40,12 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:llmobs:plugins:ci
         shell: bash
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:llmobs:plugins:ci
         shell: bash
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -61,12 +59,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:llmobs:plugins:ci
         shell: bash
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:llmobs:plugins:ci
         shell: bash
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -82,12 +79,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:llmobs:plugins:ci
         shell: bash
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:llmobs:plugins:ci
         shell: bash
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -18,11 +18,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Setup Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: '20'
-      - run: yarn
+      - uses: ./.github/actions/node/active-lts
+      - uses: ./.github/actions/install
       - name: Compute module size tree and report
         uses: qard/heaviest-objects-in-the-universe@e2af4ff3a88e5fe507bd2de1943b015ba2ddda66 # v1.0.0
         with:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -58,7 +58,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: ${{ matrix.node-version }}
@@ -164,7 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
@@ -236,13 +235,12 @@ jobs:
       PLUGINS: child_process
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:plugins:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -277,7 +275,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
@@ -310,7 +308,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:plugins:ci
       - if: always()
@@ -334,13 +332,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -363,9 +360,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -476,7 +472,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
@@ -495,13 +491,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -517,7 +512,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:plugins:ci
       - if: always()
@@ -576,12 +571,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18 # langchain doesn't support Node 16
       - run: yarn test:plugins:ci
         shell: bash
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:plugins:ci
         shell: bash
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -748,13 +742,12 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -795,7 +788,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:plugins:ci
       - if: always()
@@ -886,9 +879,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/oldest
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -904,11 +896,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/20
       - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:plugins:ci
       # - run: yarn test:plugins:upstream
       - if: always()
@@ -1022,9 +1013,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - if: always()
         uses: ./.github/actions/testagent/logs
@@ -1049,9 +1039,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - run: yarn test:plugins:upstream
       - if: always()

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
@@ -28,15 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -45,9 +44,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: '18'
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -117,7 +117,7 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
@@ -138,11 +138,8 @@ jobs:
       DD_API_KEY: ${{ secrets.DD_API_KEY_CI_APP }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: 20
       - run: yarn test:integration:vitest
         env:
           NODE_OPTIONS: '-r ./ci/init'
@@ -151,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn lint
 
@@ -159,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn type:test
       - run: yarn type:doc
@@ -168,6 +165,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: node scripts/verify-ci-config.js

--- a/.github/workflows/serverless-integration-test.yml
+++ b/.github/workflows/serverless-integration-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:

--- a/.github/workflows/tracing.yml
+++ b/.github/workflows/tracing.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
@@ -27,13 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/setup
+      - uses: ./.github/actions/node/oldest-maintenance-lts
       - uses: ./.github/actions/install
-      - uses: ./.github/actions/node/18
       - run: yarn test:trace:core:ci
-      - uses: ./.github/actions/node/20
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - run: yarn test:trace:core:ci
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node/active-lts
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
 
@@ -41,9 +40,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: '18'
+      - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1


### PR DESCRIPTION
### What does this PR do?

Clean up Node.js installation in GitHub actions
    
- Remove actions installing old Node.js versions no longer used (`14` and `16`)
- Rename `latest` action to `active-lts` to clearly signal intent (a separate `latest` or `current` action that tests non-lts, can be created in a follow up commit)
- Remove `18` action, and replace any usage of it with `oldest-maintenance-lts`
- Remove `setup` action and replace any usage of it with `active-lts`
- Move `install` action to after the first Node.js install action that actually needs it, instead of first installing one Node.js version, only to install another right after
- Change any direct usage of `actions/setup-node` to use our own Node.js installation actions instead, when a matrix is not used.
- A few places where Node.js 18 was used for testing, now use `active-lts` as this was most likely the intent (👉  **reviewers should verify!** 👈 )

### Motivation

- Align how Node.js is installed in our GitHub actions
- Reduce runtime of GitHub actions by not running unnecessary steps
- Make it easier to upgrade to newer major Node.js versions when they are released (with the use of labels like `active-lts` instead of hardcoded version numbers)
