### PR TITLE
Bump taint tracking package

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@datadog/libdatadog": "^0.5.1",
     "@datadog/native-appsec": "8.5.2",
-    "@datadog/native-iast-taint-tracking": "3.3.1",
+    "@datadog/native-iast-taint-tracking": "4.0.0",
     "@datadog/native-metrics": "^3.1.1",
     "@datadog/pprof": "5.8.0",
     "@datadog/sketches-js": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,10 +218,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-taint-tracking@3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-3.3.1.tgz#71d2c9bdb102b4482fea145d3f22ed5453628500"
-  integrity sha512-TgXpoX/CDgPfYAKu9qLmEyb9UXvRVC00D71islcSb70MCFmxQwkgXGl/gAk6YA6/NmZ4j8+cgY1lSNqStGvOMg==
+"@datadog/native-iast-taint-tracking@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.0.0.tgz#a774742e6723b93d58bf31a87728e4da1634074f"
+  integrity sha512-2uF8RnQkJO5bmLi26Zkhxg+RFJn/uEsesYTflScI/Cz/BWv+792bxI+OaCKvhgmpLkm8EElenlpidcJyZm7GYw==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
Bump `@datadog/native-iast-taint-tracking` version to 4.0.0

### Motivation
Support Node.js v24