### PR TITLE
Remove unused code in router instrumentation code

### DIFF
--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -18,7 +18,7 @@ function createWrapRouterMethod (name) {
   function wrapLayerHandle (layer, original) {
     original._name = original._name || layer.name
 
-    const handle = shimmer.wrapFunction(original, original => function () {
+    return shimmer.wrapFunction(original, original => function () {
       if (!enterChannel.hasSubscribers) return original.apply(this, arguments)
 
       const matchers = layerMatchers.get(layer)
@@ -58,12 +58,6 @@ function createWrapRouterMethod (name) {
         exitChannel.publish({ req })
       }
     })
-
-    // This is a workaround for the `loopback` library so that it can find the correct express layer
-    // that contains the real handle function
-    handle._datadog_orig = original
-
-    return handle
   }
 
   function wrapStack (stack, offset, matchers) {


### PR DESCRIPTION
### What does this PR do?

Remove `_datadog_orig` property from wrapped router handle object. The property was never used for anything.

### Motivation

Cleaner code is good code and modifying an object creates a new hidden class which is bad for performance.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


