### PR TITLE
Pin `@opentelemetry/instrumentation-express` testing to `0.47.1`

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -60,7 +60,7 @@ describe('opentelemetry', () => {
       '@opentelemetry/api@1.8.0',
       '@opentelemetry/instrumentation',
       '@opentelemetry/instrumentation-http',
-      '@opentelemetry/instrumentation-express',
+      '@opentelemetry/instrumentation-express@0.47.1',
       'express'
     ]
     if (satisfies(process.version.slice(1), '>=14')) {


### PR DESCRIPTION
### What does this PR do?
Pin version used in opentelemetry testing to `@opentelemetry/instrumentation-express@0.47.1`

### Motivation
Opentelemetry tests are blocking our release: https://github.com/DataDog/dd-trace-js/pull/5431

This is because of the latest open telemetry express release: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2726:

<img width="717" alt="Screenshot 2025-03-18 at 16 24 58" src="https://github.com/user-attachments/assets/73f78047-9296-490f-b97a-3169cd1c377f" />


### Plugin Checklist
N/A. Just make sure e2e tests pass