### PR TITLE
Report waf init and update success

### DIFF
--- a/packages/dd-trace/src/appsec/telemetry/index.js
+++ b/packages/dd-trace/src/appsec/telemetry/index.js
@@ -80,10 +80,10 @@ function incrementWafInitMetric (wafVersion, rulesVersion) {
   incrementWafInit(wafVersion, rulesVersion)
 }
 
-function incrementWafUpdatesMetric (wafVersion, rulesVersion) {
+function incrementWafUpdatesMetric (wafVersion, rulesVersion, success) {
   if (!enabled) return
 
-  incrementWafUpdates(wafVersion, rulesVersion)
+  incrementWafUpdates(wafVersion, rulesVersion, success)
 }
 
 function incrementWafRequestsMetric (req) {

--- a/packages/dd-trace/src/appsec/telemetry/waf.js
+++ b/packages/dd-trace/src/appsec/telemetry/waf.js
@@ -80,14 +80,20 @@ function getOrCreateMetricTags (store, versionsTags) {
 
 function incrementWafInit (wafVersion, rulesVersion) {
   const versionsTags = getVersionsTags(wafVersion, rulesVersion)
+  const initTags = { ...versionsTags, success: true }
 
-  appsecMetrics.count('waf.init', versionsTags).inc()
+  appsecMetrics.count('waf.init', initTags).inc()
 }
 
-function incrementWafUpdates (wafVersion, rulesVersion) {
+function incrementWafUpdates (wafVersion, rulesVersion, success) {
   const versionsTags = getVersionsTags(wafVersion, rulesVersion)
+  const updateTags = { ...versionsTags, success }
 
-  appsecMetrics.count('waf.updates', versionsTags).inc()
+  appsecMetrics.count('waf.updates', updateTags).inc()
+
+  if (!success) {
+    appsecMetrics.count('waf.config_errors', versionsTags).inc()
+  }
 }
 
 function incrementWafRequests (store) {

--- a/packages/dd-trace/src/appsec/waf/waf_manager.js
+++ b/packages/dd-trace/src/appsec/waf/waf_manager.js
@@ -49,13 +49,20 @@ class WAFManager {
   }
 
   update (newRules) {
-    this.ddwaf.update(newRules)
+    let status = true
+    try {
+      this.ddwaf.update(newRules)
+    } catch (error) {
+      status = false
 
-    if (this.ddwaf.diagnostics.ruleset_version) {
-      this.rulesVersion = this.ddwaf.diagnostics.ruleset_version
+      throw error
+    } finally {
+      if (this.ddwaf.diagnostics.ruleset_version) {
+        this.rulesVersion = this.ddwaf.diagnostics.ruleset_version
+      }
+
+      Reporter.reportWafUpdate(this.ddwafVersion, this.rulesVersion, status)
     }
-
-    Reporter.reportWafUpdate(this.ddwafVersion, this.rulesVersion)
   }
 
   destroy () {

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -380,9 +380,9 @@ describe('reporter', () => {
 
   describe('reportWafUpdate', () => {
     it('should call incrementWafUpdatesMetric', () => {
-      Reporter.reportWafUpdate('0.0.1', '0.0.2')
+      Reporter.reportWafUpdate('0.0.1', '0.0.2', true)
 
-      expect(telemetry.incrementWafUpdatesMetric).to.have.been.calledOnceWithExactly('0.0.1', '0.0.2')
+      expect(telemetry.incrementWafUpdatesMetric).to.have.been.calledOnceWithExactly('0.0.1', '0.0.2', true)
     })
   })
 

--- a/packages/dd-trace/test/appsec/telemetry/waf.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/waf.spec.js
@@ -183,7 +183,8 @@ describe('Appsec Waf Telemetry metrics', () => {
 
         expect(count).to.have.been.calledOnceWithExactly('waf.init', {
           waf_version: wafVersion,
-          event_rules_version: rulesVersion
+          event_rules_version: rulesVersion,
+          success: true
         })
         expect(inc).to.have.been.calledOnce
       })
@@ -202,16 +203,18 @@ describe('Appsec Waf Telemetry metrics', () => {
         expect(metrics.series[0].points[0][1]).to.be.eq(3)
         expect(metrics.series[0].tags).to.include('waf_version:0.0.1')
         expect(metrics.series[0].tags).to.include('event_rules_version:0.0.2')
+        expect(metrics.series[0].tags).to.include('success:true')
       })
     })
 
     describe('incWafUpdatesMetric', () => {
       it('should increment waf.updates metric', () => {
-        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion)
+        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion, true)
 
         expect(count).to.have.been.calledOnceWithExactly('waf.updates', {
           waf_version: wafVersion,
-          event_rules_version: rulesVersion
+          event_rules_version: rulesVersion,
+          success: true
         })
         expect(inc).to.have.been.calledOnce
       })
@@ -219,9 +222,9 @@ describe('Appsec Waf Telemetry metrics', () => {
       it('should increment waf.updates metric multiple times', () => {
         sinon.restore()
 
-        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion)
-        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion)
-        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion)
+        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion, true)
+        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion, true)
+        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion, true)
 
         const { metrics } = appsecNamespace.toJSON()
         expect(metrics.series.length).to.be.eq(1)
@@ -230,6 +233,24 @@ describe('Appsec Waf Telemetry metrics', () => {
         expect(metrics.series[0].points[0][1]).to.be.eq(3)
         expect(metrics.series[0].tags).to.include('waf_version:0.0.1')
         expect(metrics.series[0].tags).to.include('event_rules_version:0.0.2')
+        expect(metrics.series[0].tags).to.include('success:true')
+      })
+
+      it('should increment waf.updates and waf.config_errors on failed update', () => {
+        sinon.restore()
+
+        appsecTelemetry.incrementWafUpdatesMetric(wafVersion, rulesVersion, false)
+
+        const { metrics } = appsecNamespace.toJSON()
+        expect(metrics.series.length).to.be.eq(2)
+        expect(metrics.series[0].metric).to.be.eq('waf.updates')
+        expect(metrics.series[0].tags).to.include('waf_version:0.0.1')
+        expect(metrics.series[0].tags).to.include('event_rules_version:0.0.2')
+        expect(metrics.series[0].tags).to.include('success:false')
+
+        expect(metrics.series[1].metric).to.be.eq('waf.config_errors')
+        expect(metrics.series[1].tags).to.include('waf_version:0.0.1')
+        expect(metrics.series[1].tags).to.include('event_rules_version:0.0.2')
       })
     })
 

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -179,10 +179,10 @@ describe('WAF Manager', () => {
       waf.update(rules)
 
       expect(DDWAF.prototype.update).to.be.calledOnceWithExactly(rules)
-      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '1.0.0')
+      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '1.0.0', true)
     })
 
-    it('should call Reporter.reportWafUpdate', () => {
+    it('should call Reporter.reportWafUpdate on successful update', () => {
       const rules = {
         metadata: {
           rules_version: '4.2.0'
@@ -203,7 +203,23 @@ describe('WAF Manager', () => {
 
       waf.update(rules)
 
-      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '4.2.0')
+      expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '4.2.0', true)
+    })
+
+    it('should call Reporter.reportWafUpdate on failed update', () => {
+      const rules = {
+        metadata: {
+          rules_version: '4.2.0'
+        }
+      }
+
+      DDWAF.prototype.update = sinon.stub().throws(new Error('test'))
+
+      try {
+        waf.update(rules)
+      } catch {
+        expect(Reporter.reportWafUpdate).to.be.calledOnceWithExactly(wafVersion, '1.0.0', false)
+      }
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
Report waf related telemetry metrics [APPSEC-56986](https://datadoghq.atlassian.net/browse/APPSEC-56986)

- [x] Report waf.init with success:true
- [x] Report waf.updates with success status
- [x] Report waf.config_errors on updates failure

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


