### PR TITLE
Remove appsec distribution metrics

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'DataDog/system-tests'
+          ref: 'ugaitz/remove-more-distribution-metrics-checks'
       - name: Checkout dd-trace-js
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'DataDog/system-tests'
-          ref: 'ugaitz/remove-more-distribution-metrics-checks'
       - name: Checkout dd-trace-js
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/packages/dd-trace/src/appsec/telemetry/rasp.js
+++ b/packages/dd-trace/src/appsec/telemetry/rasp.js
@@ -55,18 +55,6 @@ function trackRaspMetrics (store, metrics, raspRule) {
 
   appsecMetrics.count('rasp.rule.eval', tags).inc(1)
 
-  if (metrics.duration) {
-    appsecMetrics.distribution('rasp.rule.duration', tags).track(metrics.duration)
-
-    const raspDuration = telemetryMetrics.raspDuration
-    appsecMetrics.distribution('rasp.duration', versionsTags).track(raspDuration)
-  }
-
-  if (metrics.durationExt) {
-    const raspDurationExt = telemetryMetrics.raspDurationExt
-    appsecMetrics.distribution('rasp.duration_ext', versionsTags).track(raspDurationExt)
-  }
-
   if (metrics.errorCode) {
     const errorTags = { ...tags, waf_error: metrics.errorCode }
 

--- a/packages/dd-trace/src/appsec/telemetry/waf.js
+++ b/packages/dd-trace/src/appsec/telemetry/waf.js
@@ -33,20 +33,8 @@ function addWafRequestMetrics (store, { duration, durationExt, wafTimeout, error
   }
 }
 
-function trackWafDurations ({ duration, durationExt }, versionsTags) {
-  if (duration) {
-    appsecMetrics.distribution('waf.duration', versionsTags).track(duration)
-  }
-
-  if (durationExt) {
-    appsecMetrics.distribution('waf.duration_ext', versionsTags).track(durationExt)
-  }
-}
-
 function trackWafMetrics (store, metrics) {
   const versionsTags = getVersionsTags(metrics.wafVersion, metrics.rulesVersion)
-
-  trackWafDurations(metrics, versionsTags)
 
   const metricTags = getOrCreateMetricTags(store, versionsTags)
 
@@ -134,24 +122,6 @@ function incrementWafRequests (store) {
 function incrementTruncatedMetrics (metrics, truncationReason) {
   const truncationTags = { truncation_reason: truncationReason }
   appsecMetrics.count('waf.input_truncated', truncationTags).inc(1)
-
-  if (metrics?.maxTruncatedString) {
-    appsecMetrics.distribution('waf.truncated_value_size', {
-      truncation_reason: TRUNCATION_FLAGS.STRING
-    }).track(metrics.maxTruncatedString)
-  }
-
-  if (metrics?.maxTruncatedContainerSize) {
-    appsecMetrics.distribution('waf.truncated_value_size', {
-      truncation_reason: TRUNCATION_FLAGS.CONTAINER_SIZE
-    }).track(metrics.maxTruncatedContainerSize)
-  }
-
-  if (metrics?.maxTruncatedContainerDepth) {
-    appsecMetrics.distribution('waf.truncated_value_size', {
-      truncation_reason: TRUNCATION_FLAGS.CONTAINER_DEPTH
-    }).track(metrics.maxTruncatedContainerDepth)
-  }
 }
 
 function getTruncationReason ({ maxTruncatedString, maxTruncatedContainerSize, maxTruncatedContainerDepth }) {

--- a/packages/dd-trace/test/appsec/telemetry/rasp.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/rasp.spec.js
@@ -84,62 +84,6 @@ describe('Appsec Rasp Telemetry metrics', () => {
         expect(inc).to.have.been.calledTwice
       })
 
-      it('should track rasp.duration and rasp.rule.duration metrics', () => {
-        appsecTelemetry.updateRaspRequestsMetricTags({
-          duration: 42,
-          wafVersion: '1.0.0',
-          rulesVersion: '2.0.0'
-        }, req, { type: 'rule-type' })
-
-        expect(distribution).to.have.been.calledWith('rasp.rule.duration', {
-          rule_type: 'rule-type',
-          waf_version: '1.0.0',
-          event_rules_version: '2.0.0'
-        })
-        expect(track.firstCall).to.have.been.calledWith(42)
-
-        expect(distribution).to.have.been.calledWith('rasp.duration', {
-          waf_version: '1.0.0',
-          event_rules_version: '2.0.0'
-        })
-        expect(track.secondCall).to.have.been.calledWith(42)
-
-        track.resetHistory()
-
-        appsecTelemetry.updateRaspRequestsMetricTags({
-          duration: 35,
-          wafVersion: '1.0.0',
-          rulesVersion: '2.0.0'
-        }, req, { type: 'rule-type' })
-
-        expect(distribution).to.have.been.calledWith('rasp.rule.duration', {
-          rule_type: 'rule-type',
-          waf_version: '1.0.0',
-          event_rules_version: '2.0.0'
-        })
-        expect(track.firstCall).to.have.been.calledWith(35)
-
-        expect(distribution).to.have.been.calledWith('rasp.duration', {
-          waf_version: '1.0.0',
-          event_rules_version: '2.0.0'
-        })
-        expect(track.secondCall).to.have.been.calledWith(77)
-      })
-
-      it('should track rasp.duration_ext', () => {
-        appsecTelemetry.updateRaspRequestsMetricTags({
-          durationExt: 42,
-          wafVersion: '1.0.0',
-          rulesVersion: '2.0.0'
-        }, req, { type: 'rule-type' })
-
-        expect(distribution).to.have.been.calledWith('rasp.duration_ext', {
-          waf_version: '1.0.0',
-          event_rules_version: '2.0.0'
-        })
-        expect(track).to.have.been.calledWith(42)
-      })
-
       it('should track rasp.error', () => {
         appsecTelemetry.updateRaspRequestsMetricTags({
           errorCode: -127,

--- a/packages/dd-trace/test/appsec/telemetry/rasp.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/rasp.spec.js
@@ -9,7 +9,7 @@ describe('Appsec Rasp Telemetry metrics', () => {
   const wafVersion = '0.0.1'
   const rulesVersion = '0.0.2'
 
-  let count, inc, req, distribution, track
+  let count, inc, req
 
   beforeEach(() => {
     req = {}
@@ -19,13 +19,7 @@ describe('Appsec Rasp Telemetry metrics', () => {
       inc
     })
 
-    track = sinon.spy()
-    distribution = sinon.stub(appsecNamespace, 'distribution').returns({
-      track
-    })
-
     appsecNamespace.metrics.clear()
-    appsecNamespace.distributions.clear()
   })
 
   afterEach(sinon.restore)

--- a/packages/dd-trace/test/appsec/telemetry/waf.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/waf.spec.js
@@ -147,25 +147,6 @@ describe('Appsec Waf Telemetry metrics', () => {
         })
       })
 
-      it('should call trackWafDurations', () => {
-        appsecTelemetry.updateWafRequestsMetricTags({
-          duration: 42,
-          durationExt: 52,
-          ...metrics
-        }, req)
-
-        expect(distribution).to.have.been.calledTwice
-
-        const tag = {
-          waf_version: wafVersion,
-          event_rules_version: rulesVersion
-        }
-        expect(distribution.firstCall.args).to.be.deep.eq(['waf.duration', tag])
-        expect(distribution.secondCall.args).to.be.deep.eq(['waf.duration_ext', tag])
-
-        expect(track).to.have.been.calledTwice
-      })
-
       it('should sum waf.duration metrics', () => {
         appsecTelemetry.updateWafRequestsMetricTags({
           duration: 42,
@@ -365,9 +346,6 @@ describe('Appsec Waf Telemetry metrics', () => {
 
         expect(count).to.have.been.calledWith('waf.input_truncated', { truncation_reason: 1 })
         expect(inc).to.have.been.calledWith(1)
-
-        expect(distribution).to.have.been.calledWith('waf.truncated_value_size', { truncation_reason: 1 })
-        expect(track).to.have.been.calledWith(5000)
       })
 
       it('should report truncated container size metrics', () => {
@@ -376,9 +354,6 @@ describe('Appsec Waf Telemetry metrics', () => {
 
         expect(count).to.have.been.calledWith('waf.input_truncated', { truncation_reason: 2 })
         expect(inc).to.have.been.calledWith(1)
-
-        expect(distribution).to.have.been.calledWith('waf.truncated_value_size', { truncation_reason: 2 })
-        expect(track).to.have.been.calledWith(300)
       })
 
       it('should report truncated container depth metrics', () => {
@@ -387,9 +362,6 @@ describe('Appsec Waf Telemetry metrics', () => {
 
         expect(count).to.have.been.calledWith('waf.input_truncated', { truncation_reason: 4 })
         expect(inc).to.have.been.calledWith(1)
-
-        expect(distribution).to.have.been.calledWith('waf.truncated_value_size', { truncation_reason: 4 })
-        expect(track).to.have.been.calledWith(20)
       })
 
       it('should combine truncation reasons when multiple truncations occur', () => {
@@ -401,9 +373,6 @@ describe('Appsec Waf Telemetry metrics', () => {
         expect(result).to.have.property('input_truncated', true)
 
         expect(count).to.have.been.calledWith('waf.input_truncated', { truncation_reason: 7 })
-        expect(distribution).to.have.been.calledWith('waf.truncated_value_size', { truncation_reason: 1 })
-        expect(distribution).to.have.been.calledWith('waf.truncated_value_size', { truncation_reason: 2 })
-        expect(distribution).to.have.been.calledWith('waf.truncated_value_size', { truncation_reason: 4 })
       })
 
       it('should not report truncation metrics when no truncation occurs', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the distribution metrics
### Motivation
<!-- What inspired you to submit this pull request? -->
This shouldn't have to be implemented as they should be sent as "sketch" and not as "distribution" metrics.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


