### PR TITLE
[test-optimization] [SDTEST-1871] Fix Playwright bug when redirecting

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -805,19 +805,25 @@ addHook({
 
     const page = this
 
-    const isRumActive = await page.evaluate(() => {
-      if (window.DD_RUM && window.DD_RUM.getInternalContext) {
-        return !!window.DD_RUM.getInternalContext()
-      } else {
-        return false
-      }
-    })
+    try {
+      if (page) {
+        const isRumActive = await page.evaluate(() => {
+          if (window.DD_RUM && window.DD_RUM.getInternalContext) {
+            return !!window.DD_RUM.getInternalContext()
+          } else {
+            return false
+          }
+        })
 
-    if (isRumActive) {
-      testPageGotoCh.publish({
-        isRumActive,
-        page
-      })
+        if (isRumActive) {
+          testPageGotoCh.publish({
+            isRumActive,
+            page
+          })
+        }
+      }
+    } catch (e) {
+      // ignore errors such as redirects, context destroyed, etc
     }
 
     return response


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This fixes a bug when you were redirected to another page once to used the `page.goto()`. This fix, just adds a `try` `catch` to ignore this errors, and avoid breaking the CI.

### Motivation
<!-- What inspired you to submit this pull request? -->
There is an issue regarding this topic &rarr; https://github.com/DataDog/dd-trace-js/issues/5589

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


