### PR TITLE
Fix Node 24 warning for invoking fs.existsSync with invalid argument type

### DIFF
--- a/packages/dd-trace/src/guardrails/telemetry.js
+++ b/packages/dd-trace/src/guardrails/telemetry.js
@@ -14,11 +14,8 @@ if (!process.env.DD_INJECTION_ENABLED) {
   module.exports = function () {}
 }
 
-if (!process.env.DD_TELEMETRY_FORWARDER_PATH) {
-  module.exports = function () {}
-}
-
-if (!fs.existsSync(process.env.DD_TELEMETRY_FORWARDER_PATH)) {
+var telemetryForwarderPath = process.env.DD_TELEMETRY_FORWARDER_PATH
+if (typeof telemetryForwarderPath !== 'string' || !fs.existsSync(telemetryForwarderPath)) {
   module.exports = function () {}
 }
 


### PR DESCRIPTION
### What does this PR do?
Fix Node 24 warning for invoking fs.existsSync with invalid argument type

### Motivation
Node 24 prints:
```
(node:83412) [DEP0187] DeprecationWarning: Passing invalid argument types to fs.existsSync is deprecated
```
on console otherwise.
