### PR TITLE
Start collecting async IDs in profiles

### DIFF
--- a/integration-tests/profiler/codehotspots.js
+++ b/integration-tests/profiler/codehotspots.js
@@ -6,13 +6,19 @@ const tracer = DDTrace.init()
 
 function busyLoop () {
   const start = process.hrtime.bigint()
+  let x = 0
   for (;;) {
     const now = process.hrtime.bigint()
     // Busy cycle for 100ms
     if (now - start > 100000000n) {
       break
     }
+    // Do something in addition to invoking hrtime
+    for (let i = 0; i < 1000; i++) {
+      x += Math.sqrt(Math.random() * 2 - 1)
+    }
   }
+  return x
 }
 
 let counter = 0

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -355,7 +355,12 @@ describe('profiler', () => {
             case threadNameKey: threadName = label.str; break
             case threadIdKey: threadId = label.str; break
             case osThreadIdKey: osThreadId = label.str; break
-            case asyncIdKey: asyncId = label.num; break
+            case asyncIdKey:
+              asyncId = label.num
+              if (asyncId === 0) {
+                asyncId = undefined
+              }
+              break
             default: assert.fail(`Unexpected label key ${strings.dedup(label.key)} ${encoded}`)
           }
         }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "@datadog/wasm-js-rewriter": "3.1.0",
     "@datadog/native-iast-taint-tracking": "3.3.0",
     "@datadog/native-metrics": "^3.1.0",
-    "@datadog/pprof": "5.6.0",
+    "@datadog/pprof": "5.7.0",
     "@datadog/sketches-js": "^2.1.0",
     "@isaacs/ttlcache": "^1.4.1",
     "@opentelemetry/api": ">=1.0.0 <1.9.0",

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -22,6 +22,7 @@ class Config {
       DD_AGENT_HOST,
       DD_ENV,
       DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED, // used for testing
+      DD_PROFILING_ASYNC_ID_ENABLED,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,
       DD_PROFILING_CPU_ENABLED,
       DD_PROFILING_DEBUG_SOURCE_MAPS,
@@ -178,6 +179,9 @@ class Config {
     checkOptionWithSamplingContextAllowed(this.timelineEnabled, 'Timeline view')
     this.timelineSamplingEnabled = isTrue(coalesce(options.timelineSamplingEnabled,
       DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED, true))
+
+    this.asyncIdEnabled = isTrue(coalesce(options.asyncIdEnabled,
+      DD_PROFILING_ASYNC_ID_ENABLED, this.timelineEnabled))
 
     this.codeHotspotsEnabled = isTrue(coalesce(options.codeHotspotsEnabled,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -15,6 +15,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../plugins/util/tags')
 const { tagger } = require('./tagger')
 const { isFalse, isTrue } = require('../util')
 const { getAzureTagsFromMetadata, getAzureAppMetadata } = require('../azure_metadata')
+const satisfies = require('semifies')
 
 class Config {
   constructor (options = {}) {
@@ -180,8 +181,9 @@ class Config {
     this.timelineSamplingEnabled = isTrue(coalesce(options.timelineSamplingEnabled,
       DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED, true))
 
+    // Async ID gathering only works reliably on Node >= 22.10.0
     this.asyncIdEnabled = isTrue(coalesce(options.asyncIdEnabled,
-      DD_PROFILING_ASYNC_ID_ENABLED, this.timelineEnabled))
+      DD_PROFILING_ASYNC_ID_ENABLED, this.timelineEnabled && satisfies(process.versions.node, '>=22.10.0')))
 
     this.codeHotspotsEnabled = isTrue(coalesce(options.codeHotspotsEnabled,
       DD_PROFILING_CODEHOTSPOTS_ENABLED,

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -70,13 +70,14 @@ function ensureChannelsActivated () {
 class NativeWallProfiler {
   constructor (options = {}) {
     this.type = 'wall'
-    this._samplingIntervalMicros = options.samplingInterval || 1e6 / 99 // 99hz
-    this._flushIntervalMillis = options.flushInterval || 60 * 1e3 // 60 seconds
-    this._codeHotspotsEnabled = !!options.codeHotspotsEnabled
-    this._endpointCollectionEnabled = !!options.endpointCollectionEnabled
-    this._timelineEnabled = !!options.timelineEnabled
     this._asyncIdEnabled = !!options.asyncIdEnabled
+    this._codeHotspotsEnabled = !!options.codeHotspotsEnabled
     this._cpuProfilingEnabled = !!options.cpuProfilingEnabled
+    this._endpointCollectionEnabled = !!options.endpointCollectionEnabled
+    this._flushIntervalMillis = options.flushInterval || 60 * 1e3 // 60 seconds
+    this._samplingIntervalMicros = options.samplingInterval || 1e6 / 99 // 99hz
+    this._timelineEnabled = !!options.timelineEnabled
+    this._v8ProfilerBugWorkaroundEnabled = !!options.v8ProfilerBugWorkaroundEnabled
     // We need to capture span data into the sample context for either code hotspots
     // or endpoint collection.
     this._captureSpanData = this._codeHotspotsEnabled || this._endpointCollectionEnabled
@@ -85,7 +86,6 @@ class NativeWallProfiler {
     // timestamps require the sample contexts feature in the pprof wall profiler), or
     // cpu profiling is enabled.
     this._withContexts = this._captureSpanData || this._timelineEnabled || this._cpuProfilingEnabled
-    this._v8ProfilerBugWorkaroundEnabled = !!options.v8ProfilerBugWorkaroundEnabled
     this._mapper = undefined
     this._pprof = undefined
 
@@ -128,14 +128,14 @@ class NativeWallProfiler {
     }
 
     this._pprof.time.start({
-      intervalMicros: this._samplingIntervalMicros,
+      collectAsyncId: this._asyncIdEnabled,
+      collectCpuTime: this._cpuProfilingEnabled,
       durationMillis: this._flushIntervalMillis,
+      intervalMicros: this._samplingIntervalMicros,
+      lineNumbers: false,
       sourceMapper: this._mapper,
       withContexts: this._withContexts,
-      lineNumbers: false,
-      workaroundV8Bug: this._v8ProfilerBugWorkaroundEnabled,
-      collectCpuTime: this._cpuProfilingEnabled,
-      collectAsyncId: this._asyncIdEnabled
+      workaroundV8Bug: this._v8ProfilerBugWorkaroundEnabled
     })
 
     if (this._withContexts) {

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -75,6 +75,7 @@ class NativeWallProfiler {
     this._codeHotspotsEnabled = !!options.codeHotspotsEnabled
     this._endpointCollectionEnabled = !!options.endpointCollectionEnabled
     this._timelineEnabled = !!options.timelineEnabled
+    this._asyncIdEnabled = !!options.asyncIdEnabled
     this._cpuProfilingEnabled = !!options.cpuProfilingEnabled
     // We need to capture span data into the sample context for either code hotspots
     // or endpoint collection.
@@ -133,7 +134,8 @@ class NativeWallProfiler {
       withContexts: this._withContexts,
       lineNumbers: false,
       workaroundV8Bug: this._v8ProfilerBugWorkaroundEnabled,
-      collectCpuTime: this._cpuProfilingEnabled
+      collectCpuTime: this._cpuProfilingEnabled,
+      collectAsyncId: this._asyncIdEnabled
     })
 
     if (this._withContexts) {

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -58,7 +58,8 @@ describe('profilers/native/wall', () => {
         withContexts: false,
         lineNumbers: false,
         workaroundV8Bug: false,
-        collectCpuTime: false
+        collectCpuTime: false,
+        collectAsyncId: false
       })
   })
 
@@ -77,7 +78,8 @@ describe('profilers/native/wall', () => {
         withContexts: false,
         lineNumbers: false,
         workaroundV8Bug: false,
-        collectCpuTime: false
+        collectCpuTime: false,
+        collectAsyncId: false
       })
   })
 
@@ -173,7 +175,8 @@ describe('profilers/native/wall', () => {
         withContexts: false,
         lineNumbers: false,
         workaroundV8Bug: false,
-        collectCpuTime: false
+        collectCpuTime: false,
+        collectAsyncId: false
       })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.6.0.tgz#b6f5c566512ba5e55c6dbf46e9f0f020cfd5c6b5"
-  integrity sha512-x7yN0s4wMnRqv3PWQ6eXKH5XE5qvCOwWbOsXqpT2Irbsc7Wcl5w5JrJUcbPCdSJGihpIh6kAeIrS6w/ZCcHy2Q==
+"@datadog/pprof@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.7.0.tgz#3dde6d0cce023091f30effc0aab0c896ad2d7fe3"
+  integrity sha512-+pTeElxHwNUQrqY11f6MUUJDk9pMTIvu0LZhEpDZPphq8WDNU9OBvqFFfX9YdQI/nLZAe4L8t2CEgeJJwzW5EQ==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
* Upgrades `@datadog/pprof` to 5.7.0
* Enables its [feature](https://github.com/DataDog/pprof-nodejs/pull/197) for collecting Node's execution async IDs in profiles.
* Adds a `DD_PROFILING_ASYNC_ID_ENABLED` env var to regulate the feature. It defaults to true when timelines are enabled. We have this env var mostly so we have a lever to give to customers to turn the feature off if it causes problems. We do not anticipate problems. (An earlier implementation of this feature did not guard against trying to retrieve the async ID while V8 was doing garbage collection. That caused crashes, and it has been fixed in pprof 5.7.0.)

### Motivation
We have an insight in the profiling backend for detecting long-running event callbacks that block other callbacks from running on the event loop thread. An initial version of this insight uses span IDs associated with profiling samples to identify streaks of adjacent samples that belong to the same invocation. We have since upgraded the backend algorithm to also be able to use execution async IDs when available. Execution async ID is a better datum for this for two reasons:
* it is less likely to cause false positives if two callbacks working on behalf of the same span run immediately one after the other, and
* async IDs are available to the profiler even when tracing is turned off.

### Additional information
* The ability to handle async IDs was already added in #5316, this PR merely turns the feature on in the underlying profiler.
* We released an earlier version of profiler with #5153 that didn't have the garbage collection safeguards then reverted it with #5174. This now re-enables the feature with the profiler having the necessary guards to only read the async ID when it can be safely done.

### Additional Notes
Jira: [PROF-11107]




[PROF-11107]: https://datadoghq.atlassian.net/browse/PROF-11107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ