### PR TITLE
[DI] Don't rely on logs track to split JSON keys on periods

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -318,7 +318,7 @@ describe('Dynamic Instrumentation', function () {
         })
 
         t.agent.on('debugger-input', ({ payload }) => {
-          payload.forEach(({ 'debugger.snapshot': { timestamp } }) => {
+          payload.forEach(({ debugger: { snapshot: { timestamp } } }) => {
             if (prev !== undefined) {
               const duration = timestamp - prev
               clearTimeout(timer)
@@ -364,8 +364,8 @@ describe('Dynamic Instrumentation', function () {
 
         t.agent.on('debugger-input', ({ payload }) => {
           payload.forEach((result) => {
-            const _state = state[result['debugger.snapshot'].probe.id]
-            const { timestamp } = result['debugger.snapshot']
+            const _state = state[result.debugger.snapshot.probe.id]
+            const { timestamp } = result.debugger.snapshot
             if (_state.prev !== undefined) {
               const duration = timestamp - _state.prev
               clearTimeout(_state.timer)
@@ -588,13 +588,15 @@ function assertBasicInputPayload (t, payload) {
       version,
       thread_name: 'MainThread'
     },
-    'debugger.snapshot': {
-      probe: {
-        id: t.rcConfig.config.id,
-        version: 0,
-        location: { file: t.breakpoint.deployedFile, lines: [String(t.breakpoint.line)] }
-      },
-      language: 'javascript'
+    debugger: {
+      snapshot: {
+        probe: {
+          id: t.rcConfig.config.id,
+          version: 0,
+          location: { file: t.breakpoint.deployedFile, lines: [String(t.breakpoint.line)] }
+        },
+        language: 'javascript'
+      }
     }
   }
 
@@ -602,14 +604,14 @@ function assertBasicInputPayload (t, payload) {
 
   assert.match(payload.logger.thread_id, /^pid:\d+$/)
 
-  assertUUID(payload['debugger.snapshot'].id)
-  assert.isNumber(payload['debugger.snapshot'].timestamp)
-  assert.isTrue(payload['debugger.snapshot'].timestamp > Date.now() - 1000 * 60)
-  assert.isTrue(payload['debugger.snapshot'].timestamp <= Date.now())
+  assertUUID(payload.debugger.snapshot.id)
+  assert.isNumber(payload.debugger.snapshot.timestamp)
+  assert.isTrue(payload.debugger.snapshot.timestamp > Date.now() - 1000 * 60)
+  assert.isTrue(payload.debugger.snapshot.timestamp <= Date.now())
 
-  assert.isArray(payload['debugger.snapshot'].stack)
-  assert.isAbove(payload['debugger.snapshot'].stack.length, 0)
-  for (const frame of payload['debugger.snapshot'].stack) {
+  assert.isArray(payload.debugger.snapshot.stack)
+  assert.isAbove(payload.debugger.snapshot.stack.length, 0)
+  for (const frame of payload.debugger.snapshot.stack) {
     assert.isObject(frame)
     assert.hasAllKeys(frame, ['fileName', 'function', 'lineNumber', 'columnNumber'])
     assert.isString(frame.fileName)
@@ -617,7 +619,7 @@ function assertBasicInputPayload (t, payload) {
     assert.isAbove(frame.lineNumber, 0)
     assert.isAbove(frame.columnNumber, 0)
   }
-  const topFrame = payload['debugger.snapshot'].stack[0]
+  const topFrame = payload.debugger.snapshot.stack[0]
   // path seems to be prefeixed with `/private` on Mac
   assert.match(topFrame.fileName, new RegExp(`${t.appFile}$`))
   assert.strictEqual(topFrame.function, 'fooHandler')

--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -16,7 +16,7 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
 
       t.agent.addRemoteConfig(t.generateRemoteConfig({ captureSnapshot: true }))
 
-      const [{ payload: [{ 'debugger.snapshot': { captures } }] }] = await promise
+      const [{ payload: [{ debugger: { snapshot: { captures } } }] }] = await promise
       const { locals } = captures.lines[t.breakpoint.line]
 
       assert.deepPropertyVal(locals, 'foo', { type: 'string', notCapturedReason: 'redactedIdent' })
@@ -38,7 +38,7 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
 
       t.agent.addRemoteConfig(t.generateRemoteConfig({ captureSnapshot: true }))
 
-      const [{ payload: [{ 'debugger.snapshot': { captures } }] }] = await promise
+      const [{ payload: [{ debugger: { snapshot: { captures } } }] }] = await promise
       const { locals } = captures.lines[t.breakpoint.line]
 
       assert.deepPropertyVal(locals, 'secret', { type: 'string', value: 'shh!' })

--- a/integration-tests/debugger/snapshot-global-sample-rate.spec.js
+++ b/integration-tests/debugger/snapshot-global-sample-rate.spec.js
@@ -50,7 +50,7 @@ describe('Dynamic Instrumentation', function () {
         })
 
         t.agent.on('debugger-input', ({ payload }) => {
-          payload.forEach(({ 'debugger.snapshot': { timestamp } }) => {
+          payload.forEach(({ debugger: { snapshot: { timestamp } } }) => {
             if (isDone) return
             if (start === 0) start = timestamp
             if (++hitBreakpoints <= MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) {

--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -13,7 +13,7 @@ describe('Dynamic Instrumentation', function () {
       it('should prune snapshot if payload is too large', function (done) {
         t.agent.on('debugger-input', ({ payload: [payload] }) => {
           assert.isBelow(Buffer.byteLength(JSON.stringify(payload)), 1024 * 1024) // 1MB
-          assert.deepEqual(payload['debugger.snapshot'].captures, {
+          assert.deepEqual(payload.debugger.snapshot.captures, {
             lines: {
               [t.breakpoint.line]: {
                 locals: {

--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -11,7 +11,7 @@ describe('Dynamic Instrumentation', function () {
       beforeEach(t.triggerBreakpoint)
 
       it('should capture a snapshot', function (done) {
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { captures } } }] }) => {
           assert.deepEqual(Object.keys(captures), ['lines'])
           assert.deepEqual(Object.keys(captures.lines), [String(t.breakpoint.line)])
 
@@ -114,7 +114,7 @@ describe('Dynamic Instrumentation', function () {
       })
 
       it('should respect maxReferenceDepth', function (done) {
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { captures } } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
           delete locals.request
           delete locals.fastify
@@ -150,7 +150,7 @@ describe('Dynamic Instrumentation', function () {
       })
 
       it('should respect maxLength', function (done) {
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { captures } } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
 
           assert.deepEqual(locals.lstr, {
@@ -167,7 +167,7 @@ describe('Dynamic Instrumentation', function () {
       })
 
       it('should respect maxCollectionSize', function (done) {
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { captures } } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
 
           assert.deepEqual(locals.arr, {
@@ -205,7 +205,7 @@ describe('Dynamic Instrumentation', function () {
           }
         }
 
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { captures } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { captures } } }] }) => {
           const { locals } = captures.lines[t.breakpoint.line]
 
           assert.deepStrictEqual(Object.keys(locals), [

--- a/integration-tests/debugger/source-map-support.spec.js
+++ b/integration-tests/debugger/source-map-support.spec.js
@@ -14,7 +14,7 @@ describe('Dynamic Instrumentation', function () {
       beforeEach(t.triggerBreakpoint)
 
       it('should support source maps', function (done) {
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { probe: { location } } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { probe: { location } } } }] }) => {
           assert.deepEqual(location, {
             file: 'target-app/source-map-support/typescript.ts',
             lines: ['9']
@@ -35,7 +35,7 @@ describe('Dynamic Instrumentation', function () {
       beforeEach(t.triggerBreakpoint)
 
       it('should support source maps', function (done) {
-        t.agent.on('debugger-input', ({ payload: [{ 'debugger.snapshot': { probe: { location } } }] }) => {
+        t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { probe: { location } } } }] }) => {
           assert.deepEqual(location, {
             file: 'target-app/source-map-support/minify.js',
             lines: ['6']

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -39,7 +39,7 @@ function send (message, logger, dd, snapshot) {
     message,
     logger,
     dd,
-    'debugger.snapshot': snapshot
+    debugger: { snapshot }
   }
 
   let json = JSON.stringify(payload)
@@ -47,7 +47,7 @@ function send (message, logger, dd, snapshot) {
 
   if (size > MAX_LOG_PAYLOAD_SIZE) {
     // TODO: This is a very crude way to handle large payloads. Proper pruning will be implemented later (DEBUG-2624)
-    const line = Object.values(payload['debugger.snapshot'].captures.lines)[0]
+    const line = Object.values(payload.debugger.snapshot.captures.lines)[0]
     line.locals = {
       notCapturedReason: 'Snapshot was too large',
       size: Object.keys(line.locals).length

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -92,6 +92,6 @@ function getPayload (_message = message) {
     message: _message,
     logger,
     dd,
-    'debugger.snapshot': snapshot
+    debugger: { snapshot }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Don't rely on logs track to split JSON keys on periods.
    
The logs track will split a JSON key like `debugger.snapshot` into `debugger: { snapshot }`. This saves a tiny amount of object creation client side, but makes each installed tracer dependant on this custom behavior from the logs track.

### Motivation

To allow us more flexibility in the future, better not rely on this oddity.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


