### PR TITLE
Ensure correct spelling of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Most of the documentation for `dd-trace` is available on these webpages:
 
 - [Tracing Node.js Applications](https://docs.datadoghq.com/tracing/languages/nodejs/) - most project documentation, including setup instructions
-- [Configuring the NodeJS Tracing Library](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs) - environment variables and config options
+- [Configuring the Node.js Tracing Library](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs) - environment variables and config options
 - [API Documentation](https://datadog.github.io/dd-trace-js) - method signatures, plugin list, and some usage examples
 - [APM Terms and Concepts](https://docs.datadoghq.com/tracing/visualization/) - a glossary of concepts applicable across all languages
 
@@ -59,7 +59,7 @@ When a new release line is introduced the previous release line then enters main
 Once that year is up the release line enters End of Life and will not receive new updates.
 The library also follows the Node.js LTS lifecycle wherein new release lines drop compatibility with Node.js versions that reach end-of-life (with the maintenance release line still receiving updates for a year).
 
-For more information about library versioning and compatibility, see the [NodeJS Compatibility Requirements](https://docs.datadoghq.com/tracing/trace_collection/compatibility/nodejs/#releases) page.
+For more information about library versioning and compatibility, see the [Node.js Compatibility Requirements](https://docs.datadoghq.com/tracing/trace_collection/compatibility/nodejs/#releases) page.
 
 Changes associated with each individual release are documented on the [GitHub Releases](https://github.com/DataDog/dd-trace-js/releases) screen.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -377,7 +377,7 @@ The following attributes are available to override Datadog-specific options:
 
 <h3 id="tracer-settings">Tracer settings</h3>
 
-Options can be configured as a parameter to the [init()](./interfaces/tracer.html#init) method or as environment variables. These are documented over on [Configuring the NodeJS Tracing Library](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs).
+Options can be configured as a parameter to the [init()](./interfaces/tracer.html#init) method or as environment variables. These are documented over on [Configuring the Node.js Tracing Library](https://docs.datadoghq.com/tracing/trace_collection/library_config/nodejs).
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/ldap-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/ldap-sensitive-analyzer.js
@@ -13,7 +13,7 @@ module.exports = function extractSensitiveRanges (evidence) {
     let regexResult = pattern.exec(evidence.value)
     while (regexResult != null) {
       if (!regexResult.groups.LITERAL) continue
-      // Computing indices manually since NodeJs 12 does not support d flag on regular expressions
+      // Computing indices manually since Node.js 12 does not support d flag on regular expressions
       // TODO Get indices from group by adding d flag in regular expression
       const start = regexResult.index + (regexResult[0].length - regexResult.groups.LITERAL.length - 1)
       const end = start + regexResult.groups.LITERAL.length


### PR DESCRIPTION
### What does this PR do?

Fix wrong spellings of Node.js (wrong: `NodeJS`, `Node.Js`, `Node.JS` etc).

### Motivation

The way we spell "Node.js" is a signal about how we treat the Node.js community. By spelling the name of their language incorrectly, it could be interpreted as not caring/respecting, which obviously we do ☺️

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


