### PR TITLE
Fix amqplib not always passing through the correct method names

### DIFF
--- a/packages/datadog-instrumentations/src/amqplib.js
+++ b/packages/datadog-instrumentations/src/amqplib.js
@@ -15,13 +15,14 @@ const startCh = channel('apm:amqplib:command:start')
 const finishCh = channel('apm:amqplib:command:finish')
 const errorCh = channel('apm:amqplib:command:error')
 
-let methods = {}
+const methods = {}
 
 addHook({ name: 'amqplib', file: 'lib/defs.js', versions: [MIN_VERSION] }, defs => {
-  methods = Object.keys(defs)
-    .filter(key => Number.isInteger(defs[key]))
-    .filter(key => isCamelCase(key))
-    .reduce((acc, key) => Object.assign(acc, { [defs[key]]: kebabCase(key).replace('-', '.') }), {})
+  for (const [key, value] of Object.entries(defs)) {
+    if (Number.isInteger(value) && isCamelCase(key)) {
+      methods[value] = kebabCase(key).replaceAll('-', '.')
+    }
+  }
   return defs
 })
 


### PR DESCRIPTION
Methods with more than two words would not be renamed properly. That way they would not be picked up anymore.

This change is missing tests. I just could not immediately see how to add a good test case for this. Suggestions welcome.