### PR TITLE
Upgrade get-port dev-dependency to v5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "eslint-plugin-promise": "^7.2.1",
     "eslint-plugin-unicorn": "^57.0.0",
     "express": "^4.21.2",
-    "get-port": "^3.2.0",
+    "get-port": "^5.1.1",
     "glob": "^7.1.6",
     "globals": "^15.10.0",
     "graphql": "0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,10 +2153,10 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-port@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
-  integrity sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==
+get-port@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
 
 get-proto@^1.0.0, get-proto@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This potentially fixes a flaky test which we think sometimes fails because it can't bind to a port. This newer version of `get-port` fixes a race-condition that might solve this for us.
