### PR TITLE
fix child_process test on node 24

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -249,6 +249,8 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
+        env:
+          OPTIONS_OVERRIDE: 1
       - uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
 
   confluentinc-kafka-javascript:


### PR DESCRIPTION
Use the OPTIONS_OVERRIDE flag to avoid messing with exec.


