### PR TITLE
fix release proposal job failing to fetch existing main branch

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-      - run: git fetch origin master:master
+      - run: git fetch origin master:master || exit 0
       - uses: ./.github/actions/node
       - run: npm i -g branch-diff
       - run: |


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix release proposal job failing to fetch existing main branch.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was added in order to be able to trigger the workflow from other branches when changes are made. However, git refuses to fetch an existing branch which is the case when the branch we want to fetch was the one that triggered the workflow (the default case) but we can ignore the error as if  the branch is already there that's what we wanted in the first place.