### PR TITLE
handle existing PRs remove inputs and add schedule

### DIFF
--- a/.github/actions/install/branch-diff/action.yml
+++ b/.github/actions/install/branch-diff/action.yml
@@ -7,6 +7,7 @@ runs:
         path: ~/.npm
         key: ${{ github.workflow }}-branch-diff-3.1.1
     - run: npm i -g branch-diff@3.1.1
+      shell: bash
     - run: |
         mkdir -p ~/.config/changelog-maker
         echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json

--- a/.github/actions/install/branch-diff/action.yml
+++ b/.github/actions/install/branch-diff/action.yml
@@ -1,4 +1,5 @@
 name: Install branch-diff
+description: Install branch-diff
 inputs:
   token:
     description: "The GitHub token to use for diff operations."

--- a/.github/actions/install/branch-diff/action.yml
+++ b/.github/actions/install/branch-diff/action.yml
@@ -1,0 +1,15 @@
+name: Install branch-diff
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+      with:
+        path: ~/.npm
+        key: ${{ github.workflow }}-branch-diff-3.1.1
+    - run: npm i -g branch-diff@3.1.1
+    - run: |
+        mkdir -p ~/.config/changelog-maker
+        echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
+        git config user.name ${{ github.actor }}
+        git config user.email ${{ github.actor }}@users.noreply.github.com
+      shell: bash

--- a/.github/actions/install/branch-diff/action.yml
+++ b/.github/actions/install/branch-diff/action.yml
@@ -1,4 +1,8 @@
 name: Install branch-diff
+inputs:
+  token:
+    description: "The GitHub token to use for diff operations."
+    required: true
 runs:
   using: composite
   steps:
@@ -10,7 +14,7 @@ runs:
       shell: bash
     - run: |
         mkdir -p ~/.config/changelog-maker
-        echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
+        echo "{\"token\":\"${{ inputs.token }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
         git config user.name ${{ github.actor }}
         git config user.email ${{ github.actor }}@users.noreply.github.com
       shell: bash

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -2,6 +2,8 @@ name: '[Release Proposal]'
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: 0 5 * * *
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -32,7 +32,11 @@ jobs:
       - uses: ./.github/actions/node
         with:
           version: ''
-      - run: npm i -g branch-diff
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ~/.npm
+          key: ${{ github.workflow }}-branch-diff-3.1.1
+      - run: npm i -g branch-diff@3.1.1
       - run: |
           mkdir -p ~/.config/changelog-maker
           echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -30,6 +30,8 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/node
+        with:
+          version: ''
       - run: npm i -g branch-diff
       - run: |
           mkdir -p ~/.config/changelog-maker

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -34,6 +34,6 @@ jobs:
           echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
-      - run: node scripts/release/proposal ${{ matrix.release-line }} -f -y
+      - run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -32,16 +32,7 @@ jobs:
       - uses: ./.github/actions/node
         with:
           version: ''
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        with:
-          path: ~/.npm
-          key: ${{ github.workflow }}-branch-diff-3.1.1
-      - run: npm i -g branch-diff@3.1.1
-      - run: |
-          mkdir -p ~/.config/changelog-maker
-          echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
-          git config user.name ${{ github.actor }}
-          git config user.email ${{ github.actor }}@users.noreply.github.com
+      - uses: ./.github/actions/install/branch-diff
       - run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -2,24 +2,6 @@ name: '[Release Proposal]'
 
 on:
   workflow_dispatch:
-    inputs:
-      release-line:
-        description: 'Release line'
-        required: true
-        default: all
-        type: choice
-        options:
-          - 'all'
-          - '5'
-      increment:
-        description: 'Version increment'
-        required: true
-        default: auto
-        type: choice
-        options:
-          - 'auto'
-          - 'minor'
-          - 'patch'
 
 concurrency:
   group: ${{ github.workflow }}
@@ -31,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         release-line: ['5']
-        exclude:
-          - release-line: ${{ inputs.release-line != 'all' && inputs.release-line != '5' && '5' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -47,7 +27,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
-      - run: git fetch origin master:master || exit 0
       - uses: ./.github/actions/node
       - run: npm i -g branch-diff
       - run: |
@@ -55,6 +34,6 @@ jobs:
           echo "{\"token\":\"${{ secrets.GITHUB_TOKEN }}\",\"user\":\"${{ github.actor }}\"}" > ~/.config/changelog-maker/config.json
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
-      - run: node scripts/release/proposal ${{ matrix.release-line }} -y --{{ inputs.increment }}
+      - run: node scripts/release/proposal ${{ matrix.release-line }} -f -y
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           version: ''
       - uses: ./.github/actions/install/branch-diff
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/scripts/release/helpers/terminal.js
+++ b/scripts/release/helpers/terminal.js
@@ -95,7 +95,7 @@ function start (title) {
 
 // Show a spinner for the current operation.
 function spin (index) {
-  if (flags.debug) return
+  if (flags.debug || process.env.CI) return
 
   print(`\r${CYAN}${frames[index]}${RESET} ${BOLD}${current}${RESET}`)
 

--- a/scripts/release/helpers/terminal.js
+++ b/scripts/release/helpers/terminal.js
@@ -115,7 +115,9 @@ function pass (result) {
       print(`: ${BOLD}${CYAN}${result}${RESET}`)
     }
 
-    print('\n')
+    if (!process.env.CI) {
+      print('\n')
+    }
   }
 
   current = undefined
@@ -128,7 +130,11 @@ function fail (err) {
   clearTimeout(timer)
 
   if (!flags.debug) {
-    print(`\r${RED}✘${RESET} ${BOLD}${current}${RESET}\n`)
+    print(`\r${RED}✘${RESET} ${BOLD}${current}${RESET}`)
+
+    if (!process.env.CI) {
+      print('\n')
+    }
   }
 
   current = undefined

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -20,6 +20,7 @@ const {
 const { checkBranchDiff, checkGitHub, checkGit } = require('./helpers/requirements')
 
 const tmpdir = process.env.RUNNER_TEMP || os.tmpdir()
+const main = 'master'
 const releaseLine = params[0]
 
 // Validate release line argument.
@@ -27,13 +28,11 @@ if (!releaseLine || releaseLine === 'help' || flags.help) {
   log(
     'Usage: node scripts/release/proposal <release-line>\n',
     'Options:',
+    '  -f         Push new changes even if a non-draft PR already exists.',
     '  -n         Do not push release proposal upstream.',
     '  -y         Push release proposal upstream.',
     '  --debug    Print raw commands and their outputs.',
-    '  --help     Show this help.',
-    '  --auto     Automatically detect version increment. (this is default)',
-    '  --minor    Force a minor release.',
-    '  --patch    Force a patch release.'
+    '  --help     Show this help.'
   )
   process.exit(0)
 } else if (!releaseLine?.match(/^\d+$/)) {
@@ -51,9 +50,12 @@ try {
 
   start('Pull release branch')
 
+  const currentBranch = capture('git rev-parse --abbrev-ref HEAD')
+
   // Make sure the release branch is up to date to prepare for new proposal.
   // The main branch is not automatically pulled to avoid inconsistencies between
   // release lines if new commits are added to it during a release.
+  run(`git checkout ${main}`)
   run(`git checkout --quiet v${releaseLine}.x`)
   run('git pull --quiet --ff-only')
 
@@ -69,12 +71,11 @@ try {
   start('Determine version increment')
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
-  const main = 'master'
   const lineDiff = capture(`${diffCmd} --markdown=true v${releaseLine}.x ${main}`)
-  const isMinor = flags.minor || (!flags.patch && lineDiff.includes('SEMVER-MINOR'))
-  const newVersion = isMinor
-    ? `${releaseLine}.${DD_MINOR + 1}.0`
-    : `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
+  const isMinor = lineDiff.includes('SEMVER-MINOR')
+  const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
+  const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
+  const newVersion = isMinor ? newMinor : newPatch
   const notesDir = path.join(tmpdir, 'release_notes')
   const notesFile = path.join(notesDir, `v${newVersion}.md`)
 
@@ -118,13 +119,15 @@ try {
 
     // Cherry pick all new commits to the proposal branch.
     try {
-      run(`echo "${proposalDiff}" | xargs git cherry-pick`)
+      run(`git cherry-pick ${proposalDiff}`)
 
       pass()
     } catch (err) {
+      run('git cherry-pick --abort')
+
       fatal(
-        'Cherry-pick failed. Resolve the conflicts and run `git cherry-pick --continue` to continue.',
-        'When all conflicts have been resolved, run this script again.'
+        'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
+        'Please make sure the release branch contains all changes from the main branch.'
       )
     }
   } else {
@@ -149,6 +152,40 @@ try {
     checkpoint('Push the release upstream and create/update PR?')
   }
 
+  start('Checking that no ready to merge PR exists')
+
+  let previousPullRequest
+
+  if (isMinor) {
+    try {
+      previousPullRequest = JSON.parse(capture(`gh pr view ${newMinor} --json isDraft,url`))
+    } catch (e) {
+      // No existing PR for minor release proposal.
+    }
+  }
+
+  try {
+    previousPullRequest = JSON.parse(capture(`gh pr view ${newPatch} --json isDraft,url`))
+  } catch (e) {
+    // No existing PR for patch release proposal.
+  }
+
+  if (previousPullRequest) {
+    if (!previousPullRequest.isDraft && !flags.f) {
+      if (flags.f) {
+        pass(`ready: ${previousPullRequest.url} (ignoring because of -f flag)`)
+      } else {
+        pass(`ready: ${previousPullRequest.url} (use -f to ignore and force update)`)
+
+        process.exit(0)
+      }
+    }
+
+    pass(`draft: ${previousPullRequest.url}`)
+  } else {
+    pass('none')
+  }
+
   start('Push proposal upstream')
 
   run(`git push -f -u origin v${newVersion}-proposal`)
@@ -162,9 +199,24 @@ try {
     run(`gh pr edit -F "${notesFile}"`)
   }
 
-  const pullRequestUrl = capture('gh pr view --json url --jq=".url"')
+  const pullRequest = JSON.parse(capture('gh pr view --json number,url'))
 
-  pass(pullRequestUrl)
+  // Close PR and delete branch for any patch proposal if new proposal is minor.
+  if (isMinor) {
+    try {
+      run(`gh pr close v${newPatch} --delete-branch --comment "Superseded by #${pullRequest.number}."`)
+    } catch (e) {
+      // PR didn't exist so nothing to close.
+    }
+  }
+
+  pass(pullRequest.url)
+
+  if (process.env.CI) {
+    log(`::notice::${pullRequest.url}`)
+  }
+
+  run(`git checkout ${currentBranch}`)
 } catch (e) {
   fail(e)
 }

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -215,7 +215,7 @@ try {
   pass(pullRequest.url)
 
   if (process.env.CI) {
-    log(`\n::notice::${pullRequest.url}`)
+    log(`\n\n::notice::${pullRequest.url}`)
   }
 
   run(`git checkout ${currentBranch}`)

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -164,10 +164,12 @@ try {
     }
   }
 
-  try {
-    previousPullRequest = JSON.parse(capture(`gh pr view ${newPatch} --json isDraft,url`))
-  } catch (e) {
-    // No existing PR for patch release proposal.
+  if (!previousPullRequest) {
+    try {
+      previousPullRequest = JSON.parse(capture(`gh pr view ${newPatch} --json isDraft,url`))
+    } catch (e) {
+      // No existing PR for patch release proposal.
+    }
   }
 
   if (previousPullRequest) {

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -215,7 +215,7 @@ try {
   pass(pullRequest.url)
 
   if (process.env.CI) {
-    log(`\n\n::notice::${pullRequest.url}`)
+    log(`\n\n::notice::${newVersion}: ${pullRequest.url}`)
   }
 
   run(`git checkout ${currentBranch}`)

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -215,7 +215,7 @@ try {
   pass(pullRequest.url)
 
   if (process.env.CI) {
-    log(`::notice::${pullRequest.url}`)
+    log(`\n::notice::${pullRequest.url}`)
   }
 
   run(`git checkout ${currentBranch}`)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Handle existing PRs and remove workflow inputs. I also added a schedule to run this automatically daily.

### Motivation
<!-- What inspired you to submit this pull request? -->

Make it possible to automate the workflow. Removing inputs makes everything easier and the release process more consistent, and handling existing PRs means they can be updated more accurately, and an old PR can be closed automatically if the version increment changed. Running on a schedule means there will always be a release proposal ready to go when we want to do a release, and it will run the tests so that we can see if something doesn't work on one of the release lines.