### PR TITLE
use a fixed version for latest in node action

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -10,6 +10,6 @@ runs:
   steps:
     - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
-        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version }}
+        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version == 'latest' && '23' || inputs.version == 'default' && '' || inputs.version }}
         check-latest: true
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - uses: ./.github/actions/node
         with:
-          version: ''
+          version: default
       - uses: ./.github/actions/install/branch-diff
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/node
         with:
-          version: ''
+          version: default
       - uses: ./.github/actions/install/branch-diff
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use a fixed version for latest in node action.

### Motivation
<!-- What inspired you to submit this pull request? -->

New Node releases don't break our CI (which is the case right now with the release of Node 24)