### PR TITLE
fix(llmobs): llmobs data can be sent to agent proxy running on uds

### DIFF
--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -41,6 +41,18 @@ class BaseLLMObsWriter {
     this._destroyed = false
   }
 
+  get url () {
+    if (this._agentless == null) return null
+
+    const baseUrl = this._baseUrl.href
+    const endpoint = this._endpoint
+
+    // Split on protocol separator to preserve it
+    // path.join will remove some slashes unnecessarily
+    const [protocol, rest] = baseUrl.split('://')
+    return protocol + '://' + path.join(rest, endpoint)
+  }
+
   append (event, byteLength) {
     if (this._buffer.length >= this._bufferLimit) {
       logger.warn(`${this.constructor.name} event buffer full (limit is ${this._bufferLimit}), dropping event`)
@@ -69,7 +81,7 @@ class BaseLLMObsWriter {
     const options = this._getOptions()
 
     request(payload, options, (err, resp, code) => {
-      parseResponseAndLog(err, code, events.length, options.url.href, this._eventType)
+      parseResponseAndLog(err, code, events.length, this.url, this._eventType)
     })
   }
 
@@ -87,17 +99,23 @@ class BaseLLMObsWriter {
 
   setAgentless (agentless) {
     this._agentless = agentless
-    this._url = this._getUrl()
-    logger.debug(`Configuring ${this.constructor.name} to ${this._url.href}`)
+    const { url, path } = this._getUrlAndPath()
+
+    this._baseUrl = url
+    this._endpoint = path
+
+    logger.debug(`Configuring ${this.constructor.name} to ${this.url}`) // TODO: fix this log
   }
 
-  _getUrl () {
+  _getUrlAndPath () {
     if (this._agentless) {
-      return new URL(format({
-        protocol: 'https:',
-        hostname: `${this._intake}.${this._config.site}`,
-        pathname: this._endpoint
-      }))
+      return {
+        url: new URL(format({
+          protocol: 'https:',
+          hostname: `${this._intake}.${this._config.site}`
+        })),
+        path: this._endpoint
+      }
     }
 
     const { hostname, port } = this._config
@@ -107,8 +125,10 @@ class BaseLLMObsWriter {
       port
     }))
 
-    const proxyPath = path.join(EVP_PROXY_AGENT_BASE_PATH, this._endpoint)
-    return new URL(proxyPath, base)
+    return {
+      url: base,
+      path: path.join(EVP_PROXY_AGENT_BASE_PATH, this._endpoint)
+    }
   }
 
   _getOptions () {
@@ -118,7 +138,8 @@ class BaseLLMObsWriter {
       },
       method: 'POST',
       timeout: this._timeout,
-      url: this._url
+      url: this._baseUrl,
+      path: this._endpoint
     }
 
     if (this._agentless) {

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -99,12 +99,12 @@ class BaseLLMObsWriter {
 
   setAgentless (agentless) {
     this._agentless = agentless
-    const { url, path } = this._getUrlAndPath()
+    const { url, endpoint } = this._getUrlAndPath()
 
     this._baseUrl = url
-    this._endpoint = path
+    this._endpoint = endpoint
 
-    logger.debug(`Configuring ${this.constructor.name} to ${this.url}`) // TODO: fix this log
+    logger.debug(`Configuring ${this.constructor.name} to ${this.url}`)
   }
 
   _getUrlAndPath () {
@@ -114,7 +114,7 @@ class BaseLLMObsWriter {
           protocol: 'https:',
           hostname: `${this._intake}.${this._config.site}`
         })),
-        path: this._endpoint
+        endpoint: this._endpoint
       }
     }
 
@@ -127,7 +127,7 @@ class BaseLLMObsWriter {
 
     return {
       url: base,
-      path: path.join(EVP_PROXY_AGENT_BASE_PATH, this._endpoint)
+      endpoint: path.join(EVP_PROXY_AGENT_BASE_PATH, this._endpoint)
     }
   }
 

--- a/packages/dd-trace/test/llmobs/writers/evaluations.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/evaluations.spec.js
@@ -22,7 +22,7 @@ describe('LLMObsEvalMetricsWriter', () => {
 
     writer.flush = flush // just to stop the beforeExit flush call
 
-    expect(writer._url.href).to.equal('https://api.datadoghq.com/api/intake/llm-obs/v1/eval-metric')
+    expect(writer.url).to.equal('https://api.datadoghq.com/api/intake/llm-obs/v1/eval-metric')
     expect(writer._eventType).to.equal('evaluation_metric')
   })
 
@@ -32,7 +32,7 @@ describe('LLMObsEvalMetricsWriter', () => {
       hostname: 'localhost'
     })
     writer.setAgentless(false)
-    expect(writer._url.href).to.equal('http://localhost:8126/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric')
+    expect(writer.url).to.equal('http://localhost:8126/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric')
     expect(writer._eventType).to.equal('evaluation_metric')
   })
 

--- a/packages/dd-trace/test/llmobs/writers/spans.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/spans.spec.js
@@ -37,7 +37,7 @@ describe('LLMObsSpanWriter', () => {
     writer = new LLMObsSpanWriter(config)
     writer.setAgentless(true)
     expect(writer._agentless).to.equal(true)
-    expect(writer._url.href).to.equal('https://llmobs-intake.datadoghq.com/api/v2/llmobs')
+    expect(writer.url).to.equal('https://llmobs-intake.datadoghq.com/api/v2/llmobs')
   })
 
   it('creates an agent proxy writer', () => {
@@ -45,7 +45,7 @@ describe('LLMObsSpanWriter', () => {
     writer.setAgentless(false)
 
     expect(writer._agentless).to.equal(false)
-    expect(writer._url.href).to.equal('http://localhost:8126/evp_proxy/v2/api/v2/llmobs')
+    expect(writer.url).to.equal('http://localhost:8126/evp_proxy/v2/api/v2/llmobs')
   })
 
   it('computes the number of bytes of the appended event', () => {


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where LLMObs data could not be sent to an agent proxy running on a unix domain socket. This is accomplished by passing the base URL and path separately into the request, instead of constructing the URL dynamically.

The only other change is aesthetic for logging - making sure the URL string is properly formatted for logging configuration for llmobs, and for when data is sent.

### Testing

Aside from some unit tests written and modified for this change, I tested locally using the setup described via our [corp docs
](https://docs.datadoghq.com/containers/docker/apm/?tab=standard&code-lang=nodejs#unix-domain-socket-uds) with a dummy app that creates 1 span and 1 evaluation metric.

```
Configuring LLMObsEvalMetricsWriter to unix:///var/run/datadog/apm.socket/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric
Configuring LLMObsSpanWriter to unix:///var/run/datadog/apm.socket/evp_proxy/v2/api/v2/llmobs

...

Sent 1 LLMObs evaluation_metric events to unix:///var/run/datadog/apm.socket/evp_proxy/v2/api/intake/llm-obs/v1/eval-metric
Sent 1 LLMObs span events to unix:///var/run/datadog/apm.socket/evp_proxy/v2/api/v2/llmobs
```

and indeed the span shows up in the UI:

![image](https://github.com/user-attachments/assets/1e488b05-2d86-4d91-8a25-6bef7e7f50cb)


### Motivation
MLOB-2736