### PR TITLE
Ignore appsec startup error in serverless

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -34,6 +34,7 @@ const UserTracking = require('./user_tracking')
 const { storage } = require('../../../datadog-core')
 const graphql = require('./graphql')
 const rasp = require('./rasp')
+const { isInServerlessEnvironment } = require('../serverless')
 
 const responseAnalyzedSet = new WeakSet()
 
@@ -83,7 +84,9 @@ function enable (_config) {
     isEnabled = true
     config = _config
   } catch (err) {
-    log.error('[ASM] Unable to start AppSec', err)
+    if (!isInServerlessEnvironment()) {
+      log.error('[ASM] Unable to start AppSec', err)
+    }
 
     disable()
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Do not log Error when appsec startup fails in serverless
### Motivation
<!-- What inspired you to submit this pull request? -->
It is not expected to work in the tracer, it works in different way.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[APPSEC-57705]


[APPSEC-57705]: https://datadoghq.atlassian.net/browse/APPSEC-57705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ