### PR TITLE
[DI] Improve logging in integration tests

### DIFF
--- a/integration-tests/debugger/target-app/basic.js
+++ b/integration-tests/debugger/target-app/basic.js
@@ -3,7 +3,7 @@
 require('dd-trace/init')
 const Fastify = require('fastify')
 
-const fastify = Fastify()
+const fastify = Fastify({ logger: { level: 'error' } })
 
 fastify.get('/foo/:name', function fooHandler (request) {
   return { hello: request.params.name } // BREAKPOINT: /foo/bar

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -3,7 +3,7 @@
 require('dd-trace/init')
 const Fastify = require('fastify')
 
-const fastify = Fastify()
+const fastify = Fastify({ logger: { level: 'error' } })
 
 fastify.get('/', function () {
   /* eslint-disable no-unused-vars */

--- a/integration-tests/debugger/target-app/snapshot-pruning.js
+++ b/integration-tests/debugger/target-app/snapshot-pruning.js
@@ -5,7 +5,7 @@ require('dd-trace/init')
 const { randomBytes } = require('crypto')
 const Fastify = require('fastify')
 
-const fastify = Fastify()
+const fastify = Fastify({ logger: { level: 'error' } })
 
 const TARGET_SIZE = 1024 * 1024 // 1MB
 const LARGE_STRING = randomBytes(1024).toString('hex')

--- a/integration-tests/debugger/target-app/snapshot.js
+++ b/integration-tests/debugger/target-app/snapshot.js
@@ -3,7 +3,7 @@
 require('dd-trace/init')
 const Fastify = require('fastify')
 
-const fastify = Fastify()
+const fastify = Fastify({ logger: { level: 'error' } })
 
 fastify.get('/:name', function handler (request) {
   /* eslint-disable no-unused-vars */

--- a/integration-tests/debugger/target-app/template.js
+++ b/integration-tests/debugger/target-app/template.js
@@ -4,7 +4,7 @@ require('dd-trace/init')
 const { inspect } = require('util')
 const Fastify = require('fastify')
 
-const fastify = Fastify()
+const fastify = Fastify({ logger: { level: 'error' } })
 
 const weakObj = {}
 


### PR DESCRIPTION
The Dynamic Instrumentation integration tests uses Fastify in some of the instrumented test apps.
    
We've seen issues in CI where the inspected application exits with exit code 1, but there's no error message being logged. So it's not possible to see what caused the process to exit.
  
By default Fastify doesn't log any messages to STDOUT/STDERR. This might be the reason why we only see the exit code, but not any error message.
   
For better visibility into such errors in CI, this PR changes the default log level to `error`, so that errors are logged to STDERR
