### PR TITLE
[DI] Clear state when last probe is removed

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -5,7 +5,13 @@ const { getGeneratedPosition } = require('./source-maps')
 const session = require('./session')
 const { compile: compileCondition, compileSegments, templateRequiresEvaluation } = require('./condition')
 const { MAX_SNAPSHOTS_PER_SECOND_PER_PROBE, MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE } = require('./defaults')
-const { findScriptFromPartialPath, locationToBreakpoint, breakpointToProbes, probeToLocation } = require('./state')
+const {
+  findScriptFromPartialPath,
+  clearState,
+  locationToBreakpoint,
+  breakpointToProbes,
+  probeToLocation
+} = require('./state')
 const log = require('../../log')
 
 let sessionStarted = false
@@ -224,6 +230,7 @@ async function start () {
 
 function stop () {
   sessionStarted = false
+  clearState()
   log.debug('[debugger:devtools_client] Stopping debugger')
   return session.post('Debugger.disable')
 }

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -16,6 +16,9 @@ module.exports = {
   breakpointToProbes: new Map(),
   probeToLocation: new Map(),
 
+  _loadedScripts: loadedScripts, // Only exposed for testing
+  _scriptUrls: scriptUrls, // Only exposed for testing
+
   /**
    * Find the script to inspect based on a partial or absolute path. Handles both Windows and POSIX paths.
    *
@@ -107,6 +110,14 @@ module.exports = {
         columnNumber: frame.location.columnNumber + 1 // Beware! columnNumber is zero-indexed
       }
     })
+  },
+
+  // The maps locationToBreakpoint, breakpointToProbes, and probeToLocation are always updated when breakpoints are
+  // removed. Therefore they do not need to get manually cleared. Only the state internal to this file needs to be
+  // cleared.
+  clearState () {
+    loadedScripts.length = 0
+    scriptUrls.clear()
   }
 }
 
@@ -117,7 +128,6 @@ module.exports = {
 // Unknown params.url values:
 // - `structured-stack` - Not sure what this is, but should just be ignored
 // - `` - Not sure what this is, but should just be ignored
-// TODO: Event fired for all files, every time debugger is enabled. So when we disable it, we need to reset the state
 session.on('Debugger.scriptParsed', ({ params }) => {
   scriptUrls.set(params.scriptId, params.url)
   if (params.url.startsWith('file:')) {

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -30,6 +30,7 @@ describe('breakpoints', function () {
         sourceMapURL: null,
         source: null
       }),
+      clearState: sinon.stub(),
       locationToBreakpoint: new Map(),
       breakpointToProbes: new Map(),
       probeToLocation: new Map(),
@@ -88,8 +89,7 @@ describe('breakpoints', function () {
         }
       })
 
-      expect(sessionMock.post.callCount).to.equal(1)
-      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.setBreakpoint')
+      expect(sessionMock.post).to.have.been.calledOnceWith('Debugger.setBreakpoint')
     })
 
     describe('add multiple probes to the same location', function () {
@@ -116,7 +116,7 @@ describe('breakpoints', function () {
           }
         })
 
-        expect(sessionMock.post.callCount).to.equal(0)
+        expect(sessionMock.post).to.not.have.been.called
       })
 
       it('mixed: 2nd probe no condition', async function () {
@@ -190,7 +190,7 @@ describe('breakpoints', function () {
           }
         })
 
-        expect(sessionMock.post.callCount).to.equal(0)
+        expect(sessionMock.post).to.not.have.been.called
       })
 
       it('all conditions', async function () {
@@ -316,8 +316,8 @@ describe('breakpoints', function () {
 
       await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-      expect(sessionMock.post.callCount).to.equal(1)
-      expect(sessionMock.post).to.have.been.calledWith('Debugger.disable')
+      expect(sessionMock.post).to.have.been.calledOnceWith('Debugger.disable')
+      expect(stateMock.clearState).to.have.been.calledOnce
     })
 
     it('should not disable debugger when there are other breakpoints', async function () {
@@ -327,8 +327,11 @@ describe('breakpoints', function () {
 
       await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-      expect(sessionMock.post.callCount).to.equal(1)
-      expect(sessionMock.post).to.have.been.calledWith('Debugger.removeBreakpoint', { breakpointId: 'bp-script-1:9:0' })
+      expect(sessionMock.post).to.have.been.calledOnceWith(
+        'Debugger.removeBreakpoint',
+        { breakpointId: 'bp-script-1:9:0' }
+      )
+      expect(stateMock.clearState).to.not.have.been.called
     })
 
     describe('update breakpoint when removing one of multiple probes at the same location', function () {
@@ -339,7 +342,7 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        expect(sessionMock.post.callCount).to.equal(0)
+        expect(sessionMock.post).to.not.have.been.called
       })
 
       it('mixed: removed probe with no condition', async function () {
@@ -381,7 +384,7 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        expect(sessionMock.post.callCount).to.equal(0)
+        expect(sessionMock.post).to.not.have.been.called
       })
 
       it('all conditions', async function () {

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -190,6 +190,26 @@ describe('findScriptFromPartialPath', function () {
     it('a Windows drive letter with a backslash', testPathNoMatch('c:\\'))
   })
 
+  describe('state', function () {
+    it('should be cleared when calling clearState', function () {
+      const path = 'server/index.js'
+
+      expect(state._loadedScripts.length).to.be.above(0)
+      expect(state._scriptUrls.size).to.be.above(0)
+
+      const result = state.findScriptFromPartialPath(path)
+      expect(result).to.be.an('object')
+
+      state.clearState()
+
+      expect(state._loadedScripts.length).to.equal(0)
+      expect(state._scriptUrls.size).to.equal(0)
+
+      const result2 = state.findScriptFromPartialPath(path)
+      expect(result2).to.be.null
+    })
+  })
+
   function testPathNoMatch (path) {
     return function () {
       const result = state.findScriptFromPartialPath(path)


### PR DESCRIPTION
### What does this PR do?

When the last probe is removed (or disabled), the debugger session is stopped. However, some of the internal state keeping track of the loaded files in the process isn't cleared. If a new probe is then later added, or an existing probe enabled, a new debugger session is started, and the internal state is re-generated. But instead of starting from an empty state, it's essentially duplicated. The more times this happens, the more memory is used, causing a memory leak.
    
To fix this, the internal state is now cleared when the debugger session is stopped.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


