### PR TITLE
fix missing composite action in docs publish job

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -67,3 +67,4 @@ jobs:
           git add -A
           git commit -m ${{ fromJson(steps.pkg.outputs.json).version }}
           git push
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing composite action in docs publish job.

### Motivation
<!-- What inspired you to submit this pull request? -->

"Post Run" steps require that the action is still present on disk to run. Since the `docs` job was checking out a different branch that doesn't contain the `.github` folder, it would result in those steps failing. Checking out the original branch again restores the folder which should fix the issue.