### PR TITLE
CI: Run spec files in datadog-instrumentations sub-dirs

### DIFF
--- a/.github/workflows/instrumentations.yml
+++ b/.github/workflows/instrumentations.yml
@@ -17,8 +17,31 @@ concurrency:
 
 
 jobs:
+  instrumentations-misc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:instrumentations:misc:ci
+        shell: bash
+      - uses: ./.github/actions/node/newest-maintenance-lts
+      - run: yarn test:instrumentations:misc:ci
+        shell: bash
+      - uses: ./.github/actions/node/active-lts
+      - run: yarn test:instrumentations:misc:ci
+        shell: bash
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:instrumentations:misc:ci
+        shell: bash
+      - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
+      - if: always()
+        uses: ./.github/actions/testagent/logs
+        with:
+          suffix: test-${{ github.job }}
 
-  # These ones don't have a plugin directory, but exist in the
+  # These ones don't have a plugin directory, but exist in the root
   # instrumentations directory, so they need to be run somewhere. This seems to
   # be a reasonable place to run them for now.
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "test:trace:core:ci": "npm run test:trace:core -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/**/*.js\"",
     "test:instrumentations": "mocha -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/**/*.spec.js'",
     "test:instrumentations:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations",
+    "test:instrumentations:misc": "mocha -r 'packages/dd-trace/test/setup/mocha.js' 'packages/datadog-instrumentations/test/*/**/*.spec.js'",
+    "test:instrumentations:misc:ci": "nyc --no-clean --include 'packages/datadog-instrumentations/src/**/*.js' -- npm run test:instrumentations:misc",
     "test:core": "tap \"packages/datadog-core/test/**/*.spec.js\"",
     "test:core:ci": "npm run test:core -- --coverage --nyc-arg=--include=\"packages/datadog-core/src/**/*.js\"",
     "test:lambda": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/dd-trace/test/lambda/**/*.spec.js\"",

--- a/packages/datadog-instrumentations/test/helpers/instrument.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/instrument.spec.js
@@ -1,9 +1,6 @@
 'use strict'
 
-require('../../../dd-trace/test/setup/tap')
-
 const { executionAsyncId } = require('async_hooks')
-const { expect } = require('chai')
 const { storage } = require('../../../datadog-core')
 const { AsyncResource } = require('../../src/helpers/instrument')
 
@@ -26,8 +23,8 @@ describe('helpers/instrument', () => {
 
       const tested = AsyncResource.bind(function (a, b, c) {
         expect(this).to.equal(self)
-        expect(test.asyncResource.asyncId()).to.equal(executionAsyncId())
-        expect(test).to.have.length(3)
+        expect(tested.asyncResource.asyncId()).to.equal(executionAsyncId())
+        expect(tested).to.have.length(3)
       }, 'test', self)
 
       tested()
@@ -40,8 +37,8 @@ describe('helpers/instrument', () => {
         storage('legacy').run('test2', () => {
           const tested = asyncResource.bind((a, b, c) => {
             expect(storage('legacy').getStore()).to.equal('test1')
-            expect(test.asyncResource).to.equal(asyncResource)
-            expect(test).to.have.length(3)
+            expect(tested.asyncResource).to.equal(asyncResource)
+            expect(tested).to.have.length(3)
           })
 
           tested()


### PR DESCRIPTION
Ensure that `*.spec.js` files inside of sub-directories of the `packages/datadog-instrumentations/test` folder are also run in CI.
    
Today, there's a `helpers` directory, which currently contains a single spec file. Since this spec file isn't run during CI, it's been silently broken since 2022. Therefore, this commit also updates the spec file to work, by:
    
- Fixing references to missing variables
- Changing it from tap to mocha, as this is the style of the other spec files in the package