### PR TITLE
[DI] Add debug logs when starting/stopping the CDP session

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -175,11 +175,13 @@ async function updateBreakpoint (breakpoint, probe) {
 
 function start () {
   sessionStarted = true
+  log.debug('[debugger:devtools_client] Starting debugger')
   return session.post('Debugger.enable')
 }
 
 function stop () {
   sessionStarted = false
+  log.debug('[debugger:devtools_client] Stopping debugger')
   return session.post('Debugger.disable')
 }
 


### PR DESCRIPTION
### What does this PR do?
    
Before the first probe is added, the Chrome DevTools Protocol (CDP) sesion is started and after the last probe has been deleted/deactivated, the CDP session is stopped.
    
When these events happen, log a debug message.

### Motivation

Improve debugging abilities when something is not working as expected.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


