### PR TITLE
feat(openai)!: change span resource names to be consistent between openai v3 and v4

### DIFF
--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -59,11 +59,17 @@ class OpenAiTracingPlugin extends TracingPlugin {
   bindStart (ctx) {
     const { methodName, args, basePath, apiKey } = ctx
     const payload = normalizeRequestPayload(methodName, args)
+    const resource = normalizeMethodName(methodName)
+
     const store = storage('legacy').getStore() || {}
+
+    // we need to hold onto the original function name for lookupOperationEndpoint later
+    // we need to be able to differentiate for fine-tune endpoints
+    store.originalMethodName = methodName
 
     const span = this.startSpan('openai.request', {
       service: this.config.service,
-      resource: methodName,
+      resource,
       type: 'openai',
       kind: 'client',
       meta: {
@@ -129,62 +135,43 @@ class OpenAiTracingPlugin extends TracingPlugin {
       tags['openai.request.stream'] = payload.stream
     }
 
-    switch (methodName) {
+    switch (resource) {
       case 'createFineTune':
-      case 'fine_tuning.jobs.create':
-      case 'fine-tune.create':
         createFineTuneRequestExtraction(tags, payload)
         break
 
       case 'createImage':
-      case 'images.generate':
       case 'createImageEdit':
-      case 'images.edit':
       case 'createImageVariation':
-      case 'images.createVariation':
         commonCreateImageRequestExtraction(tags, payload, openaiStore)
         break
 
       case 'createChatCompletion':
-      case 'chat.completions.create':
         createChatCompletionRequestExtraction(tags, payload, openaiStore)
         break
 
       case 'createFile':
-      case 'files.create':
       case 'retrieveFile':
-      case 'files.retrieve':
         commonFileRequestExtraction(tags, payload)
         break
 
       case 'createTranscription':
-      case 'audio.transcriptions.create':
       case 'createTranslation':
-      case 'audio.translations.create':
         commonCreateAudioRequestExtraction(tags, payload, openaiStore)
         break
 
       case 'retrieveModel':
-      case 'models.retrieve':
         retrieveModelRequestExtraction(tags, payload)
         break
 
       case 'listFineTuneEvents':
-      case 'fine_tuning.jobs.listEvents':
-      case 'fine-tune.listEvents':
       case 'retrieveFineTune':
-      case 'fine_tuning.jobs.retrieve':
-      case 'fine-tune.retrieve':
       case 'deleteModel':
-      case 'models.del':
       case 'cancelFineTune':
-      case 'fine_tuning.jobs.cancel':
-      case 'fine-tune.cancel':
         commonLookupFineTuneRequestExtraction(tags, payload)
         break
 
       case 'createEdit':
-      case 'edits.create':
         createEditRequestExtraction(tags, payload, openaiStore)
         break
     }
@@ -227,7 +214,9 @@ class OpenAiTracingPlugin extends TracingPlugin {
       // not using a full regex as it will likely be "https://api.openai.com/..."
       path = new URL(path).pathname
     }
-    const endpoint = lookupOperationEndpoint(methodName, path)
+
+    const originalMethodName = store.originalMethodName
+    const endpoint = lookupOperationEndpoint(methodName, originalMethodName, path)
 
     const tags = error
       ? {}
@@ -341,10 +330,88 @@ class OpenAiTracingPlugin extends TracingPlugin {
   }
 }
 
+function normalizeMethodName (methodName) {
+  switch (methodName) {
+    // moderations
+    case 'moderations.create':
+      return 'createModeration'
+
+    // completions
+    case 'completions.create':
+      return 'createCompletion'
+
+    // chat completions
+    case 'chat.completions.create':
+      return 'createChatCompletion'
+
+    // edits
+    case 'edits.create':
+      return 'createEdit'
+
+    // embeddings
+    case 'embeddings.create':
+      return 'createEmbedding'
+
+    // files
+    case 'files.create':
+      return 'createFile'
+    case 'files.retrieve':
+      return 'retrieveFile'
+    case 'files.del':
+      return 'deleteFile'
+    case 'files.retrieveContent':
+    case 'files.content':
+      return 'downloadFile'
+    case 'files.list':
+      return 'listFiles'
+
+    // fine-tuning
+    case 'fine_tuning.jobs.list':
+    case 'fine-tune.list':
+      return 'listFineTunes'
+    case 'fine_tuning.jobs.listEvents':
+    case 'fine-tune.listEvents':
+      return 'listFineTuneEvents'
+    case 'fine_tuning.jobs.create':
+    case 'fine-tune.create':
+      return 'createFineTune'
+    case 'fine_tuning.jobs.retrieve':
+    case 'fine-tune.retrieve':
+      return 'retrieveFineTune'
+    case 'fine_tuning.jobs.cancel':
+    case 'fine-tune.cancel':
+      return 'cancelFineTune'
+
+    // audio
+    case 'audio.transcriptions.create':
+      return 'createTranscription'
+    case 'audio.translations.create':
+      return 'createTranslation'
+
+    // images
+    case 'images.generate':
+      return 'createImage'
+    case 'images.edit':
+      return 'createImageEdit'
+    case 'images.createVariation':
+      return 'createImageVariation'
+
+    // models
+    case 'models.list':
+      return 'listModels'
+    case 'models.retrieve':
+      return 'retrieveModel'
+    case 'models.del':
+      return 'deleteModel'
+    default:
+      return methodName
+  }
+}
+
 function countPromptTokens (methodName, payload, model) {
   let promptTokens = 0
   let promptEstimated = false
-  if (methodName === 'chat.completions.create') {
+  if (methodName === 'createChatCompletion') {
     const messages = payload.messages
     for (const message of messages) {
       const content = message.content
@@ -365,7 +432,7 @@ function countPromptTokens (methodName, payload, model) {
         }
       }
     }
-  } else if (methodName === 'completions.create') {
+  } else if (methodName === 'createCompletion') {
     let prompt = payload.prompt
     if (!Array.isArray(prompt)) prompt = [prompt]
 
@@ -466,88 +533,60 @@ function commonCreateImageRequestExtraction (tags, payload, openaiStore) {
 function responseDataExtractionByMethod (methodName, tags, body, openaiStore) {
   switch (methodName) {
     case 'createModeration':
-    case 'moderations.create':
       createModerationResponseExtraction(tags, body)
       break
 
     case 'createCompletion':
-    case 'completions.create':
     case 'createChatCompletion':
-    case 'chat.completions.create':
     case 'createEdit':
-    case 'edits.create':
       commonCreateResponseExtraction(tags, body, openaiStore, methodName)
       break
 
     case 'listFiles':
-    case 'files.list':
     case 'listFineTunes':
-    case 'fine_tuning.jobs.list':
-    case 'fine-tune.list':
     case 'listFineTuneEvents':
-    case 'fine_tuning.jobs.listEvents':
-    case 'fine-tune.listEvents':
       commonListCountResponseExtraction(tags, body)
       break
 
     case 'createEmbedding':
-    case 'embeddings.create':
       createEmbeddingResponseExtraction(tags, body, openaiStore)
       break
 
     case 'createFile':
-    case 'files.create':
     case 'retrieveFile':
-    case 'files.retrieve':
       createRetrieveFileResponseExtraction(tags, body)
       break
 
     case 'deleteFile':
-    case 'files.del':
       deleteFileResponseExtraction(tags, body)
       break
 
     case 'downloadFile':
-    case 'files.retrieveContent':
-    case 'files.content':
       downloadFileResponseExtraction(tags, body)
       break
 
     case 'createFineTune':
-    case 'fine_tuning.jobs.create':
-    case 'fine-tune.create':
     case 'retrieveFineTune':
-    case 'fine_tuning.jobs.retrieve':
-    case 'fine-tune.retrieve':
     case 'cancelFineTune':
-    case 'fine_tuning.jobs.cancel':
-    case 'fine-tune.cancel':
       commonFineTuneResponseExtraction(tags, body)
       break
 
     case 'createTranscription':
-    case 'audio.transcriptions.create':
     case 'createTranslation':
-    case 'audio.translations.create':
       createAudioResponseExtraction(tags, body)
       break
 
     case 'createImage':
-    case 'images.generate':
     case 'createImageEdit':
-    case 'images.edit':
     case 'createImageVariation':
-    case 'images.createVariation':
       commonImageResponseExtraction(tags, body)
       break
 
     case 'listModels':
-    case 'models.list':
       listModelsResponseExtraction(tags, body)
       break
 
     case 'retrieveModel':
-    case 'models.retrieve':
       retrieveModelResponseExtraction(tags, body)
       break
   }
@@ -761,7 +800,7 @@ function usageExtraction (tags, body, methodName, openaiStore) {
     promptTokens = body.usage.prompt_tokens
     completionTokens = body.usage.completion_tokens
     totalTokens = body.usage.total_tokens
-  } else if (body.model && ['chat.completions.create', 'completions.create'].includes(methodName)) {
+  } else if (body.model && ['createChatCompletion', 'createCompletion'].includes(methodName)) {
     // estimate tokens based on method name for completions and chat completions
     const { model } = body
     let promptEstimated = false
@@ -819,8 +858,6 @@ function tagChatCompletionRequestContent (contents, messageIdx, tags) {
 function coerceResponseBody (body, methodName) {
   switch (methodName) {
     case 'downloadFile':
-    case 'files.retrieveContent':
-    case 'files.content':
       return { file: body }
   }
 
@@ -839,42 +876,42 @@ function coerceResponseBody (body, methodName) {
 }
 
 // This method is used to replace a dynamic URL segment with an asterisk
-function lookupOperationEndpoint (operationId, url) {
+function lookupOperationEndpoint (operationId, methodName, url) {
   switch (operationId) {
     case 'deleteModel':
-    case 'models.del':
     case 'retrieveModel':
-    case 'models.retrieve':
       return '/v1/models/*'
 
     case 'deleteFile':
-    case 'files.del':
     case 'retrieveFile':
-    case 'files.retrieve':
       return '/v1/files/*'
 
     case 'downloadFile':
-    case 'files.retrieveContent':
-    case 'files.content':
       return '/v1/files/*/content'
 
     case 'retrieveFineTune':
-    case 'fine-tune.retrieve':
-      return '/v1/fine-tunes/*'
-    case 'fine_tuning.jobs.retrieve':
-      return '/v1/fine_tuning/jobs/*'
+      switch (methodName) {
+        case 'fine_tuning.jobs.retrieve':
+          return '/v1/fine_tuning/jobs/*'
+        default:
+          return '/v1/fine-tunes/*'
+      }
 
     case 'listFineTuneEvents':
-    case 'fine-tune.listEvents':
-      return '/v1/fine-tunes/*/events'
-    case 'fine_tuning.jobs.listEvents':
-      return '/v1/fine_tuning/jobs/*/events'
+      switch (methodName) {
+        case 'fine_tuning.jobs.listEvents':
+          return '/v1/fine_tuning/jobs/*/events'
+        default:
+          return '/v1/fine-tunes/*/events'
+      }
 
     case 'cancelFineTune':
-    case 'fine-tune.cancel':
-      return '/v1/fine-tunes/*/cancel'
-    case 'fine_tuning.jobs.cancel':
-      return '/v1/fine_tuning/jobs/*/cancel'
+      switch (methodName) {
+        case 'fine_tuning.jobs.cancel':
+          return '/v1/fine_tuning/jobs/*/cancel'
+        default:
+          return '/v1/fine-tunes/*/cancel'
+      }
   }
 
   return url

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -324,11 +324,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'completions.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createCompletion')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createCompletion')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/completions')
@@ -411,9 +407,7 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: semver.satisfies(realVersion, '>=4.0.0')
-              ? 'sampled completions.create'
-              : 'sampled createCompletion',
+            message: 'sampled createCompletion',
             prompt: 'Hello, \n\nFriend\t\tHi',
             choices: [
               {
@@ -504,11 +498,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'embeddings.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/embeddings')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -543,7 +533,7 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: semver.satisfies(realVersion, '>=4.0.0') ? 'sampled embeddings.create' : 'sampled createEmbedding',
+            message: 'sampled createEmbedding',
             input: 'Cat?'
           })
         })
@@ -578,11 +568,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'embeddings.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/embeddings')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -618,7 +604,7 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: semver.satisfies(realVersion, '>=4.0.0') ? 'sampled embeddings.create' : 'sampled createEmbedding',
+            message: 'sampled createEmbedding',
             input: 'Cat?'
           })
         })
@@ -750,11 +736,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'models.list')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listModels')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listModels')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models')
@@ -824,11 +806,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'models.retrieve')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'retrieveModel')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'retrieveModel')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models/*')
@@ -962,7 +940,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0') ? 'sampled edits.create' : 'sampled createEdit',
+              message: 'sampled createEdit',
               input: 'What day of the wek is it?',
               instruction: 'Fix the spelling mistakes',
               choices: [{
@@ -1022,11 +1000,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.list')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listFiles')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listFiles')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -1087,11 +1061,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/files')
@@ -1156,11 +1126,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.del')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'deleteFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'deleteFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'DELETE')
@@ -1221,11 +1187,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.retrieve')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'retrieveFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'retrieveFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1284,13 +1246,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0 <4.17.1')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.retrieveContent')
-              } else if (semver.satisfies(realVersion, '>=4.17.1')) {
-                expect(traces[0][0]).to.have.property('resource', 'files.content')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'downloadFile')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'downloadFile')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1402,13 +1358,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.create')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.create')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'createFineTune')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'createFineTune')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG') // no name just id
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -1667,13 +1617,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.retrieve')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.retrieve')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'retrieveFineTune')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'retrieveFineTune')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG') // no name just id
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1813,13 +1757,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.list')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.list')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listFineTunes')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listFineTunes')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               if (semver.satisfies(realVersion, '>=4.1.0')) {
@@ -1948,13 +1886,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.listEvents')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.listEvents')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'listFineTuneEvents')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'listFineTuneEvents')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               if (semver.satisfies(realVersion, '>=4.1.0')) {
@@ -2016,11 +1948,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'models.del')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'deleteModel')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'deleteModel')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'DELETE')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models/*')
@@ -2131,13 +2059,7 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              if (semver.satisfies(realVersion, '>=4.1.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.cancel')
-              } else if (semver.satisfies(realVersion, '>=4.0.0')) {
-                expect(traces[0][0]).to.have.property('resource', 'fine-tune.cancel')
-              } else {
-                expect(traces[0][0]).to.have.property('resource', 'cancelFineTune')
-              }
+              expect(traces[0][0]).to.have.property('resource', 'cancelFineTune')
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2243,11 +2165,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'moderations.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createModeration')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createModeration')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2299,9 +2217,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled moderations.create'
-                : 'sampled createModeration',
+              message: 'sampled createModeration',
               input: 'I want to harm the robots'
             })
           })
@@ -2342,11 +2258,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'images.generate')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createImage')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createImage')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2390,9 +2302,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: 'A datadog wearing headphones'
             })
           })
@@ -2429,9 +2339,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: [999, 888, 777, 666, 555]
             })
           })
@@ -2469,9 +2377,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: ['foo', 'bar']
             })
           })
@@ -2512,9 +2418,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.generate'
-                : 'sampled createImage',
+              message: 'sampled createImage',
               prompt: [[111, 222, 333], [444, 555, 666]]
             })
           })
@@ -2553,11 +2457,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'images.edit')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createImageEdit')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createImageEdit')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2607,9 +2507,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.edit'
-                : 'sampled createImageEdit',
+              message: 'sampled createImageEdit',
               prompt: 'Change all red to blue',
               file: 'ntsc.png',
               mask: 'ntsc.png'
@@ -2650,11 +2548,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'images.createVariation')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createImageVariation')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createImageVariation')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2693,9 +2587,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled images.createVariation'
-                : 'sampled createImageVariation',
+              message: 'sampled createImageVariation',
               file: 'ntsc.png'
             })
           })
@@ -2750,11 +2642,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'chat.completions.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createChatCompletion')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createChatCompletion')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -2848,10 +2736,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message:
-                  semver.satisfies(realVersion, '>=4.0.0')
-                    ? 'sampled chat.completions.create'
-                    : 'sampled createChatCompletion',
+              message: 'sampled createChatCompletion',
               messages: [
                 {
                   role: 'user',
@@ -3058,10 +2943,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message:
-                  semver.satisfies(realVersion, '>=4.0.0')
-                    ? 'sampled chat.completions.create'
-                    : 'sampled createChatCompletion',
+              message: 'sampled createChatCompletion',
               messages: [
                 {
                   role: 'user',
@@ -3138,11 +3020,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'audio.transcriptions.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createTranscription')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createTranscription')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -3190,9 +3068,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled audio.transcriptions.create'
-                : 'sampled createTranscription',
+              message: 'sampled createTranscription',
               prompt: 'what does this say',
               file: 'hello-friend.m4a'
             })
@@ -3244,11 +3120,7 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                if (semver.satisfies(realVersion, '>=4.0.0')) {
-                  expect(traces[0][0]).to.have.property('resource', 'audio.translations.create')
-                } else {
-                  expect(traces[0][0]).to.have.property('resource', 'createTranslation')
-                }
+                expect(traces[0][0]).to.have.property('resource', 'createTranslation')
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -3292,9 +3164,7 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: semver.satisfies(realVersion, '>=4.0.0')
-                ? 'sampled audio.translations.create'
-                : 'sampled createTranslation',
+              message: 'sampled createTranslation',
               prompt: 'greeting',
               file: 'guten-tag.m4a'
             })

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -16,6 +16,8 @@ const Sampler = require('../../dd-trace/src/sampler')
 
 const tracerRequirePath = '../../dd-trace'
 
+const { DD_MAJOR } = require('../../../version')
+
 describe('Plugin', () => {
   let openai
   let clock
@@ -324,7 +326,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'createCompletion')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'completions.create')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'createCompletion')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/completions')
@@ -407,7 +413,9 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: 'sampled createCompletion',
+            message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+              ? 'sampled completions.create'
+              : 'sampled createCompletion',
             prompt: 'Hello, \n\nFriend\t\tHi',
             choices: [
               {
@@ -498,7 +506,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'embeddings.create')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/embeddings')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -533,7 +545,9 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: 'sampled createEmbedding',
+            message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+              ? 'sampled embeddings.create'
+              : 'sampled createEmbedding',
             input: 'Cat?'
           })
         })
@@ -568,7 +582,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'embeddings.create')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'createEmbedding')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/embeddings')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -604,7 +622,9 @@ describe('Plugin', () => {
 
           expect(externalLoggerStub).to.have.been.calledWith({
             status: 'info',
-            message: 'sampled createEmbedding',
+            message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+              ? 'sampled embeddings.create'
+              : 'sampled createEmbedding',
             input: 'Cat?'
           })
         })
@@ -736,7 +756,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'listModels')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'models.list')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'listModels')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models')
@@ -806,7 +830,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'retrieveModel')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'models.retrieve')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'retrieveModel')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models/*')
@@ -940,7 +968,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createEdit',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled edits.create'
+                : 'sampled createEdit',
               input: 'What day of the wek is it?',
               instruction: 'Fix the spelling mistakes',
               choices: [{
@@ -1000,7 +1030,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'listFiles')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'files.list')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'listFiles')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -1061,7 +1095,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'createFile')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'files.create')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'createFile')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/files')
@@ -1126,7 +1164,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'deleteFile')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'files.del')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'deleteFile')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'DELETE')
@@ -1187,7 +1229,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'retrieveFile')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'files.retrieve')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'retrieveFile')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1246,7 +1292,13 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'downloadFile')
+              if (semver.satisfies(realVersion, '>=4.0.0 <4.17.1') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'files.retrieveContent')
+              } else if (semver.satisfies(realVersion, '>=4.17.1') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'files.content')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'downloadFile')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1358,7 +1410,13 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'createFineTune')
+              if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.create')
+              } else if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine-tune.create')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'createFineTune')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG') // no name just id
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -1617,7 +1675,13 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'retrieveFineTune')
+              if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.retrieve')
+              } else if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine-tune.retrieve')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'retrieveFineTune')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG') // no name just id
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
@@ -1757,7 +1821,13 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'listFineTunes')
+              if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.list')
+              } else if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine-tune.list')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'listFineTunes')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               if (semver.satisfies(realVersion, '>=4.1.0')) {
@@ -1886,7 +1956,13 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'listFineTuneEvents')
+              if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.listEvents')
+              } else if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine-tune.listEvents')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'listFineTuneEvents')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'GET')
               if (semver.satisfies(realVersion, '>=4.1.0')) {
@@ -1948,7 +2024,11 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'deleteModel')
+              if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'models.del')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'deleteModel')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'DELETE')
               expect(traces[0][0].meta).to.have.property('openai.request.endpoint', '/v1/models/*')
@@ -2059,7 +2139,13 @@ describe('Plugin', () => {
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
-              expect(traces[0][0]).to.have.property('resource', 'cancelFineTune')
+              if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine_tuning.jobs.cancel')
+              } else if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                expect(traces[0][0]).to.have.property('resource', 'fine-tune.cancel')
+              } else {
+                expect(traces[0][0]).to.have.property('resource', 'cancelFineTune')
+              }
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.have.property('openai.organization.id', 'org-COOLORG')
               expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2165,7 +2251,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createModeration')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'moderations.create')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createModeration')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2217,7 +2307,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createModeration',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled moderations.create'
+                : 'sampled createModeration',
               input: 'I want to harm the robots'
             })
           })
@@ -2258,7 +2350,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createImage')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'images.generate')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createImage')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2302,7 +2398,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createImage',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled images.generate'
+                : 'sampled createImage',
               prompt: 'A datadog wearing headphones'
             })
           })
@@ -2339,7 +2437,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createImage',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled images.generate'
+                : 'sampled createImage',
               prompt: [999, 888, 777, 666, 555]
             })
           })
@@ -2377,7 +2477,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createImage',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled images.generate'
+                : 'sampled createImage',
               prompt: ['foo', 'bar']
             })
           })
@@ -2418,7 +2520,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createImage',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled images.generate'
+                : 'sampled createImage',
               prompt: [[111, 222, 333], [444, 555, 666]]
             })
           })
@@ -2457,7 +2561,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createImageEdit')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'images.edit')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createImageEdit')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2507,7 +2615,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createImageEdit',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled images.edit'
+                : 'sampled createImageEdit',
               prompt: 'Change all red to blue',
               file: 'ntsc.png',
               mask: 'ntsc.png'
@@ -2548,7 +2658,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createImageVariation')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'images.createVariation')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createImageVariation')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
                 expect(traces[0][0].meta).to.have.property('openai.request.method', 'POST')
@@ -2587,7 +2701,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createImageVariation',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled images.createVariation'
+                : 'sampled createImageVariation',
               file: 'ntsc.png'
             })
           })
@@ -2642,7 +2758,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createChatCompletion')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'chat.completions.create')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createChatCompletion')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -2736,7 +2856,10 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createChatCompletion',
+              message:
+                  semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                    ? 'sampled chat.completions.create'
+                    : 'sampled createChatCompletion',
               messages: [
                 {
                   role: 'user',
@@ -2943,7 +3066,10 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createChatCompletion',
+              message:
+                  semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                    ? 'sampled chat.completions.create'
+                    : 'sampled createChatCompletion',
               messages: [
                 {
                   role: 'user',
@@ -3020,7 +3146,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createTranscription')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'audio.transcriptions.create')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createTranscription')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -3068,7 +3198,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createTranscription',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled audio.transcriptions.create'
+                : 'sampled createTranscription',
               prompt: 'what does this say',
               file: 'hello-friend.m4a'
             })
@@ -3120,7 +3252,11 @@ describe('Plugin', () => {
               .use(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
-                expect(traces[0][0]).to.have.property('resource', 'createTranslation')
+                if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
+                  expect(traces[0][0]).to.have.property('resource', 'audio.translations.create')
+                } else {
+                  expect(traces[0][0]).to.have.property('resource', 'createTranslation')
+                }
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.have.property('openai.organization.name', 'kill-9')
 
@@ -3164,7 +3300,9 @@ describe('Plugin', () => {
 
             expect(externalLoggerStub).to.have.been.calledWith({
               status: 'info',
-              message: 'sampled createTranslation',
+              message: semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6
+                ? 'sampled audio.translations.create'
+                : 'sampled createTranslation',
               prompt: 'greeting',
               file: 'guten-tag.m4a'
             })


### PR DESCRIPTION
### What does this PR do?
Reverts OpenAI resource names for `openai>=4.0.0` to follow standards of resource naming between the Node.js tracer and Python tracer. For example:

`chat.completions.create` &#8594; `createChatCompletion`
`completions.create` &#8594; `createCompletion`

etc.

### Motivation
Consistency for resource names not only between versions of OpenAI SDK for our integration, but also between languages for the Datadog tracers.

MLOB-1055

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js


