### PR TITLE
fix shimmer slow shim by removing support for unwrap

### DIFF
--- a/integration-tests/package-guardrails/index.js
+++ b/integration-tests/package-guardrails/index.js
@@ -11,5 +11,5 @@ try {
 } catch (e) {
   const fastify = require('fastify')
 
-  console.log(fastify.toString().startsWith('function shim'))
+  console.log(fastify.toString().startsWith('function fastifyWithTrace'))
 }

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -24,9 +24,13 @@ function copyProperties (original, wrapped) {
 function wrapFunction (original, wrapper) {
   if (typeof original === 'function') assertNotClass(original)
 
-  return safeMode
+  const wrapped = safeMode
     ? safeWrapper(original, wrapper)
     : wrapper(original)
+
+  if (typeof original === 'function') copyProperties(original, wrapped)
+
+  return wrapped
 }
 
 const wrapFn = function (original, delegate) {

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -166,28 +166,6 @@ describe('shimmer', () => {
       expect(count).to.have.property('enumerable', false)
     })
 
-    it('should unwrap a method', () => {
-      const count = inc => inc
-      const obj = { count }
-
-      shimmer.wrap(obj, 'count', count => inc => count(inc) + 1)
-      shimmer.unwrap(obj, 'count')
-
-      expect(obj.count(1)).to.equal(1)
-    })
-
-    it('should unwrap a method from the prototype', () => {
-      const count = inc => inc
-      const obj = {}
-
-      Object.setPrototypeOf(obj, { count })
-
-      shimmer.wrap(obj, 'count', count => inc => count(inc) + 1)
-      shimmer.unwrap(obj, 'count')
-
-      expect(obj).to.not.have.ownProperty('count')
-    })
-
     it('should validate that there is a target object', () => {
       expect(() => shimmer.wrap()).to.throw()
     })
@@ -210,22 +188,6 @@ describe('shimmer', () => {
 
     it('should validate that the method wrapper is a function', () => {
       expect(() => shimmer.wrap({ a: () => {} }, 'a', 'notafunction')).to.throw()
-    })
-
-    it('should not throw when unwrapping without a target', () => {
-      expect(() => shimmer.unwrap(null, 'a')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping without a method', () => {
-      expect(() => shimmer.unwrap({}, 'a')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping an invalid type', () => {
-      expect(() => shimmer.unwrap({ a: 'b' }, 'a')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping a method that was not wrapped', () => {
-      expect(() => shimmer.unwrap({ a: () => {} }, 'a')).to.not.throw()
     })
 
     describe('safe mode', () => {
@@ -539,34 +501,6 @@ describe('shimmer', () => {
       expect(Object.getOwnPropertyNames(wrapped)).to.not.include('test')
     })
 
-    it('should unwrap a function', () => {
-      const count = inc => inc
-
-      const wrapped = shimmer.wrapFunction(count, count => inc => count(inc) + 1)
-
-      shimmer.unwrap(wrapped)
-
-      expect(wrapped(1)).to.equal(1)
-    })
-
-    it('should unwrap a constructor', () => {
-      const Counter = function (start) {
-        this.value = start
-      }
-
-      const WrappedCounter = shimmer.wrapFunction(Counter, Counter => function (...args) {
-        Counter.apply(this, arguments)
-        this.value++
-      })
-
-      shimmer.unwrap(WrappedCounter)
-
-      const counter = new WrappedCounter(1)
-
-      expect(counter.value).to.equal(1)
-      expect(counter).to.be.an.instanceof(Counter)
-    })
-
     it('should mass wrap methods on objects', () => {
       const foo = {
         a: () => 'original',
@@ -586,44 +520,12 @@ describe('shimmer', () => {
       expect(bar.b()).to.equal('wrapped')
     })
 
-    it('should mass wrap methods on objects', () => {
-      const foo = {
-        a: () => 'original',
-        b: () => 'original'
-      }
-
-      const bar = {
-        a: () => 'original',
-        b: () => 'original'
-      }
-
-      shimmer.massWrap([foo, bar], ['a', 'b'], () => () => 'wrapped')
-      shimmer.massUnwrap([foo, bar], ['a', 'b'])
-
-      expect(foo.a()).to.equal('original')
-      expect(foo.b()).to.equal('original')
-      expect(bar.a()).to.equal('original')
-      expect(bar.b()).to.equal('original')
-    })
-
     it('should validate that the function wrapper exists', () => {
       expect(() => shimmer.wrap(() => {})).to.throw()
     })
 
     it('should validate that the function wrapper is a function', () => {
       expect(() => shimmer.wrap(() => {}, 'a')).to.throw()
-    })
-
-    it('should never throw when unwrapping', () => {
-      expect(() => shimmer.unwrap(() => {})).to.not.throw()
-    })
-
-    it('should not throw when unwrapping an invalid type', () => {
-      expect(() => shimmer.unwrap('foo')).to.not.throw()
-    })
-
-    it('should not throw when unwrapping a function that was not wrapped', () => {
-      expect(() => shimmer.unwrap(() => {})).to.not.throw()
     })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -107,12 +107,8 @@ describe('IAST Rewriter', () => {
       rewriter.disableRewriter()
     })
 
-    it('Should unwrap module compile method on taint tracking disable', () => {
-      rewriter.disableRewriter()
-
-      expect(shimmer.unwrap).to.be.calledOnce
-      expect(shimmer.unwrap.getCall(0).args[1]).eq('_compile')
-    })
+    // TODO: This cannot be tested with mocking.
+    it('Should unwrap module compile method on taint tracking disable') // eslint-disable-line mocha/no-pending-tests
 
     it('Should keep original prepareStackTrace fn when calling enable and then disable', () => {
       const orig = Error.prepareStackTrace


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix shimmer slow shim by removing support for unwrap.

### Motivation
<!-- What inspired you to submit this pull request? -->

Last summer we changed all integrations to use shimmer instead of simple assignments in #4585 and #4634. This made everything slower by adding an additional wrapper to every instrumented function, resulting in a regression. The reason for the additional wrapper that is added by shimmer is to be able to unwrap later by replacing the inner wrapper with the original function. In reality, this was only used in 1 place, so I moved that logic there and removed it from shimmer, making wrapped functions faster.