### PR TITLE
fix wrong test error message when expected span was not received

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -530,7 +530,7 @@ function expectSpanWithDefaults (expected) {
     service,
     meta: expected.meta
   }, expected)
-  return expectSomeSpan(agent, expected)
+  return expectSomeSpan(agent, expected, 10000)
 }
 
 async function sendMessages (kafka, topic, messages) {

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -530,7 +530,7 @@ function expectSpanWithDefaults (expected) {
     service,
     meta: expected.meta
   }, expected)
-  return expectSomeSpan(agent, expected, 10000)
+  return expectSomeSpan(agent, expected)
 }
 
 async function sendMessages (kafka, topic, messages) {

--- a/packages/dd-trace/test/plugins/helpers.js
+++ b/packages/dd-trace/test/plugins/helpers.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { AssertionError } = require('assert')
+const { inspect } = require('util')
 const { AsyncResource } = require('../../../datadog-instrumentations/src/helpers/instrument')
 
 const Nomenclature = require('../../src/service-naming')
@@ -15,7 +16,6 @@ function resolveNaming (namingSchema) {
 
 function expectSomeSpan (agent, expected, timeout) {
   return agent.use(traces => {
-    const replacer = (k, v) => typeof v === 'bigint' ? Number(v) : v
     const scoredErrors = []
     for (const trace of traces) {
       for (const span of trace) {
@@ -34,7 +34,7 @@ function expectSomeSpan (agent, expected, timeout) {
     const error = scoredErrors.sort((a, b) => a.score - b.score)[0].err
     // We'll append all the spans to this error message so it's visible in test
     // output.
-    error.message += '\n\nCandidate Traces:\n' + JSON.stringify(traces, replacer, 2)
+    error.message += '\n\nCandidate Traces:\n' + inspect(traces)
     throw error
   }, timeout)
 }

--- a/packages/dd-trace/test/plugins/helpers.js
+++ b/packages/dd-trace/test/plugins/helpers.js
@@ -15,6 +15,7 @@ function resolveNaming (namingSchema) {
 
 function expectSomeSpan (agent, expected, timeout) {
   return agent.use(traces => {
+    const replacer = (k, v) => typeof v === 'bigint' ? Number(v) : v
     const scoredErrors = []
     for (const trace of traces) {
       for (const span of trace) {
@@ -33,7 +34,7 @@ function expectSomeSpan (agent, expected, timeout) {
     const error = scoredErrors.sort((a, b) => a.score - b.score)[0].err
     // We'll append all the spans to this error message so it's visible in test
     // output.
-    error.message += '\n\nCandidate Traces:\n' + JSON.stringify(traces, null, 2)
+    error.message += '\n\nCandidate Traces:\n' + JSON.stringify(traces, replacer, 2)
     throw error
   }, timeout)
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix wrong test error message when expected span was not received.

### Motivation
<!-- What inspired you to submit this pull request? -->

Now that the official MsgPack library is used for decoding traces in the test agent, some values are `BigInt` instead of numbers which is not supported by `JSON.stringify`. This ends up throwing an error which gets outputted instead of the real underlying error that was thrown by the test.