### PR TITLE
[test optimization] Fix hooks and retries logic in mocha

### DIFF
--- a/integration-tests/ci-visibility/test-nested-hooks/test-nested-hooks.js
+++ b/integration-tests/ci-visibility/test-nested-hooks/test-nested-hooks.js
@@ -1,0 +1,41 @@
+const { expect } = require('chai')
+
+let globalAttempts = 0
+
+describe('describe', function () {
+  this.retries(2)
+
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('beforeEach')
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.log('afterEach')
+  })
+
+  it('is not nested', function () {
+    // eslint-disable-next-line no-console
+    console.log('is not nested')
+    expect(process.env.SHOULD_FAIL ? globalAttempts++ : 1).to.equal(1)
+  })
+
+  context('context', () => {
+    beforeEach(() => {
+      // eslint-disable-next-line no-console
+      console.log('beforeEach in context')
+    })
+
+    afterEach(() => {
+      // eslint-disable-next-line no-console
+      console.log('afterEach in context')
+    })
+
+    it('nested test with retries', function () {
+      // eslint-disable-next-line no-console
+      console.log('nested test with retries')
+      expect(0).to.equal(0)
+    })
+  })
+})

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -30,8 +30,7 @@ const {
   newTests,
   testsQuarantined,
   getTestFullName,
-  getRunTestsWrapper,
-  isTestFailed
+  getRunTestsWrapper
 } = require('./utils')
 
 require('./common')
@@ -71,6 +70,17 @@ const testSessionFinishCh = channel('ci:mocha:session:finish')
 const itrSkippedSuitesCh = channel('ci:mocha:itr:skipped-suites')
 
 const getCodeCoverageCh = channel('ci:nyc:get-coverage')
+
+// Tests from workers do not come with `isFailed` method
+function isTestFailed (test) {
+  if (test.isFailed) {
+    return test.isFailed()
+  }
+  if (test.isPending) {
+    return !test.isPending() && test.state === 'failed'
+  }
+  return false
+}
 
 function getFilteredSuites (originalSuites) {
   return originalSuites.reduce((acc, suite) => {

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -30,7 +30,8 @@ const {
   newTests,
   testsQuarantined,
   getTestFullName,
-  getRunTestsWrapper
+  getRunTestsWrapper,
+  isTestFailed
 } = require('./utils')
 
 require('./common')
@@ -70,17 +71,6 @@ const testSessionFinishCh = channel('ci:mocha:session:finish')
 const itrSkippedSuitesCh = channel('ci:mocha:itr:skipped-suites')
 
 const getCodeCoverageCh = channel('ci:nyc:get-coverage')
-
-// Tests from workers do not come with `isFailed` method
-function isTestFailed (test) {
-  if (test.isFailed) {
-    return test.isFailed()
-  }
-  if (test.isPending) {
-    return !test.isPending() && test.state === 'failed'
-  }
-  return false
-}
 
 function getFilteredSuites (originalSuites) {
   return originalSuites.reduce((acc, suite) => {

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -28,6 +28,18 @@ const wrappedFunctions = new WeakSet()
 const newTests = {}
 const testsQuarantined = new Set()
 
+function getAfterEachHooks (testOrHook) {
+  const hooks = []
+
+  while (testOrHook.parent) {
+    if (testOrHook.parent._afterEach) {
+      hooks.push(...testOrHook.parent._afterEach)
+    }
+    testOrHook = testOrHook.parent
+  }
+  return hooks
+}
+
 function getTestProperties (test, testManagementTests) {
   const testSuite = getTestSuitePath(test.file, process.cwd())
   const testName = test.fullTitle()
@@ -238,7 +250,7 @@ function getOnTestEndHandler () {
     }
 
     // if there are afterEach to be run, we don't finish the test yet
-    if (asyncResource && !test.parent._afterEach.length) {
+    if (asyncResource && !getAfterEachHooks(test).length) {
       asyncResource.runInAsyncScope(() => {
         testFinishCh.publish({
           status,
@@ -253,18 +265,15 @@ function getOnTestEndHandler () {
 function getOnHookEndHandler () {
   return function (hook) {
     const test = hook.ctx.currentTest
-    if (test && hook.parent._afterEach.includes(hook)) { // only if it's an afterEach
-      const isLastRetry = getIsLastRetry(test)
-      if (test._retries > 0 && !isLastRetry) {
-        return
-      }
-      const isLastAfterEach = hook.parent._afterEach.indexOf(hook) === hook.parent._afterEach.length - 1
+    const afterEachHooks = getAfterEachHooks(hook)
+    if (test && afterEachHooks.includes(hook)) { // only if it's an afterEach
+      const isLastAfterEach = afterEachHooks.indexOf(hook) === afterEachHooks.length - 1
       if (isLastAfterEach) {
         const status = getTestStatus(test)
         const asyncResource = getTestAsyncResource(test)
         if (asyncResource) {
           asyncResource.runInAsyncScope(() => {
-            testFinishCh.publish({ status, hasBeenRetried: isMochaRetry(test), isLastRetry })
+            testFinishCh.publish({ status, hasBeenRetried: isMochaRetry(test), isLastRetry: getIsLastRetry(test) })
           })
         }
       }
@@ -396,6 +405,17 @@ function getRunTestsWrapper (runTests, config) {
   }
 }
 
+// Tests from workers do not come with `isFailed` method
+function isTestFailed (test) {
+  if (test.isFailed) {
+    return test.isFailed()
+  }
+  if (test.isPending) {
+    return !test.isPending() && test.state === 'failed'
+  }
+  return false
+}
+
 module.exports = {
   isNewTest,
   getTestProperties,
@@ -418,5 +438,6 @@ module.exports = {
   testFileToSuiteAr,
   getRunTestsWrapper,
   newTests,
-  testsQuarantined
+  testsQuarantined,
+  isTestFailed
 }

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -405,17 +405,6 @@ function getRunTestsWrapper (runTests, config) {
   }
 }
 
-// Tests from workers do not come with `isFailed` method
-function isTestFailed (test) {
-  if (test.isFailed) {
-    return test.isFailed()
-  }
-  if (test.isPending) {
-    return !test.isPending() && test.state === 'failed'
-  }
-  return false
-}
-
 module.exports = {
   isNewTest,
   getTestProperties,
@@ -438,6 +427,5 @@ module.exports = {
   testFileToSuiteAr,
   getRunTestsWrapper,
   newTests,
-  testsQuarantined,
-  isTestFailed
+  testsQuarantined
 }


### PR DESCRIPTION
### What does this PR do?

Fix test collection in mocha suites with retries and hooks.

### Motivation
When there were both `this.retries` and hooks, we'd run into an issue where test were not reported correctly.

```javascript
describe('feature', function () {
  this.retries(1)
  afterEach(() => {
     console.log('doing after each!')
  })
  it('is not reported', () => { ... })
})
```

The problem was in `getOnHookEndHandler`: we had logic in place not to finish the test in there if there were still retries to be run. This was a mechanism that should've been removed when we started instrumenting retries in mocha, but wasn't. 

Additionally, instead of just checking the `afterEach` hooks in the parent (via `.parent._afterEach`), we grab _all_ `afterEach` hooks, regardless of whether they're in the direct parent or not. 

### Plugin Checklist

- [x] Unit tests.
