### PR TITLE
Simplify shimmer.wrapFunction by removing wrapper

### DIFF
--- a/benchmark/sirun/shimmer-runtime/index.js
+++ b/benchmark/sirun/shimmer-runtime/index.js
@@ -43,10 +43,8 @@ if (ENABLED !== 'true') {
   }
 } else {
   if (WRAP_FUNCTION === 'true') {
-    const wrapped = shimmer.wrapFunction(testedFn, (original) => {
-      return function () {
-        return original.apply(this, arguments)
-      }
+    const wrapped = shimmer.wrapFunction(testedFn, function () {
+      return testedFn.apply(this, arguments)
     })
     for (let i = 0; i < ITERATIONS; i++) {
       wrapped()

--- a/benchmark/sirun/shimmer-startup/index.js
+++ b/benchmark/sirun/shimmer-startup/index.js
@@ -40,10 +40,8 @@ if (!testedFn) {
 if (ENABLED === 'true') {
   if (WRAP_FUNCTION === 'true') {
     for (let i = 0; i < ITERATIONS; i++) {
-      shimmer.wrapFunction(testedFn, (original) => {
-        return function () {
-          return original.apply(this, arguments)
-        }
+      shimmer.wrapFunction(testedFn, function () {
+        return testedFn.apply(this, arguments)
       })
     }
   } else {

--- a/packages/datadog-instrumentations/src/aerospike.js
+++ b/packages/datadog-instrumentations/src/aerospike.js
@@ -43,5 +43,5 @@ addHook({
   versions: ['4', '5', '6']
 },
 commandFactory => {
-  return shimmer.wrapFunction(commandFactory, f => wrapCreateCommand(f))
+  return shimmer.wrapFunction(commandFactory, wrapCreateCommand(commandFactory))
 })

--- a/packages/datadog-instrumentations/src/apollo-server.js
+++ b/packages/datadog-instrumentations/src/apollo-server.js
@@ -55,7 +55,7 @@ function apolloExpress4Hook (express4) {
     return function expressMiddleware (server, options) {
       const originalMiddleware = originalExpressMiddleware.apply(this, arguments)
 
-      return shimmer.wrapFunction(originalMiddleware, originalMiddleware => function (req, res, next) {
+      return shimmer.wrapFunction(originalMiddleware, function (req, res, next) {
         if (!graphqlMiddlewareChannel.start.hasSubscribers) {
           return originalMiddleware.apply(this, arguments)
         }

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -91,7 +91,7 @@ function wrapSmithySend (send) {
       })
 
       if (typeof cb === 'function') {
-        args[args.length - 1] = shimmer.wrapFunction(cb, cb => function (err, result) {
+        args[args.length - 1] = shimmer.wrapFunction(cb, function (err, result) {
           const message = getMessage(request, err, result)
 
           completeChannel.publish(message)
@@ -129,7 +129,7 @@ function wrapSmithySend (send) {
 
 function wrapCb (cb, serviceName, request, ar) {
   // eslint-disable-next-line n/handle-callback-err
-  return shimmer.wrapFunction(cb, cb => function wrappedCb (err, response) {
+  return shimmer.wrapFunction(cb, function wrappedCb (err, response) {
     const obj = { request, response }
     return ar.runInAsyncScope(() => {
       channel(`apm:aws:response:start:${serviceName}`).publish(obj)

--- a/packages/datadog-instrumentations/src/azure-functions.js
+++ b/packages/datadog-instrumentations/src/azure-functions.js
@@ -30,7 +30,7 @@ function wrapHandler (method) {
       shimmer.wrap(options, 'handler', handler => traceHandler(handler, name, method.name))
     } else if (typeof arg === 'function') {
       const handler = arg
-      arguments[1] = shimmer.wrapFunction(handler, handler => traceHandler(handler, name, method.name))
+      arguments[1] = shimmer.wrapFunction(handler, traceHandler(handler, name, method.name))
     }
     return method.apply(this, arguments)
   }

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -6,7 +6,7 @@ const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const bodyParserReadCh = channel('datadog:body-parser:read:finish')
 
 function publishRequestBodyAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, function () {
     if (bodyParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const body = req.body
@@ -25,7 +25,7 @@ addHook({
   file: 'lib/read.js',
   versions: ['>=1.4.0 <1.20.0']
 }, read => {
-  return shimmer.wrapFunction(read, read => function (req, res, next) {
+  return shimmer.wrapFunction(read, function (req, res, next) {
     const nextResource = new AsyncResource('bound-anonymous-fn')
     arguments[2] = nextResource.bind(publishRequestBodyAndNext(req, res, next))
     return read.apply(this, arguments)
@@ -37,7 +37,7 @@ addHook({
   file: 'lib/read.js',
   versions: ['>=1.20.0']
 }, read => {
-  return shimmer.wrapFunction(read, read => function (req, res, next) {
+  return shimmer.wrapFunction(read, function (req, res, next) {
     arguments[2] = publishRequestBodyAndNext(req, res, next)
     return read.apply(this, arguments)
   })

--- a/packages/datadog-instrumentations/src/cassandra-driver.js
+++ b/packages/datadog-instrumentations/src/cassandra-driver.js
@@ -180,7 +180,7 @@ function finish (finishCh, errorCh, error) {
 }
 
 function wrapCallback (finishCh, errorCh, asyncResource, callback) {
-  return shimmer.wrapFunction(callback, callback => asyncResource.bind(function (err) {
+  return shimmer.wrapFunction(callback, asyncResource.bind(function (err) {
     finish(finishCh, errorCh, err)
     if (callback) {
       return callback.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -248,10 +248,10 @@ function wrapChildProcessAsyncMethod (ChildProcess, shell = false) {
       })
     }
 
-    if (childProcessMethod[util.promisify.custom]) {
+    const customPromisifyMethod = childProcessMethod[util.promisify.custom]
+    if (customPromisifyMethod) {
       const wrapedChildProcessCustomPromisifyMethod =
-        shimmer.wrapFunction(childProcessMethod[util.promisify.custom],
-          promisify => wrapChildProcessCustomPromisifyMethod(promisify, shell))
+        shimmer.wrapFunction(customPromisifyMethod, wrapChildProcessCustomPromisifyMethod(customPromisifyMethod, shell))
 
       // should do it in this way because the original property is readonly
       const descriptor = Object.getOwnPropertyDescriptor(childProcessMethod, util.promisify.custom)

--- a/packages/datadog-instrumentations/src/connect.js
+++ b/packages/datadog-instrumentations/src/connect.js
@@ -59,7 +59,7 @@ function wrapLayerHandle (layer) {
 
   const original = layer.handle
 
-  return shimmer.wrapFunction(original, original => function () {
+  return shimmer.wrapFunction(original, function () {
     if (!enterChannel.hasSubscribers) return original.apply(this, arguments)
 
     const lastIndex = arguments.length - 1
@@ -90,7 +90,7 @@ function wrapLayerHandle (layer) {
 }
 
 function wrapNext (req, next) {
-  return shimmer.wrapFunction(next, next => function (error) {
+  return shimmer.wrapFunction(next, function (error) {
     if (error) {
       errorChannel.publish({ req, error })
     }
@@ -103,7 +103,7 @@ function wrapNext (req, next) {
 }
 
 addHook({ name: 'connect', versions: ['>=3'] }, connect => {
-  return shimmer.wrapFunction(connect, connect => wrapConnect(connect))
+  return shimmer.wrapFunction(connect, wrapConnect(connect))
 })
 
 addHook({ name: 'connect', versions: ['2.2.2'] }, connect => {

--- a/packages/datadog-instrumentations/src/cookie-parser.js
+++ b/packages/datadog-instrumentations/src/cookie-parser.js
@@ -6,7 +6,7 @@ const { channel, addHook } = require('./helpers/instrument')
 const cookieParserReadCh = channel('datadog:cookie-parser:read:finish')
 
 function publishRequestCookieAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function cookieParserWrapper () {
+  return shimmer.wrapFunction(next, function cookieParserWrapper () {
     if (cookieParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
 
@@ -25,10 +25,10 @@ addHook({
   name: 'cookie-parser',
   versions: ['>=1.0.0']
 }, cookieParser => {
-  return shimmer.wrapFunction(cookieParser, cookieParser => function () {
+  return shimmer.wrapFunction(cookieParser, function () {
     const cookieMiddleware = cookieParser.apply(this, arguments)
 
-    return shimmer.wrapFunction(cookieMiddleware, cookieMiddleware => function (req, res, next) {
+    return shimmer.wrapFunction(cookieMiddleware, function (req, res, next) {
       arguments[2] = publishRequestCookieAndNext(req, res, next)
       return cookieMiddleware.apply(this, arguments)
     })

--- a/packages/datadog-instrumentations/src/couchbase.js
+++ b/packages/datadog-instrumentations/src/couchbase.js
@@ -76,7 +76,7 @@ function wrap (prefix, fn) {
 
       startCh.publish({ bucket: { name: this.name || this._name }, seedNodes: this._dd_hosts })
 
-      arguments[callbackIndex] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
+      arguments[callbackIndex] = shimmer.wrapFunction(cb, asyncResource.bind(function (error, result) {
         if (error) {
           errorCh.publish(error)
         }
@@ -118,7 +118,7 @@ function wrapCBandPromise (fn, name, startData, thisArg, args) {
         // v3 offers callback or promises event handling
         // NOTE: this does not work with v3.2.0-3.2.1 cluster.query, as there is a bug in the couchbase source code
         const cb = callbackResource.bind(args[cbIndex])
-        args[cbIndex] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
+        args[cbIndex] = shimmer.wrapFunction(cb, asyncResource.bind(function (error, result) {
           if (error) {
             errorCh.publish(error)
           }

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -249,7 +249,7 @@ function wrapRun (pl, isLatestVersion) {
     testStartCh.runStores(ctx, () => { })
     const promises = {}
     try {
-      this.eventBroadcaster.on('envelope', shimmer.wrapFunction(null, () => async (testCase) => {
+      this.eventBroadcaster.on('envelope', async (testCase) => {
         // Only supported from >=8.0.0
         if (testCase?.testCaseFinished) {
           const { testCaseFinished: { willBeRetried } } = testCase
@@ -279,7 +279,7 @@ function wrapRun (pl, isLatestVersion) {
             testStartCh.runStores(newCtx, () => { })
           }
         }
-      }))
+      })
       let promise
 
       testFnCh.runStores(ctx, () => {

--- a/packages/datadog-instrumentations/src/dns.js
+++ b/packages/datadog-instrumentations/src/dns.js
@@ -71,7 +71,7 @@ function wrap (prefix, fn, expectedArgs, rrtype) {
     const ctx = { args }
 
     return startCh.runStores(ctx, () => {
-      arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function (error, result, ...args) {
+      arguments[arguments.length - 1] = shimmer.wrapFunction(cb, function (error, result, ...args) {
         if (error) {
           ctx.error = error
           errorCh.publish(ctx)

--- a/packages/datadog-instrumentations/src/elasticsearch.js
+++ b/packages/datadog-instrumentations/src/elasticsearch.js
@@ -48,7 +48,7 @@ function createWrapSelect () {
     return function () {
       if (arguments.length === 1) {
         const cb = arguments[0]
-        arguments[0] = shimmer.wrapFunction(cb, cb => function (err, connection) {
+        arguments[0] = shimmer.wrapFunction(cb, function (err, connection) {
           if (connectCh.hasSubscribers && connection && connection.host) {
             connectCh.publish({ hostname: connection.host.host, port: connection.host.port })
           }
@@ -86,7 +86,7 @@ function createWrapRequest (name) {
           if (typeof cb === 'function') {
             cb = parentResource.bind(cb)
 
-            arguments[lastIndex] = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error) {
+            arguments[lastIndex] = shimmer.wrapFunction(cb, asyncResource.bind(function (error) {
               finish(params, error)
               return cb.apply(null, arguments)
             }))

--- a/packages/datadog-instrumentations/src/express-mongo-sanitize.js
+++ b/packages/datadog-instrumentations/src/express-mongo-sanitize.js
@@ -22,15 +22,15 @@ addHook({ name: 'express-mongo-sanitize', versions: ['>=1.0.0'] }, expressMongoS
     return sanitizedObject
   })
 
-  return shimmer.wrapFunction(expressMongoSanitize, expressMongoSanitize => function () {
+  return shimmer.wrapFunction(expressMongoSanitize, function () {
     const middleware = expressMongoSanitize.apply(this, arguments)
 
-    return shimmer.wrapFunction(middleware, middleware => function (req, res, next) {
+    return shimmer.wrapFunction(middleware, function (req, res, next) {
       if (!sanitizeMiddlewareFinished.hasSubscribers) {
         return middleware.apply(this, arguments)
       }
 
-      const wrappedNext = shimmer.wrapFunction(next, next => function () {
+      const wrappedNext = shimmer.wrapFunction(next, function () {
         sanitizeMiddlewareFinished.publish({
           sanitizedProperties: propertiesToSanitize,
           req

--- a/packages/datadog-instrumentations/src/express-session.js
+++ b/packages/datadog-instrumentations/src/express-session.js
@@ -25,17 +25,13 @@ function wrapSessionMiddleware (sessionMiddleware) {
   }
 }
 
-function wrapSession (session) {
-  return function wrappedSession () {
-    const sessionMiddleware = session.apply(this, arguments)
-
-    return shimmer.wrapFunction(sessionMiddleware, wrapSessionMiddleware)
-  }
-}
-
 addHook({
   name: 'express-session',
   versions: ['>=1.5.0']
 }, session => {
-  return shimmer.wrapFunction(session, wrapSession)
+  return shimmer.wrapFunction(session, function wrappedSession () {
+    const sessionMiddleware = session.apply(this, arguments)
+
+    return shimmer.wrapFunction(sessionMiddleware, wrapSessionMiddleware(sessionMiddleware))
+  })
 })

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -84,7 +84,7 @@ addHook({ name: 'express', versions: ['>=5.0.0'] }, express => {
 const queryParserReadCh = channel('datadog:query:read:finish')
 
 function publishQueryParsedAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, function () {
     if (queryParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const query = req.query
@@ -103,10 +103,10 @@ addHook({
   versions: ['4'],
   file: 'lib/middleware/query.js'
 }, query => {
-  return shimmer.wrapFunction(query, query => function () {
+  return shimmer.wrapFunction(query, function () {
     const queryMiddleware = query.apply(this, arguments)
 
-    return shimmer.wrapFunction(queryMiddleware, queryMiddleware => function (req, res, next) {
+    return shimmer.wrapFunction(queryMiddleware, function (req, res, next) {
       arguments[2] = publishQueryParsedAndNext(req, res, next)
       return queryMiddleware.apply(this, arguments)
     })

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -36,12 +36,12 @@ function wrapFastify (fastify, hasParsingEvents) {
 }
 
 function wrapAddHook (addHook) {
-  return shimmer.wrapFunction(addHook, addHook => function addHookWithTrace (name, fn) {
+  return shimmer.wrapFunction(addHook, function addHookWithTrace (name, fn) {
     fn = arguments[arguments.length - 1]
 
     if (typeof fn !== 'function') return addHook.apply(this, arguments)
 
-    arguments[arguments.length - 1] = shimmer.wrapFunction(fn, fn => function (request, reply, done) {
+    arguments[arguments.length - 1] = shimmer.wrapFunction(fn, function (request, reply, done) {
       const req = getReq(request)
 
       try {
@@ -162,7 +162,7 @@ function onRoute (routeOptions) {
 }
 
 addHook({ name: 'fastify', versions: ['>=3'] }, fastify => {
-  const wrapped = shimmer.wrapFunction(fastify, fastify => wrapFastify(fastify, true))
+  const wrapped = shimmer.wrapFunction(fastify, wrapFastify(fastify, true))
 
   wrapped.fastify = wrapped
   wrapped.default = wrapped
@@ -171,9 +171,9 @@ addHook({ name: 'fastify', versions: ['>=3'] }, fastify => {
 })
 
 addHook({ name: 'fastify', versions: ['2'] }, fastify => {
-  return shimmer.wrapFunction(fastify, fastify => wrapFastify(fastify, true))
+  return shimmer.wrapFunction(fastify, wrapFastify(fastify, true))
 })
 
 addHook({ name: 'fastify', versions: ['1'] }, fastify => {
-  return shimmer.wrapFunction(fastify, fastify => wrapFastify(fastify, false))
+  return shimmer.wrapFunction(fastify, wrapFastify(fastify, false))
 })

--- a/packages/datadog-instrumentations/src/find-my-way.js
+++ b/packages/datadog-instrumentations/src/find-my-way.js
@@ -9,7 +9,7 @@ function wrapOn (on) {
   return function onWithTrace (method, path, opts) {
     const index = typeof opts === 'function' ? 2 : 3
     const handler = arguments[index]
-    const wrapper = shimmer.wrapFunction(handler, handler => function (req) {
+    const wrapper = shimmer.wrapFunction(handler, function (req) {
       routeChannel.publish({ req, route: path })
 
       return handler.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -275,7 +275,7 @@ function createWrapFunction (prefix = '', override = '') {
       }
 
       if (cb) {
-        arguments[lastIndex] = shimmer.wrapFunction(cb, cb => function (e) {
+        arguments[lastIndex] = shimmer.wrapFunction(cb, function (e) {
           return finish(e, () => cb.apply(this, arguments))
         })
       }

--- a/packages/datadog-instrumentations/src/google-cloud-pubsub.js
+++ b/packages/datadog-instrumentations/src/google-cloud-pubsub.js
@@ -76,7 +76,7 @@ function wrapMethod (method) {
       if (typeof cb === 'function') {
         const outerAsyncResource = new AsyncResource('bound-anonymous-fn')
 
-        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => innerAsyncResource.bind(function (error) {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, innerAsyncResource.bind(function (error) {
           if (error) {
             requestErrorCh.publish(error)
           }

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -88,7 +88,7 @@ function wrapMethod (method, path, type, hasPeer) {
     return method
   }
 
-  const wrapped = shimmer.wrapFunction(method, method => function () {
+  const wrapped = shimmer.wrapFunction(method, function () {
     const args = ensureMetadata(this, arguments, 1)
     return callMethod(this, method, args, path, args[1], type, hasPeer)
   })
@@ -99,7 +99,7 @@ function wrapMethod (method, path, type, hasPeer) {
 }
 
 function wrapCallback (ctx, callback = () => { }) {
-  return shimmer.wrapFunction(callback, callback => function (err) {
+  return shimmer.wrapFunction(callback, function (err) {
     if (err) {
       ctx.error = err
       errorChannel.publish(ctx)

--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -119,7 +119,7 @@ function wrapStream (call, ctx, onCancel) {
 }
 
 function wrapCallback (callback = () => {}, call, ctx, onCancel) {
-  return shimmer.wrapFunction(callback, callback => function (err, value, trailer, flags) {
+  return shimmer.wrapFunction(callback, function (err, value, trailer, flags) {
     if (err) {
       ctx.error = err
       errorChannel.publish(ctx)

--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -28,7 +28,7 @@ function wrapServer (server) {
 }
 
 function wrapStart (start) {
-  return shimmer.wrapFunction(start, start => function () {
+  return shimmer.wrapFunction(start, function () {
     if (this && typeof this.ext === 'function') {
       this.ext('onPreResponse', onPreResponse)
     }
@@ -38,7 +38,7 @@ function wrapStart (start) {
 }
 
 function wrapExt (ext) {
-  return shimmer.wrapFunction(ext, ext => function (events, method, options) {
+  return shimmer.wrapFunction(ext, function (events, method, options) {
     if (events !== null && typeof events === 'object') {
       arguments[0] = wrapEvents(events)
     } else {
@@ -92,7 +92,7 @@ function wrapEvents (events) {
 function wrapHandler (handler) {
   if (typeof handler !== 'function') return handler
 
-  return shimmer.wrapFunction(handler, handler => function (request, h) {
+  return shimmer.wrapFunction(handler, function (request, h) {
     const req = request && request.raw && request.raw.req
 
     if (!req) return handler.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -920,7 +920,7 @@ addHook({
 
 function jestAdapterWrapper (jestAdapter, jestVersion) {
   const adapter = jestAdapter.default ? jestAdapter.default : jestAdapter
-  const newAdapter = shimmer.wrapFunction(adapter, adapter => function () {
+  const newAdapter = shimmer.wrapFunction(adapter, function () {
     const environment = arguments[2]
     if (!environment) {
       return adapter.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -81,7 +81,7 @@ addHook({
 function wrapCallbackWithFinish (callback, finish) {
   if (typeof callback !== 'function') return callback
 
-  return shimmer.wrapFunction(callback, callback => function () {
+  return shimmer.wrapFunction(callback, function () {
     finish()
     callback.apply(this, arguments)
   })

--- a/packages/datadog-instrumentations/src/koa.js
+++ b/packages/datadog-instrumentations/src/koa.js
@@ -71,7 +71,7 @@ function wrapStack (layer) {
 
     middleware = original || middleware
 
-    const handler = shimmer.wrapFunction(middleware, middleware => wrapMiddleware(middleware, layer))
+    const handler = shimmer.wrapFunction(middleware, wrapMiddleware(middleware, layer))
 
     originals.set(handler, middleware)
 
@@ -84,7 +84,7 @@ function wrapMiddleware (fn, layer) {
 
   const name = fn.name
 
-  return shimmer.wrapFunction(fn, fn => function (ctx, next) {
+  return shimmer.wrapFunction(fn, function (ctx, next) {
     if (!ctx || !enterChannel.hasSubscribers) return fn.apply(this, arguments)
 
     const req = ctx.req
@@ -142,7 +142,7 @@ function fulfill (ctx, error) {
 }
 
 function wrapNext (req, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, function () {
     nextChannel.publish({ req })
 
     return next.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/ldapjs.js
+++ b/packages/datadog-instrumentations/src/ldapjs.js
@@ -77,7 +77,7 @@ addHook({ name: 'ldapjs', versions: ['>=2'] }, ldapjs => {
     if (callbackIndex > -1) {
       const callback = arguments[callbackIndex]
       // eslint-disable-next-line n/handle-callback-err
-      arguments[callbackIndex] = shimmer.wrapFunction(callback, callback => function (err, corkedEmitter) {
+      arguments[callbackIndex] = shimmer.wrapFunction(callback, function (err, corkedEmitter) {
         if (corkedEmitter !== null && typeof corkedEmitter === 'object' && typeof corkedEmitter.on === 'function') {
           wrapEmitter(corkedEmitter)
         }

--- a/packages/datadog-instrumentations/src/memcached.js
+++ b/packages/datadog-instrumentations/src/memcached.js
@@ -26,7 +26,7 @@ addHook({ name: 'memcached', versions: ['>=2.2'] }, Memcached => {
       const query = queryCompiler.apply(this, arguments)
       const callback = callbackResource.bind(query.callback)
 
-      query.callback = shimmer.wrapFunction(callback, callback => asyncResource.bind(function (err) {
+      query.callback = shimmer.wrapFunction(callback, asyncResource.bind(function (err) {
         if (err) {
           errorCh.publish(err)
         }

--- a/packages/datadog-instrumentations/src/microgateway-core.js
+++ b/packages/datadog-instrumentations/src/microgateway-core.js
@@ -42,7 +42,7 @@ function wrapPluginsFactory (pluginsFactory) {
 }
 
 function wrapNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function nextWithTrace (err) {
+  return shimmer.wrapFunction(next, function nextWithTrace (err) {
     const requestResource = requestResources.get(req)
 
     requestResource.runInAsyncScope(() => {
@@ -60,9 +60,9 @@ function wrapNext (req, res, next) {
 }
 
 addHook({ name, versions, file: 'lib/config-proxy-middleware.js' }, configProxyFactory => {
-  return shimmer.wrapFunction(configProxyFactory, wrapConfigProxyFactory)
+  return shimmer.wrapFunction(configProxyFactory, wrapConfigProxyFactory(configProxyFactory))
 })
 
 addHook({ name, versions, file: 'lib/plugins-middleware.js' }, pluginsFactory => {
-  return shimmer.wrapFunction(pluginsFactory, wrapPluginsFactory)
+  return shimmer.wrapFunction(pluginsFactory, wrapPluginsFactory(pluginsFactory))
 })

--- a/packages/datadog-instrumentations/src/mocha/common.js
+++ b/packages/datadog-instrumentations/src/mocha/common.js
@@ -15,7 +15,7 @@ addHook({
 
   patched.add(mochaEach)
 
-  return shimmer.wrapFunction(mochaEach, mochaEach => function () {
+  return shimmer.wrapFunction(mochaEach, function () {
     const [params] = arguments
     const { it, ...rest } = mochaEach.apply(this, arguments)
     return {

--- a/packages/datadog-instrumentations/src/moleculer/server.js
+++ b/packages/datadog-instrumentations/src/moleculer/server.js
@@ -24,7 +24,7 @@ function createMiddleware () {
     localAction (next, action) {
       const broker = this
 
-      return shimmer.wrapFunction(next, next => function datadogMiddleware (ctx) {
+      return shimmer.wrapFunction(next, function datadogMiddleware (ctx) {
         const actionResource = new AsyncResource('bound-anonymous-fn')
 
         return actionResource.runInAsyncScope(() => {

--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -164,7 +164,7 @@ function instrument (operation, command, ctx, args, server, ns, ops, options = {
   return asyncResource.runInAsyncScope(() => {
     startCh.publish({ ns, ops, options: serverInfo, name })
 
-    args[index] = shimmer.wrapFunction(callback, callback => asyncResource.bind(function (err, res) {
+    args[index] = shimmer.wrapFunction(callback, asyncResource.bind(function (err, res) {
       if (err) {
         errorCh.publish(err)
       }

--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -122,13 +122,13 @@ addHook({
                   return execResult
                 }
 
-                // wrap them method, wrap resolve and reject methods
+                // wrap then method, wrap resolve and reject methods
                 shimmer.wrap(execResult, 'then', originalThen => {
                   return function wrappedThen () {
                     const resolve = arguments[0]
                     const reject = arguments[1]
 
-                    arguments[0] = shimmer.wrapFunction(resolve, resolve => function wrappedResolve () {
+                    arguments[0] = shimmer.wrapFunction(resolve, function wrappedResolve () {
                       finish()
 
                       if (resolve) {
@@ -136,7 +136,7 @@ addHook({
                       }
                     })
 
-                    arguments[1] = shimmer.wrapFunction(reject, reject => function wrappedReject () {
+                    arguments[1] = shimmer.wrapFunction(reject, function wrappedReject () {
                       finish()
 
                       if (reject) {
@@ -168,7 +168,7 @@ addHook({
   versions: ['6', '>=7'],
   file: 'lib/helpers/query/sanitizeFilter.js'
 }, sanitizeFilter => {
-  return shimmer.wrapFunction(sanitizeFilter, sanitizeFilter => function wrappedSanitizeFilter () {
+  return shimmer.wrapFunction(sanitizeFilter, function wrappedSanitizeFilter () {
     const sanitizedObject = sanitizeFilter.apply(this, arguments)
 
     if (sanitizeFilterFinishCh.hasSubscribers) {

--- a/packages/datadog-instrumentations/src/multer.js
+++ b/packages/datadog-instrumentations/src/multer.js
@@ -6,7 +6,7 @@ const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const multerReadCh = channel('datadog:multer:read:finish')
 
 function publishRequestBodyAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, function () {
     if (multerReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const body = req.body
@@ -25,10 +25,10 @@ addHook({
   file: 'lib/make-middleware.js',
   versions: ['^1.4.4-lts.1']
 }, makeMiddleware => {
-  return shimmer.wrapFunction(makeMiddleware, makeMiddleware => function () {
+  return shimmer.wrapFunction(makeMiddleware, function () {
     const middleware = makeMiddleware.apply(this, arguments)
 
-    return shimmer.wrapFunction(middleware, middleware => function wrapMulterMiddleware (req, res, next) {
+    return shimmer.wrapFunction(middleware, function wrapMulterMiddleware (req, res, next) {
       const nextResource = new AsyncResource('bound-anonymous-fn')
       arguments[2] = nextResource.bind(publishRequestBodyAndNext(req, res, next))
       return middleware.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -37,7 +37,7 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
 
         if (res._callback) {
           const cb = callbackResource.bind(res._callback)
-          res._callback = shimmer.wrapFunction(cb, cb => asyncResource.bind(function (error, result) {
+          res._callback = shimmer.wrapFunction(cb, asyncResource.bind(function (error, result) {
             if (error) {
               errorCh.publish(error)
             }
@@ -92,7 +92,7 @@ addHook({ name: 'mysql', file: 'lib/Pool.js', versions: ['>=2'] }, Pool => {
 
       const cb = arguments[arguments.length - 1]
       if (typeof cb === 'function') {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function () {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, function () {
           finish()
           return cb.apply(this, arguments)
         })

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -104,7 +104,7 @@ function wrapConnection (Connection, version) {
   return Connection
 
   function bindExecute (cmd, execute, asyncResource) {
-    return shimmer.wrapFunction(execute, execute => asyncResource.bind(function executeWithTrace (packet, connection) {
+    return shimmer.wrapFunction(execute, asyncResource.bind(function executeWithTrace (packet, connection) {
       if (this.onResult) {
         this.onResult = asyncResource.bind(this.onResult)
       }
@@ -116,7 +116,7 @@ function wrapConnection (Connection, version) {
   function wrapExecute (cmd, execute, asyncResource, config) {
     const callbackResource = new AsyncResource('bound-anonymous-fn')
 
-    return shimmer.wrapFunction(execute, execute => asyncResource.bind(function executeWithTrace (packet, connection) {
+    return shimmer.wrapFunction(execute, asyncResource.bind(function executeWithTrace (packet, connection) {
       const sql = cmd.statement ? cmd.statement.query : cmd.sql
       const payload = { sql, conf: config }
       startCh.publish(payload)
@@ -130,7 +130,7 @@ function wrapConnection (Connection, version) {
       if (this.onResult) {
         const onResult = callbackResource.bind(this.onResult)
 
-        this.onResult = shimmer.wrapFunction(onResult, onResult => asyncResource.bind(function (error) {
+        this.onResult = shimmer.wrapFunction(onResult, asyncResource.bind(function (error) {
           if (error) {
             errorCh.publish(error)
           }

--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -52,7 +52,7 @@ addHook({ name: names }, (net, version, name) => {
       setupListeners(this, protocol, ctx, finishCh, errorCh)
 
       const emit = this.emit
-      this.emit = shimmer.wrapFunction(emit, emit => function (eventName) {
+      this.emit = shimmer.wrapFunction(emit, function (eventName) {
         switch (eventName) {
           case 'ready':
           case 'connect':

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -31,7 +31,7 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
       if (arguments.length && typeof arguments[arguments.length - 1] === 'function') {
         const cb = arguments[arguments.length - 1]
         const outerAr = new AsyncResource('apm:oracledb:outer-scope')
-        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function wrappedCb (err, result) {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, function wrappedCb (err, result) {
           finish(err)
           return outerAr.runInAsyncScope(() => cb.apply(this, arguments))
         })
@@ -67,7 +67,7 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
   shimmer.wrap(oracledb, 'getConnection', getConnection => {
     return function wrappedGetConnection (connAttrs, callback) {
       if (callback) {
-        arguments[1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
+        arguments[1] = shimmer.wrapFunction(callback, (err, connection) => {
           if (connection) {
             connectionAttributes.set(connection, connAttrs)
           }
@@ -86,7 +86,7 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
   shimmer.wrap(oracledb, 'createPool', createPool => {
     return function wrappedCreatePool (poolAttrs, callback) {
       if (callback) {
-        arguments[1] = shimmer.wrapFunction(callback, callback => (err, pool) => {
+        arguments[1] = shimmer.wrapFunction(callback, (err, pool) => {
           if (pool) {
             poolAttributes.set(pool, poolAttrs)
           }
@@ -109,7 +109,7 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
         callback = arguments[arguments.length - 1]
       }
       if (callback) {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(callback, (err, connection) => {
           if (connection) {
             connectionAttributes.set(connection, poolAttributes.get(this))
           }

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -191,7 +191,7 @@ function wrapPoolQuery (query) {
       }
 
       if (typeof cb === 'function') {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function () {
+        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, function () {
           finish()
           return cb.apply(this, arguments)
         })

--- a/packages/datadog-instrumentations/src/pino.js
+++ b/packages/datadog-instrumentations/src/pino.js
@@ -76,19 +76,19 @@ function wrapPrettyFactory (prettyFactory) {
 addHook({ name: 'pino', versions: ['2 - 3', '4', '>=5 <5.14.0'] }, pino => {
   const asJsonSym = (pino.symbols && pino.symbols.asJsonSym) || 'asJson'
 
-  return shimmer.wrapFunction(pino, pino => wrapPino(asJsonSym, wrapAsJson, pino))
+  return shimmer.wrapFunction(pino, wrapPino(asJsonSym, wrapAsJson, pino))
 })
 
 addHook({ name: 'pino', versions: ['>=5.14.0 <6.8.0'] }, pino => {
   const mixinSym = pino.symbols.mixinSym
 
-  return shimmer.wrapFunction(pino, pino => wrapPino(mixinSym, wrapMixin, pino))
+  return shimmer.wrapFunction(pino, wrapPino(mixinSym, wrapMixin, pino))
 })
 
 addHook({ name: 'pino', versions: ['>=6.8.0'] }, pino => {
   const mixinSym = pino.symbols.mixinSym
 
-  const wrapped = shimmer.wrapFunction(pino, pino => wrapPino(mixinSym, wrapMixin, pino))
+  const wrapped = shimmer.wrapFunction(pino, wrapPino(mixinSym, wrapMixin, pino))
   wrapped.pino = wrapped
   wrapped.default = wrapped
 
@@ -101,5 +101,5 @@ addHook({ name: 'pino-pretty', file: 'lib/utils.js', versions: ['>=3'] }, utils 
 })
 
 addHook({ name: 'pino-pretty', versions: ['1 - 2'] }, prettyFactory => {
-  return shimmer.wrapFunction(prettyFactory, wrapPrettyFactory)
+  return shimmer.wrapFunction(prettyFactory, wrapPrettyFactory(prettyFactory))
 })

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -156,7 +156,7 @@ function start (client, command, args, url = {}) {
 }
 
 function wrapCallback (finishCh, errorCh, callback) {
-  return shimmer.wrapFunction(callback, callback => function (err) {
+  return shimmer.wrapFunction(callback, function (err) {
     finish(finishCh, errorCh, err)
     if (callback) {
       return callback.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -40,7 +40,7 @@ function wrapMiddleware (middleware) {
 function wrapFn (fn) {
   if (Array.isArray(fn)) return wrapMiddleware(fn)
 
-  return shimmer.wrapFunction(fn, fn => function (req, res, next) {
+  return shimmer.wrapFunction(fn, function (req, res, next) {
     if (typeof next === 'function') {
       arguments[2] = wrapNext(req, next)
     }
@@ -76,7 +76,7 @@ function wrapFn (fn) {
 }
 
 function wrapNext (req, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, function () {
     nextChannel.publish({ req })
     finishChannel.publish({ req })
 

--- a/packages/datadog-instrumentations/src/rhea.js
+++ b/packages/datadog-instrumentations/src/rhea.js
@@ -153,7 +153,7 @@ function wrapDeliveryUpdate (obj, update) {
   const asyncResource = context.asyncResource
   if (obj && asyncResource) {
     const cb = asyncResource.bind(update)
-    return shimmer.wrapFunction(cb, cb => AsyncResource.bind(function wrappedUpdate (settled, stateData) {
+    return shimmer.wrapFunction(cb, AsyncResource.bind(function wrappedUpdate (settled, stateData) {
       const state = getStateFromData(stateData)
       dispatchReceiveCh.publish({ state })
       return cb.apply(this, arguments)
@@ -178,7 +178,7 @@ function patchCircularBuffer (proto, Session) {
         }
         if (CircularBuffer && !patched.has(CircularBuffer.prototype)) {
           shimmer.wrap(CircularBuffer.prototype, 'pop_if', popIf => function (fn) {
-            arguments[0] = shimmer.wrapFunction(fn, fn => AsyncResource.bind(function (entry) {
+            arguments[0] = shimmer.wrapFunction(fn, AsyncResource.bind(function (entry) {
               const context = contexts.get(entry)
               const asyncResource = context && context.asyncResource
 

--- a/packages/datadog-instrumentations/src/sharedb.js
+++ b/packages/datadog-instrumentations/src/sharedb.js
@@ -48,7 +48,7 @@ addHook({ name: 'sharedb', versions: ['>=1'], file: 'lib/agent.js' }, Agent => {
 
       callback = callbackResource.bind(callback)
 
-      arguments[1] = shimmer.wrapFunction(callback, callback => asyncResource.bind(function (error, res) {
+      arguments[1] = shimmer.wrapFunction(callback, asyncResource.bind(function (error, res) {
         if (error) {
           errorCh.publish(error)
         }

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -13,6 +13,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
 
   get serviceIdentifier () {
     const id = this.constructor.id.toLowerCase()
+    console.log('id', id)
     Object.defineProperty(this, 'serviceIdentifier', {
       configurable: true,
       writable: true,

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -34,14 +34,13 @@ function copyProperties (original, wrapped) {
 }
 
 function wrapFunction (original, wrapper) {
-  const wrapped = wrapper(original)
-
-  if (typeof original === 'function') {
-    assertNotClass(original)
-    copyProperties(original, wrapped)
+  if (typeof original !== 'function') {
+    throw new Error(`Target is not a function (${typeof original})`)
   }
+  assertNotClass(original)
+  copyProperties(original, wrapper)
 
-  return wrapped
+  return wrapper
 }
 
 function wrap (target, name, wrapper) {

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -34,11 +34,13 @@ function copyProperties (original, wrapped) {
 }
 
 function wrapFunction (original, wrapper) {
-  if (typeof original !== 'function') {
-    throw new Error(`Target is not a function (${typeof original})`)
+  if (original == null) {
+    if (typeof original !== 'function') {
+      throw new Error(`Target is not a function (${typeof original})`)
+    }
+    assertNotClass(original)
+    copyProperties(original, wrapper)
   }
-  assertNotClass(original)
-  copyProperties(original, wrapper)
 
   return wrapper
 }

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -34,7 +34,7 @@ function copyProperties (original, wrapped) {
 }
 
 function wrapFunction (original, wrapper) {
-  if (original == null) {
+  if (original != null) {
     if (typeof original !== 'function') {
       throw new Error(`Target is not a function (${typeof original})`)
     }

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -287,10 +287,17 @@ describe('shimmer', () => {
       expect(() => shimmer.wrap(() => {}, () => {})).to.throw()
     })
 
-    it('should work without a function', () => {
+    it('should not work without a function', () => {
       const a = { b: 1 }
       const wrapped = shimmer.wrapFunction(a, () => a)
       expect(wrapped()).to.equal(a)
+    })
+
+    it('should work with a undefined', () => {
+      const a = undefined
+      const wrapper = () => a
+      const wrapped = shimmer.wrapFunction(a, wrapper)
+      expect(wrapped()).to.equal(wrapper)
     })
 
     it('should wrap the function', () => {

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -289,14 +289,14 @@ describe('shimmer', () => {
 
     it('should work without a function', () => {
       const a = { b: 1 }
-      const wrapped = shimmer.wrapFunction(a, x => () => x)
+      const wrapped = shimmer.wrapFunction(a, () => a)
       expect(wrapped()).to.equal(a)
     })
 
     it('should wrap the function', () => {
       const count = inc => inc
 
-      const wrapped = shimmer.wrapFunction(count, count => inc => count(inc) + 1)
+      const wrapped = shimmer.wrapFunction(count, inc => count(inc) + 1)
 
       expect(wrapped).to.not.equal(count)
       expect(wrapped(1)).to.equal(2)
@@ -307,7 +307,7 @@ describe('shimmer', () => {
         this.value = start
       }
 
-      const WrappedCounter = shimmer.wrapFunction(Counter, Counter => function (...args) {
+      const WrappedCounter = shimmer.wrapFunction(Counter, function (...args) {
         Counter.apply(this, arguments)
         this.value++
       })
@@ -325,7 +325,7 @@ describe('shimmer', () => {
         }
       }
 
-      expect(() => shimmer.wrapFunction(Counter, Counter => function () {})).to.throw(
+      expect(() => shimmer.wrapFunction(Counter, function () {})).to.throw(
         'Target is a native class constructor and cannot be wrapped.'
       )
     })
@@ -339,7 +339,7 @@ describe('shimmer', () => {
 
       Counter.toString = 'invalid'
 
-      expect(() => shimmer.wrapFunction(Counter, Counter => function () {})).to.throw(
+      expect(() => shimmer.wrapFunction(Counter, function () {})).to.throw(
         'Target is a native class constructor and cannot be wrapped.'
       )
     })
@@ -354,7 +354,7 @@ describe('shimmer', () => {
       count.foo = 'foo'
       count[sym] = 'sym'
 
-      const wrapped = shimmer.wrapFunction(count, count => () => {})
+      const wrapped = shimmer.wrapFunction(count, () => {})
       const bar = Object.getOwnPropertyDescriptor(wrapped, 'bar')
 
       expect(wrapped).to.have.property('foo', 'foo')
@@ -367,7 +367,7 @@ describe('shimmer', () => {
     it('should preserve the original function length', () => {
       const count = (a, b, c) => {}
 
-      const wrapped = shimmer.wrapFunction(count, count => () => {})
+      const wrapped = shimmer.wrapFunction(count, () => {})
 
       expect(wrapped).to.have.length(3)
     })
@@ -375,7 +375,7 @@ describe('shimmer', () => {
     it('should preserve the original function name', () => {
       const count = function count (a, b, c) {}
 
-      const wrapped = shimmer.wrapFunction(count, count => () => {})
+      const wrapped = shimmer.wrapFunction(count, () => {})
 
       expect(wrapped).to.have.property('name', 'count')
     })
@@ -385,7 +385,7 @@ describe('shimmer', () => {
 
       Object.getPrototypeOf(count).test = 'test'
 
-      const wrapped = shimmer.wrapFunction(count, count => () => {})
+      const wrapped = shimmer.wrapFunction(count, () => {})
 
       expect(wrapped).to.have.property('test', 'test')
       expect(Object.getOwnPropertyNames(wrapped)).to.not.include('test')

--- a/packages/dd-trace/src/appsec/iast/security-controls/index.js
+++ b/packages/dd-trace/src/appsec/iast/security-controls/index.js
@@ -118,8 +118,8 @@ function resolve (path, obj, separator = '.') {
 }
 
 function wrapSanitizer (target, secureMarks) {
-  return shimmer.wrapFunction(target, orig => function () {
-    const result = orig.apply(this, arguments)
+  return shimmer.wrapFunction(target, function () {
+    const result = target.apply(this, arguments)
 
     try {
       return addSecureMarks(result, secureMarks)
@@ -134,7 +134,7 @@ function wrapSanitizer (target, secureMarks) {
 function wrapInputValidator (target, parameters, secureMarks) {
   const allParameters = !parameters?.length
 
-  return shimmer.wrapFunction(target, orig => function () {
+  return shimmer.wrapFunction(target, function () {
     try {
       [...arguments].forEach((arg, index) => {
         if (allParameters || parameters.includes(index)) {
@@ -145,7 +145,7 @@ function wrapInputValidator (target, parameters, secureMarks) {
       log.error('[ASM] Error adding Secure mark for input validator', e)
     }
 
-    return orig.apply(this, arguments)
+    return target.apply(this, arguments)
   })
 }
 

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -49,10 +49,10 @@ function ensureChannelsActivated () {
 
   shimmer.wrap(AsyncLocalStorage.prototype, 'run', function (original) {
     return function (store, callback, ...args) {
-      const wrappedCb = shimmer.wrapFunction(callback, cb => function (...args) {
+      const wrappedCb = shimmer.wrapFunction(callback, function (...args) {
         inRun = false
         enterCh.publish()
-        const retVal = cb.apply(this, args)
+        const retVal = callback.apply(this, args)
         inRun = true
         return retVal
       })


### PR DESCRIPTION
The wrapper holds on another scope which potentially adds overhead. This is now removed. The downside is a tad less safe implementation in case the variable would ever be reassigned in the outer scope.