### PR TITLE
remove release proposal dont-land-on checks

### DIFF
--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -73,10 +73,11 @@ try {
   const legacyDiff = capture(`${diffCmd} --require-label=dont-land-on-v${releaseLine}.x v${releaseLine}.x ${main}`)
 
   if (legacyDiff) {
-    fatal(
-      `The "dont-land-on-v${releaseLine}.x" label is no longer supported.`,
-      'Please remove the label from any offending PR to continue.'
-    )
+    // TODO: Re-enable this when the offending PR commits have landed properly.
+    // fatal(
+    //   `The "dont-land-on-v${releaseLine}.x" label is no longer supported.`,
+    //   'Please remove the label from any offending PR to continue.'
+    // )
   }
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove release proposal `dont-land-on` checks.

### Motivation
<!-- What inspired you to submit this pull request? -->

I added old commits with this label to #5633 which resulted in empty commits because of a prior fix, and it looks like empty commits are just discarded by GitHub so they are still detected as missing on the release branch. I'll have to merge them in a different way to make it work and then re-enable the check.