### PR TITLE
make v5.x codeowners consistent with the main branch

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,87 @@
 * @DataDog/dd-trace-js
+
+/packages/dd-trace/src/appsec/ @DataDog/asm-js
+/packages/dd-trace/test/appsec/ @DataDog/asm-js
+
+/integration-tests/debugger/ @DataDog/dd-trace-js @DataDog/debugger
+/packages/datadog-code-origin/ @DataDog/dd-trace-js @DataDog/debugger
+/packages/datadog-plugin-*/**/code_origin.* @DataDog/dd-trace-js @DataDog/debugger
+/packages/dd-trace/src/debugger/ @DataDog/dd-trace-js @DataDog/debugger
+/packages/dd-trace/test/debugger/ @DataDog/dd-trace-js @DataDog/debugger
+
+/packages/dd-trace/src/lambda/ @DataDog/serverless-aws
+/packages/dd-trace/test/lambda/ @DataDog/serverless-aws
+
+/packages/datadog-plugin-*/ @Datadog/dd-trace-js @Datadog/apm-idm-js
+/packages/datadog-instrumentations/ @Datadog/dd-trace-js @Datadog/apm-idm-js
+/packages/ddtrace/src/plugins/ @DataDog/dd-trace-js @Datadog/apm-idm-js
+/packages/ddtrace/test/plugins/ @DataDog/dd-trace-js @Datadog/apm-idm-js
+
+/packages/dd-trace/src/ci-visibility/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-jest/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-mocha/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-cucumber/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-cypress/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-playwright/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-vitest/ @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/ci_plugin.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/ci-visibility/ @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/git.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/ci-env/ @DataDog/ci-app-libraries
+
+/packages/datadog-instrumentations/src/jest.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/mocha/ @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cucumber.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cypress.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/playwright.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest.js @DataDog/ci-app-libraries
+
+/integration-tests/ci-visibility/ @DataDog/ci-app-libraries
+/integration-tests/cucumber/ @DataDog/ci-app-libraries
+/integration-tests/cypress/ @DataDog/ci-app-libraries
+/integration-tests/playwright/ @DataDog/ci-app-libraries
+/integration-tests/jest/jest.spec.js @DataDog/ci-app-libraries
+/integration-tests/mocha/mocha.spec.js @DataDog/ci-app-libraries
+/integration-tests/playwright/playwright.spec.js @DataDog/ci-app-libraries
+/integration-tests/cucumber/cucumber.spec.js @DataDog/ci-app-libraries
+/integration-tests/cypress/cypress.spec.js @DataDog/ci-app-libraries
+/integration-tests/vitest/vitest.spec.js @DataDog/ci-app-libraries
+/integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
+/integration-tests/test-api-manual.spec.js @DataDog/ci-app-libraries
+
+/packages/dd-trace/src/service-naming/ @Datadog/apm-idm-js
+/packages/dd-trace/test/service-naming/ @Datadog/apm-idm-js
+
+/packages/dd-trace/src/llmobs/ @DataDog/ml-observability
+/packages/dd-trace/test/llmobs/ @DataDog/ml-observability
+/packages/datadog-plugin-openai/ @DataDog/ml-observability
+/packages/datadog-plugin-langchain/ @DataDog/ml-observability
+/packages/datadog-plugin-google-cloud-vertexai/ @DataDog/ml-observability
+/packages/datadog-instrumentations/src/openai.js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/langchain.js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/google-cloud-vertexai.js @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js @DataDog/ml-observability
+
+# CI
+/.github/workflows/appsec.yml @DataDog/asm-js
+/.github/workflows/ci-visibility-performance.yml @DataDog/ci-app-libraries
+/.github/workflows/codeql-analysis.yml @DataDog/dd-trace-js
+/.github/workflows/core.yml @DataDog/dd-trace-js
+/.github/workflows/lambda.yml @DataDog/serverless-aws
+/.github/workflows/package-size.yml @DataDog/dd-trace-js
+/.github/workflows/plugins.yml @DataDog/dd-trace-js
+/.github/workflows/pr-labels.yml @DataDog/dd-trace-js
+/.github/workflows/profiling.yml @DataDog/profiling-js
+/.github/workflows/project.yml @DataDog/dd-trace-js
+/.github/workflows/release-3.yml @DataDog/dd-trace-js
+/.github/workflows/release-dev.yml @DataDog/dd-trace-js
+/.github/workflows/release-latest.yml @DataDog/dd-trace-js
+/.github/workflows/release-proposal.yml @DataDog/dd-trace-js
+/.github/workflows/serverless-integration-test.yml @DataDog/serverless-aws @DataDog/serverless
+/.github/workflows/system-tests.yml @DataDog/dd-trace-js @DataDog/asm-js
+/.github/workflows/test-k8s-lib-injection.yaml @DataDog/dd-trace-js
+/.github/workflows/tracing.yml @DataDog/dd-trace-js
+/.gitlab/benchmarks.yml @DataDog/dd-trace-js
+/.gitlab-ci.yml @DataDog/dd-trace-js


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Make v5.x CODEOWNERS consistent with the main branch.

### Motivation
<!-- What inspired you to submit this pull request? -->

Previously, the CODEOWNERS in release branches was always merged to keep the contents from the release branch which was all of dd-trace-js. This was done to avoid needing specific teams to approve a release. However, this added a constant source of merge conflict to the release process. There wasn't really a good reason to enforce review from a code owner anyway, so the check was removed, allowing the file to be the same as on the main branch.