### PR TITLE
v5.45.0 proposal

### DIFF
--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -15,25 +15,21 @@ concurrency:
 
 jobs:
   ubuntu:
+    strategy:
+      matrix:
+        version: [18, 20, 22, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      - run: yarn test:debugger:ci
-      - run: yarn test:integration:debugger
-      - uses: ./.github/actions/node/newest-maintenance-lts
-      - run: yarn test:debugger:ci
-      - run: yarn test:integration:debugger
-      - uses: ./.github/actions/node/active-lts
-      - run: yarn test:debugger:ci
-      - run: yarn test:integration:debugger
-      - uses: ./.github/actions/node/latest
       - run: yarn test:debugger:ci
       - run: yarn test:integration:debugger
       - if: always()
         uses: ./.github/actions/testagent/logs
         with:
-          suffix: debugger
+          suffix: debugger-ubuntu-${{ matrix.version }}
       - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.44.0",
+  "version": "5.45.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/dd-trace/src/appsec/sdk/track_event.js
+++ b/packages/dd-trace/src/appsec/sdk/track_event.js
@@ -7,6 +7,7 @@ const waf = require('../waf')
 const { keepTrace } = require('../../priority_sampler')
 const addresses = require('../addresses')
 const { ASM } = require('../../standalone/product')
+const { incrementSdkEventMetric } = require('../telemetry')
 
 function trackUserLoginSuccessEvent (tracer, user, metadata) {
   // TODO: better user check here and in _setUser() ?
@@ -14,6 +15,8 @@ function trackUserLoginSuccessEvent (tracer, user, metadata) {
     log.warn('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
     return
   }
+
+  incrementSdkEventMetric('login_success')
 
   const rootSpan = getRootSpan(tracer)
   if (!rootSpan) {
@@ -48,6 +51,8 @@ function trackUserLoginFailureEvent (tracer, userId, exists, metadata) {
   trackEvent('users.login.failure', fields, 'trackUserLoginFailureEvent', getRootSpan(tracer))
 
   runWaf('users.login.failure', { login: userId })
+
+  incrementSdkEventMetric('login_failure')
 }
 
 function trackCustomEvent (tracer, eventName, metadata) {
@@ -57,6 +62,8 @@ function trackCustomEvent (tracer, eventName, metadata) {
   }
 
   trackEvent(eventName, metadata, 'trackCustomEvent', getRootSpan(tracer))
+
+  incrementSdkEventMetric('custom')
 }
 
 function trackEvent (eventName, fields, sdkMethodName, rootSpan) {

--- a/packages/dd-trace/src/appsec/telemetry/index.js
+++ b/packages/dd-trace/src/appsec/telemetry/index.js
@@ -2,7 +2,7 @@
 
 const { DD_TELEMETRY_REQUEST_METRICS } = require('./common')
 const { addRaspRequestMetrics, trackRaspMetrics } = require('./rasp')
-const { incrementMissingUserId, incrementMissingUserLogin } = require('./user')
+const { incrementMissingUserId, incrementMissingUserLogin, incrementSdkEvent } = require('./user')
 const {
   addWafRequestMetrics,
   trackWafMetrics,
@@ -121,6 +121,12 @@ function incrementMissingUserIdMetric (framework, eventType) {
   incrementMissingUserId(framework, eventType)
 }
 
+function incrementSdkEventMetric (framework, eventType) {
+  if (!enabled) return
+
+  incrementSdkEvent(framework, eventType)
+}
+
 function getRequestMetrics (req) {
   if (req) {
     const store = getStore(req)
@@ -141,6 +147,7 @@ module.exports = {
   incrementWafRequestsMetric,
   incrementMissingUserLoginMetric,
   incrementMissingUserIdMetric,
+  incrementSdkEventMetric,
 
   getRequestMetrics
 }

--- a/packages/dd-trace/src/appsec/telemetry/user.js
+++ b/packages/dd-trace/src/appsec/telemetry/user.js
@@ -18,7 +18,15 @@ function incrementMissingUserId (framework, eventType) {
   }).inc()
 }
 
+function incrementSdkEvent (eventType) {
+  appsecMetrics.count('sdk.event', {
+    event_type: eventType,
+    sdk_version: 'v1'
+  }).inc()
+}
+
 module.exports = {
   incrementMissingUserLogin,
-  incrementMissingUserId
+  incrementMissingUserId,
+  incrementSdkEvent
 }

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -194,7 +194,6 @@ class DogStatsDClient {
   }
 }
 
-// TODO: Handle arrays of tags and tags translation.
 class MetricsAggregationClient {
   constructor (client) {
     this._client = client
@@ -211,97 +210,131 @@ class MetricsAggregationClient {
   }
 
   reset () {
-    this._counters = {}
-    this._gauges = {}
-    this._histograms = {}
+    this._counters = new Map()
+    this._gauges = new Map()
+    this._histograms = new Map()
   }
 
-  distribution (name, value, tag) {
-    this._client.distribution(name, value, tag && [tag])
+  // TODO: Aggerate with a histogram and send the buckets to the client.
+  distribution (name, value, tags) {
+    this._client.distribution(name, value, tags)
   }
 
-  boolean (name, value, tag) {
-    this.gauge(name, value ? 1 : 0, tag)
+  boolean (name, value, tags) {
+    this.gauge(name, value ? 1 : 0, tags)
   }
 
-  histogram (name, value, tag) {
-    this._histograms[name] = this._histograms[name] || new Map()
+  histogram (name, value, tags) {
+    const node = this._ensureTree(this._histograms, name, tags, null)
 
-    if (!this._histograms[name].has(tag)) {
-      this._histograms[name].set(tag, new Histogram())
+    if (!node.value) {
+      node.value = new Histogram()
     }
 
-    this._histograms[name].get(tag).record(value)
+    node.value.record(value)
   }
 
-  count (name, count, tag, monotonic = true) {
-    if (typeof tag === 'boolean') {
-      monotonic = tag
-      tag = undefined
+  count (name, count, tags = [], monotonic = true) {
+    if (typeof tags === 'boolean') {
+      monotonic = tags
+      tags = []
     }
 
-    const map = monotonic ? this._counters : this._gauges
+    const container = monotonic ? this._counters : this._gauges
+    const node = this._ensureTree(container, name, tags, 0)
 
-    map[name] = map[name] || new Map()
-
-    const value = map[name].get(tag) || 0
-
-    map[name].set(tag, value + count)
+    node.value = node.value + count
   }
 
-  gauge (name, value, tag) {
-    this._gauges[name] = this._gauges[name] || new Map()
-    this._gauges[name].set(tag, value)
+  gauge (name, value, tags) {
+    const node = this._ensureTree(this._gauges, name, tags, 0)
+
+    node.value = value
   }
 
-  increment (name, count = 1, tag) {
-    this.count(name, count, tag)
+  increment (name, count = 1, tags) {
+    this.count(name, count, tags)
   }
 
-  decrement (name, count = 1, tag) {
-    this.count(name, -count, tag)
+  decrement (name, count = 1, tags) {
+    this.count(name, -count, tags)
   }
 
   _captureGauges () {
-    Object.keys(this._gauges).forEach(name => {
-      this._gauges[name].forEach((value, tag) => {
-        this._client.gauge(name, value, tag && [tag])
-      })
+    this._captureTree(this._gauges, (node, name, tags) => {
+      this._client.gauge(name, node.value, tags)
     })
   }
 
   _captureCounters () {
-    Object.keys(this._counters).forEach(name => {
-      this._counters[name].forEach((value, tag) => {
-        this._client.increment(name, value, tag && [tag])
-      })
+    this._captureTree(this._counters, (node, name, tags) => {
+      this._client.increment(name, node.value, tags)
     })
 
-    this._counters = {}
+    this._counters.clear()
   }
 
   _captureHistograms () {
-    Object.keys(this._histograms).forEach(name => {
-      this._histograms[name].forEach((stats, tag) => {
-        const tags = tag && [tag]
+    this._captureTree(this._histograms, (node, name, tags) => {
+      let stats = node.value
 
-        // Stats can contain garbage data when a value was never recorded.
-        if (stats.count === 0) {
-          stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0, reset: stats.reset }
-        }
+      // Stats can contain garbage data when a value was never recorded.
+      if (stats.count === 0) {
+        stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0 }
+      }
 
-        this._client.gauge(`${name}.min`, stats.min, tags)
-        this._client.gauge(`${name}.max`, stats.max, tags)
-        this._client.increment(`${name}.sum`, stats.sum, tags)
-        this._client.increment(`${name}.total`, stats.sum, tags)
-        this._client.gauge(`${name}.avg`, stats.avg, tags)
-        this._client.increment(`${name}.count`, stats.count, tags)
-        this._client.gauge(`${name}.median`, stats.median, tags)
-        this._client.gauge(`${name}.95percentile`, stats.p95, tags)
+      this._client.gauge(`${name}.min`, stats.min, tags)
+      this._client.gauge(`${name}.max`, stats.max, tags)
+      this._client.increment(`${name}.sum`, stats.sum, tags)
+      this._client.increment(`${name}.total`, stats.sum, tags)
+      this._client.gauge(`${name}.avg`, stats.avg, tags)
+      this._client.increment(`${name}.count`, stats.count, tags)
+      this._client.gauge(`${name}.median`, stats.median, tags)
+      this._client.gauge(`${name}.95percentile`, stats.p95, tags)
 
-        stats.reset()
-      })
+      node.value.reset()
     })
+  }
+
+  _captureTree (tree, fn) {
+    for (const [name, root] of tree) {
+      this._captureNode(root, name, [], fn)
+    }
+  }
+
+  _captureNode (node, name, tags, fn) {
+    if (node.touched) {
+      fn(node, name, tags)
+    }
+
+    for (const [tag, next] of node.nodes) {
+      this._captureNode(next, name, tags.concat(tag), fn)
+    }
+  }
+
+  _ensureTree (tree, name, tags, value) {
+    tags = tags ? [].concat(tags) : []
+
+    let node = this._ensureNode(tree, name, value)
+
+    for (const tag of tags) {
+      node = this._ensureNode(node.nodes, tag, value)
+    }
+
+    node.touched = true
+
+    return node
+  }
+
+  _ensureNode (container, key, value) {
+    let node = container.get(key)
+
+    if (!node) {
+      node = { nodes: new Map(), touched: false, value }
+      container.set(key, node)
+    }
+
+    return node
   }
 }
 
@@ -324,43 +357,27 @@ class CustomMetrics {
   }
 
   increment (stat, value = 1, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.increment(stat, value, tag)
-    }
+    this._client.increment(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   decrement (stat, value = 1, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.decrement(stat, value, tag)
-    }
+    this._client.decrement(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   gauge (stat, value, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.gauge(stat, value, tag)
-    }
+    this._client.gauge(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   distribution (stat, value, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.distribution(stat, value, tag)
-    }
+    this._client.distribution(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   histogram (stat, value, tags) {
-    for (const tag of this._normalizeTags(tags)) {
-      this._client.histogram(stat, value, tag)
-    }
+    this._client.histogram(stat, value, CustomMetrics.tagTranslator(tags))
   }
 
   flush () {
     return this._client.flush()
-  }
-
-  _normalizeTags (tags) {
-    tags = CustomMetrics.tagTranslator(tags)
-
-    return tags.length === 0 ? [undefined] : tags
   }
 
   /**

--- a/packages/dd-trace/src/histogram.js
+++ b/packages/dd-trace/src/histogram.js
@@ -7,39 +7,28 @@ class Histogram {
     this.reset()
   }
 
-  get min () { return this._min }
-  get max () { return this._max }
-  get avg () { return this._count === 0 ? 0 : this._sum / this._count }
-  get sum () { return this._sum }
-  get count () { return this._count }
+  get min () { return this._sketch.count === 0 ? 0 : this._sketch.min }
+  get max () { return this._sketch.count === 0 ? 0 : this._sketch.max }
+  get avg () { return this._sketch.count === 0 ? 0 : this._sketch.sum / this._sketch.count }
+  get sum () { return this._sketch.sum }
+  get count () { return this._sketch.count }
   get median () { return this.percentile(50) }
   get p95 () { return this.percentile(95) }
 
   percentile (percentile) {
-    return this._histogram.getValueAtQuantile(percentile / 100) || 0
+    return this._sketch.getValueAtQuantile(percentile / 100) || 0
+  }
+
+  merge (histogram) {
+    return this._sketch.merge(histogram._sketch)
   }
 
   record (value) {
-    if (this._count === 0) {
-      this._min = this._max = value
-    } else {
-      this._min = Math.min(this._min, value)
-      this._max = Math.max(this._max, value)
-    }
-
-    this._count++
-    this._sum += value
-
-    this._histogram.accept(value)
+    this._sketch.accept(value)
   }
 
   reset () {
-    this._min = 0
-    this._max = 0
-    this._sum = 0
-    this._count = 0
-
-    this._histogram = new DDSketch()
+    this._sketch = new DDSketch()
   }
 }
 

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -6,6 +6,7 @@ const { storage } = require('./storage')
 
 const LLMObsSpanProcessor = require('./span_processor')
 
+const telemetry = require('./telemetry')
 const { channel } = require('dc-polyfill')
 const spanProcessCh = channel('dd-trace:span:process')
 const evalMetricAppendCh = channel('llmobs:eval-metric:append')
@@ -29,6 +30,7 @@ let spanWriter
 let evalWriter
 
 function enable (config) {
+  const startTime = performance.now()
   // create writers and eval writer append and flush channels
   // span writer append is handled by the span processor
   evalWriter = new LLMObsEvalMetricsWriter(config)
@@ -44,6 +46,7 @@ function enable (config) {
 
   // distributed tracing for llmobs
   injectCh.subscribe(handleLLMObsParentIdInjection)
+  telemetry.recordLLMObsEnabled(startTime, config)
 }
 
 function disable () {

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -74,6 +74,23 @@ function incrementLLMObsSpanFinishedCount (span, value = 1) {
   llmobsMetrics.count('span.finished', tags).inc(value)
 }
 
+function recordLLMObsEnabled (startTime, config, value = 1) {
+  const initTimeMs = performance.now() - startTime
+  // There isn't an easy way to determine if a user automatically enabled LLMObs via
+  // in-code or command line setup. We'll use the presence of DD_LLMOBS_ENABLED env var
+  // as a rough heuristic, but note that this isn't perfect since
+  // a user may have env vars but enable manually in code.
+  const autoEnabled = !!config._env?.['llmobs.enabled']
+  const tags = {
+    error: 0,
+    agentless: Number(config.llmobs.agentlessEnabled),
+    site: config.site,
+    auto: Number(autoEnabled)
+  }
+  llmobsMetrics.count('product_enabled', tags).inc(value)
+  llmobsMetrics.distribution('init_time', tags).track(initTimeMs)
+}
+
 function recordLLMObsRawSpanSize (event, rawEventSize) {
   const tags = extractTagsFromSpanEvent(event)
   llmobsMetrics.distribution('span.raw_size', tags).track(rawEventSize)
@@ -86,6 +103,7 @@ function recordLLMObsSpanSize (event, eventSize, shouldTruncate) {
 }
 
 module.exports = {
+  recordLLMObsEnabled,
   incrementLLMObsSpanStartCount,
   incrementLLMObsSpanFinishedCount,
   recordLLMObsRawSpanSize,

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -102,10 +102,18 @@ function recordLLMObsSpanSize (event, eventSize, shouldTruncate) {
   llmobsMetrics.distribution('span.size', tags).track(eventSize)
 }
 
+function recordDroppedPayload (numEvents, eventType, error) {
+  if (eventType !== 'span' && eventType !== 'evaluation_metric') return
+  const metricName = eventType === 'span' ? 'dropped_span_event' : 'dropped_eval_event'
+  const tags = { error }
+  llmobsMetrics.count(metricName, tags).inc(numEvents)
+}
+
 module.exports = {
   recordLLMObsEnabled,
   incrementLLMObsSpanStartCount,
   incrementLLMObsSpanFinishedCount,
   recordLLMObsRawSpanSize,
-  recordLLMObsSpanSize
+  recordLLMObsSpanSize,
+  recordDroppedPayload
 }

--- a/packages/dd-trace/src/remote_config/manager.js
+++ b/packages/dd-trace/src/remote_config/manager.js
@@ -10,6 +10,7 @@ const { getExtraServices } = require('../service-naming/extra-services')
 const { UNACKNOWLEDGED, ACKNOWLEDGED, ERROR } = require('./apply_states')
 const Scheduler = require('./scheduler')
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../plugins/util/tags')
+const tagger = require('../tagger')
 
 const clientId = uuid()
 
@@ -33,6 +34,10 @@ class RemoteConfigManager extends EventEmitter {
       hostname: config.hostname || 'localhost',
       port: config.port
     }))
+
+    tagger.add(config.tags, {
+      '_dd.rc.client_id': clientId
+    })
 
     const tags = config.repositoryUrl
       ? {

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -17,6 +17,7 @@ describe('track_event', () => {
     let getRootSpan
     let setUserTags
     let waf
+    let telemetry
     let trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent
 
     beforeEach(() => {
@@ -42,6 +43,10 @@ describe('track_event', () => {
         run: sinon.spy()
       }
 
+      telemetry = {
+        incrementSdkEventMetric: sinon.stub()
+      }
+
       const trackEvents = proxyquire('../../../src/appsec/sdk/track_event', {
         '../../log': log,
         './utils': {
@@ -50,7 +55,8 @@ describe('track_event', () => {
         './set_user': {
           setUserTags
         },
-        '../waf': waf
+        '../waf': waf,
+        '../telemetry': telemetry
       })
 
       trackUserLoginSuccessEvent = trackEvents.trackUserLoginSuccessEvent
@@ -70,6 +76,7 @@ describe('track_event', () => {
           .to.have.been.calledWithExactly('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should log warning when root span is not available', () => {
@@ -80,6 +87,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in trackUserLoginSuccessEvent')
         expect(setUserTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
 
       it('should call setUser and addTags with metadata', () => {
@@ -111,6 +119,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
 
       it('should call setUser and addTags without metadata', () => {
@@ -134,6 +143,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
 
       it('should call waf with user login', () => {
@@ -157,6 +167,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_login'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
       })
     })
 
@@ -172,6 +183,7 @@ describe('track_event', () => {
           .to.have.been.calledWithExactly('[ASM] Invalid userId provided to trackUserLoginFailureEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should log warning when root span is not available', () => {
@@ -182,6 +194,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackUserLoginFailureEvent')
         expect(setUserTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
 
       it('should call addTags with metadata', () => {
@@ -211,6 +224,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
 
       it('should send false `usr.exists` property when the user does not exist', () => {
@@ -240,6 +254,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
 
       it('should call addTags without metadata', () => {
@@ -262,6 +277,7 @@ describe('track_event', () => {
             [USER_LOGIN]: 'user_id'
           }
         })
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
       })
     })
 
@@ -277,6 +293,7 @@ describe('track_event', () => {
           .to.have.been.calledWithExactly('[ASM] Invalid eventName provided to trackCustomEvent')
         expect(setUserTags).to.not.have.been.called
         expect(rootSpan.addTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
       })
 
       it('should log warning when root span is not available', () => {
@@ -287,6 +304,7 @@ describe('track_event', () => {
         expect(log.warn)
           .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackCustomEvent')
         expect(setUserTags).to.not.have.been.called
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
       })
 
       it('should call addTags with metadata', () => {
@@ -305,6 +323,7 @@ describe('track_event', () => {
         })
         expect(prioritySampler.setPriority)
           .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
       })
 
       it('should call addTags without metadata', () => {
@@ -318,6 +337,7 @@ describe('track_event', () => {
         })
         expect(prioritySampler.setPriority)
           .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
       })
     })
   })

--- a/packages/dd-trace/test/appsec/telemetry/user.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/user.spec.js
@@ -49,5 +49,16 @@ describe('Appsec User Telemetry metrics', () => {
         })
       })
     })
+
+    describe('incrementSdkEventMetric', () => {
+      it('should increment sdk.event metric', () => {
+        appsecTelemetry.incrementSdkEventMetric('login_success')
+
+        expect(count).to.have.been.calledOnceWithExactly('sdk.event', {
+          event_type: 'login_success',
+          sdk_version: 'v1'
+        })
+      })
+    })
   })
 })

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -374,6 +374,21 @@ describe('dogstatsd', () => {
       expect(udp4.send.firstCall.args[0].toString()).to.equal('test.avg:10|g|#foo:bar\n')
     })
 
+    it('.gauge() with tags', () => {
+      client = new CustomMetrics({ dogstatsd: {} })
+
+      client.gauge('test.avg', 10, { foo: 'bar' })
+      client.gauge('test.avg', 10, { foo: 'bar', baz: 'qux' })
+      client.gauge('test.avg', 20, { foo: 'bar', baz: 'qux' })
+      client.flush()
+
+      expect(udp4.send).to.have.been.called
+      expect(udp4.send.firstCall.args[0].toString()).to.equal([
+        'test.avg:10|g|#foo:bar',
+        'test.avg:20|g|#foo:bar,baz:qux'
+      ].join('\n') + '\n')
+    })
+
     it('.increment()', () => {
       client = new CustomMetrics({ dogstatsd: {} })
 
@@ -394,6 +409,21 @@ describe('dogstatsd', () => {
 
       expect(udp4.send).to.have.been.called
       expect(udp4.send.firstCall.args[0].toString()).to.equal('test.count:2|c\n')
+    })
+
+    it('.increment() with tags', () => {
+      client = new CustomMetrics({ dogstatsd: {} })
+
+      client.increment('test.count', 10, { foo: 'bar' })
+      client.increment('test.count', 10, { foo: 'bar', baz: 'qux' })
+      client.increment('test.count', 10, { foo: 'bar', baz: 'qux' })
+      client.flush()
+
+      expect(udp4.send).to.have.been.called
+      expect(udp4.send.firstCall.args[0].toString()).to.equal([
+        'test.count:10|c|#foo:bar',
+        'test.count:20|c|#foo:bar,baz:qux'
+      ].join('\n') + '\n')
     })
 
     it('.decrement()', () => {
@@ -446,6 +476,35 @@ describe('dogstatsd', () => {
         'test.histogram.count:2|c',
         'test.histogram.median:10.074696689511441|g',
         'test.histogram.95percentile:10.074696689511441|g'
+      ].join('\n') + '\n')
+    })
+
+    it('.histogram() with tags', () => {
+      client = new CustomMetrics({ dogstatsd: {} })
+
+      client.histogram('test.histogram', 10, { foo: 'bar' })
+      client.histogram('test.histogram', 10, { foo: 'bar', baz: 'qux' })
+      client.histogram('test.histogram', 10, { foo: 'bar', baz: 'qux' })
+      client.flush()
+
+      expect(udp4.send).to.have.been.called
+      expect(udp4.send.firstCall.args[0].toString()).to.equal([
+        'test.histogram.min:10|g|#foo:bar',
+        'test.histogram.max:10|g|#foo:bar',
+        'test.histogram.sum:10|c|#foo:bar',
+        'test.histogram.total:10|c|#foo:bar',
+        'test.histogram.avg:10|g|#foo:bar',
+        'test.histogram.count:1|c|#foo:bar',
+        'test.histogram.median:10.074696689511441|g|#foo:bar',
+        'test.histogram.95percentile:10.074696689511441|g|#foo:bar',
+        'test.histogram.min:10|g|#foo:bar,baz:qux',
+        'test.histogram.max:10|g|#foo:bar,baz:qux',
+        'test.histogram.sum:20|c|#foo:bar,baz:qux',
+        'test.histogram.total:20|c|#foo:bar,baz:qux',
+        'test.histogram.avg:10|g|#foo:bar,baz:qux',
+        'test.histogram.count:2|c|#foo:bar,baz:qux',
+        'test.histogram.median:10.074696689511441|g|#foo:bar,baz:qux',
+        'test.histogram.95percentile:10.074696689511441|g|#foo:bar,baz:qux'
       ].join('\n') + '\n')
     })
 

--- a/packages/dd-trace/test/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/remote_config/manager.spec.js
@@ -15,6 +15,7 @@ describe('RemoteConfigManager', () => {
   let RemoteConfigManager
   let config
   let rc
+  let tagger
 
   beforeEach(() => {
     uuid = sinon.stub().returns('1234-5678')
@@ -32,6 +33,10 @@ describe('RemoteConfigManager', () => {
       error: sinon.spy()
     }
 
+    tagger = {
+      add: sinon.stub()
+    }
+
     extraServices = []
 
     RemoteConfigManager = proxyquire('../src/remote_config/manager', {
@@ -40,6 +45,7 @@ describe('RemoteConfigManager', () => {
       '../../../../../package.json': { version: '3.0.0' },
       '../../exporters/common/request': request,
       '../../log': log,
+      '../tagger': tagger,
       '../../service-naming/extra-services': {
         getExtraServices: () => extraServices
       }
@@ -77,6 +83,10 @@ describe('RemoteConfigManager', () => {
     expect(rc.scheduler).to.equal(scheduler)
 
     expect(rc.url).to.deep.equal(config.url)
+
+    expect(tagger.add).to.have.been.calledOnceWithExactly(config.tags, {
+      '_dd.rc.client_id': '1234-5678'
+    })
 
     expect(rc.state).to.deep.equal({
       client: {

--- a/packages/dd-trace/test/remote_config/rc-client_id.spec.js
+++ b/packages/dd-trace/test/remote_config/rc-client_id.spec.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const { createSandbox, FakeAgent, spawnProc } = require('../../../../integration-tests/helpers')
+const getPort = require('get-port')
+const path = require('path')
+const Axios = require('axios')
+const { assert } = require('chai')
+
+describe('Remote config client id', () => {
+  let axios, sandbox, cwd, appPort, appFile
+
+  before(async function () {
+    this.timeout(process.platform === 'win32' ? 90000 : 30000)
+
+    sandbox = await createSandbox(
+      ['express'],
+      false,
+      [path.join(__dirname, 'resources')]
+    )
+
+    appPort = await getPort()
+    cwd = sandbox.folder
+    appFile = path.join(cwd, 'resources', 'index.js')
+
+    axios = Axios.create({
+      baseURL: `http://localhost:${appPort}`
+    })
+  })
+
+  after(async function () {
+    this.timeout(60000)
+    await sandbox.remove()
+  })
+
+  describe('enabled', () => {
+    let agent, proc
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+      proc = await spawnProc(appFile, {
+        cwd,
+        env: {
+          DD_TRACE_AGENT_PORT: agent.port,
+          APP_PORT: appPort
+        }
+      })
+    })
+
+    afterEach(async () => {
+      proc.kill()
+      await agent.stop()
+    })
+
+    it('should add client_id tag when remote config is enabled', async () => {
+      await axios.get('/')
+
+      return agent.assertMessageReceived(({ payload }) => {
+        assert.exists(payload[0][0].meta['_dd.rc.client_id'])
+      })
+    })
+  })
+
+  describe('disabled', () => {
+    let agent, proc
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+      proc = await spawnProc(appFile, {
+        cwd,
+        env: {
+          DD_TRACE_AGENT_PORT: agent.port,
+          APP_PORT: appPort,
+          DD_REMOTE_CONFIGURATION_ENABLED: false
+        }
+      })
+    })
+
+    afterEach(async () => {
+      proc.kill()
+      await agent.stop()
+    })
+
+    it('should not add client_id tag when remote config is disbaled', async () => {
+      await axios.get('/')
+
+      return agent.assertMessageReceived(({ payload }) => {
+        assert.notExists(payload[0][0].meta['_dd.rc.client_id'])
+      })
+    })
+  })
+})

--- a/packages/dd-trace/test/remote_config/resources/index.js
+++ b/packages/dd-trace/test/remote_config/resources/index.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const tracer = require('dd-trace')
+tracer.init({
+  flushInterval: 1
+})
+
+const express = require('express')
+
+const app = express()
+const port = process.env.APP_PORT || 3000
+
+app.get('/', async (req, res) => {
+  res.end('OK')
+})
+
+app.listen(port, () => {
+  process.send({ port })
+})

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -295,6 +295,7 @@ suiteDescribe('runtimeMetrics', () => {
 
     describe('histogram', () => {
       it('should add a record to a histogram', () => {
+        runtimeMetrics.histogram('test', 0)
         runtimeMetrics.histogram('test', 1)
         runtimeMetrics.histogram('test', 2)
         runtimeMetrics.histogram('test', 3)
@@ -302,13 +303,13 @@ suiteDescribe('runtimeMetrics', () => {
         clock.tick(10000)
 
         expect(client.gauge).to.have.been.calledWith('test.max', 3)
-        expect(client.gauge).to.have.been.calledWith('test.min', 1)
+        expect(client.gauge).to.have.been.calledWith('test.min', 0)
         expect(client.increment).to.have.been.calledWith('test.sum', 6)
         expect(client.increment).to.have.been.calledWith('test.total', 6)
-        expect(client.gauge).to.have.been.calledWith('test.avg', 2)
+        expect(client.gauge).to.have.been.calledWith('test.avg', 1.5)
         expect(client.gauge).to.have.been.calledWith('test.median', sinon.match.number)
         expect(client.gauge).to.have.been.calledWith('test.95percentile', sinon.match.number)
-        expect(client.increment).to.have.been.calledWith('test.count', 3)
+        expect(client.increment).to.have.been.calledWith('test.count', 4)
       })
     })
 


### PR DESCRIPTION
* \[[`120b6b081b`](https://github.com/DataDog/dd-trace-js/commit/120b6b081b)] - **(SEMVER-PATCH)** fix duplicate custom metrics when multiple tags are used (Roch Devost) [#5491](https://github.com/DataDog/dd-trace-js/pull/5491)
* \[[`e4bf59aa2a`](https://github.com/DataDog/dd-trace-js/commit/e4bf59aa2a)] - **(SEMVER-MINOR)** report rc.client\_id tag when rc is enabled (Ilyas Shabi) [#5467](https://github.com/DataDog/dd-trace-js/pull/5467)
* \[[`762e2cf956`](https://github.com/DataDog/dd-trace-js/commit/762e2cf956)] - **(SEMVER-MINOR)** add sdk.event to communicate a login or custom event (Ilyas Shabi) [#5462](https://github.com/DataDog/dd-trace-js/pull/5462)
* \[[`50b53548f2`](https://github.com/DataDog/dd-trace-js/commit/50b53548f2)] - **(SEMVER-PATCH)** add matrix strategy to debugger ci job (Roch Devost) [#5450](https://github.com/DataDog/dd-trace-js/pull/5450)
* \[[`0ceef34fc7`](https://github.com/DataDog/dd-trace-js/commit/0ceef34fc7)] - **(SEMVER-MINOR)** chore(llmobs): add telemetry metrics for dropped span/eval payloads (Yun Kim) [#5469](https://github.com/DataDog/dd-trace-js/pull/5469)
* \[[`04f6bc4bc9`](https://github.com/DataDog/dd-trace-js/commit/04f6bc4bc9)] - **(SEMVER-MINOR)** chore(llmobs): Add llmobs product enabled telemetry metrics (Yun Kim) [#5475](https://github.com/DataDog/dd-trace-js/pull/5475)
* \[[`312a500fc9`](https://github.com/DataDog/dd-trace-js/commit/312a500fc9)] - **(SEMVER-PATCH)** chore(langchain): fix test flakiness (Sam Brenner) [#5461](https://github.com/DataDog/dd-trace-js/pull/5461)