### PR TITLE
feat(llmobs): add integration tag to llmobs spans

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -43,7 +43,7 @@ class LLMObsPlugin extends TracingPlugin {
       llmobsStorage.enterWith({ span })
       ctx.llmobs.parent = parent
 
-      this._tagger.registerLLMObsSpan(span, { parent, ...registerOptions })
+      this._tagger.registerLLMObsSpan(span, { parent, integration: this.constructor.id, ...registerOptions })
     }
   }
 

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -55,7 +55,8 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       modelName: modelName.toLowerCase(),
       modelProvider: modelProvider.toLowerCase(),
       kind: 'llm',
-      name: 'bedrock-runtime.command'
+      name: 'bedrock-runtime.command',
+      integration: 'bedrock'
     })
 
     const requestParams = extractRequestParams(request.params, modelProvider)

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -7,6 +7,7 @@ const {
   METADATA,
   INPUT_MESSAGES,
   INPUT_VALUE,
+  INTEGRATION,
   OUTPUT_MESSAGES,
   INPUT_DOCUMENTS,
   OUTPUT_DOCUMENTS,
@@ -186,6 +187,8 @@ class LLMObsSpanProcessor {
     const errType = span.context()._tags[ERROR_TYPE] || error?.name
     if (errType) tags.error_type = errType
     if (sessionId) tags.session_id = sessionId
+    const integration = LLMObsTagger.tagMap.get(span)?.[INTEGRATION]
+    if (integration) tags.integration = integration
     const existingTags = LLMObsTagger.tagMap.get(span)?.[TAGS] || {}
     if (existingTags) tags = { ...tags, ...existingTags }
     return Object.entries(tags).map(([key, value]) => `${key}:${value ?? ''}`)

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -10,6 +10,7 @@ const {
   INPUT_VALUE,
   OUTPUT_DOCUMENTS,
   INPUT_DOCUMENTS,
+  INTEGRATION,
   OUTPUT_VALUE,
   METADATA,
   METRICS,
@@ -51,7 +52,8 @@ class LLMObsTagger {
     mlApp,
     parent,
     kind,
-    name
+    name,
+    integration
   } = {}) {
     if (!this._config.llmobs.enabled) return
     if (!kind) return // do not register it in the map if it doesn't have an llmobs span kind
@@ -66,6 +68,7 @@ class LLMObsTagger {
 
     sessionId = sessionId || registry.get(parent)?.[SESSION_ID]
     if (sessionId) this._setTag(span, SESSION_ID, sessionId)
+    if (integration) this._setTag(span, INTEGRATION, integration)
 
     if (!mlApp) mlApp = registry.get(parent)?.[ML_APP] || this._config.llmobs.mlApp
     this._setTag(span, ML_APP, mlApp)

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -109,7 +109,7 @@ describe('Plugin', () => {
                   temperature: modelConfig.temperature,
                   max_tokens: modelConfig.maxTokens
                 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'bedrock' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -123,7 +123,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'Hello, world!' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -151,7 +151,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: '' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-                tags: { ml_app: 'test', language: 'javascript' },
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' },
                 error: 1,
                 errorType: 'Error',
                 errorMessage: MOCK_STRING,
@@ -210,7 +210,7 @@ describe('integrations', () => {
                 metadata: MOCK_ANY,
                 // @langchain/cohere does not provide token usage in the response
                 tokenMetrics: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -255,7 +255,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'Hello, world!', role: 'assistant' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -283,7 +283,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: '' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-                tags: { ml_app: 'test', language: 'javascript' },
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' },
                 error: 1,
                 errorType: 'Error',
                 errorMessage: MOCK_STRING,
@@ -334,7 +334,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'Hello!', role: 'assistant' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 11, output_tokens: 6, total_tokens: 17 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -398,7 +398,7 @@ describe('integrations', () => {
                 metadata: MOCK_ANY,
                 // also tests tokens not sent on llm-type spans should be 0
                 tokenMetrics: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -455,7 +455,7 @@ describe('integrations', () => {
                 inputDocuments: [{ text: 'Hello!' }],
                 outputValue: '[1 embedding(s) returned with size 2]',
                 metadata: MOCK_ANY,
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -482,7 +482,7 @@ describe('integrations', () => {
                 inputDocuments: [{ text: 'Hello!' }],
                 outputValue: '',
                 metadata: MOCK_ANY,
-                tags: { ml_app: 'test', language: 'javascript' },
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' },
                 error: 1,
                 errorType: 'Error',
                 errorMessage: MOCK_STRING,
@@ -533,7 +533,7 @@ describe('integrations', () => {
                 inputDocuments: [{ text: 'Hello!' }, { text: 'World!' }],
                 outputValue: '[2 embedding(s) returned with size 2]',
                 metadata: MOCK_ANY,
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -583,7 +583,7 @@ describe('integrations', () => {
                 inputValue: JSON.stringify({ input: 'Can you tell me about LangSmith?' }),
                 outputValue: 'LangSmith can help with testing in several ways.',
                 metadata: MOCK_ANY,
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedLLM = expectedLLMObsLLMSpanEvent({
@@ -601,7 +601,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'LangSmith can help with testing in several ways.' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(workflowSpanEvent).to.deepEqualWithMockValues(expectedWorkflow)
@@ -631,7 +631,7 @@ describe('integrations', () => {
                 inputValue: 'Hello!',
                 outputValue: '',
                 metadata: MOCK_ANY,
-                tags: { ml_app: 'test', language: 'javascript' },
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' },
                 error: 1,
                 errorType: 'Error',
                 errorMessage: MOCK_STRING,
@@ -721,7 +721,7 @@ describe('integrations', () => {
                 name: 'langchain_core.runnables.RunnableSequence',
                 inputValue: JSON.stringify({ person: 'Abraham Lincoln', language: 'Spanish' }),
                 outputValue: 'Springfield, Illinois está en los Estados Unidos.',
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedFirstSubWorkflow = expectedLLMObsNonLLMSpanEvent({
@@ -731,7 +731,7 @@ describe('integrations', () => {
                 name: 'langchain_core.runnables.RunnableSequence',
                 inputValue: JSON.stringify({ person: 'Abraham Lincoln', language: 'Spanish' }),
                 outputValue: 'Springfield, Illinois',
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedFirstLLM = expectedLLMObsLLMSpanEvent({
@@ -747,7 +747,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'Springfield, Illinois', role: 'assistant' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedSecondSubWorkflow = expectedLLMObsNonLLMSpanEvent({
@@ -757,7 +757,7 @@ describe('integrations', () => {
                 name: 'langchain_core.runnables.RunnableSequence',
                 inputValue: JSON.stringify({ language: 'Spanish', city: 'Springfield, Illinois' }),
                 outputValue: 'Springfield, Illinois está en los Estados Unidos.',
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedSecondLLM = expectedLLMObsLLMSpanEvent({
@@ -773,7 +773,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'Springfield, Illinois está en los Estados Unidos.', role: 'assistant' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(topLevelWorkflowSpanEvent).to.deepEqualWithMockValues(expectedTopLevelWorkflow)
@@ -859,7 +859,7 @@ describe('integrations', () => {
                   'Why did the chicken cross the road? To get to the other side!',
                   'Why was the dog confused? It was barking up the wrong tree!'
                 ]),
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedFirstLLM = expectedLLMObsLLMSpanEvent({
@@ -876,7 +876,7 @@ describe('integrations', () => {
                 }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 37, output_tokens: 10, total_tokens: 47 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedSecondLLM = expectedLLMObsLLMSpanEvent({
@@ -893,7 +893,7 @@ describe('integrations', () => {
                 }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 37, output_tokens: 10, total_tokens: 47 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(workflowSpanEvent).to.deepEqualWithMockValues(expectedWorkflow)
@@ -963,7 +963,7 @@ describe('integrations', () => {
                   content: 'Mitochondria',
                   role: 'assistant'
                 }),
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedLLM = expectedLLMObsLLMSpanEvent({
@@ -994,7 +994,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: 'Mitochondria', role: 'assistant' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(workflowSpanEvent).to.deepEqualWithMockValues(expectedWorkflow)
@@ -1064,7 +1064,7 @@ describe('integrations', () => {
                 name: 'langchain_core.runnables.RunnableSequence',
                 inputValue: JSON.stringify({ foo: 'bar' }),
                 outputValue: '3 squared is 9',
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               const expectedTask = expectedLLMObsNonLLMSpanEvent({
@@ -1088,7 +1088,7 @@ describe('integrations', () => {
                 outputMessages: [{ content: '3 squared is 9', role: 'assistant' }],
                 metadata: MOCK_ANY,
                 tokenMetrics: { input_tokens: 8, output_tokens: 12, total_tokens: 20 },
-                tags: { ml_app: 'test', language: 'javascript' }
+                tags: { ml_app: 'test', language: 'javascript', integration: 'langchain' }
               })
 
               expect(workflowSpanEvent).to.deepEqualWithMockValues(expectedWorkflow)

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
@@ -99,7 +99,7 @@ describe('integrations', () => {
             modelName: 'text-davinci-002',
             modelProvider: 'openai',
             metadata: {},
-            tags: { ml_app: 'test', language: 'javascript' }
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
           })
 
           expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -156,7 +156,7 @@ describe('integrations', () => {
               modelName: 'gpt-3.5-turbo-0301',
               modelProvider: 'openai',
               metadata: {},
-              tags: { ml_app: 'test', language: 'javascript' }
+              tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
             })
 
             expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -207,7 +207,7 @@ describe('integrations', () => {
             modelName: 'text-embedding-ada-002-v2',
             modelProvider: 'openai',
             metadata: { encoding_format: 'float' },
-            tags: { ml_app: 'test', language: 'javascript' }
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
           })
 
           expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -274,7 +274,7 @@ describe('integrations', () => {
                 ]
               }],
               metadata: { function_call: 'auto' },
-              tags: { ml_app: 'test', language: 'javascript' },
+              tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
               tokenMetrics: { input_tokens: 37, output_tokens: 10, total_tokens: 47 }
             })
 
@@ -311,7 +311,7 @@ describe('integrations', () => {
             modelName: 'gpt-3.5-turbo',
             modelProvider: 'openai',
             metadata: { max_tokens: 50 },
-            tags: { ml_app: 'test', language: 'javascript' },
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
             error,
             errorType: error.type || error.name,
             errorMessage: error.message,
@@ -354,7 +354,7 @@ describe('integrations', () => {
               modelName: 'gpt-3.5-turbo',
               modelProvider: 'openai',
               metadata: { max_tokens: 50 },
-              tags: { ml_app: 'test', language: 'javascript' },
+              tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
               error,
               errorType: error.type || error.name,
               errorMessage: error.message,

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
@@ -125,7 +125,7 @@ describe('integrations', () => {
             modelName: 'text-davinci-002',
             modelProvider: 'openai',
             metadata: {},
-            tags: { ml_app: 'test', language: 'javascript' }
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
           })
 
           expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -181,7 +181,7 @@ describe('integrations', () => {
             modelName: 'gpt-3.5-turbo-0301',
             modelProvider: 'openai',
             metadata: {},
-            tags: { ml_app: 'test', language: 'javascript' }
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
           })
 
           expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -231,7 +231,7 @@ describe('integrations', () => {
             modelName: 'text-embedding-ada-002-v2',
             modelProvider: 'openai',
             metadata: { encoding_format: 'float' },
-            tags: { ml_app: 'test', language: 'javascript' }
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
           })
 
           expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -306,7 +306,7 @@ describe('integrations', () => {
                 ]
               }],
               metadata: { tool_choice: 'auto' },
-              tags: { ml_app: 'test', language: 'javascript' },
+              tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
               tokenMetrics: { input_tokens: 37, output_tokens: 10, total_tokens: 47 }
             })
 
@@ -355,7 +355,7 @@ describe('integrations', () => {
               modelName: 'text-davinci-002',
               modelProvider: 'openai',
               metadata: { temperature: 0.5, stream: true },
-              tags: { ml_app: 'test', language: 'javascript' }
+              tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
             })
 
             expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -406,7 +406,7 @@ describe('integrations', () => {
               modelName: 'gpt-3.5-turbo-0301',
               modelProvider: 'openai',
               metadata: { stream: true },
-              tags: { ml_app: 'test', language: 'javascript' }
+              tags: { ml_app: 'test', language: 'javascript', integration: 'openai' }
             })
 
             expect(spanEvent).to.deepEqualWithMockValues(expected)
@@ -463,7 +463,7 @@ describe('integrations', () => {
                   ]
                 }],
                 metadata: { tool_choice: 'auto', stream: true },
-                tags: { ml_app: 'test', language: 'javascript' },
+                tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
                 tokenMetrics: { input_tokens: 9, output_tokens: 5, total_tokens: 14 }
               })
 
@@ -507,7 +507,7 @@ describe('integrations', () => {
             modelName: 'gpt-3.5-turbo',
             modelProvider: 'openai',
             metadata: { max_tokens: 50 },
-            tags: { ml_app: 'test', language: 'javascript' },
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
             error,
             errorType: error.type || error.name,
             errorMessage: error.message,
@@ -549,7 +549,7 @@ describe('integrations', () => {
             modelName: 'gpt-3.5-turbo',
             modelProvider: 'openai',
             metadata: { max_tokens: 50 },
-            tags: { ml_app: 'test', language: 'javascript' },
+            tags: { ml_app: 'test', language: 'javascript', integration: 'openai' },
             error,
             errorType: error.type || error.name,
             errorMessage: error.message,


### PR DESCRIPTION
### What does this PR do?
Adds the integration:<INTEGRATION_NAME> tag to llmobs spans that originate from an autoinstrumented library. This will be used by both customers (in Datadog UI) and our team (via telemetry which relies on this tag).
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


