### PR TITLE
update the release proposal workflow to create the proposal

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -38,4 +38,4 @@ jobs:
           mkdir -p ~/.config/changelog-maker
           echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
       - run: node scripts/release/proposal 5 -y --{{ inputs.increment }}
-        if: ${{ inputs.release-line == 'all' || inputs.release-line == '5' }}
+        if: inputs.release-line == 'all' || inputs.release-line == '5'

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -20,8 +20,11 @@ on:
           - minor
           - patch
 jobs:
-  check_labels:
+  create-proposal:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -25,6 +25,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -1,9 +1,24 @@
-name: Release Proposal PR check
+name: Release Proposal
 
 on:
-  pull_request:
-    branches:
-      - v[0-9]+.x
+  workflow_dispatch:
+    inputs:
+      release-line:
+        description: 'Release line'
+        required: true
+        default: 5
+        type: choice
+        options:
+          - 5
+      increment:
+        description: 'Version increment'
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - minor
+          - patch
 jobs:
   check_labels:
     runs-on: ubuntu-latest
@@ -16,4 +31,4 @@ jobs:
       - run: |
           mkdir -p ~/.config/changelog-maker
           echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
-      - run: node ./scripts/check-proposal-labels.js
+      - run: node scripts/release/proposal ${{ inputs.release-line }} -y --{{ inputs.increment }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -6,19 +6,20 @@ on:
       release-line:
         description: 'Release line'
         required: true
-        default: 5
+        default: all
         type: choice
         options:
-          - 5
+          - 'all'
+          - '5'
       increment:
         description: 'Version increment'
         required: true
         default: auto
         type: choice
         options:
-          - auto
-          - minor
-          - patch
+          - 'auto'
+          - 'minor'
+          - 'patch'
 jobs:
   create-proposal:
     runs-on: ubuntu-latest
@@ -36,4 +37,5 @@ jobs:
       - run: |
           mkdir -p ~/.config/changelog-maker
           echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
-      - run: node scripts/release/proposal ${{ inputs.release-line }} -y --{{ inputs.increment }}
+      - run: node scripts/release/proposal 5 -y --{{ inputs.increment }}
+        if: ${{ inputs.release-line == 'all' || inputs.release-line == '5' }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -1,4 +1,4 @@
-name: Release Proposal
+name: '[Release Proposal]'
 
 on:
   workflow_dispatch:

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -26,8 +26,10 @@ if (!releaseLine || releaseLine === 'help' || flags.help) {
   log(
     'Usage: node scripts/release/proposal <release-line>\n',
     'Options:',
+    '  -y         Always accept prompts.',
     '  --debug    Print raw commands and their outputs.',
     '  --help     Show this help.',
+    '  --auto     Automatically detect version increment. (this is default)',
     '  --minor    Force a minor release.',
     '  --patch    Force a patch release.'
   )
@@ -138,8 +140,10 @@ try {
 
   pass(notesFile)
 
-  // Stop and ask the user if they want to proceed with pushing everything upstream.
-  checkpoint('Push the release upstream and create/update PR?')
+  if (!flags.y) {
+    // Stop and ask the user if they want to proceed with pushing everything upstream.
+    checkpoint('Push the release upstream and create/update PR?')
+  }
 
   start('Push proposal upstream')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the release proposal workflow to create the proposal.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now it only checks the labels for a release proposal. However, the new proposal script handles cherry-picking the commits and already ignores the right labels, so errors shouldn't happen to begin with. This means that it can replace this workflow in-place to create the release proposal instead of only validating it.