### PR TITLE
change ioredis service name

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1042,7 +1042,7 @@ jobs:
           - 6379:6379
     env:
       PLUGINS: ioredis
-      SERVICES: ioredis
+      SERVICES: redis
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/plugins/test


### PR DESCRIPTION
### What does this PR do?
Fix ioredis service name to `redis` as defined in [L1039](https://github.com/DataDog/dd-trace-js/compare/ishabi/ioredis-service-name?expand=1#diff-660fbacbcd30e79ad55c4c69af9a034da3af7f8a37f8704d72b79617a93ee864R1039)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


