### PR TITLE
add support for cgroupv2 inode fallback

### DIFF
--- a/packages/dd-trace/src/exporters/common/docker.js
+++ b/packages/dd-trace/src/exporters/common/docker.js
@@ -2,6 +2,8 @@
 
 const fs = require('fs')
 
+const { DD_EXTERNAL_ENV } = process.env
+
 // The second part is the PCF / Garden regexp. We currently assume no suffix($) to avoid matching pod UIDs
 // See https://github.com/DataDog/datadog-agent/blob/7.40.x/pkg/util/cgroups/reader.go#L50
 const uuidSource =
@@ -51,9 +53,13 @@ module.exports = {
   inject (carrier) {
     if (entityId) {
       carrier['Datadog-Container-Id'] = entityId
-      carrier['Datadog-Entity-ID'] = `cid-${entityId}`
+      carrier['Datadog-Entity-ID'] = `ci-${entityId}`
     } else if (inode) {
       carrier['Datadog-Entity-ID'] = `in-${inode}`
+    }
+
+    if (DD_EXTERNAL_ENV) {
+      carrier['Datadog-External-Env'] = DD_EXTERNAL_ENV
     }
   }
 }

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -15,7 +15,6 @@ const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const maxActiveRequests = 8
-const containerId = docker.id()
 
 let activeRequests = 0
 
@@ -63,9 +62,7 @@ function request (data, options, callback) {
     options.headers['Content-Length'] = byteLength(dataArray)
   }
 
-  if (containerId) {
-    options.headers['Datadog-Container-ID'] = containerId
-  }
+  docker.inject(options.headers)
 
   options.agent = isSecure ? httpsAgent : httpAgent
 

--- a/packages/dd-trace/src/profiling/exporters/agent.js
+++ b/packages/dd-trace/src/profiling/exporters/agent.js
@@ -16,8 +16,6 @@ const perf = require('perf_hooks').performance
 const telemetryMetrics = require('../../telemetry/metrics')
 const profilersNamespace = telemetryMetrics.manager.namespace('profilers')
 
-const containerId = docker.id()
-
 const statusCodeCounters = []
 const requestCounter = profilersNamespace.count('profile_api.requests', [])
 const sizeDistribution = profilersNamespace.distribution('profile_api.bytes', [])
@@ -155,9 +153,7 @@ class AgentExporter extends EventSerializer {
           timeout: this._backoffTime * Math.pow(2, attempt)
         }
 
-        if (containerId) {
-          options.headers['Datadog-Container-ID'] = containerId
-        }
+        docker.inject(options.headers)
 
         if (this._url.protocol === 'unix:') {
           options.socketPath = this._url.pathname

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -5,95 +5,136 @@ require('../../setup/tap')
 describe('docker', () => {
   let docker
   let fs
+  let carrier
 
   beforeEach(() => {
     fs = {
-      readFileSync: sinon.stub()
+      readFileSync: sinon.stub(),
+      statSync: sinon.stub()
     }
+    carrier = {}
   })
 
-  it('should return an empty ID when the cgroup cannot be read', () => {
+  it('should not inject IDs when the cgroup cannot be read', () => {
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.be.undefined
+    expect(carrier['Datadog-Container-Id']).to.be.undefined
+    expect(carrier['Datadog-Entity-ID']).to.be.undefined
   })
 
   it('should support IDs with long format', () => {
+    const id = '34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376'
     const cgroup = [
-      '1:name=systemd:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376'
+      `1:name=systemd:/docker/${id}`
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
   })
 
   it('should support IDs with UUID format', () => {
+    const id = '34dc0b5e-626f-2c5c-4c51-70e34b10e765'
     const cgroup = [
-      '1:name=systemd:/uuid/34dc0b5e-626f-2c5c-4c51-70e34b10e765'
+      `1:name=systemd:/uuid/${id}`
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('34dc0b5e-626f-2c5c-4c51-70e34b10e765')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
   })
 
   it('should support IDs with ECS task format', () => {
+    const id = '34dc0b5e626f2c5c4c5170e34b10e765-1234567890'
     const cgroup = [
-      '1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890'
+      `1:name=systemd:/ecs/${id}`
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e765-1234567890')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
   })
 
   it('should support IDs with Kubernetes format', () => {
+    const id = '7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199'
     const cgroup = [
-      '1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199.scope' // eslint-disable-line @stylistic/js/max-len
+      `1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-${id}.scope` // eslint-disable-line @stylistic/js/max-len
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('7b8952daecf4c0e44bbcefe1b5c5ebc7b4839d4eefeccefe694709d3809b6199')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
   })
 
   it('should support finding IDs on any line of the cgroup', () => {
+    const id = '34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376'
     const cgroup = [
       '1:name=systemd:/nope',
-      '2:pids:/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376',
+      `2:pids:/docker/${id}`,
       '3:cpu:/invalid'
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
   })
 
   it('should support Control Group v2', () => {
+    const id = '34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376'
     const cgroup = [
-      '0::/docker/34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376'
+      `0::/docker/${id}`
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('34dc0b5e626f2c5c4c5170e34b10e7654ce36f0fcd532739f4445baabea03376')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
   })
 
   it('should support Cloud Foundry', () => {
+    const id = '6f265890-5165-7fab-6b52-18d1'
     const cgroup = [
-      '1:name=systemd:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1'
+      `1:name=systemd:/system.slice/garden.service/garden/${id}`
     ].join('\n')
 
     fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
     docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
 
-    expect(docker.id()).to.equal('6f265890-5165-7fab-6b52-18d1')
+    expect(carrier['Datadog-Container-Id']).to.equal(id)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+  })
+
+  it('should support inode when the ID is not available', () => {
+    const ino = 1234
+    const cgroup = [
+      '1:name=systemd:/system.slice/garden.service/garden/'
+    ].join('\n')
+
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.statSync.withArgs('/sys/fs/cgroup/system.slice/garden.service/garden').returns({ ino })
+    docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
+
+    expect(carrier['Datadog-Container-Id']).to.be.undefined
+    expect(carrier['Datadog-Entity-ID']).to.equal(`in-${ino}`)
   })
 })

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -6,6 +6,7 @@ describe('docker', () => {
   let docker
   let fs
   let carrier
+  let externalEnv
 
   beforeEach(() => {
     fs = {
@@ -13,6 +14,11 @@ describe('docker', () => {
       statSync: sinon.stub()
     }
     carrier = {}
+    externalEnv = process.env.DD_EXTERNAL_ENV
+  })
+
+  afterEach(() => {
+    process.env.DD_EXTERNAL_ENV = externalEnv
   })
 
   it('should not inject IDs when the cgroup cannot be read', () => {
@@ -34,7 +40,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support IDs with UUID format', () => {
@@ -48,7 +54,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support IDs with ECS task format', () => {
@@ -62,7 +68,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support IDs with Kubernetes format', () => {
@@ -76,7 +82,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support finding IDs on any line of the cgroup', () => {
@@ -92,7 +98,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support Control Group v2', () => {
@@ -106,7 +112,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support Cloud Foundry', () => {
@@ -120,7 +126,7 @@ describe('docker', () => {
     docker.inject(carrier)
 
     expect(carrier['Datadog-Container-Id']).to.equal(id)
-    expect(carrier['Datadog-Entity-ID']).to.equal(`cid-${id}`)
+    expect(carrier['Datadog-Entity-ID']).to.equal(`ci-${id}`)
   })
 
   it('should support inode when the ID is not available', () => {
@@ -136,5 +142,14 @@ describe('docker', () => {
 
     expect(carrier['Datadog-Container-Id']).to.be.undefined
     expect(carrier['Datadog-Entity-ID']).to.equal(`in-${ino}`)
+  })
+
+  it('should support external env', () => {
+    process.env.DD_EXTERNAL_ENV = 'test'
+
+    docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
+
+    expect(carrier['Datadog-External-Env']).to.equal('test')
   })
 })

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -43,7 +43,9 @@ describe('request', function () {
       debug: sinon.spy()
     }
     docker = {
-      id: sinon.stub().returns('abcd')
+      inject (carrier) {
+        carrier['datadog-container-id'] = 'abcd'
+      }
     }
     request = proxyquire('../src/exporters/common/request', {
       './docker': docker,

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -65,7 +65,7 @@ describe('exporters/agent', function () {
   let startSpan
 
   function verifyRequest (req, profiles, start, end) {
-    expect(req.headers).to.have.property('datadog-container-id', docker.id())
+    expect(req.headers).to.have.property('test', 'injected')
     expect(req.headers).to.have.property('dd-evp-origin', 'dd-trace-js')
     expect(req.headers).to.have.property('dd-evp-origin-version', version)
 
@@ -141,8 +141,8 @@ describe('exporters/agent', function () {
 
   beforeEach(() => {
     docker = {
-      id () {
-        return 'container-id'
+      inject (carrier) {
+        carrier.test = 'injected'
       }
     }
     http = {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add support for cgroupv2 inode fallback.

### Motivation
<!-- What inspired you to submit this pull request? -->

When using cgroupv2 the container ID is not always set, but the inode can be used as a fallback for correlation.