### PR TITLE
Update profiler from 5.7.0 to 5.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@datadog/native-appsec": "8.5.1",
     "@datadog/native-iast-taint-tracking": "3.3.0",
     "@datadog/native-metrics": "^3.1.0",
-    "@datadog/pprof": "5.7.0",
+    "@datadog/pprof": "5.7.1",
     "@datadog/sketches-js": "^2.1.0",
     "@datadog/wasm-js-rewriter": "3.1.0",
     "@isaacs/ttlcache": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.7.0.tgz#3dde6d0cce023091f30effc0aab0c896ad2d7fe3"
-  integrity sha512-+pTeElxHwNUQrqY11f6MUUJDk9pMTIvu0LZhEpDZPphq8WDNU9OBvqFFfX9YdQI/nLZAe4L8t2CEgeJJwzW5EQ==
+"@datadog/pprof@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.7.1.tgz#3ed62372af7331c37de401319bde9e3d4dc5a8c0"
+  integrity sha512-D5XTxsaPG36x41vZZn8hsAeC7QQDx0rv1a1Uhxo5xCXUB/9rc19+I7iCnjgJS5aH0ShXdPVOWRClo16hOSKKSw==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Updates profiler from 5.7.0 to 5.7.1

### Motivation
5.7.1 is compiled with the updated toolchain (GCC 9 and Alpine 3.11), so should both work on older Alpine versions and also be entirely free of aarch64 instructions that cause crashes on some ARM CPUs.
