### PR TITLE
use no async context frame option for now

### DIFF
--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: ./.github/actions/install
       - run: yarn test:debugger:ci
       - run: yarn test:integration:debugger
+        env:
+          OPTIONS_OVERRIDE: 1
       - if: always()
         uses: ./.github/actions/testagent/logs
         with:

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -4,6 +4,7 @@ const sinon = require('sinon')
 const chai = require('chai')
 const sinonChai = require('sinon-chai')
 const proxyquire = require('../proxyquire')
+const { NODE_MAJOR } = require('../../../../version')
 
 {
   // get-port can often return a port that is already in use, thanks to a race
@@ -47,4 +48,36 @@ process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 if (/^v\d+\.x$/.test(process.env.GITHUB_BASE_REF || '')) {
   process.env.DD_INJECTION_ENABLED = 'true'
   process.env.DD_INJECT_FORCE = 'true'
+}
+
+// TODO(bengl): remove this block once we can properly support Node.js 24 without it
+if (NODE_MAJOR >= 24 && !process.env.OPTIONS_OVERRIDE) {
+  const childProcess = require('child_process')
+  const { exec, fork } = childProcess
+
+  childProcess.exec = function (...args) {
+    const opts = args[1]
+    if (opts) {
+      if (opts?.env?.NODE_OPTIONS && !opts.env.NODE_OPTIONS.includes('--no-async-context-frame')) {
+        opts.env.NODE_OPTIONS += ' --no-async-context-frame'
+      } else {
+        opts.env ||= {}
+        opts.env.NODE_OPTIONS = '--no-async-context-frame'
+      }
+    }
+    return exec.apply(this, args)
+  }
+
+  childProcess.fork = function (...args) {
+    const opts = args[1]
+    if (opts) {
+      if (opts?.env?.NODE_OPTIONS && !opts.env.NODE_OPTIONS.includes('--no-async-context-frame')) {
+        opts.env.NODE_OPTIONS += ' --no-async-context-frame'
+      } else {
+        opts.env ||= {}
+        opts.env.NODE_OPTIONS = '--no-async-context-frame'
+      }
+    }
+    return fork.apply(this, args)
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Adds `--no-async-context-frame` on tests whenever child processes are used. This mainly applies to integration tests.

The debugger test is also affected, but since it's been updated to work with `AsyncContextFrame`, there's an override option for that one.

This makes all integration tests pass on Node.js 24, since the flag reverts to Node.js <24 behaviour.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
We'll back all of this out once we can fully support Node.js 24 and not use the flag.


