### PR TITLE
[test optimization] Fix playwright e2e tests flakiness

### DIFF
--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -47,12 +47,14 @@ versions.forEach((version) => {
     let sandbox, cwd, receiver, childProcess, webAppPort
 
     before(async function () {
-      // bump from 60 to 90 seconds because we also need to download chromium
+      // bump from 60 to 90 seconds because we also need to install dependencies and download chromium
       this.timeout(90000)
       sandbox = await createSandbox([`@playwright/test@${version}`, 'typescript'], true)
       cwd = sandbox.folder
-      // Install chromium (configured in integration-tests/playwright.config.js)
       const { NODE_OPTIONS, ...restOfEnv } = process.env
+      // Install system dependencies
+      execSync('npx playwright install-deps', { cwd, env: restOfEnv })
+      // Install chromium (configured in integration-tests/playwright.config.js)
       execSync('npx playwright install', { cwd, env: restOfEnv })
       webAppPort = await getPort()
       webAppServer.listen(webAppPort)

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -47,11 +47,11 @@ versions.forEach((version) => {
     let sandbox, cwd, receiver, childProcess, webAppPort
 
     before(async function () {
-      // bump from 30 to 60 seconds because playwright dependencies are heavy
-      this.timeout(60000)
+      // bump from 60 to 90 seconds because we also need to download chromium
+      this.timeout(90000)
       sandbox = await createSandbox([`@playwright/test@${version}`, 'typescript'], true)
       cwd = sandbox.folder
-      // install necessary browser
+      // Install chromium (configured in integration-tests/playwright.config.js)
       const { NODE_OPTIONS, ...restOfEnv } = process.env
       execSync('npx playwright install', { cwd, env: restOfEnv })
       webAppPort = await getPort()


### PR DESCRIPTION
### What does this PR do?
* Increase timeout of the installation step in playwright
* Run `install-deps`

### Motivation
Fix flakiness

[Project · DataDog/dd-trace-js@1ce996b](https://github.com/DataDog/dd-trace-js/actions/runs/13713939820/job/38355382907) 

[Project · DataDog/dd-trace-js@52279e0](https://github.com/DataDog/dd-trace-js/actions/runs/13803893928/job/38611109808) 

[Project · DataDog/dd-trace-js@4f0481e](https://github.com/DataDog/dd-trace-js/actions/runs/13891576059/job/38864356520)

### Plugin Checklist
N/A