### PR TITLE
fix correct typo in llmobs.AnnotationOptions TypeScript definition comment

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2347,7 +2347,7 @@ declare namespace tracer {
        * ```javascript
        * llmobs.trace({ kind: 'llm', name: 'myLLM', modelName: 'gpt-4o', modelProvider: 'openai' }, () => {
        *  llmobs.annotate({
-       *    inputData: [{ content: 'system prompt, role: 'system' }, { content: 'user prompt', role: 'user' }],
+       *    inputData: [{ content: 'system prompt', role: 'system' }, { content: 'user prompt', role: 'user' }],
        *    outputData: { content: 'response', role: 'ai' },
        *    metadata: { temperature: 0.7 },
        *    tags: { host: 'localhost' },


### PR DESCRIPTION
### What does this PR do?
This PR fixes a typo in the comment for the ```llmobs.AnnotationOptions``` TypeScript type definition. It only corrects the documentation comment without changing any actual functionality of the type definition.

### Motivation
To improve the accuracy and quality of the documentation. The typo was fixed to prevent confusion and incorrect information for developers who refer to these type definitions.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [x] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
- This is a simple documentation fix that doesn't affect code behavior
- Changes are limited to TypeScript type definition files (index.d.ts) only
