### PR TITLE
Fix profiler test flakiness

### DIFF
--- a/integration-tests/profiler/codehotspots.js
+++ b/integration-tests/profiler/codehotspots.js
@@ -1,16 +1,21 @@
 'use strict'
 
 const DDTrace = require('dd-trace')
-
 const tracer = DDTrace.init()
+
+// Busy cycle duration is communicated in nanoseconds through the environment
+// variable by the test. On first execution, it'll be 10 * the sampling period
+// at 99Hz (so, 101010101ns). If subsequent executions are needed, it will be
+// prolonged.
+const busyCycleTime = BigInt(process.env.BUSY_CYCLE_TIME)
 
 function busyLoop () {
   const start = process.hrtime.bigint()
   let x = 0
   for (;;) {
     const now = process.hrtime.bigint()
-    // Busy cycle for 100ms
-    if (now - start > 100000000n) {
+    // Busy cycle
+    if (now - start > busyCycleTime) {
       break
     }
     // Do something in addition to invoking hrtime


### PR DESCRIPTION
### What does this PR do?
Adds retries for execution of the prop program for the profiler integration test for code hotspots if its execution gathered less than 60% of expected samples. Adaptively adjusts the run duration of the prop to achieve the desired sample count.

### Motivation
It's flaky. 

### Additional Notes
The profiler integration test for code hotspots will execute a test program `codehotspots.js` for about 900ms (the test program creates 9 spans, each then runs a busy loop for about 101ms) while profiling it. Under normal conditions, the profiler would capture 90 samples during 900ms at its normal sampling rate of 99Hz. However various factors – most likely, CPU saturation – can cause the V8 thread that triggers PROF signals to be CPU starved, leading to a profile with too few samples (on flaky failures, we observed as little as 18 samples gathered.) We'll retry execution, adjusting the duration of the test program run until we get a profile with at least 60% of the ideal count, which should be enough for the rest of the test to succeed.

Jira: [PROF-11107]




[PROF-11107]: https://datadoghq.atlassian.net/browse/PROF-11107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ