### PR TITLE
Safer shimmer implementation

### DIFF
--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -15,16 +15,16 @@ const startCh = channel('apm:amqplib:command:start')
 const finishCh = channel('apm:amqplib:command:finish')
 const errorCh = channel('apm:amqplib:command:error')
 
-let methods = {}
+const methods = {}
 
 addHook({ name: 'amqplib', file: 'lib/defs.js', versions: [MIN_VERSION] }, defs => {
-  methods = Object.keys(defs)
-    .reduce((acc, key) => {
-      if (Number.isInteger(defs[key]) && isCamelCase(key)) {
-        Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') })
-      }
-      return acc
-    }, {})
+  for (const [key, value] of Object.entries(defs)) {
+    if (Number.isInteger(value) && isCamelCase(key)) {
+      // TODO(BridgeAR): It should replace all `-` with `.`, so it has to be replaceAll or use a regex.
+      // Example method that is not renamed properly: BasicGetEmpty = 3932232
+      methods[value] = kebabCase(key).replace('-', '.')
+    }
+  }
   return defs
 })
 

--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -19,9 +19,12 @@ let methods = {}
 
 addHook({ name: 'amqplib', file: 'lib/defs.js', versions: [MIN_VERSION] }, defs => {
   methods = Object.keys(defs)
-    .filter(key => Number.isInteger(defs[key]))
-    .filter(key => isCamelCase(key))
-    .reduce((acc, key) => Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') }), {})
+    .reduce((acc, key) => {
+      if (Number.isInteger(defs[key]) && isCamelCase(key)) {
+        Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') })
+      }
+      return acc
+    }, {})
   return defs
 })
 

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -149,11 +149,9 @@ addHook({ name: 'express', versions: ['>=4.3.0 <5.0.0'] }, express => {
 const queryReadCh = channel('datadog:express:query:finish')
 
 addHook({ name: 'express', file: ['lib/request.js'], versions: ['>=5.0.0'] }, request => {
-  const requestDescriptor = Object.getOwnPropertyDescriptor(request, 'query')
-
-  shimmer.wrap(requestDescriptor, 'get', function (originalGet) {
+  shimmer.wrap(request, 'query', function (originalGet) {
     return function wrappedGet () {
-      const query = originalGet.apply(this, arguments)
+      const query = originalGet.call(this)
 
       if (queryReadCh.hasSubscribers && query) {
         queryReadCh.publish({ query })
@@ -162,8 +160,6 @@ addHook({ name: 'express', file: ['lib/request.js'], versions: ['>=5.0.0'] }, re
       return query
     }
   })
-
-  Object.defineProperty(request, 'query', requestDescriptor)
 
   return request
 })

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -43,7 +43,7 @@ if (!disabledInstrumentations.has('process')) {
   require('../process')
 }
 
-const HOOK_SYMBOL = Symbol('hookExportsMap')
+const HOOK_SYMBOL = Symbol('hookExportsSet')
 
 if (DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false') {
   checkRequireCache.checkForRequiredModules()
@@ -89,11 +89,14 @@ for (const packageName of names) {
         fullFilePattern = filename(name, fullFilePattern)
       }
 
-      // Create a WeakMap associated with the hook function so that patches on the same moduleExport only happens once
+      // Create a WeakSet associated with the hook function so that patches on the same moduleExport only happens once
       // for example by instrumenting both dns and node:dns double the spans would be created
-      // since they both patch the same moduleExport, this WeakMap is used to mitigate that
+      // since they both patch the same moduleExport, this WeakSet is used to mitigate that
+      // TODO(BridgeAR): Instead of using a WeakSet here, why not just use aliases for the hook in register?
+      // That way it would also not be duplicated. The actual name being used has to be identified else wise.
+      // Maybe it is also not important to know what name was actually used?
       if (!hook[HOOK_SYMBOL]) {
-        hook[HOOK_SYMBOL] = new WeakMap()
+        hook[HOOK_SYMBOL] = new WeakSet()
       }
       let matchesFile = false
 
@@ -114,7 +117,7 @@ for (const packageName of names) {
           log.error('Error getting version for "%s": %s', name, e.message, e)
           continue
         }
-        if (typeof namesAndSuccesses[`${name}@${version}`] === 'undefined') {
+        if (namesAndSuccesses[`${name}@${version}`] === undefined) {
           // TODO If `file` is present, we might elsewhere instrument the result of the module
           // for a version range that actually matches, so we can't assume that we're _not_
           // going to instrument that. However, the way the data model around instrumentation
@@ -140,12 +143,19 @@ for (const packageName of names) {
             loadChannel.publish({ name, version, file })
             // Send the name and version of the module back to the callback because now addHook
             // takes in an array of names so by passing the name the callback will know which module name is being used
-            moduleExports = hook(moduleExports, version, name)
-            // Set the moduleExports in the hooks weakmap
-            hook[HOOK_SYMBOL].set(moduleExports, name)
+            // TODO(BridgeAR): This is only true in case the name is identical
+            // in all loads. If they deviate, the deviating name would not be
+            // picked up due to the unification. Check what modules actually use the name.
+            // TODO(BridgeAR): Only replace moduleExports if the hook returns a new value.
+            // This allows to reduce the instrumentation code (no return needed).
+            const newModuleExports = hook(moduleExports, version, name)
+            if (newModuleExports) {
+              moduleExports = newModuleExports
+            }
+            // Set the moduleExports in the hooks WeakSet
+            hook[HOOK_SYMBOL].add(moduleExports)
           } catch (e) {
-            log.info('Error during ddtrace instrumentation of application, aborting.')
-            log.info(e)
+            log.info('Error during ddtrace instrumentation of application, aborting.', e)
             telemetry('error', [
               `error_type:${e.constructor.name}`,
               `integration:${name}`,

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -95,9 +95,7 @@ for (const packageName of names) {
       // TODO(BridgeAR): Instead of using a WeakSet here, why not just use aliases for the hook in register?
       // That way it would also not be duplicated. The actual name being used has to be identified else wise.
       // Maybe it is also not important to know what name was actually used?
-      if (!hook[HOOK_SYMBOL]) {
-        hook[HOOK_SYMBOL] = new WeakSet()
-      }
+      hook[HOOK_SYMBOL] ??= new WeakSet()
       let matchesFile = false
 
       matchesFile = moduleName === fullFilename
@@ -148,10 +146,7 @@ for (const packageName of names) {
             // picked up due to the unification. Check what modules actually use the name.
             // TODO(BridgeAR): Only replace moduleExports if the hook returns a new value.
             // This allows to reduce the instrumentation code (no return needed).
-            const newModuleExports = hook(moduleExports, version, name)
-            if (newModuleExports) {
-              moduleExports = newModuleExports
-            }
+            moduleExports = hook(moduleExports, version, name) ?? moduleExports
             // Set the moduleExports in the hooks WeakSet
             hook[HOOK_SYMBOL].add(moduleExports)
           } catch (e) {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -635,7 +635,7 @@ addHook({
 })
 
 function cliWrapper (cli, jestVersion) {
-  const wrapped = shimmer.wrap(cli, 'runCLI', runCLI => async function () {
+  shimmer.wrap(cli, 'runCLI', runCLI => async function () {
     let onDone
     const configurationPromise = new Promise((resolve) => {
       onDone = resolve
@@ -873,8 +873,6 @@ function cliWrapper (cli, jestVersion) {
 
     return result
   })
-
-  cli.runCLI = wrapped.runCLI
 
   return cli
 }

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -70,7 +70,7 @@ function wrapRenderToHTML (renderToHTML) {
 
 function wrapRenderErrorToHTML (renderErrorToHTML) {
   return function (err, req, res, pathname, query) {
-    return instrument(req, res, err, () => renderErrorToHTML.apply(this, arguments))
+    return instrument(req, res, () => renderErrorToHTML.apply(this, arguments), err)
   }
 }
 
@@ -82,7 +82,7 @@ function wrapRenderToResponse (renderToResponse) {
 
 function wrapRenderErrorToResponse (renderErrorToResponse) {
   return function (ctx, err) {
-    return instrument(ctx.req, ctx.res, err, () => renderErrorToResponse.apply(this, arguments))
+    return instrument(ctx.req, ctx.res, () => renderErrorToResponse.apply(this, arguments), err)
   }
 }
 
@@ -121,12 +121,7 @@ function getRequestMeta (req, key) {
   return typeof key === 'string' ? meta[key] : meta
 }
 
-function instrument (req, res, error, handler) {
-  if (typeof error === 'function') {
-    handler = error
-    error = null
-  }
-
+function instrument (req, res, handler, error) {
   req = req.originalRequest || req
   res = res.originalResponse || res
 
@@ -216,13 +211,13 @@ addHook({
   name: 'next',
   versions: ['>=11.1'],
   file: 'dist/server/serve-static.js'
-}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic))
+}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, true))
 
 addHook({
   name: 'next',
   versions: ['>=10.2 <11.1'],
   file: 'dist/next-server/server/serve-static.js'
-}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic))
+}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, true))
 
 addHook({ name: 'next', versions: ['>=11.1'], file: 'dist/server/next-server.js' }, nextServer => {
   const Server = nextServer.default

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -211,13 +211,13 @@ addHook({
   name: 'next',
   versions: ['>=11.1'],
   file: 'dist/server/serve-static.js'
-}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, true))
+}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, { replaceGetter: true }))
 
 addHook({
   name: 'next',
   versions: ['>=10.2 <11.1'],
   file: 'dist/next-server/server/serve-static.js'
-}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, true))
+}, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, { replaceGetter: true }))
 
 addHook({ name: 'next', versions: ['>=11.1'], file: 'dist/server/next-server.js' }, nextServer => {
   const Server = nextServer.default

--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -282,8 +282,7 @@ addHook({
   versions: ['>=13'],
   file: 'dist/server/web/spec-extension/request.js'
 }, request => {
-  const nextUrlDescriptor = Object.getOwnPropertyDescriptor(request.NextRequest.prototype, 'nextUrl')
-  shimmer.wrap(nextUrlDescriptor, 'get', function (originalGet) {
+  shimmer.wrap(request.NextRequest.prototype, 'nextUrl', function (originalGet) {
     return function wrappedGet () {
       const nextUrl = originalGet.apply(this, arguments)
       if (queryParsedChannel.hasSubscribers) {
@@ -299,8 +298,6 @@ addHook({
       return nextUrl
     }
   })
-
-  Object.defineProperty(request.NextRequest.prototype, 'nextUrl', nextUrlDescriptor)
 
   shimmer.massWrap(request.NextRequest.prototype, ['text', 'json'], function (originalMethod) {
     return async function wrappedJson () {

--- a/packages/datadog-instrumentations/src/url.js
+++ b/packages/datadog-instrumentations/src/url.js
@@ -77,6 +77,4 @@ addHook({ name: names }, function (url) {
       }
     })
   }
-
-  return url
 })

--- a/packages/datadog-instrumentations/src/url.js
+++ b/packages/datadog-instrumentations/src/url.js
@@ -26,23 +26,17 @@ addHook({ name: names }, function (url) {
 
   const URLPrototype = url.URL.prototype.constructor.prototype
   instrumentedGetters.forEach(property => {
-    const originalDescriptor = Object.getOwnPropertyDescriptor(URLPrototype, property)
+    shimmer.wrap(URLPrototype, property, function (originalGet) {
+      return function get () {
+        const result = originalGet.call(this)
+        if (!urlGetterChannel.hasSubscribers) return result
 
-    if (originalDescriptor?.get) {
-      const newDescriptor = shimmer.wrap(originalDescriptor, 'get', function (originalGet) {
-        return function get () {
-          const result = originalGet.apply(this, arguments)
-          if (!urlGetterChannel.hasSubscribers) return result
+        const context = { urlObject: this, result, property }
+        urlGetterChannel.publish(context)
 
-          const context = { urlObject: this, result, property }
-          urlGetterChannel.publish(context)
-
-          return context.result
-        }
-      })
-
-      Object.defineProperty(URLPrototype, property, newDescriptor)
-    }
+        return context.result
+      }
+    }, 'REPLACE_GETTER')
   })
 
   shimmer.wrap(url, 'URL', (URL) => {

--- a/packages/datadog-instrumentations/src/url.js
+++ b/packages/datadog-instrumentations/src/url.js
@@ -36,7 +36,7 @@ addHook({ name: names }, function (url) {
 
         return context.result
       }
-    }, 'REPLACE_GETTER')
+    })
   })
 
   shimmer.wrap(url, 'URL', (URL) => {

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -372,8 +372,8 @@ describe('Plugin', function () {
         })
 
         describe('for static files', () => {
-          it('should do automatic instrumentation for assets', done => {
-            agent
+          it('should do automatic instrumentation for assets', () => {
+            const promise = agent
               .use(traces => {
                 const spans = traces[0]
 
@@ -386,19 +386,15 @@ describe('Plugin', function () {
                 expect(spans[1].meta).to.have.property('http.status_code', '200')
                 expect(spans[1].meta).to.have.property('component', 'next')
               })
-              .then(done)
-              .catch(done)
 
-            axios
-              .get(`http://127.0.0.1:${port}/test.txt`)
-              .catch(done)
+            return Promise.all([axios.get(`http://127.0.0.1:${port}/test.txt`), promise])
           })
 
-          it('should do automatic instrumentation for static chunks', done => {
-            // get first static chunk file programatically
+          it('should do automatic instrumentation for static chunks', () => {
+            // Get first static chunk file programmatically
             const file = readdirSync(path.join(__dirname, '.next/static/chunks'))[0]
 
-            agent
+            const promise = agent
               .use(traces => {
                 const spans = traces[0]
 
@@ -408,28 +404,20 @@ describe('Plugin', function () {
                 expect(spans[1].meta).to.have.property('http.status_code', '200')
                 expect(spans[1].meta).to.have.property('component', 'next')
               })
-              .then(done)
-              .catch(done)
 
-            axios
-              .get(`http://127.0.0.1:${port}/_next/static/chunks/${file}`)
-              .catch(done)
+            return Promise.all([axios.get(`http://127.0.0.1:${port}/_next/static/chunks/${file}`), promise])
           })
 
-          it('should pass resource path to parent span', done => {
-            agent
+          it('should pass resource path to parent span', () => {
+            const promise = agent
               .use(traces => {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'web.request')
                 expect(spans[0]).to.have.property('resource', 'GET /public/*')
               })
-              .then(done)
-              .catch(done)
 
-            axios
-              .get(`http://127.0.0.1:${port}/test.txt`)
-              .catch(done)
+            return Promise.all([axios.get(`http://127.0.0.1:${port}/test.txt`), promise])
           })
         })
 
@@ -556,8 +544,8 @@ describe('Plugin', function () {
           ]
 
           standaloneTests.forEach(([test, resource, expectedResource]) => {
-            it(`should do automatic instrumentation for ${test}`, done => {
-              agent
+            it(`should do automatic instrumentation for ${test}`, () => {
+              const promise = agent
                 .use(traces => {
                   const spans = traces[0]
 
@@ -570,12 +558,8 @@ describe('Plugin', function () {
                   expect(spans[1].meta).to.have.property('http.status_code', '200')
                   expect(spans[1].meta).to.have.property('component', 'next')
                 })
-                .then(done)
-                .catch(done)
 
-              axios
-                .get(`http://127.0.0.1:${port}${resource}`)
-                .catch(done)
+              return Promise.all([axios.get(`http://127.0.0.1:${port}${resource}`), promise])
             }).timeout(5000)
             // increase timeout for longer test in CI
             // locally, do not see any slowdowns

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -373,7 +373,7 @@ describe('Plugin', function () {
 
         describe('for static files', () => {
           it('should do automatic instrumentation for assets', () => {
-            const promise = agent
+            const tracingPromise = agent
               .use(traces => {
                 const spans = traces[0]
 
@@ -387,14 +387,14 @@ describe('Plugin', function () {
                 expect(spans[1].meta).to.have.property('component', 'next')
               })
 
-            return Promise.all([axios.get(`http://127.0.0.1:${port}/test.txt`), promise])
+            return Promise.all([axios.get(`http://127.0.0.1:${port}/test.txt`), tracingPromise])
           })
 
           it('should do automatic instrumentation for static chunks', () => {
             // Get first static chunk file programmatically
             const file = readdirSync(path.join(__dirname, '.next/static/chunks'))[0]
 
-            const promise = agent
+            const tracingPromise = agent
               .use(traces => {
                 const spans = traces[0]
 
@@ -405,11 +405,11 @@ describe('Plugin', function () {
                 expect(spans[1].meta).to.have.property('component', 'next')
               })
 
-            return Promise.all([axios.get(`http://127.0.0.1:${port}/_next/static/chunks/${file}`), promise])
+            return Promise.all([axios.get(`http://127.0.0.1:${port}/_next/static/chunks/${file}`), tracingPromise])
           })
 
           it('should pass resource path to parent span', () => {
-            const promise = agent
+            const tracingPromise = agent
               .use(traces => {
                 const spans = traces[0]
 
@@ -417,7 +417,7 @@ describe('Plugin', function () {
                 expect(spans[0]).to.have.property('resource', 'GET /public/*')
               })
 
-            return Promise.all([axios.get(`http://127.0.0.1:${port}/test.txt`), promise])
+            return Promise.all([axios.get(`http://127.0.0.1:${port}/test.txt`), tracingPromise])
           })
         })
 

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -35,7 +35,7 @@ function copyProperties (original, wrapped) {
   if (ownKeys.length !== 2) {
     for (const key of ownKeys) {
       if (skipMethods.has(key)) continue
-      const descriptor = Object.getOwnPropertyDescriptor(original, key) ?? {}
+      const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(original, key))
       if (descriptor.writable && descriptor.enumerable && descriptor.configurable) {
         wrapped[key] = original[key]
       } else if (descriptor.writable || descriptor.configurable || !Object.hasOwn(wrapped, key)) {
@@ -56,7 +56,7 @@ function copyObjectProperties (original, wrapped, skipKey) {
   const ownKeys = Reflect.ownKeys(original)
   for (const key of ownKeys) {
     if (key === skipKey) continue
-    const descriptor = Object.getOwnPropertyDescriptor(original, key) ?? {}
+    const descriptor = /** @type {PropertyDescriptor} */ (Object.getOwnPropertyDescriptor(original, key))
     if (descriptor.writable && descriptor.enumerable && descriptor.configurable) {
       wrapped[key] = original[key]
     } else if (descriptor.writable || descriptor.configurable || !Object.hasOwn(wrapped, key)) {

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -112,7 +112,7 @@ function wrap (target, name, wrapper, options) {
     enumerable: false
   }
 
-  if (descriptor.set) {
+  if (descriptor.set && (!descriptor.get || options?.replaceGetter)) {
     // It is possible to support these cases by instrumenting both the getter
     // and setter (or only the setter, in case that is a use case).
     // For now, this is not supported due to the complexity and the fact that

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -9,6 +9,7 @@ const skipMethods = new Set([
   'name',
   'length'
 ])
+const skipMethodSize = skipMethods.size
 
 const nonConfigurableModuleExports = new WeakMap()
 
@@ -180,7 +181,9 @@ function wrap (target, name, wrapper, options) {
           // This is a rare case. Accept the slight performance hit.
           skipMethods.add(name)
           copyProperties(target, moduleExports)
-          skipMethods.delete(name)
+          if (skipMethods.size === skipMethodSize + 1) {
+            skipMethods.delete(name)
+          }
         } else {
           moduleExports = Object.create(target)
           copyObjectProperties(target, moduleExports, name)

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -6,6 +6,33 @@ const shimmer = require('../src/shimmer')
 
 describe('shimmer', () => {
   describe('with a method', () => {
+    it('should wrap getter method', () => {
+      let index = 0
+      let called = false
+      const obj = { get increment () { return () => index++ } }
+
+      shimmer.wrap(obj, 'increment', getter => () => {
+        called = true
+        return getter()
+      })
+
+      assert.strictEqual(index, 0)
+      assert.strictEqual(called, false)
+      const method = obj.increment
+      assert.strictEqual(index, 0)
+      assert.strictEqual(called, true)
+      method()
+      assert.strictEqual(index, 1)
+      assert.strictEqual(called, true)
+    })
+
+    it('should not wrap setter only method', () => {
+      // eslint-disable-next-line accessor-pairs
+      const obj = { set setter (_method_) {} }
+
+      assert.throws(() => shimmer.wrap(obj, 'setter', getter => () => {}))
+    })
+
     it('should wrap the method', () => {
       const count = inc => inc
       const obj = { count }

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -45,13 +45,36 @@ describe('shimmer', () => {
     it('should wrap the method on a frozen object', () => {
       const count = inc => inc
 
-      let obj = { count }
+      let obj = { count, foo: 42 }
 
       Object.freeze(obj)
 
       obj = shimmer.wrap(obj, 'count', count => inc => count(inc) + 1)
 
       expect(obj.count(1)).to.equal(2)
+      expect(obj.foo).to.equal(42)
+      expect(Object.hasOwn(obj, 'foo')).to.equal(true)
+    })
+
+    it('should wrap the method on a frozen object', () => {
+      const count = inc => inc
+
+      function abc () { return this.answer }
+
+      let method = abc
+      method.count = count
+      method.foo = 'bar'
+      method.answer = 42
+
+      Object.freeze(method)
+
+      method = shimmer.wrap(method, 'count', count => inc => count(inc) + 1)
+
+      expect(method.count(1)).to.equal(2)
+      expect(method.foo).to.equal('bar')
+      expect(method.name).to.equal('abc')
+      expect(method).to.not.equal(abc)
+      expect(method()).to.equal(42)
     })
 
     it('should mass wrap targets', () => {

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -26,11 +26,41 @@ describe('shimmer', () => {
       assert.strictEqual(called, true)
     })
 
+    it('should replace getter method when using replaceGetter option', () => {
+      let index = 0
+      let called = 0
+      const returned = () => { assert.strictEqual(called, 0) }
+
+      const obj = {
+        get method () {
+          index++
+          return returned
+        }
+      }
+
+      shimmer.wrap(obj, 'method', method => () => {
+        called++
+        return method
+      }, { replaceGetter: true })
+
+      assert.strictEqual(index, 1)
+      assert.strictEqual(called, 0)
+      const fn = obj.method
+      assert.strictEqual(fn.name, returned.name)
+      assert.strictEqual(index, 1)
+      assert.strictEqual(called, 0)
+      fn()
+      assert.strictEqual(index, 1)
+      assert.strictEqual(called, 1)
+    })
+
     it('should not wrap setter only method', () => {
       // eslint-disable-next-line accessor-pairs
       const obj = { set setter (_method_) {} }
 
-      assert.throws(() => shimmer.wrap(obj, 'setter', getter => () => {}))
+      assert.throws(() => shimmer.wrap(obj, 'setter', setter => () => {}), {
+        message: 'Replacing setters is not supported. Implement if required.'
+      })
     })
 
     it('should wrap the method', () => {


### PR DESCRIPTION
This improves the shimmer by replacing getters safely from now on.
The getters were always replaced before. Now, they are hooked into
by default and only replaced, if a developer opts into it.

This also simplifies the usage due to not needed workarounds to
instrument getters regularly otherwise.