### PR TITLE
Test profiling sample context propagation through promises

### DIFF
--- a/integration-tests/profiler/codehotspots.js
+++ b/integration-tests/profiler/codehotspots.js
@@ -34,7 +34,7 @@ function runBusySpans () {
       for (let i = 0; i < 3; ++i) {
         const z = i
         tracer.trace('y' + i, (_, done2) => {
-          setTimeout(() => {
+          const busyWork = () => {
             busyLoop()
             done2()
             if (z === 2) {
@@ -43,7 +43,17 @@ function runBusySpans () {
               }
               done()
             }
-          }, 0)
+          }
+          if (i === 1) {
+            // Exercise sample context propagation through a promise
+            const p = new Promise((resolve) => {
+              setTimeout(resolve, 0)
+            })
+            p.then(busyWork)
+          } else {
+            // Exercise sample context propagation through a timeout
+            setTimeout(busyWork, 0)
+          }
         })
       }
     })


### PR DESCRIPTION
### What does this PR do?
Of three internal iterations in traces in `codehotspots.js` test program, make the middle one use promises instead of a timeout for asynchronous work chaining.

### Motivation
Our integration test wasn't verifying that profiler sample context is correctly preserved across promise chains. No bug is being fixed – this works, I just wanted to increase functionality coverage.
