### PR TITLE
Fix bug where MongoDB comment is improperly set to null when dbmPropagationMode is disabled

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -25,7 +25,7 @@ class MongodbCorePlugin extends DatabasePlugin {
         'out.port': options.port
       }
     })
-    comment = this.injectDbmComment(span, ops.comment, service)
+    const comment = this.injectDbmComment(span, ops.comment, service)
     if (comment) {
       ops.comment = comment
     }

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -25,7 +25,10 @@ class MongodbCorePlugin extends DatabasePlugin {
         'out.port': options.port
       }
     })
-    ops.comment = this.injectDbmComment(span, ops.comment, service)
+    comment = this.injectDbmComment(span, ops.comment, service)
+    if (comment) {
+      ops.comment = comment
+    }
   }
 
   getPeerService (tags) {

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -436,8 +436,6 @@ describe('Plugin', () => {
         it('DBM propagation should not inject comment', done => {
           agent
             .use(traces => {
-              const span = traces[0][0]
-
               expect(startSpy.called).to.be.true
               const ops = startSpy.getCall(0).args[0].ops
               expect(ops).to.not.have.property('comment')
@@ -482,8 +480,6 @@ describe('Plugin', () => {
         it('DBM propagation should not inject comment', done => {
           agent
             .use(traces => {
-              const span = traces[0][0]
-
               expect(startSpy.called).to.be.true
               const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.be.undefined
@@ -497,8 +493,6 @@ describe('Plugin', () => {
         it('DBM propagation should not alter existing comment', done => {
           agent
             .use(traces => {
-              const span = traces[0][0]
-
               expect(startSpy.called).to.be.true
               const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal('test comment')


### PR DESCRIPTION
### What does this PR do?
This PR resolves an issue where the comment field is incorrectly set to null in MongoDB 3.6 when `dbmPropagationMode` is not enabled.

In MongoDB 3.6 and earlier, the comment field only accepts string values. If `dbmPropagationMode` is not explicitly enabled and no comment is provided in the command, the tracer should not inject a `null` value. This fix ensures that comment remains unset in such cases, preventing potential compatibility issues.

### Motivation
https://github.com/DataDog/dd-trace-js/issues/5345

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


