### PR TITLE
[DI] Support enabling Dynamic Instrumentation with simple boolean

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -731,6 +731,27 @@ declare namespace tracer {
     }
 
     /**
+     * Configuration for Dynamic Instrumentation. Can be a boolean as an alias to `dynamicInstrumentation.enabled`.
+     */
+    dynamicInstrumentation?: boolean | {
+      /**
+       * Whether to enable Dynamic Instrumentation.
+       * @default false
+       */
+      enabled?: boolean,
+
+      /**
+       * List of identifiers to whos content will be redacted before being collected as part of a Dynamic Instrumentation probe.
+       */
+      redactedIdentifiers?: string[],
+
+      /**
+       * List of identifiers, which are redacted by default, but shouldn't be.
+       */
+      redactionExcludedIdentifiers?: string[],
+    }
+
+    /**
      * Configuration of the IAST. Can be a boolean as an alias to `iast.enabled`.
      */
     iast?: boolean | IastOptions

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -307,6 +307,12 @@ class Config {
       }
     }
 
+    if (typeof options.dynamicInstrumentation === 'boolean') {
+      options.dynamicInstrumentation = {
+        enabled: options.dynamicInstrumentation
+      }
+    }
+
     const DD_INSTRUMENTATION_INSTALL_ID = coalesce(
       process.env.DD_INSTRUMENTATION_INSTALL_ID,
       null

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -1699,6 +1699,14 @@ describe('Config', () => {
     expect(config).to.have.nested.property('codeOriginForSpans.enabled', true)
   })
 
+  it('should support dynamicInstrumentation as a boolean', () => {
+    const config = new Config({
+      dynamicInstrumentation: true
+    })
+
+    expect(config).to.have.nested.property('dynamicInstrumentation.enabled', true)
+  })
+
   it('should not set DD_INSTRUMENTATION_TELEMETRY_ENABLED if AWS_LAMBDA_FUNCTION_NAME is present', () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-great-lambda-function'
 


### PR DESCRIPTION
### What does this PR do?

Support configuring Dynamic Instrumentation (DI) with a simple boolean instead of a complex object:
    
```js
tracer.init({ dynamicInstrumentation: true })
```
    
Previously, you'd have to do it like so:
    
```js
tracer.init({ dynamicInstrumentation: { enabled: true } })
```
    
The old approach is still the supported. The new version is just an alias for the more complex object.

### Motivation

Make it easier to enable DI and align with how a lot of the other complex config objects work.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->


