### PR TITLE
fix(vitest): fix coverage not being reported when value is zero

### DIFF
--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -300,7 +300,7 @@ class VitestPlugin extends CiPlugin {
         this.testModuleSpan.setTag('error', error)
         this.testSessionSpan.setTag('error', error)
       }
-      if (testCodeCoverageLinesTotal) {
+      if (testCodeCoverageLinesTotal !== undefined) {
         this.testModuleSpan.setTag(TEST_CODE_COVERAGE_LINES_PCT, testCodeCoverageLinesTotal)
         this.testSessionSpan.setTag(TEST_CODE_COVERAGE_LINES_PCT, testCodeCoverageLinesTotal)
       }


### PR DESCRIPTION
### What does this PR do?
This PR ensures that code coverage is reported also in cases is zero. Since zero is a falsy value in js the way the conditional was setup before this PR was preventing zero values to be reported.

### Motivation
There are valid cases where test coverage is zero and should be reported like a monorepo project where a workspace is not tested at all. 


