### PR TITLE
Update pprof-nodejs to 5.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@datadog/native-appsec": "8.5.2",
     "@datadog/native-iast-taint-tracking": "3.3.1",
     "@datadog/native-metrics": "^3.1.1",
-    "@datadog/pprof": "5.7.1",
+    "@datadog/pprof": "5.8.0",
     "@datadog/sketches-js": "^2.1.0",
     "@datadog/wasm-js-rewriter": "4.0.1",
     "@isaacs/ttlcache": "^1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,10 +233,10 @@
     node-addon-api "^6.1.0"
     node-gyp-build "^3.9.0"
 
-"@datadog/pprof@5.7.1":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.7.1.tgz#3ed62372af7331c37de401319bde9e3d4dc5a8c0"
-  integrity sha512-D5XTxsaPG36x41vZZn8hsAeC7QQDx0rv1a1Uhxo5xCXUB/9rc19+I7iCnjgJS5aH0ShXdPVOWRClo16hOSKKSw==
+"@datadog/pprof@5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.8.0.tgz#0067b5bac159bfe1cc098b3dff69a3622e3263e8"
+  integrity sha512-3FL2qpkFWvIEptSk7x9RVs1PJeF+VCrGxQpKViloQkrnH5mjcwaIQiWyNZYyV1H1vhKJIS+ummSBcsOLkV49qA==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?

Update pprof-nodejs to 5.8.0.

### Motivation

Add support for Node 24.
