### PR TITLE
chore: fix loading of instrumentations

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -51,6 +51,7 @@ if (DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false') {
 }
 
 const seenCombo = new Set()
+const allInstrumentations = {}
 
 // TODO: make this more efficient
 for (const packageName of names) {
@@ -66,6 +67,9 @@ for (const packageName of names) {
     hookOptions.internals = hook.esmFirst
     hook = hook.fn
   }
+
+  // get the instrumentation file name to save all hooked versions
+  const instrumentationFileName = parseHookInstrumentationFileName(packageName)
 
   Hook([packageName], hookOptions, (moduleExports, moduleName, moduleBaseDir, moduleVersion) => {
     moduleName = moduleName.replace(pathSepExpr, '/')
@@ -105,6 +109,7 @@ for (const packageName of names) {
         let version = moduleVersion
         try {
           version = version || getVersion(moduleBaseDir)
+          allInstrumentations[instrumentationFileName] = allInstrumentations[instrumentationFileName] || false
         } catch (e) {
           log.error('Error getting version for "%s": %s', name, e.message, e)
           continue
@@ -114,6 +119,8 @@ for (const packageName of names) {
         }
 
         if (matchVersion(version, versions)) {
+          allInstrumentations[instrumentationFileName] = true
+
           // Check if the hook already has a set moduleExport
           if (hook[HOOK_SYMBOL].has(moduleExports)) {
             namesAndSuccesses[`${name}@${version}`] = true
@@ -143,7 +150,8 @@ for (const packageName of names) {
     for (const nameVersion of Object.keys(namesAndSuccesses)) {
       const [name, version] = nameVersion.split('@')
       const success = namesAndSuccesses[nameVersion]
-      if (!success && !seenCombo.has(nameVersion)) {
+      // we check allVersions to see if any version of the integration was successfully instrumented
+      if (!success && !seenCombo.has(nameVersion) && !allInstrumentations[instrumentationFileName]) {
         telemetry('abort.integration', [
           `integration:${name}`,
           `integration_version:${version}`
@@ -169,6 +177,38 @@ function getVersion (moduleBaseDir) {
 
 function filename (name, file) {
   return [name, file].filter(val => val).join('/')
+}
+
+// This function captures the instrumentation file name for a given package by parsing the hook require
+// function given the module name. It is used to ensure that instrumentations such as redis
+// that have several different modules being hooked, ie: 'redis' main package, and @redis/client submodule
+// return a consistent instrumentation name. This is used later to ensure that atleast some portion of
+// the integration was successfully instrumented. Prevents incorrect `Found incompatible integration version: ` messages
+// Example:
+//                  redis -> "() => require('../redis')" -> redis
+//          @redis/client -> "() => require('../redis')" -> redis
+//
+function parseHookInstrumentationFileName (packageName) {
+  let hook = hooks[packageName]
+  if (hook.fn) {
+    hook = hook.fn
+  }
+  const hookString = hook.toString()
+
+  const regex = /require\('([^']*)'\)/
+  const match = hookString.match(regex)
+
+  // try to capture the hook require file location.
+  if (match && match[1]) {
+    let moduleName = match[1]
+    // Remove leading '../' if present
+    if (moduleName.startsWith('../')) {
+      moduleName = moduleName.substring(3)
+    }
+    return moduleName
+  }
+
+  return null
 }
 
 module.exports = {


### PR DESCRIPTION
### What does this PR do?
Fixes bug causing debug logs during loading of instrumentations, where if 1 instrumentation hook was not used, due to the instrumented package not being a supported version, but the rest of the instrumentation was succesfully hooked, the debug log of `Found incompatible integration version: [instrumentation]`. 

Fixes #5092 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


