### PR TITLE
Extended Request Data Collection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -696,7 +696,12 @@ declare namespace tracer {
         /** Whether to enable RASP.
          * @default false
          */
-        enabled?: boolean
+        enabled?: boolean,
+
+        /** Whether to enable request body collection on RASP event
+         * @default false
+         */
+        bodyCollection?: boolean
       },
       /**
        * Configuration for stack trace reporting

--- a/index.d.ts
+++ b/index.d.ts
@@ -716,6 +716,25 @@ declare namespace tracer {
          * @default 32
          */
         maxDepth?: number,
+      },
+      /**
+       * Configuration for extended headers collection tied to security events
+       */
+      extendedHeadersCollection?: {
+        /** Whether to enable extended headers collection
+         * @default false
+         */
+        enabled: boolean,
+
+        /** Whether to redact collected headers
+         * @default true
+         */
+        redaction: boolean,
+
+        /** Specifies the maximum number of headers collected.
+         * @default 50
+         */
+        maxHeaders: number,
       }
     }
 

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -126,7 +126,7 @@ function getCollectedHeaders (req, res, shouldCollectEventHeaders) {
   const responseEventCollectedHeaders = filterHeaders(res.getHeaders(), RESPONSE_HEADERS_MAP)
 
   // Extended collection
-  if (!extendedCollection?.enabled) {
+  if (!extendedCollection?.enabled || extendedCollection?.redaction) {
     return Object.assign(
       mandatoryCollectedHeaders,
       requestEventCollectedHeaders,

--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -137,7 +137,7 @@ class WAFContextWrapper {
       metrics.wafTimeout = result.timeout
 
       if (ruleTriggered) {
-        Reporter.reportAttack(JSON.stringify(result.events))
+        Reporter.reportAttack(result.events)
       }
 
       Reporter.reportDerivatives(result.derivatives)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -465,6 +465,9 @@ class Config {
     this._setValue(defaults, 'appsec.blockedTemplateJson', undefined)
     this._setValue(defaults, 'appsec.enabled', undefined)
     this._setValue(defaults, 'appsec.eventTracking.mode', 'identification')
+    this._setValue(defaults, 'appsec.extendedHeadersCollection.enabled', false)
+    this._setValue(defaults, 'appsec.extendedHeadersCollection.redaction', true)
+    this._setValue(defaults, 'appsec.extendedHeadersCollection.maxHeaders', 50)
     this._setValue(defaults, 'appsec.obfuscatorKeyRegex', defaultWafObfuscatorKeyRegex)
     this._setValue(defaults, 'appsec.obfuscatorValueRegex', defaultWafObfuscatorValueRegex)
     this._setValue(defaults, 'appsec.rasp.enabled', true)
@@ -645,10 +648,13 @@ class Config {
       DD_APM_TRACING_ENABLED,
       DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE,
       DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING,
+      DD_APPSEC_COLLECT_ALL_HEADERS,
       DD_APPSEC_ENABLED,
       DD_APPSEC_GRAPHQL_BLOCKED_TEMPLATE_JSON,
+      DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED,
       DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML,
       DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON,
+      DD_APPSEC_MAX_COLLECTED_HEADERS,
       DD_APPSEC_MAX_STACK_TRACES,
       DD_APPSEC_MAX_STACK_TRACE_DEPTH,
       DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP,
@@ -803,6 +809,13 @@ class Config {
       DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE,
       DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING // TODO: remove in next major
     ))
+    this._setBoolean(env,'appsec.extendedHeadersCollection.enabled', DD_APPSEC_COLLECT_ALL_HEADERS)
+    this._setBoolean(
+      env,
+      'appsec.extendedHeadersCollection.redaction',
+      DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED
+    )
+    this._setValue(env, 'appsec.extendedHeadersCollection.maxHeaders', DD_APPSEC_MAX_COLLECTED_HEADERS)
     this._setString(env, 'appsec.obfuscatorKeyRegex', DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP)
     this._setString(env, 'appsec.obfuscatorValueRegex', DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
     this._setBoolean(env, 'appsec.rasp.enabled', DD_APPSEC_RASP_ENABLED)
@@ -1018,6 +1031,20 @@ class Config {
     this._optsUnprocessed['appsec.blockedTemplateJson'] = options.appsec?.blockedTemplateJson
     this._setBoolean(opts, 'appsec.enabled', options.appsec?.enabled)
     this._setString(opts, 'appsec.eventTracking.mode', options.appsec?.eventTracking?.mode)
+    this._setBoolean(
+      opts,
+      'appsec.extendedHeadersCollection.enabled',
+      options.appsec?.extendedHeadersCollection?.enabled
+    )
+    this._setBoolean(
+      opts,
+      'appsec.extendedHeadersCollection.redaction',
+      options.appsec?.extendedHeadersCollection?.redaction
+    )
+    this._setValue(opts,
+      'appsec.extendedHeadersCollection.maxHeaders',
+      options.appsec?.extendedHeadersCollection?.maxHeaders
+    )
     this._setString(opts, 'appsec.obfuscatorKeyRegex', options.appsec?.obfuscatorKeyRegex)
     this._setString(opts, 'appsec.obfuscatorValueRegex', options.appsec?.obfuscatorValueRegex)
     this._setBoolean(opts, 'appsec.rasp.enabled', options.appsec?.rasp?.enabled)

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -471,6 +471,7 @@ class Config {
     this._setValue(defaults, 'appsec.obfuscatorKeyRegex', defaultWafObfuscatorKeyRegex)
     this._setValue(defaults, 'appsec.obfuscatorValueRegex', defaultWafObfuscatorValueRegex)
     this._setValue(defaults, 'appsec.rasp.enabled', true)
+    this._setValue(defaults, 'appsec.rasp.bodyCollection', false)
     this._setValue(defaults, 'appsec.rateLimit', 100)
     this._setValue(defaults, 'appsec.rules', undefined)
     this._setValue(defaults, 'appsec.sca.enabled', null)
@@ -663,6 +664,7 @@ class Config {
       DD_APPSEC_SCA_ENABLED,
       DD_APPSEC_STACK_TRACE_ENABLED,
       DD_APPSEC_RASP_ENABLED,
+      DD_APPSEC_RASP_COLLECT_REQUEST_BODY,
       DD_APPSEC_TRACE_RATE_LIMIT,
       DD_APPSEC_WAF_TIMEOUT,
       DD_CRASHTRACKING_ENABLED,
@@ -819,6 +821,7 @@ class Config {
     this._setString(env, 'appsec.obfuscatorKeyRegex', DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP)
     this._setString(env, 'appsec.obfuscatorValueRegex', DD_APPSEC_OBFUSCATION_PARAMETER_VALUE_REGEXP)
     this._setBoolean(env, 'appsec.rasp.enabled', DD_APPSEC_RASP_ENABLED)
+    this._setBoolean(env, 'appsec.rasp.bodyCollection', DD_APPSEC_RASP_COLLECT_REQUEST_BODY)
     this._setValue(env, 'appsec.rateLimit', maybeInt(DD_APPSEC_TRACE_RATE_LIMIT))
     this._envUnprocessed['appsec.rateLimit'] = DD_APPSEC_TRACE_RATE_LIMIT
     this._setString(env, 'appsec.rules', DD_APPSEC_RULES)
@@ -1048,6 +1051,7 @@ class Config {
     this._setString(opts, 'appsec.obfuscatorKeyRegex', options.appsec?.obfuscatorKeyRegex)
     this._setString(opts, 'appsec.obfuscatorValueRegex', options.appsec?.obfuscatorValueRegex)
     this._setBoolean(opts, 'appsec.rasp.enabled', options.appsec?.rasp?.enabled)
+    this._setBoolean(opts, 'appsec.rasp.bodyCollection', options.appsec?.rasp?.bodyCollection)
     this._setValue(opts, 'appsec.rateLimit', maybeInt(options.appsec?.rateLimit))
     this._optsUnprocessed['appsec.rateLimit'] = options.appsec?.rateLimit
     this._setString(opts, 'appsec.rules', options.appsec?.rules)

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -287,7 +287,7 @@ describe('reporter', () => {
     it('should add tags to request span when socket is not there', () => {
       delete req.socket
 
-      const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]')
+      const result = Reporter.reportAttack([{"rule":{},"rule_matches":[{}]}])
 
       expect(result).to.not.be.false
       expect(web.root).to.have.been.calledOnceWith(req)
@@ -302,7 +302,7 @@ describe('reporter', () => {
     })
 
     it('should add tags to request span', () => {
-      const result = Reporter.reportAttack('[{"rule":{},"rule_matches":[{}]}]')
+      const result = Reporter.reportAttack([{"rule":{},"rule_matches":[{}]}])
       expect(result).to.not.be.false
       expect(web.root).to.have.been.calledOnceWith(req)
 
@@ -319,27 +319,27 @@ describe('reporter', () => {
     it('should not add manual.keep when rate limit is reached', (done) => {
       const addTags = span.addTags
 
-      expect(Reporter.reportAttack('')).to.not.be.false
-      expect(Reporter.reportAttack('')).to.not.be.false
-      expect(Reporter.reportAttack('')).to.not.be.false
+      expect(Reporter.reportAttack([])).to.not.be.false
+      expect(Reporter.reportAttack([])).to.not.be.false
+      expect(Reporter.reportAttack([])).to.not.be.false
 
       expect(prioritySampler.setPriority).to.have.callCount(3)
       expect(telemetry.updateRateLimitedMetric).to.not.have.been.called
 
       Reporter.setRateLimit(1)
 
-      expect(Reporter.reportAttack('')).to.not.be.false
+      expect(Reporter.reportAttack([])).to.not.be.false
       expect(addTags.getCall(3).firstArg).to.have.property('appsec.event').that.equals('true')
       expect(prioritySampler.setPriority).to.have.callCount(4)
       expect(telemetry.updateRateLimitedMetric).to.not.have.been.called
 
-      expect(Reporter.reportAttack('')).to.not.be.false
+      expect(Reporter.reportAttack([])).to.not.be.false
       expect(addTags.getCall(4).firstArg).to.have.property('appsec.event').that.equals('true')
       expect(prioritySampler.setPriority).to.have.callCount(4)
       expect(telemetry.updateRateLimitedMetric).to.be.calledOnceWithExactly(req)
 
       setTimeout(() => {
-        expect(Reporter.reportAttack('')).to.not.be.false
+        expect(Reporter.reportAttack([])).to.not.be.false
         expect(prioritySampler.setPriority).to.have.callCount(5)
         expect(telemetry.updateRateLimitedMetric).to.be.calledOnceWithExactly(req)
         done()
@@ -349,7 +349,7 @@ describe('reporter', () => {
     it('should not overwrite origin tag', () => {
       span.context()._tags = { '_dd.origin': 'tracer' }
 
-      const result = Reporter.reportAttack('[]')
+      const result = Reporter.reportAttack([])
       expect(result).to.not.be.false
       expect(web.root).to.have.been.calledOnceWith(req)
 
@@ -365,7 +365,7 @@ describe('reporter', () => {
     it('should merge attacks json', () => {
       span.context()._tags = { '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}' }
 
-      const result = Reporter.reportAttack('[{"rule":{}},{"rule":{},"rule_matches":[{}]}]')
+      const result = Reporter.reportAttack([{"rule":{}},{"rule":{},"rule_matches":[{}]}])
       expect(result).to.not.be.false
       expect(web.root).to.have.been.calledOnceWith(req)
 
@@ -382,7 +382,7 @@ describe('reporter', () => {
     it('should call standalone sample', () => {
       span.context()._tags = { '_dd.appsec.json': '{"triggers":[{"rule":{},"rule_matches":[{}]}]}' }
 
-      const result = Reporter.reportAttack('[{"rule":{}},{"rule":{},"rule_matches":[{}]}]')
+      const result = Reporter.reportAttack([{"rule":{}},{"rule":{},"rule_matches":[{}]}])
       expect(result).to.not.be.false
       expect(web.root).to.have.been.calledOnceWith(req)
 

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -581,15 +581,13 @@ describe('reporter', () => {
       Reporter.finishRequest(req, res)
       expect(web.root).to.have.been.calledOnceWith(req)
 
-      expect(span.addTags).to.have.been.calledTwice
-      expect(span.addTags.firstCall).to.have.been.calledWithExactly({
-        'http.request.headers.x-cloud-trace-context': 'd'
-      })
-      expect(span.addTags.secondCall).to.have.been.calledWithExactly({
+      expect(span.addTags).to.have.been.calledOnce
+      const expectedTags = {
+        'http.request.headers.x-cloud-trace-context': 'd',
         'http.response.headers.content-type': 'application/json',
         'http.response.headers.content-length': '42',
         'http.endpoint': '/path/:param'
-      })
+      }
     })
 
     it('should add http response data inside request span without endpoint', () => {
@@ -630,11 +628,14 @@ describe('reporter', () => {
 
       Reporter.finishRequest(req, res)
 
-      expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni'
-      })
+      const expectedTags = Object.assign(
+        expectedRequestTagsToTrackOnEvent,
+        {
+          'http.request.headers.user-agent': 'arachni'
+        }
+      )
 
-      expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
+      expect(span.addTags).to.have.been.calledWithExactly(expectedTags)
     })
 
     it('should add http request data inside request span when user login success is tracked', () => {
@@ -655,11 +656,14 @@ describe('reporter', () => {
 
       Reporter.finishRequest(req, res)
 
-      expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni'
-      })
+      const expectedTags = Object.assign(
+        expectedRequestTagsToTrackOnEvent,
+        {
+          'http.request.headers.user-agent': 'arachni'
+        }
+      )
 
-      expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
+      expect(span.addTags).to.have.been.calledWithExactly(expectedTags)
     })
 
     it('should add http request data inside request span when user login failure is tracked', () => {
@@ -680,11 +684,14 @@ describe('reporter', () => {
 
       Reporter.finishRequest(req, res)
 
-      expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni'
-      })
+      const expectedTags = Object.assign(
+        expectedRequestTagsToTrackOnEvent,
+        {
+          'http.request.headers.user-agent': 'arachni'
+        }
+      )
 
-      expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
+      expect(span.addTags).to.have.been.calledWithExactly(expectedTags)
     })
 
     it('should add http request data inside request span when user custom event is tracked', () => {
@@ -705,11 +712,14 @@ describe('reporter', () => {
 
       Reporter.finishRequest(req, res)
 
-      expect(span.addTags).to.have.been.calledWithExactly({
-        'http.request.headers.user-agent': 'arachni'
-      })
+      const expectedTags = Object.assign(
+        expectedRequestTagsToTrackOnEvent,
+        {
+          'http.request.headers.user-agent': 'arachni'
+        }
+      )
 
-      expect(span.addTags).to.have.been.calledWithExactly(expectedRequestTagsToTrackOnEvent)
+      expect(span.addTags).to.have.been.calledWithExactly(expectedTags)
     })
 
     it('should call incrementWafRequestsMetric', () => {

--- a/packages/dd-trace/test/appsec/waf/index.spec.js
+++ b/packages/dd-trace/test/appsec/waf/index.spec.js
@@ -325,7 +325,7 @@ describe('WAF Manager', () => {
 
         wafContextWrapper.run(params)
 
-        expect(Reporter.reportAttack).to.be.calledOnceWithExactly('["ATTACK DATA"]')
+        expect(Reporter.reportAttack).to.be.calledOnceWithExactly(['ATTACK DATA'])
       })
 
       it('should report if rule is triggered', () => {

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -508,6 +508,9 @@ describe('Config', () => {
     process.env.DD_APPSEC_GRAPHQL_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_GRAPHQL_PATH
     process.env.DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING = 'extended'
     process.env.DD_APPSEC_SCA_ENABLED = true
+    process.env.DD_APPSEC_COLLECT_ALL_HEADERS = true
+    process.env.DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED = false
+    process.env.DD_APPSEC_MAX_COLLECTED_HEADERS = 42
     process.env.DD_REMOTE_CONFIGURATION_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = '42'
     process.env.DD_IAST_ENABLED = 'true'
@@ -625,6 +628,9 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.blockedTemplateJson', BLOCKED_TEMPLATE_JSON)
     expect(config).to.have.nested.property('appsec.blockedTemplateGraphql', BLOCKED_TEMPLATE_GRAPHQL)
     expect(config).to.have.nested.property('appsec.eventTracking.mode', 'extended')
+    expect(config).to.have.nested.property('appsec.extendedHeadersCollection.enabled', true)
+    expect(config).to.have.nested.property('appsec.extendedHeadersCollection.redaction', false)
+    expect(config).to.have.nested.property('appsec.extendedHeadersCollection.maxHeaders', 42)
     expect(config).to.have.nested.property('appsec.apiSecurity.enabled', true)
     expect(config).to.have.nested.property('appsec.apiSecurity.sampleDelay', 25)
     expect(config).to.have.nested.property('appsec.sca.enabled', true)
@@ -659,6 +665,9 @@ describe('Config', () => {
       { name: 'appsec.blockedTemplateJson', value: BLOCKED_TEMPLATE_JSON_PATH, origin: 'env_var' },
       { name: 'appsec.enabled', value: true, origin: 'env_var' },
       { name: 'appsec.eventTracking.mode', value: 'extended', origin: 'env_var' },
+      { name: 'appsec.extendedHeadersCollection.enabled', value: true, origin: 'env_var' },
+      { name: 'appsec.extendedHeadersCollection.redaction', value: false, origin: 'env_var' },
+      { name: 'appsec.extendedHeadersCollection.maxHeaders', value: 42, origin: 'env_var' },
       { name: 'appsec.obfuscatorKeyRegex', value: '.*', origin: 'env_var' },
       { name: 'appsec.obfuscatorValueRegex', value: '.*', origin: 'env_var' },
       { name: 'appsec.rateLimit', value: '42', origin: 'env_var' },
@@ -1309,6 +1318,9 @@ describe('Config', () => {
     process.env.DD_APPSEC_GRAPHQL_BLOCKED_TEMPLATE_JSON = BLOCKED_TEMPLATE_JSON_PATH // json and html here
     process.env.DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE = 'disabled'
     process.env.DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING = 'disabled'
+    process.env.DD_APPSEC_COLLECT_ALL_HEADERS = 'false'
+    process.env.DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED = 'false'
+    process.env.DD_APPSEC_MAX_COLLECTED_HEADERS = 11
     process.env.DD_API_SECURITY_ENABLED = 'false'
     process.env.DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS = 11
     process.env.DD_IAST_ENABLED = 'false'
@@ -1392,6 +1404,11 @@ describe('Config', () => {
           enabled: false,
           maxDepth: 42,
           maxStackTraces: 5
+        },
+        extendedHeadersCollection: {
+          enabled: true,
+          redaction: true,
+          maxHeaders: 42,
         }
       },
       iast: {
@@ -1474,6 +1491,9 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.blockedTemplateGraphql', BLOCKED_TEMPLATE_GRAPHQL)
     expect(config).to.have.nested.property('appsec.eventTracking.mode', 'anonymous')
     expect(config).to.have.nested.property('appsec.apiSecurity.enabled', true)
+    expect(config).to.have.nested.property('appsec.extendedHeadersCollection.enabled', true)
+    expect(config).to.have.nested.property('appsec.extendedHeadersCollection.redaction', true)
+    expect(config).to.have.nested.property('appsec.extendedHeadersCollection.maxHeaders', 42)
     expect(config).to.have.nested.property('remoteConfig.pollInterval', 42)
     expect(config).to.have.nested.property('iast.enabled', true)
     expect(config).to.have.nested.property('iast.requestSampling', 30)

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -247,6 +247,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('appsec.enabled', undefined)
     expect(config).to.have.nested.property('appsec.rules', undefined)
     expect(config).to.have.nested.property('appsec.rasp.enabled', true)
+    expect(config).to.have.nested.property('appsec.rasp.bodyCollection', false)
     expect(config).to.have.nested.property('appsec.rateLimit', 100)
     expect(config).to.have.nested.property('appsec.stackTrace.enabled', true)
     expect(config).to.have.nested.property('appsec.stackTrace.maxDepth', 32)
@@ -297,6 +298,7 @@ describe('Config', () => {
         origin: 'default'
       },
       { name: 'appsec.rasp.enabled', value: true, origin: 'default' },
+      { name: 'appsec.rasp.bodyCollection', value: false, origin: 'default' },
       { name: 'appsec.rateLimit', value: 100, origin: 'default' },
       { name: 'appsec.rules', value: undefined, origin: 'default' },
       { name: 'appsec.sca.enabled', value: null, origin: 'default' },
@@ -497,6 +499,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_MAX_STACK_TRACES = '5'
     process.env.DD_APPSEC_MAX_STACK_TRACE_DEPTH = '42'
     process.env.DD_APPSEC_RASP_ENABLED = 'false'
+    process.env.DD_APPSEC_RASP_COLLECT_REQUEST_BODY = 'true'
     process.env.DD_APPSEC_RULES = RULES_JSON_PATH
     process.env.DD_APPSEC_STACK_TRACE_ENABLED = 'false'
     process.env.DD_APPSEC_TRACE_RATE_LIMIT = '42'
@@ -616,6 +619,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('apmTracingEnabled', false)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rasp.enabled', false)
+    expect(config).to.have.nested.property('appsec.rasp.bodyCollection', true)
     expect(config).to.have.nested.property('appsec.rules', RULES_JSON_PATH)
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.stackTrace.enabled', false)
@@ -672,6 +676,7 @@ describe('Config', () => {
       { name: 'appsec.obfuscatorValueRegex', value: '.*', origin: 'env_var' },
       { name: 'appsec.rateLimit', value: '42', origin: 'env_var' },
       { name: 'appsec.rasp.enabled', value: false, origin: 'env_var' },
+      { name: 'appsec.rasp.bodyCollection', value: true, origin: 'env_var' },
       { name: 'appsec.rules', value: RULES_JSON_PATH, origin: 'env_var' },
       { name: 'appsec.stackTrace.enabled', value: false, origin: 'env_var' },
       { name: 'appsec.stackTrace.maxDepth', value: '42', origin: 'env_var' },
@@ -1307,6 +1312,7 @@ describe('Config', () => {
     process.env.DD_APPSEC_MAX_STACK_TRACES = '11'
     process.env.DD_APPSEC_MAX_STACK_TRACE_DEPTH = '11'
     process.env.DD_APPSEC_RASP_ENABLED = 'true'
+    process.env.DD_APPSEC_RASP_COLLECT_REQUEST_BODY = 'false'
     process.env.DD_APPSEC_RULES = RECOMMENDED_JSON_PATH
     process.env.DD_APPSEC_STACK_TRACE_ENABLED = 'true'
     process.env.DD_APPSEC_TRACE_RATE_LIMIT = 11
@@ -1398,7 +1404,8 @@ describe('Config', () => {
           enabled: true
         },
         rasp: {
-          enabled: false
+          enabled: false,
+          bodyCollection: true
         },
         stackTrace: {
           enabled: false,
@@ -1478,6 +1485,7 @@ describe('Config', () => {
     expect(config).to.have.nested.property('apmTracingEnabled', true)
     expect(config).to.have.nested.property('appsec.enabled', true)
     expect(config).to.have.nested.property('appsec.rasp.enabled', false)
+    expect(config).to.have.nested.property('appsec.rasp.bodyCollection', true)
     expect(config).to.have.nested.property('appsec.rules', RULES_JSON_PATH)
     expect(config).to.have.nested.property('appsec.rateLimit', 42)
     expect(config).to.have.nested.property('appsec.stackTrace.enabled', false)
@@ -1530,7 +1538,8 @@ describe('Config', () => {
           enabled: true
         },
         rasp: {
-          enabled: false
+          enabled: false,
+          bodyCollection: true
         }
       },
       iast: {
@@ -1566,7 +1575,8 @@ describe('Config', () => {
             enabled: false
           },
           rasp: {
-            enabled: true
+            enabled: true,
+            bodyCollection: false
           }
         },
         iast: {
@@ -1608,7 +1618,8 @@ describe('Config', () => {
         enabled: null
       },
       rasp: {
-        enabled: false
+        enabled: false,
+        bodyCollection: true
       },
       stackTrace: {
         enabled: true,


### PR DESCRIPTION
### What does this PR do?
Provides a feature to collect additional data:
- Request and response headers on AppSec events, extending the already implemented header collection system.
- Request body on RASP events, reported using `meta_struct`

These collections are ruled by new configurations (see `index.d.ts`)

### Motivation
Meeting the need of more information for the in-depth investigation of high-risk events.

### Additional Notes
[APPSEC-57290](https://datadoghq.atlassian.net/browse/APPSEC-57290)


