### PR TITLE
[test-optimization] [SDTEST-2039] Remove unnecessary channels in Playwright

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -603,9 +603,7 @@ function runnerHook (runnerExport, playwrightVersion) {
         totalAttemptToFixFailedTestCount += testStatuses.filter(status => status === 'fail').length
       }
 
-      if (totalFailedTestCount > 0 &&
-          totalAttemptToFixFailedTestCount > 0 &&
-          totalFailedTestCount === totalAttemptToFixFailedTestCount) {
+      if (totalFailedTestCount > 0 && totalFailedTestCount === totalAttemptToFixFailedTestCount) {
         runAllTestsReturn = 'passed'
       }
     }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -11,7 +11,6 @@ const log = require('../../dd-trace/src/log')
 
 const testStartCh = channel('ci:playwright:test:start')
 const testFinishCh = channel('ci:playwright:test:finish')
-const testFnCh = channel('ci:playwright:test:fn')
 
 const testSessionStartCh = channel('ci:playwright:session:start')
 const testSessionFinishCh = channel('ci:playwright:session:finish')
@@ -928,9 +927,7 @@ addHook({
         })
       }
 
-      testFnCh.runStores(testCtx, () => {
-        res = _runTest.apply(this, arguments)
-      })
+      res = _runTest.apply(this, arguments)
 
       testInfo = this._currentTest
     })

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -183,7 +183,7 @@ class PlaywrightPlugin extends CiPlugin {
       }
     })
 
-    this.addSub('ci:playwright:test:start', (ctx) => {
+    this.addBind('ci:playwright:test:start', (ctx) => {
       const {
         testName,
         testSuiteAbsolutePath,
@@ -367,10 +367,6 @@ class PlaywrightPlugin extends CiPlugin {
       if (process.env.DD_PLAYWRIGHT_WORKER) {
         this.tracer._exporter.flush(onDone)
       }
-    })
-
-    this.addBind('ci:playwright:test:fn', (ctx) => {
-      return ctx.currentStore
     })
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This removes unnecessary channels in Playwright.

### Motivation
<!-- What inspired you to submit this pull request? -->
We noticed that some channels were redundant as they already were inside a `runStores` call.

### Notes
I removed one condition that was not necessary.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


