### PR TITLE
[DI] Use custom error property for errors reporting state snapshot

### DIFF
--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -13,16 +13,13 @@ describe('Dynamic Instrumentation', function () {
       it('should prune snapshot if payload is too large', function (done) {
         t.agent.on('debugger-input', ({ payload: [payload] }) => {
           assert.isBelow(Buffer.byteLength(JSON.stringify(payload)), 1024 * 1024) // 1MB
-          assert.deepEqual(payload.debugger.snapshot.captures, {
-            lines: {
-              [t.breakpoint.line]: {
-                locals: {
-                  notCapturedReason: 'Snapshot was too large',
-                  size: 6
-                }
-              }
-            }
-          })
+          assert.notProperty(payload.debugger.snapshot, 'captures')
+          assert.strictEqual(
+            payload.debugger.snapshot.captureError,
+            'Snapshot was too large (max allowed size is 1 MiB). ' +
+            'Consider reducing the capture depth or turn off "Capture Variables" completely, ' +
+            'and instead include the variables of interest directly in the message template.'
+          )
           done()
         })
 

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -13,7 +13,8 @@ const { version } = require('../../../../../package.json')
 module.exports = send
 
 const MAX_MESSAGE_LENGTH = 8 * 1024 // 8KB
-const MAX_LOG_PAYLOAD_SIZE = 1024 * 1024 // 1MB
+const MAX_LOG_PAYLOAD_SIZE_MB = 1
+const MAX_LOG_PAYLOAD_SIZE_BYTES = MAX_LOG_PAYLOAD_SIZE_MB * 1024 * 1024
 
 const ddsource = 'dd_debugger'
 const hostname = getHostname()
@@ -48,13 +49,13 @@ function send (message, logger, dd, snapshot) {
   let json = JSON.stringify(payload)
   let size = Buffer.byteLength(json)
 
-  if (size > MAX_LOG_PAYLOAD_SIZE) {
+  if (size > MAX_LOG_PAYLOAD_SIZE_BYTES) {
     // TODO: This is a very crude way to handle large payloads. Proper pruning will be implemented later (DEBUG-2624)
-    const line = Object.values(payload.debugger.snapshot.captures.lines)[0]
-    line.locals = {
-      notCapturedReason: 'Snapshot was too large',
-      size: Object.keys(line.locals).length
-    }
+    delete payload.debugger.snapshot.captures
+    payload.debugger.snapshot.captureError =
+      `Snapshot was too large (max allowed size is ${MAX_LOG_PAYLOAD_SIZE_MB} MiB). ` +
+      'Consider reducing the capture depth or turn off "Capture Variables" completely, ' +
+      'and instead include the variables of interest directly in the message template.'
     json = JSON.stringify(payload)
     size = Buffer.byteLength(json)
   }


### PR DESCRIPTION
### What does this PR do?

If for whatever reason the probe state snapshot cannot be captured or included in the payload, an error message should be included instead. The backend doesn’t support a root `notCapturedReason`, so instead a new `debugger.snapshot.captureError` should be introduced to hold a string error message.

Depends on the UI supporting and displaying this new property, which as of this writing, it doesn't. I'll mark this PR as ready for review once it does.

### Motivation

The backend doesn't actually support a root `notCapturedReason`. When we include it, it doesn't render as one could expect and the actual error message is not even visible.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


