### PR TITLE
[DI] Don't set empty dd tags as query params

### DIFF
--- a/integration-tests/debugger/ddtags.spec.js
+++ b/integration-tests/debugger/ddtags.spec.js
@@ -8,49 +8,78 @@ const { version } = require('../../package.json')
 
 describe('Dynamic Instrumentation', function () {
   describe('ddtags', function () {
-    const t = setup({
-      env: {
-        DD_ENV: 'test-env',
-        DD_VERSION: 'test-version',
-        DD_GIT_COMMIT_SHA: 'test-commit-sha',
-        DD_GIT_REPOSITORY_URL: 'test-repository-url'
-      },
-      testApp: 'target-app/basic.js'
-    })
-
-    it('should add the expected ddtags as a query param to /debugger/v1/input', function (done) {
-      t.triggerBreakpoint()
-
-      t.agent.on('debugger-input', ({ query }) => {
-        assert.property(query, 'ddtags')
-
-        // Before: "a:b,c:d"
-        // After: { a: 'b', c: 'd' }
-        const ddtags = query.ddtags
-          .split(',')
-          .map((tag) => tag.split(':'))
-          .reduce((acc, [k, v]) => { acc[k] = v; return acc }, {})
-
-        assert.hasAllKeys(ddtags, [
-          'env',
-          'version',
-          'debugger_version',
-          'host_name',
-          'git.commit.sha',
-          'git.repository_url'
-        ])
-
-        assert.strictEqual(ddtags.env, 'test-env')
-        assert.strictEqual(ddtags.version, 'test-version')
-        assert.strictEqual(ddtags.debugger_version, version)
-        assert.strictEqual(ddtags.host_name, os.hostname())
-        assert.strictEqual(ddtags['git.commit.sha'], 'test-commit-sha')
-        assert.strictEqual(ddtags['git.repository_url'], 'test-repository-url')
-
-        done()
+    describe('basic case', function () {
+      const t = setup({
+        env: {
+          DD_ENV: 'test-env',
+          DD_VERSION: 'test-version',
+          DD_GIT_COMMIT_SHA: 'test-commit-sha',
+          DD_GIT_REPOSITORY_URL: 'test-repository-url'
+        },
+        testApp: 'target-app/basic.js'
       })
 
-      t.agent.addRemoteConfig(t.rcConfig)
+      it('should add the expected ddtags as a query param to /debugger/v1/input', function (done) {
+        t.triggerBreakpoint()
+
+        t.agent.on('debugger-input', ({ query }) => {
+          assert.property(query, 'ddtags')
+
+          const ddtags = extractDDTagsFromQuery(query)
+
+          assert.hasAllKeys(ddtags, [
+            'env',
+            'version',
+            'debugger_version',
+            'host_name',
+            'git.commit.sha',
+            'git.repository_url'
+          ])
+
+          assert.strictEqual(ddtags.env, 'test-env')
+          assert.strictEqual(ddtags.version, 'test-version')
+          assert.strictEqual(ddtags.debugger_version, version)
+          assert.strictEqual(ddtags.host_name, os.hostname())
+          assert.strictEqual(ddtags['git.commit.sha'], 'test-commit-sha')
+          assert.strictEqual(ddtags['git.repository_url'], 'test-repository-url')
+
+          done()
+        })
+
+        t.agent.addRemoteConfig(t.rcConfig)
+      })
+    })
+
+    describe('with undefined values', function () {
+      const t = setup({ testApp: 'target-app/basic.js' })
+
+      it('should not include undefined values in the ddtags query param', function (done) {
+        t.triggerBreakpoint()
+
+        t.agent.on('debugger-input', ({ query }) => {
+          assert.property(query, 'ddtags')
+
+          const ddtags = extractDDTagsFromQuery(query)
+
+          assert.hasAllKeys(ddtags, [
+            'debugger_version',
+            'host_name'
+          ])
+
+          done()
+        })
+
+        t.agent.addRemoteConfig(t.rcConfig)
+      })
     })
   })
 })
+
+// Before: "a:b,c:d"
+// After: { a: 'b', c: 'd' }
+function extractDDTagsFromQuery (query) {
+  return query.ddtags
+    .split(',')
+    .map((tag) => tag.split(':'))
+    .reduce((acc, [k, v]) => { acc[k] = v; return acc }, {})
+}

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -26,7 +26,7 @@ const ddtags = [
   ['host_name', hostname],
   [GIT_COMMIT_SHA, config.commitSHA],
   [GIT_REPOSITORY_URL, config.repositoryUrl]
-].map((pair) => pair.join(':')).join(',')
+].filter(([, value]) => value !== undefined).map((pair) => pair.join(':')).join(',')
 
 const path = `/debugger/v1/input?${stringify({ ddtags })}`
 


### PR DESCRIPTION
When sending collected data to the agent, we augment it by setting dd-tags on the URL as query params. Some of these dd-tags are fetched from environment variables, which might not be set. If that's the case, don't set the corresponding dd-tags as they are just wasting space in the URL and might lead to hard to debug issues in the backend/UI.
