### PR TITLE
Don't use DD_ prefix on test-only env var

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -147,7 +147,7 @@ async function createSandbox (dependencies = [], isGitRepo = false,
   integrationTestsPaths = ['./integration-tests/*'], followUpCommand) {
   // We might use NODE_OPTIONS to init the tracer. We don't want this to affect this operations
   const { NODE_OPTIONS, ...restOfEnv } = process.env
-  const noSandbox = String(process.env.DD_NO_INTEGRATION_TESTS_SANDBOX)
+  const noSandbox = String(process.env.NO_INTEGRATION_TESTS_SANDBOX)
   if (noSandbox === '1' || noSandbox.toLowerCase() === 'true') {
     // Execute integration tests without a sandbox. This is useful when you have other components
     // yarn-linked into dd-trace and want to run the integration tests against them.


### PR DESCRIPTION
### What does this PR do?
Removes `DD_` prefix from a test-only env var.

### Motivation
It was pointed out we only use `DD_` prefix for customer-exposed env vars.