### PR TITLE
add sdk.event to communicate a login or custom event

### DIFF
--- a/packages/dd-trace/src/appsec/telemetry/index.js
+++ b/packages/dd-trace/src/appsec/telemetry/index.js
@@ -2,7 +2,7 @@
 
 const { DD_TELEMETRY_REQUEST_METRICS } = require('./common')
 const { addRaspRequestMetrics, trackRaspMetrics } = require('./rasp')
-const { incrementMissingUserId, incrementMissingUserLogin } = require('./user')
+const { incrementMissingUserId, incrementMissingUserLogin, incrementSdkEvent } = require('./user')
 const {
   addWafRequestMetrics,
   trackWafMetrics,
@@ -107,6 +107,12 @@ function incrementMissingUserIdMetric (framework, eventType) {
   incrementMissingUserId(framework, eventType)
 }
 
+function incrementSdkEventMetric (framework, eventType) {
+  if (!enabled) return
+
+  incrementSdkEvent(framework, eventType)
+}
+
 function getRequestMetrics (req) {
   if (req) {
     const store = getStore(req)
@@ -125,6 +131,7 @@ module.exports = {
   incrementWafRequestsMetric,
   incrementMissingUserLoginMetric,
   incrementMissingUserIdMetric,
+  incrementSdkEventMetric,
 
   getRequestMetrics
 }

--- a/packages/dd-trace/src/appsec/telemetry/user.js
+++ b/packages/dd-trace/src/appsec/telemetry/user.js
@@ -21,7 +21,7 @@ function incrementMissingUserId (framework, eventType) {
 function incrementSdkEvent (eventType) {
   appsecMetrics.count('sdk.event', {
     event_type: eventType,
-    sdk_version: 'v2'
+    sdk_version: 'v1'
   }).inc()
 }
 

--- a/packages/dd-trace/src/appsec/telemetry/user.js
+++ b/packages/dd-trace/src/appsec/telemetry/user.js
@@ -18,7 +18,15 @@ function incrementMissingUserId (framework, eventType) {
   }).inc()
 }
 
+function incrementSdkEvent (eventType) {
+  appsecMetrics.count('sdk.event', {
+    event_type: eventType,
+    sdk_version: 'v2'
+  }).inc()
+}
+
 module.exports = {
   incrementMissingUserLogin,
-  incrementMissingUserId
+  incrementMissingUserId,
+  incrementSdkEvent
 }

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -17,6 +17,7 @@ describe('track_event', () => {
     let getRootSpan
     let setUserTags
     let waf
+    let telemetry
     let trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent
 
     beforeEach(() => {
@@ -42,6 +43,10 @@ describe('track_event', () => {
         run: sinon.spy()
       }
 
+      telemetry = {
+        incrementSdkEventMetric: sinon.stub()
+      }
+
       const trackEvents = proxyquire('../../../src/appsec/sdk/track_event', {
         '../../log': log,
         './utils': {
@@ -50,7 +55,8 @@ describe('track_event', () => {
         './set_user': {
           setUserTags
         },
-        '../waf': waf
+        '../waf': waf,
+        '../telemetry': telemetry
       })
 
       trackUserLoginSuccessEvent = trackEvents.trackUserLoginSuccessEvent
@@ -70,6 +76,7 @@ describe('track_event', () => {
           .to.have.been.calledWithExactly('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should log warning when root span is not available', () => {
@@ -80,6 +87,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in trackUserLoginSuccessEvent')
         expect(setUserTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should call setUser and addTags with metadata', () => {
@@ -111,6 +119,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
 
       it('should call setUser and addTags without metadata', () => {
@@ -134,6 +143,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
 
       it('should call waf with user login', () => {
@@ -157,6 +167,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_login'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
     })
 
@@ -172,6 +183,7 @@ describe('track_event', () => {
           .to.have.been.calledWithExactly('[ASM] Invalid userId provided to trackUserLoginFailureEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should log warning when root span is not available', () => {
@@ -182,6 +194,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackUserLoginFailureEvent')
         expect(setUserTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should call addTags with metadata', () => {
@@ -211,6 +224,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
 
       it('should send false `usr.exists` property when the user does not exist', () => {
@@ -240,6 +254,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
 
       it('should call addTags without metadata', () => {
@@ -262,6 +277,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
     })
 
@@ -277,6 +293,7 @@ describe('track_event', () => {
           .to.have.been.calledWithExactly('[ASM] Invalid eventName provided to trackCustomEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should log warning when root span is not available', () => {
@@ -287,6 +304,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackCustomEvent')
         expect(setUserTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should call addTags with metadata', () => {
@@ -305,6 +323,7 @@ describe('track_event', () => {
         })
         expect(prioritySampler.setPriority)
           .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
       })
 
       it('should call addTags without metadata', () => {
@@ -318,6 +337,7 @@ describe('track_event', () => {
         })
         expect(prioritySampler.setPriority)
           .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
       })
     })
   })

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -87,7 +87,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in trackUserLoginSuccessEvent')
         expect(setUserTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
 
       it('should call setUser and addTags with metadata', () => {
@@ -194,7 +194,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackUserLoginFailureEvent')
         expect(setUserTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
 
       it('should call addTags with metadata', () => {
@@ -304,7 +304,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackCustomEvent')
         expect(setUserTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
       })
 
       it('should call addTags with metadata', () => {

--- a/packages/dd-trace/test/appsec/telemetry/user.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/user.spec.js
@@ -56,7 +56,7 @@ describe('Appsec User Telemetry metrics', () => {
 
         expect(count).to.have.been.calledOnceWithExactly('sdk.event', {
           event_type: 'login_success',
-          sdk_version: 'v2'
+          sdk_version: 'v1'
         })
       })
     })

--- a/packages/dd-trace/test/appsec/telemetry/user.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/user.spec.js
@@ -49,5 +49,16 @@ describe('Appsec User Telemetry metrics', () => {
         })
       })
     })
+
+    describe('incrementSdkEventMetric', () => {
+      it('should increment sdk.event metric', () => {
+        appsecTelemetry.incrementSdkEventMetric('login_success')
+
+        expect(count).to.have.been.calledOnceWithExactly('sdk.event', {
+          event_type: 'login_success',
+          sdk_version: 'v2'
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Count telemetry metric when the application is using the SDK to communicate a login or custom event [APPSEC-57046](https://datadoghq.atlassian.net/browse/APPSEC-57046)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->




[APPSEC-57046]: https://datadoghq.atlassian.net/browse/APPSEC-57046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ