### PR TITLE
[DI] Fix isDefined support in probe conditions

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -50,7 +50,7 @@ function compile (node) {
   } else if (type === 'isDefined') {
     return `(() => {
       try {
-        ${value}
+        ${compile(value)}
         return true
       } catch {
         return false

--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -630,18 +630,19 @@ const typeAndDefinitionChecks = [
     true
   ],
 
-  [{ isDefined: 'foo' }, { bar: 42 }, false],
-  [{ isDefined: 'bar' }, { bar: 42 }, true],
-  [{ isDefined: 'bar' }, { bar: undefined }, true],
-  { ast: { isDefined: 'foo' }, suffix: 'const foo = undefined', expected: false },
-  { ast: { isDefined: 'foo' }, suffix: 'const foo = 42', expected: false },
-  { ast: { isDefined: 'foo' }, suffix: 'let foo', expected: false },
-  { ast: { isDefined: 'foo' }, suffix: 'let foo = undefined', expected: false },
-  { ast: { isDefined: 'foo' }, suffix: 'let foo = 42', expected: false },
-  { ast: { isDefined: 'foo' }, suffix: 'var foo', expected: true }, // var is hoisted
-  { ast: { isDefined: 'foo' }, suffix: 'var foo = undefined', expected: true }, // var is hoisted
-  { ast: { isDefined: 'foo' }, suffix: 'var foo = 42', expected: true }, // var is hoisted
-  { ast: { isDefined: 'foo' }, suffix: '', expected: false }
+  [{ isDefined: { ref: 'foo' } }, { bar: 42 }, false],
+  [{ isDefined: { ref: 'bar' } }, { bar: 42 }, true],
+  [{ isDefined: { ref: 'bar' } }, { bar: undefined }, true],
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'const foo = undefined', expected: false },
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'const foo = 42', expected: false },
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'let foo', expected: false },
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'let foo = undefined', expected: false },
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'let foo = 42', expected: false },
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'var foo', expected: true }, // var is hoisted
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'var foo = undefined', expected: true }, // var is hoisted
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'var foo = 42', expected: true }, // var is hoisted
+  { ast: { isDefined: { ref: 'foo' } }, suffix: 'function foo () {}', expected: true }, // function is hoisted
+  { ast: { isDefined: { ref: 'foo' } }, suffix: '', expected: false }
 ]
 
 function overloadPropertyWithGetter (obj, propName) {


### PR DESCRIPTION
### What does this PR do?

Fix implementation of `isDefined` as the backend will never send it a string, but instead an AST which should be compiled. So the value of `isDefined` should always be compiled similar to most other operators.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


