### PR TITLE
retry test agent start when it fails

### DIFF
--- a/.github/actions/testagent/start/action.yml
+++ b/.github/actions/testagent/start/action.yml
@@ -4,5 +4,5 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - run: docker compose up -d testagent
+    - run: docker compose up -d testagent || docker compose up -d testagent
       shell: bash


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Retry test agent start when it fails.

### Motivation
<!-- What inspired you to submit this pull request? -->

Docker fails to pull the image sometimes for some reason. This could be caused either by DNS issues or GHCR flakiness. This PR assumes that the issue is the latter and adds a retry mechanism to work around the flakiness. If the issue is DNS, then this PR will have no effect and we should look into that further at that point.