### PR TITLE
[DI] Improve integration test failue output

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -109,8 +109,8 @@ function setup ({ env, testApp, testAppSource } = {}) {
   })
 
   afterEach(async function () {
-    t.proc.kill()
-    await t.agent.stop()
+    t.proc?.kill()
+    await t.agent?.stop()
   })
 
   return t


### PR DESCRIPTION
If for some reason the Dynamic Instrumentation integration tests fail in the `beforeEach` stage, there's a risk that some of the data structures that the `afterEach` block depends on have not been populated.
 
To not spam the logs with these errors that are only present because of previous errors, better use optional chaining when referencing these data structures.
