### PR TITLE
fix elasticsearch 9 support

### DIFF
--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -11,8 +11,7 @@ describe('Plugin', () => {
 
   withVersions('elasticsearch', ['elasticsearch', '@elastic/elasticsearch'], (version, moduleName) => {
     const metaModule = require(`../../../versions/${moduleName}@${version}`)
-    const hasCallbackSupport = !(moduleName === '@elastic/elasticsearch' &&
-      metaModule.version().split('.')[0] >= 8)
+    const hasCallbackSupport = !(moduleName === '@elastic/elasticsearch' && metaModule.version().split('.')[0] >= 8)
 
     describe('elasticsearch', () => {
       beforeEach(() => {

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -11,7 +11,8 @@ describe('Plugin', () => {
 
   withVersions('elasticsearch', ['elasticsearch', '@elastic/elasticsearch'], (version, moduleName) => {
     const metaModule = require(`../../../versions/${moduleName}@${version}`)
-    const hasCallbackSupport = !(moduleName === '@elastic/elasticsearch' && metaModule.version().startsWith('8.'))
+    const hasCallbackSupport = !(moduleName === '@elastic/elasticsearch' &&
+      metaModule.version().split('.')[0] >= 8)
 
     describe('elasticsearch', () => {
       beforeEach(() => {
@@ -122,13 +123,11 @@ describe('Plugin', () => {
                 'elasticsearch.body',
                 '[{"index":"docs"},{"query":{"match_all":{}}},{"index":"docs2"},{"query":{"match_all":{}}}]'
               )
-              expect(traces[0][0].meta).to.have.property('elasticsearch.params', '{"size":100}')
             })
             .then(done)
             .catch(done)
 
           client.msearch({
-            size: 100,
             body: [
               { index: 'docs' },
               {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix Elasticsearch 9 test.

### Motivation
<!-- What inspired you to submit this pull request? -->

A new major version of Elasticsearch was released, which broke 2 things:

1) Our tests for callback support checked for version 8 specifically instead of 8 and up, so all tests started failing.
2) Params are not supported for [msearch](https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/api-reference#_arguments_msearch) as the params are supposed to be set in each search entry. For some reason this was working before anyway, but it now breaks in the new version.