### PR TITLE
cut down shimmer-startup benchmark so it can run in benchmarking platform

### DIFF
--- a/benchmark/sirun/shimmer-startup/index.js
+++ b/benchmark/sirun/shimmer-startup/index.js
@@ -8,7 +8,7 @@ const {
   FUNCTION_NAME
 } = process.env
 
-const ITERATIONS = 1e6
+const ITERATIONS = 1e5
 
 let counter = 0
 function declared () {

--- a/benchmark/sirun/shimmer-startup/index.js
+++ b/benchmark/sirun/shimmer-startup/index.js
@@ -8,7 +8,7 @@ const {
   FUNCTION_NAME
 } = process.env
 
-const ITERATIONS = 2e6
+const ITERATIONS = 1e6
 
 let counter = 0
 function declared () {

--- a/benchmark/sirun/shimmer-startup/meta.json
+++ b/benchmark/sirun/shimmer-startup/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 5,
   "instructions": true,
   "variants": {
     "declared-baseline": {

--- a/benchmark/sirun/shimmer-startup/meta.json
+++ b/benchmark/sirun/shimmer-startup/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 5,
+  "iterations": 20,
   "instructions": true,
   "variants": {
     "declared-baseline": {


### PR DESCRIPTION
These benchmarks were taking too long and causing builds to be flaky.
