### PR TITLE
Add minimal fast path for esm being enabled

### DIFF
--- a/packages/datadog-plugin-langchain/src/index.js
+++ b/packages/datadog-plugin-langchain/src/index.js
@@ -2,7 +2,6 @@
 
 const langChainTracingPlugins = require('./tracing')
 const langChainLLMObsPlugins = require('../../dd-trace/src/llmobs/plugins/langchain')
-// const LangChainLLMObsPlugin = require('../../dd-trace/src/llmobs/plugins/langchain')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 const plugins = {}

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -19,9 +19,11 @@ let config
 const hardcodedSecretCh = dc.channel('datadog:secrets:result')
 let rewriter
 let unwrapCompile = () => {}
-let getPrepareStackTrace, cacheRewrittenSourceMap
+let getPrepareStackTrace
+let cacheRewrittenSourceMap
 let kSymbolPrepareStackTrace
-let esmRewriterEnabled = false
+
+function noop () {}
 
 function isFlagPresent (flag) {
   return process.env.NODE_OPTIONS?.includes(flag) ||
@@ -155,7 +157,7 @@ function shimPrepareStackTrace () {
     return
   }
   const pstDescriptor = Object.getOwnPropertyDescriptor(global.Error, 'prepareStackTrace')
-  if (!pstDescriptor || pstDescriptor.configurable) {
+  if (pstDescriptor?.configurable || pstDescriptor?.writable) {
     Object.defineProperty(global.Error, 'prepareStackTrace', getPrepareStackTraceAccessor())
   }
   shimmedPrepareStackTrace = true
@@ -181,15 +183,16 @@ function isEsmConfigured () {
   const hasLoaderArg = isFlagPresent('--loader') || isFlagPresent('--experimental-loader')
   if (hasLoaderArg) return true
 
-  const initializeLoaded = Object.keys(require.cache).find(file => file.includes('import-in-the-middle/hook.js'))
-  return !!initializeLoaded
+  // Fast path for common case when enabled
+  if (require.cache[`${process.cwd()}/node_modules/import-in-the-middle/hook.js`]) {
+    return true
+  }
+  return Object.keys(require.cache).some(file => file.endsWith('import-in-the-middle/hook.js'))
 }
 
-function enableEsmRewriter (telemetryVerbosity) {
-  if (isMainThread && Module.register && !esmRewriterEnabled && isEsmConfigured()) {
+let enableEsmRewriter = function (telemetryVerbosity) {
+  if (isMainThread && Module.register && isEsmConfigured()) {
     shimPrepareStackTrace()
-
-    esmRewriterEnabled = true
 
     const { port1, port2 } = new MessageChannel()
 
@@ -229,6 +232,8 @@ function enableEsmRewriter (telemetryVerbosity) {
     }
 
     cacheRewrittenSourceMap = require('@datadog/wasm-js-rewriter/js/source-map').cacheRewrittenSourceMap
+
+    enableEsmRewriter = noop
   }
 }
 


### PR DESCRIPTION
The main change is to check for the top level presence of import- in-the-middle. That way there is no need for extra checks.

It won't change much, but it's definitely less work in case the cache has lots and lots of entries.