### PR TITLE
v5.41.1 proposal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.41.0",
+  "version": "5.41.1",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/datadog-instrumentations/src/fetch.js
+++ b/packages/datadog-instrumentations/src/fetch.js
@@ -17,7 +17,7 @@ if (globalThis.fetch) {
 
     const ch = tracingChannel('apm:fetch:request')
     const wrapFetch = createWrapFetch(globalThis.Request, ch, () => {
-      channel('dd-trace:instrumentation:load').publish({ name: 'fetch' })
+      channel('dd-trace:instrumentation:load').publish({ name: 'global:fetch' })
     })
 
     fetch = wrapFetch(globalFetch)

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -6,6 +6,7 @@ const dgram = require('dgram')
 const isIP = require('net').isIP
 const log = require('./log')
 const { URL, format } = require('url')
+const Histogram = require('./histogram')
 
 const MAX_BUFFER_SIZE = 1024 // limit from the agent
 
@@ -193,6 +194,117 @@ class DogStatsDClient {
   }
 }
 
+// TODO: Handle arrays of tags and tags translation.
+class MetricsAggregationClient {
+  constructor (client) {
+    this._client = client
+
+    this.reset()
+  }
+
+  flush () {
+    this._captureCounters()
+    this._captureGauges()
+    this._captureHistograms()
+
+    this._client.flush()
+  }
+
+  reset () {
+    this._counters = {}
+    this._gauges = {}
+    this._histograms = {}
+  }
+
+  distribution (name, value, tag) {
+    this._client.distribution(name, value, tag && [tag])
+  }
+
+  boolean (name, value, tag) {
+    this.gauge(name, value ? 1 : 0, tag)
+  }
+
+  histogram (name, value, tag) {
+    this._histograms[name] = this._histograms[name] || new Map()
+
+    if (!this._histograms[name].has(tag)) {
+      this._histograms[name].set(tag, new Histogram())
+    }
+
+    this._histograms[name].get(tag).record(value)
+  }
+
+  count (name, count, tag, monotonic = false) {
+    if (typeof tag === 'boolean') {
+      monotonic = tag
+      tag = undefined
+    }
+
+    const map = monotonic ? this._counters : this._gauges
+
+    map[name] = map[name] || new Map()
+
+    const value = map[name].get(tag) || 0
+
+    map[name].set(tag, value + count)
+  }
+
+  gauge (name, value, tag) {
+    this._gauges[name] = this._gauges[name] || new Map()
+    this._gauges[name].set(tag, value)
+  }
+
+  increment (name, count = 1, tag, monotonic) {
+    this.count(name, count, tag, monotonic)
+  }
+
+  decrement (name, count = 1, tag) {
+    this.count(name, -count, tag)
+  }
+
+  _captureGauges () {
+    Object.keys(this._gauges).forEach(name => {
+      this._gauges[name].forEach((value, tag) => {
+        this._client.gauge(name, value, tag && [tag])
+      })
+    })
+  }
+
+  _captureCounters () {
+    Object.keys(this._counters).forEach(name => {
+      this._counters[name].forEach((value, tag) => {
+        this._client.increment(name, value, tag && [tag])
+      })
+    })
+
+    this._counters = {}
+  }
+
+  _captureHistograms () {
+    Object.keys(this._histograms).forEach(name => {
+      this._histograms[name].forEach((stats, tag) => {
+        const tags = tag && [tag]
+
+        // Stats can contain garbage data when a value was never recorded.
+        if (stats.count === 0) {
+          stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0 }
+        }
+
+        this._client.gauge(`${name}.min`, stats.min, tags)
+        this._client.gauge(`${name}.max`, stats.max, tags)
+        this._client.increment(`${name}.sum`, stats.sum, tags)
+        this._client.increment(`${name}.total`, stats.sum, tags)
+        this._client.gauge(`${name}.avg`, stats.avg, tags)
+        this._client.increment(`${name}.count`, stats.count, tags)
+        this._client.gauge(`${name}.median`, stats.median, tags)
+        this._client.gauge(`${name}.95percentile`, stats.p95, tags)
+
+        stats.reset()
+      })
+    })
+  }
+}
+
 /**
  * This is a simplified user-facing proxy to the underlying DogStatsDClient instance
  *
@@ -201,7 +313,7 @@ class DogStatsDClient {
 class CustomMetrics {
   constructor (config) {
     const clientConfig = DogStatsDClient.generateClientConfig(config)
-    this.dogstatsd = new DogStatsDClient(clientConfig)
+    this._client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
 
     const flush = this.flush.bind(this)
 
@@ -212,47 +324,43 @@ class CustomMetrics {
   }
 
   increment (stat, value = 1, tags) {
-    return this.dogstatsd.increment(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.increment(stat, value, tag)
+    }
   }
 
   decrement (stat, value = 1, tags) {
-    return this.dogstatsd.decrement(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.decrement(stat, value, tag)
+    }
   }
 
   gauge (stat, value, tags) {
-    return this.dogstatsd.gauge(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.gauge(stat, value, tag)
+    }
   }
 
   distribution (stat, value, tags) {
-    return this.dogstatsd.distribution(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.distribution(stat, value, tag)
+    }
   }
 
   histogram (stat, value, tags) {
-    return this.dogstatsd.histogram(
-      stat,
-      value,
-      CustomMetrics.tagTranslator(tags)
-    )
+    for (const tag of this._normalizeTags(tags)) {
+      this._client.histogram(stat, value, tag)
+    }
   }
 
   flush () {
-    return this.dogstatsd.flush()
+    return this._client.flush()
+  }
+
+  _normalizeTags (tags) {
+    tags = CustomMetrics.tagTranslator(tags)
+
+    return tags.length === 0 ? [undefined] : tags
   }
 
   /**
@@ -274,5 +382,6 @@ class CustomMetrics {
 
 module.exports = {
   DogStatsDClient,
-  CustomMetrics
+  CustomMetrics,
+  MetricsAggregationClient
 }

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -287,7 +287,7 @@ class MetricsAggregationClient {
 
         // Stats can contain garbage data when a value was never recorded.
         if (stats.count === 0) {
-          stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0 }
+          stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0, reset: stats.reset }
         }
 
         this._client.gauge(`${name}.min`, stats.min, tags)

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -103,10 +103,6 @@ module.exports = class PluginManager {
     this._tracerConfig = config
     this._tracer._nomenclature.configure(config)
 
-    if (!config._isInServerlessEnvironment?.()) {
-      maybeEnable(require('../../datadog-plugin-fetch/src'))
-    }
-
     for (const name in pluginClasses) {
       this.loadPlugin(name)
     }

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -39,6 +39,7 @@ module.exports = {
   get express () { return require('../../../datadog-plugin-express/src') },
   get fastify () { return require('../../../datadog-plugin-fastify/src') },
   get 'find-my-way' () { return require('../../../datadog-plugin-find-my-way/src') },
+  get 'global:fetch' () { return require('../../../datadog-plugin-fetch/src') },
   get graphql () { return require('../../../datadog-plugin-graphql/src') },
   get grpc () { return require('../../../datadog-plugin-grpc/src') },
   get hapi () { return require('../../../datadog-plugin-hapi/src') },

--- a/packages/dd-trace/test/custom-metrics.spec.js
+++ b/packages/dd-trace/test/custom-metrics.spec.js
@@ -53,7 +53,7 @@ describe('Custom Metrics', () => {
       if (stdout) console.log(stdout)
       if (stderr) console.error(stderr)
 
-      expect(metricsData.split('#')[0]).to.equal('page.views.data:1|c|')
+      expect(metricsData.split('#')[0]).to.equal('page.views.data:1|g|')
 
       done()
     })

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -367,6 +367,7 @@ describe('dogstatsd', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.gauge('test.avg', 10, { foo: 'bar' })
+      client.gauge('test.avg', 10, { foo: 'bar' })
       client.flush()
 
       expect(udp4.send).to.have.been.called
@@ -377,60 +378,75 @@ describe('dogstatsd', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.increment('test.count', 10)
+      client.increment('test.count', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:10|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:20|g\n')
     })
 
     it('.increment() with default', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.increment('test.count')
+      client.increment('test.count')
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:1|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:2|g\n')
     })
 
     it('.decrement()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.decrement('test.count', 10)
+      client.decrement('test.count', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-10|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-20|g\n')
     })
 
     it('.decrement() with default', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.decrement('test.count')
+      client.decrement('test.count')
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-1|c\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:-2|g\n')
     })
 
     it('.distribution()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.distribution('test.dist', 10)
+      client.distribution('test.dist', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.dist:10|d\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.dist:10|d\ntest.dist:10|d\n')
     })
 
     it('.histogram()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
       client.histogram('test.histogram', 10)
+      client.histogram('test.histogram', 10)
       client.flush()
 
       expect(udp4.send).to.have.been.called
-      expect(udp4.send.firstCall.args[0].toString()).to.equal('test.histogram:10|h\n')
+      expect(udp4.send.firstCall.args[0].toString()).to.equal([
+        'test.histogram.min:10|g',
+        'test.histogram.max:10|g',
+        'test.histogram.sum:20|c',
+        'test.histogram.total:20|c',
+        'test.histogram.avg:10|g',
+        'test.histogram.count:2|c',
+        'test.histogram.median:10.074696689511441|g',
+        'test.histogram.95percentile:10.074696689511441|g'
+      ].join('\n') + '\n')
     })
 
     it('should flush via interval', () => {

--- a/scripts/release/helpers/terminal.js
+++ b/scripts/release/helpers/terminal.js
@@ -23,8 +23,8 @@ let timer
 let current
 
 // Output a command to the terminal and execute it.
-function run (cmd, treatStderrAsFailure = true) {
-  capture(cmd, treatStderrAsFailure)
+function run (cmd) {
+  capture(cmd)
 }
 
 // Ask a question in terminal and return the response.
@@ -55,7 +55,7 @@ function checkpoint (question) {
 }
 
 // Run a command and capture its output to return it to the caller.
-function capture (cmd, treatStderrAsFailure = true) {
+function capture (cmd) {
   if (flags.debug) {
     log(`${GRAY}> ${cmd}${RESET}`)
   }
@@ -76,25 +76,11 @@ function capture (cmd, treatStderrAsFailure = true) {
 
   if (flags.debug) {
     log(stdout)
-    if (stderr) {
-      if (flags['no-abort-on-error']) {
-        log(`${RED}${stderr}${RESET}`)
-      } else {
-        fatal(
-          stderr,
-          'Aborting due to error! Use --no-abort-on-error to ignore and continue.'
-        )
-      }
-    }
-  } else if (treatStderrAsFailure && stderr) {
-    if (flags['no-abort-on-error']) {
-      log(`${RED}${stderr}${RESET}`)
-    } else {
-      fatal(
-        stderr,
-        'Aborting due to error! Use --no-abort-on-error to ignore and continue.'
-      )
-    }
+    log(`${RED}${stderr}${RESET}`)
+  }
+
+  if (result.status) {
+    throw new Error(stderr)
   }
 
   return stdout

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -82,7 +82,7 @@ try {
 
   try {
     // Pull latest changes in case the release was started by someone else.
-    run(`git remote show origin | grep v${newVersion} && git pull --ff-only`, false)
+    run(`git remote show origin | grep v${newVersion} && git pull --ff-only`)
   } catch (e) {
     // Either there is no remote to pull from or the local and remote branches
     // have diverged. In both cases we ignore the error and will just use our
@@ -113,7 +113,7 @@ try {
 
     // Cherry pick all new commits to the proposal branch.
     try {
-      run(`echo "${proposalDiff}" | xargs git cherry-pick`, false)
+      run(`echo "${proposalDiff}" | xargs git cherry-pick`)
 
       pass()
     } catch (err) {
@@ -147,7 +147,7 @@ try {
 
   // Create or edit the PR. This will also automatically output a link to the PR.
   try {
-    run(`gh pr create -d -B v${releaseLine}.x -t "v${newVersion} proposal" -F ${notesFile}`, false)
+    run(`gh pr create -d -B v${releaseLine}.x -t "v${newVersion} proposal" -F ${notesFile}`)
   } catch (e) {
     // PR already exists so update instead.
     // TODO: Keep existing non-release-notes PR description if there is one.


### PR DESCRIPTION
* \[[`45f26494de`](https://github.com/DataDog/dd-trace-js/commit/45f26494de)] - **(SEMVER-PATCH)** fix release proposal failing when stderr has output (Roch Devost) [#5362](https://github.com/DataDog/dd-trace-js/pull/5362)
* \[[`f9b96af1dc`](https://github.com/DataDog/dd-trace-js/commit/f9b96af1dc)] - **(SEMVER-PATCH)** fix fetch not working in serverless environments (Roch Devost) [#5366](https://github.com/DataDog/dd-trace-js/pull/5366)
* \[[`9329f6a2b0`](https://github.com/DataDog/dd-trace-js/commit/9329f6a2b0)] - **(SEMVER-PATCH)** reset histogram when a value was never recorded (Ilyas Shabi) [#5363](https://github.com/DataDog/dd-trace-js/pull/5363)
* \[[`d603d22845`](https://github.com/DataDog/dd-trace-js/commit/d603d22845)] - **(SEMVER-PATCH)** Custom metrics aggregation (Roch Devost) [#5347](https://github.com/DataDog/dd-trace-js/pull/5347)