### PR TITLE
fix aws-sdk kinesis flaky dsm test

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -353,9 +353,8 @@ describe('Kinesis', function () {
           expect(agent.dsmStatsExist(agent, expectedProducerHash)).to.equal(true)
         }, { timeoutMs: 10000 }).then(done, done)
 
+        // Swallows the error as it doesn't matter for this test.
         helpers.putTestRecords(kinesis, streamNameDSM, (err, data) => {
-          if (err) return done(err)
-
           nowStub.restore()
         })
       })

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -353,9 +353,8 @@ describe('Kinesis', function () {
           expect(agent.dsmStatsExist(agent, expectedProducerHash)).to.equal(true)
         }, { timeoutMs: 10000 }).then(done, done)
 
-        // Swallows the error as it doesn't matter for this test.
         helpers.putTestRecords(kinesis, streamNameDSM, (err, data) => {
-          nowStub.restore()
+          // Swallow the error as it doesn't matter for this test.
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `aws-sdk` kinesis flaky DSM test. I also removed a redundant call to `nowStub.restore()` which is already done in an `afterEach` block.

### Motivation
<!-- What inspired you to submit this pull request? -->

This test has been flaky for a while. The only difference with the other tests is that it mocks `Date.now()`, so my theory is that this impacts `aws-sdk` somehow and causes it to fail intermittently. Since we don't really care about the result from the server, I simply removed the error check which should solve the issue assuming my theory is correct.