### PR TITLE
lazy load ip extraction

### DIFF
--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -194,6 +194,7 @@ describe('plugins/util/web', () => {
 
         config.clientIpEnabled = true
 
+        web.normalizeConfig(config)
         web.instrument(tracer, config, req, res, 'test.request', span => {
           const tags = span.context()._tags
 
@@ -210,6 +211,7 @@ describe('plugins/util/web', () => {
 
         config.clientIpEnabled = false
 
+        web.normalizeConfig(config)
         web.instrument(tracer, config, req, res, 'test.request', span => {
           const tags = span.context()._tags
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Lazy load IP extraction.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is an AppSec feature which is disabled by default, and it has significant startup time cost because the code it uses from `net` is fairly complicated. Locally I get a 15% startup overhead reduction from not importing that single file.