### PR TITLE
chore(llmobs): add some JS docs and improved test utilities for a better developer experience

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -25,6 +25,11 @@ const flushCh = channel('llmobs:writers:flush')
 const NoopLLMObs = require('./noop')
 
 class LLMObs extends NoopLLMObs {
+  /**
+   * @param {import('../tracer')} tracer - global tracer
+   * @param {import('.')} llmobsModule - llmobs event listeners, handlers, and writers
+   * @param {import('../config')} config - tracer configuration
+   */
   constructor (tracer, llmobsModule, config) {
     super(tracer)
 

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -1,12 +1,19 @@
 'use strict'
 
 const telemetryMetrics = require('../telemetry/metrics')
+
+/** @type {import('../telemetry/metrics').Namespace} */
 const llmobsMetrics = telemetryMetrics.manager.namespace('mlobs')
 
-function incrementLLMObsSpanStartCount (tags, value = 1) {
+/**
+ * Records an LLMObs span start event, incrementing the count by the given value.
+ * @param {Record<string, string>} tags - the tags to tag the telemetry event with
+ * @param {number} value - how many span start events to record
+ */
+function recordSpanStart (tags, value = 1) {
   llmobsMetrics.count('span.start', tags).inc(value)
 }
 
 module.exports = {
-  incrementLLMObsSpanStartCount
+  incrementLLMObsSpanStartCount: recordSpanStart
 }

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -190,7 +190,7 @@ function getFunctionArguments (fn, args = []) {
 
     const argsObject = {}
 
-    for (const [argIdx, arg] of args.entries()) {
+    for (const [argIdx, arg] of Array.from(args).entries()) {
       const name = names[argIdx]
 
       const spread = name?.startsWith('...')

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -2,6 +2,11 @@
 
 const { SPAN_KINDS } = require('./constants/tags')
 
+/**
+ * Encodes a string, formatting unicode characters to their escaped representation.
+ * @param {string} str the string to encode
+ * @returns {string} the encoded string
+ */
 function encodeUnicode (str) {
   if (!str) return str
   return str.split('').map(char => {
@@ -13,6 +18,12 @@ function encodeUnicode (str) {
   }).join('')
 }
 
+/**
+ * Validates a span kind is one of the allowed kinds.
+ * @param {'llm'|'agent'|'workflow'|'retrieval'|'embedding'|'task'|'tool'} kind span kind
+ * @returns {'llm'|'agent'|'workflow'|'retrieval'|'embedding'|'task'|'tool'} validated span kind
+ * @throws if the kind is not one of the valid span kinds
+ */
 function validateKind (kind) {
   if (!SPAN_KINDS.includes(kind)) {
     throw new Error(`
@@ -24,7 +35,15 @@ function validateKind (kind) {
   return kind
 }
 
-// extracts the argument names from a function string
+/**
+ * Extracts the argument names from a function string.
+ *
+ * This is done by iterating over the characters, and selectively recording them to a string.
+ * We skip over any intermediary comments, and assignments to variables as default values.
+ *
+ * @param {string} str string of the function arguments as defined in the function signature
+ * @returns {string[]} the argument names from the function definition.
+ */
 function parseArgumentNames (str) {
   const result = []
   let current = ''
@@ -101,14 +120,21 @@ function parseArgumentNames (str) {
   return result
 }
 
-// finds the bounds of the arguments in a function string
-function findArgumentsBounds (str) {
+/**
+ * Finds the bounds of the arguments in a function string. We cannot go between the first "(" and the last ")" because
+ * of:
+ * 1. nested functions
+ * 2. functions that have a default arrow function as an argument, like `function foo (bar = () => {}) { }`
+ * @param {string} fnString - the string representation of the function
+ * @returns {[number, number]} - the start and end index of the arguments
+ */
+function findArgumentsBounds (fnString) {
   let start = -1
   let end = -1
   let closerCount = 0
 
-  for (let i = 0; i < str.length; i++) {
-    const char = str[i]
+  for (let i = 0; i < fnString.length; i++) {
+    const char = fnString[i]
 
     if (char === '(') {
       if (closerCount === 0) {
@@ -126,10 +152,26 @@ function findArgumentsBounds (str) {
     }
   }
 
-  return { start, end }
+  return [start, end]
 }
 
+/**
+ * Memoization of functions to their argument names.
+ * @type {WeakMap<Function, string[]>}
+ */
 const memo = new WeakMap()
+
+/**
+ * Gets the function arguments as an object, with the
+ * keys being their associated function argument names.
+ *
+ * Spread arguments are collected into an array.
+ *
+ * @param {Function} fn the function to extract the arguments from
+ * @param {any[]} args the arguments to the function
+ * @returns {Record<string, any> | any[]} the function arguments as an object,
+ *  defaulting to the original arguments if the function cannot be parsed
+ */
 function getFunctionArguments (fn, args = []) {
   if (!fn) return
   if (!args.length) return
@@ -141,16 +183,15 @@ function getFunctionArguments (fn, args = []) {
       names = memo.get(fn)
     } else {
       const fnString = fn.toString()
-      const { start, end } = findArgumentsBounds(fnString)
+      const [start, end] = findArgumentsBounds(fnString)
       names = parseArgumentNames(fnString.slice(start + 1, end))
       memo.set(fn, names)
     }
 
     const argsObject = {}
 
-    for (const argIdx in args) {
+    for (const [argIdx, arg] of args.entries()) {
       const name = names[argIdx]
-      const arg = args[argIdx]
 
       const spread = name?.startsWith('...')
 
@@ -169,6 +210,11 @@ function getFunctionArguments (fn, args = []) {
   }
 }
 
+/**
+ * Checks if a span has an error by looking at its tags.
+ * @param {import('../opentracing/span')} span APM span
+ * @returns {boolean} true if the span has an error, false otherwise
+ */
 function spanHasError (span) {
   const tags = span.context()._tags
   return !!(tags.error || tags['error.type'])

--- a/packages/dd-trace/src/llmobs/writers/evaluations.js
+++ b/packages/dd-trace/src/llmobs/writers/evaluations.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const { AGENTLESS_EVALULATIONS_ENDPOINT } = require('../constants/writers')
-const BaseWriter = require('./base')
+const BaseLLMObsWriter = require('./base')
 
-class LLMObsEvalMetricsWriter extends BaseWriter {
+class LLMObsEvalMetricsWriter extends BaseLLMObsWriter {
   constructor (config) {
     super({
       endpoint: AGENTLESS_EVALULATIONS_ENDPOINT,
@@ -14,6 +14,12 @@ class LLMObsEvalMetricsWriter extends BaseWriter {
     this._headers['DD-API-KEY'] = config.apiKey
   }
 
+  /**
+   * Formats the evaluation metrics payload
+   * @override
+   * @param {*} events - list of LLM Observability evaluation metrics
+   * @returns {Record<string, string | unknown[]>} the formatted payload
+   */
   makePayload (events) {
     return {
       data: {

--- a/packages/dd-trace/src/llmobs/writers/spans/base.js
+++ b/packages/dd-trace/src/llmobs/writers/spans/base.js
@@ -3,12 +3,12 @@
 const { EVP_EVENT_SIZE_LIMIT, EVP_PAYLOAD_SIZE_LIMIT } = require('../../constants/writers')
 const { DROPPED_VALUE_TEXT } = require('../../constants/text')
 const { DROPPED_IO_COLLECTION_ERROR } = require('../../constants/tags')
-const BaseWriter = require('../base')
+const BaseLLMObsWriter = require('../base')
 const logger = require('../../../log')
 
 const tracerVersion = require('../../../../../../package.json').version
 
-class LLMObsSpanWriter extends BaseWriter {
+class LLMObsSpanWriter extends BaseLLMObsWriter {
   constructor (options) {
     super({
       ...options,
@@ -16,6 +16,13 @@ class LLMObsSpanWriter extends BaseWriter {
     })
   }
 
+  /**
+   * Appends an LLM Observability span event to the writer's buffer. If the event size exceeds the
+   * 1MB limit, the event will be truncated and a warning will be logged.
+   * Additionally, if the buffer size exceeds the intake limit, the buffer will be flushed before enqueueing the event.
+   * @override
+   * @param {*} event - an LLM Observability span event
+   */
   append (event) {
     const eventSizeBytes = Buffer.from(JSON.stringify(event)).byteLength
     if (eventSizeBytes > EVP_EVENT_SIZE_LIMIT) {
@@ -24,13 +31,21 @@ class LLMObsSpanWriter extends BaseWriter {
     }
 
     if (this._bufferSize + eventSizeBytes > EVP_PAYLOAD_SIZE_LIMIT) {
-      logger.debug('Flusing queue because queing next event will exceed EvP payload limit')
+      logger.debug('Flushing queue because queuing next event will exceed EvP payload limit')
       this.flush()
     }
 
     super.append(event, eventSizeBytes)
+
+    this.makePayload()
   }
 
+  /**
+   * Formats the span payload
+   * @override
+   * @param {*} events - list of LLM Observability span events
+   * @returns {Record<string, string | unknown[]>} the formatted payload
+   */
   makePayload (events) {
     return {
       '_dd.stage': 'raw',
@@ -40,6 +55,12 @@ class LLMObsSpanWriter extends BaseWriter {
     }
   }
 
+  /**
+   * Truncates the input and output values of the LLM Observability span event.
+   * Additionally, sets the collection_errors field to indicate that the event was truncated
+   * @param {*} event - the LLM Observability span event to truncate
+   * @returns {*} the truncated event
+   */
   _truncateSpanEvent (event) {
     event.meta.input = { value: DROPPED_VALUE_TEXT }
     event.meta.output = { value: DROPPED_VALUE_TEXT }

--- a/packages/dd-trace/test/llmobs/mocks.js
+++ b/packages/dd-trace/test/llmobs/mocks.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const chai = require('chai')
+
+const BaseLLMObsSpanWriter = require('../../src/llmobs/writers/spans/base')
+const LLMObsEvalMetricsWriter = require('../../src/llmobs/writers/evaluations')
+
+const MOCK_STRING = Symbol('string')
+const MOCK_NUMBER = Symbol('number')
+const MOCK_ANY = Symbol('any')
+
+/**
+ * Sets up the test environment by adding custom chai assertions and stubbing methods.
+ *
+ * @returns {{ getSpanEvents: () => any[], getEvalMetrics: () => any[] }}
+ * An object with methods to get span events and evaluation metrics.
+ */
+function setup () {
+  chai.Assertion.addMethod('deepEqualWithMockValues', deepEqualWithMockValues)
+
+  before(() => {
+    process.removeAllListeners('beforeExit')
+
+    sinon.stub(BaseLLMObsSpanWriter.prototype, 'append')
+    sinon.stub(LLMObsEvalMetricsWriter.prototype, 'append')
+  })
+
+  afterEach(() => {
+    BaseLLMObsSpanWriter.prototype.append.reset()
+    LLMObsEvalMetricsWriter.prototype.append.reset()
+  })
+
+  after(() => {
+    BaseLLMObsSpanWriter.prototype.append.restore()
+    LLMObsEvalMetricsWriter.prototype.append.restore()
+  })
+
+  return {
+    getSpanEvents () {
+      return BaseLLMObsSpanWriter.prototype.append.getCalls().map(call => call.args[0])
+    },
+    getEvalMetrics () {
+      return LLMObsEvalMetricsWriter.prototype.append.getCalls().map(call => call.args[0])
+    }
+  }
+}
+
+function deepEqualWithMockValues (expected) {
+  const actual = this._obj // "this" here refers to the chai instance
+
+  if (actual == null) {
+    // fail the test
+    chai.expect(actual).to.exist
+  }
+
+  for (const key in actual) {
+    if (expected[key] === MOCK_STRING) {
+      chai.expect(typeof actual[key], `key ${key}`).to.equal('string')
+    } else if (expected[key] === MOCK_NUMBER) {
+      chai.expect(typeof actual[key], `key ${key}`).to.equal('number')
+    } else if (expected[key] === MOCK_ANY) {
+      chai.expect(actual[key], `key ${key}`).to.exist
+    } else if (Array.isArray(expected[key])) {
+      const sortedExpected = [...expected[key].sort()]
+      const sortedActual = [...actual[key].sort()]
+      chai.expect(sortedActual, `key: ${key}`).to.deep.equal(sortedExpected)
+    } else if (typeof expected[key] === 'object') {
+      chai.expect(actual[key], `key: ${key}`).to.deepEqualWithMockValues(expected[key])
+    } else {
+      chai.expect(actual[key], `key: ${key}`).to.equal(expected[key])
+    }
+  }
+}
+
+module.exports = {
+  setup,
+  MOCK_STRING,
+  MOCK_NUMBER,
+  MOCK_ANY
+}

--- a/packages/dd-trace/test/llmobs/mocks.js
+++ b/packages/dd-trace/test/llmobs/mocks.js
@@ -12,8 +12,32 @@ const MOCK_ANY = Symbol('any')
 /**
  * Sets up the test environment by adding custom chai assertions and stubbing methods.
  *
+ *
  * @returns {{ getSpanEvents: () => any[], getEvalMetrics: () => any[] }}
  * An object with methods to get span events and evaluation metrics.
+ *
+ * @example
+ * const llmobsMocks = require('./mocks)
+ *
+ * describe('some llmobs test', () => {
+ *  before(() => {
+ *    // maybe some test agent setup
+ *  })
+ *
+ *  const { getSpanEvents, getEvalMetrics } = llmobsMocks.setup()
+ *
+ *  // any more setup hooks
+ *
+ *  it('should test something', () => {
+ *    agent.use(traces => {
+ *     const spanEvents = getSpanEvents()
+ *
+ *     // assert span events
+ *    })
+ *
+ *    // some operation that would generate span events (or eval metrics)
+ *  })
+ * })
  */
 function setup () {
   chai.Assertion.addMethod('deepEqualWithMockValues', deepEqualWithMockValues)
@@ -45,6 +69,11 @@ function setup () {
   }
 }
 
+/**
+ * Asserts that the actual object is deeply equal to the expected object, with the ability to mock values.
+ * This mainly exists for us to set `MOCK_STRING`, `MOCK_NUMBER`, and `MOCK_ANY` values in the expected object.
+ * @param {*} expected the expected object.
+ */
 function deepEqualWithMockValues (expected) {
   const actual = this._obj // "this" here refers to the chai instance
 
@@ -74,6 +103,7 @@ function deepEqualWithMockValues (expected) {
 
 module.exports = {
   setup,
+  deepEqualWithMockValues,
   MOCK_STRING,
   MOCK_NUMBER,
   MOCK_ANY

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -1,18 +1,17 @@
 'use strict'
 
-const LLMObsAgentProxySpanWriter = require('../../../../src/llmobs/writers/spans/agentProxy')
 const { useEnv } = require('../../../../../../integration-tests/helpers')
 const agent = require('../../../../../dd-trace/test/plugins/agent')
 const {
   expectedLLMObsLLMSpanEvent,
-  expectedLLMObsNonLLMSpanEvent,
-  deepEqualWithMockValues,
+  expectedLLMObsNonLLMSpanEvent
+} = require('../../util')
+const llmobsMocks = require('../../mocks')
+
+const {
   MOCK_ANY,
   MOCK_STRING
-} = require('../../util')
-const chai = require('chai')
-
-chai.Assertion.addMethod('deepEqualWithMockValues', deepEqualWithMockValues)
+} = llmobsMocks
 
 const nock = require('nock')
 function stubCall ({ base = '', path = '', code = 200, response = {} }) {
@@ -47,26 +46,22 @@ describe('integrations', () => {
   })
 
   describe('langchain', () => {
-    before(async () => {
-      sinon.stub(LLMObsAgentProxySpanWriter.prototype, 'append')
-
-      // reduce errors related to too many listeners
-      process.removeAllListeners('beforeExit')
-
-      LLMObsAgentProxySpanWriter.prototype.append.reset()
-
-      await agent.load('langchain', {}, {
+    before(() => {
+      return agent.load('langchain', {}, {
         llmobs: {
           mlApp: 'test'
         }
       })
+    })
 
+    before(() => {
       llmobs = require('../../../../../..').llmobs
     })
 
+    const { getSpanEvents } = llmobsMocks.setup()
+
     afterEach(() => {
       nock.cleanAll()
-      LLMObsAgentProxySpanWriter.prototype.append.reset()
     })
 
     after(() => {
@@ -111,7 +106,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -139,7 +134,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -197,7 +192,7 @@ describe('integrations', () => {
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
 
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -243,7 +238,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -271,7 +266,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -322,7 +317,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -375,7 +370,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -444,7 +439,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -471,7 +466,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -522,7 +517,7 @@ describe('integrations', () => {
 
             const checkTraces = agent.use(traces => {
               const span = traces[0][0]
-              const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const spanEvent = getSpanEvents()[0]
 
               const expected = expectedLLMObsLLMSpanEvent({
                 span,
@@ -573,8 +568,8 @@ describe('integrations', () => {
               const workflowSpan = spans[0]
               const llmSpan = spans[1]
 
-              const workflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
-              const llmSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(1).args[0]
+              const workflowSpanEvent = getSpanEvents()[0]
+              const llmSpanEvent = getSpanEvents()[1]
 
               const expectedWorkflow = expectedLLMObsNonLLMSpanEvent({
                 span: workflowSpan,
@@ -622,7 +617,7 @@ describe('integrations', () => {
 
               const workflowSpan = spans[0]
 
-              const workflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+              const workflowSpanEvent = getSpanEvents()[0]
 
               const expectedWorkflow = expectedLLMObsNonLLMSpanEvent({
                 span: workflowSpan,
@@ -709,11 +704,11 @@ describe('integrations', () => {
               const secondSubWorkflow = spans[3]
               const secondLLM = spans[4]
 
-              const topLevelWorkflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
-              const firstSubWorkflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(1).args[0]
-              const firstLLMSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(2).args[0]
-              const secondSubWorkflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(3).args[0]
-              const secondLLMSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(4).args[0]
+              const topLevelWorkflowSpanEvent = getSpanEvents()[0]
+              const firstSubWorkflowSpanEvent = getSpanEvents()[1]
+              const firstLLMSpanEvent = getSpanEvents()[2]
+              const secondSubWorkflowSpanEvent = getSpanEvents()[3]
+              const secondLLMSpanEvent = getSpanEvents()[4]
 
               const expectedTopLevelWorkflow = expectedLLMObsNonLLMSpanEvent({
                 span: topLevelWorkflow,
@@ -846,9 +841,9 @@ describe('integrations', () => {
               const firstLLMSpan = spans[1]
               const secondLLMSpan = spans[2]
 
-              const workflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
-              const firstLLMSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(1).args[0]
-              const secondLLMSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(2).args[0]
+              const workflowSpanEvent = getSpanEvents()[0]
+              const firstLLMSpanEvent = getSpanEvents()[1]
+              const secondLLMSpanEvent = getSpanEvents()[2]
 
               const expectedWorkflow = expectedLLMObsNonLLMSpanEvent({
                 span: workflowSpan,
@@ -937,8 +932,8 @@ describe('integrations', () => {
               const workflowSpan = spans[0]
               const llmSpan = spans[1]
 
-              const workflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
-              const llmSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(1).args[0]
+              const workflowSpanEvent = getSpanEvents()[0]
+              const llmSpanEvent = getSpanEvents()[1]
 
               const expectedWorkflow = expectedLLMObsNonLLMSpanEvent({
                 span: workflowSpan,
@@ -1054,9 +1049,9 @@ describe('integrations', () => {
               const taskSpan = spans[1]
               const llmSpan = spans[2]
 
-              const workflowSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
-              const taskSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(1).args[0]
-              const llmSpanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(2).args[0]
+              const workflowSpanEvent = getSpanEvents()[0]
+              const taskSpanEvent = getSpanEvents()[1]
+              const llmSpanEvent = getSpanEvents()[2]
 
               const expectedWorkflow = expectedLLMObsNonLLMSpanEvent({
                 span: workflowSpan,

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
@@ -6,14 +6,9 @@ const { DogStatsDClient } = require('../../../../src/dogstatsd')
 const { NoopExternalLogger } = require('../../../../src/external-logger/src')
 
 const nock = require('nock')
-const { expectedLLMObsLLMSpanEvent, deepEqualWithMockValues } = require('../../util')
-const chai = require('chai')
+const { expectedLLMObsLLMSpanEvent } = require('../../util')
 const semver = require('semver')
-const LLMObsAgentProxySpanWriter = require('../../../../src/llmobs/writers/spans/agentProxy')
-
-const { expect } = chai
-
-chai.Assertion.addMethod('deepEqualWithMockValues', deepEqualWithMockValues)
+const llmobsMocks = require('../../mocks')
 
 const satisfiesChatCompletion = version => semver.intersects('>=3.2.0', version)
 
@@ -22,16 +17,9 @@ describe('integrations', () => {
 
   describe('openai', () => {
     before(() => {
-      sinon.stub(LLMObsAgentProxySpanWriter.prototype, 'append')
-
-      // reduce errors related to too many listeners
-      process.removeAllListeners('beforeExit')
-
       sinon.stub(DogStatsDClient.prototype, '_add')
       sinon.stub(NoopExternalLogger.prototype, 'log')
       sinon.stub(Sampler.prototype, 'isSampled').returns(true)
-
-      LLMObsAgentProxySpanWriter.prototype.append.reset()
 
       return agent.load('openai', {}, {
         llmobs: {
@@ -40,9 +28,10 @@ describe('integrations', () => {
       })
     })
 
+    const { getSpanEvents } = llmobsMocks.setup()
+
     afterEach(() => {
       nock.cleanAll()
-      LLMObsAgentProxySpanWriter.prototype.append.reset()
     })
 
     after(() => {
@@ -83,7 +72,7 @@ describe('integrations', () => {
 
         const checkSpan = agent.use(traces => {
           const span = traces[0][0]
-          const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+          const spanEvent = getSpanEvents()[0]
 
           const expected = expectedLLMObsLLMSpanEvent({
             span,
@@ -139,7 +128,7 @@ describe('integrations', () => {
 
           const checkSpan = agent.use(traces => {
             const span = traces[0][0]
-            const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+            const spanEvent = getSpanEvents()[0]
 
             const expected = expectedLLMObsLLMSpanEvent({
               span,
@@ -193,7 +182,7 @@ describe('integrations', () => {
 
         const checkSpan = agent.use(traces => {
           const span = traces[0][0]
-          const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+          const spanEvent = getSpanEvents()[0]
 
           const expected = expectedLLMObsLLMSpanEvent({
             span,
@@ -251,7 +240,7 @@ describe('integrations', () => {
 
           const checkSpan = agent.use(traces => {
             const span = traces[0][0]
-            const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+            const spanEvent = getSpanEvents()[0]
 
             const expected = expectedLLMObsLLMSpanEvent({
               span,
@@ -300,7 +289,7 @@ describe('integrations', () => {
         let error
         const checkSpan = agent.use(traces => {
           const span = traces[0][0]
-          const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+          const spanEvent = getSpanEvents()[0]
 
           const expected = expectedLLMObsLLMSpanEvent({
             span,
@@ -343,7 +332,7 @@ describe('integrations', () => {
           let error
           const checkSpan = agent.use(traces => {
             const span = traces[0][0]
-            const spanEvent = LLMObsAgentProxySpanWriter.prototype.append.getCall(0).args[0]
+            const spanEvent = getSpanEvents()[0]
 
             const expected = expectedLLMObsLLMSpanEvent({
               span,

--- a/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
@@ -8,7 +8,8 @@ const {
 } = require('../../../../../../integration-tests/helpers')
 const chai = require('chai')
 const path = require('path')
-const { expectedLLMObsNonLLMSpanEvent, deepEqualWithMockValues } = require('../../util')
+const { expectedLLMObsNonLLMSpanEvent } = require('../../util')
+const { deepEqualWithMockValues } = require('../../mocks')
 
 chai.Assertion.addMethod('deepEqualWithMockValues', deepEqualWithMockValues)
 

--- a/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
@@ -112,7 +112,7 @@ describe('typescript', () => {
           const cwd = sandbox.folder
 
           const results = {}
-          const waiters = test.setup ? test.setup(agent, results) : []
+          const waiters = test.setup?.(agent, results) || []
 
           // compile typescript
           execSync(
@@ -128,7 +128,7 @@ describe('typescript', () => {
           await Promise.all(waiters)
 
           // some tests just need the file to run, not assert payloads
-          test.runTest && test.runTest(results)
+          test.runTest?.(results)
         })
       }
     })

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -43,7 +43,7 @@ describe('span processor', () => {
       span = { context: () => ({ _tags: {} }) }
 
       processor.process({ span })
-      expect(processor.writer.append).to.not.have.been.called
+      expect(processor._writer.append).to.not.have.been.called
     })
 
     it('should format the span event for the writer', () => {

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -42,7 +42,8 @@ describe('span processor', () => {
     it('should do nothing if the span is not an llm obs span', () => {
       span = { context: () => ({ _tags: {} }) }
 
-      expect(processor._writer.append).to.not.have.been.called
+      processor.process({ span })
+      expect(processor.writer.append).to.not.have.been.called
     })
 
     it('should format the span event for the writer', () => {

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -1,34 +1,10 @@
 'use strict'
 
-const chai = require('chai')
-
 const tracerVersion = require('../../../../package.json').version
 
-const MOCK_STRING = Symbol('string')
-const MOCK_NUMBER = Symbol('number')
-const MOCK_ANY = Symbol('any')
-
-function deepEqualWithMockValues (expected) {
-  const actual = this._obj
-
-  for (const key in actual) {
-    if (expected[key] === MOCK_STRING) {
-      new chai.Assertion(typeof actual[key], `key ${key}`).to.equal('string')
-    } else if (expected[key] === MOCK_NUMBER) {
-      new chai.Assertion(typeof actual[key], `key ${key}`).to.equal('number')
-    } else if (expected[key] === MOCK_ANY) {
-      new chai.Assertion(actual[key], `key ${key}`).to.exist
-    } else if (Array.isArray(expected[key])) {
-      const sortedExpected = [...expected[key].sort()]
-      const sortedActual = [...actual[key].sort()]
-      new chai.Assertion(sortedActual, `key: ${key}`).to.deep.equal(sortedExpected)
-    } else if (typeof expected[key] === 'object') {
-      new chai.Assertion(actual[key], `key: ${key}`).to.deepEqualWithMockValues(expected[key])
-    } else {
-      new chai.Assertion(actual[key], `key: ${key}`).to.equal(expected[key])
-    }
-  }
-}
+const {
+  MOCK_STRING
+} = require('./mocks')
 
 function expectedLLMObsLLMSpanEvent (options) {
   const spanEvent = expectedLLMObsBaseEvent(options)
@@ -192,9 +168,5 @@ function fromBuffer (spanProperty, isNumber = false) {
 
 module.exports = {
   expectedLLMObsLLMSpanEvent,
-  expectedLLMObsNonLLMSpanEvent,
-  deepEqualWithMockValues,
-  MOCK_ANY,
-  MOCK_NUMBER,
-  MOCK_STRING
+  expectedLLMObsNonLLMSpanEvent
 }

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -6,6 +6,36 @@ const {
   MOCK_STRING
 } = require('./mocks')
 
+/**
+* @typedef {{
+*   span: import('../../src/opentracing/span'),
+*   parentId: string | bigint,
+*   name: string,
+*   spanKind: string,
+*   tags: Record<string, string>,
+*   sessionId: string,
+*   error: boolean,
+*   errorType: string,
+*   errorMessage: string,
+*   errorStack: string,
+*   modelName: string,
+*   modelProvider: string,
+*   inputValue: string,
+*   inputMessages: Record<string, string>,
+*   inputDocuments: Record<string, string>,
+*   outputValue: string,
+*   outputMessages: Record<string, string>,
+*   outputDocuments: Record<string, string>,
+*   metadata: Record<string, string>,
+*   tokenMetrics: Record<string, number>
+* }} ExpectedEventOptions
+*/
+
+/**
+ * Creates an expected span event for a LLM span.
+ * @param {ExpectedEventOptions} options options for the expected event
+ * @returns a mock span event to assert against
+ */
 function expectedLLMObsLLMSpanEvent (options) {
   const spanEvent = expectedLLMObsBaseEvent(options)
 
@@ -44,6 +74,11 @@ function expectedLLMObsLLMSpanEvent (options) {
   return spanEvent
 }
 
+/**
+ * Creates an expected span event for a non-LLM span.
+ * @param {ExpectedEventOptions} options
+ * @returns a mock span event to assert against
+ */
 function expectedLLMObsNonLLMSpanEvent (options) {
   const spanEvent = expectedLLMObsBaseEvent(options)
   const {
@@ -75,6 +110,11 @@ function expectedLLMObsNonLLMSpanEvent (options) {
   return spanEvent
 }
 
+/**
+ * Creates an expected base span event.
+ * @param {ExpectedEventOptions} options
+ * @returns the basis for a mock span event, without any annotation-specific fields
+ */
 function expectedLLMObsBaseEvent ({
   span,
   parentId,
@@ -121,6 +161,17 @@ function expectedLLMObsBaseEvent ({
   return spanEvent
 }
 
+/**
+ * Creates the expected tags for a span event.
+ * @param {{
+ *  span: import('../../src/opentracing/span'),
+ *  error: boolean,
+ *  errorType: string,
+ *  tags: Record<string, string>,
+ *  sessionId: string
+ * }} options the options to generate the expected tags
+ * @returns {string[]} the expected tags
+ */
 function expectedLLMObsTags ({
   span,
   error,
@@ -161,6 +212,12 @@ function expectedLLMObsTags ({
   return spanTags
 }
 
+/**
+ * Extracts the value from a buffer.
+ * @param {Buffer} spanProperty the buffer to extract the value from
+ * @param {*} isNumber whether the value is a number
+ * @returns {string | number} the extracted value
+ */
 function fromBuffer (spanProperty, isNumber = false) {
   const strVal = spanProperty.toString(10)
   return isNumber ? Number(strVal) : strVal

--- a/packages/dd-trace/test/llmobs/writers/spans/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/spans/base.spec.js
@@ -79,7 +79,7 @@ describe('LLMObsSpanWriter', () => {
 
     expect(writer.flush).to.have.been.calledOnce
     expect(logger.debug).to.have.been.calledWith(
-      'Flusing queue because queing next event will exceed EvP payload limit'
+      'Flushing queue because queuing next event will exceed EvP payload limit'
     )
   })
 


### PR DESCRIPTION
### What does this PR do?
1. Adds a bunch of JS docs with best-effort types
2. Fixes up some code inconsistencies (variable naming, and using `for (... of ...)` instead of `for (... in ...)`
3. Adds some test utilities to make getting queued span events a little less verbose for plugin tests

### Motivation
MLOB-2400, a better developer experience for contributing to LLMObs code

### Additional Notes
We should make some fields in these classes truly private (denoted by `#`) instead of the legacy `_`, which doesn't actually leave them off the prototype, so that fields we don't want user accessing, especially on the SDK directly, are not visible, but although it's a small change, is out of scope for this PR.
