### PR TITLE
disable kafka headers in confluent-kafka-js on UNKNOWN_SERVER_ERROR

### DIFF
--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -7,6 +7,8 @@ const {
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
+const log = require('../../../dd-trace/src/log')
+
 // Create channels for Confluent Kafka JavaScript
 const channels = {
   producerStart: channel('apm:@confluentinc/kafka-javascript:produce:start'),
@@ -223,7 +225,8 @@ function instrumentKafkaJS (kafkaJS) {
                             if (err) {
                               if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                                 this._ddDisableHeaderInjection = true
-                                console.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.')
+                                log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for '
+                                  + 'more information. Tracer message header injection for Kafka is disabled.')
                               }
                               channels.producerError.publish(err)
                             }

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -225,8 +225,9 @@ function instrumentKafkaJS (kafkaJS) {
                             if (err) {
                               if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                                 this._ddDisableHeaderInjection = true
-                                log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for '
-                                  + 'more information. Tracer message header injection for Kafka is disabled.')
+                                log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). ' +
+                                  'Please look at broker logs for more information. ' +
+                                  'Tracer message header injection for Kafka is disabled.')
                               }
                               channels.producerError.publish(err)
                             }

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -7,7 +7,7 @@ const {
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
-const log = require('../../../dd-trace/src/log')
+const log = require('../../dd-trace/src/log')
 
 // Create channels for Confluent Kafka JavaScript
 const channels = {
@@ -26,6 +26,8 @@ const channels = {
   batchConsumerError: channel('apm:@confluentinc/kafka-javascript:consume-batch:error'),
   batchConsumerCommit: channel('apm:@confluentinc/kafka-javascript:consume-batch:commit')
 }
+
+const disabledHeaderWeakMap = new WeakMap()
 
 // we need to store the offset per partition per topic for the consumer to track offsets for DSM
 const latestConsumerOffsets = new Map()
@@ -194,7 +196,7 @@ function instrumentKafkaJS (kafkaJS) {
                 kafka._ddBrokers = arguments[0]['bootstrap.servers']
               }
 
-              producer._ddDisableHeaderInjection = false
+              disabledHeaderWeakMap.set(producer, false)
 
               // Wrap the send method of the producer
               if (producer && typeof producer.send === 'function') {
@@ -211,7 +213,7 @@ function instrumentKafkaJS (kafkaJS) {
                           topic: payload?.topic,
                           messages: payload?.messages || [],
                           bootstrapServers: kafka._ddBrokers,
-                          disableHeaderInjection: this._ddDisableHeaderInjection
+                          disableHeaderInjection: disabledHeaderWeakMap.get(producer)
                         })
 
                         const result = send.apply(this, arguments)
@@ -223,8 +225,12 @@ function instrumentKafkaJS (kafkaJS) {
                           }),
                           asyncResource.bind(err => {
                             if (err) {
-                              if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
-                                this._ddDisableHeaderInjection = true
+                              // Fixes bug where we would inject message headers for kafka brokers
+                              // that don't support headers (version <0.11). On the error, we disable
+                              // header injection. Tnfortunately the error name / type is not more specific.
+                              // This approach is implemented by other tracers as well.
+                              if (err.name === 'KafkaJSError' && err.type === 'ERR_UNKNOWN') {
+                                disabledHeaderWeakMap.set(producer, true)
                                 log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). ' +
                                   'Please look at broker logs for more information. ' +
                                   'Tracer message header injection for Kafka is disabled.')

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -192,7 +192,6 @@ function instrumentKafkaJS (kafkaJS) {
                 kafka._ddBrokers = arguments[0]['bootstrap.servers']
               }
 
-              // Add disable header injection flag
               producer._ddDisableHeaderInjection = false
 
               // Wrap the send method of the producer
@@ -222,7 +221,6 @@ function instrumentKafkaJS (kafkaJS) {
                           }),
                           asyncResource.bind(err => {
                             if (err) {
-                              // Disable header injection for UNKNOWN_SERVER_ERROR
                               if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                                 this._ddDisableHeaderInjection = true
                                 console.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.')

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -85,8 +85,9 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
                   // disable header injection for this error (unfortunately the error name / type is not more specific)
                   if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                     this._ddDisableHeaderInjection = true
-                    log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for '
-                      + 'more information. Tracer message header injection for Kafka is disabled.')
+                    log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). ' +
+                      'Please look at broker logs for more information. ' +
+                      'Tracer message header injection for Kafka is disabled.')
                   }
                   producerErrorCh.publish(err)
                 }

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -7,6 +7,8 @@ const {
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
+const log = require('../../../dd-trace/src/log')
+
 const producerStartCh = channel('apm:kafkajs:produce:start')
 const producerCommitCh = channel('apm:kafkajs:produce:commit')
 const producerFinishCh = channel('apm:kafkajs:produce:finish')
@@ -83,7 +85,8 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
                   // disable header injection for this error (unfortunately the error name / type is not more specific)
                   if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                     this._ddDisableHeaderInjection = true
-                    console.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.')
+                    log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for '
+                      + 'more information. Tracer message header injection for Kafka is disabled.')
                   }
                   producerErrorCh.publish(err)
                 }

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -83,6 +83,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
                   // disable header injection for this error (unfortunately the error name / type is not more specific)
                   if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                     this._ddDisableHeaderInjection = true
+                    console.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.')
                   }
                   producerErrorCh.publish(err)
                 }

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -87,7 +87,7 @@ class KafkajsProducerPlugin extends ProducerPlugin {
       if (message !== null && typeof message === 'object') {
         // message headers are not supported for kafka broker versions <0.11
         if (!disableHeaderInjection) {
-          message.headers = message.headers || {}
+          message.headers ??= {}
           this.tracer.inject(span, 'text_map', message.headers)
         }
         if (this.config.dsmEnabled) {


### PR DESCRIPTION
### What does this PR do?
To be merged into https://github.com/DataDog/dd-trace-js/pull/5704. Implements the same behaviour for kafka-confluent-js library

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
Test output:

```
APP_ROLE=PRODUCER KAFKA_BOOTSTRAP_SERVERS=localhost:9092 node app-confluent.js
{
  message: 'Producer connected',
  name: 'nodejs-app#producer-1',
  fac: 'BINDING',
  timestamp: 1747158270452
}
Sending message 0
Error sending message  0 :  Error: Unknown broker error
    at Function.createLibrdkafkaError [as create] (/Users/rob.carlan/go/src/github.com/DataDog/data-streams-dev/k8s-dev-env/nodejs/kafka/node_modules/@confluentinc/kafka-javascript/lib/error.js:459:10)
    at Producer.<anonymous> (/Users/rob.carlan/go/src/github.com/DataDog/data-streams-dev/k8s-dev-env/nodejs/kafka/node_modules/@confluentinc/kafka-javascript/lib/producer.js:96:31)
    at callbackTrampoline (node:internal/async_hooks:130:17) {
  name: 'KafkaJSError',
  retriable: false,
  fatal: false,
  abortable: false,
  code: -1,
  type: 'ERR_UNKNOWN'
}
Sending message 1
Sent message  1
Sending message 2
Sent message  2
```


