### PR TITLE
[MLOB-2333] chore(llmobs): add telemetry for LLMObs span start

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -2,6 +2,7 @@
 
 const log = require('../../log')
 const { storage: llmobsStorage } = require('../storage')
+const telemetry = require('../telemetry')
 
 const TracingPlugin = require('../../plugins/tracing')
 const LLMObsTagger = require('../tagger')
@@ -36,6 +37,8 @@ class LLMObsPlugin extends TracingPlugin {
     // register options may not be set for operations we do not trace with llmobs
     // ie OpenAI fine tuning jobs, file jobs, etc.
     if (registerOptions) {
+      telemetry.incrementLLMObsSpanStartCount({ autoinstrumentation: true, kind: registerOptions.kind })
+
       ctx.llmobs = {} // initialize context-based namespace
       llmobsStorage.enterWith({ span })
       ctx.llmobs.parent = parent

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -37,7 +37,7 @@ class LLMObsPlugin extends TracingPlugin {
     // register options may not be set for operations we do not trace with llmobs
     // ie OpenAI fine tuning jobs, file jobs, etc.
     if (registerOptions) {
-      telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, kind: registerOptions.kind })
+      telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, integration: this.constructor.id })
 
       ctx.llmobs = {} // initialize context-based namespace
       llmobsStorage.enterWith({ span })

--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -37,7 +37,7 @@ class LLMObsPlugin extends TracingPlugin {
     // register options may not be set for operations we do not trace with llmobs
     // ie OpenAI fine tuning jobs, file jobs, etc.
     if (registerOptions) {
-      telemetry.incrementLLMObsSpanStartCount({ autoinstrumentation: true, kind: registerOptions.kind })
+      telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, kind: registerOptions.kind })
 
       ctx.llmobs = {} // initialize context-based namespace
       llmobsStorage.enterWith({ span })

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -47,7 +47,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
   }
 
   setLLMObsTags ({ request, span, response, modelProvider, modelName }) {
-    telemetry.incrementLLMObsSpanStartCount({ autoinstrumentation: true, kind: 'llm' })
+    telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, kind: 'llm' })
 
     const parent = llmobsStore.getStore()?.span
     this._tagger.registerLLMObsSpan(span, {

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -47,7 +47,7 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
   }
 
   setLLMObsTags ({ request, span, response, modelProvider, modelName }) {
-    telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, kind: 'llm' })
+    telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: true, integration: 'bedrock' })
 
     const parent = llmobsStore.getStore()?.span
     this._tagger.registerLLMObsSpan(span, {

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -1,6 +1,7 @@
 const BaseLLMObsPlugin = require('./base')
 const { storage } = require('../../../../datadog-core')
 const llmobsStore = storage('llmobs')
+const telemetry = require('../telemetry')
 
 const {
   extractRequestParams,
@@ -46,6 +47,8 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
   }
 
   setLLMObsTags ({ request, span, response, modelProvider, modelName }) {
+    telemetry.incrementLLMObsSpanStartCount({ autoinstrumentation: true, kind: 'llm' })
+
     const parent = llmobsStore.getStore()?.span
     this._tagger.registerLLMObsSpan(span, {
       parent,

--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -21,6 +21,7 @@ const LlmHandler = require('./handlers/llm')
 const EmbeddingHandler = require('./handlers/embedding')
 
 class LangChainLLMObsPlugin extends LLMObsPlugin {
+  static get id () { return 'langchain' }
   static get prefix () {
     return 'tracing:apm:langchain:invoke'
   }

--- a/packages/dd-trace/src/llmobs/plugins/openai.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai.js
@@ -3,6 +3,7 @@
 const LLMObsPlugin = require('./base')
 
 class OpenAiLLMObsPlugin extends LLMObsPlugin {
+  static get id () { return 'openai' }
   static get prefix () {
     return 'tracing:apm:openai:request'
   }

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -14,6 +14,7 @@ const Span = require('../opentracing/span')
 
 const tracerVersion = require('../../../../package.json').version
 const logger = require('../log')
+const telemetry = require('./telemetry')
 
 const LLMObsTagger = require('./tagger')
 
@@ -87,6 +88,8 @@ class LLMObs extends NoopLLMObs {
     }
 
     const kind = validateKind(options.kind) // will throw if kind is undefined or not an expected kind
+
+    telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: false, kind })
 
     // name is required for spans generated with `trace`
     // while `kind` is required, this should never throw (as otherwise it would have thrown above)

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -136,6 +136,8 @@ class LLMObs extends NoopLLMObs {
     const llmobs = this
 
     function wrapped () {
+      telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: false, kind })
+
       const span = llmobs._tracer.scope().active()
       const fnArgs = arguments
 

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const telemetryMetrics = require('../telemetry/metrics')
+const llmobsMetrics = telemetryMetrics.manager.namespace('mlobs')
+
+function incrementLLMObsSpanStartCount (tags, value = 1) {
+  llmobsMetrics.count('span.start', tags).inc(value)
+}
+
+module.exports = {
+  incrementLLMObsSpanStartCount
+}


### PR DESCRIPTION
### What does this PR do?
Adds a single count telemetry metric on LLMObs span start. Happens when:
- `llmobs.trace` is called
- the function wrapped by `llmobs.wrap` is called (which is also called by decorated functions)
- on auto-integrations `start` event
- on the bedrock auto-instrumentation `setLLMObsTags` call (since we can't leverage the `start` event in this integration)

This is done by adding a telemetry namespaced file for LLMObs (`mlobs`) and relevant helper functions, which can be added on to.

### Motivation
Adding some initial telemetry for the Node.js LLMObs SDK (more to come!...)