### PR TITLE
Migrating Tedious from Async Resource to runStores

### DIFF
--- a/packages/datadog-instrumentations/src/tedious.js
+++ b/packages/datadog-instrumentations/src/tedious.js
@@ -22,8 +22,7 @@ addHook({ name: 'tedious', versions: ['>=1.0.0'] }, tedious => {
     }
 
     const connectionConfig = this.config
-    const payload = { queryOrProcedure, connectionConfig }
-    const ctx = { payload }
+    const ctx = { queryOrProcedure, connectionConfig }
 
     return startCh.runStores(ctx, () => {
       queryParent[queryField] = ctx.sql

--- a/packages/datadog-instrumentations/src/tedious.js
+++ b/packages/datadog-instrumentations/src/tedious.js
@@ -34,15 +34,8 @@ addHook({ name: 'tedious', versions: ['>=1.0.0'] }, tedious => {
           ctx.error = error
           errorCh.publish(ctx)
         }
-<<<<<<< HEAD
-        finishCh.publish()
-
-        return cb.apply(this, arguments)
-      }, null, request)
-=======
         return finishCh.runStores(ctx, cb, this, error, ...args)
       }
->>>>>>> 4d8d59fe1 (migrating tedious to use runStores)
 
       try {
         return makeRequest.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/tedious.js
+++ b/packages/datadog-instrumentations/src/tedious.js
@@ -22,7 +22,8 @@ addHook({ name: 'tedious', versions: ['>=1.0.0'] }, tedious => {
     }
 
     const connectionConfig = this.config
-    const ctx = { queryOrProcedure, connectionConfig }
+    const payload = { queryOrProcedure, connectionConfig }
+    const ctx = { payload }
 
     return startCh.runStores(ctx, () => {
       queryParent[queryField] = ctx.sql

--- a/packages/datadog-instrumentations/src/tedious.js
+++ b/packages/datadog-instrumentations/src/tedious.js
@@ -2,8 +2,7 @@
 
 const {
   channel,
-  addHook,
-  AsyncResource
+  addHook
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
@@ -22,30 +21,33 @@ addHook({ name: 'tedious', versions: ['>=1.0.0'] }, tedious => {
       return makeRequest.apply(this, arguments)
     }
 
-    const callbackResource = new AsyncResource('bound-anonymous-fn')
-    const asyncResource = new AsyncResource('bound-anonymous-fn')
-
     const connectionConfig = this.config
+    const ctx = { queryOrProcedure, connectionConfig }
 
-    return asyncResource.runInAsyncScope(() => {
-      const payload = { queryOrProcedure, connectionConfig }
-      startCh.publish(payload)
-      queryParent[queryField] = payload.sql
+    return startCh.runStores(ctx, () => {
+      queryParent[queryField] = ctx.sql
 
-      const cb = callbackResource.bind(request.callback, request)
-      request.callback = asyncResource.bind(function (error) {
+      const cb = request.callback
+      request.callback = function (error, ...args) {
         if (error) {
-          errorCh.publish(error)
+          ctx.error = error
+          errorCh.publish(ctx)
         }
+<<<<<<< HEAD
         finishCh.publish()
 
         return cb.apply(this, arguments)
       }, null, request)
+=======
+        return finishCh.runStores(ctx, cb, this, error, ...args)
+      }
+>>>>>>> 4d8d59fe1 (migrating tedious to use runStores)
 
       try {
         return makeRequest.apply(this, arguments)
       } catch (error) {
-        errorCh.publish(error)
+        ctx.error = error
+        errorCh.publish(ctx)
 
         throw error
       }

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -9,27 +9,27 @@ class TediousPlugin extends DatabasePlugin {
   static get system () { return 'mssql' }
 
   bindStart (ctx) {
-    const { payload } = ctx
     const service = this.serviceName({ pluginConfig: this.config, system: this.system })
     const span = this.startSpan(this.operationName(), {
       service,
-      resource: payload.queryOrProcedure,
+      resource: ctx.queryOrProcedure,
       type: 'sql',
       kind: 'client',
       meta: {
         'db.type': 'mssql',
         component: 'tedious',
-        'out.host': payload.connectionConfig.server,
-        [CLIENT_PORT_KEY]: payload.connectionConfig.options.port,
-        'db.user': payload.connectionConfig.userName || payload.connectionConfig.authentication.options.userName,
-        'db.name': payload.connectionConfig.options.database,
-        'db.instance': payload.connectionConfig.options.instanceName
+        'out.host': ctx.connectionConfig.server,
+        [CLIENT_PORT_KEY]: ctx.connectionConfig.options.port,
+        'db.user': ctx.connectionConfig.userName || ctx.connectionConfig.authentication.options.userName,
+        'db.name': ctx.connectionConfig.options.database,
+        'db.instance': ctx.connectionConfig.options.instanceName
       }
     }, ctx)
 
     // SQL Server includes comments when caching queries
     // For that reason we allow service mode but not full mode
-    payload.sql = this.injectDbmQuery(span, payload.queryOrProcedure, service, true)
+    ctx.sql = this.injectDbmQuery(span, ctx.queryOrProcedure, service, true)
+    return ctx.currentStore
   }
 }
 

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -8,28 +8,28 @@ class TediousPlugin extends DatabasePlugin {
   static get operation () { return 'request' } // TODO: change to match other database plugins
   static get system () { return 'mssql' }
 
-  bindStart (ctx) {
+  bindStart (payload) {
     const service = this.serviceName({ pluginConfig: this.config, system: this.system })
     const span = this.startSpan(this.operationName(), {
       service,
-      resource: ctx.queryOrProcedure,
+      resource: payload.queryOrProcedure,
       type: 'sql',
       kind: 'client',
       meta: {
         'db.type': 'mssql',
         component: 'tedious',
-        'out.host': ctx.connectionConfig.server,
-        [CLIENT_PORT_KEY]: ctx.connectionConfig.options.port,
-        'db.user': ctx.connectionConfig.userName || ctx.connectionConfig.authentication.options.userName,
-        'db.name': ctx.connectionConfig.options.database,
-        'db.instance': ctx.connectionConfig.options.instanceName
+        'out.host': payload.connectionConfig.server,
+        [CLIENT_PORT_KEY]: payload.connectionConfig.options.port,
+        'db.user': payload.connectionConfig.userName || payload.connectionConfig.authentication.options.userName,
+        'db.name': payload.connectionConfig.options.database,
+        'db.instance': payload.connectionConfig.options.instanceName
       }
-    }, ctx)
+    }, payload)
 
     // SQL Server includes comments when caching queries
     // For that reason we allow service mode but not full mode
-    ctx.sql = this.injectDbmQuery(span, ctx.queryOrProcedure, service, true)
-    return ctx.currentStore
+    payload.sql = this.injectDbmQuery(span, payload.queryOrProcedure, service, true)
+    return payload.currentStore
   }
 }
 

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -8,7 +8,7 @@ class TediousPlugin extends DatabasePlugin {
   static get operation () { return 'request' } // TODO: change to match other database plugins
   static get system () { return 'mssql' }
 
-  start (payload) {
+  bindStart (payload) {
     const service = this.serviceName({ pluginConfig: this.config, system: this.system })
     const span = this.startSpan(this.operationName(), {
       service,
@@ -24,11 +24,12 @@ class TediousPlugin extends DatabasePlugin {
         'db.name': payload.connectionConfig.options.database,
         'db.instance': payload.connectionConfig.options.instanceName
       }
-    })
+    }, payload)
 
     // SQL Server includes comments when caching queries
     // For that reason we allow service mode but not full mode
     payload.sql = this.injectDbmQuery(span, payload.queryOrProcedure, service, true)
+    return payload.currentStore
   }
 }
 

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -8,7 +8,8 @@ class TediousPlugin extends DatabasePlugin {
   static get operation () { return 'request' } // TODO: change to match other database plugins
   static get system () { return 'mssql' }
 
-  bindStart (payload) {
+  bindStart (ctx) {
+    const { payload } = ctx
     const service = this.serviceName({ pluginConfig: this.config, system: this.system })
     const span = this.startSpan(this.operationName(), {
       service,
@@ -24,12 +25,11 @@ class TediousPlugin extends DatabasePlugin {
         'db.name': payload.connectionConfig.options.database,
         'db.instance': payload.connectionConfig.options.instanceName
       }
-    }, payload)
+    }, ctx)
 
     // SQL Server includes comments when caching queries
     // For that reason we allow service mode but not full mode
     payload.sql = this.injectDbmQuery(span, payload.queryOrProcedure, service, true)
-    return payload.currentStore
   }
 }
 

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -8,28 +8,28 @@ class TediousPlugin extends DatabasePlugin {
   static get operation () { return 'request' } // TODO: change to match other database plugins
   static get system () { return 'mssql' }
 
-  bindStart (payload) {
+  bindStart (ctx) {
     const service = this.serviceName({ pluginConfig: this.config, system: this.system })
     const span = this.startSpan(this.operationName(), {
       service,
-      resource: payload.queryOrProcedure,
+      resource: ctx.queryOrProcedure,
       type: 'sql',
       kind: 'client',
       meta: {
         'db.type': 'mssql',
         component: 'tedious',
-        'out.host': payload.connectionConfig.server,
-        [CLIENT_PORT_KEY]: payload.connectionConfig.options.port,
-        'db.user': payload.connectionConfig.userName || payload.connectionConfig.authentication.options.userName,
-        'db.name': payload.connectionConfig.options.database,
-        'db.instance': payload.connectionConfig.options.instanceName
+        'out.host': ctx.connectionConfig.server,
+        [CLIENT_PORT_KEY]: ctx.connectionConfig.options.port,
+        'db.user': ctx.connectionConfig.userName || ctx.connectionConfig.authentication.options.userName,
+        'db.name': ctx.connectionConfig.options.database,
+        'db.instance': ctx.connectionConfig.options.instanceName
       }
-    }, payload)
+    }, ctx)
 
     // SQL Server includes comments when caching queries
     // For that reason we allow service mode but not full mode
-    payload.sql = this.injectDbmQuery(span, payload.queryOrProcedure, service, true)
-    return payload.currentStore
+    ctx.sql = this.injectDbmQuery(span, ctx.queryOrProcedure, service, true)
+    return ctx.currentStore
   }
 }
 

--- a/packages/dd-trace/src/plugins/storage.js
+++ b/packages/dd-trace/src/plugins/storage.js
@@ -11,12 +11,12 @@ class StoragePlugin extends ClientPlugin {
     this.system = this.constructor.system || this.component
   }
 
-  startSpan (name, options) {
+  startSpan (name, options, ctx) {
     if (!options.service && this.system) {
       options.service = `${this.tracer._service}-${this.system}`
     }
 
-    return super.startSpan(name, options)
+    return super.startSpan(name, options, ctx)
   }
 }
 

--- a/packages/dd-trace/src/plugins/storage.js
+++ b/packages/dd-trace/src/plugins/storage.js
@@ -11,12 +11,12 @@ class StoragePlugin extends ClientPlugin {
     this.system = this.constructor.system || this.component
   }
 
-  startSpan (name, options, ctx) {
+  startSpan (name, options) {
     if (!options.service && this.system) {
       options.service = `${this.tracer._service}-${this.system}`
     }
 
-    return super.startSpan(name, options, ctx)
+    return super.startSpan(name, options)
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
Convert Tedious fromAsync Resource to runStores

### Motivation
Async Resource no longer works as expected in Node 24.




