### PR TITLE
[test optimization] Lazy load failed test replay logic

### DIFF
--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -38,17 +38,18 @@ class TestVisDynamicInstrumentation {
     }
     const probeId = randomUUID()
 
-    this.breakpointSetChannel.port2.postMessage(
-      { id: probeId, file, line }
-    )
-
     this.onHitBreakpointByProbeId.set(probeId, onHitBreakpoint)
 
     return [
       probeId,
       new Promise(resolve => {
+        probeIdToResolveBreakpointSet.set(probeId, resolve)
+
         this._readyPromise.then(() => {
-          probeIdToResolveBreakpointSet.set(probeId, resolve)
+          // We only post the message when the worker is ready
+          this.breakpointSetChannel.port2.postMessage(
+            { id: probeId, file, line }
+          )
         })
       })
     ]

--- a/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
+++ b/packages/dd-trace/src/ci-visibility/dynamic-instrumentation/index.js
@@ -38,19 +38,16 @@ class TestVisDynamicInstrumentation {
     }
     const probeId = randomUUID()
 
+    this.breakpointSetChannel.port2.postMessage(
+      { id: probeId, file, line }
+    )
+
     this.onHitBreakpointByProbeId.set(probeId, onHitBreakpoint)
 
     return [
       probeId,
       new Promise(resolve => {
         probeIdToResolveBreakpointSet.set(probeId, resolve)
-
-        this._readyPromise.then(() => {
-          // We only post the message when the worker is ready
-          this.breakpointSetChannel.port2.postMessage(
-            { id: probeId, file, line }
-          )
-        })
       })
     ]
   }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -40,6 +40,7 @@ const {
 } = require('../ci-visibility/telemetry')
 const { CI_PROVIDER_NAME, GIT_REPOSITORY_URL, GIT_COMMIT_SHA, GIT_BRANCH, CI_WORKSPACE_PATH } = require('./util/tags')
 const { OS_VERSION, OS_PLATFORM, OS_ARCHITECTURE, RUNTIME_NAME, RUNTIME_VERSION } = require('./util/env')
+const getDiClient = require('../ci-visibility/dynamic-instrumentation')
 
 module.exports = class CiPlugin extends Plugin {
   constructor (...args) {
@@ -207,8 +208,7 @@ module.exports = class CiPlugin extends Plugin {
     }
 
     if (config.isTestDynamicInstrumentationEnabled && !this.di) {
-      const testVisibilityDynamicInstrumentation = require('../ci-visibility/dynamic-instrumentation')
-      this.di = testVisibilityDynamicInstrumentation
+      this.di = getDiClient()
     }
 
     this.testEnvironmentMetadata = getTestEnvironmentMetadata(this.constructor.id, this.config)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -177,8 +177,9 @@ class Tracer extends NoopProxy {
       }
 
       if (config.isTestDynamicInstrumentationEnabled) {
-        const testVisibilityDynamicInstrumentation = require('./ci-visibility/dynamic-instrumentation')
-        testVisibilityDynamicInstrumentation.start(config)
+        const getDynamicInstrumentationClient = require('./ci-visibility/dynamic-instrumentation')
+        // We instantiate the client but do not start the Worker here. The worker is started lazily
+        getDynamicInstrumentationClient(config)
       }
     } catch (e) {
       log.error('Error initialising tracer', e)

--- a/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/target-app/test-visibility-dynamic-instrumentation-script.js
+++ b/packages/dd-trace/test/ci-visibility/dynamic-instrumentation/target-app/test-visibility-dynamic-instrumentation-script.js
@@ -1,18 +1,20 @@
 'use strict'
 
 const path = require('path')
-const tvDynamicInstrumentation = require('../../../../src/ci-visibility/dynamic-instrumentation')
+const getDiClient = require('../../../../src/ci-visibility/dynamic-instrumentation')
 const sum = require('./di-dependency')
 const Config = require('../../../../src/config')
 
 // keep process alive
 const intervalId = setInterval(() => {}, 5000)
 
-tvDynamicInstrumentation.start(new Config())
+const diClient = getDiClient(new Config())
 
-tvDynamicInstrumentation.isReady().then(() => {
+diClient.start()
+
+diClient.isReady().then(() => {
   const file = path.join(__dirname, 'di-dependency.js')
-  const [probeId, breakpointSetPromise] = tvDynamicInstrumentation.addLineProbe(
+  const [probeId, breakpointSetPromise] = diClient.addLineProbe(
     { file, line: 9 },
     ({ snapshot }) => {
       // once the breakpoint is hit, we can grab the snapshot and send it to the parent process


### PR DESCRIPTION
### What does this PR do?

* Do not start `TestVisDynamicInstrumentation` in `proxy.js`.
* Start it when it's needed, that is, when `addLineProbe` is called.
* Slightly change the API to make this possible

### Motivation
Reduce memory footprint if test replay logic is not being used

### Plugin Checklist
No extra tests needed, just make sure the tests we already have are passing.