### PR TITLE
[DI] Add debug log when translating breakpoint location using source map

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -48,6 +48,10 @@ async function addBreakpoint (probe) {
   const { url, scriptId, sourceMapURL, source } = script
 
   if (sourceMapURL) {
+    log.debug(
+      '[debugger:devtools_client] Translating location using source map for %s:%d:%d (probe: %s, version: %d)',
+      file, lineNumber, columnNumber, probe.id, probe.version
+    );
     ({ line: lineNumber, column: columnNumber } = await getGeneratedPosition(url, source, lineNumber, sourceMapURL))
   }
 

--- a/packages/dd-trace/src/debugger/devtools_client/source-maps.js
+++ b/packages/dd-trace/src/debugger/devtools_client/source-maps.js
@@ -27,7 +27,7 @@ const self = module.exports = {
 
   async getGeneratedPosition (url, source, line, sourceMapURL) {
     const dir = dirname(new URL(url).pathname)
-    return await SourceMapConsumer.with(
+    return SourceMapConsumer.with(
       await self.loadSourceMap(dir, sourceMapURL),
       null,
       (consumer) => consumer.generatedPositionFor({ source, line, column: 0 })


### PR DESCRIPTION
### What does this PR do?

This PR adds a debug statement just before translating a probe location using source maps. It logs the original file and line number before the translation.

This PR also reduces overhead slightly when translating the location using source map, by not awaiting the result of the translation, but simply returning the promise. The caller will await anyway, so the extra await is just creating extra promises in memory which we don't need.

### Motivation

When debugging an issue with a probe, it's useful to know what the original file/line was before being translated by the source map. It's also the only indication we have in the logs that a source map was ever involved, which is even more important in a debugging scenario (in case we want to know if source maps was deployed together with the application or not).

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


