### PR TITLE
tracing: add support for pg cursors / streams

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -135,7 +135,7 @@ function wrapQuery (query) {
         newQuery.then((res) => finish(null, res), finish)
       }
 
-      if (textPropObj.read) {
+      if (stream) {
         newQuery.on('end', () => {
           finish(null, [])
         })

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -146,6 +146,17 @@ function wrapQuery (query) {
         newQuery.then((res) => finish(null, res), finish)
       }
 
+      if (textPropObj.read) {
+        // newQuery.on('data', (chunk) => {
+        //   console.log(chunk)
+        // })
+        newQuery.on('end', () => {
+          // we don't do anything with the result so just return an empty array, if we need the result we can
+          // use on.data event shown above
+          finish(null, [])
+        })
+      }
+
       try {
         return retval
       } catch (err) {

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -147,13 +147,11 @@ function wrapQuery (query) {
       }
 
       if (textPropObj.read) {
-        // newQuery.on('data', (chunk) => {
-        //   console.log(chunk)
-        // })
         newQuery.on('end', () => {
-          // we don't do anything with the result so just return an empty array, if we need the result we can
-          // use on.data event shown above
           finish(null, [])
+        })
+        newQuery.on('error', (err) => {
+          finish(err)
         })
       }
 

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -8,7 +8,7 @@ class PGPlugin extends DatabasePlugin {
   static get operation () { return 'query' }
   static get system () { return 'postgres' }
 
-  start ({ params = {}, query, processId }) {
+  start ({ params = {}, query, processId, stream }) {
     const service = this.serviceName({ pluginConfig: this.config, params })
     const originalStatement = this.maybeTruncate(query.text)
 
@@ -26,6 +26,10 @@ class PGPlugin extends DatabasePlugin {
         [CLIENT_PORT_KEY]: params.port
       }
     })
+
+    if (stream) {
+      span.setTag('db.stream', true)
+    }
 
     query.__ddInjectableQuery = this.injectDbmQuery(span, query.text, service, !!query.name)
   }

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -28,7 +28,7 @@ class PGPlugin extends DatabasePlugin {
     })
 
     if (stream) {
-      span.setTag('db.stream', true)
+      span.setTag('db.stream', 1)
     }
 
     query.__ddInjectableQuery = this.injectDbmQuery(span, query.text, service, !!query.name)

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -216,6 +216,72 @@ describe('Plugin', () => {
               .catch(done),
             rawExpectedSchema.outbound
           )
+
+          describe('streaming capabilities', () => {
+            withVersions('pg', 'pg-cursor', pgCursorVersion => {
+              let Cursor
+
+              beforeEach(() => {
+                Cursor = require(`../../../versions/pg-cursor@${pgCursorVersion}`).get()
+              })
+
+              it('should instrument cursor-based streaming with pg-cursor', done => {
+                agent.use(traces => {
+                  expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
+                  expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
+                  expect(traces[0][0]).to.have.property('resource', 'SELECT * FROM generate_series(0, 1) num')
+                  expect(traces[0][0]).to.have.property('type', 'sql')
+                  expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                  expect(traces[0][0].meta).to.have.property('db.name', 'postgres')
+                  expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
+                  expect(traces[0][0].meta).to.have.property('component', 'pg')
+                  expect(traces[0][0].metrics).to.have.property('db.stream', 1)
+                  expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
+                }).then(done).catch(done)
+
+                const cursor = client.query(new Cursor('SELECT * FROM generate_series(0, 1) num'))
+                cursor.read(1, (err, rows) => {
+                  if (err) return done(err)
+                  cursor.close(closeErr => {
+                    if (closeErr) return done(closeErr)
+                  })
+                })
+              })
+            })
+
+            withVersions('pg', 'pg-query-stream', pgQueryStreamVersion => {
+              let QueryStream
+
+              beforeEach(() => {
+                QueryStream = require(`../../../versions/pg-query-stream@${pgQueryStreamVersion}`).get()
+              })
+
+              it('should instrument stream-based queries with pg-query-stream', async () => {
+                const agentPromise = agent.use(traces => {
+                  expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
+                  expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
+                  expect(traces[0][0]).to.have.property('resource', 'SELECT * FROM generate_series(0, 1) num')
+                  expect(traces[0][0]).to.have.property('type', 'sql')
+                  expect(traces[0][0].meta).to.have.property('span.kind', 'client')
+                  expect(traces[0][0].meta).to.have.property('db.name', 'postgres')
+                  expect(traces[0][0].meta).to.have.property('db.type', 'postgres')
+                  expect(traces[0][0].meta).to.have.property('component', 'pg')
+                  expect(traces[0][0].metrics).to.have.property('db.stream', 1)
+                  expect(traces[0][0].metrics).to.have.property('network.destination.port', 5432)
+                }).then().catch()
+
+                const query = new QueryStream('SELECT * FROM generate_series(0, 1) num', [])
+                const stream = client.query(query)
+
+                for await (const row of stream) {
+                  expect(row).to.have.property('num')
+                  continue
+                }
+
+                await agentPromise
+              })
+            })
+          })
         })
       })
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -276,7 +276,6 @@ describe('Plugin', () => {
 
                   for await (const row of stream) {
                     expect(row).to.have.property('num')
-                    continue
                   }
 
                   await agentPromise

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -431,6 +431,14 @@
     {
       "name": "express",
       "versions": [">=4"]
+    },
+    {
+      "name": "pg-query-stream",
+      "versions": [">=4"]
+    },
+    {
+      "name": "pg-cursor",
+      "versions": [">=2"]
     }
   ],
   "pino": [


### PR DESCRIPTION
### What does this PR do?
Adds support for pg-query-streams and pg-cursor usage.

### Motivation
Customer ticket

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


