### PR TITLE
remove fs dependency from lambda hook

### DIFF
--- a/packages/dd-trace/src/lambda/runtime/patch.js
+++ b/packages/dd-trace/src/lambda/runtime/patch.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 
-const { _extractModuleNameAndHandlerPath, _extractModuleRootAndHandler, _getLambdaFilePath } = require('./ritm')
+const { _extractModuleNameAndHandlerPath, _extractModuleRootAndHandler, _getLambdaFilePaths } = require('./ritm')
 const { datadog } = require('../handler')
 const { addHook } = require('../../../../datadog-instrumentations/src/helpers/instrument')
 const shimmer = require('../../../../datadog-shimmer')
@@ -65,9 +65,11 @@ if (originalLambdaHandler !== undefined) {
   const [_module, handlerPath] = _extractModuleNameAndHandlerPath(moduleAndHandler)
 
   const lambdaStylePath = path.resolve(lambdaTaskRoot, moduleRoot, _module)
-  const lambdaFilePath = _getLambdaFilePath(lambdaStylePath)
+  const lambdaFilePaths = _getLambdaFilePaths(lambdaStylePath)
 
-  addHook({ name: lambdaFilePath }, patchLambdaModule(handlerPath))
+  for (const lambdaFilePath of lambdaFilePaths) {
+    addHook({ name: lambdaFilePath }, patchLambdaModule(handlerPath))
+  }
 } else {
   // Instrumentation is done manually.
   addHook({ name: 'datadog-lambda-js' }, patchDatadogLambdaModule)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove `fs` dependency from Lambda hook.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was forcing `fs` and its integration to load, thus impacting startup time at worst and showing them incorrectly in the cold start trace at best.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

It's possible that I may be missing something and there might have been a specific reason to use `fs` here, but it didn't seem like it so I just went ahead with the change.

Ideally this would be rewritten entirely to be like any other instrumentation instead of having this second system work in parallel, but that will require a lot more work, so in the meantime I just addressed the immediate issue shown in the cold start trace.