### PR TITLE
feat(llmobs): propagate `mlApp` for LLM proxy or gateway services

### DIFF
--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -10,6 +10,7 @@ module.exports = {
   METRICS: '_ml_obs.metrics',
   ML_APP: '_ml_obs.meta.ml_app',
   PROPAGATED_PARENT_ID_KEY: '_dd.p.llmobs_parent_id',
+  PROPAGATED_ML_APP_KEY: '_dd.p.llmobs_ml_app',
   PARENT_ID_KEY: '_ml_obs.llmobs_parent_id',
   TAGS: '_ml_obs.tags',
   NAME: '_ml_obs.name',

--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -33,5 +33,8 @@ module.exports = {
   OUTPUT_TOKENS_METRIC_KEY: 'output_tokens',
   TOTAL_TOKENS_METRIC_KEY: 'total_tokens',
 
-  DROPPED_IO_COLLECTION_ERROR: 'dropped_io'
+  DROPPED_IO_COLLECTION_ERROR: 'dropped_io',
+
+  ML_PROXY_TAG: 'ml-proxy',
+  CUSTOM_ML_PROXY_VALUE: 'custom'
 }

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -80,18 +80,20 @@ class LLMObsTagger {
     const globalMlApp = this._config.llmobs.mlApp
     const propagatedMlApp = span.context()._trace.tags[PROPAGATED_ML_APP_KEY]
 
-    if (directParentMlApp) {
-      mlApp = directParentMlApp
-    } else if (globalMlApp) {
-      mlApp = globalMlApp
-    } else if (propagatedMlApp) {
-      mlApp = propagatedMlApp
-      this.tagSpanTags(span, { [ML_PROXY_TAG]: CUSTOM_ML_PROXY_VALUE })
-    } else {
-      throw new Error(
-        '[LLMObs] Cannot start an LLMObs span without an mlApp configured.' +
-        'Ensure this configuration is set before running your application.'
-      )
+    if (!mlApp) {
+      if (directParentMlApp) {
+        mlApp = directParentMlApp
+      } else if (globalMlApp) {
+        mlApp = globalMlApp
+      } else if (propagatedMlApp) {
+        mlApp = propagatedMlApp
+        this.tagSpanTags(span, { [ML_PROXY_TAG]: CUSTOM_ML_PROXY_VALUE })
+      } else {
+        throw new Error(
+          '[LLMObs] Cannot start an LLMObs span without an mlApp configured.' +
+          'Ensure this configuration is set before running your application.'
+        )
+      }
     }
 
     this._setTag(span, ML_APP, mlApp)

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -88,7 +88,7 @@ describe('module', () => {
       }
       injectCh.publish({ carrier })
 
-      expect(carrier['x-datadog-tags']).to.include(',_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test')
+      expect(carrier['x-datadog-tags']).to.equal(',_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test')
     })
 
     it('does not inject LLMObs parent ID info when there is no parent LLMObs span', () => {

--- a/packages/dd-trace/test/llmobs/index.spec.js
+++ b/packages/dd-trace/test/llmobs/index.spec.js
@@ -71,7 +71,7 @@ describe('module', () => {
   })
 
   describe('handle llmobs info injection', () => {
-    it('injects LLMObs parent ID when there is a parent LLMObs span', () => {
+    it('injects LLMObs info when there is a parent LLMObs span', () => {
       llmobsModule.enable(config)
       store.span = {
         context () {
@@ -88,11 +88,21 @@ describe('module', () => {
       }
       injectCh.publish({ carrier })
 
-      expect(carrier['x-datadog-tags']).to.equal(',_dd.p.llmobs_parent_id=parent-id')
+      expect(carrier['x-datadog-tags']).to.include(',_dd.p.llmobs_parent_id=parent-id,_dd.p.llmobs_ml_app=test')
     })
 
-    it('does not inject LLMObs parent ID when there is no parent LLMObs span', () => {
+    it('does not inject LLMObs parent ID info when there is no parent LLMObs span', () => {
       llmobsModule.enable(config)
+
+      const carrier = {
+        'x-datadog-tags': ''
+      }
+      injectCh.publish({ carrier })
+      expect(carrier['x-datadog-tags']).to.equal(',_dd.p.llmobs_ml_app=test')
+    })
+
+    it('does not inject LLMOBs info when there is no mlApp configured and no parent LLMObs span', () => {
+      llmobsModule.enable({ llmobs: {} })
 
       const carrier = {
         'x-datadog-tags': ''

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1247,7 +1247,7 @@ describe('sdk', () => {
         injectCh.publish({ carrier })
       })
 
-      expect(carrier['x-datadog-tags']).to.equal(`,_dd.p.llmobs_parent_id=${parentId}`)
+      expect(carrier['x-datadog-tags']).to.equal(`,_dd.p.llmobs_parent_id=${parentId},_dd.p.llmobs_ml_app=mlApp`)
     })
   })
 })

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -158,6 +158,28 @@ describe('tagger', () => {
 
         expect(Tagger.tagMap.get(span)).to.be.undefined
       })
+
+      describe('with no global mlApp configured', () => {
+        beforeEach(() => {
+          tagger = new Tagger({ llmobs: { enabled: true } })
+        })
+
+        it('uses the mlApp from the propagated mlApp if no mlApp is provided', () => {
+          spanContext._trace.tags['_dd.p.llmobs_ml_app'] = 'my-propagated-ml-app'
+
+          tagger.registerLLMObsSpan(span, { kind: 'llm' })
+
+          const tags = Tagger.tagMap.get(span)
+          expect(tags['_ml_obs.meta.ml_app']).to.equal('my-propagated-ml-app')
+          expect(tags['_ml_obs.tags']).to.deep.equal({
+            'ml-proxy': 'custom'
+          })
+        })
+
+        it('throws an error if no mlApp is provided and no propagated mlApp is provided', () => {
+          expect(() => tagger.registerLLMObsSpan(span, { kind: 'llm' })).to.throw()
+        })
+      })
     })
 
     describe('tagMetadata', () => {


### PR DESCRIPTION
### What does this PR do?
Adds `mlApp` propagation for use cases with a proxy service that might expect to receive requests from many different mlApps. This enables easier enablement in services using LLM Observability that aren't `mlApp`-specific.

### Motivation
Easier onboarding and observability experience for LLM proxy/gateway services

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


