### PR TITLE
[LANGPLAT-380] Fix OOM tests flakiness

### DIFF
--- a/integration-tests/profiler/oom.js
+++ b/integration-tests/profiler/oom.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable no-console */
 
-require('dd-trace').init()
+const tracer = require('dd-trace').init()
 
 const { Worker, isMainThread, threadId } = require('worker_threads')
 
@@ -44,4 +44,8 @@ function foo (size) {
   if (count < maxCount) { setTimeout(() => foo(size), sleepMs) }
 }
 
-setTimeout(() => foo(sizeQuantum), sleepMs)
+tracer.profilerStarted().then(
+  () => {
+    setTimeout(() => foo(sizeQuantum), sleepMs)
+  }
+)

--- a/packages/dd-trace/src/profiling/exporter_cli.js
+++ b/packages/dd-trace/src/profiling/exporter_cli.js
@@ -10,7 +10,7 @@ const fs = require('fs')
 const { fileURLToPath } = require('url')
 
 const logger = new ConsoleLogger()
-const timeoutMs = 10 * 1000
+const timeoutMs = 15 * 1000
 
 function exporterFromURL (url) {
   if (url.protocol === 'file:') {


### PR DESCRIPTION
### What does this PR do?

- Use `tracer.profilerStarted()` to ensure the profiler is started before running the test
- Remove export tests of strategies that are not used in the profiler and are not guaranteed to succeed (async)

### Motivation

Reduce OOM tests flakyness.


