### PR TITLE
Update rewriter to the new renamed wasm-js-rewriter 3.1.0

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2,7 +2,7 @@ Component,Origin,License,Copyright
 require,@datadog/libdatadog,Apache license 2.0,Copyright 2024 Datadog Inc.
 require,@datadog/native-appsec,Apache license 2.0,Copyright 2018 Datadog Inc.
 require,@datadog/native-metrics,Apache license 2.0,Copyright 2018 Datadog Inc.
-require,@datadog/native-iast-rewriter,Apache license 2.0,Copyright 2018 Datadog Inc.
+require,@datadog/wasm-js-rewriter,Apache license 2.0,Copyright 2018 Datadog Inc.
 require,@datadog/native-iast-taint-tracking,Apache license 2.0,Copyright 2018 Datadog Inc.
 require,@datadog/pprof,Apache license 2.0,Copyright 2019 Google Inc.
 require,@datadog/sketches-js,Apache license 2.0,Copyright 2020 Datadog Inc.

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@datadog/libdatadog": "^0.5.0",
     "@datadog/native-appsec": "8.5.1",
-    "@datadog/wasm-js-rewriter": "3.0.0",
+    "@datadog/wasm-js-rewriter": "3.1.0",
     "@datadog/native-iast-taint-tracking": "3.3.0",
     "@datadog/native-metrics": "^3.1.0",
     "@datadog/pprof": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@datadog/libdatadog": "^0.5.0",
     "@datadog/native-appsec": "8.5.1",
-    "@datadog/wasm-js-rewriter": "git+https://github.com/DataDog/dd-wasm-js-rewriter.git#ugaitz/restoring-per",
+    "@datadog/wasm-js-rewriter": "3.0.0",
     "@datadog/native-iast-taint-tracking": "3.3.0",
     "@datadog/native-metrics": "^3.1.0",
     "@datadog/pprof": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@datadog/libdatadog": "^0.5.0",
     "@datadog/native-appsec": "8.5.1",
-    "@datadog/native-iast-rewriter": "2.8.0",
+    "@datadog/wasm-js-rewriter": "3.0.0",
     "@datadog/native-iast-taint-tracking": "3.3.0",
     "@datadog/native-metrics": "^3.1.0",
     "@datadog/pprof": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@datadog/libdatadog": "^0.5.0",
     "@datadog/native-appsec": "8.5.1",
-    "@datadog/wasm-js-rewriter": "3.1.0",
+    "@datadog/wasm-js-rewriter": "git+https://github.com/DataDog/dd-wasm-js-rewriter.git#ugaitz/restoring-per",
     "@datadog/native-iast-taint-tracking": "3.3.0",
     "@datadog/native-metrics": "^3.1.0",
     "@datadog/pprof": "5.6.0",

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter-esm.mjs
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter-esm.mjs
@@ -17,7 +17,7 @@ export async function initialize (data) {
   const { csiMethods, telemetryVerbosity, chainSourceMap } = data
   port = data.port
 
-  const iastRewriter = await import('@datadog/native-iast-rewriter')
+  const iastRewriter = await import('@datadog/wasm-js-rewriter')
 
   const { NonCacheRewriter } = iastRewriter.default
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -47,7 +47,7 @@ function getGetOriginalPathAndLineFromSourceMapFunction (chainSourceMap, getOrig
 function getRewriter (telemetryVerbosity) {
   if (!rewriter) {
     try {
-      const iastRewriter = require('@datadog/native-iast-rewriter')
+      const iastRewriter = require('@datadog/wasm-js-rewriter')
       const Rewriter = iastRewriter.Rewriter
       getPrepareStackTrace = iastRewriter.getPrepareStackTrace
       kSymbolPrepareStackTrace = iastRewriter.kSymbolPrepareStackTrace

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -9,7 +9,7 @@ describe('IAST Rewriter', () => {
   it('Addon should return a rewritter instance', () => {
     let rewriter = null
     expect(() => {
-      rewriter = require('@datadog/native-iast-rewriter')
+      rewriter = require('@datadog/wasm-js-rewriter')
     }).to.not.throw(Error)
     expect(rewriter).to.not.be.null
   })
@@ -66,7 +66,7 @@ describe('IAST Rewriter', () => {
       }
 
       rewriter = proxyquire('../../../../src/appsec/iast/taint-tracking/rewriter', {
-        '@datadog/native-iast-rewriter': {
+        '@datadog/wasm-js-rewriter': {
           Rewriter,
           getPrepareStackTrace: function (fn) {
             const testWrap = function testWrappedPrepareStackTrace (error, callsites) {
@@ -338,7 +338,7 @@ describe('IAST Rewriter', () => {
     beforeEach(() => {
       getOriginalPathAndLineFromSourceMap = sinon.spy()
       rewriter = proxyquire('../../../../src/appsec/iast/taint-tracking/rewriter', {
-        '@datadog/native-iast-rewriter': {
+        '@datadog/wasm-js-rewriter': {
           getOriginalPathAndLineFromSourceMap
         }
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,10 +399,10 @@
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.1.tgz#9ec2251b3c932b4f43e1d164461fa6cb6f28b7d0"
   integrity sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==
 
-"@datadog/wasm-js-rewriter@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-3.0.0.tgz#9fa31c0c9dd3e11d9bf3ccf1882ddf20079dbcc9"
-  integrity sha512-Q1pgmwguqE3mKb4dujXkgvImyEj4D2RlYkgK1i+gG5Fmbn/ChvggzrfiLglm9YQ3dhb2J0owOt7cJcOI+rt7HA==
+"@datadog/wasm-js-rewriter@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-3.1.0.tgz#88662cc997417bcda09bd8940c1c8235f4de3726"
+  integrity sha512-OE3QUGTriE3vhVxGRt2Df0Uk0xCd0OjqXb5Tjs9TdIvJu6VxYstxszdfyVK2+VHub5vGYY0ErJ4vkSB8z+3KPg==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,9 +399,10 @@
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.1.tgz#9ec2251b3c932b4f43e1d164461fa6cb6f28b7d0"
   integrity sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==
 
-"@datadog/wasm-js-rewriter@git+https://github.com/DataDog/dd-wasm-js-rewriter.git#ugaitz/restoring-per":
-  version "3.1.0"
-  resolved "git+https://github.com/DataDog/dd-wasm-js-rewriter.git#d12562ef392e3084a72f4f2f172c370041526766"
+"@datadog/wasm-js-rewriter@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-3.0.0.tgz#9fa31c0c9dd3e11d9bf3ccf1882ddf20079dbcc9"
+  integrity sha512-Q1pgmwguqE3mKb4dujXkgvImyEj4D2RlYkgK1i+gG5Fmbn/ChvggzrfiLglm9YQ3dhb2J0owOt7cJcOI+rt7HA==
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,10 +399,9 @@
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.1.tgz#9ec2251b3c932b4f43e1d164461fa6cb6f28b7d0"
   integrity sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==
 
-"@datadog/wasm-js-rewriter@3.1.0":
+"@datadog/wasm-js-rewriter@git+https://github.com/DataDog/dd-wasm-js-rewriter.git#ugaitz/restoring-per":
   version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-3.1.0.tgz#88662cc997417bcda09bd8940c1c8235f4de3726"
-  integrity sha512-OE3QUGTriE3vhVxGRt2Df0Uk0xCd0OjqXb5Tjs9TdIvJu6VxYstxszdfyVK2+VHub5vGYY0ErJ4vkSB8z+3KPg==
+  resolved "git+https://github.com/DataDog/dd-wasm-js-rewriter.git#d12562ef392e3084a72f4f2f172c370041526766"
   dependencies:
     lru-cache "^7.14.0"
     node-gyp-build "^4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,14 +368,6 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-rewriter@2.8.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-rewriter/-/native-iast-rewriter-2.8.0.tgz#8a7eddf5e33266643afcdfb920ff5ccb30e1894a"
-  integrity sha512-DKmtvlmCld9RIJwDcPKWNkKYWYQyiuOrOtynmBppJiUv/yfCOuZtsQV4Zepj40H33sLiQyi5ct6dbWl53vxqkA==
-  dependencies:
-    lru-cache "^7.14.0"
-    node-gyp-build "^4.5.0"
-
 "@datadog/native-iast-taint-tracking@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.3.0.tgz#5a9c87e07376e7c5a4b4d4985f140a60388eee00"
@@ -406,6 +398,14 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.1.tgz#9ec2251b3c932b4f43e1d164461fa6cb6f28b7d0"
   integrity sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==
+
+"@datadog/wasm-js-rewriter@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/wasm-js-rewriter/-/wasm-js-rewriter-3.0.0.tgz#9fa31c0c9dd3e11d9bf3ccf1882ddf20079dbcc9"
+  integrity sha512-Q1pgmwguqE3mKb4dujXkgvImyEj4D2RlYkgK1i+gG5Fmbn/ChvggzrfiLglm9YQ3dhb2J0owOt7cJcOI+rt7HA==
+  dependencies:
+    lru-cache "^7.14.0"
+    node-gyp-build "^4.5.0"
 
 "@esbuild/aix-ppc64@0.25.1":
   version "0.25.1"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the rewriter

### Motivation
<!-- What inspired you to submit this pull request? -->
Fix a bug in iast with optional chaining

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
[APPSEC-57079]

[APPSEC-57079]: https://datadoghq.atlassian.net/browse/APPSEC-57079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ