### PR TITLE
fix(openai, llmobs): check for stream, and other, options on the first argument

### DIFF
--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -391,5 +391,5 @@ function finish (ctx, response, error) {
 }
 
 function getOption (args, option, defaultValue) {
-  return args[args.length - 1]?.[option] || defaultValue
+  return args[0]?.[option] || defaultValue
 }

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -3347,7 +3347,7 @@ describe('Plugin', () => {
               messages: [{ role: 'user', content: 'Hello, OpenAI!', name: 'hunter2' }],
               temperature: 0.5,
               stream: true
-            })
+            }, { /* request-specific options */ })
 
             for await (const part of stream) {
               expect(part).to.have.property('choices')


### PR DESCRIPTION
### What does this PR do?
Checks for the `stream` option, and others, on the **first** argument to the traced function for OpenAI calls. Otherwise, we would try and tag and/or iterate over an object, one of whose properties is an async iterator.

It is possible to pass in a secondary option to `chat.completons` and `completions` with request options, while the first argument is the OpenAI API options (`model`, `stream`, `messages`/`prompt`, etc.).

Without the fix, but with the test modification, the test times/fails out because we do not have the response tags, as we could not iterate over the response:
![image](https://github.com/user-attachments/assets/d8784c65-6749-4029-bed3-d5b0557c5e57)


### Motivation
Fixes #5371 