### PR TITLE
[Code Origin for Spans] Ensure entry spans are not added if disabled

### DIFF
--- a/packages/datadog-plugin-fastify/test/code_origin.spec.js
+++ b/packages/datadog-plugin-fastify/test/code_origin.spec.js
@@ -21,191 +21,224 @@ describe('Plugin', () => {
       })
 
       withExports('fastify', version, ['default', 'fastify'], '>=3', getExport => {
-        describe('with tracer config codeOriginForSpans.enabled: true', () => {
+        beforeEach(() => {
+          fastify = getExport()
+          app = fastify()
+
+          if (semver.intersects(version, '>=3')) {
+            return app.register(require('../../../versions/middie').get())
+          }
+        })
+
+        describe('code origin for spans disabled', () => {
+          const configs = [{}, { codeOriginForSpans: false }, { codeOriginForSpans: { enabled: false } }]
+
+          for (const config of configs) {
+            describe(`with tracer config ${JSON.stringify(config)}`, () => {
+              before(() => agent.load(['fastify', 'find-my-way', 'http'], [{}, {}, { client: false }], config))
+
+              after(() => agent.close({ ritmReset: false, wipe: true }))
+
+              it('should not add code_origin tag on entry spans', done => {
+                app.get('/user', function (request, reply) {
+                  reply.send()
+                })
+
+                app.listen({ host, port: 0 }, () => {
+                  const port = app.server.address().port
+
+                  agent
+                    .use(traces => {
+                      const spans = traces[0]
+                      const tagNames = Object.keys(spans[0].meta)
+                      expect(tagNames).to.all.not.match(/code_origin/)
+                    })
+                    .then(done)
+                    .catch(done)
+
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(done)
+                })
+              })
+            })
+          }
+        })
+
+        describe('code origin for spans enabled', () => {
           if (semver.satisfies(specificVersion, '<4')) return // TODO: Why doesn't it work on older versions?
 
-          before(() => {
-            return agent.load(
-              ['fastify', 'find-my-way', 'http'],
-              [{}, {}, { client: false }],
-              { codeOriginForSpans: { enabled: true } }
-            )
-          })
+          const configs = [{ codeOriginForSpans: true }, { codeOriginForSpans: { enabled: true } }]
 
-          after(() => {
-            return agent.close({ ritmReset: false })
-          })
+          for (const config of configs) {
+            describe(`with tracer config ${JSON.stringify(config)}`, () => {
+              before(() => agent.load(['fastify', 'find-my-way', 'http'], [{}, {}, { client: false }], config))
 
-          beforeEach(() => {
-            fastify = getExport()
-            app = fastify()
+              after(() => agent.close({ ritmReset: false, wipe: true }))
 
-            if (semver.intersects(version, '>=3')) {
-              return app.register(require('../../../versions/middie').get())
-            }
-          })
+              it('should add code_origin tag on entry spans when feature is enabled', done => {
+                let routeRegisterLine
 
-          it('should add code_origin tag on entry spans when feature is enabled', done => {
-            let routeRegisterLine
+                // Wrap in a named function to have at least one frame with a function name
+                function wrapperFunction () {
+                  routeRegisterLine = String(getNextLineNumber())
+                  app.get('/user', function userHandler (request, reply) {
+                    reply.send()
+                  })
+                }
 
-            // Wrap in a named function to have at least one frame with a function name
-            function wrapperFunction () {
-              routeRegisterLine = String(getNextLineNumber())
-              app.get('/user', function userHandler (request, reply) {
-                reply.send()
+                const callWrapperLine = String(getNextLineNumber())
+                wrapperFunction()
+
+                app.listen(() => {
+                  const port = app.server.address().port
+
+                  agent
+                    .use(traces => {
+                      const spans = traces[0]
+                      const tags = spans[0].meta
+
+                      expect(tags).to.have.property('_dd.code_origin.type', 'entry')
+
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'wrapperFunction')
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
+
+                      expect(tags).to.have.property('_dd.code_origin.frames.1.file', __filename)
+                      expect(tags).to.have.property('_dd.code_origin.frames.1.line', callWrapperLine)
+                      expect(tags).to.have.property('_dd.code_origin.frames.1.column').to.match(/^\d+$/)
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.1.method')
+                      expect(tags).to.have.property('_dd.code_origin.frames.1.type', 'Context')
+
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.2.file')
+                    })
+                    .then(done)
+                    .catch(done)
+
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(done)
+                })
               })
-            }
 
-            const callWrapperLine = String(getNextLineNumber())
-            wrapperFunction()
+              it('should point to where actual route handler is configured, not the prefix', done => {
+                let routeRegisterLine
 
-            app.listen(() => {
-              const port = app.server.address().port
+                app.register(function v1Handler (app, opts, done) {
+                  routeRegisterLine = String(getNextLineNumber())
+                  app.get('/user', function userHandler (request, reply) {
+                    reply.send()
+                  })
+                  done()
+                }, { prefix: '/v1' })
 
-              agent
-                .use(traces => {
-                  const spans = traces[0]
-                  const tags = spans[0].meta
+                app.listen(() => {
+                  const port = app.server.address().port
 
-                  expect(tags).to.have.property('_dd.code_origin.type', 'entry')
+                  agent
+                    .use(traces => {
+                      const spans = traces[0]
+                      const tags = spans[0].meta
 
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'wrapperFunction')
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
+                      expect(tags).to.have.property('_dd.code_origin.type', 'entry')
 
-                  expect(tags).to.have.property('_dd.code_origin.frames.1.file', __filename)
-                  expect(tags).to.have.property('_dd.code_origin.frames.1.line', callWrapperLine)
-                  expect(tags).to.have.property('_dd.code_origin.frames.1.column').to.match(/^\d+$/)
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.1.method')
-                  expect(tags).to.have.property('_dd.code_origin.frames.1.type', 'Context')
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'v1Handler')
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
 
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.2.file')
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+                    })
+                    .then(done)
+                    .catch(done)
+
+                  axios
+                    .get(`http://localhost:${port}/v1/user`)
+                    .catch(done)
                 })
-                .then(done)
-                .catch(done)
-
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
-          })
-
-          it('should point to where actual route handler is configured, not the prefix', done => {
-            let routeRegisterLine
-
-            app.register(function v1Handler (app, opts, done) {
-              routeRegisterLine = String(getNextLineNumber())
-              app.get('/user', function userHandler (request, reply) {
-                reply.send()
               })
-              done()
-            }, { prefix: '/v1' })
 
-            app.listen(() => {
-              const port = app.server.address().port
-
-              agent
-                .use(traces => {
-                  const spans = traces[0]
-                  const tags = spans[0].meta
-
-                  expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'v1Handler')
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
-
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+              it('should point to route handler even if passed through a middleware', function testCase (done) {
+                app.use(function middleware (req, res, next) {
+                  next()
                 })
-                .then(done)
-                .catch(done)
 
-              axios
-                .get(`http://localhost:${port}/v1/user`)
-                .catch(done)
-            })
-          })
-
-          it('should point to route handler even if passed through a middleware', function testCase (done) {
-            app.use(function middleware (req, res, next) {
-              next()
-            })
-
-            const routeRegisterLine = String(getNextLineNumber())
-            app.get('/user', function userHandler (request, reply) {
-              reply.send()
-            })
-
-            app.listen({ host, port: 0 }, () => {
-              const port = app.server.address().port
-
-              agent
-                .use(traces => {
-                  const spans = traces[0]
-                  const tags = spans[0].meta
-
-                  expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+                const routeRegisterLine = String(getNextLineNumber())
+                app.get('/user', function userHandler (request, reply) {
+                  reply.send()
                 })
-                .then(done)
-                .catch(done)
 
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
-            })
-          })
+                app.listen({ host, port: 0 }, () => {
+                  const port = app.server.address().port
 
-          // TODO: In Fastify, the route is resolved before the middleware is called, so we actually can get the line
-          // number of where the route handler is defined. However, this might not be the right choice and it might be
-          // better to point to the middleware.
-          it.skip('should point to middleware if middleware responds early', function testCase (done) {
-            const middlewareRegisterLine = String(getNextLineNumber())
-            app.use(function middleware (req, res, next) {
-              res.end()
-            })
+                  agent
+                    .use(traces => {
+                      const spans = traces[0]
+                      const tags = spans[0].meta
 
-            app.get('/user', function userHandler (request, reply) {
-              reply.send()
-            })
+                      expect(tags).to.have.property('_dd.code_origin.type', 'entry')
 
-            app.listen({ host, port: 0 }, () => {
-              const port = app.server.address().port
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
 
-              agent
-                .use(traces => {
-                  const spans = traces[0]
-                  const tags = spans[0].meta
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+                    })
+                    .then(done)
+                    .catch(done)
 
-                  expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.line', middlewareRegisterLine)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-                  expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-
-                  expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(done)
                 })
-                .then(done)
-                .catch(done)
+              })
 
-              axios
-                .get(`http://localhost:${port}/user`)
-                .catch(done)
+              // TODO: In Fastify, the route is resolved before the middleware is called, so we actually can get the
+              // line number of where the route handler is defined. However, this might not be the right choice and it
+              // might be better to point to the middleware.
+              it.skip('should point to middleware if middleware responds early', function testCase (done) {
+                const middlewareRegisterLine = String(getNextLineNumber())
+                app.use(function middleware (req, res, next) {
+                  res.end()
+                })
+
+                app.get('/user', function userHandler (request, reply) {
+                  reply.send()
+                })
+
+                app.listen({ host, port: 0 }, () => {
+                  const port = app.server.address().port
+
+                  agent
+                    .use(traces => {
+                      const spans = traces[0]
+                      const tags = spans[0].meta
+
+                      expect(tags).to.have.property('_dd.code_origin.type', 'entry')
+
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.line', middlewareRegisterLine)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
+                      expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
+
+                      expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+                    })
+                    .then(done)
+                    .catch(done)
+
+                  axios
+                    .get(`http://localhost:${port}/user`)
+                    .catch(done)
+                })
+              })
             })
-          })
+          }
         })
       })
     })

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -301,6 +301,12 @@ class Config {
       options.appsec = {}
     }
 
+    if (typeof options.codeOriginForSpans === 'boolean') {
+      options.codeOriginForSpans = {
+        enabled: options.codeOriginForSpans
+      }
+    }
+
     const DD_INSTRUMENTATION_INSTALL_ID = coalesce(
       process.env.DD_INSTRUMENTATION_INSTALL_ID,
       null

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -130,6 +130,7 @@ module.exports = class PluginManager {
       site,
       url,
       headerTags,
+      codeOriginForSpans,
       dbmPropagationMode,
       dsmEnabled,
       clientIpEnabled,
@@ -143,6 +144,7 @@ module.exports = class PluginManager {
     } = this._tracerConfig
 
     const sharedConfig = {
+      codeOriginForSpans,
       dbmPropagationMode,
       dsmEnabled,
       memcachedCommandEnabled,

--- a/packages/dd-trace/src/plugins/composite.js
+++ b/packages/dd-trace/src/plugins/composite.js
@@ -14,7 +14,7 @@ class CompositePlugin extends Plugin {
   configure (config) {
     super.configure(config)
     for (const name in this.constructor.plugins) {
-      const pluginConfig = config[name] === false
+      const pluginConfig = config[name] === false || config[name]?.enabled === false
         ? false
         : { ...config, ...config[name] }
 


### PR DESCRIPTION
### What does this PR do?

Fix a bug, where entry spans would be added for Fastify even if the Code Origin for Spans feature was disabled.

### Motivation

<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


