### PR TITLE
[DI] Support multiple probes in the same location

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -240,6 +240,154 @@ describe('Dynamic Instrumentation', function () {
           }
         })
       }
+
+      describe('multiple probes at the same location', function () {
+        it('should support adding multiple probes at the same location', function (done) {
+          const rcConfig1 = t.generateRemoteConfig()
+          const rcConfig2 = t.generateRemoteConfig()
+          const expectedPayloads = [{
+            ddsource: 'dd_debugger',
+            service: 'node',
+            debugger: { diagnostics: { probeId: rcConfig1.config.id, probeVersion: 0, status: 'RECEIVED' } }
+          }, {
+            ddsource: 'dd_debugger',
+            service: 'node',
+            debugger: { diagnostics: { probeId: rcConfig2.config.id, probeVersion: 0, status: 'RECEIVED' } }
+          }, {
+            ddsource: 'dd_debugger',
+            service: 'node',
+            debugger: { diagnostics: { probeId: rcConfig1.config.id, probeVersion: 0, status: 'INSTALLED' } }
+          }, {
+            ddsource: 'dd_debugger',
+            service: 'node',
+            debugger: { diagnostics: { probeId: rcConfig2.config.id, probeVersion: 0, status: 'INSTALLED' } }
+          }]
+
+          t.agent.on('debugger-diagnostics', ({ payload }) => {
+            payload.forEach((event) => {
+              const expected = expectedPayloads.shift()
+              assertObjectContains(event, expected)
+            })
+            endIfDone()
+          })
+
+          t.agent.addRemoteConfig(rcConfig1)
+          t.agent.addRemoteConfig(rcConfig2)
+
+          function endIfDone () {
+            if (expectedPayloads.length === 0) done()
+          }
+        })
+
+        it('should support triggering multiple probes added at the same location', function (done) {
+          let installed = 0
+          const rcConfig1 = t.generateRemoteConfig()
+          const rcConfig2 = t.generateRemoteConfig()
+          const expectedPayloads = new Map([
+            [rcConfig1.config.id, {
+              ddsource: 'dd_debugger',
+              service: 'node',
+              debugger: { diagnostics: { probeId: rcConfig1.config.id, probeVersion: 0, status: 'EMITTING' } }
+            }],
+            [rcConfig2.config.id, {
+              ddsource: 'dd_debugger',
+              service: 'node',
+              debugger: { diagnostics: { probeId: rcConfig2.config.id, probeVersion: 0, status: 'EMITTING' } }
+            }]
+          ])
+
+          t.agent.on('debugger-diagnostics', ({ payload }) => {
+            payload.forEach((event) => {
+              const { diagnostics } = event.debugger
+              if (diagnostics.status === 'INSTALLED') {
+                if (++installed === 2) {
+                  t.axios.get(t.breakpoint.url).catch(done)
+                }
+              } else if (diagnostics.status === 'EMITTING') {
+                const expected = expectedPayloads.get(diagnostics.probeId)
+                expectedPayloads.delete(diagnostics.probeId)
+                assertObjectContains(event, expected)
+              }
+            })
+            endIfDone()
+          })
+
+          t.agent.addRemoteConfig(rcConfig1)
+          t.agent.addRemoteConfig(rcConfig2)
+
+          function endIfDone () {
+            if (expectedPayloads.size === 0) done()
+          }
+        })
+
+        it('should support not triggering any probes when all conditions are not met', function (done) {
+          let installed = 0
+          const rcConfig1 = t.generateRemoteConfig({ when: { json: { eq: [{ ref: 'foo' }, 'bar'] } } })
+          const rcConfig2 = t.generateRemoteConfig({ when: { json: { eq: [{ ref: 'foo' }, 'baz'] } } })
+
+          t.agent.on('debugger-diagnostics', ({ payload }) => {
+            payload.forEach((event) => {
+              const { diagnostics } = event.debugger
+              if (diagnostics.status === 'INSTALLED') {
+                if (++installed === 2) {
+                  t.axios.get(t.breakpoint.url).catch(done)
+                  setTimeout(done, 2000)
+                }
+              } else if (diagnostics.status === 'EMITTING') {
+                assert.fail('should not trigger any probes when all conditions are not met')
+              }
+            })
+          })
+
+          t.agent.addRemoteConfig(rcConfig1)
+          t.agent.addRemoteConfig(rcConfig2)
+        })
+
+        it('should support only triggering the probes whos conditions are met', function (done) {
+          let installed = 0
+          const rcConfig1 = t.generateRemoteConfig({ when: { json: { eq: [{ ref: 'foo' }, 'bar'] } } })
+          const rcConfig2 = t.generateRemoteConfig({
+            when: { json: { eq: [{ getmember: [{ getmember: [{ ref: 'request' }, 'params'] }, 'name'] }, 'bar'] } }
+          })
+          const rcConfig3 = t.generateRemoteConfig()
+          const expectedPayloads = new Map([
+            [rcConfig2.config.id, {
+              ddsource: 'dd_debugger',
+              service: 'node',
+              debugger: { diagnostics: { probeId: rcConfig2.config.id, probeVersion: 0, status: 'EMITTING' } }
+            }],
+            [rcConfig3.config.id, {
+              ddsource: 'dd_debugger',
+              service: 'node',
+              debugger: { diagnostics: { probeId: rcConfig3.config.id, probeVersion: 0, status: 'EMITTING' } }
+            }]
+          ])
+
+          t.agent.on('debugger-diagnostics', ({ payload }) => {
+            payload.forEach((event) => {
+              const { diagnostics } = event.debugger
+              if (diagnostics.status === 'INSTALLED') {
+                if (++installed === 3) {
+                  t.axios.get(t.breakpoint.url).catch(done)
+                }
+              } else if (diagnostics.status === 'EMITTING') {
+                const expected = expectedPayloads.get(diagnostics.probeId)
+                expectedPayloads.delete(diagnostics.probeId)
+                assertObjectContains(event, expected)
+              }
+            })
+            endIfDone()
+          })
+
+          t.agent.addRemoteConfig(rcConfig1)
+          t.agent.addRemoteConfig(rcConfig2)
+          t.agent.addRemoteConfig(rcConfig3)
+
+          function endIfDone () {
+            if (expectedPayloads.size === 0) done()
+          }
+        })
+      })
     })
 
     describe('input messages', function () {
@@ -395,7 +543,7 @@ describe('Dynamic Instrumentation', function () {
       beforeEach(t.triggerBreakpoint)
 
       it('should trigger when condition is met', function (done) {
-        t.agent.on('debugger-input', (x) => {
+        t.agent.on('debugger-input', () => {
           done()
         })
 

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -52,15 +52,15 @@ async function addBreakpoint (probe) {
 
   const release = await lock()
 
-  log.debug(
-    '[debugger:devtools_client] Adding breakpoint at %s:%d:%d (probe: %s, version: %d)',
-    url, lineNumber, columnNumber, probe.id, probe.version
-  )
-
-  const locationKey = generateLocationKey(scriptId, lineNumber, columnNumber)
-  const breakpoint = locationToBreakpoint.get(locationKey)
-
   try {
+    log.debug(
+      '[debugger:devtools_client] Adding breakpoint at %s:%d:%d (probe: %s, version: %d)',
+      url, lineNumber, columnNumber, probe.id, probe.version
+    )
+
+    const locationKey = generateLocationKey(scriptId, lineNumber, columnNumber)
+    const breakpoint = locationToBreakpoint.get(locationKey)
+
     if (breakpoint) {
       // A breakpoint already exists at this location, so we need to add the probe to the existing breakpoint
       await updateBreakpoint(breakpoint, probe)

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const { getGeneratedPosition } = require('./source-maps')
+const lock = require('./lock')()
 const session = require('./session')
 const compileCondition = require('./condition')
 const { MAX_SNAPSHOTS_PER_SECOND_PER_PROBE, MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE } = require('./defaults')
-const { findScriptFromPartialPath, probes, breakpoints } = require('./state')
+const { findScriptFromPartialPath, locationToBreakpoint, breakpointToProbes, probeToLocation } = require('./state')
 const log = require('../../log')
 
 let sessionStarted = false
@@ -43,29 +44,44 @@ async function addBreakpoint (probe) {
     ({ line: lineNumber, column: columnNumber } = await getGeneratedPosition(url, source, lineNumber, sourceMapURL))
   }
 
+  try {
+    probe.condition = probe.when?.json && compileCondition(probe.when.json)
+  } catch (err) {
+    throw new Error(`Cannot compile expression: ${probe.when.dsl}`, { cause: err })
+  }
+
+  const release = await lock()
+
   log.debug(
     '[debugger:devtools_client] Adding breakpoint at %s:%d:%d (probe: %s, version: %d)',
     url, lineNumber, columnNumber, probe.id, probe.version
   )
 
-  let condition
+  const locationKey = generateLocationKey(scriptId, lineNumber, columnNumber)
+  const breakpoint = locationToBreakpoint.get(locationKey)
+
   try {
-    condition = probe.when?.json && compileCondition(probe.when.json)
-  } catch (err) {
-    throw new Error(`Cannot compile expression: ${probe.when.dsl}`, { cause: err })
+    if (breakpoint) {
+      // A breakpoint already exists at this location, so we need to add the probe to the existing breakpoint
+      await updateBreakpoint(breakpoint, probe)
+    } else {
+      // No breakpoint exists at this location, so we need to create a new one
+      const location = {
+        scriptId,
+        lineNumber: lineNumber - 1, // Beware! lineNumber is zero-indexed
+        columnNumber
+      }
+      const result = await session.post('Debugger.setBreakpoint', {
+        location,
+        condition: probe.condition
+      })
+      probeToLocation.set(probe.id, locationKey)
+      locationToBreakpoint.set(locationKey, { id: result.breakpointId, location, locationKey })
+      breakpointToProbes.set(result.breakpointId, new Map([[probe.id, probe]]))
+    }
+  } finally {
+    release()
   }
-
-  const { breakpointId } = await session.post('Debugger.setBreakpoint', {
-    location: {
-      scriptId,
-      lineNumber: lineNumber - 1, // Beware! lineNumber is zero-indexed
-      columnNumber
-    },
-    condition
-  })
-
-  probes.set(probe.id, breakpointId)
-  breakpoints.set(breakpointId, probe)
 }
 
 async function removeBreakpoint ({ id }) {
@@ -73,24 +89,79 @@ async function removeBreakpoint ({ id }) {
     // We should not get in this state, but abort if we do, so the code doesn't fail unexpected
     throw Error(`Cannot remove probe ${id}: Debugger not started`)
   }
-  if (!probes.has(id)) {
+  if (!probeToLocation.has(id)) {
     throw Error(`Unknown probe id: ${id}`)
   }
 
-  const breakpointId = probes.get(id)
-  await session.post('Debugger.removeBreakpoint', { breakpointId })
-  probes.delete(id)
-  breakpoints.delete(breakpointId)
+  const release = await lock()
 
-  if (breakpoints.size === 0) return stop() // return instead of await to reduce number of promises created
+  try {
+    const locationKey = probeToLocation.get(id)
+    const breakpoint = locationToBreakpoint.get(locationKey)
+    const probesAtLocation = breakpointToProbes.get(breakpoint.id)
+
+    probesAtLocation.delete(id)
+    probeToLocation.delete(id)
+
+    if (probesAtLocation.size === 0) {
+      locationToBreakpoint.delete(locationKey)
+      breakpointToProbes.delete(breakpoint.id)
+      if (breakpointToProbes.size === 0) {
+        await stop() // TODO: Will this actually delete the breakpoint?
+      } else {
+        await session.post('Debugger.removeBreakpoint', { breakpointId: breakpoint.id })
+      }
+    } else {
+      await updateBreakpoint(breakpoint)
+    }
+  } finally {
+    release()
+  }
+}
+
+async function updateBreakpoint (breakpoint, probe) {
+  const probesAtLocation = breakpointToProbes.get(breakpoint.id)
+  const conditionBeforeNewProbe = compileCompoundCondition(Array.from(probesAtLocation.values()))
+
+  // If a probe is provided, add it to the breakpoint. If not, it's because we're removing a probe, but potentially
+  // need to update the condtion of the breakpoint.
+  if (probe) {
+    probesAtLocation.set(probe.id, probe)
+    probeToLocation.set(probe.id, breakpoint.locationKey)
+  }
+
+  const condition = compileCompoundCondition(Array.from(probesAtLocation.values()))
+
+  if (condition || conditionBeforeNewProbe !== condition) {
+    await session.post('Debugger.removeBreakpoint', { breakpointId: breakpoint.id })
+    breakpointToProbes.delete(breakpoint.id)
+    const result = await session.post('Debugger.setBreakpoint', {
+      location: breakpoint.location,
+      condition
+    })
+    breakpoint.id = result.breakpointId
+    breakpointToProbes.set(result.breakpointId, probesAtLocation)
+  }
 }
 
 function start () {
   sessionStarted = true
-  return session.post('Debugger.enable') // return instead of await to reduce number of promises created
+  return session.post('Debugger.enable')
 }
 
 function stop () {
   sessionStarted = false
-  return session.post('Debugger.disable') // return instead of await to reduce number of promises created
+  return session.post('Debugger.disable')
+}
+
+// Only if all probes have a condition can we use a compound condition.
+// Otherwise, we need to evaluate each probe individually once the breakpoint is hit.
+function compileCompoundCondition (probes) {
+  return probes.every(p => p.condition)
+    ? probes.map(p => p.condition).filter(Boolean).join(' || ')
+    : undefined
+}
+
+function generateLocationKey (scriptId, lineNumber, columnNumber) {
+  return `${scriptId}:${lineNumber}:${columnNumber}`
 }

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -66,13 +66,13 @@ session.on('Debugger.paused', async ({ params }) => {
       }
     }
 
-    // If all the probes has a condition, we know that it triggered. If at least one probe doesn't have a condition, we
+    // If all the probes have a condition, we know that it triggered. If at least one probe doesn't have a condition, we
     // need to verify which conditions are met.
-    const shouldVerifyConditions = !(
+    const shouldVerifyConditions = (
       SUPPORT_ITERATOR_METHODS
         ? probesAtLocation.values()
         : Array.from(probesAtLocation.values())
-    ).every((probe) => probe.condition !== undefined)
+    ).some((probe) => probe.condition === undefined)
 
     for (const probe of probesAtLocation.values()) {
       if (start - probe.lastCaptureNs < probe.nsBetweenSampling) {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { randomUUID } = require('crypto')
-const { breakpoints } = require('./state')
+const { breakpointToProbes } = require('./state')
 const session = require('./session')
 const { getLocalStateForCallFrame } = require('./snapshot')
 const send = require('./send')
@@ -11,6 +11,7 @@ const { parentThreadId } = require('./config')
 const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('./defaults')
 const log = require('../../log')
 const { version } = require('../../../../../package.json')
+const { NODE_MAJOR } = require('../../../../../version')
 
 require('./remote_config')
 
@@ -25,57 +26,92 @@ const expression = `
 const threadId = parentThreadId === 0 ? `pid:${process.pid}` : `pid:${process.pid};tid:${parentThreadId}`
 const threadName = parentThreadId === 0 ? 'MainThread' : `WorkerThread:${parentThreadId}`
 
+const SUPPORT_ITERATOR_METHODS = NODE_MAJOR >= 22
+const SUPPORT_ARRAY_BUFFER_RESIZE = NODE_MAJOR >= 20
 const oneSecondNs = 1_000_000_000n
 let globalSnapshotSamplingRateWindowStart = 0n
 let snapshotsSampledWithinTheLastSecond = 0
+// TODO: Is a limit of 256 snapshots ever going to be a problem?
+const snapshotProbeIndexBuffer = new ArrayBuffer(1, { maxByteLength: 256 })
+// TODO: Is a limit of 256 probes ever going to be a problem?
+// TODO: Change to const once we drop support for Node.js 18
+let snapshotProbeIndex = new Uint8Array(snapshotProbeIndexBuffer)
 
 // WARNING: The code above the line `await session.post('Debugger.resume')` is highly optimized. Please edit with care!
 session.on('Debugger.paused', async ({ params }) => {
   const start = process.hrtime.bigint()
 
   let maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength
+  let sampled = false
+  let numberOfProbesWithSnapshots = 0
+  const probes = []
 
   // V8 doesn't allow setting more than one breakpoint at a specific location, however, it's possible to set two
   // breakpoints just next to each other that will "snap" to the same logical location, which in turn will be hit at the
   // same time. E.g. index.js:1:1 and index.js:1:2.
-  // TODO: Investigate if it will improve performance to create a fast-path for when there's only a single breakpoint
-  let sampled = false
-  const length = params.hitBreakpoints.length
-  const probes = []
-  // TODO: Consider reusing this array between pauses and only recreating it if it needs to grow
-  const snapshotProbeIndex = new Uint8Array(length) // TODO: Is a limit of 256 probes ever going to be a problem?
-  let numberOfProbesWithSnapshots = 0
-  for (let i = 0; i < length; i++) {
-    const id = params.hitBreakpoints[i]
-    const probe = breakpoints.get(id)
+  let numberOfProbesOnBreakpoint = params.hitBreakpoints.length
 
-    if (start - probe.lastCaptureNs < probe.nsBetweenSampling) {
-      continue
+  // TODO: Investigate if it will improve performance to create a fast-path for when there's only a single breakpoint
+  for (let i = 0; i < params.hitBreakpoints.length; i++) {
+    const probesAtLocation = breakpointToProbes.get(params.hitBreakpoints[i])
+
+    if (probesAtLocation.size !== 1) {
+      numberOfProbesOnBreakpoint = numberOfProbesOnBreakpoint + probesAtLocation.size - 1
+      if (numberOfProbesOnBreakpoint > snapshotProbeIndex.length) {
+        if (SUPPORT_ARRAY_BUFFER_RESIZE) {
+          snapshotProbeIndexBuffer.resize(numberOfProbesOnBreakpoint)
+        } else {
+          snapshotProbeIndex = new Uint8Array(numberOfProbesOnBreakpoint)
+        }
+      }
     }
 
-    if (probe.captureSnapshot === true) {
-      // This algorithm to calculate number of sampled snapshots within the last second is not perfect, as it's not a
-      // sliding window. But it's quick and easy :)
-      if (i === 0 && start - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
-        snapshotsSampledWithinTheLastSecond = 1
-        globalSnapshotSamplingRateWindowStart = start
-      } else if (snapshotsSampledWithinTheLastSecond >= MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) {
+    // If all the probes has a condition, we know that it triggered. If at least one probe doesn't have a condition, we
+    // need to verify which conditions are met.
+    const shouldVerifyConditions = !(
+      SUPPORT_ITERATOR_METHODS
+        ? probesAtLocation.values()
+        : Array.from(probesAtLocation.values())
+    ).every((probe) => probe.condition !== undefined)
+
+    for (const probe of probesAtLocation.values()) {
+      if (start - probe.lastCaptureNs < probe.nsBetweenSampling) {
         continue
-      } else {
-        snapshotsSampledWithinTheLastSecond++
       }
 
-      snapshotProbeIndex[numberOfProbesWithSnapshots++] = probes.length
-      maxReferenceDepth = highestOrUndefined(probe.capture.maxReferenceDepth, maxReferenceDepth)
-      maxCollectionSize = highestOrUndefined(probe.capture.maxCollectionSize, maxCollectionSize)
-      maxFieldCount = highestOrUndefined(probe.capture.maxFieldCount, maxFieldCount)
-      maxLength = highestOrUndefined(probe.capture.maxLength, maxLength)
+      if (shouldVerifyConditions && probe.condition !== undefined) {
+        const { result } = await session.post('Debugger.evaluateOnCallFrame', {
+          callFrameId: params.callFrames[0].callFrameId,
+          expression: probe.condition,
+          returnByValue: true
+        })
+        if (result.value !== true) continue
+      }
+
+      if (probe.captureSnapshot === true) {
+        // This algorithm to calculate number of sampled snapshots within the last second is not perfect, as it's not a
+        // sliding window. But it's quick and easy :)
+        if (i === 0 && start - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
+          snapshotsSampledWithinTheLastSecond = 1
+          globalSnapshotSamplingRateWindowStart = start
+        } else if (snapshotsSampledWithinTheLastSecond >= MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) {
+          continue
+        } else {
+          snapshotsSampledWithinTheLastSecond++
+        }
+
+        snapshotProbeIndex[numberOfProbesWithSnapshots++] = probes.length
+        maxReferenceDepth = highestOrUndefined(probe.capture.maxReferenceDepth, maxReferenceDepth)
+        maxCollectionSize = highestOrUndefined(probe.capture.maxCollectionSize, maxCollectionSize)
+        maxFieldCount = highestOrUndefined(probe.capture.maxFieldCount, maxFieldCount)
+        maxLength = highestOrUndefined(probe.capture.maxLength, maxLength)
+      }
+
+      sampled = true
+      probe.lastCaptureNs = start
+
+      probes.push(probe)
     }
-
-    sampled = true
-    probe.lastCaptureNs = start
-
-    probes.push(probe)
   }
 
   if (sampled === false) {

--- a/packages/dd-trace/src/debugger/devtools_client/lock.js
+++ b/packages/dd-trace/src/debugger/devtools_client/lock.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = () => async function lock () {
+  if (lock.p) await lock.p
+  let resolve
+  lock.p = new Promise((_resolve) => { resolve = _resolve }).then(() => { lock.p = null })
+  return resolve
+}

--- a/packages/dd-trace/src/debugger/devtools_client/remote_config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/remote_config.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { workerData: { rcPort } } = require('node:worker_threads')
+const lock = require('./lock')()
 const { addBreakpoint, removeBreakpoint } = require('./breakpoints')
 const { ackReceived, ackInstalled, ackError } = require('./status')
 const log = require('../../log')
@@ -97,11 +98,4 @@ async function processMsg (action, probe) {
   } finally {
     release()
   }
-}
-
-async function lock () {
-  if (lock.p) await lock.p
-  let resolve
-  lock.p = new Promise((_resolve) => { resolve = _resolve }).then(() => { lock.p = null })
-  return resolve
 }

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -11,8 +11,9 @@ const loadedScripts = []
 const scriptUrls = new Map()
 
 module.exports = {
-  probes: new Map(),
-  breakpoints: new Map(),
+  locationToBreakpoint: new Map(),
+  breakpointToProbes: new Map(),
+  probeToLocation: new Map(),
 
   /**
    * Find the script to inspect based on a partial or absolute path. Handles both Windows and POSIX paths.

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -1,0 +1,450 @@
+'use strict'
+
+require('../../setup/mocha')
+
+describe('breakpoints', function () {
+  let breakpoints
+  let sessionMock
+  let stateMock
+
+  beforeEach(function () {
+    sessionMock = {
+      post: sinon.stub().callsFake((method, { location } = {}) => {
+        if (method === 'Debugger.setBreakpoint') {
+          return Promise.resolve({
+            breakpointId: `bp-${location.scriptId}:${location.lineNumber}:${location.columnNumber}`
+          })
+        }
+        return Promise.resolve({})
+      }),
+      '@noCallThru': true
+    }
+
+    stateMock = {
+      findScriptFromPartialPath: sinon.stub().returns({
+        url: 'file:///path/to/test.js',
+        scriptId: 'script-1',
+        sourceMapURL: null,
+        source: null
+      }),
+      locationToBreakpoint: new Map(),
+      breakpointToProbes: new Map(),
+      probeToLocation: new Map(),
+      '@noCallThru': true
+    }
+
+    breakpoints = proxyquire('../src/debugger/devtools_client/breakpoints', {
+      './session': sessionMock,
+      './state': stateMock
+    })
+  })
+
+  describe('addBreakpoint', function () {
+    it('should enable debugger for the first breakpoint', async function () {
+      await breakpoints.addBreakpoint({
+        id: 'probe-1',
+        version: 1,
+        where: {
+          sourceFile: 'test.js',
+          lines: ['10']
+        }
+      })
+
+      expect(sessionMock.post.callCount).to.equal(2)
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.enable')
+      expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+        location: {
+          scriptId: 'script-1',
+          lineNumber: 9,
+          columnNumber: 0
+        },
+        condition: undefined
+      })
+    })
+
+    it('should not enable debugger for subsequent breakpoints', async function () {
+      // First breakpoint
+      await breakpoints.addBreakpoint({
+        id: 'probe-1',
+        version: 1,
+        where: {
+          sourceFile: 'test.js',
+          lines: ['10']
+        }
+      })
+
+      sessionMock.post.resetHistory()
+
+      // Second breakpoint
+      await breakpoints.addBreakpoint({
+        id: 'probe-2',
+        version: 1,
+        where: {
+          sourceFile: 'test2.js',
+          lines: ['20']
+        }
+      })
+
+      expect(sessionMock.post.callCount).to.equal(1)
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.setBreakpoint')
+    })
+
+    describe('add multiple probes to the same location', function () {
+      it('no conditions', async function () {
+        // Add first probe
+        await breakpoints.addBreakpoint({
+          id: 'probe-1',
+          version: 1,
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        sessionMock.post.resetHistory()
+
+        // Add second probe to same location
+        await breakpoints.addBreakpoint({
+          id: 'probe-2',
+          version: 1,
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        expect(sessionMock.post.callCount).to.equal(0)
+      })
+
+      it('mixed: 2nd probe no condition', async function () {
+        // Add first probe
+        await breakpoints.addBreakpoint({
+          id: 'probe-1',
+          version: 1,
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo = 42'
+          },
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        // Reset call history
+        sessionMock.post.resetHistory()
+
+        // Add second probe to same location
+        await breakpoints.addBreakpoint({
+          id: 'probe-2',
+          version: 1,
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        // Should remove previous breakpoint and create a new one with both conditions
+        expect(sessionMock.post.callCount).to.equal(2)
+        expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
+          breakpointId: 'bp-script-1:9:0'
+        })
+        expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0
+          },
+          condition: undefined
+        })
+      })
+
+      it('mixed: 1st probe no condition', async function () {
+        // Add first probe
+        await breakpoints.addBreakpoint({
+          id: 'probe-1',
+          version: 1,
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        // Reset call history
+        sessionMock.post.resetHistory()
+
+        // Add second probe to same location
+        await breakpoints.addBreakpoint({
+          id: 'probe-2',
+          version: 1,
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo = 42'
+          },
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        expect(sessionMock.post.callCount).to.equal(0)
+      })
+
+      it('all conditions', async function () {
+        // Add first probe
+        await breakpoints.addBreakpoint({
+          id: 'probe-1',
+          version: 1,
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo == 42'
+          },
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        // Reset call history
+        sessionMock.post.resetHistory()
+
+        // Add second probe to same location
+        await breakpoints.addBreakpoint({
+          id: 'probe-2',
+          version: 1,
+          when: {
+            json: { eq: [{ ref: 'foo' }, 43] },
+            dsl: 'foo == 43'
+          },
+          where: {
+            sourceFile: 'test.js',
+            lines: ['10']
+          }
+        })
+
+        // Should remove previous breakpoint and create a new one with both conditions
+        expect(sessionMock.post.callCount).to.equal(2)
+        expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
+          breakpointId: 'bp-script-1:9:0'
+        })
+        expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0
+          },
+          condition: '(foo) === (42) || (foo) === (43)'
+        })
+      })
+
+      it('should allow adding multiple probes at the same location synchronously', async function () {
+        // Test we don't hit a race condition where the internal state isn't updated before we try to add a new probe
+        await Promise.all([
+          breakpoints.addBreakpoint({
+            id: 'probe-1',
+            version: 1,
+            where: { sourceFile: 'test.js', lines: ['10'] }
+          }),
+          breakpoints.addBreakpoint({
+            id: 'probe-2',
+            version: 1,
+            where: { sourceFile: 'test.js', lines: ['10'] }
+          })
+        ])
+        expect(sessionMock.post.callCount).to.equal(2)
+        expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.enable')
+        expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint')
+      })
+    })
+
+    it('should throw error if script not found', async function () {
+      stateMock.findScriptFromPartialPath.returns(null)
+
+      const probe = {
+        id: 'probe-1',
+        version: 1,
+        where: {
+          sourceFile: 'test.js',
+          lines: ['10']
+        }
+      }
+
+      await breakpoints.addBreakpoint(probe)
+        .then(() => {
+          throw new Error('Should not resolve')
+        })
+        .catch((err) => {
+          expect(err).to.be.instanceOf(Error)
+          expect(err.message).to.equal('No loaded script found for test.js (probe: probe-1, version: 1)')
+        })
+    })
+
+    it('should handle condition compilation errors', async function () {
+      const probe = {
+        id: 'probe-1',
+        version: 1,
+        where: {
+          sourceFile: 'test.js',
+          lines: ['10']
+        },
+        when: {
+          json: { invalid: 'condition' },
+          dsl: 'this is an invalid condition'
+        }
+      }
+
+      await breakpoints.addBreakpoint(probe)
+        .then(() => {
+          throw new Error('Should not resolve')
+        })
+        .catch((err) => {
+          expect(err).to.be.instanceOf(Error)
+          expect(err.message).to.equal('Cannot compile expression: this is an invalid condition')
+        })
+    })
+  })
+
+  describe('removeBreakpoint', function () {
+    it('should disable debugger instead of removing the breakpoint if it is the last breakpoint', async function () {
+      await addProbe()
+      sessionMock.post.resetHistory()
+
+      await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+      expect(sessionMock.post.callCount).to.equal(1)
+      expect(sessionMock.post).to.have.been.calledWith('Debugger.disable')
+    })
+
+    it('should not disable debugger when there are other breakpoints', async function () {
+      await addProbe()
+      await addProbe({ id: 'probe-2', where: { sourceFile: 'test2.js', lines: ['20'] } })
+      sessionMock.post.resetHistory()
+
+      await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+      expect(sessionMock.post.callCount).to.equal(1)
+      expect(sessionMock.post).to.have.been.calledWith('Debugger.removeBreakpoint', { breakpointId: 'bp-script-1:9:0' })
+    })
+
+    describe('update breakpoint when removing one of multiple probes at the same location', function () {
+      it('no conditions', async function () {
+        await addProbe()
+        await addProbe({ id: 'probe-2' })
+        sessionMock.post.resetHistory()
+
+        await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+        expect(sessionMock.post.callCount).to.equal(0)
+      })
+
+      it('mixed: removed probe with no condition', async function () {
+        await addProbe()
+        await addProbe({
+          id: 'probe-2',
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo = 42'
+          }
+        })
+        sessionMock.post.resetHistory()
+
+        await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+        expect(sessionMock.post.callCount).to.equal(2)
+        expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
+          breakpointId: 'bp-script-1:9:0'
+        })
+        expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0
+          },
+          condition: '(foo) === (42)'
+        })
+      })
+
+      it('mixed: removed probe with condtion', async function () {
+        await addProbe({
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo = 42'
+          }
+        })
+        await addProbe({ id: 'probe-2' })
+        sessionMock.post.resetHistory()
+
+        await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+        expect(sessionMock.post.callCount).to.equal(0)
+      })
+
+      it('all conditions', async function () {
+        await addProbe({
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo = 42'
+          }
+        })
+        await addProbe({
+          id: 'probe-2',
+          when: {
+            json: { eq: [{ ref: 'foo' }, 43] },
+            dsl: 'foo = 43'
+          }
+        })
+        sessionMock.post.resetHistory()
+
+        await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+        expect(sessionMock.post.callCount).to.equal(2)
+        expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
+          breakpointId: 'bp-script-1:9:0'
+        })
+        expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0
+          },
+          condition: '(foo) === (43)'
+        })
+      })
+    })
+
+    it('should throw error if debugger not started', async function () {
+      await breakpoints.removeBreakpoint({ id: 'probe-1' })
+        .then(() => {
+          throw new Error('Should not resolve')
+        })
+        .catch((err) => {
+          expect(err).to.be.instanceOf(Error)
+          expect(err.message).to.equal('Cannot remove probe probe-1: Debugger not started')
+        })
+    })
+
+    it('should throw error if probe is unknown', async function () {
+      await addProbe()
+      await breakpoints.removeBreakpoint({ id: 'unknown-probe' })
+        .then(() => {
+          throw new Error('Should not resolve')
+        })
+        .catch((err) => {
+          expect(err).to.be.instanceOf(Error)
+          expect(err.message).to.equal('Unknown probe id: unknown-probe')
+        })
+    })
+  })
+
+  async function addProbe ({ id, version, where, when } = {}) {
+    await breakpoints.addBreakpoint({
+      id: id || 'probe-1',
+      version: version || 1,
+      where: where || {
+        sourceFile: 'test.js',
+        lines: ['10']
+      },
+      when
+    })
+  }
+})


### PR DESCRIPTION
### What does this PR do?

Allow the user to set multiple probes on the same location (file/line/column).

The Chrome DevTools Protocol API that we use (`Debugger.setBreakpoint`) does not allow more than one breakpoint per location. To get around this, we keep a reference to which probes should be at each physical breakpoint and "execute" those when the shared breakpoint is hit.

### Motivation

Align on feature parity with the other tracers

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


