### PR TITLE
lazy load dd-trace-api integration

### DIFF
--- a/packages/datadog-instrumentations/src/dd-trace-api.js
+++ b/packages/datadog-instrumentations/src/dd-trace-api.js
@@ -3,4 +3,5 @@
 const { addHook } = require('./helpers/instrument')
 
 // Empty hook just to make the plugin load.
+// TODO: Add version range when the module is released on npm.
 addHook({ name: 'dd-trace-api' }, api => api)

--- a/packages/datadog-instrumentations/src/dd-trace-api.js
+++ b/packages/datadog-instrumentations/src/dd-trace-api.js
@@ -1,0 +1,6 @@
+'use strict'
+
+const { addHook } = require('./helpers/instrument')
+
+// Empty hook just to make the plugin load.
+addHook({ name: 'dd-trace-api' }, api => api)

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -43,6 +43,7 @@ module.exports = {
   couchbase: () => require('../couchbase'),
   crypto: () => require('../crypto'),
   cypress: () => require('../cypress'),
+  'dd-trace-api': () => require('../dd-trace-api'),
   dns: () => require('../dns'),
   elasticsearch: () => require('../elasticsearch'),
   express: () => require('../express'),

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -158,7 +158,7 @@ for (const packageName of names) {
 }
 
 function matchVersion (version, ranges) {
-  return !version || (ranges && ranges.some(range => satisfies(version, range)))
+  return !version || !ranges || ranges.some(range => satisfies(version, range))
 }
 
 function getVersion (moduleBaseDir) {

--- a/packages/datadog-plugin-dd-trace-api/test/index.spec.js
+++ b/packages/datadog-plugin-dd-trace-api/test/index.spec.js
@@ -22,6 +22,9 @@ describe('Plugin', () => {
 
       tracer = require('../../dd-trace')
 
+      // TODO: Use the real module when it's released.
+      dc.channel('dd-trace:instrumentation:load').publish({ name: 'dd-trace-api' })
+
       sinon.spy(tracer)
       sinon.spy(tracer.appsec)
       sinon.spy(tracer.dogstatsd)

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -28,9 +28,6 @@ loadChannel.subscribe(({ name }) => {
   maybeEnable(plugins[name])
 })
 
-// Always enabled
-maybeEnable(require('../../datadog-plugin-dd-trace-api/src'))
-
 function maybeEnable (Plugin) {
   if (!Plugin || typeof Plugin !== 'function') return
   if (!pluginClasses[Plugin.id]) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Lazy load `dd-trace-api` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now it's always loaded which impacts startup time.
