### PR TITLE
fix duplicate custom metrics when multiple tags are used

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -194,7 +194,6 @@ class DogStatsDClient {
   }
 }
 
-// TODO: Handle arrays of tags and tags translation.
 class MetricsAggregationClient {
   constructor (client) {
     this._client = client
@@ -216,92 +215,158 @@ class MetricsAggregationClient {
     this._histograms = {}
   }
 
-  distribution (name, value, tag) {
-    this._client.distribution(name, value, tag && [tag])
+  // TODO: Aggerate with a histogram and send the buckets to the client.
+  distribution (name, value, tags) {
+    this._client.distribution(name, value, tags)
   }
 
-  boolean (name, value, tag) {
-    this.gauge(name, value ? 1 : 0, tag)
+  boolean (name, value, tags) {
+    this.gauge(name, value ? 1 : 0, tags)
   }
 
-  histogram (name, value, tag) {
-    this._histograms[name] = this._histograms[name] || new Map()
+  histogram (name, value, tags) {
+    const node = this._ensureNode(this._histograms, name, tags, null, false)
 
-    if (!this._histograms[name].has(tag)) {
-      this._histograms[name].set(tag, new Histogram())
+    if (!node.value) {
+      node.value = new Histogram()
     }
 
-    this._histograms[name].get(tag).record(value)
+    node.touched = true
+    node.value.record(value)
   }
 
-  count (name, count, tag, monotonic = true) {
-    if (typeof tag === 'boolean') {
-      monotonic = tag
-      tag = undefined
+  count (name, count, tags = [], monotonic = true) {
+    if (typeof tags === 'boolean') {
+      monotonic = tags
+      tags = []
     }
 
-    const map = monotonic ? this._counters : this._gauges
+    const container = monotonic ? this._counters : this._gauges
+    const node = this._ensureNode(container, name, tags, 0, false)
 
-    map[name] = map[name] || new Map()
-
-    const value = map[name].get(tag) || 0
-
-    map[name].set(tag, value + count)
+    node.touched = true
+    node.value = node.value + count
   }
 
-  gauge (name, value, tag) {
-    this._gauges[name] = this._gauges[name] || new Map()
-    this._gauges[name].set(tag, value)
+  gauge (name, value, tags) {
+    const node = this._ensureNode(this._gauges, name, tags, 0, 0n)
+
+    node.touched = process.hrtime.bigint()
+    node.value = value
   }
 
-  increment (name, count = 1, tag) {
-    this.count(name, count, tag)
+  increment (name, count = 1, tags) {
+    this.count(name, count, tags)
   }
 
-  decrement (name, count = 1, tag) {
-    this.count(name, -count, tag)
+  decrement (name, count = 1, tags) {
+    this.count(name, -count, tags)
+  }
+
+  _ensureNode (container, name, tags, value, touched) {
+    tags = tags ? [].concat(tags) : []
+
+    let node = container[name] = container[name] || { nodes: {}, touched, value }
+    let tagIdx = tags.length
+
+    while (node) {
+      if (tagIdx === 0) {
+        return node
+      } else {
+        const tag = tags[--tagIdx]
+        node = node.nodes[tag] = node.nodes[tag] || { nodes: {}, touched, value }
+      }
+    }
   }
 
   _captureGauges () {
-    Object.keys(this._gauges).forEach(name => {
-      this._gauges[name].forEach((value, tag) => {
-        this._client.gauge(name, value, tag && [tag])
-      })
+    const gauges = this._normalizeTree(this._gauges, (node, current) => {
+      return !current || current.touched < node.touched ? node : current
+    })
+
+    this._captureTree(gauges, (node, name, tags) => {
+      this._client.gauge(name, node.value, tags)
     })
   }
 
   _captureCounters () {
-    Object.keys(this._counters).forEach(name => {
-      this._counters[name].forEach((value, tag) => {
-        this._client.increment(name, value, tag && [tag])
-      })
+    const counters = this._normalizeTree(this._counters, (node, current) => {
+      if (!current) return node
+
+      return {
+        value: node.value + current.value
+      }
+    })
+
+    this._captureTree(counters, (node, name, tags) => {
+      this._client.increment(name, node.value, tags)
     })
 
     this._counters = {}
   }
 
   _captureHistograms () {
-    Object.keys(this._histograms).forEach(name => {
-      this._histograms[name].forEach((stats, tag) => {
-        const tags = tag && [tag]
-
-        // Stats can contain garbage data when a value was never recorded.
-        if (stats.count === 0) {
-          stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0, reset: stats.reset }
+    const histograms = this._normalizeTree(this._histograms, (node, current) => {
+      if (!current) {
+        current = {
+          value: new Histogram()
         }
+      }
 
-        this._client.gauge(`${name}.min`, stats.min, tags)
-        this._client.gauge(`${name}.max`, stats.max, tags)
-        this._client.increment(`${name}.sum`, stats.sum, tags)
-        this._client.increment(`${name}.total`, stats.sum, tags)
-        this._client.gauge(`${name}.avg`, stats.avg, tags)
-        this._client.increment(`${name}.count`, stats.count, tags)
-        this._client.gauge(`${name}.median`, stats.median, tags)
-        this._client.gauge(`${name}.95percentile`, stats.p95, tags)
+      current.value.merge(node.value)
+      node.value.reset()
 
-        stats.reset()
-      })
+      return current
     })
+
+    this._captureTree(histograms, (node, name, tags) => {
+      let stats = node.value
+
+      // Stats can contain garbage data when a value was never recorded.
+      if (stats.count === 0) {
+        stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0, reset: stats.reset }
+      }
+
+      this._client.gauge(`${name}.min`, stats.min, tags)
+      this._client.gauge(`${name}.max`, stats.max, tags)
+      this._client.increment(`${name}.sum`, stats.sum, tags)
+      this._client.increment(`${name}.total`, stats.sum, tags)
+      this._client.gauge(`${name}.avg`, stats.avg, tags)
+      this._client.increment(`${name}.count`, stats.count, tags)
+      this._client.gauge(`${name}.median`, stats.median, tags)
+      this._client.gauge(`${name}.95percentile`, stats.p95, tags)
+    })
+  }
+
+  _captureTree (tree, fn) {
+    for (const [name, root] of Object.entries(tree)) {
+      for (const [tags, node] of Object.entries(root)) {
+        fn(node, name, tags ? tags.split(',') : [])
+      }
+    }
+  }
+
+  _normalizeTree (nodes, normalizer) {
+    const flattened = {}
+
+    for (const [name, node] of Object.entries(nodes)) {
+      this._normalizeNode(name, node, [], flattened, normalizer)
+    }
+
+    return flattened
+  }
+
+  _normalizeNode (name, node, tags, flattened, normalizer) {
+    if (node.touched) {
+      const key = [].concat(tags).sort().join(',')
+
+      flattened[name] = flattened[name] || {}
+      flattened[name][key] = normalizer(node, flattened[name][key])
+    }
+
+    for (const [tag, child] of Object.entries(node.nodes)) {
+      this._normalizeNode(name, child, tags.concat(tag), flattened, normalizer)
+    }
   }
 }
 
@@ -324,43 +389,27 @@ class CustomMetrics {
   }
 
   increment (stat, value = 1, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.increment(stat, value, tag)
-    }
+    this._client.increment(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   decrement (stat, value = 1, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.decrement(stat, value, tag)
-    }
+    this._client.decrement(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   gauge (stat, value, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.gauge(stat, value, tag)
-    }
+    this._client.gauge(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   distribution (stat, value, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.distribution(stat, value, tag)
-    }
+    this._client.distribution(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   histogram (stat, value, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.histogram(stat, value, tag)
-    }
+    this._client.histogram(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   flush () {
     return this._client.flush()
-  }
-
-  _normalizeTags (tags) {
-    tags = CustomMetrics.tagTranslator(tags)
-
-    return tags.length === 0 ? [undefined] : tags
   }
 
   /**

--- a/packages/dd-trace/src/histogram.js
+++ b/packages/dd-trace/src/histogram.js
@@ -7,39 +7,28 @@ class Histogram {
     this.reset()
   }
 
-  get min () { return this._min }
-  get max () { return this._max }
-  get avg () { return this._count === 0 ? 0 : this._sum / this._count }
-  get sum () { return this._sum }
-  get count () { return this._count }
+  get min () { return this._sketch.min }
+  get max () { return this._sketch.max }
+  get avg () { return this._sketch.count === 0 ? 0 : this._sketch.sum / this._sketch.count }
+  get sum () { return this._sketch.sum }
+  get count () { return this._sketch.count }
   get median () { return this.percentile(50) }
   get p95 () { return this.percentile(95) }
 
   percentile (percentile) {
-    return this._histogram.getValueAtQuantile(percentile / 100) || 0
+    return this._sketch.getValueAtQuantile(percentile / 100) || 0
+  }
+
+  merge (histogram) {
+    return this._sketch.merge(histogram._sketch)
   }
 
   record (value) {
-    if (this._count === 0) {
-      this._min = this._max = value
-    } else {
-      this._min = Math.min(this._min, value)
-      this._max = Math.max(this._max, value)
-    }
-
-    this._count++
-    this._sum += value
-
-    this._histogram.accept(value)
+    this._sketch.accept(value)
   }
 
   reset () {
-    this._min = 0
-    this._max = 0
-    this._sum = 0
-    this._count = 0
-
-    this._histogram = new DDSketch()
+    this._sketch = new DDSketch()
   }
 }
 

--- a/packages/dd-trace/src/histogram.js
+++ b/packages/dd-trace/src/histogram.js
@@ -7,8 +7,8 @@ class Histogram {
     this.reset()
   }
 
-  get min () { return this._sketch.min }
-  get max () { return this._sketch.max }
+  get min () { return this._sketch.count === 0 ? 0 : this._sketch.min }
+  get max () { return this._sketch.count === 0 ? 0 : this._sketch.max }
   get avg () { return this._sketch.count === 0 ? 0 : this._sketch.sum / this._sketch.count }
   get sum () { return this._sketch.sum }
   get count () { return this._sketch.count }

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -379,13 +379,13 @@ describe('dogstatsd', () => {
 
       client.gauge('test.avg', 10, { foo: 'bar' })
       client.gauge('test.avg', 10, { foo: 'bar', baz: 'qux' })
-      client.gauge('test.avg', 20, { baz: 'qux', foo: 'bar' })
+      client.gauge('test.avg', 20, { foo: 'bar', baz: 'qux' })
       client.flush()
 
       expect(udp4.send).to.have.been.called
       expect(udp4.send.firstCall.args[0].toString()).to.equal([
         'test.avg:10|g|#foo:bar',
-        'test.avg:20|g|#baz:qux,foo:bar'
+        'test.avg:20|g|#foo:bar,baz:qux'
       ].join('\n') + '\n')
     })
 
@@ -416,13 +416,13 @@ describe('dogstatsd', () => {
 
       client.increment('test.count', 10, { foo: 'bar' })
       client.increment('test.count', 10, { foo: 'bar', baz: 'qux' })
-      client.increment('test.count', 10, { baz: 'qux', foo: 'bar' })
+      client.increment('test.count', 10, { foo: 'bar', baz: 'qux' })
       client.flush()
 
       expect(udp4.send).to.have.been.called
       expect(udp4.send.firstCall.args[0].toString()).to.equal([
         'test.count:10|c|#foo:bar',
-        'test.count:20|c|#baz:qux,foo:bar'
+        'test.count:20|c|#foo:bar,baz:qux'
       ].join('\n') + '\n')
     })
 
@@ -484,7 +484,7 @@ describe('dogstatsd', () => {
 
       client.histogram('test.histogram', 10, { foo: 'bar' })
       client.histogram('test.histogram', 10, { foo: 'bar', baz: 'qux' })
-      client.histogram('test.histogram', 10, { baz: 'qux', foo: 'bar' })
+      client.histogram('test.histogram', 10, { foo: 'bar', baz: 'qux' })
       client.flush()
 
       expect(udp4.send).to.have.been.called
@@ -497,28 +497,19 @@ describe('dogstatsd', () => {
         'test.histogram.count:1|c|#foo:bar',
         'test.histogram.median:10.074696689511441|g|#foo:bar',
         'test.histogram.95percentile:10.074696689511441|g|#foo:bar',
-        'test.histogram.min:10|g|#baz:qux,foo:bar',
-        'test.histogram.max:10|g|#baz:qux,foo:bar',
-        'test.histogram.sum:20|c|#baz:qux,foo:bar',
-        'test.histogram.total:20|c|#baz:qux,foo:bar',
-        'test.histogram.avg:10|g|#baz:qux,foo:bar',
-        'test.histogram.count:2|c|#baz:qux,foo:bar',
-        'test.histogram.median:10.074696689511441|g|#baz:qux,foo:bar',
-        'test.histogram.95percentile:10.074696689511441|g|#baz:qux,foo:bar'
+        'test.histogram.min:10|g|#foo:bar,baz:qux',
+        'test.histogram.max:10|g|#foo:bar,baz:qux',
+        'test.histogram.sum:20|c|#foo:bar,baz:qux',
+        'test.histogram.total:20|c|#foo:bar,baz:qux',
+        'test.histogram.avg:10|g|#foo:bar,baz:qux',
+        'test.histogram.count:2|c|#foo:bar,baz:qux',
+        'test.histogram.median:10.074696689511441|g|#foo:bar,baz:qux',
+        'test.histogram.95percentile:10.074696689511441|g|#foo:bar,baz:qux'
       ].join('\n') + '\n')
     })
 
     it('should flush via interval', () => {
-      const clock = sinon.useFakeTimers({
-        toFake: [ // skip process.hrtime
-          'setTimeout',
-          'clearTimeout',
-          'setInterval',
-          'clearInterval',
-          'setImmediate',
-          'clearImmediate'
-        ]
-      })
+      const clock = sinon.useFakeTimers()
 
       client = new CustomMetrics({ dogstatsd: {} })
 

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -510,7 +510,7 @@ describe('dogstatsd', () => {
 
     it('should flush via interval', () => {
       const clock = sinon.useFakeTimers({
-        toFake: [
+        toFake: [ // skip process.hrtime
           'setTimeout',
           'clearTimeout',
           'setInterval',

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -147,16 +147,7 @@ suiteDescribe('runtimeMetrics', () => {
     }
 
     setImmediate = require('timers/promises').setImmediate
-    clock = sinon.useFakeTimers({
-      toFake: [ // skip process.hrtime
-        'setTimeout',
-        'clearTimeout',
-        'setInterval',
-        'clearInterval',
-        'setImmediate',
-        'clearImmediate'
-      ]
-    })
+    clock = sinon.useFakeTimers()
 
     runtimeMetrics.start(config)
   })

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -295,6 +295,7 @@ suiteDescribe('runtimeMetrics', () => {
 
     describe('histogram', () => {
       it('should add a record to a histogram', () => {
+        runtimeMetrics.histogram('test', 0)
         runtimeMetrics.histogram('test', 1)
         runtimeMetrics.histogram('test', 2)
         runtimeMetrics.histogram('test', 3)
@@ -302,13 +303,13 @@ suiteDescribe('runtimeMetrics', () => {
         clock.tick(10000)
 
         expect(client.gauge).to.have.been.calledWith('test.max', 3)
-        expect(client.gauge).to.have.been.calledWith('test.min', 1)
+        expect(client.gauge).to.have.been.calledWith('test.min', 0)
         expect(client.increment).to.have.been.calledWith('test.sum', 6)
         expect(client.increment).to.have.been.calledWith('test.total', 6)
-        expect(client.gauge).to.have.been.calledWith('test.avg', 2)
+        expect(client.gauge).to.have.been.calledWith('test.avg', 1.5)
         expect(client.gauge).to.have.been.calledWith('test.median', sinon.match.number)
         expect(client.gauge).to.have.been.calledWith('test.95percentile', sinon.match.number)
-        expect(client.increment).to.have.been.calledWith('test.count', 3)
+        expect(client.increment).to.have.been.calledWith('test.count', 4)
       })
     })
 

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -147,7 +147,16 @@ suiteDescribe('runtimeMetrics', () => {
     }
 
     setImmediate = require('timers/promises').setImmediate
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: [ // skip process.hrtime
+        'setTimeout',
+        'clearTimeout',
+        'setInterval',
+        'clearInterval',
+        'setImmediate',
+        'clearImmediate'
+      ]
+    })
 
     runtimeMetrics.start(config)
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix duplicate custom metrics when multiple tags are used.

### Motivation
<!-- What inspired you to submit this pull request? -->

The new aggregation client was sending counts individually for each tag instead of once combination of tags. This worked fine for runtime metrics since only one tag is ever used, but for custom metrics the number of tags is arbitrary.

Fixes #5405