### PR TITLE
fix(llmobs): span tags update instead correctly

### DIFF
--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -148,12 +148,12 @@ class LLMObsTagger {
   }
 
   tagSpanTags (span, tags) {
-    // new tags will be merged with existing tags
     const currentTags = registry.get(span)?.[TAGS]
     if (currentTags) {
-      Object.assign(tags, currentTags)
+      Object.assign(currentTags, tags)
+    } else {
+      this._setTag(span, TAGS, tags)
     }
-    this._setTag(span, TAGS, tags)
   }
 
   changeKind (span, newKind) {

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -230,12 +230,12 @@ describe('tagger', () => {
         })
       })
 
-      it('merges tags so they do not overwrite', () => {
+      it('merges tags so they update', () => {
         Tagger.tagMap.set(span, { '_ml_obs.tags': { a: 1 } })
         const tags = { a: 2, b: 1 }
         tagger.tagSpanTags(span, tags)
         expect(Tagger.tagMap.get(span)).to.deep.equal({
-          '_ml_obs.tags': { a: 1, b: 1 }
+          '_ml_obs.tags': { a: 2, b: 1 }
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
Span tags should update correctly. Previously:
```js
llmobs.trace({ kind: 'workflow', name: 'my-chain' }, () => {
  llmobs.annotate({ tags: { a: 5, c: 8 })
  // ...
  llmobs.annotate({ tags: { a: 6, b: 7 })
})
```
Would have the final annotation as `{ a: 5, b: 7, c: 8 }`, when it should be `{ a: 6, b: 7, c: 8 }`.

No new test added - the existing was testing incorrect behavior, so it was modified.

### Motivation
Bug fix


