### PR TITLE
Configurable NativeSpaceProfiler samplingInterval

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -35,6 +35,7 @@ class Config {
       DD_PROFILING_EXPERIMENTAL_OOM_MONITORING_ENABLED,
       DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED,
       DD_PROFILING_HEAP_ENABLED,
+      DD_PROFILING_HEAP_SAMPLING_INTERVAL,
       DD_PROFILING_PPROF_PREFIX,
       DD_PROFILING_PROFILERS,
       DD_PROFILING_SOURCE_MAP,
@@ -191,6 +192,8 @@ class Config {
     logExperimentalVarDeprecation('CPU_ENABLED')
     checkOptionWithSamplingContextAllowed(this.cpuProfilingEnabled, 'CPU profiling')
 
+    this.heapSamplingInterval = coalesce(options.heapSamplingInterval,
+      Number(DD_PROFILING_HEAP_SAMPLING_INTERVAL))
     this.profilers = ensureProfilers(profilers, this)
   }
 }

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -10,7 +10,7 @@ function strategiesToCallbackMode (strategies, callbackMode) {
 class NativeSpaceProfiler {
   constructor (options = {}) {
     this.type = 'space'
-    this._samplingInterval = options.samplingInterval || 512 * 1024
+    this._samplingInterval = options.heapSamplingInterval || 512 * 1024
     this._stackDepth = options.stackDepth || 64
     this._pprof = undefined
     this._oomMonitoring = options.oomMonitoring || {}

--- a/packages/dd-trace/test/profiling/profilers/space.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/space.spec.js
@@ -34,14 +34,14 @@ describe('profilers/native/space', () => {
   })
 
   it('should use the provided configuration options', () => {
-    const samplingInterval = 1024
+    const heapSamplingInterval = 1024
     const stackDepth = 10
-    const profiler = new NativeSpaceProfiler({ samplingInterval, stackDepth })
+    const profiler = new NativeSpaceProfiler({ heapSamplingInterval, stackDepth })
 
     profiler.start()
 
     sinon.assert.calledOnce(pprof.heap.start)
-    sinon.assert.calledWith(pprof.heap.start, samplingInterval, stackDepth)
+    sinon.assert.calledWith(pprof.heap.start, heapSamplingInterval, stackDepth)
   })
 
   it('should stop the internal space profiler', () => {


### PR DESCRIPTION
### What does this PR do?
Allow users of ddtrace to configure samplingIntervals for the NativeSpaceProfiler. 

### Motivation
Heap sampling rate needs to be configurable for JS applications that have very high allocation rates. In services, with high allocation rates, the default sampling interval can cause unacceptable slow downs. This change allows users to find a more appropriate heap sampling rate that is tuned to their application's allocation rate.

Prior to this Wall, Events, and Space Profilers were all referencing the same option: samplingInterval, however, they had different units. NativeWallProfiler and EventsProfiler expected samplingInterval to be in hertz, and NativeSpaceProfiler expected samplingInterval to be in number of bytes between samples. This and the lack of environment variable support made it impossible for users to configure the NativeSpaceProfiler samplingInterval.

### Additional Notes
This breaks the API of NativeSpaceProfiler since it switches from accepting samplingInterval to accepting heapSamplingInterval. That said, this is not a publicly exported class, so it seems acceptable to make this change in a non-backwards compatible way. If that is not acceptable, it would also be possible to update this change to allow for both samplingInterval and heapSamplingInterval and give the latter precedence. I did not do that, because it seemed to add unnecessary complexity to the profiler.

### Tests
All of the following tests have been verified locally:
* yarn test:profiler
* yarn test:integration:profiler
* yarn lint