### PR TITLE
chore: add tracing macrobenchmark with runtime metrics enabled

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -65,3 +65,9 @@ only-tracing:
   extends: .macrobenchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-tracing
+
+only-tracing-with-runtime-metrics-enabled:
+  extends: .macrobenchmarks
+  variables:
+    DD_BENCHMARKS_CONFIGURATION: only-tracing
+    DD_RUNTIME_METRICS_ENABLED: "true"


### PR DESCRIPTION
### What does this PR do?
Adds another recurring macrobenchmark job to run tracing with runtime metrics enabled.

### Motivation
We're investigating enabling runtime metrics by default, so this recurring job will help validate that the feature does not incur significant overhead for tracing users.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


