### PR TITLE
[DI] Fix edge-case where probe payload is too large, but no snapshot collected

### DIFF
--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -1,10 +1,17 @@
 'use strict'
 
 const { assert } = require('chai')
+const { join } = require('path')
 const { setup } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
-  const t = setup()
+  const t = setup({
+    env: {
+      PATH_TO_UTILS: join(
+        __dirname, '..', '..', 'packages', 'dd-trace', 'test', 'debugger', 'devtools_client', 'utils.js'
+      )
+    }
+  })
 
   describe('input messages', function () {
     describe('with snapshot', function () {
@@ -18,7 +25,7 @@ describe('Dynamic Instrumentation', function () {
               [t.breakpoint.line]: {
                 locals: {
                   notCapturedReason: 'Snapshot was too large',
-                  size: 6
+                  size: 5
                 }
               }
             }

--- a/integration-tests/debugger/target-app/snapshot-pruning.js
+++ b/integration-tests/debugger/target-app/snapshot-pruning.js
@@ -1,18 +1,17 @@
 'use strict'
 
 require('dd-trace/init')
+const { generateObjectWithJSONSizeLargerThan } = require(process.env.PATH_TO_UTILS)
 
-const { randomBytes } = require('crypto')
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })
 
 const TARGET_SIZE = 1024 * 1024 // 1MB
-const LARGE_STRING = randomBytes(1024).toString('hex')
 
 fastify.get('/:name', function handler (request) {
   // eslint-disable-next-line no-unused-vars
-  const obj = generateObjectWithJSONSizeLargerThan1MB()
+  const obj = generateObjectWithJSONSizeLargerThan(TARGET_SIZE)
 
   return { hello: request.params.name } // BREAKPOINT: /foo
 })
@@ -24,18 +23,3 @@ fastify.listen({ port: process.env.APP_PORT }, (err) => {
   }
   process.send({ port: process.env.APP_PORT })
 })
-
-function generateObjectWithJSONSizeLargerThan1MB () {
-  const obj = {}
-  let i = 0
-
-  while (++i) {
-    if (i % 100 === 0) {
-      const size = JSON.stringify(obj).length
-      if (size > TARGET_SIZE) break
-    }
-    obj[i] = LARGE_STRING
-  }
-
-  return obj
-}

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -49,6 +49,16 @@ function send (message, logger, dd, snapshot) {
   let size = Buffer.byteLength(json)
 
   if (size > MAX_LOG_PAYLOAD_SIZE) {
+    if (payload.debugger.snapshot.captures == null) {
+      // This should never happen as there should never be a situation where the payload is too large, but doesn't
+      // contain a snapshot, but just in case, it's better to abort than to fail.
+      log.error(
+        // eslint-disable-next-line @stylistic/js/max-len
+        '[debugger:devtools_client] Snapshot was too large, but no snapshot found that could be pruned! Dropping payload.'
+      )
+      return
+    }
+
     // TODO: This is a very crude way to handle large payloads. Proper pruning will be implemented later (DEBUG-2624)
     const line = Object.values(payload.debugger.snapshot.captures.lines)[0]
     line.locals = {

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -3,7 +3,7 @@
 require('../../setup/mocha')
 
 const { hostname: getHostname } = require('os')
-const { expectWithin, getRequestOptions } = require('./utils')
+const { expectWithin, getRequestOptions, generateObjectWithJSONSizeLargerThan } = require('./utils')
 const JSONBuffer = require('../../../src/debugger/devtools_client/json-buffer')
 const { version } = require('../../../../../package.json')
 
@@ -81,6 +81,14 @@ describe('input message http requests', function () {
 
       done()
     })
+  })
+
+  it('should not throw if payload is too large, but there is no snapshot', function () {
+    const unrealisticlyLargeSnapshotWithoutACapturesProperty = generateObjectWithJSONSizeLargerThan(1024 * 1024) // 1MB
+
+    expect(() => {
+      send(message, logger, dd, unrealisticlyLargeSnapshotWithoutACapturesProperty)
+    }).to.not.throw()
   })
 })
 

--- a/packages/dd-trace/test/debugger/devtools_client/utils.js
+++ b/packages/dd-trace/test/debugger/devtools_client/utils.js
@@ -1,11 +1,12 @@
 'use strict'
 
-const { randomUUID } = require('node:crypto')
+const { randomUUID, randomBytes } = require('node:crypto')
 
 module.exports = {
   expectWithin,
   generateProbeConfig,
-  getRequestOptions
+  getRequestOptions,
+  generateObjectWithJSONSizeLargerThan
 }
 
 function expectWithin (timeout, fn, start = Date.now(), backoff = 1) {
@@ -40,4 +41,20 @@ function generateProbeConfig (breakpoint, overrides = {}) {
 
 function getRequestOptions (request) {
   return request.lastCall.args[1]
+}
+
+function generateObjectWithJSONSizeLargerThan (targetSize) {
+  const obj = {}
+  let i = 0
+  const largeString = randomBytes(1024).toString('hex')
+
+  while (++i) {
+    if (i % 100 === 0) {
+      const size = JSON.stringify(obj).length
+      if (size > targetSize) break
+    }
+    obj[i] = largeString
+  }
+
+  return obj
 }


### PR DESCRIPTION
### What does this PR do?

As the title says.

### Motivation

This should never happen as there should never be a situation where the payload is too large, but doesn't contain a snapshot, but just in case, it's better to abort than to throw.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


