### PR TITLE
Add _dd.integration to spans to calculate internal stats

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -242,6 +242,7 @@ class DatadogSpan {
     }
 
     getIntegrationCounter('spans_finished', this._integrationName).inc()
+    this.setTag('_dd.integration', this._integrationName)
 
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.decrement('runtime.node.spans.unfinished')

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -471,6 +471,17 @@ describe('Span', () => {
       expect(processor.process).to.have.been.calledOnce
     })
 
+    it('should add _dd.integration', () => {
+      processor.process.returns(Promise.resolve())
+
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+      span.setTag('component', 'custom')
+      span.finish()
+
+      expect(tagger.add).to.have.been.calledWith(span.context()._tags, { component: 'custom' })
+      expect(tagger.add).to.have.been.calledWith(span.context()._tags, { '_dd.integration': 'opentracing' })
+    })
+
     describe('tracePropagationBehaviorExtract and Baggage', () => {
       let parent
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds `_dd.integration` tag to all the spans containing the integration name. While the `component` tag could have the same information, there is no guarantee about the content of the component tag since it can be modified by the user. 
This one is internal and the user cannot change it.

We are changing all the tracers to infer this information in order to calculate stats upstream around integration usage

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


