### PR TITLE
Only activate async_hooks when they're needed for profiler features

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -115,8 +115,6 @@ class NativeWallProfiler {
   start ({ mapper } = {}) {
     if (this._started) return
 
-    ensureChannelsActivated()
-
     this._mapper = mapper
     this._pprof = require('@datadog/pprof')
     kSampleCount = this._pprof.time.constants.kSampleCount
@@ -146,6 +144,8 @@ class NativeWallProfiler {
       if (this._captureSpanData) {
         this._profilerState = this._pprof.time.getState()
         this._lastSampleCount = 0
+
+        ensureChannelsActivated()
 
         beforeCh.subscribe(this._enter)
         enterCh.subscribe(this._enter)


### PR DESCRIPTION
### What does this PR do?
Makes `async_hooks` activation in CPU profiler conditional on use of features that actually require them – namely code hotspots and endpoint profiling. This is a simpler version of #5505 that can be incrementally introduced.

### Motivation
We want to provide customers with an option to reduce the overhead caused by async_hooks by turning off features they mightn't need.
