### PR TITLE
[DI] Improve integration test error handling

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -79,7 +79,7 @@ function setup ({ env, testApp, testAppSource } = {}) {
   })
 
   after(async function () {
-    await sandbox.remove()
+    await sandbox?.remove()
   })
 
   beforeEach(async function () {


### PR DESCRIPTION
### What does this PR do?

In case the integration tests times out trying to create the sandbox, don't also fail trying to remove it (since it doesn't exist).

### Motivation

Better debugging experience in case of certain test failures.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


