### PR TITLE
Profiler needn't use async_hooks when tracing is off

### DIFF
--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -8,7 +8,19 @@ process.once('beforeExit', () => { profiler.stop() })
 
 module.exports = {
   start: config => {
-    const { service, version, env, url, hostname, port, tags, repositoryUrl, commitSHA, injectionEnabled } = config
+    const {
+      commitSHA,
+      env,
+      hostname,
+      injectionEnabled,
+      port,
+      repositoryUrl,
+      service,
+      tags,
+      tracing,
+      url,
+      version
+    } = config
     const { enabled, sourceMap, exporters } = config.profiling
     const logger = {
       debug: (message) => log.debug(message),
@@ -28,20 +40,21 @@ module.exports = {
     } // else activation = undefined
 
     return profiler.start({
-      service,
-      version,
-      env,
-      logger,
-      sourceMap,
-      exporters,
-      url,
-      hostname,
-      port,
-      tags,
-      repositoryUrl,
+      activation,
       commitSHA,
+      env,
+      exporters,
+      hostname,
       libraryInjected,
-      activation
+      logger,
+      port,
+      repositoryUrl,
+      service,
+      sourceMap,
+      tags,
+      tracing,
+      url,
+      version
     })
   },
 

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -115,6 +115,7 @@ class Config {
     this.flushInterval = flushInterval
     this.uploadTimeout = uploadTimeout
     this.sourceMap = sourceMap
+    this.tracing = options.tracing
     this.debugSourceMaps = isTrue(coalesce(options.debugSourceMaps, DD_PROFILING_DEBUG_SOURCE_MAPS, false))
     this.endpointCollectionEnabled = isTrue(coalesce(options.endpointCollection,
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED,


### PR DESCRIPTION
### What does this PR do?
We can delay profiler’s initialization of `async_hooks` until it's needed for either code hotspots or endpoint profiling. We can also make sure that these features are not enabled when tracing is off.

### Motivation
This should reduce the overhead of profiling when tracing is disabled as it avoids initializing and using `async_hooks`. `async_hooks` is used for features that collect data from tracing spans, so when tracing is disabled we can avoid hook initialization.