### PR TITLE
fix fetch not working in serverless environments

### DIFF
--- a/packages/datadog-instrumentations/src/fetch.js
+++ b/packages/datadog-instrumentations/src/fetch.js
@@ -17,7 +17,7 @@ if (globalThis.fetch) {
 
     const ch = tracingChannel('apm:fetch:request')
     const wrapFetch = createWrapFetch(globalThis.Request, ch, () => {
-      channel('dd-trace:instrumentation:load').publish({ name: 'fetch' })
+      channel('dd-trace:instrumentation:load').publish({ name: 'global:fetch' })
     })
 
     fetch = wrapFetch(globalFetch)

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -103,10 +103,6 @@ module.exports = class PluginManager {
     this._tracerConfig = config
     this._tracer._nomenclature.configure(config)
 
-    if (!config._isInServerlessEnvironment?.()) {
-      maybeEnable(require('../../datadog-plugin-fetch/src'))
-    }
-
     for (const name in pluginClasses) {
       this.loadPlugin(name)
     }

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -39,6 +39,7 @@ module.exports = {
   get express () { return require('../../../datadog-plugin-express/src') },
   get fastify () { return require('../../../datadog-plugin-fastify/src') },
   get 'find-my-way' () { return require('../../../datadog-plugin-find-my-way/src') },
+  get 'global:fetch' () { return require('../../../datadog-plugin-fetch/src') },
   get graphql () { return require('../../../datadog-plugin-graphql/src') },
   get grpc () { return require('../../../datadog-plugin-grpc/src') },
   get hapi () { return require('../../../datadog-plugin-hapi/src') },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix fetch not working in Serverless environments.

### Motivation
<!-- What inspired you to submit this pull request? -->

Previous logic would prevent the plugin from loading in Serverless environments. By using the existing lazy plugin loading logic instead we make sure it's loaded properly regardless of if the instrumentation was eagerly or lazily loaded. I used a `global:` prefix to make it clear it's a global and not an actual module, and to avoid collisions.