### PR TITLE
[test-optimization] [SDTEST-1954] Check objects before accessing them in Jest

### DIFF
--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -154,7 +154,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           const hasKnownTests = !!knownTests?.jest
           earlyFlakeDetectionNumRetries = this.testEnvironmentOptions._ddEarlyFlakeDetectionNumRetries
           this.knownTestsForThisSuite = hasKnownTests
-            ? (knownTests?.jest[this.testSuite] || [])
+            ? (knownTests?.jest?.[this.testSuite] || [])
             : this.getKnownTestsForSuite(this.testEnvironmentOptions._ddKnownTests)
         } catch (e) {
           // If there has been an error parsing the tests, we'll disable Early Flake Deteciton
@@ -172,10 +172,10 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
       if (this.isTestManagementTestsEnabled) {
         try {
-          const hasTestManagementTests = !!testManagementTests.jest
+          const hasTestManagementTests = !!testManagementTests?.jest
           testManagementAttemptToFixRetries = this.testEnvironmentOptions._ddTestManagementAttemptToFixRetries
           this.testManagementTestsForThisSuite = hasTestManagementTests
-            ? this.getTestManagementTestsForSuite(testManagementTests.jest.suites?.[this.testSuite]?.tests)
+            ? this.getTestManagementTestsForSuite(testManagementTests?.jest?.suites?.[this.testSuite]?.tests)
             : this.getTestManagementTestsForSuite(this.testEnvironmentOptions._ddTestManagementTests)
         } catch (e) {
           log.error('Error parsing test management tests', e)
@@ -1186,7 +1186,7 @@ addHook({
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, globalConfig.rootDir || process.cwd())
       const suiteKnownTests = knownTests?.jest?.[testSuite] || []
 
-      const suiteTestManagementTests = testManagementTests.jest?.suites?.[testSuite]?.tests || {}
+      const suiteTestManagementTests = testManagementTests?.jest?.suites?.[testSuite]?.tests || {}
 
       args[0].config = {
         ...config,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We check the object exist before accessing to avoid throwing this type of errors: `TypeError: Cannot read properties of undefined (reading 'jest')`

### Motivation
<!-- What inspired you to submit this pull request? -->
There have been a few reports with this case

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


