### PR TITLE
simple benchmark helper for adding operations per second

### DIFF
--- a/benchmark/sirun/helpers.js
+++ b/benchmark/sirun/helpers.js
@@ -1,0 +1,23 @@
+const StatsD = require('./statsd')
+
+let statsd
+
+const benchOps = {
+  start (name, iterations = 1) {
+    const start = process.hrtime.bigint()
+    if (!statsd) {
+      statsd = new StatsD()
+      process.on('beforeExit', () => statsd.flush())
+    }
+    return {
+      end () {
+        const end = process.hrtime.bigint()
+        const duration = Number(end - start)
+        const ops = iterations * 1e9 / duration
+        statsd.gauge(name + '.ops', ops)
+      }
+    }
+  }
+}
+
+exports.benchOps = benchOps

--- a/benchmark/sirun/spans/spans.js
+++ b/benchmark/sirun/spans/spans.js
@@ -1,3 +1,4 @@
+const { benchOps } = require('../helpers')
 const tracer = require('../../..').init()
 
 tracer._tracer._processor.process = function process (span) {
@@ -9,7 +10,10 @@ const { FINISH } = process.env
 
 const spans = []
 
-for (let i = 0; i < 100000; i++) {
+const ITERATIONS = 100000
+
+const bench = benchOps.start('spans', ITERATIONS)
+for (let i = 0; i < ITERATIONS; i++) {
   const span = tracer.startSpan('some.span.name', {})
   if (FINISH === 'now') {
     span.finish()
@@ -19,7 +23,8 @@ for (let i = 0; i < 100000; i++) {
 }
 
 if (FINISH !== 'now') {
-  for (let i = 0; i < 100000; i++) {
+  for (let i = 0; i < ITERATIONS; i++) {
     spans[i].finish()
   }
 }
+bench.end()


### PR DESCRIPTION
Adds a benchmark helper for calculating the operations per second in a given benchmark, then sending that off to Sirun via statsd, for inclusion in the output.


