### PR TITLE
fix release proposal failing when stderr has output

### DIFF
--- a/scripts/release/helpers/terminal.js
+++ b/scripts/release/helpers/terminal.js
@@ -23,8 +23,8 @@ let timer
 let current
 
 // Output a command to the terminal and execute it.
-function run (cmd, treatStderrAsFailure = true) {
-  capture(cmd, treatStderrAsFailure)
+function run (cmd) {
+  capture(cmd)
 }
 
 // Ask a question in terminal and return the response.
@@ -55,7 +55,7 @@ function checkpoint (question) {
 }
 
 // Run a command and capture its output to return it to the caller.
-function capture (cmd, treatStderrAsFailure = true) {
+function capture (cmd) {
   if (flags.debug) {
     log(`${GRAY}> ${cmd}${RESET}`)
   }
@@ -76,25 +76,11 @@ function capture (cmd, treatStderrAsFailure = true) {
 
   if (flags.debug) {
     log(stdout)
-    if (stderr) {
-      if (flags['no-abort-on-error']) {
-        log(`${RED}${stderr}${RESET}`)
-      } else {
-        fatal(
-          stderr,
-          'Aborting due to error! Use --no-abort-on-error to ignore and continue.'
-        )
-      }
-    }
-  } else if (treatStderrAsFailure && stderr) {
-    if (flags['no-abort-on-error']) {
-      log(`${RED}${stderr}${RESET}`)
-    } else {
-      fatal(
-        stderr,
-        'Aborting due to error! Use --no-abort-on-error to ignore and continue.'
-      )
-    }
+    log(`${RED}${stderr}${RESET}`)
+  }
+
+  if (result.status) {
+    throw new Error(stderr)
   }
 
   return stdout

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -82,7 +82,7 @@ try {
 
   try {
     // Pull latest changes in case the release was started by someone else.
-    run(`git remote show origin | grep v${newVersion} && git pull --ff-only`, false)
+    run(`git remote show origin | grep v${newVersion} && git pull --ff-only`)
   } catch (e) {
     // Either there is no remote to pull from or the local and remote branches
     // have diverged. In both cases we ignore the error and will just use our
@@ -113,7 +113,7 @@ try {
 
     // Cherry pick all new commits to the proposal branch.
     try {
-      run(`echo "${proposalDiff}" | xargs git cherry-pick`, false)
+      run(`echo "${proposalDiff}" | xargs git cherry-pick`)
 
       pass()
     } catch (err) {
@@ -147,7 +147,7 @@ try {
 
   // Create or edit the PR. This will also automatically output a link to the PR.
   try {
-    run(`gh pr create -d -B v${releaseLine}.x -t "v${newVersion} proposal" -F ${notesFile}`, false)
+    run(`gh pr create -d -B v${releaseLine}.x -t "v${newVersion} proposal" -F ${notesFile}`)
   } catch (e) {
     // PR already exists so update instead.
     // TODO: Keep existing non-release-notes PR description if there is one.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix release proposal failing when stderr has output.

### Motivation
<!-- What inspired you to submit this pull request? -->

It's common for `stderr` to have output even without any error, which would end up failing the script. By instead relying on the status code, we can simplify the code and only abort on actual errors.