### PR TITLE
[test-optimization] [SDTEST-1990] Make compatible Test Optimization instrumentations with Node 24

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -10,6 +10,6 @@ runs:
   steps:
     - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
-        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version == 'latest' && '23' || inputs.version }}
+        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version == 'latest' && '24' || inputs.version }}
         check-latest: true
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -8,6 +8,7 @@ const log = require('../../dd-trace/src/log')
 const testStartCh = channel('ci:cucumber:test:start')
 const testRetryCh = channel('ci:cucumber:test:retry')
 const testFinishCh = channel('ci:cucumber:test:finish') // used for test steps too
+const testFnCh = channel('ci:cucumber:test:fn')
 
 const testStepStartCh = channel('ci:cucumber:test-step:start')
 
@@ -52,7 +53,7 @@ const patched = new WeakSet()
 
 const lastStatusByPickleId = new Map()
 const numRetriesByPickleId = new Map()
-const numAttemptToAsyncResource = new Map()
+const numAttemptToCtx = new Map()
 const newTestsByTestFullname = new Map()
 
 let eventDataCollector = null
@@ -227,15 +228,11 @@ function wrapRun (pl, isLatestVersion) {
   patched.add(pl)
 
   shimmer.wrap(pl.prototype, 'run', run => function () {
-    if (!testStartCh.hasSubscribers) {
+    if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
 
     let numAttempt = 0
-
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-
-    numAttemptToAsyncResource.set(numAttempt, asyncResource)
 
     const testFileAbsolutePath = this.pickle.uri
 
@@ -247,9 +244,9 @@ function wrapRun (pl, isLatestVersion) {
       testSourceLine,
       isParallel: !!process.env.CUCUMBER_WORKER_ID
     }
-    asyncResource.runInAsyncScope(() => {
-      testStartCh.publish(testStartPayload)
-    })
+    const ctx = testStartPayload
+    numAttemptToCtx.set(numAttempt, ctx)
+    testStartCh.runStores(ctx, () => { })
     const promises = {}
     try {
       this.eventBroadcaster.on('envelope', shimmer.wrapFunction(null, () => async (testCase) => {
@@ -265,7 +262,7 @@ function wrapRun (pl, isLatestVersion) {
               // ignore error
             }
 
-            const failedAttemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
+            const failedAttemptCtx = numAttemptToCtx.get(numAttempt)
             const isFirstAttempt = numAttempt++ === 0
             const isAtrRetry = !isFirstAttempt && isFlakyTestRetriesEnabled
 
@@ -273,23 +270,19 @@ function wrapRun (pl, isLatestVersion) {
               await promises.hitBreakpointPromise
             }
 
-            failedAttemptAsyncResource.runInAsyncScope(() => {
-              // the current span will be finished and a new one will be created
-              testRetryCh.publish({ isFirstAttempt, error, isAtrRetry })
-            })
+            // the current span will be finished and a new one will be created
+            testRetryCh.publish({ isFirstAttempt, error, isAtrRetry, ...failedAttemptCtx.currentStore })
 
-            const newAsyncResource = new AsyncResource('bound-anonymous-fn')
-            numAttemptToAsyncResource.set(numAttempt, newAsyncResource)
+            const newCtx = { ...testStartPayload, promises }
+            numAttemptToCtx.set(numAttempt, newCtx)
 
-            newAsyncResource.runInAsyncScope(() => {
-              testStartCh.publish({ ...testStartPayload, promises }) // a new span will be created
-            })
+            testStartCh.runStores(newCtx, () => { })
           }
         }
       }))
       let promise
 
-      asyncResource.runInAsyncScope(() => {
+      testFnCh.runStores(ctx, () => {
         promise = run.apply(this, arguments)
       })
       promise.finally(async () => {
@@ -343,39 +336,40 @@ function wrapRun (pl, isLatestVersion) {
           isEfdRetry = numRetries > 0
         }
 
-        const attemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
+        const attemptCtx = numAttemptToCtx.get(numAttempt)
 
         const error = getErrorFromCucumberResult(result)
 
         if (promises.hitBreakpointPromise) {
           await promises.hitBreakpointPromise
         }
-        attemptAsyncResource.runInAsyncScope(() => {
-          testFinishCh.publish({
-            status,
-            skipReason,
-            error,
-            isNew,
-            isEfdRetry,
-            isFlakyRetry: numAttempt > 0,
-            isAttemptToFix,
-            isAttemptToFixRetry,
-            hasFailedAllRetries,
-            hasPassedAllRetries,
-            hasFailedAttemptToFix,
-            isDisabled,
-            isQuarantined
-          })
+        testFinishCh.publish({
+          status,
+          skipReason,
+          error,
+          isNew,
+          isEfdRetry,
+          isFlakyRetry: numAttempt > 0,
+          isAttemptToFix,
+          isAttemptToFixRetry,
+          hasFailedAllRetries,
+          hasPassedAllRetries,
+          hasFailedAttemptToFix,
+          isDisabled,
+          isQuarantined,
+          ...attemptCtx.currentStore
         })
       })
       return promise
     } catch (err) {
-      errorCh.publish(err)
-      throw err
+      ctx.err = err
+      errorCh.runStores(ctx, () => {
+        throw err
+      })
     }
   })
   shimmer.wrap(pl.prototype, 'runStep', runStep => function () {
-    if (!testStepStartCh.hasSubscribers) {
+    if (!testFinishCh.hasSubscribers) {
       return runStep.apply(this, arguments)
     }
     const testStep = arguments[0]
@@ -387,9 +381,8 @@ function wrapRun (pl, isLatestVersion) {
       resource = testStep.isHook ? 'hook' : testStep.pickleStep.text
     }
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-    return asyncResource.runInAsyncScope(() => {
-      testStepStartCh.publish({ resource })
+    const ctx = { resource }
+    return testStepStartCh.runStores(ctx, () => {
       try {
         const promise = runStep.apply(this, arguments)
 
@@ -398,12 +391,14 @@ function wrapRun (pl, isLatestVersion) {
             ? getStatusFromResultLatest(result)
             : getStatusFromResult(result)
 
-          testFinishCh.publish({ isStep: true, status, skipReason, errorMessage })
+          testFinishCh.publish({ isStep: true, status, skipReason, errorMessage, ...ctx.currentStore })
         })
         return promise
       } catch (err) {
-        errorCh.publish(err)
-        throw err
+        ctx.err = err
+        errorCh.runStores(ctx, () => {
+          throw err
+        })
       }
     })
   })

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -144,7 +144,7 @@ function getTestContext (test) {
 
 function runnableWrapper (RunnablePackage, libraryConfig) {
   shimmer.wrap(RunnablePackage.prototype, 'run', run => function () {
-    if (!testStartCh.hasSubscribers) {
+    if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
     // Flaky test retries does not work in parallel mode

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -355,6 +355,7 @@ function getOnFailHandler (isMain) {
         // if it's a hook and it has failed, 'test end' will not be called
         testFinishCh.publish({ status: 'fail', hasBeenRetried: isMochaRetry(test), ...testContext.currentStore })
       } else {
+        testContext.err = err
         errorCh.runStores(testContext, () => { })
       }
     }
@@ -368,7 +369,7 @@ function getOnFailHandler (isMain) {
           `"${testOrHook.parent.fullTitle()}" failed with message "${err.message}"`
         )
         testSuiteError.stack = err.stack
-        testSuiteContext.testSuiteError = testSuiteError
+        testSuiteContext.error = testSuiteError
         testSuiteErrorCh.runStores(testSuiteContext, () => { })
       }
     }

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -7,7 +7,7 @@ const {
   addAttemptToFixStringToTestName,
   removeAttemptToFixStringFromTestName
 } = require('../../../dd-trace/src/plugins/util/test')
-const { channel, AsyncResource } = require('../helpers/instrument')
+const { channel } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
 // test channels
@@ -17,15 +17,16 @@ const testFinishCh = channel('ci:mocha:test:finish')
 const testRetryCh = channel('ci:mocha:test:retry')
 const errorCh = channel('ci:mocha:test:error')
 const skipCh = channel('ci:mocha:test:skip')
+const testFnCh = channel('ci:mocha:test:fn')
 
 // suite channels
 const testSuiteErrorCh = channel('ci:mocha:test-suite:error')
 
 const BREAKPOINT_HIT_GRACE_PERIOD_MS = 200
-const testToAr = new WeakMap()
+const testToContext = new WeakMap()
 const originalFns = new WeakMap()
 const testToStartLine = new WeakMap()
-const testFileToSuiteAr = new Map()
+const testFileToSuiteCtx = new Map()
 const wrappedFunctions = new WeakSet()
 const newTests = {}
 const testsAttemptToFix = new Set()
@@ -125,7 +126,7 @@ function getTestStatus (test) {
   return 'pass'
 }
 
-function getTestToArKey (test) {
+function getTestToContextKey (test) {
   if (!test.fn) {
     return test
   }
@@ -136,9 +137,9 @@ function getTestToArKey (test) {
   return originalFn
 }
 
-function getTestAsyncResource (test) {
-  const key = getTestToArKey(test)
-  return testToAr.get(key)
+function getTestContext (test) {
+  const key = getTestToContextKey(test)
+  return testToContext.get(key)
 }
 
 function runnableWrapper (RunnablePackage, libraryConfig) {
@@ -167,14 +168,17 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
 
     if (isTestHook || this.type === 'test') {
       const test = isTestHook ? this.ctx.currentTest : this
-      const asyncResource = getTestAsyncResource(test)
+      const ctx = getTestContext(test)
 
-      if (asyncResource) {
-        // we bind the test fn to the correct async resource
-        const newFn = asyncResource.bind(this.fn)
+      if (ctx) {
+        const originalFn = this.fn
+        // we bind the test fn to the correct context
+        const newFn = function () {
+          return testFnCh.runStores(ctx, () => originalFn.apply(this, arguments))
+        }
 
         // we store the original function, not to lose it
-        originalFns.set(newFn, this.fn)
+        originalFns.set(newFn, originalFn)
         this.fn = newFn
 
         wrappedFunctions.add(this.fn)
@@ -189,7 +193,6 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
 function getOnTestHandler (isMain) {
   return function (test) {
     const testStartLine = testToStartLine.get(test)
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
 
     // This may be a retry. If this is the case, `test.fn` is already wrapped,
     // so we need to restore it.
@@ -198,7 +201,6 @@ function getOnTestHandler (isMain) {
       test.fn = originalFn
       wrappedFunctions.delete(test.fn)
     }
-    testToAr.set(test.fn, asyncResource)
 
     const {
       file: testSuiteAbsolutePath,
@@ -242,15 +244,15 @@ function getOnTestHandler (isMain) {
       test.pending = true
     }
 
-    asyncResource.runInAsyncScope(() => {
-      testStartCh.publish(testInfo)
-    })
+    const ctx = testInfo
+    testToContext.set(test.fn, ctx)
+    testStartCh.runStores(ctx, () => { })
   }
 }
 
 function getOnTestEndHandler (config) {
   return async function (test) {
-    const asyncResource = getTestAsyncResource(test)
+    const ctx = getTestContext(test)
     const status = getTestStatus(test)
 
     // After finishing it might take a bit for the snapshot to be handled.
@@ -295,18 +297,17 @@ function getOnTestEndHandler (config) {
       !test._ddIsEfdRetry
 
     // if there are afterEach to be run, we don't finish the test yet
-    if (asyncResource && !getAfterEachHooks(test).length) {
-      asyncResource.runInAsyncScope(() => {
-        testFinishCh.publish({
-          status,
-          hasBeenRetried: isMochaRetry(test),
-          isLastRetry: getIsLastRetry(test),
-          hasFailedAllRetries,
-          attemptToFixPassed,
-          attemptToFixFailed,
-          isAttemptToFixRetry,
-          isAtrRetry
-        })
+    if (ctx && !getAfterEachHooks(test).length) {
+      testFinishCh.publish({
+        status,
+        hasBeenRetried: isMochaRetry(test),
+        isLastRetry: getIsLastRetry(test),
+        hasFailedAllRetries,
+        attemptToFixPassed,
+        attemptToFixFailed,
+        isAttemptToFixRetry,
+        isAtrRetry,
+        ...ctx.currentStore
       })
     }
   }
@@ -320,10 +321,13 @@ function getOnHookEndHandler () {
       const isLastAfterEach = afterEachHooks.indexOf(hook) === afterEachHooks.length - 1
       if (isLastAfterEach) {
         const status = getTestStatus(test)
-        const asyncResource = getTestAsyncResource(test)
-        if (asyncResource) {
-          asyncResource.runInAsyncScope(() => {
-            testFinishCh.publish({ status, hasBeenRetried: isMochaRetry(test), isLastRetry: getIsLastRetry(test) })
+        const ctx = getTestContext(test)
+        if (ctx) {
+          testFinishCh.publish({
+            status,
+            hasBeenRetried: isMochaRetry(test),
+            isLastRetry: getIsLastRetry(test),
+            ...ctx.currentStore
           })
         }
       }
@@ -339,35 +343,33 @@ function getOnFailHandler (isMain) {
     if (isHook && testOrHook.ctx) {
       test = testOrHook.ctx.currentTest
     }
-    let testAsyncResource
+    let testContext
     if (test) {
-      testAsyncResource = getTestAsyncResource(test)
+      testContext = getTestContext(test)
     }
-    if (testAsyncResource) {
-      testAsyncResource.runInAsyncScope(() => {
-        if (isHook) {
-          err.message = `${testOrHook.fullTitle()}: ${err.message}`
-          errorCh.publish(err)
-          // if it's a hook and it has failed, 'test end' will not be called
-          testFinishCh.publish({ status: 'fail', hasBeenRetried: isMochaRetry(test) })
-        } else {
-          errorCh.publish(err)
-        }
-      })
+    if (testContext) {
+      if (isHook) {
+        err.message = `${testOrHook.fullTitle()}: ${err.message}`
+        testContext.err = err
+        errorCh.runStores(testContext, () => { })
+        // if it's a hook and it has failed, 'test end' will not be called
+        testFinishCh.publish({ status: 'fail', hasBeenRetried: isMochaRetry(test), ...testContext.currentStore })
+      } else {
+        errorCh.runStores(testContext, () => { })
+      }
     }
 
     if (isMain) {
-      const testSuiteAsyncResource = testFileToSuiteAr.get(testFile)
+      const testSuiteContext = testFileToSuiteCtx.get(testFile)
 
-      if (testSuiteAsyncResource) {
+      if (testSuiteContext) {
         // we propagate the error to the suite
         const testSuiteError = new Error(
           `"${testOrHook.parent.fullTitle()}" failed with message "${err.message}"`
         )
         testSuiteError.stack = err.stack
-        testSuiteAsyncResource.runInAsyncScope(() => {
-          testSuiteErrorCh.publish(testSuiteError)
-        })
+        testSuiteContext.testSuiteError = testSuiteError
+        testSuiteErrorCh.runStores(testSuiteContext, () => { })
       }
     }
   }
@@ -375,20 +377,18 @@ function getOnFailHandler (isMain) {
 
 function getOnTestRetryHandler (config) {
   return function (test, err) {
-    const asyncResource = getTestAsyncResource(test)
-    if (asyncResource) {
+    const ctx = getTestContext(test)
+    if (ctx) {
       const isFirstAttempt = test._currentRetry === 0
       const willBeRetried = test._currentRetry < test._retries
       const isAtrRetry = !isFirstAttempt &&
         config.isFlakyTestRetriesEnabled &&
         !test._ddIsAttemptToFix &&
         !test._ddIsEfdRetry
-      asyncResource.runInAsyncScope(() => {
-        testRetryCh.publish({ isFirstAttempt, err, willBeRetried, test, isAtrRetry })
-      })
+      testRetryCh.publish({ isFirstAttempt, err, willBeRetried, test, isAtrRetry, ...ctx.currentStore })
     }
-    const key = getTestToArKey(test)
-    testToAr.delete(key)
+    const key = getTestToContextKey(test)
+    testToContext.delete(key)
   }
 }
 
@@ -407,23 +407,19 @@ function getOnPendingHandler () {
       testStartLine
     }
 
-    const asyncResource = getTestAsyncResource(test)
-    if (asyncResource) {
-      asyncResource.runInAsyncScope(() => {
-        skipCh.publish(testInfo)
-      })
+    const ctx = getTestContext(test)
+    if (ctx) {
+      skipCh.publish(testInfo)
     } else {
-      // if there is no async resource, the test has been skipped through `test.skip`
+      // if there is no context, the test has been skipped through `test.skip`
       // or the parent suite is skipped
-      const skippedTestAsyncResource = new AsyncResource('bound-anonymous-fn')
+      const testCtx = testInfo
       if (test.fn) {
-        testToAr.set(test.fn, skippedTestAsyncResource)
+        testToContext.set(test.fn, testCtx)
       } else {
-        testToAr.set(test, skippedTestAsyncResource)
+        testToContext.set(test, testCtx)
       }
-      skippedTestAsyncResource.runInAsyncScope(() => {
-        skipCh.publish(testInfo)
-      })
+      skipCh.runStores(testCtx, () => { })
     }
   }
 }
@@ -484,9 +480,9 @@ module.exports = {
   getTestFullName,
   getTestStatus,
   runnableWrapper,
-  testToAr,
+  testToContext,
   originalFns,
-  getTestAsyncResource,
+  getTestContext,
   testToStartLine,
   getOnTestHandler,
   getOnTestEndHandler,
@@ -494,7 +490,7 @@ module.exports = {
   getOnHookEndHandler,
   getOnFailHandler,
   getOnPendingHandler,
-  testFileToSuiteAr,
+  testFileToSuiteCtx,
   getRunTestsWrapper,
   newTests,
   testsQuarantined,

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -221,13 +221,8 @@ class CucumberPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: 'istanbul' })
     })
 
-    this.addSub('ci:cucumber:test:start', ({
-      testName,
-      testFileAbsolutePath,
-      testSourceLine,
-      isParallel,
-      promises
-    }) => {
+    this.addBind('ci:cucumber:test:start', (ctx) => {
+      const { testName, testFileAbsolutePath, testSourceLine, isParallel, promises } = ctx
       const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
@@ -240,22 +235,23 @@ class CucumberPlugin extends CiPlugin {
         extraTags[CUCUMBER_IS_PARALLEL] = 'true'
       }
 
-      const testSpan = this.startTestSpan(testName, testSuite, extraTags)
+      const span = this.startTestSpan(testName, testSuite, extraTags)
 
-      this.enter(testSpan, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, span }
 
-      this.activeTestSpan = testSpan
+      this.activeTestSpan = span
       // Time we give the breakpoint to be hit
       if (promises && this.runningTestProbe) {
         promises.hitBreakpointPromise = new Promise((resolve) => {
           setTimeout(resolve, BREAKPOINT_HIT_GRACE_PERIOD_MS)
         })
       }
+
+      return ctx.currentStore
     })
 
-    this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error, isAtrRetry }) => {
-      const store = storage('legacy').getStore()
-      const span = store.span
+    this.addSub('ci:cucumber:test:retry', ({ span, isFirstAttempt, error, isAtrRetry }) => {
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
         if (isAtrRetry) {
@@ -284,7 +280,9 @@ class CucumberPlugin extends CiPlugin {
       finishAllTraceSpans(span)
     })
 
-    this.addSub('ci:cucumber:test-step:start', ({ resource }) => {
+    this.addBind('ci:cucumber:test-step:start', (ctx) => {
+      const { resource } = ctx
+
       const store = storage('legacy').getStore()
       const childOf = store ? store.span : store
       const span = this.tracer.startSpan('cucumber.step', {
@@ -295,7 +293,10 @@ class CucumberPlugin extends CiPlugin {
           [RESOURCE_NAME]: resource
         }
       })
-      this.enter(span, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, span }
+
+      return ctx.currentStore
     })
 
     this.addSub('ci:cucumber:worker-report:trace', (traces) => {
@@ -329,6 +330,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test:finish', ({
+      span,
       isStep,
       status,
       skipReason,
@@ -345,7 +347,6 @@ class CucumberPlugin extends CiPlugin {
       isDisabled,
       isQuarantined
     }) => {
-      const span = storage('legacy').getStore().span
       const statusTag = isStep ? 'step.status' : TEST_STATUS
 
       span.setTag(statusTag, status)
@@ -425,11 +426,21 @@ class CucumberPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:cucumber:error', (err) => {
+    this.addBind('ci:cucumber:error', (ctx) => {
+      const { err } = ctx
       if (err) {
-        const span = storage('legacy').getStore().span
+        const span = ctx.currentStore.span
         span.setTag('error', err)
+
+        ctx.parentStore = ctx.currentStore
+        ctx.currentStore = { ...ctx.currentStore, span }
       }
+
+      return ctx.currentStore
+    })
+
+    this.addBind('ci:cucumber:test:fn', (ctx) => {
+      return ctx.currentStore
     })
   }
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -178,10 +178,11 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addBind('ci:mocha:test-suite:error', (ctx) => {
-      const { span, testSuiteError } = ctx
+      const { error } = ctx
+      const span = ctx.currentStore?.span
 
       if (span) {
-        span.setTag('error', testSuiteError)
+        span.setTag('error', error)
         span.setTag(TEST_STATUS, 'fail')
 
         ctx.parentStore = ctx.currentStore
@@ -282,7 +283,8 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addBind('ci:mocha:test:error', (ctx) => {
-      const { err, span } = ctx
+      const { err } = ctx
+      const span = ctx.currentStore?.span
 
       if (err && span) {
         if (err.constructor.name === 'Pending' && !this.forbidPending) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Replace `AsyncResource` usage for `runStores` in the following frameworks:
- **Jest**
- **Mocha**
- **Cucumber** (WIP)
- **Playwright** (WIP)
- **Vitest** (WIP)

### Motivation
<!-- What inspired you to submit this pull request? -->
There is a bug in _Node 24_ when using `AsyncResource` that isn't triggered when using `runStores` instead.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


