### PR TITLE
switch from default token to app token for release proposal

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -24,20 +24,26 @@ jobs:
   create-proposal:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      contents: read
+      pull-requests: read
     steps:
+      - uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/node
       - run: npm i -g branch-diff
       - run: |
           mkdir -p ~/.config/changelog-maker
-          echo "{\"token\":\"${{secrets.GITHUB_TOKEN}}\",\"user\":\"${{github.actor}}\"}" > ~/.config/changelog-maker/config.json
+          echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
-      - run: node scripts/release/proposal 5 -y --{{ inputs.increment }}
-        if: inputs.release-line == 'all' || inputs.release-line == '5'
+      - if: inputs.release-line == 'all' || inputs.release-line == '5'
+        run: node scripts/release/proposal 5 -y --{{ inputs.increment }}
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch from default token to app token for release proposal.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is required for a workflow triggered by the `workflow_dispatch` event to trigger other types of workflow, otherwise no workflow will run, for example `on: push` or `on: pull_request`.

Reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I kept the default token with read-only permissions for `branch-diff` since it doesn't need to write.
