### PR TITLE
[DI] Reduce size of compiled code when comparing number literals

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -35,7 +35,9 @@ const reservedWords = new Set([
 
 // TODO: Consider storing some of these functions on `process` so they can be reused across probes
 function compile (node) {
-  if (node === null || typeof node === 'number' || typeof node === 'boolean' || typeof node === 'string') {
+  if (node === null || typeof node === 'number' || typeof node === 'boolean') {
+    return node
+  } else if (typeof node === 'string') {
     return JSON.stringify(node)
   }
 
@@ -210,6 +212,9 @@ function guardAgainstPropertyAccessSideEffects (variable, propertyName) {
 }
 
 function guardAgainstCoercionSideEffects (variable) {
+  // shortcut if we're comparing number literals
+  if (typeof variable === 'number') return variable
+
   return `((val) => {
     if (
       typeof val === 'object' && val !== null && (

--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -280,6 +280,7 @@ const equality = [
   [{ gt: [{ ref: 'str' }, 'a'] }, { str: 'a' }, false],
   [{ gt: [{ ref: 'str' }, 'b'] }, { str: 'a' }, false],
   [{ gt: [{ or: [2, 0] }, { and: [1, 1] }] }, {}, true],
+  { ast: { gt: [1, 2] }, expected: '1 > 2', execute: false },
   [
     { gt: [{ ref: 'obj' }, 5] },
     { obj: objectWithToPrimitiveSymbol },
@@ -328,6 +329,7 @@ const equality = [
   [{ ge: [{ ref: 'str' }, 'a'] }, { str: 'a' }, true],
   [{ ge: [{ ref: 'str' }, 'b'] }, { str: 'a' }, false],
   [{ ge: [{ or: [1, 0] }, { and: [1, 2] }] }, {}, false],
+  { ast: { ge: [1, 2] }, expected: '1 >= 2', execute: false },
   [
     { ge: [{ ref: 'obj' }, 5] },
     { obj: objectWithToPrimitiveSymbol },
@@ -351,6 +353,7 @@ const equality = [
   [{ lt: [{ ref: 'str' }, 'a'] }, { str: 'a' }, false],
   [{ lt: [{ ref: 'str' }, 'b'] }, { str: 'a' }, true],
   [{ lt: [{ or: [1, 0] }, { and: [1, 0] }] }, {}, false],
+  { ast: { lt: [1, 2] }, expected: '1 < 2', execute: false },
   [
     { lt: [{ ref: 'obj' }, 5] },
     { obj: objectWithToPrimitiveSymbol },
@@ -374,6 +377,7 @@ const equality = [
   [{ le: [{ ref: 'str' }, 'a'] }, { str: 'a' }, true],
   [{ le: [{ ref: 'str' }, 'b'] }, { str: 'a' }, true],
   [{ le: [{ or: [2, 0] }, { and: [1, 1] }] }, {}, false],
+  { ast: { le: [1, 2] }, expected: '1 <= 2', execute: false },
   [
     { le: [{ ref: 'obj' }, 5] },
     { obj: objectWithToPrimitiveSymbol },


### PR DESCRIPTION
### What does this PR do?

If comparing two things using either `<`, `<=`, `>`, or `>=`, there's a risk of coercion side-effects if one of the sides of the comparator is an object. We already guard against this, but we didn't have a fast-path for if a given side of the comparator was a number-literal.

This PR now adds that fast-path, so the resulting code is shorter and simpler.

### Motivation

There's no need to guard against coercion if we know that we're comparing against a number literal. That just creates more complex code.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


