### PR TITLE
fix: Support for inode when /proc/self/cgroup is a multiline string

### DIFF
--- a/packages/dd-trace/src/exporters/common/docker.js
+++ b/packages/dd-trace/src/exporters/common/docker.js
@@ -10,7 +10,7 @@ const uuidSource =
 '[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{8}(?:-[0-9a-f]{4}){4}$'
 const containerSource = '[0-9a-f]{64}'
 const taskSource = '[0-9a-f]{32}-\\d+'
-const lineReg = /^(\d+):([^:]*):(.+)$/
+const lineReg = /^(\d+):([^:]*):(.+)$/m
 const entityReg = new RegExp(`.*(${uuidSource}|${containerSource}|${taskSource})(?:\\.scope)?$`, 'm')
 
 const cgroup = readControlGroup()

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -144,6 +144,22 @@ describe('docker', () => {
     expect(carrier['Datadog-Entity-ID']).to.equal(`in-${ino}`)
   })
 
+  it('should support inode when the ID is not available (any line)', () => {
+    const ino = 1234
+    const cgroup = [
+      '1:name=systemd:/',
+      '0::/'
+    ].join('\n')
+
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.statSync.withArgs('/sys/fs/cgroup/').returns({ ino })
+    docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
+
+    expect(carrier['Datadog-Container-Id']).to.be.undefined
+    expect(carrier['Datadog-Entity-ID']).to.equal(`in-${ino}`)
+  })
+
   it('should support external env', () => {
     process.env.DD_EXTERNAL_ENV = 'test'
 


### PR DESCRIPTION
### What does this PR do?
Fix inode detection when `/proc/self/cgroup` contains a multi-line string.

### Motivation
We're porting some Kubernetes hosts from Amazon Linux 2023 to Bottlerocket OS and the contents of `/proc/self/cgroup` have changed from `0::/` to `1:name=systemd:/\n0::/`, which caused the inode detection to break.  As a result, the `namespaceLabelsAsTags` directed in our Datadog agent no longer works.

### Additional Notes
We also run Java applications with [Datadog/dd-trace-java](https://github.com/DataDog/dd-trace-java) and did not encounter this problem for our Java apps.


