### PR TITLE
fix: Add mongo heartbeatEnabled param to tracer entrypoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1750,6 +1750,13 @@ declare namespace tracer {
      */
     interface mongodb_core extends Instrumentation {
       /**
+       * Whether to enable mongo heartbeats spans.
+       *
+       * @default true
+       */
+      heartbeatEnabled?: boolean;
+
+      /**
        * Whether to include the query contents in the resource name.
        */
       queryInResourceName?: boolean;


### PR DESCRIPTION
### What does this PR do?

This PR intends to fix the newly added `heartbeatEnabled` parameter for the mongo plugin.

### Motivation

While the parameter is used in the plugin's code, I cannot use it as is in the tracer config, because of the missing typing.

```
error TS2353: Object literal may only specify known properties, and 'heartbeatEnabled' does not exist in type 'mongodb_core'
```

### Additional Notes

Follows https://github.com/DataDog/dd-trace-js/pull/5526 and  https://github.com/DataDog/dd-trace-js/pull/5562

