### PR TITLE
[DI] Condtions: Allow using len to count keys in objects

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -172,8 +172,12 @@ function getSize (variable) {
       return ${guardAgainstPropertyAccessSideEffects('val', '"length"')}
     } else if (${isInstanceOfCoreType('Set', 'val')} || ${isInstanceOfCoreType('Map', 'val')}) {
       return ${guardAgainstPropertyAccessSideEffects('val', '"size"')}
+    } else if (${isInstanceOfCoreType('WeakSet', 'val')} || ${isInstanceOfCoreType('WeakMap', 'val')}) {
+      throw new TypeError('Cannot get size of WeakSet or WeakMap')
+    } else if (typeof val === 'object' && val !== null) {
+      return Object.keys(val).length
     } else {
-      throw new TypeError('Cannot get length or size of string/collection')
+      throw new TypeError('Cannot get length of variable')
     }
   })(${variable})`
 }

--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -195,12 +195,12 @@ const sizes = [
   [
     { len: { ref: 'wset' } },
     { wset: new WeakSet([weakKey]) },
-    new TypeError('Cannot get length or size of string/collection')
+    new TypeError('Cannot get size of WeakSet or WeakMap')
   ],
   [
     { len: { ref: 'wmap' } },
     { wmap: new WeakMap([[weakKey, 2]]) },
-    new TypeError('Cannot get length or size of string/collection')
+    new TypeError('Cannot get size of WeakSet or WeakMap')
   ],
   [{ len: { getmember: [{ ref: 'obj' }, 'arr'] } }, { obj: { arr: Array(10).fill(0) } }, 10],
   [{ len: { getmember: [{ ref: 'obj' }, 'tarr'] } }, { obj: { tarr: new Int16Array([10, 20, 30]) } }, 3],
@@ -212,7 +212,7 @@ const sizes = [
   [
     { len: { getmember: [{ ref: 'obj' }, 'unknownProp'] } },
     { obj: {} },
-    new TypeError('Cannot get length or size of string/collection')
+    new TypeError('Cannot get length of variable')
   ],
   [{ len: { ref: 'invalid' } }, {}, new ReferenceError('invalid is not defined')],
 
@@ -237,7 +237,7 @@ const sizes = [
   [
     { isEmpty: { ref: 'obj' } },
     { obj: new WeakSet() },
-    new TypeError('Cannot get length or size of string/collection')
+    new TypeError('Cannot get size of WeakSet or WeakMap')
   ]
 ]
 

--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -209,6 +209,7 @@ const sizes = [
     { obj: { tarr: overloadPropertyWithGetter(new Int16Array([10, 20, 30]), 'length') } },
     new Error('Possibility of side effect')
   ],
+  [{ len: { ref: 'pojo' } }, { pojo: { a: 1, b: 2, c: 3 } }, 3],
   [
     { len: { getmember: [{ ref: 'obj' }, 'unknownProp'] } },
     { obj: {} },


### PR DESCRIPTION
### What does this PR do?

As the title says

### Motivation

Otherwise there would be no way to get the number of keys in an object.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


