### PR TITLE
increase next.js test timeout to 5 minutes

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -30,7 +30,7 @@ describe('Plugin', function () {
         })
 
         before(function (done) {
-          this.timeout(120000)
+          this.timeout(300 * 1000)
           const cwd = standalone
             ? path.join(__dirname, '.next/standalone')
             : __dirname
@@ -68,7 +68,7 @@ describe('Plugin', function () {
         })
 
         after(async function () {
-          this.timeout(5000)
+          this.timeout(30 * 1000)
 
           server.kill()
 

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('next', 'next', '>=11.1', version => {
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
-      this.timeout(120 * 1000)
+      this.timeout(300 * 1000)
       sandbox = await createSandbox([`'next@${version}'`, 'react@^18.2.0', 'react-dom@^18.2.0'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'],
         'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build')
@@ -47,6 +47,6 @@ describe('esm', () => {
         assert.isArray(payload)
         assert.strictEqual(checkSpansForServiceName(payload, 'next.request'), true)
       }, undefined, undefined, true)
-    }).timeout(120 * 1000)
+    }).timeout(300 * 1000)
   })
 })

--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -23,7 +23,7 @@ describe('test suite', () => {
       const appDir = path.join(__dirname, 'next', appName)
 
       before(async function () {
-        this.timeout(120 * 1000) // Webpack is very slow and builds on every test run
+        this.timeout(300 * 1000) // Webpack is very slow and builds on every test run
 
         const cwd = appDir
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase Next.js test timeout to 5 minutes.

### Motivation
<!-- What inspired you to submit this pull request? -->

Looking at CI logs, it looks like most of the time these tests take 30-60 seconds. However, there are occurrences where it gets close to 2 minutes, and sometimes ends up taking more which times out, which results in flakiness. This happens infrequently enough that I think 5 minutes should be more than enough room to fix the problem entirely.