### PR TITLE
dbm: tedious (sql server) service mode

### DIFF
--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -8,22 +8,27 @@ class TediousPlugin extends DatabasePlugin {
   static get operation () { return 'request' } // TODO: change to match other database plugins
   static get system () { return 'mssql' }
 
-  start ({ queryOrProcedure, connectionConfig }) {
-    this.startSpan(this.operationName(), {
-      service: this.serviceName({ pluginConfig: this.config, system: this.system }),
-      resource: queryOrProcedure,
+  start (payload) {
+    const service = this.serviceName({ pluginConfig: this.config, system: this.system })
+    const span = this.startSpan(this.operationName(), {
+      service,
+      resource: payload.queryOrProcedure,
       type: 'sql',
       kind: 'client',
       meta: {
         'db.type': 'mssql',
         component: 'tedious',
-        'out.host': connectionConfig.server,
-        [CLIENT_PORT_KEY]: connectionConfig.options.port,
-        'db.user': connectionConfig.userName || connectionConfig.authentication.options.userName,
-        'db.name': connectionConfig.options.database,
-        'db.instance': connectionConfig.options.instanceName
+        'out.host': payload.connectionConfig.server,
+        [CLIENT_PORT_KEY]: payload.connectionConfig.options.port,
+        'db.user': payload.connectionConfig.userName || payload.connectionConfig.authentication.options.userName,
+        'db.name': payload.connectionConfig.options.database,
+        'db.instance': payload.connectionConfig.options.instanceName
       }
     })
+
+    // SQL Server includes comments when caching queries
+    // For that reason we allow service mode but not full mode
+    payload.sql = this.injectDbmQuery(span, payload.queryOrProcedure, service, true)
   }
 }
 

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -63,7 +63,7 @@ class DatabasePlugin extends StoragePlugin {
     return tracerService
   }
 
-  createDbmComment (span, serviceName, isPreparedStatement = false) {
+  createDbmComment (span, serviceName, disableFullMode = false) {
     const mode = this.config.dbmPropagationMode
     const dbmService = this.getDbmServiceName(span, serviceName)
 
@@ -73,7 +73,7 @@ class DatabasePlugin extends StoragePlugin {
 
     const servicePropagation = this.createDBMPropagationCommentService(dbmService, span)
 
-    if (isPreparedStatement || mode === 'service') {
+    if (disableFullMode || mode === 'service') {
       return servicePropagation
     } else if (mode === 'full') {
       span.setTag('_dd.dbm_trace_injected', 'true')
@@ -82,8 +82,8 @@ class DatabasePlugin extends StoragePlugin {
     }
   }
 
-  injectDbmQuery (span, query, serviceName, isPreparedStatement = false) {
-    const dbmTraceComment = this.createDbmComment(span, serviceName, isPreparedStatement)
+  injectDbmQuery (span, query, serviceName, disableFullMode = false) {
+    const dbmTraceComment = this.createDbmComment(span, serviceName, disableFullMode)
 
     if (!dbmTraceComment) {
       return query


### PR DESCRIPTION
### What does this PR do?
- adds DBM service mode tracing to tedious (MS SQL Server)

### Motivation
- users want it

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


