### PR TITLE
WIP: modify method of baggage propagation

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -157,24 +157,29 @@ class DatadogSpan {
   }
 
   setBaggageItem (key, value) {
-    this._spanContext._baggageItems[key] = value
+    // this._spanContext._baggageItems[key] = value
+    storage('baggage').enterWith({ ...storage('baggage').getStore(), [key]: value })
     return this
   }
 
   getBaggageItem (key) {
-    return this._spanContext._baggageItems[key]
+    // return this._spanContext._baggageItems[key]
+    return storage('baggage').getStore()?.[key]
   }
 
   getAllBaggageItems () {
-    return JSON.stringify(this._spanContext._baggageItems)
+    return JSON.stringify(storage('baggage').getStore())
+    // return JSON.stringify(this._spanContext._baggageItems)
   }
 
   removeBaggageItem (key) {
-    delete this._spanContext._baggageItems[key]
+    // delete this._spanContext._baggageItems[key]
+    delete storage('baggage').getStore()?.[key]
   }
 
   removeAllBaggageItems () {
-    this._spanContext._baggageItems = {}
+    // this._spanContext._baggageItems = {}
+    storage('baggage').enterWith({})
   }
 
   setTag (key, value) {


### PR DESCRIPTION
### What does this PR do?
Updates baggage to be consistent with [OpenTelemetry baggage](https://opentelemetry.io/docs/concepts/signals/baggage/), in which baggages are propagated independently of spans.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


