### PR TITLE
Improve tagger and format

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -79,7 +79,7 @@ describe('opentelemetry', () => {
     await sandbox.remove()
   })
 
-  it('should not capture telemetry DD and OTEL vars dont conflict', () => {
+  it("should not capture telemetry DD and OTEL vars don't conflict", () => {
     proc = fork(join(cwd, 'opentelemetry/basic.js'), {
       cwd,
       env: {

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -26,6 +26,7 @@ module.exports = {
   ERROR_TYPE: 'error.type',
   ERROR_MESSAGE: 'error.message',
   ERROR_STACK: 'error.stack',
+  ERROR_OTEL: Symbol('error_otel'),
   COMPONENT: 'component',
   CLIENT_PORT_KEY: 'network.destination.port',
   PEER_SERVICE_KEY: 'peer.service',

--- a/packages/dd-trace/src/format.js
+++ b/packages/dd-trace/src/format.js
@@ -22,7 +22,9 @@ const PROCESS_ID = constants.PROCESS_ID
 const ERROR_MESSAGE = constants.ERROR_MESSAGE
 const ERROR_STACK = constants.ERROR_STACK
 const ERROR_TYPE = constants.ERROR_TYPE
+const { ERROR_OTEL } = constants
 
+// TODO(BridgeAR)[31.03.2025]: Should these land in the constants file?
 const map = {
   'operation.name': 'name',
   'service.name': 'service',
@@ -69,46 +71,49 @@ function setSingleSpanIngestionTags (span, options) {
 }
 
 function extractSpanLinks (trace, span) {
-  const links = []
-  if (span._links) {
-    for (const link of span._links) {
-      const { context, attributes } = link
-      const formattedLink = {}
-
-      formattedLink.trace_id = context.toTraceId(true)
-      formattedLink.span_id = context.toSpanId(true)
-
-      if (attributes && Object.keys(attributes).length > 0) {
-        formattedLink.attributes = attributes
-      }
-      if (context?._sampling?.priority >= 0) formattedLink.flags = context._sampling.priority > 0 ? 1 : 0
-      if (context?._tracestate) formattedLink.tracestate = context._tracestate.toString()
-
-      links.push(formattedLink)
-    }
+  if (!span._links?.length) {
+    return
   }
-  if (links.length > 0) { trace.meta['_dd.span_links'] = JSON.stringify(links) }
+  const links = []
+  for (const link of span._links) {
+    const { context, attributes } = link
+    const formattedLink = {
+      trace_id: context.toTraceId(true),
+      span_id: context.toSpanId(true)
+    }
+
+    if (attributes && Object.keys(attributes).length > 0) {
+      formattedLink.attributes = attributes
+    }
+    if (context?._sampling?.priority >= 0) formattedLink.flags = context._sampling.priority > 0 ? 1 : 0
+    if (context?._tracestate) formattedLink.tracestate = context._tracestate.toString()
+
+    links.push(formattedLink)
+  }
+  trace.meta['_dd.span_links'] = JSON.stringify(links)
 }
 
 function extractSpanEvents (trace, span) {
-  const events = []
-  if (span._events) {
-    for (const event of span._events) {
-      const formattedEvent = {
-        name: event.name,
-        time_unix_nano: Math.round(event.startTime * 1e6),
-        attributes: event.attributes && Object.keys(event.attributes).length > 0 ? event.attributes : undefined
-      }
-
-      events.push(formattedEvent)
-    }
+  if (!span._events?.length) {
+    return
   }
-  if (events.length > 0) { trace.meta.events = JSON.stringify(events) }
+  const events = []
+  for (const event of span._events) {
+    const formattedEvent = {
+      name: event.name,
+      time_unix_nano: Math.round(event.startTime * 1e6),
+      attributes: event.attributes && Object.keys(event.attributes).length > 0 ? event.attributes : undefined
+    }
+
+    events.push(formattedEvent)
+  }
+  trace.meta.events = JSON.stringify(events)
 }
 
 function extractTags (trace, span) {
   const context = span.context()
   const origin = context._trace.origin
+  // TODO(BridgeAR)[31.03.2025]: Change the tags to a map. That is way more efficient
   const tags = context._tags
   const hostname = context._hostname
   const priority = context._sampling.priority
@@ -124,43 +129,48 @@ function extractTags (trace, span) {
     registerExtraService(tags['service.name'])
   }
 
-  for (const tag in tags) {
+  for (const [tag, value] of Object.entries(tags)) {
+    // TODO(BridgeAR)[31.03.2025]: Check how many tags are defined in average.
+    // In case there are more than 2 tags in average, check for all special
+    // cases up front and loop over the tags afterwards, skipping the already
+    // visited property names by checking a map with these keys.
     switch (tag) {
       case 'service.name':
       case 'span.type':
       case 'resource.name':
-        addTag(trace, {}, map[tag], tags[tag])
+        addTag(trace, {}, map[tag], value)
         break
       // HACK: remove when Datadog supports numeric status code
       case 'http.status_code':
-        addTag(trace.meta, {}, tag, tags[tag] && String(tags[tag]))
+        addTag(trace.meta, {}, tag, value && String(value))
         break
       case 'analytics.event':
-        addTag({}, trace.metrics, ANALYTICS, tags[tag] === undefined || tags[tag] ? 1 : 0)
+        addTag({}, trace.metrics, ANALYTICS, value === undefined || value ? 1 : 0)
         break
       case HOSTNAME_KEY:
       case MEASURED:
-        addTag({}, trace.metrics, tag, tags[tag] === undefined || tags[tag] ? 1 : 0)
+        addTag({}, trace.metrics, tag, value === undefined || value ? 1 : 0)
         break
+      // TODO(BridgeAR)[31.03.2025]: How come we use two different ways to pass
+      // through errors? Can we just unify the behavior to always use one way?
       case 'error':
         if (context._name !== 'fs.operation') {
-          extractError(trace, tags[tag])
+          extractError(trace, value)
         }
         break
       case ERROR_TYPE:
       case ERROR_MESSAGE:
       case ERROR_STACK:
         // HACK: remove when implemented in the backend
-        if (context._name !== 'fs.operation') {
-          // HACK: to ensure otel.recordException does not influence trace.error
-          if (tags.setTraceError) {
-            trace.error = 1
-          }
-        } else {
+        if (context._name === 'fs.operation') {
           break
         }
+        // otel.recordException should not influence trace.error
+        if (!tags[ERROR_OTEL]) {
+          trace.error = 1
+        }
       default: // eslint-disable-line no-fallthrough
-        addTag(trace.meta, trace.metrics, tag, tags[tag])
+        addTag(trace.meta, trace.metrics, tag, value)
     }
   }
   setSingleSpanIngestionTags(trace, context._spanSampling)
@@ -177,7 +187,7 @@ function extractRootTags (trace, span) {
   const isLocalRoot = span === context._trace.started[0]
   const parentId = context._parentId
 
-  if (!isLocalRoot || (parentId && parentId.toString(10) !== '0')) return
+  if (!isLocalRoot || (parentId && parentId !== '0')) return
 
   addTag({}, trace.metrics, SAMPLING_RULE_DECISION, context._trace[SAMPLING_RULE_DECISION])
   addTag({}, trace.metrics, SAMPLING_LIMIT_DECISION, context._trace[SAMPLING_LIMIT_DECISION])
@@ -191,8 +201,8 @@ function extractChunkTags (trace, span) {
 
   if (!isLocalRoot) return
 
-  for (const key in context._trace.tags) {
-    addTag(trace.meta, trace.metrics, key, context._trace.tags[key])
+  for (const [key, value] of Object.entries(context._trace.tags)) {
+    addTag(trace.meta, trace.metrics, key, value)
   }
 }
 
@@ -203,6 +213,8 @@ function extractError (trace, error) {
 
   if (isError(error)) {
     // AggregateError only has a code and no message.
+    // TODO(BridgeAR)[31.03.2025]: An AggregateError can have a message. Should
+    // the code just generally be added, if available?
     addTag(trace.meta, trace.metrics, ERROR_MESSAGE, error.message || error.code)
     addTag(trace.meta, trace.metrics, ERROR_TYPE, error.name)
     addTag(trace.meta, trace.metrics, ERROR_STACK, error.stack)
@@ -221,28 +233,19 @@ function addTag (meta, metrics, key, value, nested) {
     case 'boolean':
       metrics[key] = value ? 1 : 0
       break
-    case 'undefined':
-      break
-    case 'object':
-      if (value === null) break
+    default:
+      if (value == null) break
 
       // Special case for Node.js Buffer and URL
+      // TODO(BridgeAR)[31.03.2025]: Figure out if all typed arrays should be treated as buffers.
       if (isNodeBuffer(value) || isUrl(value)) {
         metrics[key] = value.toString()
       } else if (!Array.isArray(value) && !nested) {
-        for (const prop in value) {
-          if (!hasOwn(value, prop)) continue
-
-          addTag(meta, metrics, `${key}.${prop}`, value[prop], true)
+        for (const [prop, val] of Object.entries(value)) {
+          addTag(meta, metrics, `${key}.${prop}`, val, true)
         }
       }
-
-      break
   }
-}
-
-function hasOwn (object, prop) {
-  return Object.prototype.hasOwnProperty.call(object, prop)
 }
 
 function isNodeBuffer (obj) {

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -9,7 +9,7 @@ const { timeInputToHrTime } = require('@opentelemetry/core')
 
 const tracer = require('../../')
 const DatadogSpan = require('../opentracing/span')
-const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../constants')
+const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK, ERROR_OTEL } = require('../constants')
 const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
 
@@ -278,12 +278,11 @@ class Span {
   }
 
   recordException (exception, timeInput) {
-    // HACK: identifier is added so that trace.error remains unchanged after a call to otel.recordException
     this._ddSpan.addTags({
       [ERROR_TYPE]: exception.name,
       [ERROR_MESSAGE]: exception.message,
       [ERROR_STACK]: exception.stack,
-      doNotSetTraceError: true
+      [ERROR_OTEL]: true
     })
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message

--- a/packages/dd-trace/src/tagger.js
+++ b/packages/dd-trace/src/tagger.js
@@ -1,43 +1,56 @@
 'use strict'
 
-const constants = require('./constants')
-const log = require('./log')
-const ERROR_MESSAGE = constants.ERROR_MESSAGE
-const ERROR_STACK = constants.ERROR_STACK
-const ERROR_TYPE = constants.ERROR_TYPE
+let log
+
+function addNonEmpty (carrier, key, value) {
+  if (key !== '') {
+    carrier[key] = value
+  }
+}
 
 function add (carrier, keyValuePairs) {
-  if (!carrier || !keyValuePairs) return
+  if (!carrier) return
 
-  if (Array.isArray(keyValuePairs)) {
-    return keyValuePairs.forEach(tags => add(carrier, tags))
-  }
   try {
     if (typeof keyValuePairs === 'string') {
-      const segments = keyValuePairs.split(',')
-      for (const segment of segments) {
-        const separatorIndex = segment.indexOf(':')
+      let valueStart = 0
+      let keyStart = 0
 
-        let value = ''
-        let key = segment
-        if (separatorIndex !== -1) {
-          key = segment.slice(0, separatorIndex)
-          value = segment.slice(separatorIndex + 1)
+      for (let i = 0; i < keyValuePairs.length; i++) {
+        const char = keyValuePairs[i]
+
+        if (char === ':') {
+          if (valueStart === 0) {
+            valueStart = i
+          }
+        } else if (char === ',') {
+          valueStart ||= i
+          addNonEmpty(
+            carrier,
+            keyValuePairs.slice(keyStart, valueStart).trim(),
+            keyValuePairs.slice(valueStart + 1, i).trim()
+          )
+          keyStart = i + 1
+          valueStart = 0
         }
-
-        carrier[key.trim()] = value.trim()
       }
+
+      if (keyValuePairs.at(-1) !== ',') {
+        valueStart ||= keyValuePairs.length
+        addNonEmpty(
+          carrier,
+          keyValuePairs.slice(keyStart, valueStart).trim(),
+          keyValuePairs.slice(valueStart + 1).trim()
+        )
+      }
+    } else if (Array.isArray(keyValuePairs)) {
+      return keyValuePairs.forEach(tags => add(carrier, tags))
     } else {
-      // HACK: to ensure otel.recordException does not influence trace.error
-      if (ERROR_MESSAGE in keyValuePairs || ERROR_STACK in keyValuePairs || ERROR_TYPE in keyValuePairs) {
-        if (!('doNotSetTraceError' in keyValuePairs)) {
-          carrier.setTraceError = true
-        }
-      }
       Object.assign(carrier, keyValuePairs)
     }
-  } catch (e) {
-    log.error('Error adding tags', e)
+  } catch (error) {
+    log ??= require('./log')
+    log.error('Error adding tags', error)
   }
 }
 

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -13,13 +13,7 @@ function isFalse (str) {
 }
 
 function isError (value) {
-  if (value instanceof Error) {
-    return true
-  }
-  if (value && value.message) {
-    return true
-  }
-  return false
+  return Boolean(value?.message || value instanceof Error)
 }
 
 // Matches a glob pattern to a given subject string

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -764,6 +764,7 @@ describe('Config', () => {
     process.env.DD_TAGS = 'env:test,aKey:aVal bKey:bVal cKey:'
 
     config = new Config()
+
     expect(config.tags).to.have.property('env', 'test')
     expect(config.tags).to.have.property('aKey', 'aVal bKey:bVal cKey:')
 

--- a/packages/dd-trace/test/format.spec.js
+++ b/packages/dd-trace/test/format.spec.js
@@ -442,14 +442,14 @@ describe('format', () => {
       })
     })
 
-    it('should not set the error flag when there is an error-related tag without a set trace tag', () => {
+    it('should set the error flag when there is an error-related tag without a set trace tag', () => {
       spanContext._tags[ERROR_TYPE] = 'Error'
       spanContext._tags[ERROR_MESSAGE] = 'boom'
       spanContext._tags[ERROR_STACK] = ''
 
       trace = format(span)
 
-      expect(trace.error).to.equal(0)
+      expect(trace.error).to.equal(1)
     })
 
     it('should set the error flag when there is an error-related tag with should setTrace', () => {

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -15,9 +15,10 @@ const TracerProvider = require('../../src/opentelemetry/tracer_provider')
 const SpanContext = require('../../src/opentelemetry/span_context')
 const { NoopSpanProcessor } = require('../../src/opentelemetry/span_processor')
 
-const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../src/constants')
+const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE, ERROR_OTEL } = require('../../src/constants')
 const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
+const format = require('../../src/format')
 
 const spanKindNames = {
   [api.SpanKind.INTERNAL]: kinds.INTERNAL,
@@ -372,13 +373,9 @@ describe('OTel Span', () => {
   it('should record exceptions', () => {
     const span = makeSpan('name')
 
-    class TestError extends Error {
-      constructor () {
-        super('test message')
-      }
-    }
+    class TestError extends Error {}
 
-    const error = new TestError()
+    const error = new TestError('test message')
     const datenow = Date.now()
     span.recordException(error, datenow)
 
@@ -386,6 +383,7 @@ describe('OTel Span', () => {
     expect(_tags).to.have.property(ERROR_TYPE, error.name)
     expect(_tags).to.have.property(ERROR_MESSAGE, error.message)
     expect(_tags).to.have.property(ERROR_STACK, error.stack)
+    expect(_tags).to.have.property(ERROR_OTEL, true)
 
     const events = span._ddSpan._events
     expect(events).to.have.lengthOf(1)
@@ -397,6 +395,10 @@ describe('OTel Span', () => {
       },
       startTime: datenow
     }])
+
+    const formatted = format(span._ddSpan)
+    expect(formatted).to.have.property('error', 0)
+    expect(formatted.meta).to.not.have.property('doNotSetTraceError')
   })
 
   it('should record exception without passing in time', () => {

--- a/packages/dd-trace/test/tagger.spec.js
+++ b/packages/dd-trace/test/tagger.spec.js
@@ -22,11 +22,34 @@ describe('tagger', () => {
   })
 
   it('should add tags as a string', () => {
-    tagger.add(carrier, 'foo:bar,baz:qux:quxx,invalid')
+    tagger.add(carrier, 'foo: bar,def,abc:,,baz:qux:quxx,  valid')
 
     expect(carrier).to.have.property('foo', 'bar')
     expect(carrier).to.have.property('baz', 'qux:quxx')
-    expect(carrier).to.have.property('invalid', '')
+    expect(carrier).to.have.property('def', '')
+    expect(carrier).to.have.property('abc', '')
+    expect(carrier).to.not.have.property('')
+    expect(carrier).to.have.property('valid', '')
+
+    tagger.add(carrier, ':')
+
+    expect(carrier).to.not.have.property('')
+  })
+
+  it('should not add empty tags', () => {
+    tagger.add(carrier, '  ')
+
+    expect(carrier).to.not.have.property('')
+
+    tagger.add(carrier, 'a:true,\t')
+
+    expect(carrier).to.have.property('a', 'true')
+    expect(carrier).to.not.have.property('')
+
+    tagger.add(carrier, 'a:true,')
+
+    expect(carrier).to.have.property('a', 'true')
+    expect(carrier).to.not.have.property('')
   })
 
   it('should add tags as an array', () => {
@@ -61,6 +84,7 @@ describe('tagger', () => {
     expect(carrier).to.have.property(ERROR_TYPE, 'foo')
     expect(carrier).to.have.property(ERROR_MESSAGE, 'foo')
     expect(carrier).to.have.property(ERROR_STACK, 'foo')
+    expect(carrier).to.have.property('doNotSetTraceError')
     expect(carrier).to.not.have.property('setTraceError')
 
     tagger.add(carrier, {
@@ -72,6 +96,6 @@ describe('tagger', () => {
     expect(carrier).to.have.property(ERROR_TYPE, 'foo')
     expect(carrier).to.have.property(ERROR_MESSAGE, 'foo')
     expect(carrier).to.have.property(ERROR_STACK, 'foo')
-    expect(carrier).to.have.property('setTraceError', true)
+    expect(carrier).to.not.have.property('setTraceError', true)
   })
 })


### PR DESCRIPTION
These are hot code paths and the otel parts should not be part of the tagger. This removes the special handling for errors in the tagger while also improving the performance and not adding tags that have no purpose.