### PR TITLE
fix profiling test expecting minimum 2 requests instead of 1

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -692,9 +692,9 @@ describe('profiler', () => {
         assert.equal(series[0].metric, 'profile_api.requests')
         assert.equal(series[0].type, 'count')
         // There's a race between metrics and on-shutdown profile, so metric
-        // value will be between 2 and 3
+        // value will be between 1 and 3
         requestCount = series[0].points[0][1]
-        assert.isAtLeast(requestCount, 2)
+        assert.isAtLeast(requestCount, 1)
         assert.isAtMost(requestCount, 3)
 
         assert.equal(series[1].metric, 'profile_api.responses')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix profiling test expecting minimum 2 requests instead of 1.

### Motivation
<!-- What inspired you to submit this pull request? -->

There is a know race condition, which in the test is commented as being between 2 and 3 requests, but in CI we often only get 1 request, so it seems the range is actually 1 to 3.
