### PR TITLE
[test optimization] Deprecate dd-trace support for cypress <10.2.0

### DIFF
--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -1,5 +1,6 @@
 const NoopTracer = require('../../dd-trace/src/noop/tracer')
 const cypressPlugin = require('./cypress-plugin')
+const satisfies = require('semifies')
 
 const noopTask = {
   'dd:testSuiteStart': () => {
@@ -18,6 +19,15 @@ const noopTask = {
 
 module.exports = (on, config) => {
   const tracer = require('../../dd-trace')
+
+  if (satisfies(config.version, '<10.2.0')) {
+    // console.warn does not seem to work in cypress, so using console.log instead
+    // eslint-disable-next-line no-console
+    console.log(
+      'WARNING: dd-trace support for Cypress<10.2.0 is deprecated' +
+      ' and will not be supported in future versions of dd-trace.'
+    )
+  }
 
   // The tracer was not init correctly for whatever reason (such as invalid DD_SITE)
   if (tracer._tracer instanceof NoopTracer) {


### PR DESCRIPTION
### What does this PR do?
Deprecate cypress <10.2.0. The intention is to ship a breaking change in the next major release that stops supporting these cypress versions.

### Motivation
Preparation for https://github.com/DataDog/dd-trace-js/pull/5397

Older versions of cypress carry a problem: they come bundled with old versions of node.js, which we no longer support. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
