### PR TITLE
tracing: fix instrumentation register code

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/instrument.js
+++ b/packages/datadog-instrumentations/src/helpers/instrument.js
@@ -14,6 +14,28 @@ exports.channel = function (name) {
   return ch
 }
 
+const packageLinks = new Map()
+
+/**
+ * Registers a link between a parent package and its internally instrumented children.
+ * Helps determine compatibility if the parent lacks direct hooks.
+ * @param {string} parentName The name of the parent package (e.g., 'redis')
+ * @param {string[]} childNames An array of instrumented child package names (e.g., ['@redis/client'])
+ */
+exports.registerPackageLink = function registerPackageLink (parentName, childNames) {
+  if (!packageLinks.has(parentName)) {
+    packageLinks.set(parentName, new Set())
+  }
+  const links = packageLinks.get(parentName)
+  for (const childName of childNames) {
+    links.add(childName)
+  }
+}
+
+exports.getPackageLinks = function getPackageLinks () {
+  return packageLinks
+}
+
 /**
  * @param {string} args.name module name
  * @param {string[]} args.versions array of semver range strings

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -3,9 +3,12 @@
 const {
   channel,
   addHook,
-  AsyncResource
+  AsyncResource,
+  registerPackageLink
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
+
+registerPackageLink('redis', ['@redis/client', '@node-redis/client'])
 
 const startCh = channel('apm:redis:command:start')
 const finishCh = channel('apm:redis:command:finish')


### PR DESCRIPTION
### What does this PR do?

Addresses an issue where "incompatible integration version" was incorrectly logged for packages like Redis v4+ and Express v4. This occurred because the compatibility check didn't recognize when instrumentation succeeded by patching internal dependencies (e.g., `@redis/client` for redis) rather than the main package directly, or when only a partial patch was applied (for Express, we have different hooking code between v4 and v5).

This PR introduces a package linking mechanism via registerPackageLink in `helpers/instrument.js`. The registration logic in helpers/register.js now uses this metadata and a global success tracking set (`successfullyPatchedCombos`). Before logging incompatibility for a package version, it checks if any explicitly linked dependent package has already been successfully instrumented (using a prefix check against the global set). This prevents the incompatability log when the core functionality is covered via a related module. The specific Redis link (`redis -> @redis/client, @node-redis/client`) has been added. Additionally, it uses `successfullyPatchedCombos` to check whether some portion of the package was successfully instrumented, since express was previously throwing the incompatability log since only either v4 or v5 patching hooks were being matched.

Fixes #5092 

### Motivation
This impacts SSI injection since the instrumentation was logging that it was being aborted for v4 express, which is not correct.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


