### PR TITLE
feat(llmobs): add support for Azure OpenAI and Deepseek calls made through the OpenAI SDK

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/openai.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai.js
@@ -23,10 +23,13 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
     const inputs = ctx.args[0] // completion, chat completion, and embeddings take one argument
     const operation = getOperation(methodName)
     const kind = operation === 'embedding' ? 'embedding' : 'llm'
-    const name = `openai.${methodName}`
+
+    const { modelProvider, prefix } = this._getModelProviderAndSpanNamePrefix(ctx.basePath)
+
+    const name = `${prefix}.${methodName}`
 
     return {
-      modelProvider: 'openai',
+      modelProvider,
       modelName: inputs.model,
       kind,
       name
@@ -56,6 +59,16 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
     if (!error) {
       const metrics = this._extractMetrics(response)
       this._tagger.tagMetrics(span, metrics)
+    }
+  }
+
+  _getModelProviderAndSpanNamePrefix (baseUrl = '') {
+    if (baseUrl.includes('azure')) {
+      return { modelProvider: 'azure_openai', prefix: 'AzureOpenAI' }
+    } else if (baseUrl.includes('deepseek')) {
+      return { modelProvider: 'deepseek', prefix: 'DeepSeek' }
+    } else {
+      return { modelProvider: 'openai', prefix: 'OpenAI' }
     }
   }
 

--- a/packages/dd-trace/src/llmobs/plugins/openai.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai.js
@@ -24,9 +24,9 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
     const operation = getOperation(methodName)
     const kind = operation === 'embedding' ? 'embedding' : 'llm'
 
-    const { modelProvider, prefix } = this._getModelProviderAndSpanNamePrefix(ctx.basePath)
+    const { modelProvider, client } = this._getModelProviderAndClient(ctx.basePath)
 
-    const name = `${prefix}.${methodName}`
+    const name = `${client}.${methodName}`
 
     return {
       modelProvider,
@@ -62,13 +62,13 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
     }
   }
 
-  _getModelProviderAndSpanNamePrefix (baseUrl = '') {
+  _getModelProviderAndClient (baseUrl = '') {
     if (baseUrl.includes('azure')) {
-      return { modelProvider: 'azure_openai', prefix: 'AzureOpenAI' }
+      return { modelProvider: 'azure_openai', client: 'AzureOpenAI' }
     } else if (baseUrl.includes('deepseek')) {
-      return { modelProvider: 'deepseek', prefix: 'DeepSeek' }
+      return { modelProvider: 'deepseek', client: 'DeepSeek' }
     } else {
-      return { modelProvider: 'openai', prefix: 'OpenAI' }
+      return { modelProvider: 'openai', client: 'OpenAI' }
     }
   }
 

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
@@ -88,7 +88,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'llm',
-            name: 'openai.createCompletion',
+            name: 'OpenAI.createCompletion',
             inputMessages: [
               { content: 'How are you?' }
             ],
@@ -144,7 +144,7 @@ describe('integrations', () => {
             const expected = expectedLLMObsLLMSpanEvent({
               span,
               spanKind: 'llm',
-              name: 'openai.createChatCompletion',
+              name: 'OpenAI.createChatCompletion',
               inputMessages: [
                 { role: 'system', content: 'You are a helpful assistant' },
                 { role: 'user', content: 'How are you?' }
@@ -198,7 +198,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'embedding',
-            name: 'openai.createEmbedding',
+            name: 'OpenAI.createEmbedding',
             inputDocuments: [
               { text: 'Hello, world!' }
             ],
@@ -256,7 +256,7 @@ describe('integrations', () => {
             const expected = expectedLLMObsLLMSpanEvent({
               span,
               spanKind: 'llm',
-              name: 'openai.createChatCompletion',
+              name: 'OpenAI.createChatCompletion',
               modelName: 'gpt-3.5-turbo-0301',
               modelProvider: 'openai',
               inputMessages: [{ role: 'user', content: 'What is SpongeBob SquarePants\'s origin?' }],
@@ -305,7 +305,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'llm',
-            name: 'openai.createCompletion',
+            name: 'OpenAI.createCompletion',
             inputMessages: [{ content: 'Hello' }],
             outputMessages: [{ content: '' }],
             modelName: 'gpt-3.5-turbo',
@@ -348,7 +348,7 @@ describe('integrations', () => {
             const expected = expectedLLMObsLLMSpanEvent({
               span,
               spanKind: 'llm',
-              name: 'openai.createChatCompletion',
+              name: 'OpenAI.createChatCompletion',
               inputMessages: [{ role: 'user', content: 'Hello' }],
               outputMessages: [{ content: '' }],
               modelName: 'gpt-3.5-turbo',

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
@@ -92,7 +92,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'llm',
-            name: 'openai.createCompletion',
+            name: 'OpenAI.createCompletion',
             inputMessages: [
               { content: 'How are you?' }
             ],
@@ -147,7 +147,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'llm',
-            name: 'openai.createChatCompletion',
+            name: 'OpenAI.createChatCompletion',
             inputMessages: [
               { role: 'system', content: 'You are a helpful assistant' },
               { role: 'user', content: 'How are you?' }
@@ -200,7 +200,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'embedding',
-            name: 'openai.createEmbedding',
+            name: 'OpenAI.createEmbedding',
             inputDocuments: [
               { text: 'Hello, world!' }
             ],
@@ -264,7 +264,7 @@ describe('integrations', () => {
             const expected = expectedLLMObsLLMSpanEvent({
               span,
               spanKind: 'llm',
-              name: 'openai.createChatCompletion',
+              name: 'OpenAI.createChatCompletion',
               modelName: 'gpt-3.5-turbo-0301',
               modelProvider: 'openai',
               inputMessages: [{ role: 'user', content: 'What is SpongeBob SquarePants\'s origin?' }],
@@ -322,7 +322,7 @@ describe('integrations', () => {
             const expected = expectedLLMObsLLMSpanEvent({
               span,
               spanKind: 'llm',
-              name: 'openai.createCompletion',
+              name: 'OpenAI.createCompletion',
               inputMessages: [
                 { content: 'Can you say this is a test?' }
               ],
@@ -373,7 +373,7 @@ describe('integrations', () => {
             const expected = expectedLLMObsLLMSpanEvent({
               span,
               spanKind: 'llm',
-              name: 'openai.createChatCompletion',
+              name: 'OpenAI.createChatCompletion',
               inputMessages: [
                 { role: 'user', content: 'Hello' }
               ],
@@ -424,7 +424,7 @@ describe('integrations', () => {
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
                 spanKind: 'llm',
-                name: 'openai.createChatCompletion',
+                name: 'OpenAI.createChatCompletion',
                 modelName: 'gpt-3.5-turbo-0301',
                 modelProvider: 'openai',
                 inputMessages: [{ role: 'user', content: 'What function would you call to finish this?' }],
@@ -479,7 +479,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'llm',
-            name: 'openai.createCompletion',
+            name: 'OpenAI.createCompletion',
             inputMessages: [{ content: 'Hello' }],
             outputMessages: [{ content: '' }],
             modelName: 'gpt-3.5-turbo',
@@ -521,7 +521,7 @@ describe('integrations', () => {
           const expected = expectedLLMObsLLMSpanEvent({
             span,
             spanKind: 'llm',
-            name: 'openai.createChatCompletion',
+            name: 'OpenAI.createChatCompletion',
             inputMessages: [{ role: 'user', content: 'Hello' }],
             outputMessages: [{ content: '' }],
             modelName: 'gpt-3.5-turbo',


### PR DESCRIPTION
### What does this PR do?
Adds support for marking requests sent to Azure OpenAI and Deepseek through the OpenAI client library appropriately.

Deepseek is supported when the base URL `https://api.deepseek.com` is set:
```javascript
const OpenAI = require('openai');
const client = new OpenAI({
  baseURL: 'https://api.deepseek.com'
  apiKey: ...
});
```

Azure OpenAI is supported either when importing `AzureOpenAI` from the `openai` package, or when setting a custom base URL:
```javascript
const { AzureOpenAI } = require('openai');
const client = new AzureOpenAI({
  endpoint: 'https://<<MYURL>>.openai.azure.com/',
  apiKey: ...,
  apiVersion: ...
});

// OR
const OpenAI = require('openai')
const client = new OpenAI({
  baseURL: 'https://<<MYURL>>.openai.azure.com/',
  apiKey: ...,
  apiVersion: ...
});
```


Additionally, normalizes span names to be capitalized properly (ie `OpenAI` instead of `openai` in `OpenAI.createChatCompletion`).

### Motivation
MLOB-2364