### PR TITLE
Fix CI for mariadb

### DIFF
--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -155,15 +155,15 @@ function wrapPoolMethod (createConnection) {
 
 const name = 'mariadb'
 
-addHook({ name, file: 'lib/cmd/query.js', versions: ['>=3'] }, (Query) => {
+addHook({ name, file: 'lib/cmd/query.js', versions: ['>=3 <3.4.1'] }, (Query) => {
   return wrapCommand(Query)
 })
 
-addHook({ name, file: 'lib/cmd/execute.js', versions: ['>=3'] }, (Execute) => {
+addHook({ name, file: 'lib/cmd/execute.js', versions: ['>=3 <3.4.1'] }, (Execute) => {
   return wrapCommand(Execute)
 })
 
-addHook({ name, file: 'lib/pool.js', versions: ['>=3'] }, (Pool) => {
+addHook({ name, file: 'lib/pool.js', versions: ['>=3 <3.4.1'] }, (Pool) => {
   shimmer.wrap(Pool.prototype, '_createConnection', wrapPoolMethod)
 
   return Pool

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -155,6 +155,8 @@ function wrapPoolMethod (createConnection) {
 
 const name = 'mariadb'
 
+// TODO: Open the version range again as soon as we support newer versions.
+// That applies to all places where we limit the version to 3.4.1
 addHook({ name, file: 'lib/cmd/query.js', versions: ['>=3 <3.4.1'] }, (Query) => {
   return wrapCommand(Query)
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove support from 3.4.1 version of mariadb. We should address a fix in a different PR, this PR is only to unblock other unrelated PRs.

### Motivation
<!-- What inspired you to submit this pull request? -->
CI is red, unblock other PRs
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


