### PR TITLE
fix: Support for inode when /proc/self/cgroup is a multiline string

### DIFF
--- a/packages/dd-trace/src/exporters/common/docker.js
+++ b/packages/dd-trace/src/exporters/common/docker.js
@@ -13,40 +13,22 @@ const taskSource = '[0-9a-f]{32}-\\d+'
 const lineReg = /^(\d+):([^:]*):(.+)$/m
 const entityReg = new RegExp(`.*(${uuidSource}|${containerSource}|${taskSource})(?:\\.scope)?$`, 'm')
 
-const cgroup = readControlGroup()
-const entityId = getEntityId()
-const inode = getInode()
+let inode = 0
+let cgroup = ''
+let entityId
 
-function getEntityId () {
-  const match = cgroup.match(entityReg) || []
+try {
+  cgroup = fs.readFileSync('/proc/self/cgroup', 'utf8').trim()
+  entityId = cgroup.match(entityReg)?.[1]
+} catch { /* Ignore error */ }
 
-  return match[1]
-}
-
-function getInode () {
-  const match = cgroup.match(lineReg) || []
-
-  return readInode(match[3])
-}
-
-function readControlGroup () {
-  try {
-    return fs.readFileSync('/proc/self/cgroup').toString().trim()
-  } catch (err) {
-    return ''
-  }
-}
-
-function readInode (path) {
-  if (!path) return 0
-
-  const strippedPath = path.replace(/^\//, '').replace(/\/$/, '')
+const inodePath = cgroup.match(lineReg)?.[3]
+if (inodePath) {
+  const strippedPath = inodePath.replace(/^\/|\/$/g, '')
 
   try {
-    return fs.statSync(`/sys/fs/cgroup/${strippedPath}`).ino
-  } catch (err) {
-    return 0
-  }
+    inode = fs.statSync(`/sys/fs/cgroup/${strippedPath}`).ino
+  } catch { /* Ignore error */ }
 }
 
 module.exports = {

--- a/packages/dd-trace/src/exporters/common/docker.js
+++ b/packages/dd-trace/src/exporters/common/docker.js
@@ -10,7 +10,7 @@ const uuidSource =
 '[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{8}(?:-[0-9a-f]{4}){4}$'
 const containerSource = '[0-9a-f]{64}'
 const taskSource = '[0-9a-f]{32}-\\d+'
-const lineReg = /^(\d+):([^:]*):(.+)$/
+const lineReg = /^(\d+):([^:]*):(.+)$/m
 const entityReg = new RegExp(`.*(${uuidSource}|${containerSource}|${taskSource})(?:\\.scope)?$`, 'm')
 
 const cgroup = readControlGroup()

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -35,7 +35,7 @@ describe('docker', () => {
       `1:name=systemd:/docker/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -49,7 +49,7 @@ describe('docker', () => {
       `1:name=systemd:/uuid/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -63,7 +63,7 @@ describe('docker', () => {
       `1:name=systemd:/ecs/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -77,7 +77,7 @@ describe('docker', () => {
       `1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-${id}.scope` // eslint-disable-line @stylistic/js/max-len
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -93,7 +93,7 @@ describe('docker', () => {
       '3:cpu:/invalid'
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -107,7 +107,7 @@ describe('docker', () => {
       `0::/docker/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -121,7 +121,7 @@ describe('docker', () => {
       `1:name=systemd:/system.slice/garden.service/garden/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -135,7 +135,7 @@ describe('docker', () => {
       '1:name=systemd:/system.slice/garden.service/garden/'
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     fs.statSync.withArgs('/sys/fs/cgroup/system.slice/garden.service/garden').returns({ ino })
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
@@ -151,7 +151,7 @@ describe('docker', () => {
       '0::/'
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
     fs.statSync.withArgs('/sys/fs/cgroup/').returns({ ino })
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -144,6 +144,22 @@ describe('docker', () => {
     expect(carrier['Datadog-Entity-ID']).to.equal(`in-${ino}`)
   })
 
+  it('should support inode when the ID is not available (any line)', () => {
+    const ino = 1234
+    const cgroup = [
+      '1:name=systemd:/',
+      '0::/'
+    ].join('\n')
+
+    fs.readFileSync.withArgs('/proc/self/cgroup').returns(Buffer.from(cgroup))
+    fs.statSync.withArgs('/sys/fs/cgroup/').returns({ ino })
+    docker = proxyquire('../src/exporters/common/docker', { fs })
+    docker.inject(carrier)
+
+    expect(carrier['Datadog-Container-Id']).to.be.undefined
+    expect(carrier['Datadog-Entity-ID']).to.equal(`in-${ino}`)
+  })
+
   it('should support external env', () => {
     process.env.DD_EXTERNAL_ENV = 'test'
 

--- a/packages/dd-trace/test/exporters/common/docker.spec.js
+++ b/packages/dd-trace/test/exporters/common/docker.spec.js
@@ -35,7 +35,7 @@ describe('docker', () => {
       `1:name=systemd:/docker/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -49,7 +49,7 @@ describe('docker', () => {
       `1:name=systemd:/uuid/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -63,7 +63,7 @@ describe('docker', () => {
       `1:name=systemd:/ecs/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -77,7 +77,7 @@ describe('docker', () => {
       `1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-${id}.scope` // eslint-disable-line @stylistic/js/max-len
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -93,7 +93,7 @@ describe('docker', () => {
       '3:cpu:/invalid'
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -107,7 +107,7 @@ describe('docker', () => {
       `0::/docker/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -121,7 +121,7 @@ describe('docker', () => {
       `1:name=systemd:/system.slice/garden.service/garden/${id}`
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
 
@@ -135,7 +135,7 @@ describe('docker', () => {
       '1:name=systemd:/system.slice/garden.service/garden/'
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     fs.statSync.withArgs('/sys/fs/cgroup/system.slice/garden.service/garden').returns({ ino })
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)
@@ -151,7 +151,7 @@ describe('docker', () => {
       '0::/'
     ].join('\n')
 
-    fs.readFileSync.withArgs('/proc/self/cgroup').returns(cgroup)
+    fs.readFileSync.withArgs('/proc/self/cgroup', 'utf8').returns(cgroup)
     fs.statSync.withArgs('/sys/fs/cgroup/').returns({ ino })
     docker = proxyquire('../src/exporters/common/docker', { fs })
     docker.inject(carrier)


### PR DESCRIPTION
There could be more than one subsystem and we only use one. I guess that's fine? Or should we look into this closer?

I did a small refactoring of the code since I had to stare at it for a bit too see what part did what. I feel the less lines are nicer to read while I am also fine to keep the old code.

Closes #5646