### PR TITLE
Fix user agent in fingerprinting tests

### DIFF
--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.express.plugin.spec.js
@@ -61,6 +61,7 @@ withVersions('express', 'express', expressVersion => {
         },
         {
           headers: {
+            'User-Agent': 'test-user-agent',
             headerName: 'headerValue',
             'x-real-ip': '255.255.255.255'
           }
@@ -70,7 +71,7 @@ withVersions('express', 'express', expressVersion => {
       await agent.use((traces) => {
         const span = traces[0][0]
         assert.property(span.meta, '_dd.appsec.fp.http.header')
-        assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-24b31d51-5-55682ec1')
+        assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-74c2908f-5-55682ec1')
         assert.property(span.meta, '_dd.appsec.fp.http.network')
         assert.equal(span.meta['_dd.appsec.fp.http.network'], 'net-1-0100000000')
         assert.property(span.meta, '_dd.appsec.fp.http.endpoint')

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
@@ -10,7 +10,7 @@ const Config = require('../../src/config')
 function assertFingerprintInTraces (traces) {
   const span = traces[0][0]
   assert.property(span.meta, '_dd.appsec.fp.http.header')
-  assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-24b31d51-5-e58aa9dd')
+  assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-74c2908f-5-e58aa9dd')
   assert.property(span.meta, '_dd.appsec.fp.http.network')
   assert.equal(span.meta['_dd.appsec.fp.http.network'], 'net-0-0000000000')
   assert.property(span.meta, '_dd.appsec.fp.http.endpoint')
@@ -61,7 +61,10 @@ withVersions('passport-http', 'passport-http', version => {
       server = app.listen(port, () => {
         port = server.address().port
         axios = Axios.create({
-          baseURL: `http://localhost:${port}`
+          baseURL: `http://localhost:${port}`,
+          headers: {
+            'User-Agent': 'test-user-agent'
+          }
         })
         done()
       })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
@@ -10,7 +10,7 @@ const Config = require('../../src/config')
 function assertFingerprintInTraces (traces) {
   const span = traces[0][0]
   assert.property(span.meta, '_dd.appsec.fp.http.header')
-  assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-24b31d51-4-c348f529')
+  assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-74c2908f-4-c348f529')
   assert.property(span.meta, '_dd.appsec.fp.http.network')
   assert.equal(span.meta['_dd.appsec.fp.http.network'], 'net-0-0000000000')
   assert.property(span.meta, '_dd.appsec.fp.http.endpoint')
@@ -61,7 +61,10 @@ withVersions('passport-local', 'passport-local', version => {
       server = app.listen(port, () => {
         port = server.address().port
         axios = Axios.create({
-          baseURL: `http://localhost:${port}`
+          baseURL: `http://localhost:${port}`,
+          headers: {
+            'User-Agent': 'test-user-agent'
+          }
         })
         done()
       })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.spec.js
@@ -56,12 +56,16 @@ describe('Attacker fingerprinting', () => {
 
       agent.use(traces => {
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.header')
-        assert.equal(traces[0][0].meta['_dd.appsec.fp.http.header'], 'hdr-0110000010-24b31d51-3-98425651')
+        assert.equal(traces[0][0].meta['_dd.appsec.fp.http.header'], 'hdr-0110000010-74c2908f-3-98425651')
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.network')
         assert.equal(traces[0][0].meta['_dd.appsec.fp.http.network'], 'net-0-0000000000')
       }).then(done).catch(done)
 
-      axios.get(`http://localhost:${port}/`)
+      axios.get(`http://localhost:${port}/`, {
+        headers: {
+          'User-Agent': 'test-user-agent'
+        }
+      })
     })
 
     it('should provide fingerprinting on failed user login track', (done) => {
@@ -72,12 +76,16 @@ describe('Attacker fingerprinting', () => {
 
       agent.use(traces => {
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.header')
-        assert.equal(traces[0][0].meta['_dd.appsec.fp.http.header'], 'hdr-0110000010-24b31d51-3-98425651')
+        assert.equal(traces[0][0].meta['_dd.appsec.fp.http.header'], 'hdr-0110000010-74c2908f-3-98425651')
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.network')
         assert.equal(traces[0][0].meta['_dd.appsec.fp.http.network'], 'net-0-0000000000')
       }).then(done).catch(done)
 
-      axios.get(`http://localhost:${port}/`)
+      axios.get(`http://localhost:${port}/`, {
+        headers: {
+          'User-Agent': 'test-user-agent'
+        }
+      })
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Defines an static user agent in fingerprinting tests to prevent dependency to the axios version

### Motivation
<!-- What inspired you to submit this pull request? -->
Fix axios dependant flaky test


