### PR TITLE
prevent exclusion of commit based on the release line

### DIFF
--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -68,14 +68,18 @@ try {
 
   pass(`v${releaseLine}.x`)
 
-  const diffCmd = [
-    'branch-diff',
-    '--user DataDog',
-    '--repo dd-trace-js',
-    `--exclude-label=semver-major,dont-land-on-v${releaseLine}.x`
-  ].join(' ')
+  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major'
 
   start('Determine version increment')
+
+  const legacyDiff = capture(`${diffCmd} --require-label=dont-land-on-v${releaseLine}.x v${releaseLine}.x ${main}`)
+
+  if (legacyDiff) {
+    fatal(
+      `The "dont-land-on-v${releaseLine}.x" label is no longer supported.`,
+      'Please remove the label from any offending PR to continue.'
+    )
+  }
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
   const lineDiff = capture(`${diffCmd} --markdown=true v${releaseLine}.x ${main}`)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Prevent exclusion of commit based on the release line.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is a continuation of the work to prevent merge conflicts and release line branches deviating. If this ever ends up being needed and a blocker, we can re-evaluate for the specific commit, but conditions that can land everywhere cleanly should be prioritized to enable automation.