### PR TITLE
fix user tracking tests

### DIFF
--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const proxyquire = require('proxyquire')
+
 describe('blocking', () => {
   const defaultBlockedTemplate = {
     html: 'block test',
@@ -26,7 +28,7 @@ describe('blocking', () => {
       updateBlockFailureMetric: sinon.stub()
     }
 
-    const blocking = proxyquire('../src/appsec/blocking', {
+    const blocking = proxyquire('../../src/appsec/blocking', {
       '../log': log,
       './blocked_templates': defaultBlockedTemplate,
       './telemetry': telemetry

--- a/packages/dd-trace/test/appsec/sdk/track_event-integration.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event-integration.spec.js
@@ -1,0 +1,157 @@
+'use strict'
+
+const agent = require('../../plugins/agent')
+const axios = require('axios')
+const tracer = require('../../../../../index')
+const { USER_KEEP } = require('../../../../../ext/priority')
+
+describe('track_event - Integration with the tracer', () => {
+  let http
+  let controller
+  let appListener
+  let port
+
+  function listener (req, res) {
+    if (controller) {
+      controller(req, res)
+    }
+  }
+
+  before(async () => {
+    await agent.load('http')
+    http = require('http')
+  })
+
+  before(done => {
+    const server = new http.Server(listener)
+    appListener = server
+      .listen(port, 'localhost', () => {
+        port = appListener.address().port
+        done()
+      })
+  })
+
+  after(() => {
+    appListener.close()
+    return agent.close({ ritmReset: false })
+  })
+
+  describe('trackUserLoginSuccessEvent', () => {
+    it('should track valid user', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackUserLoginSuccessEvent({
+          id: 'test_user_id'
+        }, { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.success.track', 'true')
+        expect(traces[0][0].meta).to.have.property('usr.id', 'test_user_id')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.success.metakey', 'metaValue')
+        expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not track without user', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackUserLoginSuccessEvent(undefined, { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.success.track', 'true')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not track without calling the sdk method', (done) => {
+      controller = (req, res) => {
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.success.track', 'true')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+  })
+
+  describe('trackUserLoginFailureEvent', () => {
+    it('should track valid existing user', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackUserLoginFailureEvent('test_user_id', true, { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.track', 'true')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.id', 'test_user_id')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.exists', 'true')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.metakey', 'metaValue')
+        expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should track valid non existing user', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackUserLoginFailureEvent('test_user_id', false, { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.track', 'true')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.id', 'test_user_id')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.exists', 'false')
+        expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.metakey', 'metaValue')
+        expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not track without user', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackUserLoginFailureEvent(undefined, false, { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.failure.track', 'true')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not track without calling the sdk method', (done) => {
+      controller = (req, res) => {
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.failure.track', 'true')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+  })
+
+  describe('trackCustomEvent', () => {
+    it('should track valid event name', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackCustomEvent('my-custom-event', { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.events.my-custom-event.track', 'true')
+        expect(traces[0][0].meta).to.have.property('appsec.events.my-custom-event.metakey', 'metaValue')
+        expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not track invalid event name', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackCustomEvent(null, { metakey: 'metaValue' })
+        tracer.appsec.trackCustomEvent({ event: 'name' }, { metakey: 'metaValue' })
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].metrics).to.not.have.property('_sampling_priority_v1', USER_KEEP)
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/sdk/track_event.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event.spec.js
@@ -1,495 +1,339 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const agent = require('../../plugins/agent')
-const axios = require('axios')
-const tracer = require('../../../../../index')
 const { LOGIN_SUCCESS, LOGIN_FAILURE, USER_ID, USER_LOGIN } = require('../../../src/appsec/addresses')
 const { USER_KEEP } = require('../../../../../ext/priority')
 const { ASM } = require('../../../src/standalone/product')
 
-describe('track_event', () => {
-  describe('Internal API', () => {
-    const tracer = {}
-    let log
-    let prioritySampler
-    let rootSpan
-    let getRootSpan
-    let setUserTags
-    let waf
-    let telemetry
-    let trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent
+describe('track_event - Internal API', () => {
+  const tracer = {}
+  let log
+  let prioritySampler
+  let rootSpan
+  let getRootSpan
+  let setUserTags
+  let waf
+  let telemetry
+  let trackUserLoginSuccessEvent, trackUserLoginFailureEvent, trackCustomEvent
 
-    beforeEach(() => {
-      log = {
-        warn: sinon.stub()
-      }
+  beforeEach(() => {
+    log = {
+      warn: sinon.stub()
+    }
 
-      prioritySampler = {
-        setPriority: sinon.stub()
-      }
+    prioritySampler = {
+      setPriority: sinon.stub()
+    }
 
-      rootSpan = {
-        _prioritySampler: prioritySampler,
-        addTags: sinon.stub(),
-        keep: sinon.stub()
-      }
+    rootSpan = {
+      _prioritySampler: prioritySampler,
+      addTags: sinon.stub(),
+      keep: sinon.stub()
+    }
 
-      getRootSpan = sinon.stub().callsFake(() => rootSpan)
+    getRootSpan = sinon.stub().callsFake(() => rootSpan)
 
-      setUserTags = sinon.stub()
+    setUserTags = sinon.stub()
 
-      waf = {
-        run: sinon.spy()
-      }
+    waf = {
+      run: sinon.spy()
+    }
 
-      telemetry = {
-        incrementSdkEventMetric: sinon.stub()
-      }
+    telemetry = {
+      incrementSdkEventMetric: sinon.stub()
+    }
 
-      const trackEvents = proxyquire('../../../src/appsec/sdk/track_event', {
-        '../../log': log,
-        './utils': {
-          getRootSpan
-        },
-        './set_user': {
-          setUserTags
-        },
-        '../waf': waf,
-        '../telemetry': telemetry
-      })
-
-      trackUserLoginSuccessEvent = trackEvents.trackUserLoginSuccessEvent
-      trackUserLoginFailureEvent = trackEvents.trackUserLoginFailureEvent
-      trackCustomEvent = trackEvents.trackCustomEvent
+    const trackEvents = proxyquire('../../../src/appsec/sdk/track_event', {
+      '../../log': log,
+      './utils': {
+        getRootSpan
+      },
+      './set_user': {
+        setUserTags
+      },
+      '../waf': waf,
+      '../telemetry': telemetry
     })
 
-    describe('trackUserLoginSuccessEvent', () => {
-      it('should log warning when passed invalid user', () => {
-        trackUserLoginSuccessEvent(tracer, null, { key: 'value' })
-        trackUserLoginSuccessEvent(tracer, {}, { key: 'value' })
+    trackUserLoginSuccessEvent = trackEvents.trackUserLoginSuccessEvent
+    trackUserLoginFailureEvent = trackEvents.trackUserLoginFailureEvent
+    trackCustomEvent = trackEvents.trackCustomEvent
+  })
 
-        expect(log.warn).to.have.been.calledTwice
-        expect(log.warn.firstCall)
-          .to.have.been.calledWithExactly('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
-        expect(log.warn.secondCall)
-          .to.have.been.calledWithExactly('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+  describe('trackUserLoginSuccessEvent', () => {
+    it('should log warning when passed invalid user', () => {
+      trackUserLoginSuccessEvent(tracer, null, { key: 'value' })
+      trackUserLoginSuccessEvent(tracer, {}, { key: 'value' })
+
+      expect(log.warn).to.have.been.calledTwice
+      expect(log.warn.firstCall)
+        .to.have.been.calledWithExactly('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
+      expect(log.warn.secondCall)
+        .to.have.been.calledWithExactly('[ASM] Invalid user provided to trackUserLoginSuccessEvent')
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.not.have.been.called
+      expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+    })
+
+    it('should log warning when root span is not available', () => {
+      rootSpan = undefined
+
+      trackUserLoginSuccessEvent(tracer, { id: 'user_id' }, { key: 'value' })
+
+      expect(log.warn)
+        .to.have.been.calledOnceWithExactly('[ASM] Root span not available in trackUserLoginSuccessEvent')
+      expect(setUserTags).to.not.have.been.called
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
+    })
+
+    it('should call setUser and addTags with metadata', () => {
+      const user = { id: 'user_id' }
+
+      trackUserLoginSuccessEvent(tracer, user, {
+        metakey1: 'metaValue1',
+        metakey2: 'metaValue2',
+        metakey3: 'metaValue3'
       })
 
-      it('should log warning when root span is not available', () => {
-        rootSpan = undefined
-
-        trackUserLoginSuccessEvent(tracer, { id: 'user_id' }, { key: 'value' })
-
-        expect(log.warn)
-          .to.have.been.calledOnceWithExactly('[ASM] Root span not available in trackUserLoginSuccessEvent')
-        expect(setUserTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
-      })
-
-      it('should call setUser and addTags with metadata', () => {
-        const user = { id: 'user_id' }
-
-        trackUserLoginSuccessEvent(tracer, user, {
-          metakey1: 'metaValue1',
-          metakey2: 'metaValue2',
-          metakey3: 'metaValue3'
-        })
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.have.been.calledOnceWithExactly(user, rootSpan)
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly(
-          {
-            'appsec.events.users.login.success.track': 'true',
-            '_dd.appsec.events.users.login.success.sdk': 'true',
-            'appsec.events.users.login.success.usr.login': 'user_id',
-            'appsec.events.users.login.success.metakey1': 'metaValue1',
-            'appsec.events.users.login.success.metakey2': 'metaValue2',
-            'appsec.events.users.login.success.metakey3': 'metaValue3'
-          })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(waf.run).to.have.been.calledOnceWithExactly({
-          persistent: {
-            [LOGIN_SUCCESS]: null,
-            [USER_ID]: 'user_id',
-            [USER_LOGIN]: 'user_id'
-          }
-        })
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
-      })
-
-      it('should call setUser and addTags without metadata', () => {
-        const user = { id: 'user_id' }
-
-        trackUserLoginSuccessEvent(tracer, user)
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.have.been.calledOnceWithExactly(user, rootSpan)
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.have.been.calledOnceWithExactly(user, rootSpan)
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly(
+        {
           'appsec.events.users.login.success.track': 'true',
           '_dd.appsec.events.users.login.success.sdk': 'true',
-          'appsec.events.users.login.success.usr.login': 'user_id'
+          'appsec.events.users.login.success.usr.login': 'user_id',
+          'appsec.events.users.login.success.metakey1': 'metaValue1',
+          'appsec.events.users.login.success.metakey2': 'metaValue2',
+          'appsec.events.users.login.success.metakey3': 'metaValue3'
         })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(waf.run).to.have.been.calledOnceWithExactly({
-          persistent: {
-            [LOGIN_SUCCESS]: null,
-            [USER_ID]: 'user_id',
-            [USER_LOGIN]: 'user_id'
-          }
-        })
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        persistent: {
+          [LOGIN_SUCCESS]: null,
+          [USER_ID]: 'user_id',
+          [USER_LOGIN]: 'user_id'
+        }
       })
-
-      it('should call waf with user login', () => {
-        const user = { id: 'user_id', login: 'user_login' }
-
-        trackUserLoginSuccessEvent(tracer, user)
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.have.been.calledOnceWithExactly(user, rootSpan)
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
-          'appsec.events.users.login.success.track': 'true',
-          '_dd.appsec.events.users.login.success.sdk': 'true',
-          'appsec.events.users.login.success.usr.login': 'user_login'
-        })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(waf.run).to.have.been.calledOnceWithExactly({
-          persistent: {
-            [LOGIN_SUCCESS]: null,
-            [USER_ID]: 'user_id',
-            [USER_LOGIN]: 'user_login'
-          }
-        })
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
-      })
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
     })
 
-    describe('trackUserLoginFailureEvent', () => {
-      it('should log warning when passed invalid userId', () => {
-        trackUserLoginFailureEvent(tracer, null, false, { key: 'value' })
-        trackUserLoginFailureEvent(tracer, [], false, { key: 'value' })
+    it('should call setUser and addTags without metadata', () => {
+      const user = { id: 'user_id' }
 
-        expect(log.warn).to.have.been.calledTwice
-        expect(log.warn.firstCall)
-          .to.have.been.calledWithExactly('[ASM] Invalid userId provided to trackUserLoginFailureEvent')
-        expect(log.warn.secondCall)
-          .to.have.been.calledWithExactly('[ASM] Invalid userId provided to trackUserLoginFailureEvent')
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+      trackUserLoginSuccessEvent(tracer, user)
+
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.have.been.calledOnceWithExactly(user, rootSpan)
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.users.login.success.track': 'true',
+        '_dd.appsec.events.users.login.success.sdk': 'true',
+        'appsec.events.users.login.success.usr.login': 'user_id'
       })
-
-      it('should log warning when root span is not available', () => {
-        rootSpan = undefined
-
-        trackUserLoginFailureEvent(tracer, 'user_id', false, { key: 'value' })
-
-        expect(log.warn)
-          .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackUserLoginFailureEvent')
-        expect(setUserTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        persistent: {
+          [LOGIN_SUCCESS]: null,
+          [USER_ID]: 'user_id',
+          [USER_LOGIN]: 'user_id'
+        }
       })
-
-      it('should call addTags with metadata', () => {
-        trackUserLoginFailureEvent(tracer, 'user_id', true, {
-          metakey1: 'metaValue1',
-          metakey2: 'metaValue2',
-          metakey3: 'metaValue3'
-        })
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
-          'appsec.events.users.login.failure.track': 'true',
-          '_dd.appsec.events.users.login.failure.sdk': 'true',
-          'appsec.events.users.login.failure.usr.id': 'user_id',
-          'appsec.events.users.login.failure.usr.login': 'user_id',
-          'appsec.events.users.login.failure.usr.exists': 'true',
-          'appsec.events.users.login.failure.metakey1': 'metaValue1',
-          'appsec.events.users.login.failure.metakey2': 'metaValue2',
-          'appsec.events.users.login.failure.metakey3': 'metaValue3'
-        })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(waf.run).to.have.been.calledOnceWithExactly({
-          persistent: {
-            [LOGIN_FAILURE]: null,
-            [USER_LOGIN]: 'user_id'
-          }
-        })
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
-      })
-
-      it('should send false `usr.exists` property when the user does not exist', () => {
-        trackUserLoginFailureEvent(tracer, 'user_id', false, {
-          metakey1: 'metaValue1',
-          metakey2: 'metaValue2',
-          metakey3: 'metaValue3'
-        })
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
-          'appsec.events.users.login.failure.track': 'true',
-          '_dd.appsec.events.users.login.failure.sdk': 'true',
-          'appsec.events.users.login.failure.usr.id': 'user_id',
-          'appsec.events.users.login.failure.usr.login': 'user_id',
-          'appsec.events.users.login.failure.usr.exists': 'false',
-          'appsec.events.users.login.failure.metakey1': 'metaValue1',
-          'appsec.events.users.login.failure.metakey2': 'metaValue2',
-          'appsec.events.users.login.failure.metakey3': 'metaValue3'
-        })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(waf.run).to.have.been.calledOnceWithExactly({
-          persistent: {
-            [LOGIN_FAILURE]: null,
-            [USER_LOGIN]: 'user_id'
-          }
-        })
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
-      })
-
-      it('should call addTags without metadata', () => {
-        trackUserLoginFailureEvent(tracer, 'user_id', true)
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
-          'appsec.events.users.login.failure.track': 'true',
-          '_dd.appsec.events.users.login.failure.sdk': 'true',
-          'appsec.events.users.login.failure.usr.id': 'user_id',
-          'appsec.events.users.login.failure.usr.login': 'user_id',
-          'appsec.events.users.login.failure.usr.exists': 'true'
-        })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(waf.run).to.have.been.calledOnceWithExactly({
-          persistent: {
-            [LOGIN_FAILURE]: null,
-            [USER_LOGIN]: 'user_id'
-          }
-        })
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
-      })
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
     })
 
-    describe('trackCustomEvent', () => {
-      it('should log warning when passed invalid eventName', () => {
-        trackCustomEvent(tracer, null)
-        trackCustomEvent(tracer, { name: 'name' })
+    it('should call waf with user login', () => {
+      const user = { id: 'user_id', login: 'user_login' }
 
-        expect(log.warn).to.have.been.calledTwice
-        expect(log.warn.firstCall)
-          .to.have.been.calledWithExactly('[ASM] Invalid eventName provided to trackCustomEvent')
-        expect(log.warn.secondCall)
-          .to.have.been.calledWithExactly('[ASM] Invalid eventName provided to trackCustomEvent')
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
+      trackUserLoginSuccessEvent(tracer, user)
+
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.have.been.calledOnceWithExactly(user, rootSpan)
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.users.login.success.track': 'true',
+        '_dd.appsec.events.users.login.success.sdk': 'true',
+        'appsec.events.users.login.success.usr.login': 'user_login'
       })
-
-      it('should log warning when root span is not available', () => {
-        rootSpan = undefined
-
-        trackCustomEvent(tracer, 'custom_event')
-
-        expect(log.warn)
-          .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackCustomEvent')
-        expect(setUserTags).to.not.have.been.called
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        persistent: {
+          [LOGIN_SUCCESS]: null,
+          [USER_ID]: 'user_id',
+          [USER_LOGIN]: 'user_login'
+        }
       })
-
-      it('should call addTags with metadata', () => {
-        trackCustomEvent(tracer, 'custom_event', {
-          metaKey1: 'metaValue1',
-          metakey2: 'metaValue2'
-        })
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
-          'appsec.events.custom_event.track': 'true',
-          '_dd.appsec.events.custom_event.sdk': 'true',
-          'appsec.events.custom_event.metaKey1': 'metaValue1',
-          'appsec.events.custom_event.metakey2': 'metaValue2'
-        })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
-      })
-
-      it('should call addTags without metadata', () => {
-        trackCustomEvent(tracer, 'custom_event')
-
-        expect(log.warn).to.not.have.been.called
-        expect(setUserTags).to.not.have.been.called
-        expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
-          'appsec.events.custom_event.track': 'true',
-          '_dd.appsec.events.custom_event.sdk': 'true'
-        })
-        expect(prioritySampler.setPriority)
-          .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
-        expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
-      })
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_success')
     })
   })
 
-  describe('Integration with the tracer', () => {
-    let http
-    let controller
-    let appListener
-    let port
+  describe('trackUserLoginFailureEvent', () => {
+    it('should log warning when passed invalid userId', () => {
+      trackUserLoginFailureEvent(tracer, null, false, { key: 'value' })
+      trackUserLoginFailureEvent(tracer, [], false, { key: 'value' })
 
-    function listener (req, res) {
-      if (controller) {
-        controller(req, res)
-      }
-    }
-
-    before(async () => {
-      await agent.load('http')
-      http = require('http')
+      expect(log.warn).to.have.been.calledTwice
+      expect(log.warn.firstCall)
+        .to.have.been.calledWithExactly('[ASM] Invalid userId provided to trackUserLoginFailureEvent')
+      expect(log.warn.secondCall)
+        .to.have.been.calledWithExactly('[ASM] Invalid userId provided to trackUserLoginFailureEvent')
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.not.have.been.called
+      expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
     })
 
-    before(done => {
-      const server = new http.Server(listener)
-      appListener = server
-        .listen(port, 'localhost', () => {
-          port = appListener.address().port
-          done()
-        })
+    it('should log warning when root span is not available', () => {
+      rootSpan = undefined
+
+      trackUserLoginFailureEvent(tracer, 'user_id', false, { key: 'value' })
+
+      expect(log.warn)
+        .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackUserLoginFailureEvent')
+      expect(setUserTags).to.not.have.been.called
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
     })
 
-    after(() => {
-      appListener.close()
-      return agent.close({ ritmReset: false })
+    it('should call addTags with metadata', () => {
+      trackUserLoginFailureEvent(tracer, 'user_id', true, {
+        metakey1: 'metaValue1',
+        metakey2: 'metaValue2',
+        metakey3: 'metaValue3'
+      })
+
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.users.login.failure.track': 'true',
+        '_dd.appsec.events.users.login.failure.sdk': 'true',
+        'appsec.events.users.login.failure.usr.id': 'user_id',
+        'appsec.events.users.login.failure.usr.login': 'user_id',
+        'appsec.events.users.login.failure.usr.exists': 'true',
+        'appsec.events.users.login.failure.metakey1': 'metaValue1',
+        'appsec.events.users.login.failure.metakey2': 'metaValue2',
+        'appsec.events.users.login.failure.metakey3': 'metaValue3'
+      })
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        persistent: {
+          [LOGIN_FAILURE]: null,
+          [USER_LOGIN]: 'user_id'
+        }
+      })
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
     })
 
-    describe('trackUserLoginSuccessEvent', () => {
-      it('should track valid user', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackUserLoginSuccessEvent({
-            id: 'test_user_id'
-          }, { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.success.track', 'true')
-          expect(traces[0][0].meta).to.have.property('usr.id', 'test_user_id')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.success.metakey', 'metaValue')
-          expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+    it('should send false `usr.exists` property when the user does not exist', () => {
+      trackUserLoginFailureEvent(tracer, 'user_id', false, {
+        metakey1: 'metaValue1',
+        metakey2: 'metaValue2',
+        metakey3: 'metaValue3'
       })
 
-      it('should not track without user', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackUserLoginSuccessEvent(undefined, { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.success.track', 'true')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.users.login.failure.track': 'true',
+        '_dd.appsec.events.users.login.failure.sdk': 'true',
+        'appsec.events.users.login.failure.usr.id': 'user_id',
+        'appsec.events.users.login.failure.usr.login': 'user_id',
+        'appsec.events.users.login.failure.usr.exists': 'false',
+        'appsec.events.users.login.failure.metakey1': 'metaValue1',
+        'appsec.events.users.login.failure.metakey2': 'metaValue2',
+        'appsec.events.users.login.failure.metakey3': 'metaValue3'
       })
-
-      it('should not track without calling the sdk method', (done) => {
-        controller = (req, res) => {
-          res.end()
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        persistent: {
+          [LOGIN_FAILURE]: null,
+          [USER_LOGIN]: 'user_id'
         }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.success.track', 'true')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
       })
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
     })
 
-    describe('trackUserLoginFailureEvent', () => {
-      it('should track valid existing user', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackUserLoginFailureEvent('test_user_id', true, { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.track', 'true')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.id', 'test_user_id')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.exists', 'true')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.metakey', 'metaValue')
-          expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
+    it('should call addTags without metadata', () => {
+      trackUserLoginFailureEvent(tracer, 'user_id', true)
 
-      it('should track valid non existing user', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackUserLoginFailureEvent('test_user_id', false, { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.track', 'true')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.id', 'test_user_id')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.exists', 'false')
-          expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.metakey', 'metaValue')
-          expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.users.login.failure.track': 'true',
+        '_dd.appsec.events.users.login.failure.sdk': 'true',
+        'appsec.events.users.login.failure.usr.id': 'user_id',
+        'appsec.events.users.login.failure.usr.login': 'user_id',
+        'appsec.events.users.login.failure.usr.exists': 'true'
       })
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(waf.run).to.have.been.calledOnceWithExactly({
+        persistent: {
+          [LOGIN_FAILURE]: null,
+          [USER_LOGIN]: 'user_id'
+        }
+      })
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('login_failure')
+    })
+  })
 
-      it('should not track without user', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackUserLoginFailureEvent(undefined, false, { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.failure.track', 'true')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
+  describe('trackCustomEvent', () => {
+    it('should log warning when passed invalid eventName', () => {
+      trackCustomEvent(tracer, null)
+      trackCustomEvent(tracer, { name: 'name' })
 
-      it('should not track without calling the sdk method', (done) => {
-        controller = (req, res) => {
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.failure.track', 'true')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
+      expect(log.warn).to.have.been.calledTwice
+      expect(log.warn.firstCall)
+        .to.have.been.calledWithExactly('[ASM] Invalid eventName provided to trackCustomEvent')
+      expect(log.warn.secondCall)
+        .to.have.been.calledWithExactly('[ASM] Invalid eventName provided to trackCustomEvent')
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.not.have.been.called
+      expect(telemetry.incrementSdkEventMetric).to.not.have.been.called
     })
 
-    describe('trackCustomEvent', () => {
-      it('should track valid event name', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackCustomEvent('my-custom-event', { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.events.my-custom-event.track', 'true')
-          expect(traces[0][0].meta).to.have.property('appsec.events.my-custom-event.metakey', 'metaValue')
-          expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+    it('should log warning when root span is not available', () => {
+      rootSpan = undefined
+
+      trackCustomEvent(tracer, 'custom_event')
+
+      expect(log.warn)
+        .to.have.been.calledOnceWithExactly('[ASM] Root span not available in %s', 'trackCustomEvent')
+      expect(setUserTags).to.not.have.been.called
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
+    })
+
+    it('should call addTags with metadata', () => {
+      trackCustomEvent(tracer, 'custom_event', {
+        metaKey1: 'metaValue1',
+        metakey2: 'metaValue2'
       })
 
-      it('should not track invalid event name', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackCustomEvent(null, { metakey: 'metaValue' })
-          tracer.appsec.trackCustomEvent({ event: 'name' }, { metakey: 'metaValue' })
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].metrics).to.not.have.property('_sampling_priority_v1', USER_KEEP)
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.custom_event.track': 'true',
+        '_dd.appsec.events.custom_event.sdk': 'true',
+        'appsec.events.custom_event.metaKey1': 'metaValue1',
+        'appsec.events.custom_event.metakey2': 'metaValue2'
       })
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
+    })
+
+    it('should call addTags without metadata', () => {
+      trackCustomEvent(tracer, 'custom_event')
+
+      expect(log.warn).to.not.have.been.called
+      expect(setUserTags).to.not.have.been.called
+      expect(rootSpan.addTags).to.have.been.calledOnceWithExactly({
+        'appsec.events.custom_event.track': 'true',
+        '_dd.appsec.events.custom_event.sdk': 'true'
+      })
+      expect(prioritySampler.setPriority)
+        .to.have.been.calledOnceWithExactly(rootSpan, USER_KEEP, ASM)
+      expect(telemetry.incrementSdkEventMetric).to.have.been.calledWith('custom')
     })
   })
 })

--- a/packages/dd-trace/test/appsec/sdk/user_blocking-integration.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking-integration.spec.js
@@ -1,0 +1,186 @@
+'use strict'
+
+const agent = require('../../plugins/agent')
+const tracer = require('../../../../../index')
+const appsec = require('../../../src/appsec')
+const Config = require('../../../src/config')
+const axios = require('axios')
+const path = require('path')
+const blocking = require('../../../src/appsec/blocking')
+
+describe('user_blocking - Integration with the tracer', () => {
+  const config = new Config({
+    appsec: {
+      enabled: true,
+      rules: path.join(__dirname, './user_blocking_rules.json')
+    }
+  })
+
+  let http
+  let controller
+  let appListener
+  let port
+
+  function listener (req, res) {
+    if (controller) {
+      controller(req, res)
+    }
+  }
+
+  before(async () => {
+    await agent.load('http')
+    http = require('http')
+  })
+
+  before(done => {
+    const server = new http.Server(listener)
+    appListener = server
+      .listen(port, 'localhost', () => {
+        port = appListener.address().port
+        done()
+      })
+
+    appsec.enable(config)
+  })
+
+  after(() => {
+    appsec.disable()
+
+    appListener.close()
+    return agent.close({ ritmReset: false })
+  })
+
+  describe('isUserBlocked', () => {
+    it('should set the user if user is not defined', (done) => {
+      controller = (req, res) => {
+        const ret = tracer.appsec.isUserBlocked({ id: 'testUser3' })
+        expect(ret).to.be.false
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('usr.id', 'testUser3')
+        expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not set the user if user is already defined', (done) => {
+      controller = (req, res) => {
+        tracer.setUser({ id: 'testUser' })
+
+        const ret = tracer.appsec.isUserBlocked({ id: 'testUser3' })
+        expect(ret).to.be.false
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('usr.id', 'testUser')
+        expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should return true if user is in the blocklist', (done) => {
+      controller = (req, res) => {
+        const ret = tracer.appsec.isUserBlocked({ id: 'blockedUser' })
+        expect(ret).to.be.true
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
+        expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should return true action if userID was matched before with trackUserLoginSuccessEvent()', (done) => {
+      controller = (req, res) => {
+        tracer.appsec.trackUserLoginSuccessEvent({ id: 'blockedUser' })
+        const ret = tracer.appsec.isUserBlocked({ id: 'blockedUser' })
+        expect(ret).to.be.true
+        res.end()
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+  })
+
+  describe('blockRequest', () => {
+    beforeEach(() => {
+      // reset to default, other tests may have changed it with RC
+      blocking.setDefaultBlockingActionParameters(undefined)
+    })
+
+    afterEach(() => {
+      // reset to default
+      blocking.setDefaultBlockingActionParameters(undefined)
+    })
+
+    it('should set the proper tags', (done) => {
+      controller = (req, res) => {
+        const ret = tracer.appsec.blockRequest(req, res)
+        expect(ret).to.be.true
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
+        expect(traces[0][0].meta).to.have.property('http.status_code', '403')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should set the proper tags even when not passed req and res', (done) => {
+      controller = (req, res) => {
+        const ret = tracer.appsec.blockRequest()
+        expect(ret).to.be.true
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
+        expect(traces[0][0].meta).to.have.property('http.status_code', '403')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should not set the proper tags when response has already been sent', (done) => {
+      controller = (req, res) => {
+        res.end()
+        const ret = tracer.appsec.blockRequest()
+        expect(ret).to.be.false
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.not.have.property('appsec.blocked', 'true')
+        expect(traces[0][0].meta).to.have.property('http.status_code', '200')
+        expect(traces[0][0].metrics).to.have.property('_dd.appsec.block.failed', 1)
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`)
+    })
+
+    it('should block using redirect data if it is configured', (done) => {
+      blocking.setDefaultBlockingActionParameters([
+        {
+          id: 'notblock',
+          parameters: {
+            location: '/notfound',
+            status_code: 404
+          }
+        },
+        {
+          id: 'block',
+          parameters: {
+            location: '/redirected',
+            status_code: 302
+          }
+        }
+      ])
+      controller = (req, res) => {
+        const ret = tracer.appsec.blockRequest(req, res)
+        expect(ret).to.be.true
+      }
+      agent.use(traces => {
+        expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
+        expect(traces[0][0].meta).to.have.property('http.status_code', '302')
+      }).then(done).catch(done)
+      axios.get(`http://localhost:${port}/`, { maxRedirects: 0 })
+    })
+  })
+})

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -1,15 +1,8 @@
 'use strict'
 
 const proxyquire = require('proxyquire')
-const agent = require('../../plugins/agent')
-const tracer = require('../../../../../index')
-const appsec = require('../../../src/appsec')
-const Config = require('../../../src/config')
-const axios = require('axios')
-const path = require('path')
 const waf = require('../../../src/appsec/waf')
 const { USER_ID } = require('../../../src/appsec/addresses')
-const blocking = require('../../../src/appsec/blocking')
 
 const resultActions = {
   block_request: {
@@ -19,310 +12,131 @@ const resultActions = {
   }
 }
 
-describe('user_blocking', () => {
-  describe('Internal API', () => {
-    const req = { protocol: 'https' }
-    const res = { headersSent: false }
-    const tracer = {}
+describe('user_blocking - Internal API', () => {
+  const req = { protocol: 'https' }
+  const res = { headersSent: false }
+  const tracer = {}
 
-    let rootSpan, getRootSpan, block, legacyStorage, log, userBlocking
+  let rootSpan, getRootSpan, block, legacyStorage, log, userBlocking
 
-    before(() => {
-      const runStub = sinon.stub(waf, 'run')
-      runStub.withArgs({ persistent: { [USER_ID]: 'user' } }).returns(resultActions)
-      runStub.withArgs({ persistent: { [USER_ID]: 'gooduser' } }).returns({})
-    })
+  before(() => {
+    const runStub = sinon.stub(waf, 'run')
+    runStub.withArgs({ persistent: { [USER_ID]: 'user' } }).returns(resultActions)
+    runStub.withArgs({ persistent: { [USER_ID]: 'gooduser' } }).returns({})
+  })
 
-    beforeEach(() => {
-      rootSpan = {
-        context: () => {
-          return { _tags: {} }
-        },
-        setTag: sinon.stub()
-      }
-      getRootSpan = sinon.stub().returns(rootSpan)
+  beforeEach(() => {
+    rootSpan = {
+      context: () => {
+        return { _tags: {} }
+      },
+      setTag: sinon.stub()
+    }
+    getRootSpan = sinon.stub().returns(rootSpan)
 
-      block = sinon.stub().returns(true)
+    block = sinon.stub().returns(true)
 
-      legacyStorage = {
-        getStore: sinon.stub().returns({ req, res })
-      }
+    legacyStorage = {
+      getStore: sinon.stub().returns({ req, res })
+    }
 
-      log = {
-        warn: sinon.stub()
-      }
+    log = {
+      warn: sinon.stub()
+    }
 
-      userBlocking = proxyquire('../../../src/appsec/sdk/user_blocking', {
-        './utils': { getRootSpan },
-        '../blocking': { block },
-        '../../../../datadog-core': { storage: () => legacyStorage },
-        '../../log': log
-      })
-    })
-
-    describe('checkUserAndSetUser', () => {
-      it('should return false and log warn when passed no user', () => {
-        const ret = userBlocking.checkUserAndSetUser()
-        expect(ret).to.be.false
-        expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Invalid user provided to isUserBlocked')
-      })
-
-      it('should return false and log warn when passed invalid user', () => {
-        const ret = userBlocking.checkUserAndSetUser({})
-        expect(ret).to.be.false
-        expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Invalid user provided to isUserBlocked')
-      })
-
-      it('should set user when not already set', () => {
-        const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
-        expect(ret).to.be.true
-        expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
-        expect(rootSpan.setTag).to.have.been.calledWithExactly('usr.id', 'user')
-        expect(rootSpan.setTag).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
-      })
-
-      it('should not override user when already set', () => {
-        rootSpan.context = () => {
-          return { _tags: { 'usr.id': 'mockUser' } }
-        }
-
-        const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
-        expect(ret).to.be.true
-        expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
-        expect(rootSpan.setTag).to.not.have.been.called
-      })
-
-      it('should log warn when rootSpan is not available', () => {
-        getRootSpan.returns(undefined)
-
-        const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
-        expect(ret).to.be.true
-        expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
-        expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Root span not available in isUserBlocked')
-        expect(rootSpan.setTag).to.not.have.been.called
-      })
-
-      it('should return false when received no results', () => {
-        const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'gooduser' })
-        expect(ret).to.be.false
-        expect(rootSpan.setTag).to.have.been.calledWithExactly('usr.id', 'gooduser')
-        expect(rootSpan.setTag).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
-      })
-    })
-
-    describe('blockRequest', () => {
-      it('should get req and res from local storage when they are not passed', () => {
-        const ret = userBlocking.blockRequest(tracer)
-        expect(ret).to.be.true
-        expect(legacyStorage.getStore).to.have.been.calledOnce
-        expect(block).to.be.calledOnceWithExactly(req, res, rootSpan)
-      })
-
-      it('should log warning when req or res is not available', () => {
-        legacyStorage.getStore.returns(undefined)
-
-        const ret = userBlocking.blockRequest(tracer)
-        expect(ret).to.be.false
-        expect(legacyStorage.getStore).to.have.been.calledOnce
-        expect(log.warn)
-          .to.have.been.calledOnceWithExactly('[ASM] Requests or response object not available in blockRequest')
-        expect(block).to.not.have.been.called
-      })
-
-      it('should return false and log warn when rootSpan is not available', () => {
-        getRootSpan.returns(undefined)
-
-        const ret = userBlocking.blockRequest(tracer, {}, {})
-        expect(ret).to.be.false
-        expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Root span not available in blockRequest')
-        expect(block).to.not.have.been.called
-      })
-
-      it('should call block with proper arguments', () => {
-        const req = {}
-        const res = {}
-        const ret = userBlocking.blockRequest(tracer, req, res)
-        expect(ret).to.be.true
-        expect(log.warn).to.not.have.been.called
-        expect(block).to.have.been.calledOnceWithExactly(req, res, rootSpan)
-      })
+    userBlocking = proxyquire('../../../src/appsec/sdk/user_blocking', {
+      './utils': { getRootSpan },
+      '../blocking': { block },
+      '../../../../datadog-core': { storage: () => legacyStorage },
+      '../../log': log
     })
   })
 
-  describe('Integration with the tracer', () => {
-    const config = new Config({
-      appsec: {
-        enabled: true,
-        rules: path.join(__dirname, './user_blocking_rules.json')
+  describe('checkUserAndSetUser', () => {
+    it('should return false and log warn when passed no user', () => {
+      const ret = userBlocking.checkUserAndSetUser()
+      expect(ret).to.be.false
+      expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Invalid user provided to isUserBlocked')
+    })
+
+    it('should return false and log warn when passed invalid user', () => {
+      const ret = userBlocking.checkUserAndSetUser({})
+      expect(ret).to.be.false
+      expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Invalid user provided to isUserBlocked')
+    })
+
+    it('should set user when not already set', () => {
+      const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
+      expect(ret).to.be.true
+      expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
+      expect(rootSpan.setTag).to.have.been.calledWithExactly('usr.id', 'user')
+      expect(rootSpan.setTag).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
+    })
+
+    it('should not override user when already set', () => {
+      rootSpan.context = () => {
+        return { _tags: { 'usr.id': 'mockUser' } }
       }
+
+      const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
+      expect(ret).to.be.true
+      expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
+      expect(rootSpan.setTag).to.not.have.been.called
     })
 
-    let http
-    let controller
-    let appListener
-    let port
+    it('should log warn when rootSpan is not available', () => {
+      getRootSpan.returns(undefined)
 
-    function listener (req, res) {
-      if (controller) {
-        controller(req, res)
-      }
-    }
-
-    before(async () => {
-      await agent.load('http')
-      http = require('http')
+      const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
+      expect(ret).to.be.true
+      expect(getRootSpan).to.have.been.calledOnceWithExactly(tracer)
+      expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Root span not available in isUserBlocked')
+      expect(rootSpan.setTag).to.not.have.been.called
     })
 
-    before(done => {
-      const server = new http.Server(listener)
-      appListener = server
-        .listen(port, 'localhost', () => {
-          port = appListener.address().port
-          done()
-        })
+    it('should return false when received no results', () => {
+      const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'gooduser' })
+      expect(ret).to.be.false
+      expect(rootSpan.setTag).to.have.been.calledWithExactly('usr.id', 'gooduser')
+      expect(rootSpan.setTag).to.have.been.calledWithExactly('_dd.appsec.user.collection_mode', 'sdk')
+    })
+  })
 
-      appsec.enable(config)
+  describe('blockRequest', () => {
+    it('should get req and res from local storage when they are not passed', () => {
+      const ret = userBlocking.blockRequest(tracer)
+      expect(ret).to.be.true
+      expect(legacyStorage.getStore).to.have.been.calledOnce
+      expect(block).to.be.calledOnceWithExactly(req, res, rootSpan)
     })
 
-    after(() => {
-      appsec.disable()
+    it('should log warning when req or res is not available', () => {
+      legacyStorage.getStore.returns(undefined)
 
-      appListener.close()
-      return agent.close({ ritmReset: false })
+      const ret = userBlocking.blockRequest(tracer)
+      expect(ret).to.be.false
+      expect(legacyStorage.getStore).to.have.been.calledOnce
+      expect(log.warn)
+        .to.have.been.calledOnceWithExactly('[ASM] Requests or response object not available in blockRequest')
+      expect(block).to.not.have.been.called
     })
 
-    describe('isUserBlocked', () => {
-      it('should set the user if user is not defined', (done) => {
-        controller = (req, res) => {
-          const ret = tracer.appsec.isUserBlocked({ id: 'testUser3' })
-          expect(ret).to.be.false
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('usr.id', 'testUser3')
-          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
+    it('should return false and log warn when rootSpan is not available', () => {
+      getRootSpan.returns(undefined)
 
-      it('should not set the user if user is already defined', (done) => {
-        controller = (req, res) => {
-          tracer.setUser({ id: 'testUser' })
-
-          const ret = tracer.appsec.isUserBlocked({ id: 'testUser3' })
-          expect(ret).to.be.false
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('usr.id', 'testUser')
-          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
-
-      it('should return true if user is in the blocklist', (done) => {
-        controller = (req, res) => {
-          const ret = tracer.appsec.isUserBlocked({ id: 'blockedUser' })
-          expect(ret).to.be.true
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
-          expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
-
-      it('should return true action if userID was matched before with trackUserLoginSuccessEvent()', (done) => {
-        controller = (req, res) => {
-          tracer.appsec.trackUserLoginSuccessEvent({ id: 'blockedUser' })
-          const ret = tracer.appsec.isUserBlocked({ id: 'blockedUser' })
-          expect(ret).to.be.true
-          res.end()
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
+      const ret = userBlocking.blockRequest(tracer, {}, {})
+      expect(ret).to.be.false
+      expect(log.warn).to.have.been.calledOnceWithExactly('[ASM] Root span not available in blockRequest')
+      expect(block).to.not.have.been.called
     })
 
-    describe('blockRequest', () => {
-      beforeEach(() => {
-        // reset to default, other tests may have changed it with RC
-        blocking.setDefaultBlockingActionParameters(undefined)
-      })
-
-      afterEach(() => {
-        // reset to default
-        blocking.setDefaultBlockingActionParameters(undefined)
-      })
-
-      it('should set the proper tags', (done) => {
-        controller = (req, res) => {
-          const ret = tracer.appsec.blockRequest(req, res)
-          expect(ret).to.be.true
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '403')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
-
-      it('should set the proper tags even when not passed req and res', (done) => {
-        controller = (req, res) => {
-          const ret = tracer.appsec.blockRequest()
-          expect(ret).to.be.true
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '403')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
-
-      it('should not set the proper tags when response has already been sent', (done) => {
-        controller = (req, res) => {
-          res.end()
-          const ret = tracer.appsec.blockRequest()
-          expect(ret).to.be.false
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.not.have.property('appsec.blocked', 'true')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '200')
-          expect(traces[0][0].metrics).to.have.property('_dd.appsec.block.failed', 1)
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`)
-      })
-
-      it('should block using redirect data if it is configured', (done) => {
-        blocking.setDefaultBlockingActionParameters([
-          {
-            id: 'notblock',
-            parameters: {
-              location: '/notfound',
-              status_code: 404
-            }
-          },
-          {
-            id: 'block',
-            parameters: {
-              location: '/redirected',
-              status_code: 302
-            }
-          }
-        ])
-        controller = (req, res) => {
-          const ret = tracer.appsec.blockRequest(req, res)
-          expect(ret).to.be.true
-        }
-        agent.use(traces => {
-          expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
-          expect(traces[0][0].meta).to.have.property('http.status_code', '302')
-        }).then(done).catch(done)
-        axios.get(`http://localhost:${port}/`, { maxRedirects: 0 })
-      })
+    it('should call block with proper arguments', () => {
+      const req = {}
+      const res = {}
+      const ret = userBlocking.blockRequest(tracer, req, res)
+      expect(ret).to.be.true
+      expect(log.warn).to.not.have.been.called
+      expect(block).to.have.been.calledOnceWithExactly(req, res, rootSpan)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/user_tracking.spec.js
+++ b/packages/dd-trace/test/appsec/user_tracking.spec.js
@@ -1,15 +1,16 @@
 'use strict'
 
 const assert = require('assert')
+const proxyquire = require('proxyquire')
 
 const telemetry = require('../../src/appsec/telemetry')
-const waf = require('../../src/appsec/waf')
 const { ASM } = require('../../src/standalone/product')
 
 describe('User Tracking', () => {
   let currentTags
   let rootSpan
   let log
+  let waf
   let keepTrace
 
   let setCollectionMode
@@ -19,7 +20,8 @@ describe('User Tracking', () => {
   beforeEach(() => {
     sinon.stub(telemetry, 'incrementMissingUserLoginMetric')
     sinon.stub(telemetry, 'incrementMissingUserIdMetric')
-    sinon.stub(waf, 'run').returns(['action1'])
+
+    waf = { run: sinon.stub().returns(['action1']) }
 
     currentTags = {}
 
@@ -36,9 +38,10 @@ describe('User Tracking', () => {
 
     keepTrace = sinon.stub()
 
-    const UserTracking = proxyquire('../src/appsec/user_tracking', {
+    const UserTracking = proxyquire('../../src/appsec/user_tracking', {
       '../log': log,
-      '../priority_sampler': { keepTrace }
+      '../priority_sampler': { keepTrace },
+      './waf': waf
     })
 
     setCollectionMode = UserTracking.setCollectionMode


### PR DESCRIPTION
### What does this PR do?
[APPSEC-56955](https://datadoghq.atlassian.net/browse/APPSEC-56955)

- Separating unit tests from integration tests
- Unify the way we call proxyquire
- Fix user_tracking test

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->




[APPSEC-56955]: https://datadoghq.atlassian.net/browse/APPSEC-56955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ