### PR TITLE
Constrain async ID collection to main thread only

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -70,7 +70,9 @@ function ensureChannelsActivated () {
 class NativeWallProfiler {
   constructor (options = {}) {
     this.type = 'wall'
-    this._asyncIdEnabled = !!options.asyncIdEnabled
+    // Currently there's a crash sometimes on worker threads trying to collect async IDs so for the
+    // time being we'll constrain it to only the main thread.
+    this._asyncIdEnabled = !!options.asyncIdEnabled && require('worker_threads').isMainThread
     this._codeHotspotsEnabled = !!options.codeHotspotsEnabled
     this._cpuProfilingEnabled = !!options.cpuProfilingEnabled
     this._endpointCollectionEnabled = !!options.endpointCollectionEnabled


### PR DESCRIPTION
### What does this PR do?
Constrains async ID collection to main thread only.

### Motivation
Seems like in worker threads it can cause crashes. Until we can reproduce and fix the crashes we'll limit the use of the feature.

### Additional Notes
A typical crash has the stack trace:
```
_ZN2v87Isolate17GetCurrentContextEv
_ZN4node29AsyncHooksGetExecutionAsyncIdEPN2v87IsolateE
_ZN2dd14GetAsyncIdNoGCEPN2v87IsolateE
_ZN2dd12_GLOBAL__N_113SignalHandler20HandleProfilerSignalEiP9siginfo_tPv
_ZN2v88internal11HandleScope16DeleteExtensionsEPNS0_7IsolateE
_ZN4node11Environment9RunTimersEP10uv_timer_s
uv__run_timers
uv_run
_ZN4node21SpinEventLoopInternalEPNS_11EnvironmentE
_ZN4node6worker6Worker3RunEv
_ZZN4node6worker6Worker11StartThreadERKN2v820FunctionCallbackInfoINS2_5ValueEEEENUlPvE_4_FUNES8_
start_thread
clone
```

Jira: [PROF-11628]

[PROF-11628]: https://datadoghq.atlassian.net/browse/PROF-11628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ