### PR TITLE
Upgrade `attempt_to_fix` to `v3`

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -2129,11 +2129,12 @@ versions.forEach(version => {
                   }
                   if (isLastAttempt) {
                     if (shouldFailSometimes) {
-                      assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                      assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                       assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
                     } else if (shouldAlwaysPass) {
                       assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
                     } else {
+                      assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                       assert.propertyVal(test.meta, TEST_HAS_FAILED_ALL_RETRIES, 'true')
                     }
                   }
@@ -2497,7 +2498,7 @@ versions.forEach(version => {
                 assert.equal(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
                 assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
                 assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-                assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '2')
+                assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '3')
                 // capabilities logic does not overwrite test session name
                 assert.equal(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
               })

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1875,13 +1875,13 @@ moduleTypes.forEach(({
                 if (isLastAttempt) {
                   if (shouldFailSometimes) {
                     assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
-                    assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                    assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                   } else if (shouldAlwaysPass) {
                     assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
                     assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
                   } else {
                     assert.propertyVal(test.meta, TEST_HAS_FAILED_ALL_RETRIES, 'true')
-                    assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                    assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                   }
                 }
               }
@@ -2239,7 +2239,7 @@ moduleTypes.forEach(({
               assert.equal(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
               assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
               assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-              assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '2')
+              assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '3')
               // capabilities logic does not overwrite test session name
               assert.equal(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
             })

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -3051,9 +3051,10 @@ describe('jest CommonJS', () => {
                   assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
                 } else if (shouldFailSometimes) {
                   assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
-                  assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                  assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                 } else {
                   assert.propertyVal(test.meta, TEST_HAS_FAILED_ALL_RETRIES, 'true')
+                  assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                 }
               }
             }
@@ -3491,7 +3492,7 @@ describe('jest CommonJS', () => {
             assert.equal(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
             assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
             assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-            assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '2')
+            assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '3')
             // capabilities logic does not overwrite test session name
             assert.equal(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
           })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2670,10 +2670,10 @@ describe('mocha CommonJS', function () {
                   assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
                 } else if (shouldFailSometimes) {
                   assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
-                  assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                  assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                 } else {
                   assert.propertyVal(test.meta, TEST_HAS_FAILED_ALL_RETRIES, 'true')
-                  assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                  assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                 }
               }
             }
@@ -3069,7 +3069,7 @@ describe('mocha CommonJS', function () {
             assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], undefined)
           } else {
             assert.equal(metadata.test[DD_CAPABILITIES_TEST_IMPACT_ANALYSIS], '1')
-            assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '2')
+            assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '3')
           }
           assert.equal(metadata.test[DD_CAPABILITIES_EARLY_FLAKE_DETECTION], '1')
           assert.equal(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -1000,17 +1000,24 @@ versions.forEach((version) => {
                   test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'true'
                 ).length
 
+                const testsMarkedAsFailed = attemptedToFixTests.filter(test =>
+                  test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'false'
+                ).length
+
                 if (isAttemptingToFix) {
                   assert.equal(countAttemptToFixTests, attemptedToFixTests.length)
                   assert.equal(countRetriedAttemptToFixTests, attemptedToFixTests.length - 1)
                   if (shouldAlwaysPass) {
                     assert.equal(testsMarkedAsFailedAllRetries, 0)
+                    assert.equal(testsMarkedAsFailed, 0)
                     assert.equal(testsMarkedAsPassedAllRetries, 1)
                   } else if (shouldFailSometimes) {
                     assert.equal(testsMarkedAsFailedAllRetries, 0)
+                    assert.equal(testsMarkedAsFailed, 1)
                     assert.equal(testsMarkedAsPassedAllRetries, 0)
                   } else { // always fail
                     assert.equal(testsMarkedAsFailedAllRetries, 1)
+                    assert.equal(testsMarkedAsFailed, 1)
                     assert.equal(testsMarkedAsPassedAllRetries, 0)
                   }
                 } else {
@@ -1337,7 +1344,7 @@ versions.forEach((version) => {
               assert.equal(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
               assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
               assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-              assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '2')
+              assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '3')
               // capabilities logic does not overwrite test session name
               assert.equal(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
             })

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -1431,10 +1431,11 @@ versions.forEach((version) => {
                       if (shouldAlwaysPass) {
                         assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
                       } else if (shouldFailSometimes) {
-                        assert.notProperty(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED)
+                        assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                         assert.notProperty(test.meta, TEST_HAS_FAILED_ALL_RETRIES)
                       } else {
                         assert.propertyVal(test.meta, TEST_HAS_FAILED_ALL_RETRIES, 'true')
+                        assert.propertyVal(test.meta, TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
                       }
                     }
                   } else {
@@ -1807,7 +1808,7 @@ versions.forEach((version) => {
               assert.equal(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
               assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
               assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-              assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '2')
+              assert.equal(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '3')
               // capabilities logic does not overwrite test session name
               assert.equal(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
             })

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -309,6 +309,7 @@ function wrapRun (pl, isLatestVersion) {
         let isAttemptToFixRetry = false
         let hasFailedAllRetries = false
         let hasPassedAllRetries = false
+        let hasFailedAttemptToFix = false
         let isDisabled = false
         let isQuarantined = false
 
@@ -330,6 +331,7 @@ function wrapRun (pl, isLatestVersion) {
               }, { pass: 0, fail: 0 })
               hasFailedAllRetries = fail === testManagementAttemptToFixRetries + 1
               hasPassedAllRetries = pass === testManagementAttemptToFixRetries + 1
+              hasFailedAttemptToFix = fail > 0
             }
           }
         }
@@ -360,6 +362,7 @@ function wrapRun (pl, isLatestVersion) {
             isAttemptToFixRetry,
             hasFailedAllRetries,
             hasPassedAllRetries,
+            hasFailedAttemptToFix,
             isDisabled,
             isQuarantined
           })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -408,6 +408,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         event.test.fn = originalTestFns.get(event.test)
 
         let attemptToFixPassed = false
+        let attemptToFixFailed = false
         let failedAllTests = false
         let isAttemptToFix = false
         if (this.isTestManagementTestsEnabled) {
@@ -425,6 +426,9 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             // If it is, we'll set the failedAllTests flag to true if all the tests failed
             // If all tests passed, we'll set the attemptToFixPassed flag to true
             if (testStatuses.length === testManagementAttemptToFixRetries + 1) {
+              if (testStatuses.some(status => status === 'fail')) {
+                attemptToFixFailed = true
+              }
               if (testStatuses.every(status => status === 'fail')) {
                 failedAllTests = true
               } else if (testStatuses.every(status => status === 'pass')) {
@@ -490,6 +494,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             testStartLine: getTestLineStart(event.test.asyncError, this.testSuite),
             attemptToFixPassed,
             failedAllTests,
+            attemptToFixFailed,
             isAtrRetry
           })
         })

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -265,6 +265,7 @@ function getOnTestEndHandler (config) {
 
     let hasFailedAllRetries = false
     let attemptToFixPassed = false
+    let attemptToFixFailed = false
 
     const testName = getTestFullName(test)
 
@@ -278,6 +279,9 @@ function getOnTestEndHandler (config) {
     const isLastAttempt = testStatuses.length === config.testManagementAttemptToFixRetries + 1
 
     if (test._ddIsAttemptToFix && isLastAttempt) {
+      if (testStatuses.some(status => status === 'fail')) {
+        attemptToFixFailed = true
+      }
       if (testStatuses.every(status => status === 'fail')) {
         hasFailedAllRetries = true
       } else if (testStatuses.every(status => status === 'pass')) {
@@ -299,6 +303,7 @@ function getOnTestEndHandler (config) {
           isLastRetry: getIsLastRetry(test),
           hasFailedAllRetries,
           attemptToFixPassed,
+          attemptToFixFailed,
           isAttemptToFixRetry,
           isAtrRetry
         })

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -337,6 +337,9 @@ function testEndHandler (test, annotations, testStatus, error, isTimeout, isMain
   }
 
   if (testStatuses.length === testManagementAttemptToFixRetries + 1) {
+    if (testStatuses.some(status => status === 'fail')) {
+      test._ddHasFailedAttemptToFixRetries = true
+    }
     if (testStatuses.every(status => status === 'fail')) {
       test._ddHasFailedAllRetries = true
     } else if (testStatuses.every(status => status === 'pass')) {
@@ -366,6 +369,7 @@ function testEndHandler (test, annotations, testStatus, error, isTimeout, isMain
         isEfdRetry: test._ddIsEfdRetry,
         hasFailedAllRetries: test._ddHasFailedAllRetries,
         hasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
+        hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
         isAtrRetry
       })
     })
@@ -492,6 +496,7 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
           _ddIsEfdRetry: test._ddIsEfdRetry,
           _ddHasFailedAllRetries: test._ddHasFailedAllRetries,
           _ddHasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
+          _ddHasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
           _ddIsAtrRetry: isAtrRetry
         }
       })
@@ -986,6 +991,7 @@ addHook({
         isAttemptToFixRetry: test._ddIsAttemptToFixRetry,
         hasFailedAllRetries: test._ddHasFailedAllRetries,
         hasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
+        hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
         isAtrRetry: test._ddIsAtrRetry,
         onDone
       })

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -341,6 +341,7 @@ class CucumberPlugin extends CiPlugin {
       isAttemptToFixRetry,
       hasFailedAllRetries,
       hasPassedAllRetries,
+      hasFailedAttemptToFix,
       isDisabled,
       isQuarantined
     }) => {
@@ -385,6 +386,8 @@ class CucumberPlugin extends CiPlugin {
         span.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.atf)
         if (hasPassedAllRetries) {
           span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
+        } else if (hasFailedAttemptToFix) {
+          span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
         }
       }
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -838,6 +838,9 @@ class CypressPlugin {
           }
           const isLastAttempt = testStatuses.length === this.testManagementAttemptToFixRetries + 1
           if (isLastAttempt) {
+            if (testStatuses.some(status => status === 'fail')) {
+              this.activeTestSpan.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
+            }
             if (testStatuses.every(status => status === 'fail')) {
               this.activeTestSpan.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
             } else if (testStatuses.every(status => status === 'pass')) {

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -346,6 +346,7 @@ class JestPlugin extends CiPlugin {
       testStartLine,
       attemptToFixPassed,
       failedAllTests,
+      attemptToFixFailed,
       isAtrRetry
     }) => {
       const span = storage('legacy').getStore().span
@@ -355,6 +356,8 @@ class JestPlugin extends CiPlugin {
       }
       if (attemptToFixPassed) {
         span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
+      } else if (attemptToFixFailed) {
+        span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
       }
       if (failedAllTests) {
         span.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -208,6 +208,7 @@ class MochaPlugin extends CiPlugin {
       isLastRetry,
       hasFailedAllRetries,
       attemptToFixPassed,
+      attemptToFixFailed,
       isAttemptToFixRetry,
       isAtrRetry
     }) => {
@@ -229,6 +230,8 @@ class MochaPlugin extends CiPlugin {
         }
         if (attemptToFixPassed) {
           span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
+        } else if (attemptToFixFailed) {
+          span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
         }
         if (isAttemptToFixRetry) {
           span.setTag(TEST_IS_RETRY, 'true')

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -267,6 +267,7 @@ class PlaywrightPlugin extends CiPlugin {
       isAttemptToFixRetry,
       hasFailedAllRetries,
       hasPassedAttemptToFixRetries,
+      hasFailedAttemptToFixRetries,
       isAtrRetry,
       onDone
     }) => {
@@ -311,6 +312,8 @@ class PlaywrightPlugin extends CiPlugin {
       }
       if (hasPassedAttemptToFixRetries) {
         span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'true')
+      } else if (hasFailedAttemptToFixRetries) {
+        span.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
       }
       if (isDisabled) {
         span.setTag(TEST_MANAGEMENT_IS_DISABLED, 'true')

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -786,7 +786,7 @@ function getLibraryCapabilitiesTags (testFramework, isParallel) {
     [DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE]: '1',
     [DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE]: '1',
     [DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX]: isAttemptToFixSupported(testFramework, isParallel)
-      ? '2'
+      ? '3'
       : undefined
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
With this change we upgrade the `attempt_to_fix` to the `v3`:
- We will mark `attempt_to_fix_passed` as `false` is not all the attempt to fix retries has passed.
- We will send `3` in the libraries capabilities of attempt to fix.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to have our features updated to latest versions.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


