### PR TITLE
use isPromise from nodejs util/types

### DIFF
--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const util = require('node:util')
 const {
   channel,
   addHook,
@@ -96,7 +97,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
         })
       }
 
-      if (!isPromise(kafkaClusterIdPromise)) {
+      if (!util.types.isPromise(kafkaClusterIdPromise)) {
         // promise is already resolved
         return wrappedSend(kafkaClusterIdPromise)
       } else {
@@ -157,7 +158,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
         })
       }
 
-      if (!isPromise(kafkaClusterIdPromise)) {
+      if (!util.types.isPromise(kafkaClusterIdPromise)) {
         // promise is already resolved
         return wrapConsume(kafkaClusterIdPromise)
       } else {
@@ -234,8 +235,4 @@ const getKafkaClusterId = (kafka) => {
     .catch((error) => {
       throw error
     })
-}
-
-function isPromise (obj) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function'
 }

--- a/packages/datadog-instrumentations/src/protobufjs.js
+++ b/packages/datadog-instrumentations/src/protobufjs.js
@@ -1,3 +1,6 @@
+'use strict'
+
+const util = require('node:util')
 const shimmer = require('../../datadog-shimmer')
 const { addHook } = require('./helpers/instrument')
 
@@ -87,17 +90,13 @@ function wrapReflection (protobuf) {
   })
 }
 
-function isPromise (obj) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function'
-}
-
 addHook({
   name: 'protobufjs',
   versions: ['>=6.8.0']
 }, protobuf => {
   shimmer.wrap(protobuf.Root.prototype, 'load', original => function () {
     const result = original.apply(this, arguments)
-    if (isPromise(result)) {
+    if (util.types.isPromise(result)) {
       return result.then(root => {
         wrapProtobufClasses(root)
         return root

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -54,10 +54,6 @@ class Scope {
   _spanOrActive (span) {
     return span !== undefined ? span : this.active()
   }
-
-  _isPromise (promise) {
-    return promise && typeof promise.then === 'function'
-  }
 }
 
 module.exports = Scope


### PR DESCRIPTION
### What does this PR do?
- Use `isPromise` from `require('util')` instead of custom function
- Remove unused `_isPromise`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


