### PR TITLE
[test-optimization] [SDTEST-1830] Add @test.retry_reason to the retries of different frameworks

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -55,7 +55,8 @@ const {
   DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_HAS_FAILED_ALL_RETRIES,
-  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED
+  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
+  TEST_RETRY_REASON_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 
@@ -897,7 +898,7 @@ versions.forEach(version => {
                 )
                 assert.equal(retriedTests.length, NUM_RETRIES_EFD)
                 retriedTests.forEach(test => {
-                  assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
+                  assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
                 })
                 // Test name does not change
                 newTests.forEach(test => {
@@ -1487,7 +1488,7 @@ versions.forEach(version => {
                   const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
                   assert.equal(retriedTests.length, 2)
                   assert.equal(retriedTests.filter(
-                    test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
                   ).length, 2)
                 })
 
@@ -1526,7 +1527,9 @@ versions.forEach(version => {
 
                   assert.equal(tests.length, 1)
 
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+                  const retriedTests = tests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+                  )
                   assert.equal(retriedTests.length, 0)
                 })
 
@@ -1575,7 +1578,9 @@ versions.forEach(version => {
                   assert.equal(passedTests.length, 0)
 
                   // All but the first one are retries
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+                  const retriedTests = tests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+                  )
                   assert.equal(retriedTests.length, 1)
                 })
 
@@ -1611,7 +1616,9 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+                  const retriedTests = tests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+                  )
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1660,7 +1667,9 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+                  const retriedTests = tests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+                  )
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1709,7 +1718,9 @@ versions.forEach(version => {
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+                  const retriedTests = tests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+                  )
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1787,7 +1798,9 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+                  const retriedTests = tests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+                  )
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -2112,7 +2125,7 @@ versions.forEach(version => {
                   assert.propertyVal(test.meta, TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX, 'true')
                   if (!isFirstAttempt) {
                     assert.propertyVal(test.meta, TEST_IS_RETRY, 'true')
-                    assert.propertyVal(test.meta, TEST_RETRY_REASON, 'attempt_to_fix')
+                    assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
                   }
                   if (isLastAttempt) {
                     if (shouldFailSometimes) {

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -1486,6 +1486,7 @@ versions.forEach(version => {
                   // All but the first one are retries
                   const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
                   assert.equal(retriedTests.length, 2)
+                  assert.equal(retriedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
                 })
 
               childProcess = exec(
@@ -1523,7 +1524,7 @@ versions.forEach(version => {
 
                   assert.equal(tests.length, 1)
 
-                  const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
                   assert.equal(retriedTests.length, 0)
                 })
 
@@ -1572,7 +1573,7 @@ versions.forEach(version => {
                   assert.equal(passedTests.length, 0)
 
                   // All but the first one are retries
-                  const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
                   assert.equal(retriedTests.length, 1)
                 })
 
@@ -1608,7 +1609,7 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1657,7 +1658,7 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1706,7 +1707,7 @@ versions.forEach(version => {
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-                  const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1784,7 +1785,7 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -897,7 +897,7 @@ versions.forEach(version => {
                 )
                 assert.equal(retriedTests.length, NUM_RETRIES_EFD)
                 retriedTests.forEach(test => {
-                  assert.propertyVal(test.meta, TEST_RETRY_REASON, 'efd')
+                  assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
                 })
                 // Test name does not change
                 newTests.forEach(test => {
@@ -1486,7 +1486,9 @@ versions.forEach(version => {
                   // All but the first one are retries
                   const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
                   assert.equal(retriedTests.length, 2)
-                  assert.equal(retriedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
+                  assert.equal(retriedTests.filter(
+                    test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+                  ).length, 2)
                 })
 
               childProcess = exec(
@@ -1524,7 +1526,7 @@ versions.forEach(version => {
 
                   assert.equal(tests.length, 1)
 
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
                   assert.equal(retriedTests.length, 0)
                 })
 
@@ -1573,7 +1575,7 @@ versions.forEach(version => {
                   assert.equal(passedTests.length, 0)
 
                   // All but the first one are retries
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
                   assert.equal(retriedTests.length, 1)
                 })
 
@@ -1609,7 +1611,7 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1658,7 +1660,7 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1707,7 +1709,7 @@ versions.forEach(version => {
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests
@@ -1785,7 +1787,7 @@ versions.forEach(version => {
                   const events = payloads.flatMap(({ payload }) => payload.events)
 
                   const tests = events.filter(event => event.type === 'test').map(event => event.content)
-                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+                  const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
                   assert.equal(retriedTests.length, 1)
                   const [retriedTest] = retriedTests

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1432,6 +1432,7 @@ moduleTypes.forEach(({
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 2)
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+            assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
 
             const neverPassingTest = tests.filter(
               test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry never passes'
@@ -1440,6 +1441,7 @@ moduleTypes.forEach(({
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
+            assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 5)
           })
 
         const {
@@ -1495,7 +1497,7 @@ moduleTypes.forEach(({
               'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
               'cypress/e2e/flaky-test-retries.js.flaky test retry always passes'
             ])
-            assert.equal(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 0)
+            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 0)
           })
 
         const {
@@ -1553,7 +1555,7 @@ moduleTypes.forEach(({
               'cypress/e2e/flaky-test-retries.js.flaky test retry always passes'
             ])
 
-            assert.equal(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
           })
 
         const {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -51,7 +51,8 @@ const {
   DD_CAPABILITIES_AUTO_TEST_RETRIES,
   DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE,
   DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE,
-  DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX
+  DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
+  TEST_RETRY_REASON_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -1107,7 +1108,7 @@ moduleTypes.forEach(({
             assert.equal(retriedTests.length, NUM_RETRIES_EFD)
 
             retriedTests.forEach((retriedTest) => {
-              assert.equal(retriedTest.meta[TEST_RETRY_REASON], 'early_flake_detection')
+              assert.equal(retriedTest.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
             })
 
             newTests.forEach(newTest => {
@@ -1433,7 +1434,7 @@ moduleTypes.forEach(({
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
             assert.equal(eventuallyPassingTest.filter(test =>
-              test.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+              test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
             ).length, 2)
 
             const neverPassingTest = tests.filter(
@@ -1443,7 +1444,9 @@ moduleTypes.forEach(({
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
-            assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 5)
+            assert.equal(neverPassingTest.filter(
+              test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+            ).length, 5)
           })
 
         const {
@@ -1499,7 +1502,7 @@ moduleTypes.forEach(({
               'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
               'cypress/e2e/flaky-test-retries.js.flaky test retry always passes'
             ])
-            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 0)
+            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length, 0)
           })
 
         const {
@@ -1557,7 +1560,7 @@ moduleTypes.forEach(({
               'cypress/e2e/flaky-test-retries.js.flaky test retry always passes'
             ])
 
-            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 2)
+            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length, 2)
           })
 
         const {
@@ -1867,7 +1870,7 @@ moduleTypes.forEach(({
                   assert.notProperty(test.meta, TEST_RETRY_REASON)
                 } else {
                   assert.propertyVal(test.meta, TEST_IS_RETRY, 'true')
-                  assert.propertyVal(test.meta, TEST_RETRY_REASON, 'attempt_to_fix')
+                  assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
                 }
                 if (isLastAttempt) {
                   if (shouldFailSometimes) {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1107,7 +1107,7 @@ moduleTypes.forEach(({
             assert.equal(retriedTests.length, NUM_RETRIES_EFD)
 
             retriedTests.forEach((retriedTest) => {
-              assert.equal(retriedTest.meta[TEST_RETRY_REASON], 'efd')
+              assert.equal(retriedTest.meta[TEST_RETRY_REASON], 'early_flake_detection')
             })
 
             newTests.forEach(newTest => {
@@ -1432,7 +1432,9 @@ moduleTypes.forEach(({
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 2)
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
             assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
-            assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
+            assert.equal(eventuallyPassingTest.filter(test =>
+              test.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+            ).length, 2)
 
             const neverPassingTest = tests.filter(
               test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry never passes'
@@ -1441,7 +1443,7 @@ moduleTypes.forEach(({
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
             assert.equal(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
-            assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 5)
+            assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 5)
           })
 
         const {
@@ -1497,7 +1499,7 @@ moduleTypes.forEach(({
               'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
               'cypress/e2e/flaky-test-retries.js.flaky test retry always passes'
             ])
-            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 0)
+            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 0)
           })
 
         const {
@@ -1555,7 +1557,7 @@ moduleTypes.forEach(({
               'cypress/e2e/flaky-test-retries.js.flaky test retry always passes'
             ])
 
-            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
+            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 2)
           })
 
         const {

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -52,7 +52,8 @@ const {
   DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_HAS_FAILED_ALL_RETRIES,
-  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED
+  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
+  TEST_RETRY_REASON_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -531,7 +532,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 2)
           const retriedTest = retriedTests.find(test => test.meta[TEST_SUITE].includes('test-hit-breakpoint.js'))
@@ -1666,7 +1667,7 @@ describe('jest CommonJS', () => {
           )
           assert.equal(retriedTests.length, NUM_RETRIES_EFD)
           retriedTests.forEach(test => {
-            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
+            assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
           })
           // Test name does not change
           newTests.forEach(test => {
@@ -2407,7 +2408,7 @@ describe('jest CommonJS', () => {
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
           assert.equal(eventuallyPassingTest.filter(test =>
-            test.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+            test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
           ).length, 2)
 
           const neverPassingTest = tests.filter(
@@ -2418,7 +2419,9 @@ describe('jest CommonJS', () => {
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
-          assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 5)
+          assert.equal(neverPassingTest.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          ).length, 5)
 
           const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
 
@@ -2477,7 +2480,7 @@ describe('jest CommonJS', () => {
             'ci-visibility/jest-flaky/flaky-fails.js.test-flaky-test-retries can retry failed tests'
           ])
 
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 0)
         })
@@ -2519,7 +2522,7 @@ describe('jest CommonJS', () => {
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
           assert.equal(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
-          assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 2)
+          assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length, 2)
 
           assert.equal(tests.length, 5)
           // only one retry
@@ -2562,7 +2565,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2611,7 +2614,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2660,7 +2663,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2744,7 +2747,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2792,7 +2795,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -3040,7 +3043,7 @@ describe('jest CommonJS', () => {
                 assert.notProperty(test.meta, TEST_RETRY_REASON)
               } else {
                 assert.propertyVal(test.meta, TEST_IS_RETRY, 'true')
-                assert.propertyVal(test.meta, TEST_RETRY_REASON, 'attempt_to_fix')
+                assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
               }
 
               if (isLastAttempt) {

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -531,7 +531,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 2)
           const retriedTest = retriedTests.find(test => test.meta[TEST_SUITE].includes('test-hit-breakpoint.js'))
@@ -1666,7 +1666,7 @@ describe('jest CommonJS', () => {
           )
           assert.equal(retriedTests.length, NUM_RETRIES_EFD)
           retriedTests.forEach(test => {
-            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'efd')
+            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
           })
           // Test name does not change
           newTests.forEach(test => {
@@ -2406,7 +2406,9 @@ describe('jest CommonJS', () => {
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 2)
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
-          assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
+          assert.equal(eventuallyPassingTest.filter(test =>
+            test.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+          ).length, 2)
 
           const neverPassingTest = tests.filter(
             test => test.resource ===
@@ -2416,7 +2418,7 @@ describe('jest CommonJS', () => {
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
-          assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 5)
+          assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 5)
 
           const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
 
@@ -2475,7 +2477,7 @@ describe('jest CommonJS', () => {
             'ci-visibility/jest-flaky/flaky-fails.js.test-flaky-test-retries can retry failed tests'
           ])
 
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 0)
         })
@@ -2517,7 +2519,7 @@ describe('jest CommonJS', () => {
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
           assert.equal(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
-          assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
+          assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 2)
 
           assert.equal(tests.length, 5)
           // only one retry
@@ -2560,7 +2562,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2609,7 +2611,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2658,7 +2660,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2742,7 +2744,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2790,7 +2792,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -531,7 +531,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 2)
           const retriedTest = retriedTests.find(test => test.meta[TEST_SUITE].includes('test-hit-breakpoint.js'))
@@ -2406,6 +2406,7 @@ describe('jest CommonJS', () => {
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 2)
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
           assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+          assert.equal(eventuallyPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
 
           const neverPassingTest = tests.filter(
             test => test.resource ===
@@ -2415,6 +2416,7 @@ describe('jest CommonJS', () => {
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
           assert.equal(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
+          assert.equal(neverPassingTest.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 5)
 
           const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
 
@@ -2473,7 +2475,7 @@ describe('jest CommonJS', () => {
             'ci-visibility/jest-flaky/flaky-fails.js.test-flaky-test-retries can retry failed tests'
           ])
 
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 0)
         })
@@ -2514,6 +2516,8 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          assert.equal(tests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+          assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr').length, 2)
 
           assert.equal(tests.length, 5)
           // only one retry
@@ -2556,7 +2560,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2605,7 +2609,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2654,7 +2658,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2738,7 +2742,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2786,7 +2790,7 @@ describe('jest CommonJS', () => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1199,7 +1199,7 @@ describe('mocha CommonJS', function () {
           )
           assert.equal(retriedTests.length, NUM_RETRIES_EFD)
           retriedTests.forEach(test => {
-            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'efd')
+            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
           })
           // Test name does not change
           newTests.forEach(test => {
@@ -1777,7 +1777,7 @@ describe('mocha CommonJS', function () {
             // Test name does not change
             retriedTests.forEach(test => {
               assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
-              assert.equal(test.meta[TEST_RETRY_REASON], 'efd')
+              assert.equal(test.meta[TEST_RETRY_REASON], 'early_flake_detection')
             })
           })
 
@@ -2031,12 +2031,12 @@ describe('mocha CommonJS', function () {
           })
 
           // The first attempt is not marked as a retry
-          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
           assert.equal(retriedFailure.length, 1)
 
           const passedAttempt = tests.find(test => test.meta[TEST_STATUS] === 'pass')
           assert.equal(passedAttempt.meta[TEST_IS_RETRY], 'true')
-          assert.equal(passedAttempt.meta[TEST_RETRY_REASON], 'atr')
+          assert.equal(passedAttempt.meta[TEST_RETRY_REASON], 'auto_test_retry')
         })
 
       childProcess.on('exit', () => {
@@ -2064,7 +2064,7 @@ describe('mocha CommonJS', function () {
 
           assert.equal(tests.length, 1)
 
-          const retries = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retries = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
           assert.equal(retries.length, 0)
         })
 
@@ -2111,7 +2111,7 @@ describe('mocha CommonJS', function () {
           const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
           assert.equal(failedAttempts.length, 2)
 
-          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
           assert.equal(retriedFailure.length, 1)
         })
 
@@ -2234,7 +2234,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2287,7 +2287,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2342,7 +2342,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2430,7 +2430,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2510,7 +2510,7 @@ describe('mocha CommonJS', function () {
           newTests.forEach(test => {
             assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
           })
-          const retriedTests = newTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+          const retriedTests = newTests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
           // no test has been retried
           assert.equal(retriedTests.length, 0)
         })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2031,11 +2031,12 @@ describe('mocha CommonJS', function () {
           })
 
           // The first attempt is not marked as a retry
-          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
           assert.equal(retriedFailure.length, 1)
 
           const passedAttempt = tests.find(test => test.meta[TEST_STATUS] === 'pass')
           assert.equal(passedAttempt.meta[TEST_IS_RETRY], 'true')
+          assert.equal(passedAttempt.meta[TEST_RETRY_REASON], 'atr')
         })
 
       childProcess.on('exit', () => {
@@ -2063,7 +2064,7 @@ describe('mocha CommonJS', function () {
 
           assert.equal(tests.length, 1)
 
-          const retries = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retries = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
           assert.equal(retries.length, 0)
         })
 
@@ -2110,7 +2111,7 @@ describe('mocha CommonJS', function () {
           const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
           assert.equal(failedAttempts.length, 2)
 
-          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
           assert.equal(retriedFailure.length, 1)
         })
 
@@ -2233,7 +2234,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2286,7 +2287,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2341,7 +2342,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2429,7 +2430,7 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2509,7 +2510,7 @@ describe('mocha CommonJS', function () {
           newTests.forEach(test => {
             assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
           })
-          const retriedTests = newTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          const retriedTests = newTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
           // no test has been retried
           assert.equal(retriedTests.length, 0)
         })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -54,7 +54,8 @@ const {
   DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_HAS_FAILED_ALL_RETRIES,
-  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED
+  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
+  TEST_RETRY_REASON_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -1199,7 +1200,7 @@ describe('mocha CommonJS', function () {
           )
           assert.equal(retriedTests.length, NUM_RETRIES_EFD)
           retriedTests.forEach(test => {
-            assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
+            assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
           })
           // Test name does not change
           newTests.forEach(test => {
@@ -1777,7 +1778,7 @@ describe('mocha CommonJS', function () {
             // Test name does not change
             retriedTests.forEach(test => {
               assert.equal(test.meta[TEST_NAME], 'fail occasionally fails')
-              assert.equal(test.meta[TEST_RETRY_REASON], 'early_flake_detection')
+              assert.equal(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
             })
           })
 
@@ -2031,12 +2032,14 @@ describe('mocha CommonJS', function () {
           })
 
           // The first attempt is not marked as a retry
-          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedFailure = failedAttempts.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
           assert.equal(retriedFailure.length, 1)
 
           const passedAttempt = tests.find(test => test.meta[TEST_STATUS] === 'pass')
           assert.equal(passedAttempt.meta[TEST_IS_RETRY], 'true')
-          assert.equal(passedAttempt.meta[TEST_RETRY_REASON], 'auto_test_retry')
+          assert.equal(passedAttempt.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
         })
 
       childProcess.on('exit', () => {
@@ -2064,7 +2067,7 @@ describe('mocha CommonJS', function () {
 
           assert.equal(tests.length, 1)
 
-          const retries = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retries = tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
           assert.equal(retries.length, 0)
         })
 
@@ -2111,7 +2114,9 @@ describe('mocha CommonJS', function () {
           const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
           assert.equal(failedAttempts.length, 2)
 
-          const retriedFailure = failedAttempts.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedFailure = failedAttempts.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
           assert.equal(retriedFailure.length, 1)
         })
 
@@ -2234,7 +2239,9 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2287,7 +2294,9 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2342,7 +2351,9 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2430,7 +2441,9 @@ describe('mocha CommonJS', function () {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
-          const retriedTests = tests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          )
 
           assert.equal(retriedTests.length, 1)
           const [retriedTest] = retriedTests
@@ -2510,7 +2523,7 @@ describe('mocha CommonJS', function () {
           newTests.forEach(test => {
             assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
           })
-          const retriedTests = newTests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+          const retriedTests = newTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
           // no test has been retried
           assert.equal(retriedTests.length, 0)
         })
@@ -2640,7 +2653,7 @@ describe('mocha CommonJS', function () {
                 assert.notProperty(test.meta, TEST_RETRY_REASON)
               } else {
                 assert.propertyVal(test.meta, TEST_IS_RETRY, 'true')
-                assert.propertyVal(test.meta, TEST_RETRY_REASON, 'attempt_to_fix')
+                assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
               }
 
               if (isQuarantined) {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -659,12 +659,13 @@ versions.forEach((version) => {
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 2)
 
-            const failedRetryTests = failedTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
             assert.equal(failedRetryTests.length, 1) // the first one is not a retry
 
             const passedTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
             assert.equal(passedTests.length, 1)
             assert.equal(passedTests[0].meta[TEST_IS_RETRY], 'true')
+            assert.equal(passedTests[0].meta[TEST_RETRY_REASON], 'atr')
           }, 30000)
 
         childProcess = exec(
@@ -704,7 +705,7 @@ versions.forEach((version) => {
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
             assert.equal(tests.length, 1)
-            assert.equal(tests.filter((test) => test.meta[TEST_IS_RETRY]).length, 0)
+            assert.equal(tests.filter((test) => test.meta[TEST_RETRY_REASON] === 'atr').length, 0)
           }, 30000)
 
         childProcess = exec(
@@ -749,7 +750,7 @@ versions.forEach((version) => {
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 2)
 
-            const failedRetryTests = failedTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
             assert.equal(failedRetryTests.length, 1)
           }, 30000)
 

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -330,7 +330,7 @@ versions.forEach((version) => {
               assert.equal(retriedTests.length, NUM_RETRIES_EFD)
 
               retriedTests.forEach(test => {
-                assert.propertyVal(test.meta, TEST_RETRY_REASON, 'efd')
+                assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
               })
 
               // all but one has been retried
@@ -659,13 +659,13 @@ versions.forEach((version) => {
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 2)
 
-            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
             assert.equal(failedRetryTests.length, 1) // the first one is not a retry
 
             const passedTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
             assert.equal(passedTests.length, 1)
             assert.equal(passedTests[0].meta[TEST_IS_RETRY], 'true')
-            assert.equal(passedTests[0].meta[TEST_RETRY_REASON], 'atr')
+            assert.equal(passedTests[0].meta[TEST_RETRY_REASON], 'auto_test_retry')
           }, 30000)
 
         childProcess = exec(
@@ -705,7 +705,7 @@ versions.forEach((version) => {
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
             assert.equal(tests.length, 1)
-            assert.equal(tests.filter((test) => test.meta[TEST_RETRY_REASON] === 'atr').length, 0)
+            assert.equal(tests.filter((test) => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 0)
           }, 30000)
 
         childProcess = exec(
@@ -750,7 +750,7 @@ versions.forEach((version) => {
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 2)
 
-            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'atr')
+            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
             assert.equal(failedRetryTests.length, 1)
           }, 30000)
 

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -42,7 +42,8 @@ const {
   TEST_NAME,
   TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
   TEST_IS_RUM_ACTIVE,
-  TEST_BROWSER_VERSION
+  TEST_BROWSER_VERSION,
+  TEST_RETRY_REASON_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -330,7 +331,7 @@ versions.forEach((version) => {
               assert.equal(retriedTests.length, NUM_RETRIES_EFD)
 
               retriedTests.forEach(test => {
-                assert.propertyVal(test.meta, TEST_RETRY_REASON, 'early_flake_detection')
+                assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
               })
 
               // all but one has been retried
@@ -659,13 +660,15 @@ versions.forEach((version) => {
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 2)
 
-            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+            const failedRetryTests = failedTests.filter(
+              test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+            )
             assert.equal(failedRetryTests.length, 1) // the first one is not a retry
 
             const passedTests = tests.filter(test => test.meta[TEST_STATUS] === 'pass')
             assert.equal(passedTests.length, 1)
             assert.equal(passedTests[0].meta[TEST_IS_RETRY], 'true')
-            assert.equal(passedTests[0].meta[TEST_RETRY_REASON], 'auto_test_retry')
+            assert.equal(passedTests[0].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
           }, 30000)
 
         childProcess = exec(
@@ -705,7 +708,9 @@ versions.forEach((version) => {
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
             assert.equal(tests.length, 1)
-            assert.equal(tests.filter((test) => test.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 0)
+            assert.equal(tests.filter(
+              (test) => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+            ).length, 0)
           }, 30000)
 
         childProcess = exec(
@@ -750,7 +755,9 @@ versions.forEach((version) => {
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.equal(failedTests.length, 2)
 
-            const failedRetryTests = failedTests.filter(test => test.meta[TEST_RETRY_REASON] === 'auto_test_retry')
+            const failedRetryTests = failedTests.filter(
+              test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+            )
             assert.equal(failedRetryTests.length, 1)
           }, 30000)
 
@@ -978,7 +985,7 @@ versions.forEach((version) => {
                 const countRetriedAttemptToFixTests = attemptedToFixTests.filter(test =>
                   test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true' &&
                   test.meta[TEST_IS_RETRY] === 'true' &&
-                  test.meta[TEST_RETRY_REASON] === 'attempt_to_fix'
+                  test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atf
                 ).length
 
                 const testsMarkedAsFailedAllRetries = attemptedToFixTests.filter(test =>

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -43,7 +43,8 @@ const {
   DD_CAPABILITIES_AUTO_TEST_RETRIES,
   DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE,
   DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE,
-  DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX
+  DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
+  TEST_RETRY_REASON_TYPES
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 
@@ -244,7 +245,7 @@ versions.forEach((version) => {
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 1)
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 3)
           assert.equal(eventuallyPassingTest.filter(test =>
-            test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+            test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
           ).length, 3)
 
           const neverPassingTest = testEvents.filter(
@@ -256,7 +257,7 @@ versions.forEach((version) => {
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 0)
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 5)
           assert.equal(neverPassingTest.filter(test =>
-            test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+            test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
           ).length, 5)
         }).then(() => done()).catch(done)
 
@@ -295,7 +296,9 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
           ])
-          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 0)
+          assert.equal(testEvents.filter(
+            test => test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          ).length, 0)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -336,7 +339,9 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
           ])
-          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 2)
+          assert.equal(testEvents.filter(
+            test => test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+          ).length, 2)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -496,7 +501,7 @@ versions.forEach((version) => {
             assert.equal(retriedTests.length, 9) // 3 retries of the 3 new tests
 
             retriedTests.forEach(test => {
-              assert.equal(test.meta[TEST_RETRY_REASON], 'early_flake_detection')
+              assert.equal(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
             })
 
             // exit code should be 0 and test session should be reported as passed,
@@ -1421,7 +1426,7 @@ versions.forEach((version) => {
                       continue
                     }
                     assert.propertyVal(test.meta, TEST_IS_RETRY, 'true')
-                    assert.propertyVal(test.meta, TEST_RETRY_REASON, 'attempt_to_fix')
+                    assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
                     if (isLastAttempt) {
                       if (shouldAlwaysPass) {
                         assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -243,7 +243,9 @@ versions.forEach((version) => {
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 3)
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 1)
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 3)
-          assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 3)
+          assert.equal(eventuallyPassingTest.filter(test =>
+            test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+          ).length, 3)
 
           const neverPassingTest = testEvents.filter(
             test => test.content.resource ===
@@ -253,7 +255,9 @@ versions.forEach((version) => {
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 6)
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 0)
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 5)
-          assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 5)
+          assert.equal(neverPassingTest.filter(test =>
+            test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry'
+          ).length, 5)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -291,7 +295,7 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
           ])
-          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 0)
+          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 0)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -332,7 +336,7 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
           ])
-          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 2)
+          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'auto_test_retry').length, 2)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -492,7 +496,7 @@ versions.forEach((version) => {
             assert.equal(retriedTests.length, 9) // 3 retries of the 3 new tests
 
             retriedTests.forEach(test => {
-              assert.equal(test.meta[TEST_RETRY_REASON], 'efd')
+              assert.equal(test.meta[TEST_RETRY_REASON], 'early_flake_detection')
             })
 
             // exit code should be 0 and test session should be reported as passed,

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -243,6 +243,7 @@ versions.forEach((version) => {
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 3)
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 1)
           assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 3)
+          assert.equal(eventuallyPassingTest.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 3)
 
           const neverPassingTest = testEvents.filter(
             test => test.content.resource ===
@@ -252,6 +253,7 @@ versions.forEach((version) => {
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 6)
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 0)
           assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 5)
+          assert.equal(neverPassingTest.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 5)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -289,7 +291,7 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
           ])
-          assert.equal(testEvents.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 0)
+          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 0)
         }).then(() => done()).catch(done)
 
         childProcess = exec(
@@ -330,7 +332,7 @@ versions.forEach((version) => {
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
             'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
           ])
-          assert.equal(testEvents.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 2)
+          assert.equal(testEvents.filter(test => test.content.meta[TEST_RETRY_REASON] === 'atr').length, 2)
         }).then(() => done()).catch(done)
 
         childProcess = exec(

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -267,6 +267,7 @@ function wrapRun (pl, isLatestVersion) {
 
             const failedAttemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
             const isFirstAttempt = numAttempt++ === 0
+            const isAtrRetry = !isFirstAttempt && isFlakyTestRetriesEnabled
 
             if (promises.hitBreakpointPromise) {
               await promises.hitBreakpointPromise
@@ -274,7 +275,7 @@ function wrapRun (pl, isLatestVersion) {
 
             failedAttemptAsyncResource.runInAsyncScope(() => {
               // the current span will be finished and a new one will be created
-              testRetryCh.publish({ isFirstAttempt, error })
+              testRetryCh.publish({ isFirstAttempt, error, isAtrRetry })
             })
 
             const newAsyncResource = new AsyncResource('bound-anonymous-fn')

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -417,7 +417,7 @@ addHook({
 
     this.on('test end', getOnTestEndHandler(config))
 
-    this.on('retry', getOnTestRetryHandler())
+    this.on('retry', getOnTestRetryHandler(config))
 
     // If the hook passes, 'hook end' will be emitted. Otherwise, 'fail' will be emitted
     this.on('hook end', getOnHookEndHandler())

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -82,7 +82,8 @@ function getProvidedContext () {
       isKnownTestsEnabled: false,
       isTestManagementTestsEnabled: false,
       testManagementAttemptToFixRetries: 0,
-      testManagementTests: {}
+      testManagementTests: {},
+      isFlakyTestRetriesEnabled: false
     }
   }
 }
@@ -466,7 +467,8 @@ addHook({
       isEarlyFlakeDetectionEnabled,
       isDiEnabled,
       isTestManagementTestsEnabled,
-      testManagementTests
+      testManagementTests,
+      isFlakyTestRetriesEnabled
     } = getProvidedContext()
 
     if (isKnownTestsEnabled) {
@@ -566,6 +568,11 @@ addHook({
       }
     }
 
+    const isRetryReasonAtr = numAttempt > 0 &&
+      isFlakyTestRetriesEnabled &&
+      !isRetryReasonAttemptToFix &&
+      !isRetryReasonEfd
+
     const asyncResource = new AsyncResource('bound-anonymous-fn')
     taskToAsync.set(task, asyncResource)
 
@@ -580,7 +587,8 @@ addHook({
         mightHitProbe: isDiEnabled && numAttempt > 0,
         isAttemptToFix: attemptToFixTasks.has(task),
         isDisabled: disabledTasks.has(task),
-        isQuarantined
+        isQuarantined,
+        isRetryReasonAtr
       })
     })
     return onBeforeTryTask.apply(this, arguments)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -260,7 +260,7 @@ class CucumberPlugin extends CiPlugin {
         if (isAtrRetry) {
           span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
         } else {
-          span.setTag(TEST_RETRY_REASON, 'unknown')
+          span.setTag(TEST_RETRY_REASON, 'external')
         }
       }
       span.setTag('error', error)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -260,7 +260,7 @@ class CucumberPlugin extends CiPlugin {
         if (isAtrRetry) {
           span.setTag(TEST_RETRY_REASON, 'atr')
         } else {
-          span.setTag(TEST_RETRY_REASON, 'native_retry')
+          span.setTag(TEST_RETRY_REASON, 'unknown')
         }
       }
       span.setTag('error', error)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -252,11 +252,16 @@ class CucumberPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error }) => {
+    this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error, isAtrRetry }) => {
       const store = storage('legacy').getStore()
       const span = store.span
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
+        if (isAtrRetry) {
+          span.setTag(TEST_RETRY_REASON, 'atr')
+        } else {
+          span.setTag(TEST_RETRY_REASON, 'native_retry')
+        }
       }
       span.setTag('error', error)
       if (isFirstAttempt && this.di && error && this.libraryConfig?.isDiEnabled) {
@@ -363,6 +368,7 @@ class CucumberPlugin extends CiPlugin {
 
       if (isFlakyRetry > 0) {
         span.setTag(TEST_IS_RETRY, 'true')
+        span.setTag(TEST_RETRY_REASON, 'atr')
       }
 
       if (hasFailedAllRetries) {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -33,7 +33,8 @@ const {
   TEST_MANAGEMENT_IS_DISABLED,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_HAS_FAILED_ALL_RETRIES,
-  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED
+  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
+  TEST_RETRY_REASON_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT, ERROR_MESSAGE } = require('../../dd-trace/src/constants')
@@ -258,9 +259,9 @@ class CucumberPlugin extends CiPlugin {
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
         if (isAtrRetry) {
-          span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
         } else {
-          span.setTag(TEST_RETRY_REASON, 'external')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
         }
       }
       span.setTag('error', error)
@@ -352,7 +353,7 @@ class CucumberPlugin extends CiPlugin {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
-          span.setTag(TEST_RETRY_REASON, 'early_flake_detection')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
         }
       }
 
@@ -368,7 +369,7 @@ class CucumberPlugin extends CiPlugin {
 
       if (isFlakyRetry > 0) {
         span.setTag(TEST_IS_RETRY, 'true')
-        span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+        span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
       }
 
       if (hasFailedAllRetries) {
@@ -381,7 +382,7 @@ class CucumberPlugin extends CiPlugin {
 
       if (isAttemptToFixRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
-        span.setTag(TEST_RETRY_REASON, 'attempt_to_fix')
+        span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
         if (hasPassedAllRetries) {
           span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
         }

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -258,7 +258,7 @@ class CucumberPlugin extends CiPlugin {
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
         if (isAtrRetry) {
-          span.setTag(TEST_RETRY_REASON, 'atr')
+          span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
         } else {
           span.setTag(TEST_RETRY_REASON, 'unknown')
         }
@@ -352,7 +352,7 @@ class CucumberPlugin extends CiPlugin {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
-          span.setTag(TEST_RETRY_REASON, 'efd')
+          span.setTag(TEST_RETRY_REASON, 'early_flake_detection')
         }
       }
 
@@ -368,7 +368,7 @@ class CucumberPlugin extends CiPlugin {
 
       if (isFlakyRetry > 0) {
         span.setTag(TEST_IS_RETRY, 'true')
-        span.setTag(TEST_RETRY_REASON, 'atr')
+        span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
       }
 
       if (hasFailedAllRetries) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -667,7 +667,7 @@ class CypressPlugin {
             } else if (isAtrRetry) {
               finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'auto_test_retry')
             } else {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'unknown')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'external')
             }
           }
         }

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -667,7 +667,7 @@ class CypressPlugin {
             } else if (isAtrRetry) {
               finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'atr')
             } else {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'native_retry')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'unknown')
             }
           }
         }

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -663,9 +663,9 @@ class CypressPlugin {
           if (attemptIndex > 0) {
             finishedTest.testSpan.setTag(TEST_IS_RETRY, 'true')
             if (finishedTest.isEfdRetry) {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'efd')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'early_flake_detection')
             } else if (isAtrRetry) {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'atr')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'auto_test_retry')
             } else {
               finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'unknown')
             }
@@ -826,7 +826,7 @@ class CypressPlugin {
           this.activeTestSpan.setTag(TEST_IS_NEW, 'true')
           if (isEfdRetry) {
             this.activeTestSpan.setTag(TEST_IS_RETRY, 'true')
-            this.activeTestSpan.setTag(TEST_RETRY_REASON, 'efd')
+            this.activeTestSpan.setTag(TEST_RETRY_REASON, 'early_flake_detection')
           }
         }
         if (isAttemptToFix) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -40,7 +40,8 @@ const {
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
   TEST_HAS_FAILED_ALL_RETRIES,
-  getLibraryCapabilitiesTags
+  getLibraryCapabilitiesTags,
+  TEST_RETRY_REASON_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
@@ -663,11 +664,11 @@ class CypressPlugin {
           if (attemptIndex > 0) {
             finishedTest.testSpan.setTag(TEST_IS_RETRY, 'true')
             if (finishedTest.isEfdRetry) {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'early_flake_detection')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
             } else if (isAtrRetry) {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
             } else {
-              finishedTest.testSpan.setTag(TEST_RETRY_REASON, 'external')
+              finishedTest.testSpan.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
             }
           }
         }
@@ -826,14 +827,14 @@ class CypressPlugin {
           this.activeTestSpan.setTag(TEST_IS_NEW, 'true')
           if (isEfdRetry) {
             this.activeTestSpan.setTag(TEST_IS_RETRY, 'true')
-            this.activeTestSpan.setTag(TEST_RETRY_REASON, 'early_flake_detection')
+            this.activeTestSpan.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
           }
         }
         if (isAttemptToFix) {
           this.activeTestSpan.setTag(TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX, 'true')
           if (testStatuses.length > 1) {
             this.activeTestSpan.setTag(TEST_IS_RETRY, 'true')
-            this.activeTestSpan.setTag(TEST_RETRY_REASON, 'attempt_to_fix')
+            this.activeTestSpan.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
           }
           const isLastAttempt = testStatuses.length === this.testManagementAttemptToFixRetries + 1
           if (isLastAttempt) {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -360,7 +360,7 @@ class JestPlugin extends CiPlugin {
       }
       if (isAtrRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
-        span.setTag(TEST_RETRY_REASON, 'atr')
+        span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
       }
 
       const spanTags = span.context()._tags
@@ -467,7 +467,7 @@ class JestPlugin extends CiPlugin {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
-        extraTags[TEST_RETRY_REASON] = 'efd'
+        extraTags[TEST_RETRY_REASON] = 'early_flake_detection'
       }
     }
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -344,7 +344,8 @@ class JestPlugin extends CiPlugin {
       status,
       testStartLine,
       attemptToFixPassed,
-      failedAllTests
+      failedAllTests,
+      isAtrRetry
     }) => {
       const span = storage('legacy').getStore().span
       span.setTag(TEST_STATUS, status)
@@ -356,6 +357,10 @@ class JestPlugin extends CiPlugin {
       }
       if (failedAllTests) {
         span.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
+      }
+      if (isAtrRetry) {
+        span.setTag(TEST_IS_RETRY, 'true')
+        span.setTag(TEST_RETRY_REASON, 'atr')
       }
 
       const spanTags = span.context()._tags

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -473,7 +473,7 @@ class JestPlugin extends CiPlugin {
 
     if (isJestRetry) {
       extraTags[TEST_IS_RETRY] = 'true'
-      extraTags[TEST_RETRY_REASON] = 'unknown'
+      extraTags[TEST_RETRY_REASON] = 'external'
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -30,7 +30,8 @@ const {
   TEST_MANAGEMENT_IS_DISABLED,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
-  TEST_HAS_FAILED_ALL_RETRIES
+  TEST_HAS_FAILED_ALL_RETRIES,
+  TEST_RETRY_REASON_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -360,7 +361,7 @@ class JestPlugin extends CiPlugin {
       }
       if (isAtrRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
-        span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+        span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
       }
 
       const spanTags = span.context()._tags
@@ -452,7 +453,7 @@ class JestPlugin extends CiPlugin {
 
     if (isAttemptToFixRetry) {
       extraTags[TEST_IS_RETRY] = 'true'
-      extraTags[TEST_RETRY_REASON] = 'attempt_to_fix'
+      extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.atf
     }
 
     if (isDisabled) {
@@ -467,13 +468,13 @@ class JestPlugin extends CiPlugin {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
-        extraTags[TEST_RETRY_REASON] = 'early_flake_detection'
+        extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.efd
       }
     }
 
     if (isJestRetry) {
       extraTags[TEST_IS_RETRY] = 'true'
-      extraTags[TEST_RETRY_REASON] = 'external'
+      extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.ext
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -473,7 +473,7 @@ class JestPlugin extends CiPlugin {
 
     if (isJestRetry) {
       extraTags[TEST_IS_RETRY] = 'true'
-      extraTags[TEST_RETRY_REASON] = 'native_retry'
+      extraTags[TEST_RETRY_REASON] = 'unknown'
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -473,6 +473,7 @@ class JestPlugin extends CiPlugin {
 
     if (isJestRetry) {
       extraTags[TEST_IS_RETRY] = 'true'
+      extraTags[TEST_RETRY_REASON] = 'native_retry'
     }
 
     return super.startTestSpan(name, suite, this.testSuiteSpan, extraTags)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -220,7 +220,7 @@ class MochaPlugin extends CiPlugin {
           if (isAtrRetry) {
             span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
           } else {
-            span.setTag(TEST_RETRY_REASON, 'unknown')
+            span.setTag(TEST_RETRY_REASON, 'external')
           }
         }
         if (hasFailedAllRetries) {
@@ -289,7 +289,7 @@ class MochaPlugin extends CiPlugin {
           if (isAtrRetry) {
             span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
           } else {
-            span.setTag(TEST_RETRY_REASON, 'unknown')
+            span.setTag(TEST_RETRY_REASON, 'external')
           }
         }
         if (err) {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -218,7 +218,7 @@ class MochaPlugin extends CiPlugin {
         if (hasBeenRetried) {
           span.setTag(TEST_IS_RETRY, 'true')
           if (isAtrRetry) {
-            span.setTag(TEST_RETRY_REASON, 'atr')
+            span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
           } else {
             span.setTag(TEST_RETRY_REASON, 'unknown')
           }
@@ -287,7 +287,7 @@ class MochaPlugin extends CiPlugin {
         if (!isFirstAttempt) {
           span.setTag(TEST_IS_RETRY, 'true')
           if (isAtrRetry) {
-            span.setTag(TEST_RETRY_REASON, 'atr')
+            span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
           } else {
             span.setTag(TEST_RETRY_REASON, 'unknown')
           }
@@ -484,7 +484,7 @@ class MochaPlugin extends CiPlugin {
       extraTags[TEST_IS_NEW] = 'true'
       if (isEfdRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
-        extraTags[TEST_RETRY_REASON] = 'efd'
+        extraTags[TEST_RETRY_REASON] = 'early_flake_detection'
       }
     }
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -36,7 +36,8 @@ const {
   TEST_MANAGEMENT_IS_DISABLED,
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_HAS_FAILED_ALL_RETRIES,
-  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED
+  TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
+  TEST_RETRY_REASON_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -218,9 +219,9 @@ class MochaPlugin extends CiPlugin {
         if (hasBeenRetried) {
           span.setTag(TEST_IS_RETRY, 'true')
           if (isAtrRetry) {
-            span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+            span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
           } else {
-            span.setTag(TEST_RETRY_REASON, 'external')
+            span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
           }
         }
         if (hasFailedAllRetries) {
@@ -231,7 +232,7 @@ class MochaPlugin extends CiPlugin {
         }
         if (isAttemptToFixRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
-          span.setTag(TEST_RETRY_REASON, 'attempt_to_fix')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
         }
 
         const spanTags = span.context()._tags
@@ -287,9 +288,9 @@ class MochaPlugin extends CiPlugin {
         if (!isFirstAttempt) {
           span.setTag(TEST_IS_RETRY, 'true')
           if (isAtrRetry) {
-            span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+            span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
           } else {
-            span.setTag(TEST_RETRY_REASON, 'external')
+            span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
           }
         }
         if (err) {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -220,7 +220,7 @@ class MochaPlugin extends CiPlugin {
           if (isAtrRetry) {
             span.setTag(TEST_RETRY_REASON, 'atr')
           } else {
-            span.setTag(TEST_RETRY_REASON, 'native_retry')
+            span.setTag(TEST_RETRY_REASON, 'unknown')
           }
         }
         if (hasFailedAllRetries) {
@@ -289,7 +289,7 @@ class MochaPlugin extends CiPlugin {
           if (isAtrRetry) {
             span.setTag(TEST_RETRY_REASON, 'atr')
           } else {
-            span.setTag(TEST_RETRY_REASON, 'native_retry')
+            span.setTag(TEST_RETRY_REASON, 'unknown')
           }
         }
         if (err) {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -266,6 +266,7 @@ class PlaywrightPlugin extends CiPlugin {
       isAttemptToFixRetry,
       hasFailedAllRetries,
       hasPassedAttemptToFixRetries,
+      isAtrRetry,
       onDone
     }) => {
       const store = storage('legacy').getStore()
@@ -291,6 +292,11 @@ class PlaywrightPlugin extends CiPlugin {
       }
       if (isRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
+        if (isAtrRetry) {
+          span.setTag(TEST_RETRY_REASON, 'atr')
+        } else {
+          span.setTag(TEST_RETRY_REASON, 'native_retry')
+        }
       }
       if (hasFailedAllRetries) {
         span.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -295,7 +295,7 @@ class PlaywrightPlugin extends CiPlugin {
         if (isAtrRetry) {
           span.setTag(TEST_RETRY_REASON, 'atr')
         } else {
-          span.setTag(TEST_RETRY_REASON, 'native_retry')
+          span.setTag(TEST_RETRY_REASON, 'unknown')
         }
       }
       if (hasFailedAllRetries) {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -295,7 +295,7 @@ class PlaywrightPlugin extends CiPlugin {
         if (isAtrRetry) {
           span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
         } else {
-          span.setTag(TEST_RETRY_REASON, 'unknown')
+          span.setTag(TEST_RETRY_REASON, 'external')
         }
       }
       if (hasFailedAllRetries) {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -33,7 +33,8 @@ const {
   TEST_SUITE_ID,
   TEST_NAME,
   TEST_IS_RUM_ACTIVE,
-  TEST_BROWSER_VERSION
+  TEST_BROWSER_VERSION,
+  TEST_RETRY_REASON_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { RESOURCE_NAME } = require('../../../ext/tags')
 const { COMPONENT } = require('../../dd-trace/src/constants')
@@ -287,15 +288,15 @@ class PlaywrightPlugin extends CiPlugin {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
-          span.setTag(TEST_RETRY_REASON, 'early_flake_detection')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
         }
       }
       if (isRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
         if (isAtrRetry) {
-          span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atr)
         } else {
-          span.setTag(TEST_RETRY_REASON, 'external')
+          span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
         }
       }
       if (hasFailedAllRetries) {
@@ -306,7 +307,7 @@ class PlaywrightPlugin extends CiPlugin {
       }
       if (isAttemptToFixRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
-        span.setTag(TEST_RETRY_REASON, 'attempt_to_fix')
+        span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
       }
       if (hasPassedAttemptToFixRetries) {
         span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -287,13 +287,13 @@ class PlaywrightPlugin extends CiPlugin {
         span.setTag(TEST_IS_NEW, 'true')
         if (isEfdRetry) {
           span.setTag(TEST_IS_RETRY, 'true')
-          span.setTag(TEST_RETRY_REASON, 'efd')
+          span.setTag(TEST_RETRY_REASON, 'early_flake_detection')
         }
       }
       if (isRetry) {
         span.setTag(TEST_IS_RETRY, 'true')
         if (isAtrRetry) {
-          span.setTag(TEST_RETRY_REASON, 'atr')
+          span.setTag(TEST_RETRY_REASON, 'auto_test_retry')
         } else {
           span.setTag(TEST_RETRY_REASON, 'unknown')
         }

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -25,7 +25,8 @@ const {
   TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX,
   TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
   TEST_HAS_FAILED_ALL_RETRIES,
-  getLibraryCapabilitiesTags
+  getLibraryCapabilitiesTags,
+  TEST_RETRY_REASON_TYPES
 } = require('../../dd-trace/src/plugins/util/test')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 const {
@@ -116,13 +117,13 @@ class VitestPlugin extends CiPlugin {
       if (isRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
         if (isRetryReasonAttemptToFix) {
-          extraTags[TEST_RETRY_REASON] = 'attempt_to_fix'
+          extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.atf
         } else if (isRetryReasonEfd) {
-          extraTags[TEST_RETRY_REASON] = 'early_flake_detection'
+          extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.efd
         } else if (isRetryReasonAtr) {
-          extraTags[TEST_RETRY_REASON] = 'auto_test_retry'
+          extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.atr
         } else {
-          extraTags[TEST_RETRY_REASON] = 'external'
+          extraTags[TEST_RETRY_REASON] = TEST_RETRY_REASON_TYPES.ext
         }
       }
       if (isNew) {

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -122,7 +122,7 @@ class VitestPlugin extends CiPlugin {
         } else if (isRetryReasonAtr) {
           extraTags[TEST_RETRY_REASON] = 'auto_test_retry'
         } else {
-          extraTags[TEST_RETRY_REASON] = 'unknown'
+          extraTags[TEST_RETRY_REASON] = 'external'
         }
       }
       if (isNew) {

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -104,7 +104,8 @@ class VitestPlugin extends CiPlugin {
       isDisabled,
       mightHitProbe,
       isRetryReasonEfd,
-      isRetryReasonAttemptToFix
+      isRetryReasonAttemptToFix,
+      isRetryReasonAtr
     }) => {
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const store = storage('legacy').getStore()
@@ -114,18 +115,21 @@ class VitestPlugin extends CiPlugin {
       }
       if (isRetry) {
         extraTags[TEST_IS_RETRY] = 'true'
+        if (isRetryReasonAttemptToFix) {
+          extraTags[TEST_RETRY_REASON] = 'attempt_to_fix'
+        } else if (isRetryReasonEfd) {
+          extraTags[TEST_RETRY_REASON] = 'efd'
+        } else if (isRetryReasonAtr) {
+          extraTags[TEST_RETRY_REASON] = 'atr'
+        } else {
+          extraTags[TEST_RETRY_REASON] = 'unknown'
+        }
       }
       if (isNew) {
         extraTags[TEST_IS_NEW] = 'true'
       }
-      if (isRetryReasonEfd) {
-        extraTags[TEST_RETRY_REASON] = 'efd'
-      }
       if (isAttemptToFix) {
         extraTags[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] = 'true'
-      }
-      if (isRetryReasonAttemptToFix) {
-        extraTags[TEST_RETRY_REASON] = 'attempt_to_fix'
       }
       if (isQuarantined) {
         extraTags[TEST_MANAGEMENT_IS_QUARANTINED] = 'true'

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -118,9 +118,9 @@ class VitestPlugin extends CiPlugin {
         if (isRetryReasonAttemptToFix) {
           extraTags[TEST_RETRY_REASON] = 'attempt_to_fix'
         } else if (isRetryReasonEfd) {
-          extraTags[TEST_RETRY_REASON] = 'efd'
+          extraTags[TEST_RETRY_REASON] = 'early_flake_detection'
         } else if (isRetryReasonAtr) {
-          extraTags[TEST_RETRY_REASON] = 'atr'
+          extraTags[TEST_RETRY_REASON] = 'auto_test_retry'
         } else {
           extraTags[TEST_RETRY_REASON] = 'unknown'
         }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -120,6 +120,12 @@ const TEST_LEVEL_EVENT_TYPES = [
   'test_module_end',
   'test_session_end'
 ]
+const TEST_RETRY_REASON_TYPES = {
+  efd: 'early_flake_detection',
+  atr: 'auto_test_retry',
+  atf: 'attempt_to_fix',
+  ext: 'external'
+}
 
 const DD_TEST_IS_USER_PROVIDED_SERVICE = '_dd.test.is_user_provided_service'
 
@@ -227,6 +233,7 @@ module.exports = {
   DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE,
   DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
   TEST_LEVEL_EVENT_TYPES,
+  TEST_RETRY_REASON_TYPES,
   getNumFromKnownTests,
   getFileAndLineNumberFromError,
   DI_ERROR_DEBUG_INFO_CAPTURED,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds `@test.retry_reason` tag to all retries. The new type of retries are the following ones:
- `early_flake_detection` previously (`efd`): The retry is from Early Flake Detection
- `auto_test_retry`: The retry is from Auto Test Retries
- `attempt_to_fix`: The retry is from Test Management (Attempt to Fix)
- `external`: The retry is from an unknown source

The frameworks which tags are changed are the following ones:
- **Jest**
- **Mocha**
- **Cucumber**
- **Playwright**
- **Cypress**
- **Vitest**

### Motivation
<!-- What inspired you to submit this pull request? -->
Previously we were missing the tags in the retries and it was hard to identify which type of retry it was. Specially for the cases where the retry was done by the testing framework.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


