### PR TITLE
fix appsec tests

### DIFF
--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const proxyquire = require('proxyquire')
+
 describe('blocking', () => {
   const defaultBlockedTemplate = {
     html: 'block test',
@@ -22,7 +24,7 @@ describe('blocking', () => {
       warn: sinon.stub()
     }
 
-    const blocking = proxyquire('../src/appsec/blocking', {
+    const blocking = proxyquire('../../src/appsec/blocking', {
       '../log': log,
       './blocked_templates': defaultBlockedTemplate
     })

--- a/packages/dd-trace/test/appsec/user_tracking.spec.js
+++ b/packages/dd-trace/test/appsec/user_tracking.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('assert')
+const proxyquire = require('proxyquire')
 
 const telemetry = require('../../src/appsec/telemetry')
 const waf = require('../../src/appsec/waf')
@@ -36,7 +37,7 @@ describe('User Tracking', () => {
 
     keepTrace = sinon.stub()
 
-    const UserTracking = proxyquire('../src/appsec/user_tracking', {
+    const UserTracking = proxyquire('../../src/appsec/user_tracking', {
       '../log': log,
       '../priority_sampler': { keepTrace }
     })


### PR DESCRIPTION
### What does this PR do?
Fix proxyquire import in some Appsec tests

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


