### PR TITLE
[DI] Temporarily disable the Node.js 18 Debugger tests

### DIFF
--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -17,7 +17,7 @@ jobs:
   ubuntu:
     strategy:
       matrix:
-        version: [18, 20, 22, latest]
+        version: [20, 22, latest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### What does this PR do?

As the title says :)

### Motivation

There's a race condition in Node.js 18 that these tests sometimes trigger when requiring the `async_hooks` module.
    
Once https://github.com/DataDog/dd-trace-js/pull/5357 is merged, this PR can be reverted.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


