### PR TITLE
set dc-polyfill version to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/core": "^1.14.0",
     "crypto-randomuuid": "^1.0.0",
-    "dc-polyfill": "^0.1.4",
+    "dc-polyfill": "0.1.6",
     "ignore": "^5.2.4",
     "import-in-the-middle": "1.13.1",
     "istanbul-lib-coverage": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1788,7 +1788,7 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-dc-polyfill@^0.1.4:
+dc-polyfill@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.6.tgz#c2940fa68ffb24a7bf127cc6cfdd15b39f0e7f02"
   integrity sha512-UV33cugmCC49a5uWAApM+6Ev9ZdvIUMTrtCO9fj96TPGOQiea54oeO3tiEVdVeo3J9N2UdJEmbS4zOkkEA35uQ==


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set `dc-polyfill` version to 0.1.6.

### Motivation
<!-- What inspired you to submit this pull request? -->

0.1.7 is failing our integration tests, so for now I would assume something is broken, thus we should use a fixed version for now.

