### PR TITLE
update libdatadog to 0.5.1 and native-metrics to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/libdatadog": "^0.5.0",
+    "@datadog/libdatadog": "^0.5.1",
     "@datadog/native-appsec": "8.5.2",
     "@datadog/native-iast-taint-tracking": "3.3.1",
-    "@datadog/native-metrics": "^3.1.0",
+    "@datadog/native-metrics": "^3.1.1",
     "@datadog/pprof": "5.7.1",
     "@datadog/sketches-js": "^2.1.0",
     "@datadog/wasm-js-rewriter": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,10 +356,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@datadog/libdatadog@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.5.0.tgz#0ef2a2a76bb9505a0e7e5bc9be1415b467dbf368"
-  integrity sha512-YvLUVOhYVjJssm0f22/RnDQMc7ZZt/w1bA0nty1vvjyaDz5EWaHfWaaV4GYpCt5MRvnGjCBxIwwbRivmGseKeQ==
+"@datadog/libdatadog@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.5.1.tgz#fe5c101c457998b74cb66f555f63197b34cad4ba"
+  integrity sha512-KsdOxTUmtjoygaZInSS5U0+KnqoxPKGpcBjGgOHR9NDKfXzmbpy5AmoaPL7JxmMxQzwknpxSi7qzBOSB3yMoJg==
 
 "@datadog/native-appsec@8.5.2":
   version "8.5.2"
@@ -375,10 +375,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-metrics@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.1.0.tgz#c2378841accd9fdd6866d0e49bdf6e3d76e79f22"
-  integrity sha512-yOBi4x0OQRaGNPZ2bx9TGvDIgEdQ8fkudLTFAe7gEM1nAlvFmbE5YfpH8WenEtTSEBwojSau06m2q7axtEEmCg==
+"@datadog/native-metrics@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@datadog/native-metrics/-/native-metrics-3.1.1.tgz#4e5c9775751af13e353e64e573ab724104538cee"
+  integrity sha512-MU1gHrolwryrU4X9g+fylA1KPH3S46oqJPEtVyrO+3Kh29z80fegmtyrU22bNt8LigPUK/EdPCnSbMe88QbnxQ==
   dependencies:
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update libdatadog to 0.5.1 and native-metrics to 3.1.1

### Motivation
<!-- What inspired you to submit this pull request? -->

These versions are now built with GCC 9 which fixes a bug that can crash on ARM, and on Alpine 3.11 to fix support for older versions of Alpine.