### PR TITLE
fix(llmobs): additional options like for manual span instrumentation are properly recognized

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -105,12 +105,12 @@ class LLMObs extends NoopLLMObs {
 
     if (fn.length > 1) {
       return this._tracer.trace(name, spanOptions, (span, cb) =>
-        this._activate(span, { kind, options: llmobsOptions }, () => fn(span, cb))
+        this._activate(span, { kind, ...llmobsOptions }, () => fn(span, cb))
       )
     }
 
     return this._tracer.trace(name, spanOptions, span =>
-      this._activate(span, { kind, options: llmobsOptions }, () => fn(span))
+      this._activate(span, { kind, ...llmobsOptions }, () => fn(span))
     )
   }
 
@@ -166,7 +166,7 @@ class LLMObs extends NoopLLMObs {
       }
 
       try {
-        const result = llmobs._activate(span, { kind, options: llmobsOptions }, () => fn.apply(this, fnArgs))
+        const result = llmobs._activate(span, { kind, ...llmobsOptions }, () => fn.apply(this, fnArgs))
 
         if (result && typeof result.then === 'function') {
           return result.then(

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -327,6 +327,29 @@ describe('sdk', () => {
           })
         })
       })
+
+      it('passes the options to the tagger correctly', () => {
+        let span
+        llmobs.trace({
+          kind: 'workflow',
+          name: 'test',
+          mlApp: 'override',
+          sessionId: 'sessionId',
+          modelName: 'modelName',
+          modelProvider: 'modelProvider'
+        }, (_span) => {
+          span = _span
+        })
+
+        expect(LLMObsTagger.tagMap.get(span)).to.deep.equal({
+          '_ml_obs.meta.span.kind': 'workflow',
+          '_ml_obs.meta.ml_app': 'override',
+          '_ml_obs.meta.model_name': 'modelName',
+          '_ml_obs.meta.model_provider': 'modelProvider',
+          '_ml_obs.session_id': 'sessionId',
+          '_ml_obs.llmobs_parent_id': 'undefined'
+        })
+      })
     })
 
     describe('wrap', () => {
@@ -743,6 +766,32 @@ describe('sdk', () => {
           const wrappedInner2 = llmobs.wrap({ kind: 'task' }, inner2)
 
           wrappedOuter()
+        })
+      })
+
+      it('passes the options to the tagger correctly', () => {
+        let span
+
+        const fn = llmobs.wrap({
+          kind: 'workflow',
+          name: 'test',
+          mlApp: 'override',
+          sessionId: 'sessionId',
+          modelName: 'modelName',
+          modelProvider: 'modelProvider'
+        }, () => {
+          span = llmobs._active()
+        })
+
+        fn()
+
+        expect(LLMObsTagger.tagMap.get(span)).to.deep.equal({
+          '_ml_obs.meta.span.kind': 'workflow',
+          '_ml_obs.meta.ml_app': 'override',
+          '_ml_obs.meta.model_name': 'modelName',
+          '_ml_obs.meta.model_provider': 'modelProvider',
+          '_ml_obs.session_id': 'sessionId',
+          '_ml_obs.llmobs_parent_id': 'undefined'
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where specifying additional LLM Observability span options other than `name` and `kind` on manually instrumented spans were not passed on appropriately to the tagger. This was due to a bad refactor in https://github.com/DataDog/dd-trace-js/pull/4960 for `_activate` in which a parameter name was changed without spreading it in correctly.

There should have been a test for this (there was on the tagger side, but not on the SDK side to assert proper usage) - tests are now in place.

We would previously try and pass this object shape into the `tagger.registerLLMObsSpan` options object:
```
{
  kind: ...
  options: {
    mlApp: ...,
    sessionId: ...,
    ...
  }
}
```
instead of
```
{
  kind: ...
  mlApp: ...,
  sessionId: ...
  ...
}
```
which leads to those options not being correctly read in the tagger, as the tagger assumes they're all just properties on the same object.

### Motivation
MLOB-2419
