### PR TITLE
centralize node version numbers for ci workflows

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -1,0 +1,13 @@
+name: Node.js
+description: Install the version of Node.js matching the input identifier
+inputs:
+  version:
+    description: "Version identifier of the version to use."
+    required: false
+    default: 'latest'
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version }}

--- a/.github/actions/node/active-lts/action.yml
+++ b/.github/actions/node/active-lts/action.yml
@@ -3,6 +3,6 @@ description: Install the current Active LTS version of Node.js
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/node
       with:
-        node-version: '22'
+        version: active

--- a/.github/actions/node/latest/action.yml
+++ b/.github/actions/node/latest/action.yml
@@ -3,6 +3,6 @@ description: Install the latest version of Node.js
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/node
       with:
-        node-version: 'latest'
+        version: latest

--- a/.github/actions/node/newest-maintenance-lts/action.yml
+++ b/.github/actions/node/newest-maintenance-lts/action.yml
@@ -3,6 +3,6 @@ description: Install the newest Maintenance LTS version of Node.js
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/node
       with:
-        node-version: '20'
+        version: maintenance

--- a/.github/actions/node/oldest-maintenance-lts/action.yml
+++ b/.github/actions/node/oldest-maintenance-lts/action.yml
@@ -3,6 +3,6 @@ description: Install the oldest Maintenance LTS version of Node.js
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: ./.github/actions/node
       with:
-        node-version: '18'
+        version: oldest

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -17,14 +17,14 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-        version: [18, 20, 22, latest]
+        version: [oldest, maintenance, active, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      - uses: ./.github/actions/node
         with:
-          node-version: ${{ matrix.version }}
+          version: ${{ matrix.version }}
       - uses: ./.github/actions/install
       - run: yarn test:debugger:ci
       - run: yarn test:integration:debugger

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -17,14 +17,14 @@ jobs:
   sdk:
     strategy:
       matrix:
-        version: [18, 20, 22, latest]
+        version: [oldest, maintenance, active, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      - uses: ./.github/actions/node
         with:
-          node-version: ${{ matrix.version }}
+          version: ${{ matrix.version }}
       - uses: ./.github/actions/install
       - run: yarn test:llmobs:sdk:ci
       - if: always()

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -20,13 +20,13 @@ jobs:
       # setting fail-fast to false in an attempt to prevent this from happening
       fail-fast: false
       matrix:
-        version: [18, 20, 22, latest]
+        version: [oldest, maintenance, active, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      - uses: ./.github/actions/node
         with:
-          node-version: ${{ matrix.version }}
+          version: ${{ matrix.version }}
       # Disable core dumps since some integration tests intentionally abort and core dump generation takes around 5-10s
       - uses: ./.github/actions/install
       - run: sudo sysctl -w kernel.core_pattern='|/bin/false'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Centralize Node version numbers for CI workflows.

### Motivation
<!-- What inspired you to submit this pull request? -->

Previous approach was repeating version numbers explicitly in the workflows, which is more difficult to maintain when a new version is released and the semantics change.
