### PR TITLE
Add message to the profiler startup error consistent with one in proxy.js

### DIFF
--- a/packages/dd-trace/src/profiler.js
+++ b/packages/dd-trace/src/profiler.js
@@ -14,7 +14,7 @@ module.exports = {
       debug: (message) => log.debug(message),
       info: (message) => log.info(message),
       warn: (message) => log.warn(message),
-      error: (message) => log.error(message)
+      error: (...args) => log.error(...args)
     }
 
     const libraryInjected = injectionEnabled.length > 0

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -18,9 +18,9 @@ function maybeSourceMap (sourceMap, SourceMapper, debug) {
   ], debug)
 }
 
-function logError (logger, err) {
+function logError (logger, ...args) {
   if (logger) {
-    logger.error(err)
+    logger.error(...args)
   }
 }
 
@@ -52,7 +52,8 @@ class Profiler extends EventEmitter {
 
   start (options) {
     return this._start(options).catch((err) => {
-      logError(options.logger, err)
+      logError(options.logger, 'Error starting profiler. For troubleshooting tips, see ' +
+        '<https://dtdg.co/nodejs-profiler-troubleshooting>', err)
       return false
     })
   }


### PR DESCRIPTION
### What does this PR do?
Add message to the profiler startup error, consistent with one in [proxy.js](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/proxy.js#L222). As such, this is a continuation of #5242.

### Motivation
Exceptions thrown in the async part of profiler initialization would not get the message that points to the troubleshooting link. Now they do. Before the change a telemetry log message from here would look like this:

```
{
  level: 'ERROR',
  count: 1,
  message: 'Generic Error',
  stack_trace: 'Error: BOOM! Async profiler startup error\n' +
    '    at Profiler._start (dd-trace/src/profiling/profiler.js:65:11)\n' +
    '    at Profiler.start (dd-trace/src/profiling/profiler.js:54:17)\n' +
    '    at Object.start (dd-trace/src/profiler.js:30:21)\n' +
    '    at Tracer._startProfiler (dd-trace/src/proxy.js:219:36)\n' +
    '    at Tracer.init (dd-trace/src/proxy.js:152:40)'
}
```

After the change:
```
{
  level: 'ERROR',
  count: 1,
  message: 'Error starting profiler. For troubleshooting tips, see <https://dtdg.co/nodejs-profiler-troubleshooting>',
  stack_trace: 'Error: BOOM! Async profiler startup error\n' +
    '    at Profiler._start (dd-trace/src/profiling/profiler.js:66:11)\n' +
    '    at Profiler.start (dd-trace/src/profiling/profiler.js:54:17)\n' +
    '    at Object.start (dd-trace/src/profiler.js:30:21)\n' +
    '    at Tracer._startProfiler (dd-trace/src/proxy.js:219:36)\n' +
    '    at Tracer.init (dd-trace/src/proxy.js:152:40)'
}
```
That is, it shows something more useful than "Generic Error".

Jira: [PROF-11346]

[PROF-11346]: https://datadoghq.atlassian.net/browse/PROF-11346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ