### PR TITLE
[test-optimization] [SDTEST-1990] Make compatible Test Optimization instrumentations with Node 24

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -10,6 +10,6 @@ runs:
   steps:
     - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
-        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version == 'latest' && '23' || inputs.version }}
+        node-version: ${{ inputs.version == 'eol' && '16' || inputs.version == 'oldest' && '18' || inputs.version == 'maintenance' && '20' || inputs.version == 'active' && '22' || inputs.version == 'latest' && '24' || inputs.version }}
         check-latest: true
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -70,6 +70,7 @@ jobs:
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      OPTIONS_OVERRIDE: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/node
@@ -92,6 +93,7 @@ jobs:
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      OPTIONS_OVERRIDE: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/node
@@ -148,6 +150,7 @@ jobs:
           CYPRESS_VERSION: ${{ matrix.cypress-version }}
           NODE_OPTIONS: '-r ./ci/init'
           CYPRESS_MODULE_TYPE: ${{ matrix.module-type }}
+          OPTIONS_OVERRIDE: 1
 
 
   integration-vitest:
@@ -156,6 +159,7 @@ jobs:
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      OPTIONS_OVERRIDE: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/node/active-lts

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -155,6 +155,9 @@ jobs:
 
   integration-vitest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [oldest, latest]
     env:
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
@@ -162,7 +165,9 @@ jobs:
       OPTIONS_OVERRIDE: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/node/active-lts
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
       - uses: ./.github/actions/install
       - run: yarn test:integration:vitest
         env:

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -8,6 +8,7 @@ const log = require('../../dd-trace/src/log')
 const testStartCh = channel('ci:cucumber:test:start')
 const testRetryCh = channel('ci:cucumber:test:retry')
 const testFinishCh = channel('ci:cucumber:test:finish') // used for test steps too
+const testFnCh = channel('ci:cucumber:test:fn')
 
 const testStepStartCh = channel('ci:cucumber:test-step:start')
 
@@ -52,7 +53,7 @@ const patched = new WeakSet()
 
 const lastStatusByPickleId = new Map()
 const numRetriesByPickleId = new Map()
-const numAttemptToAsyncResource = new Map()
+const numAttemptToCtx = new Map()
 const newTestsByTestFullname = new Map()
 
 let eventDataCollector = null
@@ -227,15 +228,11 @@ function wrapRun (pl, isLatestVersion) {
   patched.add(pl)
 
   shimmer.wrap(pl.prototype, 'run', run => function () {
-    if (!testStartCh.hasSubscribers) {
+    if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
 
     let numAttempt = 0
-
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-
-    numAttemptToAsyncResource.set(numAttempt, asyncResource)
 
     const testFileAbsolutePath = this.pickle.uri
 
@@ -247,9 +244,9 @@ function wrapRun (pl, isLatestVersion) {
       testSourceLine,
       isParallel: !!process.env.CUCUMBER_WORKER_ID
     }
-    asyncResource.runInAsyncScope(() => {
-      testStartCh.publish(testStartPayload)
-    })
+    const ctx = testStartPayload
+    numAttemptToCtx.set(numAttempt, ctx)
+    testStartCh.runStores(ctx, () => { })
     const promises = {}
     try {
       this.eventBroadcaster.on('envelope', shimmer.wrapFunction(null, () => async (testCase) => {
@@ -265,7 +262,7 @@ function wrapRun (pl, isLatestVersion) {
               // ignore error
             }
 
-            const failedAttemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
+            const failedAttemptCtx = numAttemptToCtx.get(numAttempt)
             const isFirstAttempt = numAttempt++ === 0
             const isAtrRetry = !isFirstAttempt && isFlakyTestRetriesEnabled
 
@@ -273,23 +270,19 @@ function wrapRun (pl, isLatestVersion) {
               await promises.hitBreakpointPromise
             }
 
-            failedAttemptAsyncResource.runInAsyncScope(() => {
-              // the current span will be finished and a new one will be created
-              testRetryCh.publish({ isFirstAttempt, error, isAtrRetry })
-            })
+            // the current span will be finished and a new one will be created
+            testRetryCh.publish({ isFirstAttempt, error, isAtrRetry, ...failedAttemptCtx.currentStore })
 
-            const newAsyncResource = new AsyncResource('bound-anonymous-fn')
-            numAttemptToAsyncResource.set(numAttempt, newAsyncResource)
+            const newCtx = { ...testStartPayload, promises }
+            numAttemptToCtx.set(numAttempt, newCtx)
 
-            newAsyncResource.runInAsyncScope(() => {
-              testStartCh.publish({ ...testStartPayload, promises }) // a new span will be created
-            })
+            testStartCh.runStores(newCtx, () => { })
           }
         }
       }))
       let promise
 
-      asyncResource.runInAsyncScope(() => {
+      testFnCh.runStores(ctx, () => {
         promise = run.apply(this, arguments)
       })
       promise.finally(async () => {
@@ -343,39 +336,40 @@ function wrapRun (pl, isLatestVersion) {
           isEfdRetry = numRetries > 0
         }
 
-        const attemptAsyncResource = numAttemptToAsyncResource.get(numAttempt)
+        const attemptCtx = numAttemptToCtx.get(numAttempt)
 
         const error = getErrorFromCucumberResult(result)
 
         if (promises.hitBreakpointPromise) {
           await promises.hitBreakpointPromise
         }
-        attemptAsyncResource.runInAsyncScope(() => {
-          testFinishCh.publish({
-            status,
-            skipReason,
-            error,
-            isNew,
-            isEfdRetry,
-            isFlakyRetry: numAttempt > 0,
-            isAttemptToFix,
-            isAttemptToFixRetry,
-            hasFailedAllRetries,
-            hasPassedAllRetries,
-            hasFailedAttemptToFix,
-            isDisabled,
-            isQuarantined
-          })
+        testFinishCh.publish({
+          status,
+          skipReason,
+          error,
+          isNew,
+          isEfdRetry,
+          isFlakyRetry: numAttempt > 0,
+          isAttemptToFix,
+          isAttemptToFixRetry,
+          hasFailedAllRetries,
+          hasPassedAllRetries,
+          hasFailedAttemptToFix,
+          isDisabled,
+          isQuarantined,
+          ...attemptCtx.currentStore
         })
       })
       return promise
     } catch (err) {
-      errorCh.publish(err)
-      throw err
+      ctx.err = err
+      errorCh.runStores(ctx, () => {
+        throw err
+      })
     }
   })
   shimmer.wrap(pl.prototype, 'runStep', runStep => function () {
-    if (!testStepStartCh.hasSubscribers) {
+    if (!testFinishCh.hasSubscribers) {
       return runStep.apply(this, arguments)
     }
     const testStep = arguments[0]
@@ -387,9 +381,8 @@ function wrapRun (pl, isLatestVersion) {
       resource = testStep.isHook ? 'hook' : testStep.pickleStep.text
     }
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-    return asyncResource.runInAsyncScope(() => {
-      testStepStartCh.publish({ resource })
+    const ctx = { resource }
+    return testStepStartCh.runStores(ctx, () => {
       try {
         const promise = runStep.apply(this, arguments)
 
@@ -398,12 +391,14 @@ function wrapRun (pl, isLatestVersion) {
             ? getStatusFromResultLatest(result)
             : getStatusFromResult(result)
 
-          testFinishCh.publish({ isStep: true, status, skipReason, errorMessage })
+          testFinishCh.publish({ isStep: true, status, skipReason, errorMessage, ...ctx.currentStore })
         })
         return promise
       } catch (err) {
-        errorCh.publish(err)
-        throw err
+        ctx.err = err
+        errorCh.runStores(ctx, () => {
+          throw err
+        })
       }
     })
   })

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -144,7 +144,7 @@ function getTestContext (test) {
 
 function runnableWrapper (RunnablePackage, libraryConfig) {
   shimmer.wrap(RunnablePackage.prototype, 'run', run => function () {
-    if (!testStartCh.hasSubscribers) {
+    if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
     // Flaky test retries does not work in parallel mode

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -355,6 +355,7 @@ function getOnFailHandler (isMain) {
         // if it's a hook and it has failed, 'test end' will not be called
         testFinishCh.publish({ status: 'fail', hasBeenRetried: isMochaRetry(test), ...testContext.currentStore })
       } else {
+        testContext.err = err
         errorCh.runStores(testContext, () => { })
       }
     }
@@ -368,7 +369,7 @@ function getOnFailHandler (isMain) {
           `"${testOrHook.parent.fullTitle()}" failed with message "${err.message}"`
         )
         testSuiteError.stack = err.stack
-        testSuiteContext.testSuiteError = testSuiteError
+        testSuiteContext.error = testSuiteError
         testSuiteErrorCh.runStores(testSuiteContext, () => { })
       }
     }

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -7,7 +7,7 @@ const {
   addAttemptToFixStringToTestName,
   removeAttemptToFixStringFromTestName
 } = require('../../../dd-trace/src/plugins/util/test')
-const { channel, AsyncResource } = require('../helpers/instrument')
+const { channel } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 
 // test channels
@@ -17,15 +17,16 @@ const testFinishCh = channel('ci:mocha:test:finish')
 const testRetryCh = channel('ci:mocha:test:retry')
 const errorCh = channel('ci:mocha:test:error')
 const skipCh = channel('ci:mocha:test:skip')
+const testFnCh = channel('ci:mocha:test:fn')
 
 // suite channels
 const testSuiteErrorCh = channel('ci:mocha:test-suite:error')
 
 const BREAKPOINT_HIT_GRACE_PERIOD_MS = 200
-const testToAr = new WeakMap()
+const testToContext = new WeakMap()
 const originalFns = new WeakMap()
 const testToStartLine = new WeakMap()
-const testFileToSuiteAr = new Map()
+const testFileToSuiteCtx = new Map()
 const wrappedFunctions = new WeakSet()
 const newTests = {}
 const testsAttemptToFix = new Set()
@@ -125,7 +126,7 @@ function getTestStatus (test) {
   return 'pass'
 }
 
-function getTestToArKey (test) {
+function getTestToContextKey (test) {
   if (!test.fn) {
     return test
   }
@@ -136,9 +137,9 @@ function getTestToArKey (test) {
   return originalFn
 }
 
-function getTestAsyncResource (test) {
-  const key = getTestToArKey(test)
-  return testToAr.get(key)
+function getTestContext (test) {
+  const key = getTestToContextKey(test)
+  return testToContext.get(key)
 }
 
 function runnableWrapper (RunnablePackage, libraryConfig) {
@@ -167,14 +168,17 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
 
     if (isTestHook || this.type === 'test') {
       const test = isTestHook ? this.ctx.currentTest : this
-      const asyncResource = getTestAsyncResource(test)
+      const ctx = getTestContext(test)
 
-      if (asyncResource) {
-        // we bind the test fn to the correct async resource
-        const newFn = asyncResource.bind(this.fn)
+      if (ctx) {
+        const originalFn = this.fn
+        // we bind the test fn to the correct context
+        const newFn = function () {
+          return testFnCh.runStores(ctx, () => originalFn.apply(this, arguments))
+        }
 
         // we store the original function, not to lose it
-        originalFns.set(newFn, this.fn)
+        originalFns.set(newFn, originalFn)
         this.fn = newFn
 
         wrappedFunctions.add(this.fn)
@@ -189,7 +193,6 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
 function getOnTestHandler (isMain) {
   return function (test) {
     const testStartLine = testToStartLine.get(test)
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
 
     // This may be a retry. If this is the case, `test.fn` is already wrapped,
     // so we need to restore it.
@@ -198,7 +201,6 @@ function getOnTestHandler (isMain) {
       test.fn = originalFn
       wrappedFunctions.delete(test.fn)
     }
-    testToAr.set(test.fn, asyncResource)
 
     const {
       file: testSuiteAbsolutePath,
@@ -242,15 +244,15 @@ function getOnTestHandler (isMain) {
       test.pending = true
     }
 
-    asyncResource.runInAsyncScope(() => {
-      testStartCh.publish(testInfo)
-    })
+    const ctx = testInfo
+    testToContext.set(test.fn, ctx)
+    testStartCh.runStores(ctx, () => { })
   }
 }
 
 function getOnTestEndHandler (config) {
   return async function (test) {
-    const asyncResource = getTestAsyncResource(test)
+    const ctx = getTestContext(test)
     const status = getTestStatus(test)
 
     // After finishing it might take a bit for the snapshot to be handled.
@@ -295,18 +297,17 @@ function getOnTestEndHandler (config) {
       !test._ddIsEfdRetry
 
     // if there are afterEach to be run, we don't finish the test yet
-    if (asyncResource && !getAfterEachHooks(test).length) {
-      asyncResource.runInAsyncScope(() => {
-        testFinishCh.publish({
-          status,
-          hasBeenRetried: isMochaRetry(test),
-          isLastRetry: getIsLastRetry(test),
-          hasFailedAllRetries,
-          attemptToFixPassed,
-          attemptToFixFailed,
-          isAttemptToFixRetry,
-          isAtrRetry
-        })
+    if (ctx && !getAfterEachHooks(test).length) {
+      testFinishCh.publish({
+        status,
+        hasBeenRetried: isMochaRetry(test),
+        isLastRetry: getIsLastRetry(test),
+        hasFailedAllRetries,
+        attemptToFixPassed,
+        attemptToFixFailed,
+        isAttemptToFixRetry,
+        isAtrRetry,
+        ...ctx.currentStore
       })
     }
   }
@@ -320,10 +321,13 @@ function getOnHookEndHandler () {
       const isLastAfterEach = afterEachHooks.indexOf(hook) === afterEachHooks.length - 1
       if (isLastAfterEach) {
         const status = getTestStatus(test)
-        const asyncResource = getTestAsyncResource(test)
-        if (asyncResource) {
-          asyncResource.runInAsyncScope(() => {
-            testFinishCh.publish({ status, hasBeenRetried: isMochaRetry(test), isLastRetry: getIsLastRetry(test) })
+        const ctx = getTestContext(test)
+        if (ctx) {
+          testFinishCh.publish({
+            status,
+            hasBeenRetried: isMochaRetry(test),
+            isLastRetry: getIsLastRetry(test),
+            ...ctx.currentStore
           })
         }
       }
@@ -339,35 +343,33 @@ function getOnFailHandler (isMain) {
     if (isHook && testOrHook.ctx) {
       test = testOrHook.ctx.currentTest
     }
-    let testAsyncResource
+    let testContext
     if (test) {
-      testAsyncResource = getTestAsyncResource(test)
+      testContext = getTestContext(test)
     }
-    if (testAsyncResource) {
-      testAsyncResource.runInAsyncScope(() => {
-        if (isHook) {
-          err.message = `${testOrHook.fullTitle()}: ${err.message}`
-          errorCh.publish(err)
-          // if it's a hook and it has failed, 'test end' will not be called
-          testFinishCh.publish({ status: 'fail', hasBeenRetried: isMochaRetry(test) })
-        } else {
-          errorCh.publish(err)
-        }
-      })
+    if (testContext) {
+      if (isHook) {
+        err.message = `${testOrHook.fullTitle()}: ${err.message}`
+        testContext.err = err
+        errorCh.runStores(testContext, () => { })
+        // if it's a hook and it has failed, 'test end' will not be called
+        testFinishCh.publish({ status: 'fail', hasBeenRetried: isMochaRetry(test), ...testContext.currentStore })
+      } else {
+        errorCh.runStores(testContext, () => { })
+      }
     }
 
     if (isMain) {
-      const testSuiteAsyncResource = testFileToSuiteAr.get(testFile)
+      const testSuiteContext = testFileToSuiteCtx.get(testFile)
 
-      if (testSuiteAsyncResource) {
+      if (testSuiteContext) {
         // we propagate the error to the suite
         const testSuiteError = new Error(
           `"${testOrHook.parent.fullTitle()}" failed with message "${err.message}"`
         )
         testSuiteError.stack = err.stack
-        testSuiteAsyncResource.runInAsyncScope(() => {
-          testSuiteErrorCh.publish(testSuiteError)
-        })
+        testSuiteContext.testSuiteError = testSuiteError
+        testSuiteErrorCh.runStores(testSuiteContext, () => { })
       }
     }
   }
@@ -375,20 +377,18 @@ function getOnFailHandler (isMain) {
 
 function getOnTestRetryHandler (config) {
   return function (test, err) {
-    const asyncResource = getTestAsyncResource(test)
-    if (asyncResource) {
+    const ctx = getTestContext(test)
+    if (ctx) {
       const isFirstAttempt = test._currentRetry === 0
       const willBeRetried = test._currentRetry < test._retries
       const isAtrRetry = !isFirstAttempt &&
         config.isFlakyTestRetriesEnabled &&
         !test._ddIsAttemptToFix &&
         !test._ddIsEfdRetry
-      asyncResource.runInAsyncScope(() => {
-        testRetryCh.publish({ isFirstAttempt, err, willBeRetried, test, isAtrRetry })
-      })
+      testRetryCh.publish({ isFirstAttempt, err, willBeRetried, test, isAtrRetry, ...ctx.currentStore })
     }
-    const key = getTestToArKey(test)
-    testToAr.delete(key)
+    const key = getTestToContextKey(test)
+    testToContext.delete(key)
   }
 }
 
@@ -407,23 +407,19 @@ function getOnPendingHandler () {
       testStartLine
     }
 
-    const asyncResource = getTestAsyncResource(test)
-    if (asyncResource) {
-      asyncResource.runInAsyncScope(() => {
-        skipCh.publish(testInfo)
-      })
+    const ctx = getTestContext(test)
+    if (ctx) {
+      skipCh.publish(testInfo)
     } else {
-      // if there is no async resource, the test has been skipped through `test.skip`
+      // if there is no context, the test has been skipped through `test.skip`
       // or the parent suite is skipped
-      const skippedTestAsyncResource = new AsyncResource('bound-anonymous-fn')
+      const testCtx = testInfo
       if (test.fn) {
-        testToAr.set(test.fn, skippedTestAsyncResource)
+        testToContext.set(test.fn, testCtx)
       } else {
-        testToAr.set(test, skippedTestAsyncResource)
+        testToContext.set(test, testCtx)
       }
-      skippedTestAsyncResource.runInAsyncScope(() => {
-        skipCh.publish(testInfo)
-      })
+      skipCh.runStores(testCtx, () => { })
     }
   }
 }
@@ -484,9 +480,9 @@ module.exports = {
   getTestFullName,
   getTestStatus,
   runnableWrapper,
-  testToAr,
+  testToContext,
   originalFns,
-  getTestAsyncResource,
+  getTestContext,
   testToStartLine,
   getOnTestHandler,
   getOnTestEndHandler,
@@ -494,7 +490,7 @@ module.exports = {
   getOnHookEndHandler,
   getOnFailHandler,
   getOnPendingHandler,
-  testFileToSuiteAr,
+  testFileToSuiteCtx,
   getRunTestsWrapper,
   newTests,
   testsQuarantined,

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -11,6 +11,7 @@ const log = require('../../dd-trace/src/log')
 
 const testStartCh = channel('ci:playwright:test:start')
 const testFinishCh = channel('ci:playwright:test:finish')
+const testFnCh = channel('ci:playwright:test:fn')
 
 const testSessionStartCh = channel('ci:playwright:session:start')
 const testSessionFinishCh = channel('ci:playwright:session:finish')
@@ -25,8 +26,8 @@ const testSuiteFinishCh = channel('ci:playwright:test-suite:finish')
 const workerReportCh = channel('ci:playwright:worker:report')
 const testPageGotoCh = channel('ci:playwright:test:page-goto')
 
-const testToAr = new WeakMap()
-const testSuiteToAr = new Map()
+const testToCtx = new WeakMap()
+const testSuiteToCtx = new Map()
 const testSuiteToTestStatuses = new Map()
 const testSuiteToErrors = new Map()
 const testsToTestStatuses = new Map()
@@ -279,11 +280,9 @@ function testBeginHandler (test, browserName, isMainProcess) {
 
   if (isNewTestSuite) {
     startedSuites.push(testSuiteAbsolutePath)
-    const testSuiteAsyncResource = new AsyncResource('bound-anonymous-fn')
-    testSuiteToAr.set(testSuiteAbsolutePath, testSuiteAsyncResource)
-    testSuiteAsyncResource.runInAsyncScope(() => {
-      testSuiteStartCh.publish(testSuiteAbsolutePath)
-    })
+    const testSuiteCtx = { testSuiteAbsolutePath }
+    testSuiteToCtx.set(testSuiteAbsolutePath, testSuiteCtx)
+    testSuiteStartCh.runStores(testSuiteCtx, () => { })
   }
 
   // We disable retries by default if attemptToFix is true
@@ -293,19 +292,17 @@ function testBeginHandler (test, browserName, isMainProcess) {
 
   // this handles tests that do not go through the worker process (because they're skipped)
   if (isMainProcess) {
-    const testAsyncResource = new AsyncResource('bound-anonymous-fn')
-    testToAr.set(test, testAsyncResource)
     const testName = getTestFullname(test)
+    const testCtx = {
+      testName,
+      testSuiteAbsolutePath,
+      testSourceLine,
+      browserName,
+      isDisabled: test._ddIsDisabled
+    }
+    testToCtx.set(test, testCtx)
 
-    testAsyncResource.runInAsyncScope(() => {
-      testStartCh.publish({
-        testName,
-        testSuiteAbsolutePath,
-        testSourceLine,
-        browserName,
-        isDisabled: test._ddIsDisabled
-      })
-    })
+    testStartCh.runStores(testCtx, () => { })
   }
 }
 
@@ -350,28 +347,27 @@ function testEndHandler (test, annotations, testStatus, error, isTimeout, isMain
   // this handles tests that do not go through the worker process (because they're skipped)
   if (isMainProcess) {
     const testResult = results[results.length - 1]
-    const testAsyncResource = testToAr.get(test)
+    const testCtx = testToCtx.get(test)
     const isAtrRetry = testResult?.retry > 0 &&
       isFlakyTestRetriesEnabled &&
       !test._ddIsAttemptToFix &&
       !test._ddIsEfdRetry
-    testAsyncResource.runInAsyncScope(() => {
-      testFinishCh.publish({
-        testStatus,
-        steps: testResult?.steps || [],
-        isRetry: testResult?.retry > 0,
-        error,
-        extraTags: annotationTags,
-        isNew: test._ddIsNew,
-        isAttemptToFix: test._ddIsAttemptToFix,
-        isAttemptToFixRetry: test._ddIsAttemptToFixRetry,
-        isQuarantined: test._ddIsQuarantined,
-        isEfdRetry: test._ddIsEfdRetry,
-        hasFailedAllRetries: test._ddHasFailedAllRetries,
-        hasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
-        hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
-        isAtrRetry
-      })
+    testFinishCh.publish({
+      testStatus,
+      steps: testResult?.steps || [],
+      isRetry: testResult?.retry > 0,
+      error,
+      extraTags: annotationTags,
+      isNew: test._ddIsNew,
+      isAttemptToFix: test._ddIsAttemptToFix,
+      isAttemptToFixRetry: test._ddIsAttemptToFixRetry,
+      isQuarantined: test._ddIsQuarantined,
+      isEfdRetry: test._ddIsEfdRetry,
+      hasFailedAllRetries: test._ddHasFailedAllRetries,
+      hasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
+      hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
+      isAtrRetry,
+      ...testCtx.currentStore
     })
   }
 
@@ -401,10 +397,8 @@ function testEndHandler (test, annotations, testStatus, error, isTimeout, isMain
     }
 
     const suiteError = getTestSuiteError(testSuiteAbsolutePath)
-    const testSuiteAsyncResource = testSuiteToAr.get(testSuiteAbsolutePath)
-    testSuiteAsyncResource.runInAsyncScope(() => {
-      testSuiteFinishCh.publish({ status: testSuiteStatus, error: suiteError })
-    })
+    const testSuiteCtx = testSuiteToCtx.get(testSuiteAbsolutePath)
+    testSuiteFinishCh.publish({ status: testSuiteStatus, error: suiteError, ...testSuiteCtx.currentStore })
   }
 }
 
@@ -873,17 +867,16 @@ addHook({
     // If test events are created in the worker process I need to stop creating it in the main process
     // Probably yet another test worker exporter is needed in addition to the ones for mocha, jest and cucumber
     // it's probably hard to tell that's a playwright worker though, as I don't think there is a specific env variable
-    const testAsyncResource = new AsyncResource('bound-anonymous-fn')
+    const testCtx = {
+      testName,
+      testSuiteAbsolutePath,
+      testSourceLine,
+      browserName
+    }
+    testToCtx.set(test, testCtx)
     // TODO - In the future we may need to implement a mechanism to send test properties
     // to the worker process before _runTest is called
-    testAsyncResource.runInAsyncScope(() => {
-      testStartCh.publish({
-        testName,
-        testSuiteAbsolutePath,
-        testSourceLine,
-        browserName
-      })
-
+    testStartCh.runStores(testCtx, () => {
       let existAfterEachHook = false
 
       // We try to find an existing afterEach hook with _ddHook to avoid adding a new one
@@ -933,7 +926,9 @@ addHook({
         })
       }
 
-      res = _runTest.apply(this, arguments)
+      testFnCh.runStores(testCtx, () => {
+        res = _runTest.apply(this, arguments)
+      })
 
       testInfo = this._currentTest
     })
@@ -976,25 +971,24 @@ addHook({
     // Wait for the properties to be received
     await ddPropertiesPromise
 
-    testAsyncResource.runInAsyncScope(() => {
-      testFinishCh.publish({
-        testStatus: STATUS_TO_TEST_STATUS[status],
-        steps: steps.filter(step => step.testId === testId),
-        error,
-        extraTags: annotationTags,
-        isNew: test._ddIsNew,
-        isRetry: retry > 0,
-        isEfdRetry: test._ddIsEfdRetry,
-        isAttemptToFix: test._ddIsAttemptToFix,
-        isDisabled: test._ddIsDisabled,
-        isQuarantined: test._ddIsQuarantined,
-        isAttemptToFixRetry: test._ddIsAttemptToFixRetry,
-        hasFailedAllRetries: test._ddHasFailedAllRetries,
-        hasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
-        hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
-        isAtrRetry: test._ddIsAtrRetry,
-        onDone
-      })
+    testFinishCh.publish({
+      testStatus: STATUS_TO_TEST_STATUS[status],
+      steps: steps.filter(step => step.testId === testId),
+      error,
+      extraTags: annotationTags,
+      isNew: test._ddIsNew,
+      isRetry: retry > 0,
+      isEfdRetry: test._ddIsEfdRetry,
+      isAttemptToFix: test._ddIsAttemptToFix,
+      isDisabled: test._ddIsDisabled,
+      isQuarantined: test._ddIsQuarantined,
+      isAttemptToFixRetry: test._ddIsAttemptToFixRetry,
+      hasFailedAllRetries: test._ddHasFailedAllRetries,
+      hasPassedAttemptToFixRetries: test._ddHasPassedAttemptToFixRetries,
+      hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
+      isAtrRetry: test._ddIsAtrRetry,
+      onDone,
+      ...testCtx.currentStore
     })
 
     await flushPromise

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -26,7 +26,7 @@ const knownTestsCh = channel('ci:vitest:known-tests')
 const isEarlyFlakeDetectionFaultyCh = channel('ci:vitest:is-early-flake-detection-faulty')
 const testManagementTestsCh = channel('ci:vitest:test-management-tests')
 
-const taskToAsync = new WeakMap()
+const taskToCtx = new WeakMap()
 const taskToStatuses = new WeakMap()
 const newTasks = new WeakSet()
 const disabledTasks = new WeakSet()
@@ -455,7 +455,7 @@ addHook({
   // test start (only tests that are not marked as skip or todo)
   // `onBeforeTryTask` is run for every repetition and attempt of the test
   shimmer.wrap(VitestTestRunner.prototype, 'onBeforeTryTask', onBeforeTryTask => async function (task, retryInfo) {
-    if (!testStartCh.hasSubscribers) {
+    if (!testPassCh.hasSubscribers && !testErrorCh.hasSubscribers && !testSkipCh.hasSubscribers) {
       return onBeforeTryTask.apply(this, arguments)
     }
     const testName = getTestName(task)
@@ -500,15 +500,14 @@ addHook({
 
       const promises = {}
       const shouldSetProbe = isDiEnabled && numAttempt === 1
-      const asyncResource = taskToAsync.get(task)
+      const ctx = taskToCtx.get(task)
       const testError = task.result?.errors?.[0]
-      if (asyncResource) {
-        asyncResource.runInAsyncScope(() => {
-          testErrorCh.publish({
-            error: testError,
-            shouldSetProbe,
-            promises
-          })
+      if (ctx) {
+        testErrorCh.publish({
+          error: testError,
+          shouldSetProbe,
+          promises,
+          ...ctx.currentStore
         })
         // We wait for the probe to be set
         if (promises.setProbePromise) {
@@ -528,17 +527,13 @@ addHook({
       // as long as it's not the _last_ iteration (which will be finished normally)
 
       // TODO: check test duration (not to repeat if it's too slow)
-      const asyncResource = taskToAsync.get(task)
-      if (asyncResource) {
+      const ctx = taskToCtx.get(task)
+      if (ctx) {
         if (lastExecutionStatus === 'fail') {
           const testError = task.result?.errors?.[0]
-          asyncResource.runInAsyncScope(() => {
-            testErrorCh.publish({ error: testError })
-          })
+          testErrorCh.publish({ error: testError, ...ctx.currentStore })
         } else {
-          asyncResource.runInAsyncScope(() => {
-            testPassCh.publish({ task })
-          })
+          testPassCh.publish({ task, ...ctx.currentStore })
         }
         if (shouldFlipStatus) {
           statuses.push(lastExecutionStatus)
@@ -555,16 +550,12 @@ addHook({
         statuses.push(lastExecutionStatus)
       }
 
-      const asyncResource = taskToAsync.get(task)
+      const ctx = taskToCtx.get(task)
       if (lastExecutionStatus === 'fail') {
         const testError = task.result?.errors?.[0]
-        asyncResource.runInAsyncScope(() => {
-          testErrorCh.publish({ error: testError })
-        })
+        testErrorCh.publish({ error: testError, ...ctx.currentStore })
       } else {
-        asyncResource.runInAsyncScope(() => {
-          testPassCh.publish({ task })
-        })
+        testPassCh.publish({ task, ...ctx.currentStore })
       }
     }
 
@@ -573,31 +564,29 @@ addHook({
       !isRetryReasonAttemptToFix &&
       !isRetryReasonEfd
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-    taskToAsync.set(task, asyncResource)
+    const ctx = {
+      testName,
+      testSuiteAbsolutePath: task.file.filepath,
+      isRetry: numAttempt > 0 || numRepetition > 0,
+      isRetryReasonEfd,
+      isRetryReasonAttemptToFix: isRetryReasonAttemptToFix && numRepetition > 0,
+      isNew,
+      mightHitProbe: isDiEnabled && numAttempt > 0,
+      isAttemptToFix: attemptToFixTasks.has(task),
+      isDisabled: disabledTasks.has(task),
+      isQuarantined,
+      isRetryReasonAtr
+    }
+    taskToCtx.set(task, ctx)
 
-    asyncResource.runInAsyncScope(() => {
-      testStartCh.publish({
-        testName,
-        testSuiteAbsolutePath: task.file.filepath,
-        isRetry: numAttempt > 0 || numRepetition > 0,
-        isRetryReasonEfd,
-        isRetryReasonAttemptToFix: isRetryReasonAttemptToFix && numRepetition > 0,
-        isNew,
-        mightHitProbe: isDiEnabled && numAttempt > 0,
-        isAttemptToFix: attemptToFixTasks.has(task),
-        isDisabled: disabledTasks.has(task),
-        isQuarantined,
-        isRetryReasonAtr
-      })
-    })
+    testStartCh.runStores(ctx, () => { })
     return onBeforeTryTask.apply(this, arguments)
   })
 
   // test finish (only passed tests)
   shimmer.wrap(VitestTestRunner.prototype, 'onAfterTryTask', onAfterTryTask =>
     async function (task, { retry: retryCount }) {
-      if (!testFinishTimeCh.hasSubscribers) {
+      if (!testPassCh.hasSubscribers && !testErrorCh.hasSubscribers && !testSkipCh.hasSubscribers) {
         return onAfterTryTask.apply(this, arguments)
       }
       const result = await onAfterTryTask.apply(this, arguments)
@@ -605,7 +594,7 @@ addHook({
       const { testManagementAttemptToFixRetries } = getProvidedContext()
 
       const status = getVitestTestStatus(task, retryCount)
-      const asyncResource = taskToAsync.get(task)
+      const ctx = taskToCtx.get(task)
 
       const { isDiEnabled } = getProvidedContext()
 
@@ -626,11 +615,13 @@ addHook({
         }
       }
 
-      if (asyncResource) {
+      if (ctx) {
         // We don't finish here because the test might fail in a later hook (afterEach)
-        asyncResource.runInAsyncScope(() => {
-          testFinishTimeCh.publish({ status, task, attemptToFixPassed, attemptToFixFailed })
-        })
+        ctx.status = status
+        ctx.task = task
+        ctx.attemptToFixPassed = attemptToFixPassed
+        ctx.attemptToFixFailed = attemptToFixFailed
+        testFinishTimeCh.runStores(ctx, () => { })
       }
 
       return result
@@ -728,19 +719,14 @@ addHook({
 }, (vitestPackage, frameworkVersion) => {
   shimmer.wrap(vitestPackage, 'startTests', startTests => async function (testPaths) {
     let testSuiteError = null
-    if (!testSuiteStartCh.hasSubscribers) {
+    if (!testSuiteFinishCh.hasSubscribers) {
       return startTests.apply(this, arguments)
     }
     // From >=3.0.1, the first arguments changes from a string to an object containing the filepath
     const testSuiteAbsolutePath = testPaths[0]?.filepath || testPaths[0]
 
-    const testSuiteAsyncResource = new AsyncResource('bound-anonymous-fn')
-    testSuiteAsyncResource.runInAsyncScope(() => {
-      testSuiteStartCh.publish({
-        testSuiteAbsolutePath,
-        frameworkVersion
-      })
-    })
+    const testSuiteCtx = { testSuiteAbsolutePath, frameworkVersion }
+    testSuiteStartCh.runStores(testSuiteCtx, () => { })
     const startTestsResponse = await startTests.apply(this, arguments)
 
     let onFinish = null
@@ -752,7 +738,7 @@ addHook({
 
     // Only one test task per test, even if there are retries
     testTasks.forEach(task => {
-      const testAsyncResource = taskToAsync.get(task)
+      const testCtx = taskToCtx.get(task)
       const { result } = task
       // We have to trick vitest into thinking that the test has passed
       // but we want to report it as failed if it did fail
@@ -768,10 +754,8 @@ addHook({
             isDisabled: disabledTasks.has(task)
           })
         } else if (state === 'pass' && !isSwitchedStatus) {
-          if (testAsyncResource) {
-            testAsyncResource.runInAsyncScope(() => {
-              testPassCh.publish({ task })
-            })
+          if (testCtx) {
+            testPassCh.publish({ task, ...testCtx.currentStore })
           }
         } else if (state === 'fail' || isSwitchedStatus) {
           let testError
@@ -792,16 +776,15 @@ addHook({
             }
           }
 
-          if (testAsyncResource) {
+          if (testCtx) {
             const isRetry = task.result?.retryCount > 0
             // `duration` is the duration of all the retries, so it can't be used if there are retries
-            testAsyncResource.runInAsyncScope(() => {
-              testErrorCh.publish({
-                duration: !isRetry ? duration : undefined,
-                error: testError,
-                hasFailedAllRetries,
-                attemptToFixFailed
-              })
+            testErrorCh.publish({
+              duration: !isRetry ? duration : undefined,
+              error: testError,
+              hasFailedAllRetries,
+              attemptToFixFailed,
+              ...testCtx.currentStore
             })
           }
           if (errors?.length) {
@@ -831,14 +814,11 @@ addHook({
     }
 
     if (testSuiteError) {
-      testSuiteAsyncResource.runInAsyncScope(() => {
-        testSuiteErrorCh.publish({ error: testSuiteError })
-      })
+      testSuiteCtx.error = testSuiteError
+      testSuiteErrorCh.runStores(testSuiteCtx, () => { })
     }
 
-    testSuiteAsyncResource.runInAsyncScope(() => {
-      testSuiteFinishCh.publish({ status: testSuiteResult.state, onFinish })
-    })
+    testSuiteFinishCh.publish({ status: testSuiteResult.state, onFinish, ...testSuiteCtx.currentStore })
 
     // TODO: fix too frequent flushes
     await onFinishPromise

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -221,13 +221,8 @@ class CucumberPlugin extends CiPlugin {
       this.telemetry.ciVisEvent(TELEMETRY_CODE_COVERAGE_FINISHED, 'suite', { library: 'istanbul' })
     })
 
-    this.addSub('ci:cucumber:test:start', ({
-      testName,
-      testFileAbsolutePath,
-      testSourceLine,
-      isParallel,
-      promises
-    }) => {
+    this.addBind('ci:cucumber:test:start', (ctx) => {
+      const { testName, testFileAbsolutePath, testSourceLine, isParallel, promises } = ctx
       const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testFileAbsolutePath, this.sourceRoot)
       const testSourceFile = getTestSuitePath(testFileAbsolutePath, this.repositoryRoot)
@@ -240,22 +235,23 @@ class CucumberPlugin extends CiPlugin {
         extraTags[CUCUMBER_IS_PARALLEL] = 'true'
       }
 
-      const testSpan = this.startTestSpan(testName, testSuite, extraTags)
+      const span = this.startTestSpan(testName, testSuite, extraTags)
 
-      this.enter(testSpan, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, span }
 
-      this.activeTestSpan = testSpan
+      this.activeTestSpan = span
       // Time we give the breakpoint to be hit
       if (promises && this.runningTestProbe) {
         promises.hitBreakpointPromise = new Promise((resolve) => {
           setTimeout(resolve, BREAKPOINT_HIT_GRACE_PERIOD_MS)
         })
       }
+
+      return ctx.currentStore
     })
 
-    this.addSub('ci:cucumber:test:retry', ({ isFirstAttempt, error, isAtrRetry }) => {
-      const store = storage('legacy').getStore()
-      const span = store.span
+    this.addSub('ci:cucumber:test:retry', ({ span, isFirstAttempt, error, isAtrRetry }) => {
       if (!isFirstAttempt) {
         span.setTag(TEST_IS_RETRY, 'true')
         if (isAtrRetry) {
@@ -284,7 +280,9 @@ class CucumberPlugin extends CiPlugin {
       finishAllTraceSpans(span)
     })
 
-    this.addSub('ci:cucumber:test-step:start', ({ resource }) => {
+    this.addBind('ci:cucumber:test-step:start', (ctx) => {
+      const { resource } = ctx
+
       const store = storage('legacy').getStore()
       const childOf = store ? store.span : store
       const span = this.tracer.startSpan('cucumber.step', {
@@ -295,7 +293,10 @@ class CucumberPlugin extends CiPlugin {
           [RESOURCE_NAME]: resource
         }
       })
-      this.enter(span, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, span }
+
+      return ctx.currentStore
     })
 
     this.addSub('ci:cucumber:worker-report:trace', (traces) => {
@@ -329,6 +330,7 @@ class CucumberPlugin extends CiPlugin {
     })
 
     this.addSub('ci:cucumber:test:finish', ({
+      span,
       isStep,
       status,
       skipReason,
@@ -345,7 +347,6 @@ class CucumberPlugin extends CiPlugin {
       isDisabled,
       isQuarantined
     }) => {
-      const span = storage('legacy').getStore().span
       const statusTag = isStep ? 'step.status' : TEST_STATUS
 
       span.setTag(statusTag, status)
@@ -425,11 +426,21 @@ class CucumberPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:cucumber:error', (err) => {
+    this.addBind('ci:cucumber:error', (ctx) => {
+      const { err } = ctx
       if (err) {
-        const span = storage('legacy').getStore().span
+        const span = ctx.currentStore.span
         span.setTag('error', err)
+
+        ctx.parentStore = ctx.currentStore
+        ctx.currentStore = { ...ctx.currentStore, span }
       }
+
+      return ctx.currentStore
+    })
+
+    this.addBind('ci:cucumber:test:fn', (ctx) => {
+      return ctx.currentStore
     })
   }
 

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -178,10 +178,11 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addBind('ci:mocha:test-suite:error', (ctx) => {
-      const { span, testSuiteError } = ctx
+      const { error } = ctx
+      const span = ctx.currentStore?.span
 
       if (span) {
-        span.setTag('error', testSuiteError)
+        span.setTag('error', error)
         span.setTag(TEST_STATUS, 'fail')
 
         ctx.parentStore = ctx.currentStore
@@ -282,7 +283,8 @@ class MochaPlugin extends CiPlugin {
     })
 
     this.addBind('ci:mocha:test:error', (ctx) => {
-      const { err, span } = ctx
+      const { err } = ctx
+      const span = ctx.currentStore?.span
 
       if (err && span) {
         if (err.constructor.name === 'Pending' && !this.forbidPending) {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -97,7 +97,9 @@ class PlaywrightPlugin extends CiPlugin {
       this.numFailedTests = 0
     })
 
-    this.addSub('ci:playwright:test-suite:start', (testSuiteAbsolutePath) => {
+    this.addBind('ci:playwright:test-suite:start', (ctx) => {
+      const { testSuiteAbsolutePath } = ctx
+
       const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
@@ -126,27 +128,28 @@ class PlaywrightPlugin extends CiPlugin {
         }
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
-      this.enter(testSuiteSpan, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, testSuiteSpan }
 
       this._testSuites.set(testSuiteAbsolutePath, testSuiteSpan)
+
+      return ctx.currentStore
     })
 
-    this.addSub('ci:playwright:test-suite:finish', ({ status, error }) => {
-      const store = storage('legacy').getStore()
-      const span = store && store.span
-      if (!span) return
+    this.addSub('ci:playwright:test-suite:finish', ({ testSuiteSpan, status, error }) => {
+      if (!testSuiteSpan) return
       if (error) {
-        span.setTag('error', error)
-        span.setTag(TEST_STATUS, 'fail')
+        testSuiteSpan.setTag('error', error)
+        testSuiteSpan.setTag(TEST_STATUS, 'fail')
       } else {
-        span.setTag(TEST_STATUS, status)
+        testSuiteSpan.setTag(TEST_STATUS, status)
       }
 
       if (status === 'fail' || error) {
         this.numFailedSuites++
       }
 
-      span.finish()
+      testSuiteSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
     })
 
@@ -180,13 +183,14 @@ class PlaywrightPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:playwright:test:start', ({
-      testName,
-      testSuiteAbsolutePath,
-      testSourceLine,
-      browserName,
-      isDisabled
-    }) => {
+    this.addSub('ci:playwright:test:start', (ctx) => {
+      const {
+        testName,
+        testSuiteAbsolutePath,
+        testSourceLine,
+        browserName,
+        isDisabled
+      } = ctx
       const store = storage('legacy').getStore()
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.rootDir)
       const testSourceFile = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
@@ -203,7 +207,10 @@ class PlaywrightPlugin extends CiPlugin {
         span.setTag(TEST_MANAGEMENT_IS_DISABLED, 'true')
       }
 
-      this.enter(span, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, span }
+
+      return ctx.currentStore
     })
 
     this.addSub('ci:playwright:worker:report', (serializedTraces) => {
@@ -254,6 +261,7 @@ class PlaywrightPlugin extends CiPlugin {
     })
 
     this.addSub('ci:playwright:test:finish', ({
+      span,
       testStatus,
       steps,
       error,
@@ -271,8 +279,6 @@ class PlaywrightPlugin extends CiPlugin {
       isAtrRetry,
       onDone
     }) => {
-      const store = storage('legacy').getStore()
-      const span = store && store.span
       if (!span) return
 
       const isRUMActive = span.context()._tags[TEST_IS_RUM_ACTIVE]
@@ -361,6 +367,10 @@ class PlaywrightPlugin extends CiPlugin {
       if (process.env.DD_PLAYWRIGHT_WORKER) {
         this.tracer._exporter.flush(onDone)
       }
+    })
+
+    this.addBind('ci:playwright:test:fn', (ctx) => {
+      return ctx.currentStore
     })
   }
 

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -95,19 +95,21 @@ class VitestPlugin extends CiPlugin {
       onDone(isFaulty)
     })
 
-    this.addSub('ci:vitest:test:start', ({
-      testName,
-      testSuiteAbsolutePath,
-      isRetry,
-      isNew,
-      isAttemptToFix,
-      isQuarantined,
-      isDisabled,
-      mightHitProbe,
-      isRetryReasonEfd,
-      isRetryReasonAttemptToFix,
-      isRetryReasonAtr
-    }) => {
+    this.addBind('ci:vitest:test:start', (ctx) => {
+      const {
+        testName,
+        testSuiteAbsolutePath,
+        isRetry,
+        isNew,
+        isAttemptToFix,
+        isQuarantined,
+        isDisabled,
+        mightHitProbe,
+        isRetryReasonEfd,
+        isRetryReasonAttemptToFix,
+        isRetryReasonAtr
+      } = ctx
+
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
       const store = storage('legacy').getStore()
 
@@ -146,18 +148,21 @@ class VitestPlugin extends CiPlugin {
         extraTags
       )
 
-      this.enter(span, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, span }
 
       // TODO: there might be multiple tests for which mightHitProbe is true, so activeTestSpan
       // might be wrongly overwritten.
       if (mightHitProbe) {
         this.activeTestSpan = span
       }
+
+      return ctx.currentStore
     })
 
-    this.addSub('ci:vitest:test:finish-time', ({ status, task, attemptToFixPassed, attemptToFixFailed }) => {
-      const store = storage('legacy').getStore()
-      const span = store?.span
+    this.addBind('ci:vitest:test:finish-time', (ctx) => {
+      const { status, task, attemptToFixPassed, attemptToFixFailed } = ctx
+      const span = ctx.currentStore?.span
 
       // we store the finish time to finish at a later hook
       // this is because the test might fail at a `afterEach` hook
@@ -171,13 +176,15 @@ class VitestPlugin extends CiPlugin {
         }
 
         this.taskToFinishTime.set(task, span._getTime())
+
+        ctx.parentStore = ctx.currentStore
+        ctx.currentStore = { ...ctx.currentStore, span }
       }
+
+      return ctx.currentStore
     })
 
-    this.addSub('ci:vitest:test:pass', ({ task }) => {
-      const store = storage('legacy').getStore()
-      const span = store?.span
-
+    this.addSub('ci:vitest:test:pass', ({ span, task }) => {
       if (span) {
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'test', {
           hasCodeowners: !!span.context()._tags[TEST_CODE_OWNERS]
@@ -189,6 +196,7 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addSub('ci:vitest:test:error', ({
+      span,
       duration,
       error,
       shouldSetProbe,
@@ -196,9 +204,6 @@ class VitestPlugin extends CiPlugin {
       hasFailedAllRetries,
       attemptToFixFailed
     }) => {
-      const store = storage('legacy').getStore()
-      const span = store?.span
-
       if (span) {
         if (shouldSetProbe && this.di) {
           const probeInformation = this.addDiProbe(error)
@@ -252,10 +257,9 @@ class VitestPlugin extends CiPlugin {
       testSpan.finish()
     })
 
-    this.addSub('ci:vitest:test-suite:start', ({
-      testSuiteAbsolutePath,
-      frameworkVersion
-    }) => {
+    this.addBind('ci:vitest:test-suite:start', (ctx) => {
+      const { testSuiteAbsolutePath, frameworkVersion } = ctx
+
       this.command = process.env.DD_CIVISIBILITY_TEST_COMMAND
       this.frameworkVersion = frameworkVersion
       const testSessionSpanContext = this.tracer.extract('text_map', {
@@ -305,17 +309,18 @@ class VitestPlugin extends CiPlugin {
       })
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
       const store = storage('legacy').getStore()
-      this.enter(testSuiteSpan, store)
+      ctx.parentStore = store
+      ctx.currentStore = { ...store, testSuiteSpan }
       this.testSuiteSpan = testSuiteSpan
+
+      return ctx.currentStore
     })
 
-    this.addSub('ci:vitest:test-suite:finish', ({ status, onFinish }) => {
-      const store = storage('legacy').getStore()
-      const span = store?.span
-      if (span) {
-        span.setTag(TEST_STATUS, status)
-        span.finish()
-        finishAllTraceSpans(span)
+    this.addSub('ci:vitest:test-suite:finish', ({ testSuiteSpan, status, onFinish }) => {
+      if (testSuiteSpan) {
+        testSuiteSpan.setTag(TEST_STATUS, status)
+        testSuiteSpan.finish()
+        finishAllTraceSpans(testSuiteSpan)
       }
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
       // TODO: too frequent flush - find for method in worker to decrease frequency
@@ -325,13 +330,19 @@ class VitestPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:vitest:test-suite:error', ({ error }) => {
-      const store = storage('legacy').getStore()
-      const span = store?.span
-      if (span && error) {
-        span.setTag('error', error)
-        span.setTag(TEST_STATUS, 'fail')
+    this.addBind('ci:vitest:test-suite:error', (ctx) => {
+      const { error } = ctx
+      const testSuiteSpan = ctx.currentStore?.testSuiteSpan
+
+      if (testSuiteSpan && error) {
+        testSuiteSpan.setTag('error', error)
+        testSuiteSpan.setTag(TEST_STATUS, 'fail')
+
+        ctx.parentStore = ctx.currentStore
+        ctx.currentStore = { ...ctx.currentStore, testSuiteSpan }
       }
+
+      return ctx.currentStore
     })
 
     this.addSub('ci:vitest:session:finish', ({


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Replace `AsyncResource` usage for `runStores` in the following frameworks:
- **Jest**
- **Mocha**
- **Cucumber**
- **Vitest**
- **Playwright**

### Motivation
<!-- What inspired you to submit this pull request? -->
There is a bug in _Node 24_ when using `AsyncResource` that isn't triggered when using `runStores` instead.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


