### PR TITLE
[DI] Conditions: Allow testing of primitives with instanceof

### DIFF
--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -621,8 +621,21 @@ const membershipAndMatching = [
 ]
 
 const typeAndDefinitionChecks = [
+  // Primitive types
+  [{ instanceof: [{ ref: 'foo' }, 'string'] }, { foo: 'foo' }, true],
+  [{ instanceof: [{ ref: 'foo' }, 'number'] }, { foo: 42 }, true],
+  [{ instanceof: [{ ref: 'foo' }, 'number'] }, { foo: '42' }, false],
+  [{ instanceof: [{ ref: 'foo' }, 'bigint'] }, { foo: 42n }, true],
+  [{ instanceof: [{ ref: 'foo' }, 'boolean'] }, { foo: false }, true],
+  [{ instanceof: [{ ref: 'foo' }, 'boolean'] }, { foo: 0 }, false],
+  [{ instanceof: [{ ref: 'foo' }, 'undefined'] }, { foo: undefined }, true],
+  [{ instanceof: [{ ref: 'foo' }, 'symbol'] }, { foo: Symbol('foo') }, true],
+  [{ instanceof: [{ ref: 'foo' }, 'null'] }, { foo: null }, false], // typeof null is 'object'
+
+  // Objects
   [{ instanceof: [{ ref: 'bar' }, 'Object'] }, { bar: {} }, true],
   [{ instanceof: [{ ref: 'bar' }, 'Error'] }, { bar: new Error() }, true],
+  [{ instanceof: [{ ref: 'bar' }, 'Error'] }, { bar: {} }, false],
   [{ instanceof: [{ ref: 'bar' }, 'CustomObject'] }, { bar: new CustomObject(), CustomObject }, true],
   [
     { instanceof: [{ ref: 'bar' }, 'HasInstanceSideEffect'] },

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -100,10 +100,19 @@ function generateTestCaseName (ast, dataOrSuffix, expected) {
     ? JSON.stringify(dataOrSuffix)
     : Object
       .entries(dataOrSuffix)
-      .map(([key, value]) => `${key} = ${JSON.stringify(value)}`)
+      .map(([key, value]) => `${key} = ${serialize(value)}`)
       .join('; ')
 
   return `${JSON.stringify(ast)} + "${code}" = ${expected}`
+}
+
+function serialize (value) {
+  try {
+    return JSON.stringify(value)
+  } catch (e) {
+    // Some values are not serializable to JSON, so we fall back to stringification
+    return String(value)
+  }
 }
 
 function runWithDebug (fn, args = []) {


### PR DESCRIPTION
### What does this PR do?

Check for magic strings on the right side of the `instanceof` operator and use a `typeof` check instead if any of the primitive types are being tested (`string`, `number`, `symbol` etc).

### Motivation

Otherwise it wouldn't be possible to check the type of a variable against a primitive type.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


