### PR TITLE
[DI] Refactor mutex code guarding race condition

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/remote_config.js
+++ b/packages/dd-trace/src/debugger/devtools_client/remote_config.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const { workerData: { rcPort } } = require('node:worker_threads')
-const lock = require('mutexify/promise')()
-const { addBreakpoint, removeBreakpoint } = require('./breakpoints')
+const { addBreakpoint, removeBreakpoint, modifyBreakpoint } = require('./breakpoints')
 const { ackReceived, ackInstalled, ackError } = require('./status')
 const log = require('../../log')
 
@@ -62,40 +61,21 @@ async function processMsg (action, probe) {
     )
   }
 
-  // This lock is to ensure that we don't get the following race condition:
-  //
-  // When a breakpoint is being removed and there are no other breakpoints, we disable the debugger by calling
-  // `Debugger.disable` to free resources. However, if a new breakpoint is being added around the same time, we might
-  // have a race condition where the new breakpoint thinks that the debugger is already enabled because the removal of
-  // the other breakpoint hasn't had a chance to call `Debugger.disable` yet. Then once the code that's adding the new
-  // breakpoints tries to call `Debugger.setBreakpoint` it fails because in the meantime `Debugger.disable` was called.
-  //
-  // If the code is ever refactored to not tear down the debugger if there's no active breakpoints, we can safely remove
-  // this lock.
-  const release = await lock()
-
-  try {
-    switch (action) {
-      case 'unapply':
-        await removeBreakpoint(probe)
-        break
-      case 'apply':
-        await addBreakpoint(probe)
-        ackInstalled(probe)
-        break
-      case 'modify':
-        // TODO: Modify existing probe instead of removing it (DEBUG-2817)
-        await removeBreakpoint(probe)
-        await addBreakpoint(probe)
-        ackInstalled(probe) // TODO: Should we also send ackInstalled when modifying a probe?
-        break
-      default:
-        throw new Error(
-          // eslint-disable-next-line @stylistic/js/max-len
-          `Cannot process probe ${probe.id} (version: ${probe.version}) - unknown remote configuration action: ${action}`
-        )
-    }
-  } finally {
-    release()
+  switch (action) {
+    case 'unapply':
+      await removeBreakpoint(probe)
+      break
+    case 'apply':
+      await addBreakpoint(probe)
+      ackInstalled(probe)
+      break
+    case 'modify':
+      await modifyBreakpoint(probe)
+      ackInstalled(probe)
+      break
+    default:
+      throw new Error(
+        `Cannot process probe ${probe.id} (version: ${probe.version}) - unknown remote configuration action: ${action}`
+      )
   }
 }

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -45,16 +45,8 @@ describe('breakpoints', function () {
 
   describe('addBreakpoint', function () {
     it('should enable debugger for the first breakpoint', async function () {
-      await breakpoints.addBreakpoint({
-        id: 'probe-1',
-        version: 1,
-        where: {
-          sourceFile: 'test.js',
-          lines: ['10']
-        }
-      })
+      await addProbe()
 
-      expect(sessionMock.post.callCount).to.equal(2)
       expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.enable')
       expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
         location: {
@@ -64,91 +56,63 @@ describe('breakpoints', function () {
         },
         condition: undefined
       })
+      expect(sessionMock.post).to.have.been.calledTwice
     })
 
     it('should not enable debugger for subsequent breakpoints', async function () {
-      // First breakpoint
-      await breakpoints.addBreakpoint({
-        id: 'probe-1',
-        version: 1,
-        where: {
-          sourceFile: 'test.js',
-          lines: ['10']
-        }
-      })
-
+      await addProbe()
       sessionMock.post.resetHistory()
 
-      // Second breakpoint
-      await breakpoints.addBreakpoint({
-        id: 'probe-2',
-        version: 1,
-        where: {
-          sourceFile: 'test2.js',
-          lines: ['20']
-        }
-      })
+      await addProbe({ id: 'probe-2', where: { sourceFile: 'test2.js', lines: ['20'] } })
 
       expect(sessionMock.post).to.have.been.calledOnceWith('Debugger.setBreakpoint')
     })
 
+    it('2nd probe should wait until the debugger has finished enabling before being applied', async function () {
+      // Not enabling the debugger more than once is easy to test, but testing that the 2nd probe waits for the
+      // debugger to be completely enabled before being applied is a lot harder to test. Here we rely on the order of
+      // the calls to `stateMock.findScriptFromPartialPath` to be in the same order as the probes are added.
+
+      await Promise.all([
+        addProbe(),
+        addProbe({ id: 'probe-2', where: { sourceFile: 'test2.js', lines: ['20'] } })
+      ])
+
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.enable')
+      expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint')
+      expect(sessionMock.post.thirdCall).to.have.been.calledWith('Debugger.setBreakpoint')
+      expect(sessionMock.post).to.have.been.calledThrice
+
+      expect(stateMock.findScriptFromPartialPath.firstCall).to.have.been.calledWith('test.js')
+      expect(stateMock.findScriptFromPartialPath.secondCall).to.have.been.calledWith('test2.js')
+      expect(stateMock.findScriptFromPartialPath).to.have.been.calledTwice
+    })
+
     describe('add multiple probes to the same location', function () {
       it('no conditions', async function () {
-        // Add first probe
-        await breakpoints.addBreakpoint({
-          id: 'probe-1',
-          version: 1,
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
-          }
-        })
+        await addProbe()
 
         sessionMock.post.resetHistory()
 
         // Add second probe to same location
-        await breakpoints.addBreakpoint({
-          id: 'probe-2',
-          version: 1,
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
-          }
-        })
+        await addProbe({ id: 'probe-2' })
 
         expect(sessionMock.post).to.not.have.been.called
       })
 
       it('mixed: 2nd probe no condition', async function () {
-        // Add first probe
-        await breakpoints.addBreakpoint({
-          id: 'probe-1',
-          version: 1,
+        await addProbe({
           when: {
             json: { eq: [{ ref: 'foo' }, 42] },
             dsl: 'foo = 42'
-          },
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
           }
         })
-
-        // Reset call history
         sessionMock.post.resetHistory()
 
         // Add second probe to same location
-        await breakpoints.addBreakpoint({
-          id: 'probe-2',
-          version: 1,
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
-          }
-        })
+        await addProbe({ id: 'probe-2' })
 
         // Should remove previous breakpoint and create a new one with both conditions
-        expect(sessionMock.post.callCount).to.equal(2)
         expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
           breakpointId: 'bp-script-1:9:0'
         })
@@ -160,33 +124,19 @@ describe('breakpoints', function () {
           },
           condition: undefined
         })
+        expect(sessionMock.post).to.have.been.calledTwice
       })
 
       it('mixed: 1st probe no condition', async function () {
-        // Add first probe
-        await breakpoints.addBreakpoint({
-          id: 'probe-1',
-          version: 1,
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
-          }
-        })
-
-        // Reset call history
+        await addProbe()
         sessionMock.post.resetHistory()
 
         // Add second probe to same location
-        await breakpoints.addBreakpoint({
+        await addProbe({
           id: 'probe-2',
-          version: 1,
           when: {
             json: { eq: [{ ref: 'foo' }, 42] },
             dsl: 'foo = 42'
-          },
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
           }
         })
 
@@ -194,39 +144,24 @@ describe('breakpoints', function () {
       })
 
       it('all conditions', async function () {
-        // Add first probe
-        await breakpoints.addBreakpoint({
-          id: 'probe-1',
-          version: 1,
+        await addProbe({
           when: {
             json: { eq: [{ ref: 'foo' }, 42] },
             dsl: 'foo == 42'
-          },
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
           }
         })
-
-        // Reset call history
         sessionMock.post.resetHistory()
 
         // Add second probe to same location
-        await breakpoints.addBreakpoint({
+        await addProbe({
           id: 'probe-2',
-          version: 1,
           when: {
             json: { eq: [{ ref: 'foo' }, 43] },
             dsl: 'foo == 43'
-          },
-          where: {
-            sourceFile: 'test.js',
-            lines: ['10']
           }
         })
 
         // Should remove previous breakpoint and create a new one with both conditions
-        expect(sessionMock.post.callCount).to.equal(2)
         expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
           breakpointId: 'bp-script-1:9:0'
         })
@@ -240,41 +175,25 @@ describe('breakpoints', function () {
             '(() => { try { return (foo) === (42) } catch { return false } })() || ' +
             '(() => { try { return (foo) === (43) } catch { return false } })()'
         })
+        expect(sessionMock.post).to.have.been.calledTwice
       })
 
       it('should allow adding multiple probes at the same location synchronously', async function () {
         // Test we don't hit a race condition where the internal state isn't updated before we try to add a new probe
         await Promise.all([
-          breakpoints.addBreakpoint({
-            id: 'probe-1',
-            version: 1,
-            where: { sourceFile: 'test.js', lines: ['10'] }
-          }),
-          breakpoints.addBreakpoint({
-            id: 'probe-2',
-            version: 1,
-            where: { sourceFile: 'test.js', lines: ['10'] }
-          })
+          addProbe(),
+          addProbe({ id: 'probe-2' })
         ])
-        expect(sessionMock.post.callCount).to.equal(2)
         expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.enable')
         expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint')
+        expect(sessionMock.post).to.have.been.calledTwice
       })
     })
 
     it('should throw error if script not found', async function () {
       stateMock.findScriptFromPartialPath.returns(null)
 
-      const probe = {
-        id: 'probe-1',
-        version: 1,
-        where: {
-          sourceFile: 'test.js',
-          lines: ['10']
-        }
-      }
-
-      await breakpoints.addBreakpoint(probe)
+      await addProbe()
         .then(() => {
           throw new Error('Should not resolve')
         })
@@ -285,20 +204,14 @@ describe('breakpoints', function () {
     })
 
     it('should handle condition compilation errors', async function () {
-      const probe = {
-        id: 'probe-1',
-        version: 1,
-        where: {
-          sourceFile: 'test.js',
-          lines: ['10']
-        },
+      const config = {
         when: {
           json: { invalid: 'condition' },
           dsl: 'this is an invalid condition'
         }
       }
 
-      await breakpoints.addBreakpoint(probe)
+      await addProbe(config)
         .then(() => {
           throw new Error('Should not resolve')
         })
@@ -334,6 +247,36 @@ describe('breakpoints', function () {
       expect(stateMock.clearState).to.not.have.been.called
     })
 
+    it('should wait re-enabling the debugger if it is in the middle of being disabled', async function () {
+      await addProbe()
+      sessionMock.post.resetHistory()
+
+      await Promise.all([
+        breakpoints.removeBreakpoint({ id: 'probe-1' }),
+        addProbe({ id: 'probe-2', where: { sourceFile: 'test2.js', lines: ['20'] } })
+      ])
+
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.disable')
+      expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.enable')
+      expect(sessionMock.post.thirdCall).to.have.been.calledWith('Debugger.setBreakpoint')
+      expect(sessionMock.post).to.have.been.calledThrice
+    })
+
+    it('should not disable the debugger if a new probe is in the process of being added', async function () {
+      await addProbe()
+
+      sessionMock.post.resetHistory()
+
+      await Promise.all([
+        addProbe({ id: 'probe-2', where: { sourceFile: 'test2.js', lines: ['20'] } }),
+        breakpoints.removeBreakpoint({ id: 'probe-1' })
+      ])
+
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.setBreakpoint')
+      expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.removeBreakpoint')
+      expect(sessionMock.post).to.have.been.calledTwice
+    })
+
     describe('update breakpoint when removing one of multiple probes at the same location', function () {
       it('no conditions', async function () {
         await addProbe()
@@ -358,7 +301,6 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        expect(sessionMock.post.callCount).to.equal(2)
         expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
           breakpointId: 'bp-script-1:9:0'
         })
@@ -370,6 +312,7 @@ describe('breakpoints', function () {
           },
           condition: '(foo) === (42)'
         })
+        expect(sessionMock.post).to.have.been.calledTwice
       })
 
       it('mixed: removed probe with condtion', async function () {
@@ -405,7 +348,6 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        expect(sessionMock.post.callCount).to.equal(2)
         expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
           breakpointId: 'bp-script-1:9:0'
         })
@@ -417,6 +359,7 @@ describe('breakpoints', function () {
           },
           condition: '(foo) === (43)'
         })
+        expect(sessionMock.post).to.have.been.calledTwice
       })
     })
 
@@ -444,15 +387,74 @@ describe('breakpoints', function () {
     })
   })
 
-  async function addProbe ({ id, version, where, when } = {}) {
-    await breakpoints.addBreakpoint({
-      id: id || 'probe-1',
-      version: version || 1,
-      where: where || {
-        sourceFile: 'test.js',
-        lines: ['10']
-      },
-      when
+  describe('modifyBreakpoint', function () {
+    it('should re-add the probe when it is the only active probe', async function () {
+      await addProbe()
+      sessionMock.post.resetHistory()
+
+      // Generate updated config for probe-1
+      const probe = genProbeConfig({
+        version: 2,
+        when: {
+          json: { eq: [{ ref: 'foo' }, 42] },
+          dsl: 'foo = 42'
+        }
+      })
+      await breakpoints.modifyBreakpoint(probe)
+
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.disable')
+      expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.enable')
+      expect(sessionMock.post.thirdCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+        location: {
+          scriptId: 'script-1',
+          lineNumber: 9,
+          columnNumber: 0
+        },
+        condition: '(foo) === (42)'
+      })
+      expect(sessionMock.post).to.have.been.calledThrice
     })
+
+    it('should re-add the probe when there are other active probes', async function () {
+      await addProbe()
+      await addProbe({ id: 'probe-2', version: 2, where: { sourceFile: 'test2.js', lines: ['20'] } })
+      sessionMock.post.resetHistory()
+
+      // Generate updated config for probe-1
+      const probe = genProbeConfig({
+        version: 2,
+        when: {
+          json: { eq: [{ ref: 'foo' }, 42] },
+          dsl: 'foo = 42'
+        }
+      })
+      await breakpoints.modifyBreakpoint(probe)
+
+      expect(sessionMock.post.firstCall).to.have.been.calledWith('Debugger.removeBreakpoint', {
+        breakpointId: 'bp-script-1:9:0'
+      })
+      expect(sessionMock.post.secondCall).to.have.been.calledWith('Debugger.setBreakpoint', {
+        location: {
+          scriptId: 'script-1',
+          lineNumber: 9,
+          columnNumber: 0
+        },
+        condition: '(foo) === (42)'
+      })
+      expect(sessionMock.post).to.have.been.calledTwice
+    })
+  })
+
+  async function addProbe (probe) {
+    await breakpoints.addBreakpoint(genProbeConfig(probe))
   }
 })
+
+function genProbeConfig ({ id, version, where, when } = {}) {
+  return {
+    id: id || 'probe-1',
+    version: version || 1,
+    where: where || { sourceFile: 'test.js', lines: ['10'] },
+    when
+  }
+}


### PR DESCRIPTION
### What does this PR do?
    
When adding, removing or modifying a breakpoint there can be a race condtion if two Remove Config configs are received in quick succession. We already have a mutex to guard against this, but the code was in need of a refactor because:
    
1. We had duplicate mutex code in two different files, where only one was needed
2. We couldn't easily test the main mutex code in a unit test as it was added in the calling file and therefore not isolated to the function containing the race condition.

This PR fixes these issues by refactoring the code.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes

This PR contains a lot of white space changes. Use "Hide whitespace" when reviewing for a better diff.


