### PR TITLE
Fix span event serialization for array attributes

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -395,7 +395,7 @@ function convertSpanEventAttributeValues (key, value, depth = 0) {
       if (convertedArray.length > 0) {
         return {
           type: 4,
-          array_value: convertedArray
+          array_value: { values: convertedArray }
         }
       } else {
         // If all elements were unsupported, return undefined

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -522,12 +522,14 @@ describe('encode', () => {
             rating: { type: 3, double_value: 9.8 },
             other: {
               type: 4,
-              array_value: [
-                { type: 0, string_value: 'hi' },
-                { type: 1, bool_value: false },
-                { type: 2, int_value: 1 },
-                { type: 3, double_value: 1.2 }
-              ]
+              array_value: {
+                values: [
+                  { type: 0, string_value: 'hi' },
+                  { type: 1, bool_value: false },
+                  { type: 2, int_value: 1 },
+                  { type: 3, double_value: 1.2 }
+                ]
+              }
             }
           }
         }
@@ -568,7 +570,7 @@ describe('encode', () => {
         {
           name: 'I can sing!!!',
           time_unix_nano: 1633023102000000,
-          attributes: { array: { type: 4, array_value: [{ type: 0, string_value: 'valid_value' }] } }
+          attributes: { array: { type: 4, array_value: { values: [{ type: 0, string_value: 'valid_value' }] } } }
         }
       ]
 


### PR DESCRIPTION
### What does this PR do?
Addresses an issue with serializing array attributes for span events.
The array should be wrapped in an object with the `values` key:
```diff
-array_value: [{...}, {...}]
+array_value: { values: [{...}, {...}] }
```

Tested by this new system-tests PR: https://github.com/DataDog/system-tests/pull/4398

- [x] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CircleCI [jobs/workflows][4].
- [x] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


