### PR TITLE
Fix reporting of profiling_enabled in startup log

### DIFF
--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -86,7 +86,8 @@ function tracerInfo () {
 
   out.log_injection_enabled = !!config.logInjection
   out.runtime_metrics_enabled = !!config.runtimeMetrics
-  out.profiling_enabled = !!(config.profiling || {}).enabled
+  const profilingEnabled = config.profiling?.enabled
+  out.profiling_enabled = profilingEnabled === 'true' || profilingEnabled === 'auto'
   Object.assign(out, getIntegrationsAndAnalytics())
 
   out.appsec_enabled = !!config.appsec.enabled


### PR DESCRIPTION
### What does this PR do?
Fixes the reporting of `profiling_enabled` value in startup log.

### Motivation
It was always reporting true due to the way the `profiling.enabled` value is not a boolean, but rather a three-valued string. The problem was basically that `!!'false' === true`

### Additional Notes
Jira: [PROF-11492]




[PROF-11492]: https://datadoghq.atlassian.net/browse/PROF-11492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ