### PR TITLE
fix mysql/mysql2/pg dbm trace id tests

### DIFF
--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -460,7 +460,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
@@ -542,7 +542,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -468,9 +468,7 @@ describe('Plugin', () => {
               `/*dddb='db',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
-          const clock = sinon.useFakeTimers(new Date())
           connection.query('SELECT 1 + 1 AS solution', () => {
-            clock.restore()
             queryText = connection._protocol._queue[0].sql
           })
         })
@@ -550,9 +548,7 @@ describe('Plugin', () => {
               `/*dddb='db',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}',` +
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
-          const clock = sinon.useFakeTimers(new Date())
           pool.query('SELECT 1 + 1 AS solution', () => {
-            clock.restore()
             queryText = pool._allConnections[0]._protocol._queue[0].sql
           })
         })

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -455,9 +455,7 @@ describe('Plugin', () => {
               `/*dddb='db',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}',` +
             `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
-          const clock = sinon.useFakeTimers(new Date())
           const connect = connection.query('SELECT 1 + 1 AS solution', () => {
-            clock.restore()
             queryText = connect.sql
           })
         })
@@ -537,9 +535,7 @@ describe('Plugin', () => {
               `/*dddb='db',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}',` +
             `traceparent='00-${traceId}-${spanId}-00'*/ SELECT 1 + 1 AS solution`)
           }).then(done, done)
-          const clock = sinon.useFakeTimers(new Date())
           const queryPool = pool.query('SELECT 1 + 1 AS solution', () => {
-            clock.restore()
             queryText = queryPool.sql
           })
         })

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -447,7 +447,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 
@@ -529,7 +529,7 @@ describe('Plugin', () => {
         it('query text should contain traceparent', done => {
           let queryText = ''
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -493,9 +493,7 @@ describe('Plugin', () => {
             expect(seenSpanId).to.equal(spanId)
           }).then(done, done)
 
-          const clock = sinon.useFakeTimers(new Date())
           client.query('SELECT $1::text as message', ['Hello World!'], (err, result) => {
-            clock.restore()
             if (err) return done(err)
             expect(seenTraceParent).to.be.true
             client.end((err) => {
@@ -577,9 +575,7 @@ describe('Plugin', () => {
               `traceparent='00-${traceId}-${spanId}-00'*/ SELECT $1::text as message`)
           }).then(done, done)
 
-          const clock = sinon.useFakeTimers(new Date())
           client.query(query, ['Hello world!'], (err) => {
-            clock.restore()
             if (err) return done(err)
 
             client.end((err) => {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -486,7 +486,7 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
             expect(seenTraceId).to.equal(traceId)
@@ -568,7 +568,7 @@ describe('Plugin', () => {
           }
 
           agent.use(traces => {
-            const expectedTimePrefix = Math.floor(clock.now / 1000).toString(16).padStart(8, '0').padEnd(16, '0')
+            const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix mysql/mysql2/pg DBM trace ID tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

The tests were trying to guess the start of the trace ID instead of using the real one, which was often a byte off. This PR changes the code to check against the actual trace ID.