### PR TITLE
feat: Apollo Server ESM

### DIFF
--- a/packages/datadog-instrumentations/src/apollo-server.js
+++ b/packages/datadog-instrumentations/src/apollo-server.js
@@ -78,5 +78,8 @@ function apolloServerHook (apolloServer) {
 }
 
 addHook({ name: '@apollo/server', file: 'dist/cjs/ApolloServer.js', versions: ['>=4.0.0'] }, apolloServerHook)
+addHook({ name: '@apollo/server', file: 'dist/esm/ApolloServer.js', versions: ['>=4.0.0'] }, apolloServerHook)
 addHook({ name: '@apollo/server', file: 'dist/cjs/express4/index.js', versions: ['>=4.0.0'] }, apolloExpress4Hook)
+addHook({ name: '@apollo/server', file: 'dist/esm/express4/index.js', versions: ['>=4.0.0'] }, apolloExpress4Hook)
 addHook({ name: '@apollo/server', file: 'dist/cjs/utils/HeaderMap.js', versions: ['>=4.0.0'] }, apolloHeaderMapHook)
+addHook({ name: '@apollo/server', file: 'dist/esm/utils/HeaderMap.js', versions: ['>=4.0.0'] }, apolloHeaderMapHook)


### PR DESCRIPTION
### What does this PR do?

Adds the `esm` files for `@apollo/server` instrumentation

I've not added tests as there were none for the `cjs` instrumentation

### Motivation

ESMing

### Additional Notes

The ESM instrumentation still won't work because of this issue I've created this morning: https://github.com/DataDog/dd-trace-js/issues/5479


