### PR TITLE
Supporting last mariadb version

### DIFF
--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -155,10 +155,10 @@ function wrapPoolMethod (createConnection) {
 
 function wrapPoolGetConnectionMethod (getConnection) {
   return function wrappedGetConnection () {
-    const callbackResource = new AsyncResource('bound-anonymous-fn')
     const cb = arguments[arguments.length - 1]
     if (typeof cb !== 'function') return getConnection.apply(this, arguments)
 
+    const callbackResource = new AsyncResource('bound-anonymous-fn')
     arguments[arguments.length - 1] = callbackResource.bind(cb)
 
     return getConnection.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -175,6 +175,7 @@ addHook({ name, file: 'lib/cmd/execute.js', versions: ['>=3'] }, (Execute) => {
   return wrapCommand(Execute)
 })
 
+// in 3.4.1 getConnection method start to use callbacks instead of promises
 addHook({ name, file: 'lib/pool.js', versions: ['>=3.4.1'] }, (Pool) => {
   shimmer.wrap(Pool.prototype, 'getConnection', wrapPoolGetConnectionMethod)
 

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -322,7 +322,7 @@
   "mariadb": [
     {
       "name": "mariadb",
-      "versions": ["2.5.6", "3.0.0"]
+      "versions": ["2.5.6", "3.0.0", "3.4.0"]
     }
   ],
   "mocha": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add support to the latest mariadb version

### Motivation
<!-- What inspired you to submit this pull request? -->
In the latest version, mariadb changed behaviour of `pool.getConnection` method to work with callbacks instead o Promises, breaking the tracer behaviour.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


