### PR TITLE
add release status checks

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -35,6 +35,19 @@ jobs:
           git push origin v${{ fromJson(steps.pkg.outputs.json).version }}
       - run: node scripts/release/notes --latest
 
+  status:
+    needs: ['publish']
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+      - run: yarn release:status
+
   docs:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-      - run: yarn release:status
+      - run: node scripts/release/status
 
   docs:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "node scripts/check_licenses.js && eslint . --max-warnings 0 --fix && yarn audit",
     "lint:inspect": "npx @eslint/config-inspector@latest",
     "release:proposal": "node scripts/release/proposal",
+    "release:status": "node scripts/release/status",
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
     "test": "SERVICES=* yarn services && mocha --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
     "test:appsec": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" \"packages/dd-trace/test/appsec/**/*.spec.js\"",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "lint:fix": "node scripts/check_licenses.js && eslint . --max-warnings 0 --fix && yarn audit",
     "lint:inspect": "npx @eslint/config-inspector@latest",
     "release:proposal": "node scripts/release/proposal",
-    "release:status": "node scripts/release/status",
     "services": "node ./scripts/install_plugin_modules && node packages/dd-trace/test/setup/services",
     "test": "SERVICES=* yarn services && mocha --expose-gc 'packages/dd-trace/test/setup/node.js' 'packages/*/test/**/*.spec.js'",
     "test:appsec": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" --exclude \"packages/dd-trace/test/appsec/**/*.plugin.spec.js\" \"packages/dd-trace/test/appsec/**/*.spec.js\"",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add release status checks.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since we release from a branch and not from a PR, the status checks are not reported in the same way and it's not obvious when the release isn't successful because even through the jobs in GitHub are green, it's not necessarily true for jobs outside of GitHub like any GitLab jobs. This adds a job in GitHub that reports the status of any important external checks to make sure the release workflow is marked as failed if there is any failures.