### PR TITLE
[DI] Fix race condition bug in certain scenarios when adding/removing probes

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const lock = require('mutexify/promise')()
+const mutex = require('mutexify/promise')()
 const { getGeneratedPosition } = require('./source-maps')
 const session = require('./session')
 const { compile: compileCondition, compileSegments, templateRequiresEvaluation } = require('./condition')
@@ -30,12 +30,12 @@ session.on('scriptLoadingStabilized', () => {
 })
 
 module.exports = {
-  addBreakpoint,
-  removeBreakpoint
+  addBreakpoint: lock(addBreakpoint),
+  removeBreakpoint: lock(removeBreakpoint)
 }
 
 async function addBreakpoint (probe) {
-  if (!sessionStarted) await start()
+  await start()
 
   probes.set(probe.id, probe)
 
@@ -83,42 +83,36 @@ async function addBreakpoint (probe) {
     throw new Error(`Cannot compile expression: ${probe.when.dsl}`, { cause: err })
   }
 
-  const release = await lock()
+  const locationKey = generateLocationKey(scriptId, lineNumber, columnNumber)
+  const breakpoint = locationToBreakpoint.get(locationKey)
 
-  try {
-    const locationKey = generateLocationKey(scriptId, lineNumber, columnNumber)
-    const breakpoint = locationToBreakpoint.get(locationKey)
+  log.debug(
+    '[debugger:devtools_client] %s breakpoint at %s:%d:%d (probe: %s, version: %d)',
+    breakpoint ? 'Updating' : 'Adding', url, lineNumber, columnNumber, probe.id, probe.version
+  )
 
-    log.debug(
-      '[debugger:devtools_client] %s breakpoint at %s:%d:%d (probe: %s, version: %d)',
-      breakpoint ? 'Updating' : 'Adding', url, lineNumber, columnNumber, probe.id, probe.version
-    )
-
-    if (breakpoint) {
-      // A breakpoint already exists at this location, so we need to add the probe to the existing breakpoint
-      await updateBreakpoint(breakpoint, probe)
-    } else {
-      // No breakpoint exists at this location, so we need to create a new one
-      const location = {
-        scriptId,
-        lineNumber: lineNumber - 1, // Beware! lineNumber is zero-indexed
-        columnNumber
-      }
-      let result
-      try {
-        result = await session.post('Debugger.setBreakpoint', {
-          location,
-          condition: probe.condition
-        })
-      } catch (err) {
-        throw new Error(`Error setting breakpoint for probe ${probe.id}`, { cause: err })
-      }
-      probeToLocation.set(probe.id, locationKey)
-      locationToBreakpoint.set(locationKey, { id: result.breakpointId, location, locationKey })
-      breakpointToProbes.set(result.breakpointId, new Map([[probe.id, probe]]))
+  if (breakpoint) {
+    // A breakpoint already exists at this location, so we need to add the probe to the existing breakpoint
+    await updateBreakpoint(breakpoint, probe)
+  } else {
+    // No breakpoint exists at this location, so we need to create a new one
+    const location = {
+      scriptId,
+      lineNumber: lineNumber - 1, // Beware! lineNumber is zero-indexed
+      columnNumber
     }
-  } finally {
-    release()
+    let result
+    try {
+      result = await session.post('Debugger.setBreakpoint', {
+        location,
+        condition: probe.condition
+      })
+    } catch (err) {
+      throw new Error(`Error setting breakpoint for probe ${probe.id}`, { cause: err })
+    }
+    probeToLocation.set(probe.id, locationKey)
+    locationToBreakpoint.set(locationKey, { id: result.breakpointId, location, locationKey })
+    breakpointToProbes.set(result.breakpointId, new Map([[probe.id, probe]]))
   }
 }
 
@@ -133,33 +127,27 @@ async function removeBreakpoint ({ id }) {
 
   probes.delete(id)
 
-  const release = await lock()
+  const locationKey = probeToLocation.get(id)
+  const breakpoint = locationToBreakpoint.get(locationKey)
+  const probesAtLocation = breakpointToProbes.get(breakpoint.id)
 
-  try {
-    const locationKey = probeToLocation.get(id)
-    const breakpoint = locationToBreakpoint.get(locationKey)
-    const probesAtLocation = breakpointToProbes.get(breakpoint.id)
+  probesAtLocation.delete(id)
+  probeToLocation.delete(id)
 
-    probesAtLocation.delete(id)
-    probeToLocation.delete(id)
-
-    if (probesAtLocation.size === 0) {
-      locationToBreakpoint.delete(locationKey)
-      breakpointToProbes.delete(breakpoint.id)
-      if (breakpointToProbes.size === 0) {
-        await stop() // TODO: Will this actually delete the breakpoint?
-      } else {
-        try {
-          await session.post('Debugger.removeBreakpoint', { breakpointId: breakpoint.id })
-        } catch (err) {
-          throw new Error(`Error removing breakpoint for probe ${id}`, { cause: err })
-        }
-      }
+  if (probesAtLocation.size === 0) {
+    locationToBreakpoint.delete(locationKey)
+    breakpointToProbes.delete(breakpoint.id)
+    if (breakpointToProbes.size === 0) {
+      await stop() // This will also remove the breakpoint
     } else {
-      await updateBreakpoint(breakpoint)
+      try {
+        await session.post('Debugger.removeBreakpoint', { breakpointId: breakpoint.id })
+      } catch (err) {
+        throw new Error(`Error removing breakpoint for probe ${id}`, { cause: err })
+      }
     }
-  } finally {
-    release()
+  } else {
+    await updateBreakpoint(breakpoint)
   }
 }
 
@@ -211,6 +199,8 @@ async function reEvaluateProbe (probe) {
 }
 
 async function start () {
+  if (sessionStarted) return
+
   sessionStarted = true
   log.debug('[debugger:devtools_client] Starting debugger')
   await session.post('Debugger.enable')
@@ -226,6 +216,17 @@ function stop () {
   sessionStarted = false
   log.debug('[debugger:devtools_client] Stopping debugger')
   return session.post('Debugger.disable')
+}
+
+function lock (fn) {
+  return async function (...args) {
+    const release = await mutex()
+    try {
+      return await fn(...args)
+    } finally {
+      release()
+    }
+  }
 }
 
 // Only if all probes have a condition can we use a compound condition.


### PR DESCRIPTION
### What does this PR do?

This fixes a few race conditions in the logic related to adding and removing breakpoints:
    
- If there's no active debug session and two probes are being added at the same time, the 2nd of the two might try to attach it self to the session before the first probe has had a chance to start it.
- When removing the last probe, the debug session is stopped. But if another probe is being added while the session is being stopped, the session might not be started up again.
- When adding a new probe while there’s only a single existing probe and that existing probe is also being removed, the breakpoint logic might think it’s the last probe and disable the debugger.

### Additional Notes

There's a lot of whitespace changes in this PR. Enable "Hide whitespace" for an easier review experience 😃 


