### PR TITLE
convert mysql from asyncresource to runstores

### DIFF
--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -1,10 +1,6 @@
 'use strict'
 
-const {
-  channel,
-  addHook,
-  AsyncResource
-} = require('./helpers/instrument')
+const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
 addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connection => {
@@ -20,42 +16,38 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
     const sql = arguments[0].sql || arguments[0]
     const conf = this.config
     const payload = { sql, conf }
+    const ctx = { payload }
 
-    const callbackResource = new AsyncResource('bound-anonymous-fn')
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-
-    return asyncResource.runInAsyncScope(() => {
-      startCh.publish(payload)
-
+    return startCh.runStores(ctx, () => {
       if (arguments[0].sql) {
         arguments[0].sql = payload.sql
       } else {
         arguments[0] = payload.sql
       }
+
       try {
         const res = query.apply(this, arguments)
 
         if (res._callback) {
-          const cb = callbackResource.bind(res._callback)
-          res._callback = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
+          const cb = res._callback
+          res._callback = shimmer.wrapFunction(cb, cb => function (error, result) {
             if (error) {
-              errorCh.publish(error)
+              ctx.error = error
+              errorCh.publish(ctx)
             }
-            finishCh.publish(result)
+            ctx.result = result
 
-            return cb.apply(this, arguments)
-          }))
-        } else {
-          const cb = asyncResource.bind(function () {
-            finishCh.publish(undefined)
+            return finishCh.runStores(ctx, cb, this, error, result)
           })
-          res.on('end', cb)
+        } else {
+          res.on('end', () => finishCh.publish(ctx))
         }
 
         return res
       } catch (err) {
         err.stack // trigger getting the stack at the original throwing point
-        errorCh.publish(err)
+        ctx.error = err
+        errorCh.publish(ctx)
 
         throw err
       }
@@ -79,16 +71,11 @@ addHook({ name: 'mysql', file: 'lib/Pool.js', versions: ['>=2'] }, Pool => {
       return query.apply(this, arguments)
     }
 
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-
     const sql = arguments[0].sql || arguments[0]
+    const ctx = { sql }
 
-    return asyncResource.runInAsyncScope(() => {
-      startPoolQueryCh.publish({ sql })
-
-      const finish = asyncResource.bind(function () {
-        finishPoolQueryCh.publish()
-      })
+    return startPoolQueryCh.runStores(ctx, () => {
+      const finish = () => finishPoolQueryCh.publish(ctx)
 
       const cb = arguments[arguments.length - 1]
       if (typeof cb === 'function') {

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -7,7 +7,8 @@ class MySQLPlugin extends DatabasePlugin {
   static get id () { return 'mysql' }
   static get system () { return 'mysql' }
 
-  start (payload) {
+  bindStart (ctx) {
+    const { payload } = ctx
     const service = this.serviceName({ pluginConfig: this.config, dbConfig: payload.conf, system: this.system })
     const span = this.startSpan(this.operationName(), {
       service,
@@ -21,8 +22,10 @@ class MySQLPlugin extends DatabasePlugin {
         'out.host': payload.conf.host,
         [CLIENT_PORT_KEY]: payload.conf.port
       }
-    })
+    }, ctx)
     payload.sql = this.injectDbmQuery(span, payload.sql, service)
+
+    return ctx.currentStore
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Convert `mysql` from AsyncResource to runStores.

### Motivation
<!-- What inspired you to submit this pull request? -->

AsyncResource is broken in Node 24.