### PR TITLE
[DI] Clean up code in integration test

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -174,20 +174,25 @@ describe('Dynamic Instrumentation', function () {
         }
       })
 
-      const unsupporedOrInvalidProbes = [[
+      it(
         'should send expected error diagnostics messages if probe doesn\'t conform to expected schema',
-        'bad config!!!',
-        { status: 'ERROR' }
-      ], [
-        'should send expected error diagnostics messages if probe type isn\'t supported',
-        t.generateProbeConfig({ type: 'INVALID_PROBE' })
-      ], [
-        'should send expected error diagnostics messages if it isn\'t a line-probe',
-        t.generateProbeConfig({ where: { foo: 'bar' } }) // TODO: Use valid schema for method probe instead
-      ]]
+        unsupporedOrInvalidProbesTest('bad config!!!', { status: 'ERROR' })
+      )
 
-      for (const [title, config, customErrorDiagnosticsObj] of unsupporedOrInvalidProbes) {
-        it(title, function (done) {
+      it(
+        'should send expected error diagnostics messages if probe type isn\'t supported',
+        unsupporedOrInvalidProbesTest(t.generateProbeConfig({ type: 'INVALID_PROBE' }))
+      )
+
+      it(
+        'should send expected error diagnostics messages if it isn\'t a line-probe',
+        unsupporedOrInvalidProbesTest(
+          t.generateProbeConfig({ where: { typeName: 'index.js', methodName: 'handlerA' } })
+        )
+      )
+
+      function unsupporedOrInvalidProbesTest (config, customErrorDiagnosticsObj) {
+        return function (done) {
           let receivedAckUpdate = false
 
           t.agent.on('remote-config-ack-update', (id, version, state, error) => {
@@ -238,7 +243,7 @@ describe('Dynamic Instrumentation', function () {
           function endIfDone () {
             if (receivedAckUpdate && expectedPayloads.length === 0) done()
           }
-        })
+        }
       }
 
       describe('multiple probes at the same location', function () {


### PR DESCRIPTION
### What does this PR do?

As the title says

### Motivation

It's best practice to not call `it` dynamically in a for-loop, but instead have a function that returns a test function so that the `it` statements can be hard coded even when you need to re-use a test function.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


