### PR TITLE
Do not test koa 1.x middleware signature in koa 3.x

### DIFF
--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -15,7 +15,6 @@ describe('Plugin', () => {
 
   describe('koa', () => {
     withVersions('koa', 'koa', (version, _, realVersion) => {
-      console.log('realVersion', realVersion)
       beforeEach(() => {
         tracer = require('../../dd-trace')
         Koa = require(`../../../versions/koa@${version}`).get()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Do not test koa 1.x middleware signature in koa 3.x
### Motivation
<!-- What inspired you to submit this pull request? -->
1.x middleware signature is not supported in koa >3

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


