### PR TITLE
add concurrency and matrix to release proposal

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -20,8 +20,19 @@ on:
           - 'auto'
           - 'minor'
           - 'patch'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   create-proposal:
+    strategy:
+      fail-fast: false
+      matrix:
+        release-line: ['5']
+        exclude:
+          - release-line: ${{ inputs.release-line != 'all' && inputs.release-line != '5' && '5' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,6 +47,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
+      - run: git fetch origin master:master
       - uses: ./.github/actions/node
       - run: npm i -g branch-diff
       - run: |
@@ -43,7 +55,6 @@ jobs:
           echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
-      - if: inputs.release-line == 'all' || inputs.release-line == '5'
-        run: node scripts/release/proposal 5 -y --{{ inputs.increment }}
+      - run: node scripts/release/proposal ${{ matrix.release-line }} -y --{{ inputs.increment }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -19,6 +19,7 @@ const {
 } = require('./helpers/terminal')
 const { checkBranchDiff, checkGitHub, checkGit } = require('./helpers/requirements')
 
+const tmpdir = process.env.RUNNER_TEMP || os.tmpdir()
 const releaseLine = params[0]
 
 // Validate release line argument.
@@ -26,7 +27,8 @@ if (!releaseLine || releaseLine === 'help' || flags.help) {
   log(
     'Usage: node scripts/release/proposal <release-line>\n',
     'Options:',
-    '  -y         Always accept prompts.',
+    '  -n         Do not push release proposal upstream.',
+    '  -y         Push release proposal upstream.',
     '  --debug    Print raw commands and their outputs.',
     '  --help     Show this help.',
     '  --auto     Automatically detect version increment. (this is default)',
@@ -73,8 +75,8 @@ try {
   const newVersion = isMinor
     ? `${releaseLine}.${DD_MINOR + 1}.0`
     : `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
-  const notesDir = path.join(os.tmpdir(), 'release_notes')
-  const notesFile = path.join(notesDir, `${newVersion}.md`)
+  const notesDir = path.join(tmpdir, 'release_notes')
+  const notesFile = path.join(notesDir, `v${newVersion}.md`)
 
   pass(`${isMinor ? 'minor' : 'patch'} (${DD_MAJOR}.${DD_MINOR}.${DD_PATCH} -> ${newVersion})`)
 
@@ -141,6 +143,7 @@ try {
 
   pass(notesFile)
 
+  if (flags.n) process.exit(0)
   if (!flags.y) {
     // Stop and ask the user if they want to proceed with pushing everything upstream.
     checkpoint('Push the release upstream and create/update PR?')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add concurrency and matrix to release proposal.

### Motivation
<!-- What inspired you to submit this pull request? -->

Better split multiple runs of the workflow job. Using a matrix allows us to parallelize each release line, and using concurrency avoids any issue with multiple runs trying to write to the same PR at once.