### PR TITLE
CI: Configure supported Node.js version range using repository variables

### DIFF
--- a/.github/actions/node/active-lts/action.yml
+++ b/.github/actions/node/active-lts/action.yml
@@ -6,4 +6,4 @@ runs:
     - uses: actions/setup-node@v4
       with:
         cache: yarn
-        node-version: '22'
+        node-version: ${{ vars.ACTIVE_LTS }}

--- a/.github/actions/node/newest-maintenance-lts/action.yml
+++ b/.github/actions/node/newest-maintenance-lts/action.yml
@@ -6,4 +6,4 @@ runs:
     - uses: actions/setup-node@v4
       with:
         cache: yarn
-        node-version: '20'
+        node-version: ${{ vars.NEWEST_MAINTENANCE_LTS }}

--- a/.github/actions/node/oldest-maintenance-lts/action.yml
+++ b/.github/actions/node/oldest-maintenance-lts/action.yml
@@ -6,4 +6,4 @@ runs:
     - uses: actions/setup-node@v4
       with:
         cache: yarn
-        node-version: '18'
+        node-version: ${{ vars.OLDEST_MAINTENANCE_LTS }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -25,22 +25,22 @@ jobs:
         aerospike-image: [ce-5.7.0.15]
         test-image: [ubuntu-22.04]
         include:
-          - node-version: 18
+          - node-version: ${{ vars.OLDEST_MAINTENANCE_LTS }}
             range: '>=5.2.0'
             range_clean: gte.5.2.0
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
-          - node-version: 20
+          - node-version: ${{ vars.NEWEST_MAINTENANCE_LTS }}
             range: '>=5.5.0'
             range_clean: gte.5.5.0
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
-          - node-version: 22
+          - node-version: ${{ vars.ACTIVE_LTS }}
             range: '>=5.12.1'
             range_clean: gte.5.12.1
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
-          - node-version: 22
+          - node-version: ${{ vars.ACTIVE_LTS }}
             range: '>=6.0.0'
             range_clean: gte.6.0.0
             aerospike-image: ce-6.4.0.3
@@ -124,7 +124,7 @@ jobs:
   aws-sdk:
     strategy:
       matrix:
-        node-version: ['18', 'latest']
+        node-version: [vars.OLDEST_MAINTENANCE_LTS, latest]
     runs-on: ubuntu-latest
     services:
       localstack:
@@ -258,7 +258,7 @@ jobs:
         node-version: [16]
         range: ['^2.6.12', '^3.0.7', '>=4.0.0 <4.2.0']
         include:
-          - node-version: 18
+          - node-version: ${{ vars.OLDEST_MAINTENANCE_LTS }}
             range: '>=4.2.0'
     runs-on: ubuntu-latest
     services:
@@ -465,7 +465,7 @@ jobs:
   http:
     strategy:
       matrix:
-        node-version: ['18', '20', 'latest']
+        node-version: [vars.OLDEST_MAINTENANCE_LTS, vars.NEWEST_MAINTENANCE_LTS, latest]
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
@@ -760,9 +760,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - 18
-          - latest
+        version: [vars.OLDEST_MAINTENANCE_LTS, latest]
         range: ['>=10.2.0 <11', '>=11.0.0 <13', '11.1.4', '>=13.0.0 <14', '13.2.0', '>=14.0.0 <=14.2.6', '>=14.2.7 <15', '>=15.0.0']
         include:
           - range: '>=10.2.0 <11'

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -20,7 +20,7 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18, 20, 22, latest]
+        version: [vars.OLDEST_MAINTENANCE_LTS, vars.NEWEST_MAINTENANCE_LTS, vars.ACTIVE_LTS, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -64,7 +64,7 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        version: [18, latest]
+        version: [vars.OLDEST_MAINTENANCE_LTS, latest]
         framework: [cucumber, playwright, selenium, jest, mocha]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/serverless-integration-test.yml
+++ b/.github/workflows/serverless-integration-test.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: 'write'
     strategy:
       matrix:
-        version: [18, latest]
+        version: [vars.OLDEST_MAINTENANCE_LTS, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### What does this PR do?

Configure supported Node.js version range using [repository variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables)
    
Currently, the following repository variables are created:
    
- `ACTIVE_LTS` (set to `22` as of this commit)
- `NESTEST_MAINTENANCE_LTS` (set to `20` as of this commit)
- `OLDEST_MAINTENANCE_LTS` (set to `18` as of this commit)

### Motivation

Make it easier to upgrade to newer major Node.js versions when they are released.

