### PR TITLE
Fix MongoDB heartbeat filtering when DD_TRACE_MONGODB_HEARTBEAT_ENABL…

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
+const { isTrue } = require('../../dd-trace/src/util')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 const coalesce = require('koalas')
-const { isTrue } = require('../../dd-trace/src/util')
 
 class MongodbCorePlugin extends DatabasePlugin {
   static get id () { return 'mongodb-core' }

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -14,7 +14,7 @@ class MongodbCorePlugin extends DatabasePlugin {
     super.configure(config)
     this.config.heartbeatEnabled = coalesce(
       config.heartbeatEnabled,
-      process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED,
+      process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED === 'false' ? false : null,
       true
     )
   }

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -2,6 +2,7 @@
 
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 const coalesce = require('koalas')
+const { isTrue } = require('../../dd-trace/src/util')
 
 class MongodbCorePlugin extends DatabasePlugin {
   static get id () { return 'mongodb-core' }
@@ -14,7 +15,7 @@ class MongodbCorePlugin extends DatabasePlugin {
     super.configure(config)
     this.config.heartbeatEnabled = coalesce(
       config.heartbeatEnabled,
-      process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED === 'false' ? false : null,
+      isTrue(process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED),
       true
     )
   }

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -13,9 +13,12 @@ class MongodbCorePlugin extends DatabasePlugin {
 
   configure (config) {
     super.configure(config)
+
+    const heartbeatFromEnv = process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
+
     this.config.heartbeatEnabled = coalesce(
       config.heartbeatEnabled,
-      isTrue(process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED),
+      heartbeatFromEnv && isTrue(heartbeatFromEnv),
       true
     )
   }


### PR DESCRIPTION
…ED is set to 'false'

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes an issue where MongoDB heartbeat traces were still being collected even when the environment variable `DD_TRACE_MONGODB_HEARTBEAT_ENABLED` was set to 'false'. The fix properly converts the string 'false' to a boolean value to ensure the heartbeat filtering works as expected.

### Motivation
<!-- What inspired you to submit this pull request? -->
While testing MongoDB tracing, we discovered that setting `DD_TRACE_MONGODB_HEARTBEAT_ENABLED=false` didn't actually disable heartbeat traces. This was because the string value 'false' is truthy in JavaScript, causing the heartbeat filtering condition to fail. This fix ensures that MongoDB monitoring heartbeats can be properly excluded from traces when users want to reduce trace volume.
![image](https://github.com/user-attachments/assets/d70d23e0-7190-4105-bec1-8668ad99c4e0)


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


