### PR TITLE
Custom metrics aggregation

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -305,7 +305,11 @@ class MetricsAggregationClient {
   }
 }
 
-// This is a simplified user-facing proxy to the underlying DogStatsDClient instance
+/**
+ * This is a simplified user-facing proxy to the underlying DogStatsDClient instance
+ *
+ * @implements {DogStatsD}
+ */
 class CustomMetrics {
   constructor (config) {
     const clientConfig = DogStatsDClient.generateClientConfig(config)

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -6,6 +6,7 @@ const dgram = require('dgram')
 const isIP = require('net').isIP
 const log = require('./log')
 const { URL, format } = require('url')
+const Histogram = require('./histogram')
 
 const MAX_BUFFER_SIZE = 1024 // limit from the agent
 
@@ -193,15 +194,122 @@ class DogStatsDClient {
   }
 }
 
-/**
- * This is a simplified user-facing proxy to the underlying DogStatsDClient instance
- *
- * @implements {DogStatsD}
- */
+// TODO: Handle arrays of tags and tags translation.
+class MetricsAggregationClient {
+  constructor (client) {
+    this._client = client
+
+    this.reset()
+  }
+
+  flush () {
+    this._captureCounters()
+    this._captureGauges()
+    this._captureHistograms()
+
+    this._client.flush()
+  }
+
+  reset () {
+    this._counters = {}
+    this._gauges = {}
+    this._histograms = {}
+  }
+
+  distribution (name, value, tag) {
+    this._client.distribution(name, value, tag && [tag])
+  }
+
+  boolean (name, value, tag) {
+    this.gauge(name, value ? 1 : 0, tag)
+  }
+
+  histogram (name, value, tag) {
+    this._histograms[name] = this._histograms[name] || new Map()
+
+    if (!this._histograms[name].has(tag)) {
+      this._histograms[name].set(tag, new Histogram())
+    }
+
+    this._histograms[name].get(tag).record(value)
+  }
+
+  count (name, count, tag, monotonic = false) {
+    if (typeof tag === 'boolean') {
+      monotonic = tag
+      tag = undefined
+    }
+
+    const map = monotonic ? this._counters : this._gauges
+
+    map[name] = map[name] || new Map()
+
+    const value = map[name].get(tag) || 0
+
+    map[name].set(tag, value + count)
+  }
+
+  gauge (name, value, tag) {
+    this._gauges[name] = this._gauges[name] || new Map()
+    this._gauges[name].set(tag, value)
+  }
+
+  increment (name, count = 1, tag, monotonic) {
+    this.count(name, count, tag, monotonic)
+  }
+
+  decrement (name, count = 1, tag) {
+    this.count(name, -count, tag)
+  }
+
+  _captureGauges () {
+    Object.keys(this._gauges).forEach(name => {
+      this._gauges[name].forEach((value, tag) => {
+        this._client.gauge(name, value, tag && [tag])
+      })
+    })
+  }
+
+  _captureCounters () {
+    Object.keys(this._counters).forEach(name => {
+      this._counters[name].forEach((value, tag) => {
+        this._client.increment(name, value, tag && [tag])
+      })
+    })
+
+    this._counters = {}
+  }
+
+  _captureHistograms () {
+    Object.keys(this._histograms).forEach(name => {
+      this._histograms[name].forEach((stats, tag) => {
+        const tags = tag && [tag]
+
+        // Stats can contain garbage data when a value was never recorded.
+        if (stats.count === 0) {
+          stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0 }
+        }
+
+        this._client.gauge(`${name}.min`, stats.min, tags)
+        this._client.gauge(`${name}.max`, stats.max, tags)
+        this._client.increment(`${name}.sum`, stats.sum, tags)
+        this._client.increment(`${name}.total`, stats.sum, tags)
+        this._client.gauge(`${name}.avg`, stats.avg, tags)
+        this._client.increment(`${name}.count`, stats.count, tags)
+        this._client.gauge(`${name}.median`, stats.median, tags)
+        this._client.gauge(`${name}.95percentile`, stats.p95, tags)
+
+        stats.reset()
+      })
+    })
+  }
+}
+
+// This is a simplified user-facing proxy to the underlying DogStatsDClient instance
 class CustomMetrics {
   constructor (config) {
     const clientConfig = DogStatsDClient.generateClientConfig(config)
-    this.dogstatsd = new DogStatsDClient(clientConfig)
+    this._client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
 
     const flush = this.flush.bind(this)
 
@@ -212,47 +320,43 @@ class CustomMetrics {
   }
 
   increment (stat, value = 1, tags) {
-    return this.dogstatsd.increment(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.increment(stat, value, tag)
+    }
   }
 
   decrement (stat, value = 1, tags) {
-    return this.dogstatsd.decrement(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.decrement(stat, value, tag)
+    }
   }
 
   gauge (stat, value, tags) {
-    return this.dogstatsd.gauge(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.gauge(stat, value, tag)
+    }
   }
 
   distribution (stat, value, tags) {
-    return this.dogstatsd.distribution(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.distribution(stat, value, tag)
+    }
   }
 
   histogram (stat, value, tags) {
-    return this.dogstatsd.histogram(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.histogram(stat, value, tag)
+    }
   }
 
   flush () {
-    return this.dogstatsd.flush()
+    return this._client.flush()
+  }
+
+  _normalizeTags (tags) {
+    tags = CustomMetrics.tagTranslator(tags)
+
+    return tags.length === 0 ? [undefined] : tags
   }
 
   /**
@@ -274,5 +378,6 @@ class CustomMetrics {
 
 module.exports = {
   DogStatsDClient,
-  CustomMetrics
+  CustomMetrics,
+  MetricsAggregationClient
 }

--- a/packages/dd-trace/test/custom-metrics.spec.js
+++ b/packages/dd-trace/test/custom-metrics.spec.js
@@ -53,7 +53,7 @@ describe('Custom Metrics', () => {
       if (stdout) console.log(stdout)
       if (stderr) console.error(stderr)
 
-      expect(metricsData.split('#')[0]).to.equal('page.views.data:1|c|')
+      expect(metricsData.split('#')[0]).to.equal('page.views.data:1|g|')
 
       done()
     })

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -367,6 +367,7 @@ describe('dogstatsd', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.gauge('test.avg', 10, { foo: 'bar' })
+      client.gauge('test.avg', 10, { foo: 'bar' })
       client.flush()
 
       expect(udp4.send).to.have.been.called
@@ -377,60 +378,75 @@ describe('dogstatsd', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.increment('test.count', 10)
+      client.increment('test.count', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:10|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:20|g\n')
     })
 
     it('.increment() with default', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.increment('test.count')
+      client.increment('test.count')
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:1|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:2|g\n')
     })
 
     it('.decrement()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.decrement('test.count', 10)
+      client.decrement('test.count', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-10|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-20|g\n')
     })
 
     it('.decrement() with default', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.decrement('test.count')
+      client.decrement('test.count')
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-1|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-2|g\n')
     })
 
     it('.distribution()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.distribution('test.dist', 10)
+      client.distribution('test.dist', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.dist:10|d\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.dist:10|d\ntest.dist:10|d\n')
     })
 
     it('.histogram()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.histogram('test.histogram', 10)
+      client.histogram('test.histogram', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.histogram:10|h\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal([
+        'test.histogram.min:10|g',
+        'test.histogram.max:10|g',
+        'test.histogram.sum:20|c',
+        'test.histogram.total:20|c',
+        'test.histogram.avg:10|g',
+        'test.histogram.count:2|c',
+        'test.histogram.median:10.074696689511441|g',
+        'test.histogram.95percentile:10.074696689511441|g'
+      ].join('\n') + '\n')
     })
 
     it('should flush via interval', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add pre-aggregation support to custom metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now only runtime metrics are pre-aggregated, and every data point is sent for custom metrics. This is problematic because there might be too many data points which might go above the threshold of the agent. This normalizes the aggregation logic to apply to both runtime metrics and custom metrics.