### PR TITLE
remove async resource usage from net integration

### DIFF
--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -1,10 +1,6 @@
 'use strict'
 
-const {
-  channel,
-  addHook,
-  AsyncResource
-} = require('./helpers/instrument')
+const { channel, addHook } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
 const startICPCh = channel('apm:net:ipc:start')
@@ -15,6 +11,7 @@ const startTCPCh = channel('apm:net:tcp:start')
 const finishTCPCh = channel('apm:net:tcp:finish')
 const errorTCPCh = channel('apm:net:tcp:error')
 
+const readyCh = channel('apm:net:tcp:ready')
 const connectionCh = channel('apm:net:tcp:connection')
 
 const names = ['net', 'node:net']
@@ -39,30 +36,27 @@ addHook({ name: names }, (net, version, name) => {
 
     if (!options) return connect.apply(this, arguments)
 
-    const callbackResource = new AsyncResource('bound-anonymous-fn')
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
+    const protocol = options.path ? 'ipc' : 'tcp'
+    const startCh = protocol === 'ipc' ? startICPCh : startTCPCh
+    const finishCh = protocol === 'ipc' ? finishICPCh : finishTCPCh
+    const errorCh = protocol === 'ipc' ? errorICPCh : errorTCPCh
+    const ctx = { options }
 
     if (typeof callback === 'function') {
-      arguments[lastIndex] = callbackResource.bind(callback)
+      arguments[lastIndex] = function (...args) {
+        return finishCh.runStores(ctx, callback, this, ...args)
+      }
     }
 
-    const protocol = options.path ? 'ipc' : 'tcp'
-
-    return asyncResource.runInAsyncScope(() => {
-      if (protocol === 'ipc') {
-        startICPCh.publish({ options })
-        setupListeners(this, 'ipc', asyncResource)
-      } else {
-        startTCPCh.publish({ options })
-        setupListeners(this, 'tcp', asyncResource)
-      }
+    return startCh.runStores(ctx, () => {
+      setupListeners(this, protocol, ctx, finishCh, errorCh)
 
       const emit = this.emit
       this.emit = shimmer.wrapFunction(emit, emit => function (eventName) {
         switch (eventName) {
           case 'ready':
           case 'connect':
-            return callbackResource.runInAsyncScope(() => {
+            return readyCh.runStores(ctx, () => {
               return emit.apply(this, arguments)
             })
           default:
@@ -73,7 +67,7 @@ addHook({ name: names }, (net, version, name) => {
       try {
         return connect.apply(this, arguments)
       } catch (err) {
-        protocol === 'ipc' ? errorICPCh.publish(err) : errorTCPCh.publish(err)
+        errorCh.publish(err)
 
         throw err
       }
@@ -104,19 +98,21 @@ function getOptions (args) {
   }
 }
 
-function setupListeners (socket, protocol, asyncResource) {
+function setupListeners (socket, protocol, ctx, finishCh, errorCh) {
   const events = ['connect', 'error', 'close', 'timeout']
 
-  const wrapListener = asyncResource.bind(function (error) {
+  const wrapListener = function (error) {
     if (error) {
-      protocol === 'ipc' ? errorICPCh.publish(error) : errorTCPCh.publish(error)
+      ctx.error = error
+      errorCh.publish(ctx)
     }
-    protocol === 'ipc' ? finishICPCh.publish(undefined) : finishTCPCh.publish(undefined)
-  })
+    finishCh.runStores(ctx, () => {})
+  }
 
-  const localListener = asyncResource.bind(function () {
-    connectionCh.publish({ socket })
-  })
+  const localListener = function () {
+    ctx.socket = socket
+    connectionCh.publish(ctx)
+  }
 
   const cleanupListener = function () {
     socket.removeListener('connect', localListener)

--- a/packages/datadog-plugin-net/src/ipc.js
+++ b/packages/datadog-plugin-net/src/ipc.js
@@ -1,20 +1,30 @@
 'use strict'
 
+const { storage } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class NetIPCPlugin extends ClientPlugin {
   static get id () { return 'net' }
   static get operation () { return 'ipc' }
 
-  start ({ options }) {
-    this.startSpan('ipc.connect', {
+  bindStart (ctx) {
+    const store = storage('legacy').getStore()
+    const childOf = store ? store.span : null
+
+    const span = this.startSpan('ipc.connect', {
+      childOf,
       service: this.config.service,
-      resource: options.path,
+      resource: ctx.options.path,
       kind: 'client',
       meta: {
-        'ipc.path': options.path
+        'ipc.path': ctx.options.path
       }
-    })
+    }, false)
+
+    ctx.parentStore = store
+    ctx.currentStore = { ...store, span }
+
+    return ctx.currentStore
   }
 }
 

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -87,8 +87,13 @@ class OutboundPlugin extends TracingPlugin {
     return peerData
   }
 
-  finish () {
-    this.tagPeerService(this.activeSpan)
+  bindFinish (ctx) {
+    return ctx.parentStore
+  }
+
+  finish (ctx) {
+    const span = ctx?.currentStore?.span || this.activeSpan
+    this.tagPeerService(span)
     super.finish(...arguments)
   }
 

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -53,8 +53,9 @@ class TracingPlugin extends Plugin {
 
   start () {} // implemented by individual plugins
 
-  finish () {
-    this.activeSpan?.finish()
+  finish (ctx) {
+    const span = ctx?.currentStore?.span || this.activeSpan
+    span?.finish()
   }
 
   error (ctxOrError) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove `AsyncResource` usage from `net` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

Using `AsyncResource` for this is incorrect as it will change the underlying resource for all stores and not just ours. There is also a bug in Node 24 when using `AsyncResource` that isn't triggered when using `runStores` instead.