### PR TITLE
improve performance of dogstatsd client and ignore non-string name/tags

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -227,7 +227,7 @@ class MetricsAggregationClient {
   histogram (name, value, tags) {
     const node = this._ensureTree(this._histograms, name, tags, null)
 
-    if (!node.value && node.touched) {
+    if (!node.value) {
       node.value = new Histogram()
     }
 

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -113,6 +113,9 @@ suiteDescribe('runtimeMetrics', () => {
   let Client
 
   beforeEach(() => {
+    // This is needed because sinon spies keep references to arguments which
+    // breaks tests because the tags parameter is now mutated right after the
+    // call.
     const wrapSpy = (client, spy) => {
       return function (stat, value, tags) {
         return spy.call(client, stat, value, [].concat(tags))

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -113,8 +113,19 @@ suiteDescribe('runtimeMetrics', () => {
   let Client
 
   beforeEach(() => {
+    const wrapSpy = (client, spy) => {
+      return function (stat, value, tags) {
+        return spy.call(client, stat, value, [].concat(tags))
+      }
+    }
+
     Client = sinon.spy(function () {
-      return client
+      return {
+        gauge: wrapSpy(client, client.gauge),
+        increment: wrapSpy(client, client.increment),
+        histogram: wrapSpy(client, client.histogram),
+        flush: client.flush.bind(client)
+      }
     })
 
     Client.generateClientConfig = DogStatsDClient.generateClientConfig


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Improve performance of DogStatsD client and ignore non-string tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

Make runtime and custom metrics more efficient and prevent memory leaks when misused.