### PR TITLE
Fix release proposal workflow commit permissions

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -24,7 +24,7 @@ jobs:
   create-proposal:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,5 +37,7 @@ jobs:
       - run: |
           mkdir -p ~/.config/changelog-maker
           echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
       - run: node scripts/release/proposal 5 -y --{{ inputs.increment }}
         if: inputs.release-line == 'all' || inputs.release-line == '5'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix release proposal workflow commit permissions.

### Motivation
<!-- What inspired you to submit this pull request? -->

There is no username/email by default for commits in GitHub Actions. This PR uses the same user as for `branch-diff`.