### PR TITLE
re-enable release proposal dont-land-on checks

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,3 +13,10 @@ jobs:
           mode: exactly
           count: 1
           labels: "semver-patch, semver-minor, semver-major"
+      - uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5.0
+        with:
+          mode: exactly
+          count: 0
+          use_regex: true
+          labels: |
+            dont-land-on-.+

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -13,10 +13,3 @@ jobs:
           mode: exactly
           count: 1
           labels: "semver-patch, semver-minor, semver-major"
-      - uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5.0
-        with:
-          mode: exactly
-          count: 0
-          use_regex: true
-          labels: |
-            dont-land-on-.+

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -70,15 +70,6 @@ try {
 
   start('Determine version increment')
 
-  const legacyDiff = capture(`${diffCmd} --require-label=dont-land-on-v${releaseLine}.x v${releaseLine}.x ${main}`)
-
-  if (legacyDiff) {
-    fatal(
-      `The "dont-land-on-v${releaseLine}.x" label is no longer supported.`,
-      'Please remove the label from any offending PR to continue.'
-    )
-  }
-
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
   const lineDiff = capture(`${diffCmd} --markdown=true v${releaseLine}.x ${main}`)
 

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -66,19 +66,17 @@ try {
 
   pass(`v${releaseLine}.x`)
 
-  const diffCmd =
-    `branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major,dont-land-on-v${releaseLine}.x`
+  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major'
 
   start('Determine version increment')
 
   const legacyDiff = capture(`${diffCmd} --require-label=dont-land-on-v${releaseLine}.x v${releaseLine}.x ${main}`)
 
   if (legacyDiff) {
-    // TODO: Re-enable this when the offending PR commits have landed properly.
-    // fatal(
-    //   `The "dont-land-on-v${releaseLine}.x" label is no longer supported.`,
-    //   'Please remove the label from any offending PR to continue.'
-    // )
+    fatal(
+      `The "dont-land-on-v${releaseLine}.x" label is no longer supported.`,
+      'Please remove the label from any offending PR to continue.'
+    )
   }
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')

--- a/scripts/release/validate.js
+++ b/scripts/release/validate.js
@@ -37,7 +37,8 @@ try {
 
   start('Pull release branch')
 
-  const proposalBranch = params[0] || capture('git rev-parse --abbrev-ref HEAD')
+  const currentBranch = capture('git rev-parse --abbrev-ref HEAD')
+  const proposalBranch = params[0] || currentBranch
   const tempBranch = randomUUID()
   const newVersion = proposalBranch.match(/^v([0-9]+\.[0-9]+\.[0-9]+).+/)[1]
   const releaseLine = newVersion.match(/^([0-9]+).+/)[1]
@@ -45,7 +46,7 @@ try {
   // Restore current branch on success.
   process.once('exit', code => {
     if (code === 0) {
-      run(`git checkout ${proposalBranch}`)
+      run(`git checkout ${currentBranch}`)
     }
 
     run(`git branch -D ${tempBranch}`)
@@ -57,12 +58,7 @@ try {
 
   pass()
 
-  const diffCmd = [
-    'branch-diff',
-    '--user DataDog',
-    '--repo dd-trace-js',
-    `--exclude-label=semver-major,dont-land-on-v${releaseLine}.x`
-  ].join(' ')
+  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major'
 
   start('Validate differences between proposal and main branch.')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Re-enable release proposal `dont-land-on-` checks.

### Motivation
<!-- What inspired you to submit this pull request? -->

This was previously added prematurely as some older PRs with the offending tags were never included on the release branches. Now that these changes have landed, this check can be enabled again to avoid release lines deviating from the main branch.