### PR TITLE
fix connection pool error in mongoose tests

### DIFF
--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -29,11 +29,11 @@ describe('Plugin', () => {
         })
       }
 
-      before(() => {
+      beforeEach(() => {
         return agent.load(['mongodb-core'])
       })
 
-      before(async () => {
+      beforeEach(async () => {
         tracer = require('../../dd-trace')
 
         mongoose = require(`../../../versions/mongoose@${version}`).get()
@@ -43,11 +43,11 @@ describe('Plugin', () => {
         await connect()
       })
 
-      after(async () => {
+      afterEach(async () => {
         return await mongoose.disconnect()
       })
 
-      after(() => {
+      afterEach(() => {
         return agent.close({ ritmReset: false })
       })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix connection pool error in mongoose tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

There have been a lot of flakiness around Mongoose tests, usually with either a `PoolClosedError` or `MongoExpiredSessionError` error. I'm not sure the exact underlying cause, but switching to `beforeEach` for the connection instead of `before` seems to resolve it after ~100 local runs.