### PR TITLE
convert aws-sdk to runstores instead of asyncresource

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -159,7 +159,6 @@ jobs:
     env:
       PLUGINS: aws-sdk
       SERVICES: localstack localstack-legacy
-      DD_DATA_STREAMS_ENABLED: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/testagent/start

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -1,10 +1,6 @@
 'use strict'
 
-const {
-  channel,
-  addHook,
-  AsyncResource
-} = require('./helpers/instrument')
+const { channel, addHook } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
 function wrapRequest (send) {
@@ -15,26 +11,30 @@ function wrapRequest (send) {
     const channelSuffix = getChannelSuffix(serviceIdentifier)
     const startCh = channel(`apm:aws:request:start:${channelSuffix}`)
     if (!startCh.hasSubscribers) return send.apply(this, arguments)
-    const innerAr = new AsyncResource('apm:aws:request:inner')
-    const outerAr = new AsyncResource('apm:aws:request:outer')
 
-    return innerAr.runInAsyncScope(() => {
-      this.on('complete', innerAr.bind(response => {
-        const cbExists = typeof cb === 'function'
-        channel(`apm:aws:request:complete:${channelSuffix}`).publish({ response, cbExists })
-      }))
+    this.on('complete', response => {
+      ctx.response = response
+    })
 
-      startCh.publish({
-        serviceIdentifier,
-        operation: this.operation,
-        awsRegion: this.service.config && this.service.config.region,
-        awsService: this.service.api && this.service.api.className,
-        request: this
-      })
+    const ctx = {
+      serviceIdentifier,
+      operation: this.operation,
+      awsRegion: this.service.config && this.service.config.region,
+      awsService: this.service.api && this.service.api.className,
+      request: this
+    }
 
-      if (typeof cb === 'function') {
-        arguments[0] = wrapCb(cb, channelSuffix, this, outerAr)
+    return startCh.runStores(ctx, () => {
+      ctx.cbExists = typeof cb === 'function'
+
+      if (ctx.cbExists) {
+        arguments[0] = wrapCb(cb, channelSuffix, ctx)
+      } else {
+        this.on('complete', response => {
+          channel(`apm:aws:request:complete:${channelSuffix}`).publish(ctx)
+        })
       }
+
       return send.apply(this, arguments)
     })
   }
@@ -55,8 +55,6 @@ function wrapDeserialize (deserialize, channelSuffix) {
 function wrapSmithySend (send) {
   return function (command, ...args) {
     const cb = args[args.length - 1]
-    const innerAr = new AsyncResource('apm:aws:request:inner')
-    const outerAr = new AsyncResource('apm:aws:request:outer')
     const serviceIdentifier = this.config.serviceId.toLowerCase()
     const channelSuffix = getChannelSuffix(serviceIdentifier)
     const commandName = command.constructor.name
@@ -77,46 +75,47 @@ function wrapSmithySend (send) {
       shimmer.wrap(command, 'deserialize', deserialize => wrapDeserialize(deserialize, channelSuffix))
     }
 
-    return innerAr.runInAsyncScope(() => {
-      startCh.publish({
-        serviceIdentifier,
-        operation,
-        awsService: clientName,
-        request
-      })
+    const ctx = {
+      serviceIdentifier,
+      operation,
+      awsService: clientName,
+      request
+    }
 
+    return startCh.runStores(ctx, () => {
       // When the region is not set this never resolves so we can't await.
       this.config.region().then(region => {
-        regionCh.publish(region)
+        ctx.region = region
+        regionCh.publish(ctx)
       })
 
       if (typeof cb === 'function') {
         args[args.length - 1] = shimmer.wrapFunction(cb, cb => function (err, result) {
-          const message = getMessage(request, err, result)
+          addResponse(ctx, err, result)
 
-          completeChannel.publish(message)
+          completeChannel.runStores(ctx, () => {
+            const responseCtx = { request, response: ctx.response }
 
-          outerAr.runInAsyncScope(() => {
-            responseStartChannel.publish(message)
+            responseStartChannel.runStores(responseCtx, () => {
+              cb.apply(this, arguments)
 
-            cb.apply(this, arguments)
-
-            if (message.needsFinish) {
-              responseFinishChannel.publish(message.response.error)
-            }
+              if (responseCtx.needsFinish) {
+                responseFinishChannel.publish(responseCtx)
+              }
+            })
           })
         })
       } else { // always a promise
         return send.call(this, command, ...args)
           .then(
             result => {
-              const message = getMessage(request, null, result)
-              completeChannel.publish(message)
+              addResponse(ctx, null, result)
+              completeChannel.publish(ctx)
               return result
             },
             error => {
-              const message = getMessage(request, error)
-              completeChannel.publish(message)
+              addResponse(ctx, error)
+              completeChannel.publish(ctx)
               throw error
             }
           )
@@ -127,47 +126,51 @@ function wrapSmithySend (send) {
   }
 }
 
-function wrapCb (cb, serviceName, request, ar) {
+function wrapCb (cb, serviceName, ctx) {
   // eslint-disable-next-line n/handle-callback-err
   return shimmer.wrapFunction(cb, cb => function wrappedCb (err, response) {
-    const obj = { request, response }
-    return ar.runInAsyncScope(() => {
-      channel(`apm:aws:response:start:${serviceName}`).publish(obj)
-      // TODO(bengl) make this work without needing a needsFinish property added to the object
-      if (!obj.needsFinish) {
-        return cb.apply(this, arguments)
-      }
-      const finishChannel = channel(`apm:aws:response:finish:${serviceName}`)
-      try {
-        let result = cb.apply(this, arguments)
-        if (result && result.then) {
-          result = result.then(x => {
-            finishChannel.publish()
-            return x
-          }, e => {
-            finishChannel.publish(e)
-            throw e
-          })
-        } else {
-          finishChannel.publish()
+    return channel(`apm:aws:request:complete:${serviceName}`).runStores(ctx, () => {
+      ctx = { request: ctx.request, response }
+      return channel(`apm:aws:response:start:${serviceName}`).runStores(ctx, () => {
+        // TODO(bengl) make this work without needing a needsFinish property added to the object
+        if (!ctx.needsFinish) {
+          return cb.apply(this, arguments)
         }
-        return result
-      } catch (e) {
-        finishChannel.publish(e)
-        throw e
-      }
+        const finishChannel = channel(`apm:aws:response:finish:${serviceName}`)
+        try {
+          let result = cb.apply(this, arguments)
+          if (result && result.then) {
+            result = result.then(x => {
+              finishChannel.publish(ctx)
+              return x
+            }, e => {
+              ctx.error = e
+              finishChannel.publish(ctx)
+              throw e
+            })
+          } else {
+            finishChannel.publish(ctx)
+          }
+          return result
+        } catch (e) {
+          ctx.error = e
+          finishChannel.publish(ctx)
+          throw e
+        }
+      })
     })
   })
 }
 
-function getMessage (request, error, result) {
+function addResponse (ctx, error, result) {
+  const request = ctx.request
   const response = { request, error, ...result }
 
   if (result && result.$metadata) {
     response.requestId = result.$metadata.requestId
   }
 
-  return { request, response }
+  ctx.response = response
 }
 
 function getChannelSuffix (name) {

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -99,9 +99,7 @@ function wrapSmithySend (send) {
             responseStartChannel.runStores(responseCtx, () => {
               cb.apply(this, arguments)
 
-              if (responseCtx.needsFinish) {
-                responseFinishChannel.publish(responseCtx)
-              }
+              responseFinishChannel.publish(responseCtx)
             })
           })
         })
@@ -132,10 +130,6 @@ function wrapCb (cb, serviceName, ctx) {
     return channel(`apm:aws:request:complete:${serviceName}`).runStores(ctx, () => {
       ctx = { request: ctx.request, response }
       return channel(`apm:aws:response:start:${serviceName}`).runStores(ctx, () => {
-        // TODO(bengl) make this work without needing a needsFinish property added to the object
-        if (!ctx.needsFinish) {
-          return cb.apply(this, arguments)
-        }
         const finishChannel = channel(`apm:aws:response:finish:${serviceName}`)
         try {
           let result = cb.apply(this, arguments)

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -41,7 +41,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         awsService
       } = ctx
 
-      const childOf = this.tracer.scope().active()
+      const childOf = ctx.parentStore = this.tracer.scope().active()
 
       if (!this.isEnabled(request)) {
         return childOf

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -16,48 +16,53 @@ class Kinesis extends BaseAwsSdkPlugin {
     // in the base class
     this.requestTags = new WeakMap()
 
-    this.addSub('apm:aws:response:start:kinesis', obj => {
-      const { request, response } = obj
-      const store = storage('legacy').getStore()
+    this.addBind('apm:aws:response:start:kinesis', ctx => {
+      const { request, response } = ctx
       const plugin = this
+
+      let store = storage('legacy').getStore()
 
       // if we have either of these operations, we want to store the streamName param
       // since it is not typically available during get/put records requests
       if (request.operation === 'getShardIterator' || request.operation === 'listShards') {
-        this.storeStreamName(request.params, request.operation, store)
-        return
+        return this.storeStreamName(request.params, request.operation, store)
       }
 
       if (request.operation === 'getRecords') {
         let span
         const responseExtraction = this.responseExtract(request.params, request.operation, response)
         if (responseExtraction && responseExtraction.maybeChildOf) {
-          obj.needsFinish = true
+          ctx.needsFinish = true
           const options = {
             childOf: responseExtraction.maybeChildOf,
-            tags: Object.assign(
+            meta: Object.assign(
               {},
               this.requestTags.get(request) || {},
               { 'span.kind': 'server' }
             )
           }
-          span = plugin.tracer.startSpan('aws.response', options)
-          this.enter(span, store)
+          span = plugin.startSpan('aws.response', options, ctx)
+          store = ctx.currentStore
         }
 
-        // get the stream name that should have been stored previously
-        const { streamName } = storage('legacy').getStore()
+        storage('legacy').run(store, () => {
+          if (!store) return
 
-        // extract DSM context after as we might not have a parent-child but may have a DSM context
-        this.responseExtractDSMContext(
-          request.operation, request.params, response, span || null, { streamName }
-        )
+          // get the stream name that should have been stored previously
+          const { streamName } = store
+
+          // extract DSM context after as we might not have a parent-child but may have a DSM context
+          this.responseExtractDSMContext(
+            request.operation, request.params, response, span || null, { streamName }
+          )
+        })
       }
+
+      return store
     })
 
-    this.addSub('apm:aws:response:finish:kinesis', err => {
-      const { span } = storage('legacy').getStore()
-      this.finish(span, null, err)
+    this.addSub('apm:aws:response:finish:kinesis', ctx => {
+      this.finish(ctx)
     })
   }
 
@@ -72,11 +77,12 @@ class Kinesis extends BaseAwsSdkPlugin {
   }
 
   storeStreamName (params, operation, store) {
-    if (!operation || (operation !== 'getShardIterator' && operation !== 'listShards')) return
-    if (!params || !params.StreamName) return
+    if (!operation) return store
+    if (operation !== 'getShardIterator' && operation !== 'listShards') return store
+    if (!params || !params.StreamName) return store
 
     const streamName = params.StreamName
-    storage('legacy').enterWith({ ...store, streamName })
+    return { ...store, streamName }
   }
 
   responseExtract (params, operation, response) {

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -62,6 +62,7 @@ class Kinesis extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:kinesis', ctx => {
+      if (!ctx.needsFinish) return
       this.finish(ctx)
     })
   }

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -54,6 +54,7 @@ class Sqs extends BaseAwsSdkPlugin {
     })
 
     this.addSub('apm:aws:response:finish:sqs', ctx => {
+      if (!ctx.needsFinish) return
       this.finish(ctx)
     })
   }

--- a/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
@@ -19,7 +19,7 @@ async function resetLocalStackDynamo () {
   }
 }
 
-describe('Plugin', () => {
+describe.only('Plugin', () => {
   describe('aws-sdk (dynamodb)', function () {
     setup()
 

--- a/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
@@ -19,7 +19,7 @@ async function resetLocalStackDynamo () {
   }
 }
 
-describe.only('Plugin', () => {
+describe('Plugin', () => {
   describe('aws-sdk (dynamodb)', function () {
     setup()
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -46,10 +46,6 @@ describe.only('Kinesis', function () {
       })
     }
 
-    before(() => {
-      process.env.DD_DATA_STREAMS_ENABLED = 'true'
-    })
-
     describe('no configuration', () => {
       before(() => {
         return agent.load('aws-sdk', { kinesis: { dsmEnabled: false, batchPropagationEnabled: true } }, { dsmEnabled: true })

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -7,8 +7,8 @@ const { setup } = require('./spec_helpers')
 const helpers = require('./kinesis_helpers')
 const { rawExpectedSchema } = require('./kinesis-naming')
 
-describe('Kinesis', function () {
-  this.timeout(10000)
+describe.only('Kinesis', function () {
+  this.timeout(2000)
   setup()
 
   withVersions('aws-sdk', ['aws-sdk', '@aws-sdk/smithy-client'], (version, moduleName) => {
@@ -229,7 +229,7 @@ describe('Kinesis', function () {
           expect(getRecordSpanMeta).to.include({
             'pathway.hash': expectedConsumerHash
           })
-        }, { timeoutMs: 10000 }).then(done, done)
+        }, { timeoutMs: 2000 }).then(done, done)
 
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
           if (err) return done(err)
@@ -289,10 +289,10 @@ describe('Kinesis', function () {
                 statsPointsReceived += statsBuckets.Stats.length
               })
             }
-          }, { timeoutMs: 10000 })
+          }, { timeoutMs: 2000 })
           expect(statsPointsReceived).to.be.at.least(2)
           expect(agent.dsmStatsExist(agent, expectedConsumerHash)).to.equal(true)
-        }, { timeoutMs: 10000 }).then(done, done)
+        }, { timeoutMs: 2000 }).then(done, done)
 
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
           if (err) return done(err)
@@ -313,10 +313,10 @@ describe('Kinesis', function () {
                 statsPointsReceived += statsBuckets.Stats.length
               })
             }
-          }, { timeoutMs: 10000 })
+          }, { timeoutMs: 2000 })
           expect(statsPointsReceived).to.equal(1)
           expect(agent.dsmStatsExistWithParentHash(agent, '0')).to.equal(true)
-        }, { timeoutMs: 10000 }).then(done, done)
+        }, { timeoutMs: 2000 }).then(done, done)
 
         agent.reload('aws-sdk', { kinesis: { dsmEnabled: false } }, { dsmEnabled: false })
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
@@ -335,7 +335,7 @@ describe('Kinesis', function () {
         let now = Date.now()
         nowStub = sinon.stub(Date, 'now')
         nowStub.callsFake(() => {
-          now += 1000000
+          now += 200000
           return now
         })
 
@@ -351,7 +351,7 @@ describe('Kinesis', function () {
           })
           expect(statsPointsReceived).to.be.at.least(3)
           expect(agent.dsmStatsExist(agent, expectedProducerHash)).to.equal(true)
-        }, { timeoutMs: 10000 }).then(done, done)
+        }, { timeoutMs: 2000 }).then(done, done)
 
         helpers.putTestRecords(kinesis, streamNameDSM, (err, data) => {
           // Swallow the error as it doesn't matter for this test.

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -7,8 +7,8 @@ const { setup } = require('./spec_helpers')
 const helpers = require('./kinesis_helpers')
 const { rawExpectedSchema } = require('./kinesis-naming')
 
-describe.only('Kinesis', function () {
-  this.timeout(2000)
+describe('Kinesis', function () {
+  this.timeout(10000)
   setup()
 
   withVersions('aws-sdk', ['aws-sdk', '@aws-sdk/smithy-client'], (version, moduleName) => {
@@ -225,7 +225,7 @@ describe.only('Kinesis', function () {
           expect(getRecordSpanMeta).to.include({
             'pathway.hash': expectedConsumerHash
           })
-        }, { timeoutMs: 2000 }).then(done, done)
+        }, { timeoutMs: 10000 }).then(done, done)
 
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
           if (err) return done(err)
@@ -285,10 +285,10 @@ describe.only('Kinesis', function () {
                 statsPointsReceived += statsBuckets.Stats.length
               })
             }
-          }, { timeoutMs: 2000 })
+          }, { timeoutMs: 10000 })
           expect(statsPointsReceived).to.be.at.least(2)
           expect(agent.dsmStatsExist(agent, expectedConsumerHash)).to.equal(true)
-        }, { timeoutMs: 2000 }).then(done, done)
+        }, { timeoutMs: 10000 }).then(done, done)
 
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
           if (err) return done(err)
@@ -309,10 +309,10 @@ describe.only('Kinesis', function () {
                 statsPointsReceived += statsBuckets.Stats.length
               })
             }
-          }, { timeoutMs: 2000 })
+          }, { timeoutMs: 10000 })
           expect(statsPointsReceived).to.equal(1)
           expect(agent.dsmStatsExistWithParentHash(agent, '0')).to.equal(true)
-        }, { timeoutMs: 2000 }).then(done, done)
+        }, { timeoutMs: 10000 }).then(done, done)
 
         agent.reload('aws-sdk', { kinesis: { dsmEnabled: false } }, { dsmEnabled: false })
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
@@ -331,7 +331,7 @@ describe.only('Kinesis', function () {
         let now = Date.now()
         nowStub = sinon.stub(Date, 'now')
         nowStub.callsFake(() => {
-          now += 200000
+          now += 1000000
           return now
         })
 
@@ -347,7 +347,7 @@ describe.only('Kinesis', function () {
           })
           expect(statsPointsReceived).to.be.at.least(3)
           expect(agent.dsmStatsExist(agent, expectedProducerHash)).to.equal(true)
-        }, { timeoutMs: 2000 }).then(done, done)
+        }, { timeoutMs: 10000 }).then(done, done)
 
         helpers.putTestRecords(kinesis, streamNameDSM, (err, data) => {
           // Swallow the error as it doesn't matter for this test.

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -329,7 +329,6 @@ describe('Sns', function () {
       })
 
       before(done => {
-        process.env.DD_DATA_STREAMS_ENABLED = 'true'
         tracer = require('../../dd-trace')
         tracer.use('aws-sdk', { sns: { dsmEnabled: false, batchPropagationEnabled: true } })
 
@@ -504,7 +503,6 @@ describe('Sns', function () {
       })
 
       before(done => {
-        process.env.DD_DATA_STREAMS_ENABLED = 'true'
         tracer = require('../../dd-trace')
         tracer.use('aws-sdk', { sns: { dsmEnabled: true }, sqs: { dsmEnabled: true } })
 

--- a/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
@@ -9,11 +9,13 @@ const helpers = {
     before(() => {
       process.env.AWS_SECRET_ACCESS_KEY = '0000000000/00000000000000000000000000000'
       process.env.AWS_ACCESS_KEY_ID = '00000000000000000000'
+      process.env.DD_DATA_STREAMS_ENABLED = 'true'
     })
 
     after(() => {
       delete process.env.AWS_SECRET_ACCESS_KEY
       delete process.env.AWS_ACCESS_KEY_ID
+      delete process.env.DD_DATA_STREAMS_ENABLED
     })
   }
 }

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -39,7 +39,6 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         before(() => {
-          process.env.DD_DATA_STREAMS_ENABLED = 'true'
           tracer = require('../../dd-trace')
           tracer.use('aws-sdk', { sqs: { batchPropagationEnabled: true } })
 
@@ -389,7 +388,6 @@ describe('Plugin', () => {
         let nowStub
 
         before(() => {
-          process.env.DD_DATA_STREAMS_ENABLED = 'true'
           tracer = require('../../dd-trace')
           tracer.use('aws-sdk', { sqs: { dsmEnabled: true } })
         })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Convert `aws-sdk` to `runStores` instead of `AsyncResource`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise it's broken on Node 24 as `AsyncResource` is broken.