### PR TITLE
[test-optimization] [SDTEST-1870] Add support for Playwright >= 1.52.0

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -761,9 +761,17 @@ addHook({
     return rootSuite
   }
 
-  loadUtilsPackage.createRootSuite = newCreateRootSuite
+  // We need to proxy the createRootSuite function because the function is not configurable
+  const proxy = new Proxy(loadUtilsPackage, {
+    get (target, prop) {
+      if (prop === 'createRootSuite') {
+        return newCreateRootSuite
+      }
+      return target[prop]
+    }
+  })
 
-  return loadUtilsPackage
+  return proxy
 })
 
 // main process hook


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Latest release of Playwright made some functionalities related to test retries fail. The issue was that in the latest release the `loadUtils.js` made his functions not configurable. When the `Object.getOwnPropertyDescriptor(loadUtilsPackage, 'createRootSuite')` was runned this was the output:
```text
{ 
  get: [Function: get], 
  set: undefined, 
  enumerable: true, 
  configurable: false 
}
```
Due to the value of the `configurable` equal to `false`, we need to use a `proxy`.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to keep supporting newer versions of the Playwright framework.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


