### PR TITLE
Improve log safety

### DIFF
--- a/packages/datadog-plugin-winston/test/index.spec.js
+++ b/packages/datadog-plugin-winston/test/index.spec.js
@@ -5,6 +5,7 @@ const agent = require('../../dd-trace/test/plugins/agent')
 const http = require('http')
 const { expect } = require('chai')
 const proxyquire = require('proxyquire').noPreserveCache()
+const { inspect } = require('util')
 
 function createLogServer () {
   return new Promise((resolve, reject) => {
@@ -194,7 +195,6 @@ describe('Plugin', () => {
                 span_id: span.context().toSpanId()
               }
             }
-
             const error = new Error('boom')
 
             tracer.scope().activate(span, () => {
@@ -203,7 +203,7 @@ describe('Plugin', () => {
               const index = semver.intersects(version, '>=3') ? 0 : 2
               const record = log.firstCall.args[index]
 
-              expect(record).to.be.an('error')
+              expect(record).to.be.an.instanceof(Error)
               expect(error).to.not.have.property('dd')
               expect(spy).to.have.been.calledWithMatch(meta.dd)
             })
@@ -211,6 +211,34 @@ describe('Plugin', () => {
           })
 
           if (semver.intersects(version, '>=3')) {
+            it('should support sets and getters', async () => {
+              const meta = {
+                dd: {
+                  trace_id: span.context().toTraceId(true),
+                  span_id: span.context().toSpanId()
+                }
+              }
+              const set = new Set([1])
+              Object.defineProperty(set, 'getter', {
+                get () {
+                  return this.size
+                },
+                enumerable: true
+              })
+
+              tracer.scope().activate(span, () => {
+                winston.log('info', set)
+
+                const record = log.firstCall.args[0]
+
+                expect(record).to.be.an.instanceof(Set)
+                expect(inspect(record)).to.match(/"getter":1,/)
+                expect(set).to.not.have.property('dd')
+                expect(spy).to.have.been.calledWithMatch(meta.dd)
+              })
+              expect(await logServer.logPromise).to.include(meta.dd)
+            })
+
             it('should add the trace identifiers when streaming', async () => {
               const logger = winston.createLogger({
                 transports: [transport, httpTransport]

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -4,31 +4,21 @@ const { LOG } = require('../../../../ext/formats')
 const Plugin = require('./plugin')
 const { storage } = require('../../../datadog-core')
 
-const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop)
-
 function messageProxy (message, holder) {
   return new Proxy(message, {
-    get (target, p, receiver) {
-      if (p === Symbol.toStringTag) {
-        return Object.prototype.toString.call(target).slice(8, -1)
-      }
-
-      if (shouldOverride(target, p)) {
+    get (target, key) {
+      if (shouldOverride(target, key)) {
         return holder.dd
       }
 
-      // This is a workaround for a V8 bug that surfaced in Node.js 22
-      if (p === 'stack') {
-        return target.stack
-      }
-
-      return Reflect.get(target, p, receiver)
+      return target[key]
     },
     ownKeys (target) {
       const ownKeys = Reflect.ownKeys(target)
-      return hasOwn(target, 'dd') || !Reflect.isExtensible(target)
-        ? ownKeys
-        : ['dd', ...ownKeys]
+      if (!Object.hasOwn(target, 'dd') && Reflect.isExtensible(target)) {
+        ownKeys.push('dd')
+      }
+      return ownKeys
     },
     getOwnPropertyDescriptor (target, p) {
       return Reflect.getOwnPropertyDescriptor(shouldOverride(target, p) ? holder : target, p)
@@ -37,7 +27,7 @@ function messageProxy (message, holder) {
 }
 
 function shouldOverride (target, p) {
-  return p === 'dd' && !Reflect.has(target, p) && Reflect.isExtensible(target)
+  return p === 'dd' && !Object.hasOwn(target, p) && Reflect.isExtensible(target)
 }
 
 module.exports = class LogPlugin extends Plugin {
@@ -45,8 +35,7 @@ module.exports = class LogPlugin extends Plugin {
     super(...args)
 
     this.addSub(`apm:${this.constructor.id}:log`, (arg) => {
-      const store = storage('legacy').getStore()
-      const span = store && store.span
+      const span = storage('legacy').getStore()?.span
 
       // NOTE: This needs to run whether or not there is a span
       // so service, version, and env will always get injected.


### PR DESCRIPTION
The logger instrumentation is using a proxy. Calling Reflect.get with a receiver might actually cause issues at times. Instead, just access the target directly. That is easier and safer in this situation.
On top, remove the special handling for Symbol.toStringTag. That was added for the testing library and should not have been there in the first place.
As a drive-by fix, it also improves the performance / cleans up the code.