### PR TITLE
increase appsec next test start timeout to 5 minutes

### DIFF
--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -105,7 +105,7 @@ describe('test suite', () => {
       })
 
       before(function (done) {
-        this.timeout(40000)
+        this.timeout(300 * 1000)
         const cwd = appDir
 
         server = spawn('node', [serverPath], {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase AppSec next test start timeout to 5 minutes.

### Motivation
<!-- What inspired you to submit this pull request? -->

Test is flaky and sometimes times out. I'm not sure why, but given Next is involved, I just went with a timeout increase as Next is extremely slow. If that doesn't work, then there might be another issue at play (like `done()` not being called), but since I can find occurrences of the test taking ~30 seconds, I think it's very likely the timeout.