### PR TITLE
[test-optimization] [SDTEST-1784] Co-relate Playwright tests with RUM sessions

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-rum/active-test-span-rum-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-rum/active-test-span-rum-test.js
@@ -1,8 +1,11 @@
 const { test, expect } = require('@playwright/test')
 
+beforeEach(async ({ page }) => {
+  await page.goto(process.env.PW_BASE_URL)
+})
+
 test.describe('playwright', () => {
   test('should have RUM active', async ({ page }) => {
-    await page.goto(process.env.PW_BASE_URL)
     await expect(page.locator('.hello-world')).toHaveText([
       'Hello World'
     ])

--- a/integration-tests/ci-visibility/playwright-tests-rum/active-test-span-rum-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-rum/active-test-span-rum-test.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test')
 
-beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto(process.env.PW_BASE_URL)
 })
 

--- a/integration-tests/ci-visibility/playwright-tests-rum/active-test-span-rum-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-rum/active-test-span-rum-test.js
@@ -1,0 +1,10 @@
+const { test, expect } = require('@playwright/test')
+
+test.describe('playwright', () => {
+  test('should have RUM active', async ({ page }) => {
+    await page.goto(process.env.PW_BASE_URL)
+    await expect(page.locator('.hello-world')).toHaveText([
+      'Hello World'
+    ])
+  })
+})

--- a/integration-tests/ci-visibility/web-app-server.js
+++ b/integration-tests/ci-visibility/web-app-server.js
@@ -11,6 +11,9 @@ module.exports = http.createServer((req, res) => {
       <title>Hello World</title>
       <script>
         window.DD_RUM = {
+          getInternalContext: () => {
+            return true
+          },
           stopSession: () => {
             return true
           }

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -907,7 +907,7 @@ versions.forEach((version) => {
 
     if (version === 'latest') {
       context('test management', () => {
-        context('attempt to fix', () => {
+        context.only('attempt to fix', () => {
           beforeEach(() => {
             receiver.setTestManagementTests({
               playwright: {
@@ -1040,6 +1040,8 @@ versions.forEach((version) => {
                 stdio: 'pipe'
               }
             )
+
+            childProcess.stdout.pipe(process.stdout)
 
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1420,38 +1420,38 @@ versions.forEach((version) => {
         })
       })
 
-      // context('correlation between tests and RUM sessions', () => {
-      //   it('can correlate tests and RUM sessions', (done) => {
-      //     const receiverPromise = receiver
-      //       .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-      //         const events = payloads.flatMap(({ payload }) => payload.events)
-      //         const playwrightTest = events.find(event => event.type === 'test').content
-      //         assert.include(playwrightTest.meta, {
-      //           [TEST_BROWSER_NAME]: 'chromium',
-      //           [TEST_TYPE]: 'browser',
-      //           [TEST_IS_RUM_ACTIVE]: 'true'
-      //         })
-      //         assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
-      //       })
+      context('correlation between tests and RUM sessions', () => {
+        it.only('can correlate tests and RUM sessions', (done) => {
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const playwrightTest = events.find(event => event.type === 'test').content
+              assert.include(playwrightTest.meta, {
+                [TEST_BROWSER_NAME]: 'chromium',
+                [TEST_TYPE]: 'browser',
+                [TEST_IS_RUM_ACTIVE]: 'true'
+              })
+              assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
+            })
 
-      //     childProcess = exec(
-      //       './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
-      //       {
-      //         cwd,
-      //         env: {
-      //           ...getCiVisAgentlessConfig(receiver.port),
-      //           PW_BASE_URL: `http://localhost:${webAppPort}`,
-      //           TEST_DIR: './ci-visibility/playwright-tests-rum'
-      //         },
-      //         stdio: 'pipe'
-      //       }
-      //     )
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                TEST_DIR: './ci-visibility/playwright-tests-rum'
+              },
+              stdio: 'pipe'
+            }
+          )
 
-      //     childProcess.on('exit', () => {
-      //       receiverPromise.then(() => done()).catch(done)
-      //     })
-      //   })
-      // })
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
+      })
     }
   })
 })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1447,8 +1447,6 @@ versions.forEach((version) => {
             }
           )
 
-          childProcess.stdout.pipe(process.stdout)
-
           childProcess.on('exit', () => {
             receiverPromise.then(() => done()).catch(done)
           })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1420,38 +1420,38 @@ versions.forEach((version) => {
         })
       })
 
-      // context('correlation between tests and RUM sessions', () => {
-      //   it('can correlate tests and RUM sessions', (done) => {
-      //     const receiverPromise = receiver
-      //       .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-      //         const events = payloads.flatMap(({ payload }) => payload.events)
-      //         const playwrightTest = events.find(event => event.type === 'test').content
-      //         assert.include(playwrightTest.meta, {
-      //           [TEST_BROWSER_NAME]: 'chromium',
-      //           [TEST_TYPE]: 'browser',
-      //           [TEST_IS_RUM_ACTIVE]: 'true'
-      //         })
-      //         assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
-      //       })
+      context('correlation between tests and RUM sessions', () => {
+        it('can correlate tests and RUM sessions', (done) => {
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const playwrightTest = events.find(event => event.type === 'test').content
+              assert.include(playwrightTest.meta, {
+                [TEST_BROWSER_NAME]: 'chromium',
+                [TEST_TYPE]: 'browser',
+                [TEST_IS_RUM_ACTIVE]: 'true'
+              })
+              assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
+            })
 
-      //     childProcess = exec(
-      //       './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
-      //       {
-      //         cwd,
-      //         env: {
-      //           ...getCiVisAgentlessConfig(receiver.port),
-      //           PW_BASE_URL: `http://localhost:${webAppPort}`,
-      //           TEST_DIR: './ci-visibility/playwright-tests-rum'
-      //         },
-      //         stdio: 'pipe'
-      //       }
-      //     )
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                TEST_DIR: './ci-visibility/playwright-tests-rum'
+              },
+              stdio: 'pipe'
+            }
+          )
 
-      //     childProcess.on('exit', () => {
-      //       receiverPromise.then(() => done()).catch(done)
-      //     })
-      //   })
-      // })
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
+      })
     }
   })
 })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -906,7 +906,7 @@ versions.forEach((version) => {
     })
 
     if (version === 'latest') {
-      context('test management', () => {
+      context.only('test management', () => {
         context('attempt to fix', () => {
           beforeEach(() => {
             receiver.setTestManagementTests({
@@ -1040,6 +1040,8 @@ versions.forEach((version) => {
                 stdio: 'pipe'
               }
             )
+
+            childProcess.stdout.pipe(process.stdout)
 
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {
@@ -1188,6 +1190,8 @@ versions.forEach((version) => {
               }
             )
 
+            childProcess.stdout.pipe(process.stdout)
+
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {
                 if (isDisabling) {
@@ -1278,6 +1282,8 @@ versions.forEach((version) => {
                 stdio: 'pipe'
               }
             )
+
+            childProcess.stdout.pipe(process.stdout)
 
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1041,8 +1041,6 @@ versions.forEach((version) => {
               }
             )
 
-            childProcess.stdout.pipe(process.stdout)
-
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {
                 if (isQuarantined || isDisabled || shouldAlwaysPass) {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -40,7 +40,9 @@ const {
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_HAS_FAILED_ALL_RETRIES,
   TEST_NAME,
-  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED
+  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
+  TEST_IS_RUM_ACTIVE,
+  TEST_BROWSER_VERSION
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -1411,6 +1413,41 @@ versions.forEach((version) => {
               stdio: 'pipe'
             }
           )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
+      })
+
+      context('correlation between tests and RUM sessions', () => {
+        it('can correlate tests and RUM sessions', (done) => {
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const playwrightTest = events.find(event => event.type === 'test').content
+              assert.include(playwrightTest.meta, {
+                [TEST_BROWSER_NAME]: 'chromium',
+                [TEST_TYPE]: 'browser',
+                [TEST_IS_RUM_ACTIVE]: 'true'
+              })
+              assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                TEST_DIR: './ci-visibility/playwright-tests-rum'
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.stdout.pipe(process.stdout)
 
           childProcess.on('exit', () => {
             receiverPromise.then(() => done()).catch(done)

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -906,7 +906,7 @@ versions.forEach((version) => {
     })
 
     if (version === 'latest') {
-      context.only('test management', () => {
+      context('test management', () => {
         context('attempt to fix', () => {
           beforeEach(() => {
             receiver.setTestManagementTests({
@@ -1040,8 +1040,6 @@ versions.forEach((version) => {
                 stdio: 'pipe'
               }
             )
-
-            childProcess.stdout.pipe(process.stdout)
 
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {
@@ -1190,8 +1188,6 @@ versions.forEach((version) => {
               }
             )
 
-            childProcess.stdout.pipe(process.stdout)
-
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {
                 if (isDisabling) {
@@ -1282,8 +1278,6 @@ versions.forEach((version) => {
                 stdio: 'pipe'
               }
             )
-
-            childProcess.stdout.pipe(process.stdout)
 
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -907,7 +907,7 @@ versions.forEach((version) => {
 
     if (version === 'latest') {
       context('test management', () => {
-        context.only('attempt to fix', () => {
+        context('attempt to fix', () => {
           beforeEach(() => {
             receiver.setTestManagementTests({
               playwright: {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1420,38 +1420,38 @@ versions.forEach((version) => {
         })
       })
 
-      context('correlation between tests and RUM sessions', () => {
-        it('can correlate tests and RUM sessions', (done) => {
-          const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const playwrightTest = events.find(event => event.type === 'test').content
-              assert.include(playwrightTest.meta, {
-                [TEST_BROWSER_NAME]: 'chromium',
-                [TEST_TYPE]: 'browser',
-                [TEST_IS_RUM_ACTIVE]: 'true'
-              })
-              assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
-            })
+      // context('correlation between tests and RUM sessions', () => {
+      //   it('can correlate tests and RUM sessions', (done) => {
+      //     const receiverPromise = receiver
+      //       .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+      //         const events = payloads.flatMap(({ payload }) => payload.events)
+      //         const playwrightTest = events.find(event => event.type === 'test').content
+      //         assert.include(playwrightTest.meta, {
+      //           [TEST_BROWSER_NAME]: 'chromium',
+      //           [TEST_TYPE]: 'browser',
+      //           [TEST_IS_RUM_ACTIVE]: 'true'
+      //         })
+      //         assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
+      //       })
 
-          childProcess = exec(
-            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
-            {
-              cwd,
-              env: {
-                ...getCiVisAgentlessConfig(receiver.port),
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                TEST_DIR: './ci-visibility/playwright-tests-rum'
-              },
-              stdio: 'pipe'
-            }
-          )
+      //     childProcess = exec(
+      //       './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
+      //       {
+      //         cwd,
+      //         env: {
+      //           ...getCiVisAgentlessConfig(receiver.port),
+      //           PW_BASE_URL: `http://localhost:${webAppPort}`,
+      //           TEST_DIR: './ci-visibility/playwright-tests-rum'
+      //         },
+      //         stdio: 'pipe'
+      //       }
+      //     )
 
-          childProcess.on('exit', () => {
-            receiverPromise.then(() => done()).catch(done)
-          })
-        })
-      })
+      //     childProcess.on('exit', () => {
+      //       receiverPromise.then(() => done()).catch(done)
+      //     })
+      //   })
+      // })
     }
   })
 })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1420,38 +1420,38 @@ versions.forEach((version) => {
         })
       })
 
-      context('correlation between tests and RUM sessions', () => {
-        it.only('can correlate tests and RUM sessions', (done) => {
-          const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const playwrightTest = events.find(event => event.type === 'test').content
-              assert.include(playwrightTest.meta, {
-                [TEST_BROWSER_NAME]: 'chromium',
-                [TEST_TYPE]: 'browser',
-                [TEST_IS_RUM_ACTIVE]: 'true'
-              })
-              assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
-            })
+      // context('correlation between tests and RUM sessions', () => {
+      //   it('can correlate tests and RUM sessions', (done) => {
+      //     const receiverPromise = receiver
+      //       .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+      //         const events = payloads.flatMap(({ payload }) => payload.events)
+      //         const playwrightTest = events.find(event => event.type === 'test').content
+      //         assert.include(playwrightTest.meta, {
+      //           [TEST_BROWSER_NAME]: 'chromium',
+      //           [TEST_TYPE]: 'browser',
+      //           [TEST_IS_RUM_ACTIVE]: 'true'
+      //         })
+      //         assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
+      //       })
 
-          childProcess = exec(
-            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
-            {
-              cwd,
-              env: {
-                ...getCiVisAgentlessConfig(receiver.port),
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                TEST_DIR: './ci-visibility/playwright-tests-rum'
-              },
-              stdio: 'pipe'
-            }
-          )
+      //     childProcess = exec(
+      //       './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
+      //       {
+      //         cwd,
+      //         env: {
+      //           ...getCiVisAgentlessConfig(receiver.port),
+      //           PW_BASE_URL: `http://localhost:${webAppPort}`,
+      //           TEST_DIR: './ci-visibility/playwright-tests-rum'
+      //         },
+      //         stdio: 'pipe'
+      //       }
+      //     )
 
-          childProcess.on('exit', () => {
-            receiverPromise.then(() => done()).catch(done)
-          })
-        })
-      })
+      //     childProcess.on('exit', () => {
+      //       receiverPromise.then(() => done()).catch(done)
+      //     })
+      //   })
+      // })
     }
   })
 })

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:integration:debugger": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/debugger/*.spec.js\"",
     "test:integration:jest": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/jest/*.spec.js\"",
     "test:integration:mocha": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/mocha/*.spec.js\"",
-    "test:integration:playwright": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/playwright/*.spec.js\"",
+    "test:integration:playwright": "node --trace-warnings node_modules/.bin/mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/playwright/*.spec.js\"",
     "test:integration:selenium": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/selenium/*.spec.js\"",
     "test:integration:vitest": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/vitest/*.spec.js\"",
     "test:integration:profiler": "mocha --timeout 180000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/profiler/*.spec.js\"",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:integration:debugger": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/debugger/*.spec.js\"",
     "test:integration:jest": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/jest/*.spec.js\"",
     "test:integration:mocha": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/mocha/*.spec.js\"",
-    "test:integration:playwright": "node --trace-warnings node_modules/.bin/mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/playwright/*.spec.js\"",
+    "test:integration:playwright": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/playwright/*.spec.js\"",
     "test:integration:selenium": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/selenium/*.spec.js\"",
     "test:integration:vitest": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/vitest/*.spec.js\"",
     "test:integration:profiler": "mocha --timeout 180000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/profiler/*.spec.js\"",

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -111,6 +111,7 @@ module.exports = {
   pino: () => require('../pino'),
   'pino-pretty': () => require('../pino'),
   playwright: () => require('../playwright'),
+  'playwright-core': () => require('../playwright'),
   'promise-js': () => require('../promise-js'),
   promise: () => require('../promise'),
   protobufjs: () => require('../protobufjs'),

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -916,7 +916,8 @@ addHook({
       if (afterEachHook) {
         test.parent._hooks.push({
           type: 'afterEach',
-          fn: handleAfterEachHook(() => {})
+          fn: handleAfterEachHook(() => {}),
+          title: 'afterEach hook'
         })
       }
 

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -660,8 +660,7 @@ function createAfterEachHook (emptyAsyncFunction) {
       }
     }
 
-    // This avoids issues with promise rejection handling in Node 18
-    // const emptyAsyncFunction = async function () {}
+    // This avoids issues with promise rejection handling in older versions of Node
     const boundFn = emptyAsyncFunction.bind(this)
     return await boundFn(...originalArgs)
   }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -623,51 +623,51 @@ function runnerHook (runnerExport, playwrightVersion) {
   return runnerExport
 }
 
-function handleAfterEachHook (originalAfterEachHook) {
-  const symbols = Object.getOwnPropertySymbols(originalAfterEachHook)
+// function handleAfterEachHook (originalAfterEachHook) {
+//   const symbols = Object.getOwnPropertySymbols(originalAfterEachHook)
 
-  const wrappedFunction = async function ({ page }) {
-    const response = await originalAfterEachHook.apply(this, arguments)
+//   const wrappedFunction = async function ({ page }) {
+//     const response = await originalAfterEachHook.apply(this, arguments)
 
-    const isRumActive = await page.evaluate(() => {
-      if (window.DD_RUM && window.DD_RUM.stopSession) {
-        window.DD_RUM.stopSession()
-        return true
-      } else {
-        return false
-      }
-    })
+//     const isRumActive = await page.evaluate(() => {
+//       if (window.DD_RUM && window.DD_RUM.stopSession) {
+//         window.DD_RUM.stopSession()
+//         return true
+//       } else {
+//         return false
+//       }
+//     })
 
-    if (isRumActive) {
-      const url = page.url()
-      const domain = new URL(url).hostname
+//     if (isRumActive) {
+//       const url = page.url()
+//       const domain = new URL(url).hostname
 
-      await page.context().addCookies([{
-        name: 'datadog-ci-visibility-test-execution-id',
-        value: '',
-        domain,
-        expires: 0,
-        path: '/'
-      }])
-    }
+//       await page.context().addCookies([{
+//         name: 'datadog-ci-visibility-test-execution-id',
+//         value: '',
+//         domain,
+//         expires: 0,
+//         path: '/'
+//       }])
+//     }
 
-    // This is needed to enable RUM sending data
-    await page.waitForTimeout(500)
+//     // This is needed to enable RUM sending data
+//     await page.waitForTimeout(500)
 
-    return response
-  }
+//     return response
+//   }
 
-  // Copy over all symbols from the original function to the wrapped function
-  // We need to add 'page' to the symbols that don't already have it
-  symbols.forEach(symbol => {
-    if (!originalAfterEachHook[symbol].includes('page')) {
-      originalAfterEachHook[symbol].push('page')
-    }
-    wrappedFunction[symbol] = originalAfterEachHook[symbol]
-  })
+//   // Copy over all symbols from the original function to the wrapped function
+//   // We need to add 'page' to the symbols that don't already have it
+//   symbols.forEach(symbol => {
+//     if (!originalAfterEachHook[symbol].includes('page')) {
+//       originalAfterEachHook[symbol].push('page')
+//     }
+//     wrappedFunction[symbol] = originalAfterEachHook[symbol]
+//   })
 
-  return wrappedFunction
-}
+//   return wrappedFunction
+// }
 
 addHook({
   name: '@playwright/test',
@@ -830,39 +830,39 @@ addHook({
   return processHostPackage
 })
 
-addHook({
-  name: 'playwright-core',
-  file: 'lib/client/page.js',
-  versions: ['>=1.38.0']
-}, (pagePackage) => {
-  shimmer.wrap(pagePackage.Page.prototype, 'goto', goto => async function (url, options) {
-    const response = await goto.apply(this, arguments)
+// addHook({
+//   name: 'playwright-core',
+//   file: 'lib/client/page.js',
+//   versions: ['>=1.38.0']
+// }, (pagePackage) => {
+//   shimmer.wrap(pagePackage.Page.prototype, 'goto', goto => async function (url, options) {
+//     const response = await goto.apply(this, arguments)
 
-    const page = this
+//     const page = this
 
-    const isRumActive = await page.evaluate(() => {
-      if (window.DD_RUM && window.DD_RUM.getInternalContext) {
-        return !!window.DD_RUM.getInternalContext()
-      } else {
-        return false
-      }
-    })
+//     const isRumActive = await page.evaluate(() => {
+//       if (window.DD_RUM && window.DD_RUM.getInternalContext) {
+//         return !!window.DD_RUM.getInternalContext()
+//       } else {
+//         return false
+//       }
+//     })
 
-    if (isRumActive) {
-      // const testAsyncResource = new AsyncResource('bound-anonymous-fn')
-      // testAsyncResource.runInAsyncScope(() => {
-      testPageGotoCh.publish({
-        isRumActive,
-        page
-      })
-      // })
-    }
+//     if (isRumActive) {
+//       const testAsyncResource = new AsyncResource('bound-anonymous-fn')
+//       testAsyncResource.runInAsyncScope(() => {
+//         testPageGotoCh.publish({
+//           isRumActive,
+//           page
+//         })
+//       })
+//     }
 
-    return response
-  })
+//     return response
+//   })
 
-  return pagePackage
-})
+//   return pagePackage
+// })
 
 // Only in worker
 addHook({
@@ -903,25 +903,25 @@ addHook({
         browserName
       })
 
-      let afterEachHook = true
+      // let afterEachHook = true
 
-      // We intercept the afterEach hook to add a correlation between the test and the RUM session
-      for (const hook of test.parent._hooks) {
-        if (hook.type === 'afterEach' && !hook._ddHook) {
-          hook.fn = handleAfterEachHook(hook.fn)
-          hook._ddHook = true
-          afterEachHook = false
-        }
-      }
+      // // We intercept the afterEach hook to add a correlation between the test and the RUM session
+      // for (const hook of test.parent._hooks) {
+      //   if (hook.type === 'afterEach' && !hook._ddHook) {
+      //     hook.fn = handleAfterEachHook(hook.fn)
+      //     hook._ddHook = true
+      //     afterEachHook = false
+      //   }
+      // }
 
-      if (afterEachHook) {
-        test.parent._hooks.push({
-          type: 'afterEach',
-          fn: handleAfterEachHook(() => {}),
-          title: 'afterEach hook',
-          _ddHook: true
-        })
-      }
+      // if (afterEachHook) {
+      //   test.parent._hooks.push({
+      //     type: 'afterEach',
+      //     fn: handleAfterEachHook(() => {}),
+      //     title: 'afterEach hook',
+      //     _ddHook: true
+      //   })
+      // }
 
       res = _runTest.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -884,7 +884,7 @@ addHook({
 
     let existAfterEachHook = false
 
-    // // We intercept the afterEach hook to add a correlation between the test and the RUM session
+    // We try to find an existing afterEach hook with _ddHook to avoid adding a new one
     for (const hook of test.parent._hooks) {
       if (hook.type === 'afterEach' && hook._ddHook) {
         existAfterEachHook = true
@@ -892,7 +892,7 @@ addHook({
       }
     }
 
-    // In cases where there is no afterHook with _ddHook, we need to add one
+    // In cases where there is no afterEach hook with _ddHook, we need to add one
     if (!existAfterEachHook) {
       const wrappedAfterEachHook = createAfterEachHook()
       test.parent._hooks.push({

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -849,13 +849,13 @@ addHook({
     })
 
     if (isRumActive) {
-      const testAsyncResource = new AsyncResource('bound-anonymous-fn')
-      testAsyncResource.runInAsyncScope(() => {
-        testPageGotoCh.publish({
-          isRumActive,
-          page
-        })
+      // const testAsyncResource = new AsyncResource('bound-anonymous-fn')
+      // testAsyncResource.runInAsyncScope(() => {
+      testPageGotoCh.publish({
+        isRumActive,
+        page
       })
+      // })
     }
 
     return response

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -907,8 +907,9 @@ addHook({
 
       // We intercept the afterEach hook to add a correlation between the test and the RUM session
       for (const hook of test.parent._hooks) {
-        if (hook.type === 'afterEach') {
+        if (hook.type === 'afterEach' && !hook._ddHook) {
           hook.fn = handleAfterEachHook(hook.fn)
+          hook._ddHook = true
           afterEachHook = false
         }
       }
@@ -917,7 +918,8 @@ addHook({
         test.parent._hooks.push({
           type: 'afterEach',
           fn: handleAfterEachHook(() => {}),
-          title: 'afterEach hook'
+          title: 'afterEach hook',
+          _ddHook: true
         })
       }
 

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -623,56 +623,6 @@ function runnerHook (runnerExport, playwrightVersion) {
   return runnerExport
 }
 
-// TODO - CLEAN UP THIS CODE
-// function createAfterEachHook (emptyAsyncFunction) {
-//   // It is important to pass the page object to the function to make it available in the async function
-//   // See: https://github.com/microsoft/playwright/blob/release-1.38/packages/playwright/src/common/fixtures.ts#L234
-//   const wrappedFunction = async function ({ page }) {
-//     const originalArgs = arguments
-
-//     if (page) {
-//       try {
-//         const isRumActive = await page.evaluate(() => {
-//           if (window.DD_RUM && window.DD_RUM.stopSession) {
-//             window.DD_RUM.stopSession()
-//             return true
-//           } else {
-//             return false
-//           }
-//         }).catch(() => false)
-
-//         if (isRumActive) {
-//           const url = page.url()
-//           if (url) {
-//             const domain = new URL(url).hostname
-//             await page.context().addCookies([{
-//               name: 'datadog-ci-visibility-test-execution-id',
-//               value: '',
-//               domain,
-//               expires: 0,
-//               path: '/'
-//             }]).catch(() => {})
-//           }
-//         }
-
-//         // This is needed to enable RUM sending data
-//         await page.waitForTimeout(500).catch(() => {})
-//       } catch (e) {
-//         // ignore errors
-//       }
-//     }
-
-//     // This avoids issues with promise rejection handling in older versions of Node
-//     const boundFn = emptyAsyncFunction.bind(this)
-//     return await boundFn(...originalArgs).catch(e => {
-//       // Explicitly catch and re-throw to ensure proper handling
-//       throw e
-//     })
-//   }
-
-//   return wrappedFunction
-// }
-
 addHook({
   name: '@playwright/test',
   file: 'lib/runner.js',
@@ -943,9 +893,6 @@ addHook({
                     }])
                   }
                 }
-
-                // This is needed to enable RUM sending data
-                // await page.waitForTimeout(500)
               }
             } catch (e) {
               // ignore errors

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -859,14 +859,10 @@ addHook({
     })
 
     if (isRumActive) {
-      // TODO - CLEAN THIS UP
-      // const testAsyncResource = new AsyncResource('bound-anonymous-fn')
-      // testAsyncResource.runInAsyncScope(() => {
       testPageGotoCh.publish({
         isRumActive,
         page
       })
-      // })
     }
 
     return response

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -885,25 +885,28 @@ addHook({
     const testName = getTestFullname(test)
     const browserName = this._project.project.name
 
-    let existAfterEachHook = false
+    // We only need to add an afterEach hook if the test is not an attempt to fix retry
+    if (!test._ddIsAttemptToFixRetry) {
+      let existAfterEachHook = false
 
-    // We try to find an existing afterEach hook with _ddHook to avoid adding a new one
-    for (const hook of test.parent._hooks) {
-      if (hook.type === 'afterEach' && hook._ddHook) {
-        existAfterEachHook = true
-        break
+      // We try to find an existing afterEach hook with _ddHook to avoid adding a new one
+      for (const hook of test.parent._hooks) {
+        if (hook.type === 'afterEach' && hook._ddHook) {
+          existAfterEachHook = true
+          break
+        }
       }
-    }
 
-    // In cases where there is no afterEach hook with _ddHook, we need to add one
-    if (!existAfterEachHook) {
-      const wrappedAfterEachHook = createAfterEachHook(async function () {})
-      test.parent._hooks.push({
-        type: 'afterEach',
-        fn: wrappedAfterEachHook,
-        title: 'afterEach hook',
-        _ddHook: true
-      })
+      // In cases where there is no afterEach hook with _ddHook, we need to add one
+      if (!existAfterEachHook) {
+        const wrappedAfterEachHook = createAfterEachHook(async function () {})
+        test.parent._hooks.push({
+          type: 'afterEach',
+          fn: wrappedAfterEachHook,
+          title: 'afterEach hook',
+          _ddHook: true
+        })
+      }
     }
 
     // If test events are created in the worker process I need to stop creating it in the main process

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -830,39 +830,39 @@ addHook({
   return processHostPackage
 })
 
-// addHook({
-//   name: 'playwright-core',
-//   file: 'lib/client/page.js',
-//   versions: ['>=1.38.0']
-// }, (pagePackage) => {
-//   shimmer.wrap(pagePackage.Page.prototype, 'goto', goto => async function (url, options) {
-//     const response = await goto.apply(this, arguments)
+addHook({
+  name: 'playwright-core',
+  file: 'lib/client/page.js',
+  versions: ['>=1.38.0']
+}, (pagePackage) => {
+  shimmer.wrap(pagePackage.Page.prototype, 'goto', goto => async function (url, options) {
+    const response = await goto.apply(this, arguments)
 
-//     const page = this
+    const page = this
 
-//     const isRumActive = await page.evaluate(() => {
-//       if (window.DD_RUM && window.DD_RUM.getInternalContext) {
-//         return !!window.DD_RUM.getInternalContext()
-//       } else {
-//         return false
-//       }
-//     })
+    const isRumActive = await page.evaluate(() => {
+      if (window.DD_RUM && window.DD_RUM.getInternalContext) {
+        return !!window.DD_RUM.getInternalContext()
+      } else {
+        return false
+      }
+    })
 
-//     if (isRumActive) {
-//       const testAsyncResource = new AsyncResource('bound-anonymous-fn')
-//       testAsyncResource.runInAsyncScope(() => {
-//         testPageGotoCh.publish({
-//           isRumActive,
-//           page
-//         })
-//       })
-//     }
+    if (isRumActive) {
+      // const testAsyncResource = new AsyncResource('bound-anonymous-fn')
+      // testAsyncResource.runInAsyncScope(() => {
+      testPageGotoCh.publish({
+        isRumActive,
+        page
+      })
+      // })
+    }
 
-//     return response
-//   })
+    return response
+  })
 
-//   return pagePackage
-// })
+  return pagePackage
+})
 
 // Only in worker
 addHook({

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -622,41 +622,6 @@ function runnerHook (runnerExport, playwrightVersion) {
 
   return runnerExport
 }
-// TODO - CLEAN THIS UP
-// function handleBeforeEachHook (originalBeforeEachHook) {
-//   const symbols = Object.getOwnPropertySymbols(originalBeforeEachHook)
-//   const wrappedFunction = async function ({ page }) {
-//     const response = await originalBeforeEachHook.apply(this, arguments)
-
-//     const isRumActive = await page.evaluate(() => {
-//       if (window.DD_RUM && window.DD_RUM.getInternalContext) {
-//         return !!window.DD_RUM.getInternalContext()
-//       } else {
-//         return false
-//       }
-//     })
-
-//     if (isRumActive) {
-//       testPageGotoCh.publish({
-//         isRumActive,
-//         page
-//       })
-//     }
-
-//     return response
-//   }
-
-//   // Copy over all symbols from the original function to the wrapped function
-//   // We need to add 'page' to the symbols that don't already have it
-//   symbols.forEach(symbol => {
-//     if (!originalBeforeEachHook[symbol].includes('page')) {
-//       originalBeforeEachHook[symbol].push('page')
-//     }
-//     wrappedFunction[symbol] = originalBeforeEachHook[symbol]
-//   })
-
-//   return wrappedFunction
-// }
 
 function handleAfterEachHook (originalAfterEachHook) {
   const symbols = Object.getOwnPropertySymbols(originalAfterEachHook)
@@ -938,29 +903,15 @@ addHook({
         browserName
       })
 
-      // TODO - CLEAN THIS UP
-      // let beforeEachHook = true
       let afterEachHook = true
 
-      // // We intercept the beforeEach hook to add a correlation between the test and the RUM session
+      // We intercept the afterEach hook to add a correlation between the test and the RUM session
       for (const hook of test.parent._hooks) {
-      // if (hook.type === 'beforeEach') {
-      //   hook.fn = handleBeforeEachHook(hook.fn)
-      //   beforeEachHook = false
-      // } else if (hook.type === 'afterEach') {
         if (hook.type === 'afterEach') {
           hook.fn = handleAfterEachHook(hook.fn)
           afterEachHook = false
         }
       }
-
-      // In cases where the beforeEach or afterEach hook is not defined, we need to add it
-      // if (beforeEachHook) {
-      //   test.parent._hooks.push({
-      //     type: 'beforeEach',
-      //     fn: handleBeforeEachHook(() => {})
-      //   })
-      // }
 
       if (afterEachHook) {
         test.parent._hooks.push({

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -916,12 +916,11 @@ addHook({
 
       // In cases where there is no afterEach hook with _ddHook, we need to add one
       if (!existAfterEachHook) {
-        // const wrappedAfterEachHook = createAfterEachHook(async function () {})
         test.parent._hooks.push({
           type: 'afterEach',
           fn: async function ({ page }) {
-            if (page) {
-              try {
+            try {
+              if (page) {
                 const isRumActive = await page.evaluate(() => {
                   if (window.DD_RUM && window.DD_RUM.stopSession) {
                     window.DD_RUM.stopSession()
@@ -946,11 +945,10 @@ addHook({
                 }
 
                 // This is needed to enable RUM sending data
-                await page.waitForTimeout(500)
-              } catch (e) {
-                console.error(e)
-                // ignore errors
+                // await page.waitForTimeout(500)
               }
+            } catch (e) {
+              // ignore errors
             }
           },
           title: 'afterEach hook',

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -32,7 +32,8 @@ const {
   TEST_SUITE,
   TEST_SUITE_ID,
   TEST_NAME,
-  TEST_IS_RUM_ACTIVE
+  TEST_IS_RUM_ACTIVE,
+  TEST_BROWSER_VERSION
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -160,6 +161,12 @@ class PlaywrightPlugin extends CiPlugin {
         span.setTag(TEST_IS_RUM_ACTIVE, 'true')
 
         if (page) {
+          const browserVersion = page.context().browser().version()
+
+          if (browserVersion) {
+            span.setTag(TEST_BROWSER_VERSION, browserVersion)
+          }
+
           const url = page.url()
           const domain = new URL(url).hostname
           page.context().addCookies([{


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PRs co-relate Playwright E2E reporting to RUM sessions. We will co-relate them using a cookie that will contain the `trace_id` of the span.

### Motivation
<!-- What inspired you to submit this pull request? -->
There have been some Feature Requests where some customers wanted to have something similar to what we have now with the Cypress and Selenium E2E tests.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Example on how will be shown:
<img width="1044" alt="Screenshot 2025-04-02 at 11 31 52" src="https://github.com/user-attachments/assets/39e7989c-771e-47ae-bf08-8df599829d7e" />

