### PR TITLE
test: rename agent.use() to .assertSomeTraces()

### DIFF
--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -62,7 +62,7 @@ describe('Plugin', () => {
 
           it('should instrument put', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.command.opName)
                 expect(span).to.have.property('service', expectedSchema.command.serviceName)
@@ -88,7 +88,7 @@ describe('Plugin', () => {
 
           it('should instrument connect', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.command.opName)
                 expect(span).to.have.property('service', expectedSchema.command.serviceName)
@@ -105,7 +105,7 @@ describe('Plugin', () => {
 
           it('should instrument get', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.command.opName)
                 expect(span).to.have.property('service', expectedSchema.command.serviceName)
@@ -129,7 +129,7 @@ describe('Plugin', () => {
 
           it('should instrument operate', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.command.opName)
                 expect(span).to.have.property('service', expectedSchema.command.serviceName)
@@ -160,7 +160,7 @@ describe('Plugin', () => {
 
           it('should instrument createIndex', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.command.opName)
                 expect(span).to.have.property('service', expectedSchema.command.serviceName)
@@ -192,7 +192,7 @@ describe('Plugin', () => {
 
           it('should instrument query', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.command.opName)
                 expect(span).to.have.property('service', expectedSchema.command.serviceName)
@@ -246,7 +246,7 @@ describe('Plugin', () => {
             let error
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
                 expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
                 expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -293,7 +293,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.command.opName)
               expect(traces[0][0]).to.have.property('service', 'custom')
             })

--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -71,7 +71,7 @@ describe('Plugin', () => {
 
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span).to.have.property('name', expectedSchema.send.opName)
@@ -100,7 +100,7 @@ describe('Plugin', () => {
             let error
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span.error).to.equal(1)
@@ -144,7 +144,7 @@ describe('Plugin', () => {
         describe('when consuming messages', () => {
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.receive.opName)
                 expect(span).to.have.property('service', expectedSchema.receive.serviceName)
@@ -210,7 +210,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.have.property('service', 'test-custom-name')

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -479,7 +479,7 @@ describe('Plugin', () => {
               channel.sendToQueue(ok.queue, Buffer.from('dsm test'))
 
               let produceSpanMeta = {}
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 if (span.resource.startsWith('basic.publish')) {
@@ -502,7 +502,7 @@ describe('Plugin', () => {
                 if (err) return done(err)
 
                 let consumeSpanMeta = {}
-                agent.use(traces => {
+                agent.assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   if (span.resource.startsWith('basic.deliver')) {

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -67,7 +67,7 @@ describe('Plugin', () => {
 
             it('should do automatic instrumentation for immediate commands', done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
                   expect(span).to.have.property('name', expectedSchema.controlPlane.opName)
                   expect(span).to.have.property('service', expectedSchema.controlPlane.serviceName)
@@ -86,7 +86,7 @@ describe('Plugin', () => {
 
             it('should do automatic instrumentation for queued commands', done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   expect(span).to.have.property('name', expectedSchema.controlPlane.opName)
@@ -109,7 +109,7 @@ describe('Plugin', () => {
               let error
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   expect(span).to.have.property('error', 1)
@@ -145,7 +145,7 @@ describe('Plugin', () => {
 
             it('should do automatic instrumentation', done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   expect(span).to.have.property('name', expectedSchema.send.opName)
@@ -169,7 +169,7 @@ describe('Plugin', () => {
               let error
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   expect(span).to.have.property('error', 1)
@@ -203,7 +203,7 @@ describe('Plugin', () => {
               let queue
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
                   expect(span).to.have.property('name', expectedSchema.receive.opName)
                   expect(span).to.have.property('service', expectedSchema.receive.serviceName)
@@ -543,7 +543,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'test-custom-service')
               expect(traces[0][0]).to.have.property('resource', `queue.declare ${queue}`)
             }, 2)

--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -112,7 +112,7 @@ describe('Plugin', () => {
               }
             }`
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][1]).to.have.property('name', 'apollo.gateway.validate')
               expect(traces[0][2]).to.have.property('name', 'apollo.gateway.plan')
@@ -139,7 +139,7 @@ describe('Plugin', () => {
           const source = `query ${operationName} { hello(name: "world") }`
           const variableValues = { who: 'world' }
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               // the spans are in order of execution
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -194,7 +194,7 @@ describe('Plugin', () => {
         it('should instrument schema resolver', done => {
           const source = '{ hello(name: "world") }'
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.server.serviceName)
               expect(traces[0][0]).to.have.property('resource', '{hello(name:"")}')
@@ -226,7 +226,7 @@ describe('Plugin', () => {
             }
           `
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.server.serviceName)
               expect(traces[0][0]).to.have.property('resource', '{human{address{civicNumber street}name}}')
@@ -249,7 +249,7 @@ describe('Plugin', () => {
           const source = 'mutation { human { name } }'
 
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0][0].meta).to.have.property('graphql.operation.type', 'mutation')
             })
             .then(done)
@@ -284,7 +284,7 @@ describe('Plugin', () => {
             }`
           const variableValues = { who: 'world' }
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0].length).equal(2)
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -319,7 +319,7 @@ describe('Plugin', () => {
           const source = `subscription ${operationName} { hello(name: "world") }`
           const variableValues = { who: 'world' }
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0].length).equal(3)
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -354,7 +354,7 @@ describe('Plugin', () => {
           const source = `query ${operationName} { hello(name: "world") }`
           const variableValues = { who: 'world' }
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
@@ -414,7 +414,7 @@ describe('Plugin', () => {
           const variableValues = { who: 'world' }
 
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               // the spans are in order of execution
               expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
 
@@ -470,7 +470,7 @@ describe('Plugin', () => {
             const source = `query ${operationName} { hello(name: "world") }`
             const variableValues = { who: 'world' }
             agent
-              .use((traces) => {
+              .assertSomeTraces((traces) => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.server.opName)
                 expect(traces[0][0]).to.have.property('service', 'custom')
                 expect(traces[0][0]).to.have.property('resource', `query ${operationName}`)

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -25,7 +25,7 @@ describe('Plugin', () => {
         })
 
         it('should instrument service methods with a callback', (done) => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
 
             expect(span).to.include({
@@ -48,7 +48,7 @@ describe('Plugin', () => {
         })
 
         it('should instrument service methods using promise()', (done) => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
 
             expect(span).to.include({
@@ -92,7 +92,7 @@ describe('Plugin', () => {
         })
 
         it('should instrument service methods with a callback', (done) => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
 
             expect(span).to.include({
@@ -117,7 +117,7 @@ describe('Plugin', () => {
         it('should mark error responses', (done) => {
           let error
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
 
             expect(span).to.include({
@@ -148,7 +148,7 @@ describe('Plugin', () => {
 
         if (!semver.intersects(version, '<3')) {
           it('should instrument service methods using promises', (done) => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = sort(traces[0])[0]
 
               expect(span).to.include({
@@ -162,7 +162,7 @@ describe('Plugin', () => {
           })
         } else if (!semver.intersects(version, '<2.3.0')) {
           it('should instrument service methods using promise()', (done) => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = sort(traces[0])[0]
 
               expect(span).to.include({
@@ -178,7 +178,7 @@ describe('Plugin', () => {
           it('should instrument service methods using promise() with custom promises', (done) => {
             AWS.config.setPromisesDependency(null)
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = sort(traces[0])[0]
 
               expect(span).to.include({
@@ -235,7 +235,7 @@ describe('Plugin', () => {
         })
 
         it('should be configured', (done) => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
             expect(span).to.include({
               name: 'aws.request',
@@ -277,7 +277,7 @@ describe('Plugin', () => {
         it('should allow disabling a specific service', (done) => {
           let total = 0
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
 
             expect(span).to.include({
@@ -289,7 +289,7 @@ describe('Plugin', () => {
             total++
           }).catch(() => {}, { timeoutMs: 100 })
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
 
             expect(span).to.include({

--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
@@ -54,7 +54,7 @@ describe('Plugin', () => {
 
             const command = new AWS.InvokeModelCommand(request)
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span.meta).to.include({
                 'aws.operation': 'invokeModel',

--- a/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
@@ -153,7 +153,7 @@ describe('Plugin', () => {
 
         describe('with payload tagging', () => {
           it('adds request and response payloads as flattened tags for putItem', async () => {
-            const agentPromise = agent.use(traces => {
+            const agentPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span.resource).to.equal(`putItem ${oneKeyTableName}`)
@@ -179,7 +179,7 @@ describe('Plugin', () => {
           })
 
           it('adds request and response payloads as flattened tags for updateItem', async () => {
-            const agentPromise = agent.use(traces => {
+            const agentPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span.resource).to.equal(`updateItem ${oneKeyTableName}`)
@@ -210,7 +210,7 @@ describe('Plugin', () => {
           })
 
           it('adds request and response payloads as flattened tags for deleteItem', async () => {
-            const agentPromise = agent.use(traces => {
+            const agentPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span.resource).to.equal(`deleteItem ${oneKeyTableName}`)
@@ -246,7 +246,7 @@ describe('Plugin', () => {
             // Wait a bit to ensure the put completes
             await wait(100)
 
-            const agentPromise = agent.use(traces => {
+            const agentPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span.resource).to.equal(`getItem ${oneKeyTableName}`)
@@ -292,7 +292,7 @@ describe('Plugin', () => {
             if (expectedHashes) {
               expectedLength = Array.isArray(expectedHashes) ? expectedHashes.length : 1
             }
-            const agentPromise = agent.use(traces => {
+            const agentPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
 

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -143,7 +143,7 @@ describe('Kinesis', function () {
       })
 
       it('generates tags for proper input', done => {
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           expect(span.meta).to.include({
             streamname: streamName,
@@ -219,7 +219,7 @@ describe('Kinesis', function () {
 
       it('injects DSM pathway hash during Kinesis getRecord to the span', done => {
         let getRecordSpanMeta = {}
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const span = traces[0][0]
 
           if (span.name === 'aws.response') {
@@ -242,7 +242,7 @@ describe('Kinesis', function () {
 
       it('injects DSM pathway hash during Kinesis putRecord to the span', done => {
         let putRecordSpanMeta = {}
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const span = traces[0][0]
 
           if (span.resource.startsWith('putRecord')) {

--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -84,7 +84,7 @@ describe('Plugin', () => {
         it('should propagate the tracing context with existing ClientContext and `custom` key', (done) => {
           let receivedContext
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const clientContextSent = Buffer.from(receivedContext, 'base64').toString('utf-8')
             const injectedTraceData = JSON.parse(clientContextSent).custom
@@ -115,7 +115,7 @@ describe('Plugin', () => {
         it('should propagate the tracing context with existing ClientContext and no `custom` key', (done) => {
           let receivedContext
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const clientContextSent = Buffer.from(receivedContext, 'base64').toString('utf-8')
             const injectedTraceData = JSON.parse(clientContextSent).custom
@@ -142,7 +142,7 @@ describe('Plugin', () => {
         it('should propagate the tracing context without an existing ClientContext', (done) => {
           let receivedContext
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const clientContextSent = Buffer.from(receivedContext, 'base64').toString('utf-8')
             const injectedTraceData = JSON.parse(clientContextSent).custom

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -76,7 +76,7 @@ describe('Plugin', () => {
 
         describe('span pointers', () => {
           it('should add span pointer for putObject operation', (done) => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               try {
                 const span = traces[0][0]
                 const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
@@ -106,7 +106,7 @@ describe('Plugin', () => {
           })
 
           it('should add span pointer for copyObject operation', (done) => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               try {
                 const span = traces[0][0]
                 const links = JSON.parse(span.meta?.['_dd.span_links'] || '[]')
@@ -181,7 +181,7 @@ describe('Plugin', () => {
 
                 s3.completeMultipartUpload(completeParams, (err) => {
                   if (err) done(err)
-                  agent.use(traces => {
+                  agent.assertSomeTraces(traces => {
                     const span = traces[0][0]
                     const operation = span.meta?.['aws.operation']
                     if (operation === 'completeMultipartUpload') {
@@ -209,7 +209,7 @@ describe('Plugin', () => {
         it('should allow disabling a specific span kind of a service', (done) => {
           let total = 0
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             expect(span).to.include({
               name: 'aws.request',

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -27,7 +27,7 @@ describe('Sns', function () {
 
     let childSpansFound = 0
     const assertPropagation = (done, childSpans = 1) => {
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         const span = traces[0][0]
 
         if (span.resource.startsWith('publish')) {
@@ -112,7 +112,7 @@ describe('Sns', function () {
       })
 
       it('adds request and response payloads as flattened tags', done => {
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const span = traces[0][0]
 
           expect(span.resource).to.equal(`publish ${TopicArn}`)
@@ -145,7 +145,7 @@ describe('Sns', function () {
       })
 
       it('expands and redacts keys identified as expandable', done => {
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const span = traces[0][0]
 
           expect(span.resource).to.equal(`publish ${TopicArn}`)
@@ -175,7 +175,7 @@ describe('Sns', function () {
 
       describe('user-defined redaction', () => {
         it('redacts user-defined keys to suppress in request', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span.resource).to.equal(`publish ${TopicArn}`)
@@ -208,7 +208,7 @@ describe('Sns', function () {
 
         // TODO add response tests
         it('redacts user-defined keys to suppress in response', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             expect(span.resource).to.equal(`getTopicAttributes ${TopicArn}`)
             expect(span.meta).to.include({
@@ -252,7 +252,7 @@ describe('Sns', function () {
             })
 
             it('redacts phone numbers in request', done => {
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span.resource).to.equal('publish')
@@ -271,7 +271,7 @@ describe('Sns', function () {
             })
 
             it('redacts phone numbers in response', done => {
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span.resource).to.equal('publish')
@@ -292,7 +292,7 @@ describe('Sns', function () {
 
         describe('subscription confirmation tokens', () => {
           it('redacts tokens in request', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span.resource).to.equal(`confirmSubscription ${TopicArn}`)
@@ -478,7 +478,7 @@ describe('Sns', function () {
       }
 
       it('generates tags for proper publish calls', done => {
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const span = traces[0][0]
 
           expect(span.resource).to.equal(`publish ${TopicArn}`)
@@ -542,7 +542,7 @@ describe('Sns', function () {
               if (err) return done(err)
 
               let publishSpanMeta = {}
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 if (span.resource.startsWith('publish')) {
@@ -573,7 +573,7 @@ describe('Sns', function () {
               if (err) return done(err)
 
               let consumeSpanMeta = {}
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 if (span.name === 'aws.response') {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -119,7 +119,7 @@ describe('Plugin', () => {
           let parentId
           let traceId
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span.resource.startsWith('sendMessage')).to.equal(true)
@@ -131,7 +131,7 @@ describe('Plugin', () => {
             traceId = span.trace_id.toString()
           })
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(parentId).to.be.a('string')
@@ -158,7 +158,7 @@ describe('Plugin', () => {
           let parentId
           let traceId
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span.resource.startsWith('sendMessageBatch')).to.equal(true)
@@ -171,7 +171,7 @@ describe('Plugin', () => {
           })
 
           let batchChildSpans = 0
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(parentId).to.be.a('string')
@@ -335,7 +335,7 @@ describe('Plugin', () => {
         it('should allow disabling a specific span kind of a service', (done) => {
           let total = 0
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span).to.include({
@@ -351,7 +351,7 @@ describe('Plugin', () => {
             total++
           }).catch(() => {}, { timeoutMs: 100 })
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span).to.include({
@@ -455,7 +455,7 @@ describe('Plugin', () => {
             if (err) return done(err)
 
             let produceSpanMeta = {}
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               if (span.resource.startsWith('sendMessage')) {
@@ -483,7 +483,7 @@ describe('Plugin', () => {
               if (err) return done(err)
 
               let consumeSpanMeta = {}
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 if (span.name === 'aws.response') {
@@ -506,7 +506,7 @@ describe('Plugin', () => {
 
               let consumeSpanMeta = {}
               return new Promise((resolve, reject) => {
-                agent.use(traces => {
+                agent.assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   if (span.name === 'aws.request' && span.meta['aws.operation'] === 'receiveMessage') {

--- a/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
@@ -106,7 +106,7 @@ describe('Sfn', () => {
             stateMachineArn,
             input: JSON.stringify({ moduleName })
           }
-          const expectSpanPromise = agent.use(traces => {
+          const expectSpanPromise = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             expect(span).to.have.property('resource', 'startExecution')
             expect(span.meta).to.have.property('statemachinearn', stateMachineArn)

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -189,7 +189,7 @@ describe('Plugin', () => {
         })
 
         it('should be configured with the correct values', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('service', 'custom')
             done()
           })

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -53,7 +53,7 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           const query = 'SELECT now() FROM local;'
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', query)
@@ -81,7 +81,7 @@ describe('Plugin', () => {
           ]
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
             })
             .then(done)
@@ -98,7 +98,7 @@ describe('Plugin', () => {
           ]
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
             })
             .then(done)
@@ -115,7 +115,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -247,7 +247,7 @@ describe('Plugin', () => {
             const query = 'SELECT now() FROM local;'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                 expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                 expect(traces[0][0]).to.have.property('resource', query)
@@ -275,7 +275,7 @@ describe('Plugin', () => {
             ]
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
               })
               .then(done)

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
@@ -92,7 +92,7 @@ describe('Plugin', () => {
             it('should be instrumented w/ error', async () => {
               let error
 
-              const expectedSpanPromise = agent.use(traces => {
+              const expectedSpanPromise = agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span).to.include({
@@ -186,7 +186,7 @@ describe('Plugin', () => {
             })
 
             it('should propagate context', async () => {
-              const expectedSpanPromise = agent.use(traces => {
+              const expectedSpanPromise = agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span).to.include({
@@ -303,7 +303,7 @@ describe('Plugin', () => {
             })
 
             it('should be instrumented with error', async () => {
-              const expectedSpanPromise = agent.use(traces => {
+              const expectedSpanPromise = agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span).to.include({
@@ -384,7 +384,7 @@ describe('Plugin', () => {
             })
 
             it('should propagate context', async () => {
-              const expectedSpanPromise = agent.use(traces => {
+              const expectedSpanPromise = agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span).to.include({
@@ -420,7 +420,7 @@ describe('Plugin', () => {
             // it('should be instrumented with error', async () => {
             //   const fakeError = new Error('Oh No!')
 
-            //   const expectedSpanPromise = agent.use(traces => {
+            //   const expectedSpanPromise = agent.assertSomeTraces(traces => {
             //     const errorSpans = traces[0].filter(span => span.error === 1)
             //     expect(errorSpans.length).to.be.at.least(1)
 

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -48,7 +48,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
@@ -79,7 +79,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans).to.have.length(3)
@@ -112,7 +112,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
@@ -140,7 +140,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans.filter(span => span.name === 'connect.request')).to.have.length(1)
@@ -199,7 +199,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app')
@@ -256,7 +256,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET')
@@ -311,7 +311,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app')
@@ -371,7 +371,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -406,7 +406,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 0)
@@ -435,7 +435,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -499,7 +499,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -553,7 +553,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'custom')
@@ -579,7 +579,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -606,7 +606,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0].meta).to.have.property('http.request.headers.user-agent', 'test')
@@ -634,7 +634,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'custom')
@@ -669,7 +669,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -704,7 +704,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -751,7 +751,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans).to.have.length(1)
@@ -810,7 +810,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -841,7 +841,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -334,7 +334,7 @@ describe('Plugin', () => {
           appListener = http.createServer(app).listen(0, 'localhost', () => {
             const port = appListener.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].trace_id.toString()).to.equal('1234')

--- a/packages/datadog-plugin-couchbase/test/index.spec.js
+++ b/packages/datadog-plugin-couchbase/test/index.spec.js
@@ -75,7 +75,7 @@ describe('Plugin', () => {
             const query = 'SELECT 1+1'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.query.opName)
                 expect(span).to.have.property('service', expectedSchema.query.serviceName)
@@ -104,7 +104,7 @@ describe('Plugin', () => {
 
           it('should handle storage queries', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.upsert.opName)
                 expect(span).to.have.property('service', expectedSchema.upsert.serviceName)
@@ -136,7 +136,7 @@ describe('Plugin', () => {
             const query = 'SELECT 1+2'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.query.opName)
                 expect(span).to.have.property('service', expectedSchema.query.serviceName)
@@ -217,7 +217,7 @@ describe('Plugin', () => {
             const query = 'SELECT 1+1'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.query.opName)
                 expect(span).to.have.property('service', expectedSchema.query.serviceName)
@@ -234,7 +234,7 @@ describe('Plugin', () => {
 
           it('should handle storage queries', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.upsert.opName)
                 expect(span).to.have.property('service', expectedSchema.upsert.serviceName)
@@ -272,7 +272,7 @@ describe('Plugin', () => {
         describe('operations still work with callbacks', () => {
           it('should perform normal cluster query operation with callback', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', expectedSchema.query.opName)
                 expect(span).to.have.property('service', expectedSchema.query.serviceName)
@@ -302,7 +302,7 @@ describe('Plugin', () => {
                 const invalidQuery = 'SELECT'
                 const cb = sinon.spy()
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const span = traces[0][0]
                     expect(cb).to.have.been.calledOnce
                     // different couchbase sdk versions will have different error messages/types

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -74,7 +74,7 @@ describe('Plugin', function () {
     describe('cucumber', () => {
       describe('passing test', () => {
         it('should create a test span', async function () {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(4)
@@ -115,7 +115,7 @@ describe('Plugin', function () {
             { name: 'run', stepStatus: 'pass' },
             { name: 'pass', stepStatus: 'pass' }
           ]
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const testTrace = traces[0]
             const testSpan = testTrace.find(span => span.name === 'cucumber.test')
             // step spans
@@ -140,7 +140,7 @@ describe('Plugin', function () {
 
       describe('failing test', () => {
         it('should create a test span', async function () {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(4)
@@ -177,7 +177,7 @@ describe('Plugin', function () {
             { name: 'fail', stepStatus: 'fail' }
           ]
           const errors = ['AssertionError', undefined, undefined, 'AssertionError']
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const testTrace = traces[0]
             const testSpan = testTrace.find(span => span.name === 'cucumber.test')
             // step spans
@@ -208,7 +208,7 @@ describe('Plugin', function () {
 
       describe('skipped test', () => {
         it('should create a test span', async function () {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(4)
@@ -244,7 +244,7 @@ describe('Plugin', function () {
             { name: 'run', stepStatus: 'pass' },
             { name: 'skip', stepStatus: 'skip' }
           ]
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const testTrace = traces[0]
             const testSpan = testTrace.find(span => span.name === 'cucumber.test')
             // step spans
@@ -269,7 +269,7 @@ describe('Plugin', function () {
 
       describe('skipped test based on tag', () => {
         it('should create a test span', async function () {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(2)
@@ -309,7 +309,7 @@ describe('Plugin', function () {
           const steps = [
             { name: 'datadog', stepStatus: 'skip' }
           ]
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const testTrace = traces[0]
             const testSpan = testTrace.find(span => span.name === 'cucumber.test')
             // step spans
@@ -340,7 +340,7 @@ describe('Plugin', function () {
 
       describe('not implemented step', () => {
         it('should create a test span with a skip reason', async () => {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(4)
@@ -371,7 +371,7 @@ describe('Plugin', function () {
 
       describe('integration test', () => {
         it('should create a test span and a span for the integration', async function () {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(5)
@@ -412,7 +412,7 @@ describe('Plugin', function () {
             { name: 'integration', stepStatus: 'pass' },
             { name: 'pass', stepStatus: 'pass' }
           ]
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const testTrace = traces[0]
             const testSpan = testTrace.find(span => span.name === 'cucumber.test')
             // step spans
@@ -437,7 +437,7 @@ describe('Plugin', function () {
 
       describe('hook fail', () => {
         it('should create a test span', async function () {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces.length).to.equal(1)
             const testTrace = traces[0]
             expect(testTrace.length).to.equal(4)
@@ -479,7 +479,7 @@ describe('Plugin', function () {
             { name: 'run', stepStatus: 'skip' },
             { name: 'pass', stepStatus: 'skip' }
           ]
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const testTrace = traces[0]
             const testSpan = testTrace.find(span => span.name === 'cucumber.test')
             // step spans

--- a/packages/datadog-plugin-cypress/test/index.spec.js
+++ b/packages/datadog-plugin-cypress/test/index.spec.js
@@ -65,7 +65,7 @@ describe('Plugin', function () {
           headless: true
         })
 
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const passedTestSpan = traces[0][0]
           const failedTestSpan = traces[1][0]
           expect(passedTestSpan.name).to.equal('cypress.test')

--- a/packages/datadog-plugin-dns/test/index.spec.js
+++ b/packages/datadog-plugin-dns/test/index.spec.js
@@ -26,7 +26,7 @@ describe('Plugin', () => {
 
       it('should instrument lookup', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.lookup',
               service: 'test',
@@ -47,7 +47,7 @@ describe('Plugin', () => {
 
       it('should instrument lookup with all addresses', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.lookup',
               service: 'test',
@@ -69,7 +69,7 @@ describe('Plugin', () => {
 
       it('should instrument errors correctly', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.lookup',
               service: 'test',
@@ -94,7 +94,7 @@ describe('Plugin', () => {
 
       it('should instrument lookupService', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.lookup_service',
               service: 'test',
@@ -117,7 +117,7 @@ describe('Plugin', () => {
 
       it('should instrument resolve', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.resolve',
               service: 'test',
@@ -138,7 +138,7 @@ describe('Plugin', () => {
 
       it('should instrument resolve shorthands', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.resolve',
               service: 'test',
@@ -159,7 +159,7 @@ describe('Plugin', () => {
 
       it('should instrument reverse', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.reverse',
               service: 'test',
@@ -204,7 +204,7 @@ describe('Plugin', () => {
         const resolver = new dns.Resolver()
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'dns.resolve',
               service: 'test',
@@ -227,7 +227,7 @@ describe('Plugin', () => {
         const timer = setTimeout(done, 200)
 
         agent
-          .use(() => {
+          .assertSomeTraces(() => {
             done(new Error('Resolve was traced.'))
             clearTimeout(timer)
           })

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -260,7 +260,7 @@ describe('Plugin', () => {
           it('should handle errors', done => {
             let error
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -43,7 +43,7 @@ describe('Plugin', () => {
 
         it('should sanitize the resource name', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'POST /logstash-?.?.?/_search')
             })
             .then(done)
@@ -73,7 +73,7 @@ describe('Plugin', () => {
 
         it('should set the correct tags', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0].meta).to.have.property('component', 'elasticsearch')
@@ -110,7 +110,7 @@ describe('Plugin', () => {
 
         it('should set the correct tags on msearch', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0].meta).to.have.property('component', 'elasticsearch')
@@ -146,7 +146,7 @@ describe('Plugin', () => {
 
         it('should skip tags for unavailable fields', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.not.have.property('elasticsearch.body')
             })
             .then(done)
@@ -163,7 +163,7 @@ describe('Plugin', () => {
           describe('when using a callback', () => {
             it('should do automatic instrumentation', done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                   expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                   expect(traces[0][0]).to.have.property('resource', 'HEAD /')
@@ -177,7 +177,7 @@ describe('Plugin', () => {
 
             it('should propagate context', done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.have.property('parent_id')
                   expect(traces[0][0].parent_id).to.not.be.null
                 })
@@ -202,7 +202,7 @@ describe('Plugin', () => {
               let error
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
                   expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
                   expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -227,7 +227,7 @@ describe('Plugin', () => {
         describe('when using a promise', () => {
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                 expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                 expect(traces[0][0]).to.have.property('resource', 'HEAD /')
@@ -241,7 +241,7 @@ describe('Plugin', () => {
 
           it('should propagate context', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('parent_id')
                 expect(traces[0][0].parent_id).to.not.be.null
               })
@@ -287,7 +287,7 @@ describe('Plugin', () => {
 
           it('should work with userland promises', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', 'test-elasticsearch')
                 expect(traces[0][0]).to.have.property('resource', 'HEAD /')
                 expect(traces[0][0]).to.have.property('type', 'elasticsearch')
@@ -348,7 +348,7 @@ describe('Plugin', () => {
           }, hasCallbackSupport ? () => {} : undefined)
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', 'custom')
               expect(traces[0][0].meta).to.have.property('component', 'elasticsearch')

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -103,7 +103,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
@@ -139,7 +139,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
@@ -176,7 +176,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
@@ -212,7 +212,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 const isExpress4 = semver.intersects(version, '<5.0.0')
                 let index = 0
@@ -296,7 +296,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 const breakingSpanIndex = semver.intersects(version, '<5.0.0') ? 3 : 1
@@ -342,7 +342,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 const errorSpanIndex = semver.intersects(version, '<5.0.0') ? 4 : 2
 
@@ -375,7 +375,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app(/^\\/user\\/(\\d)$/)')
@@ -403,7 +403,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -437,7 +437,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
@@ -465,7 +465,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -494,7 +494,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -522,7 +522,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans.filter(span => span.name === 'express.request')).to.have.length(1)
@@ -590,7 +590,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -622,7 +622,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -651,7 +651,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app')
@@ -686,7 +686,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /v1/a')
@@ -716,7 +716,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app')
@@ -752,7 +752,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
@@ -788,7 +788,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
@@ -826,7 +826,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /foo/bar')
@@ -857,7 +857,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /v1/a')
@@ -914,7 +914,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET')
@@ -1006,7 +1006,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -1127,7 +1127,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -1159,7 +1159,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 const secondErrorIndex = spans.length - 2
 
@@ -1196,7 +1196,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 const secondErrorIndex = spans.length - 2
 
@@ -1238,7 +1238,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /:path(*)')
@@ -1264,7 +1264,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /*user')
@@ -1380,7 +1380,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('service', 'test')
@@ -1415,7 +1415,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[4]).to.have.property('name', 'express.middleware')
@@ -1461,7 +1461,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'custom')
@@ -1486,7 +1486,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -1513,7 +1513,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0].meta).to.have.property('http.request.headers.user-agent', 'test')
@@ -1541,7 +1541,7 @@ describe('Plugin', () => {
             const spy = sinon.spy()
 
             agent
-              .use(spy)
+              .assertSomeTraces(spy)
               .catch(done)
 
             setTimeout(() => {
@@ -1618,7 +1618,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /user')
@@ -1681,7 +1681,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 0)
@@ -1711,7 +1711,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -1741,7 +1741,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -49,7 +49,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
             const timer = setTimeout(done, 100)
 
-            agent.use(() => {
+            agent.assertSomeTraces(() => {
               clearTimeout(timer)
               done(new Error('Agent received an unexpected trace.'))
             })
@@ -1029,7 +1029,7 @@ describe('Plugin', () => {
           appListener = app.listen(0, 'localhost', () => {
             const port = appListener.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].trace_id.toString()).to.equal('1234')
@@ -1064,7 +1064,7 @@ describe('Plugin', () => {
           appListener = app.listen(0, 'localhost', () => {
             const port = appListener.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('error', 1)
@@ -1098,7 +1098,7 @@ describe('Plugin', () => {
           appListener = app.listen(0, 'localhost', () => {
             const port = appListener.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('error', 0)
@@ -1342,7 +1342,7 @@ describe('Plugin', () => {
           appListener = app.listen(0, 'localhost', () => {
             const port = appListener.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('error', 0)
@@ -1646,7 +1646,7 @@ describe('Plugin', () => {
           appListener = app.listen(0, 'localhost', () => {
             const port = appListener.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('error', 1)

--- a/packages/datadog-plugin-fastify/test/code_origin.spec.js
+++ b/packages/datadog-plugin-fastify/test/code_origin.spec.js
@@ -44,7 +44,7 @@ describe('Plugin', () => {
               await app.listen(getListenOptions())
 
               await Promise.all([
-                agent.use(traces => {
+                agent.assertSomeTraces(traces => {
                   const spans = traces[0]
                   const tagNames = Object.keys(spans[0].meta)
                   expect(tagNames).to.all.not.match(/code_origin/)
@@ -83,7 +83,7 @@ describe('Plugin', () => {
                 await app.listen(getListenOptions())
 
                 await Promise.all([
-                  agent.use(traces => {
+                  agent.assertSomeTraces(traces => {
                     const spans = traces[0]
                     const tags = spans[0].meta
 
@@ -121,7 +121,7 @@ describe('Plugin', () => {
                 await app.listen(getListenOptions())
 
                 await Promise.all([
-                  agent.use(traces => {
+                  agent.assertSomeTraces(traces => {
                     const spans = traces[0]
                     const tags = spans[0].meta
 
@@ -152,7 +152,7 @@ describe('Plugin', () => {
                 await app.listen(getListenOptions())
 
                 await Promise.all([
-                  agent.use(traces => {
+                  agent.assertSomeTraces(traces => {
                     const spans = traces[0]
                     const tags = spans[0].meta
 
@@ -186,7 +186,7 @@ describe('Plugin', () => {
                 await app.listen(getListenOptions())
 
                 await Promise.all([
-                  agent.use(traces => {
+                  agent.assertSomeTraces(traces => {
                     const spans = traces[0]
                     const tags = spans[0].meta
 

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -54,7 +54,7 @@ describe('Plugin', () => {
               const port = app.server.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -89,7 +89,7 @@ describe('Plugin', () => {
               const port = app.server.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -123,7 +123,7 @@ describe('Plugin', () => {
                 const port = app.server.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = traces[0]
 
                     expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -270,7 +270,7 @@ describe('Plugin', () => {
               const port = app.server.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -349,7 +349,7 @@ describe('Plugin', () => {
               const port = app.server.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -382,7 +382,7 @@ describe('Plugin', () => {
                 const port = app.server.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = traces[0]
 
                     expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -413,7 +413,7 @@ describe('Plugin', () => {
                 const port = app.server.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = traces[0]
 
                     expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -447,7 +447,7 @@ describe('Plugin', () => {
                 const port = app.server.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = traces[0]
 
                     expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -480,7 +480,7 @@ describe('Plugin', () => {
                 const port = app.server.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = traces[0]
 
                     expect(spans[0]).to.have.property('name', 'fastify.request')
@@ -519,7 +519,7 @@ describe('Plugin', () => {
                 const port = app.server.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = traces[0]
 
                     expect(spans[0]).to.have.property('name', 'fastify.request')

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -69,7 +69,7 @@ describe('Plugin', function () {
         })
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
               expect(traces[0][0]).to.have.property('type', 'http')
               expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -94,7 +94,7 @@ describe('Plugin', function () {
         })
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
               expect(traces[0][0]).to.have.property('type', 'http')
               expect(traces[0][0]).to.have.property('resource', 'POST')
@@ -119,7 +119,7 @@ describe('Plugin', function () {
         })
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
               expect(traces[0][0]).to.have.property('type', 'http')
               expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -161,7 +161,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
             })
@@ -184,7 +184,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('http.status_code', '200')
             })
             .then(done)
@@ -207,7 +207,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('http.status_code', '200')
             })
             .then(done)
@@ -221,7 +221,7 @@ describe('Plugin', function () {
         let error
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message || error.code)
             expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -244,7 +244,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 0)
             })
             .then(done)
@@ -263,7 +263,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
             })
             .then(done)
@@ -280,7 +280,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.not.have.property('http.status_code')
             })
@@ -306,7 +306,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
             })
             .then(done)
@@ -333,7 +333,7 @@ describe('Plugin', function () {
           const timer = setTimeout(done, 100)
 
           agent
-            .use(() => {
+            .assertSomeTraces(() => {
               done(new Error('Noop request was traced.'))
               clearTimeout(timer)
             })
@@ -373,7 +373,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
             .then(done)
@@ -408,7 +408,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
             })
             .then(done)
@@ -443,7 +443,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', `localhost:${port}`)
             })
             .then(done)
@@ -479,7 +479,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const meta = traces[0][0].meta
 
               expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-baz`, 'qux')
@@ -525,7 +525,7 @@ describe('Plugin', function () {
 
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('foo', '/foo')
             })
             .then(done)
@@ -599,7 +599,7 @@ describe('Plugin', function () {
           const timer = setTimeout(done, 100)
 
           agent
-            .use(() => {
+            .assertSomeTraces(() => {
               clearTimeout(timer)
               done(new Error('Blocklisted requests should not be recorded.'))
             })
@@ -650,7 +650,7 @@ describe('Plugin', function () {
         })
         appListener = server(app, port => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
               expect(traces[0][0]).to.have.property('type', 'http')
               expect(traces[0][0]).to.have.property('resource', 'GET')

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
       describe('open', () => {
         it('should not be instrumented', (done) => {
           function waitForNextTrace () {
-            agent.use((data) => {
+            agent.assertSomeTraces((data) => {
               if (data) {
                 data.forEach((arr) => {
                   arr.forEach((trace) => {
@@ -95,7 +95,7 @@ describe('Plugin', () => {
     describe('without parent span', () => {
       describe('open', () => {
         it('should not be instrumented', (done) => {
-          agent.use(() => {
+          agent.assertSomeTraces(() => {
             expect.fail('should not have been any traces')
           }).catch(done)
 

--- a/packages/datadog-plugin-google-cloud-vertexai/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/test/index.spec.js
@@ -92,7 +92,7 @@ describe('Plugin', () => {
         useScenario({ scenario: 'generate-content-single-response' })
 
         it('makes a successful call', async () => {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span).to.have.property('name', 'vertexai.request')
@@ -129,7 +129,7 @@ describe('Plugin', () => {
         })
 
         it('makes a successful call with a string argument', async () => {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property('vertexai.request.contents.0.text',
               'Hello, how are you?')
           })
@@ -145,7 +145,7 @@ describe('Plugin', () => {
           useScenario({ scenario: 'generate-content-single-response-with-tools' })
 
           it('makes a successful call', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span.meta).to.have.property('vertexai.response.candidates.0.content.parts.0.text', 'undefined')
@@ -166,7 +166,7 @@ describe('Plugin', () => {
         useScenario({ scenario: 'generate-content-stream-single-response', statusCode: 200, stream: true })
 
         it('makes a successful call', async () => {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
 
             expect(span).to.have.property('name', 'vertexai.request')
@@ -218,7 +218,7 @@ describe('Plugin', () => {
           useScenario({ scenario: 'generate-content-single-response' })
 
           it('makes a successful call', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.have.property('name', 'vertexai.request')
@@ -264,7 +264,7 @@ describe('Plugin', () => {
           })
 
           it('tags a string input', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('vertexai.request.contents.0.text',
                 'Hello, how are you?')
             })
@@ -278,7 +278,7 @@ describe('Plugin', () => {
           })
 
           it('tags an array of string inputs', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('vertexai.request.contents.0.text',
                 'Hello, how are you?')
               expect(traces[0][0].meta).to.have.property('vertexai.request.contents.1.text',
@@ -298,7 +298,7 @@ describe('Plugin', () => {
           useScenario({ scenario: 'generate-content-stream-single-response', statusCode: 200, stream: true })
 
           it('makes a successful call', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.have.property('name', 'vertexai.request')
@@ -352,7 +352,7 @@ describe('Plugin', () => {
           useScenario({ statusCode: 404 })
 
           it('tags the error', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
             })
 
@@ -372,7 +372,7 @@ describe('Plugin', () => {
           useScenario({ scenario: 'malformed-stream', stream: true })
 
           it('tags the error', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
             })
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -690,7 +690,7 @@ describe('Plugin', () => {
         it('should not instrument schema resolvers multiple times', done => {
           const source = '{ hello(name: "world") }'
 
-          agent.use(() => { // skip first call
+          agent.assertSomeTraces(() => { // skip first call
             agent
               .use(traces => {
                 const spans = sort(traces[0])
@@ -808,15 +808,15 @@ describe('Plugin', () => {
 
           Promise
             .all([
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 expect(spans[0]).to.have.property('name', 'graphql.parse')
               }),
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 expect(spans[0]).to.have.property('name', 'graphql.validate')
               }),
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 expect(spans[0]).to.have.property('name', expectedSchema.server.opName)
                 expect(spans[1]).to.have.property('name', 'graphql.resolve')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -247,7 +247,7 @@ describe('Plugin', () => {
 
           it('should instrument graphql-yoga execution', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -309,7 +309,7 @@ describe('Plugin', () => {
           const variableValues = { who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.have.property('service', 'test')
@@ -331,7 +331,7 @@ describe('Plugin', () => {
           const variableValues = { who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.have.property('service', 'test')
@@ -353,7 +353,7 @@ describe('Plugin', () => {
           const variableValues = { who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -376,7 +376,7 @@ describe('Plugin', () => {
           const variableValues = { who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
               expect(spans[0].meta).to.not.have.property('graphql.variables')
             })
@@ -390,7 +390,7 @@ describe('Plugin', () => {
           const source = '{ hello(name: "world") }'
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -493,7 +493,7 @@ describe('Plugin', () => {
           `
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
               expect(spans).to.have.length(6)
 
@@ -554,7 +554,7 @@ describe('Plugin', () => {
           }`
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(5)
@@ -597,7 +597,7 @@ describe('Plugin', () => {
           const source = 'mutation { human { name } }'
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'mutation')
@@ -612,7 +612,7 @@ describe('Plugin', () => {
           const source = 'subscription { human { name } }'
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].meta).to.have.property('graphql.operation.type', 'subscription')
@@ -645,7 +645,7 @@ describe('Plugin', () => {
           const rootValue = { hello: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -674,7 +674,7 @@ describe('Plugin', () => {
           }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -692,7 +692,7 @@ describe('Plugin', () => {
 
           agent.assertSomeTraces(() => { // skip first call
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans).to.have.length(2)
@@ -712,7 +712,7 @@ describe('Plugin', () => {
           const span = tracer.startSpan('test.request')
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(5)
@@ -836,7 +836,7 @@ describe('Plugin', () => {
           const document = graphql.parse(new graphql.Source(source))
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -856,7 +856,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -882,7 +882,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -909,7 +909,7 @@ describe('Plugin', () => {
           const document = graphql.parse(source)
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -946,7 +946,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -987,7 +987,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -1039,7 +1039,7 @@ describe('Plugin', () => {
           }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -1073,7 +1073,7 @@ describe('Plugin', () => {
           }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -1158,7 +1158,7 @@ describe('Plugin', () => {
           const variableValues = { who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -1188,7 +1188,7 @@ describe('Plugin', () => {
           `
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               const resource = 'query WithFragments{human{...firstFields}}fragment firstFields on Human{name}'
@@ -1215,7 +1215,7 @@ describe('Plugin', () => {
           `
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('service', 'test')
@@ -1239,7 +1239,7 @@ describe('Plugin', () => {
             const variableValues = { who: 'world' }
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', expectedSchema.server.serviceName)
@@ -1268,7 +1268,7 @@ describe('Plugin', () => {
 
         // it('should not disable signature with invalid arguments', done => {
         //   agent
-        //     .use(traces => {
+        //     .assertSomeTraces(traces => {
         //       const spans = sort(traces[0])
 
         //       console.log(spans.map(span => `${span.name} | ${span.resource}`))
@@ -1328,7 +1328,7 @@ describe('Plugin', () => {
           const source = '{ hello(name: "world") }'
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(2)
@@ -1354,7 +1354,7 @@ describe('Plugin', () => {
           const variableValues = { title: 'planet', who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].meta).to.have.property('graphql.variables.title', 'planet')
@@ -1396,7 +1396,7 @@ describe('Plugin', () => {
           const variableValues = { title: 'planet', who: 'world' }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].meta).to.have.property('graphql.variables.title', 'planet')
@@ -1439,7 +1439,7 @@ describe('Plugin', () => {
           `
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -1511,7 +1511,7 @@ describe('Plugin', () => {
           `
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
               const ignored = spans.filter(span => {
                 return [
@@ -1550,7 +1550,7 @@ describe('Plugin', () => {
           const source = '{ friends { name } }'
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(4)
@@ -1604,7 +1604,7 @@ describe('Plugin', () => {
           const source = 'query WithoutSignature { friends { name } }'
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('name', expectedSchema.server.opName)
@@ -1671,7 +1671,7 @@ describe('Plugin', () => {
           let result
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -1708,7 +1708,7 @@ describe('Plugin', () => {
           const document = graphql.parse(source)
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -1733,7 +1733,7 @@ describe('Plugin', () => {
           let document
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans).to.have.length(1)
@@ -1793,7 +1793,7 @@ describe('Plugin', () => {
 
           it('should support apollo-server schema stitching', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans).to.have.length(3)

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -136,7 +136,7 @@ describe('Plugin', () => {
 
                 client.getUnary({ first: 'foobar' }, () => {})
                 return agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     expect(traces[0][0].meta).to.include({
                       'network.destination.ip': '127.0.0.1',
                       'network.destination.port': port.toString(),
@@ -155,7 +155,7 @@ describe('Plugin', () => {
 
               client.getUnary({ first: 'foobar' }, () => {})
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
@@ -192,7 +192,7 @@ describe('Plugin', () => {
               call.on('data', () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
@@ -227,7 +227,7 @@ describe('Plugin', () => {
               client.getClientStream(() => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
@@ -262,7 +262,7 @@ describe('Plugin', () => {
               call.on('data', () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
@@ -289,7 +289,7 @@ describe('Plugin', () => {
               call = client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
                 })
             })
@@ -305,7 +305,7 @@ describe('Plugin', () => {
               call.on('error', () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
                 })
             })
@@ -321,7 +321,7 @@ describe('Plugin', () => {
               call.on('error', () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
                 })
             })
@@ -334,7 +334,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.have.property('error', 1)
                   expect(traces[0][0].meta).to.include({
                     [ERROR_MESSAGE]: '2 UNKNOWN: foobar',
@@ -362,7 +362,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.have.property('error', 0)
                   expect(traces[0][0].metrics).to.have.property('grpc.status.code', 2)
                   tracer._tracer._config.grpc.client.error.statuses =
@@ -380,7 +380,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.have.property('error', 1)
                   expect(traces[0][0].meta).to.include({
                     [ERROR_TYPE]: 'Error',
@@ -415,7 +415,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' })
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
@@ -447,7 +447,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, undefined, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     name: DD_MAJOR <= 2 ? 'grpc.request' : 'grpc.client',
                     service: 'test',
@@ -560,7 +560,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.deep.include({
                     service: 'custom'
                   })
@@ -599,7 +599,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, metadata, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
                 })
             })
@@ -618,7 +618,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
                 })
             })
@@ -656,7 +656,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, metadata, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].meta).to.deep.include({
                     'grpc.method.name': 'getUnary',
                     'grpc.method.service': 'TestService',
@@ -684,7 +684,7 @@ describe('Plugin', () => {
               client.getUnary({ first: 'foobar' }, () => {})
 
               return agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].meta).to.deep.include({
                     'grpc.method.name': 'getUnary',
                     'grpc.method.service': 'TestService',

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -107,7 +107,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.deep.include({
                 name: 'grpc.server',
                 service: 'test',
@@ -133,7 +133,7 @@ describe('Plugin', () => {
           client.getServerStream({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.deep.include({
                 name: 'grpc.server',
                 service: 'test',
@@ -159,7 +159,7 @@ describe('Plugin', () => {
           call.on('error', () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.deep.include({
                 name: 'grpc.server',
                 service: 'test',
@@ -186,7 +186,7 @@ describe('Plugin', () => {
           call.on('error', () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
             })
         })
@@ -201,7 +201,7 @@ describe('Plugin', () => {
           call.on('error', () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
             })
         })
@@ -215,7 +215,7 @@ describe('Plugin', () => {
           call.on('error', () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].metrics).to.have.property('grpc.status.code', 1)
             })
         })
@@ -234,7 +234,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, 'foobar')
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, 'Error')
@@ -266,7 +266,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, 'foobar')
               expect(traces[0][0].meta[ERROR_STACK]).to.match(/^Error: foobar\n {4}at Object.getUnary.*/)
@@ -301,7 +301,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
               tracer._tracer._config.grpc.server.error.statuses = GRPC_SERVER_ERROR_STATUSES
@@ -322,7 +322,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, 'foobar')
               expect(traces[0][0].metrics).to.have.property('grpc.status.code', 5)
@@ -345,7 +345,7 @@ describe('Plugin', () => {
           call.on('error', () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, 'foobar')
               expect(traces[0][0].meta[ERROR_STACK]).to.equal(error.stack)
@@ -419,7 +419,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.deep.include({
                 service: 'custom'
               })
@@ -458,7 +458,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, metadata, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('grpc.request.metadata.foo', 'bar')
             })
         })
@@ -477,7 +477,7 @@ describe('Plugin', () => {
           client.getUnary({ first: 'foobar' }, () => {})
 
           return agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('grpc.response.metadata.foo', 'bar')
             })
         })

--- a/packages/datadog-plugin-hapi/test/index.spec.js
+++ b/packages/datadog-plugin-hapi/test/index.spec.js
@@ -93,7 +93,7 @@ describe('Plugin', () => {
         })
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', 'hapi.request')
             expect(traces[0][0]).to.have.property('service', 'test')
             expect(traces[0][0]).to.have.property('type', 'web')
@@ -259,7 +259,7 @@ describe('Plugin', () => {
         })
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].trace_id.toString()).to.equal('1234')
             expect(traces[0][0].parent_id.toString()).to.equal('5678')
           })
@@ -279,7 +279,7 @@ describe('Plugin', () => {
 
       it('should instrument the default route handler', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', 'hapi.request')
           })
           .then(done)
@@ -306,7 +306,7 @@ describe('Plugin', () => {
         })
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('error', 1)
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
@@ -338,7 +338,7 @@ describe('Plugin', () => {
         })
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('error', 0)
             expect(traces[0][0].meta).to.have.property('component', 'hapi')
           })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -102,7 +102,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
                 expect(traces[0][0]).to.have.property('type', 'http')
                 expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -132,7 +132,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               expect(traces[0][0]).to.not.be.undefined
             })
@@ -156,7 +156,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
                 expect(traces[0][0]).to.have.property('type', 'http')
                 expect(traces[0][0]).to.have.property('resource', 'CONNECT')
@@ -200,7 +200,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
                 expect(traces[0][0]).to.have.property('type', 'http')
                 expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -246,7 +246,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -273,7 +273,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
@@ -299,7 +299,7 @@ describe('Plugin', () => {
 
             appListener = server(app, port => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                   expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
                 })
@@ -322,7 +322,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
@@ -368,7 +368,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/`)
               })
               .then(done)
@@ -391,7 +391,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.not.be.undefined
             })
             .then(done)
@@ -434,7 +434,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('http.status_code', '200')
             })
             .then(done)
@@ -546,7 +546,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message || error.code)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -572,7 +572,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 0)
             })
             .then(done)
@@ -595,7 +595,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
             })
             .then(done)
@@ -618,7 +618,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
@@ -648,7 +648,7 @@ describe('Plugin', () => {
           app.get('/user', (req, res) => {})
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 0)
               expect(traces[0][0].meta).to.not.have.property('http.status_code')
             })
@@ -672,7 +672,7 @@ describe('Plugin', () => {
           app.get('/user', (req, res) => {})
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.not.have.property('http.status_code')
             })
@@ -703,7 +703,7 @@ describe('Plugin', () => {
             })
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 0)
               })
               .then(done)
@@ -731,7 +731,7 @@ describe('Plugin', () => {
             })
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
               })
               .then(done)
@@ -763,7 +763,7 @@ describe('Plugin', () => {
             })
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
               })
               .then(done)
@@ -799,7 +799,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
               expect(spans.length).to.equal(3)
             })
@@ -835,7 +835,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
             })
             .then(done)
@@ -857,7 +857,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
@@ -885,7 +885,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][1]).to.have.property('error', 0)
                 expect(traces[0][1].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][1].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
@@ -917,7 +917,7 @@ describe('Plugin', () => {
             const timer = setTimeout(done, 100)
 
             agent
-              .use(() => {
+              .assertSomeTraces(() => {
                 done(new Error('Noop request was traced.'))
                 clearTimeout(timer)
               })
@@ -938,7 +938,7 @@ describe('Plugin', () => {
 
         it('should record unfinished http requests as error spans', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.not.have.property('http.status_code')
             })
@@ -1023,7 +1023,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
             .then(done)
@@ -1065,7 +1065,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
             })
             .then(done)
@@ -1135,7 +1135,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', `localhost:${port}`)
               })
               .then(done)
@@ -1179,7 +1179,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const meta = traces[0][0].meta
 
                 expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.host`, `localhost:${port}`)
@@ -1208,7 +1208,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const meta = traces[0][0].meta
 
               expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-foo`, 'bar')
@@ -1234,7 +1234,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const meta = traces[0][0].meta
 
               expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-foo`, 'bar1,bar2')
@@ -1283,7 +1283,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'GET /user')
             })
             .then(done)
@@ -1374,7 +1374,7 @@ describe('Plugin', () => {
           const timer = setTimeout(done, 100)
 
           agent
-            .use(() => {
+            .assertSomeTraces(() => {
               clearTimeout(timer)
               done(new Error('Blocklisted requests should not be recorded.'))
             })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -349,7 +349,7 @@ describe('Plugin', () => {
 
             app.get('/user', (req, res) => res.status(200).send())
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
             }).then(done, done)

--- a/packages/datadog-plugin-http/test/code_origin.spec.js
+++ b/packages/datadog-plugin-http/test/code_origin.spec.js
@@ -29,7 +29,7 @@ describe('Plugin', () => {
           const http = require('http')
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span.meta).to.have.property('_dd.code_origin.type', 'exit')
 

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -60,7 +60,7 @@ describe('Plugin', () => {
         it('should send traces to agent', (done) => {
           app = sinon.stub()
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(app).not.to.have.been.called // request should be cancelled before call to app
               expect(traces[0][0]).to.have.property('name', 'web.request')
               expect(traces[0][0]).to.have.property('service', 'test')
@@ -104,7 +104,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'web.request')
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('type', 'web')
@@ -242,7 +242,7 @@ describe('Plugin', () => {
           const spy = sinon.spy(() => {})
 
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               spy()
             })
             .catch(done)

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -216,7 +216,7 @@ describe('Plugin', () => {
 
         // see https://github.com/DataDog/dd-trace-js/issues/2453
         it('should not have disabled tracing', (done) => {
-          agent.use(() => {})
+          agent.assertSomeTraces(() => {})
             .then(done)
             .catch(done)
 

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -99,7 +99,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
                 expect(traces[0][0]).to.have.property('type', 'http')
                 expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -135,7 +135,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('span.kind', 'client')
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/`)
               })
@@ -163,7 +163,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -196,7 +196,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -224,7 +224,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -269,7 +269,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/user`)
               })
               .then(done)
@@ -313,7 +313,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.url', `${protocol}://localhost:${port}/`)
               })
               .then(done)
@@ -348,7 +348,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               })
               .then(done)
@@ -523,7 +523,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -552,7 +552,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 0)
               })
               .then(done)
@@ -579,7 +579,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
               })
               .then(done)
@@ -607,7 +607,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
                 expect(spans.length).to.equal(3)
               })
@@ -662,7 +662,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', 'custom')
               })
               .then(done)
@@ -753,7 +753,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
               })
               .then(done)
@@ -832,7 +832,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', `localhost:${port}`)
               })
               .then(done)
@@ -876,7 +876,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const meta = traces[0][0].meta
 
                 expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.:path`, '/user')
@@ -924,7 +924,7 @@ describe('Plugin', () => {
             const timer = setTimeout(done, 100)
 
             agent
-              .use(() => {
+              .assertSomeTraces(() => {
                 clearTimeout(timer)
                 done(new Error('Blocklisted requests should not be recorded.'))
               })

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -98,7 +98,7 @@ describe('Plugin', () => {
         it('should send traces to agent', (done) => {
           app = sinon.stub()
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(app).not.to.have.been.called // request should be cancelled before call to app
               expect(traces[0][0]).to.have.property('name', 'web.request')
               expect(traces[0][0]).to.have.property('service', 'test')
@@ -147,7 +147,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'web.request')
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('type', 'web')
@@ -233,7 +233,7 @@ describe('Plugin', () => {
           const spy = sinon.spy(() => {})
 
           agent
-            .use((traces) => {
+            .assertSomeTraces((traces) => {
               spy()
             })
             .catch(done)

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -64,7 +64,7 @@ describe('Plugin', () => {
 
           agent.assertSomeTraces(() => {}) // wait for initial info command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
@@ -83,7 +83,7 @@ describe('Plugin', () => {
         it('should work with userland promises', done => {
           agent.assertSomeTraces(() => {}) // wait for initial info command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'get')
@@ -121,7 +121,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom-test')
             })
             .then(done)
@@ -133,7 +133,7 @@ describe('Plugin', () => {
         it('should be able to filter commands', done => {
           agent.assertSomeTraces(() => {}) // wait for initial command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)
@@ -167,7 +167,7 @@ describe('Plugin', () => {
         it('should be able to filter commands', done => {
           agent.assertSomeTraces(() => {}) // wait for initial command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -30,8 +30,8 @@ describe('Plugin', () => {
         afterEach(() => agent.close({ ritmReset: false }))
 
         it('should do automatic instrumentation when using callbacks', done => {
-          agent.use(() => {}) // wait for initial info command
-          agent.use(traces => {
+          agent.assertSomeTraces(() => {}) // wait for initial info command
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', 'get')
@@ -62,7 +62,7 @@ describe('Plugin', () => {
         it('should handle errors', done => {
           let error
 
-          agent.use(() => {}) // wait for initial info command
+          agent.assertSomeTraces(() => {}) // wait for initial info command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
@@ -81,7 +81,7 @@ describe('Plugin', () => {
         })
 
         it('should work with userland promises', done => {
-          agent.use(() => {}) // wait for initial info command
+          agent.assertSomeTraces(() => {}) // wait for initial info command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
@@ -131,7 +131,7 @@ describe('Plugin', () => {
         })
 
         it('should be able to filter commands', done => {
-          agent.use(() => {}) // wait for initial command
+          agent.assertSomeTraces(() => {}) // wait for initial command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
@@ -165,7 +165,7 @@ describe('Plugin', () => {
         after(() => agent.close({ ritmReset: false }))
 
         it('should be able to filter commands', done => {
-          agent.use(() => {}) // wait for initial command
+          agent.assertSomeTraces(() => {}) // wait for initial command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')

--- a/packages/datadog-plugin-iovalkey/test/index.spec.js
+++ b/packages/datadog-plugin-iovalkey/test/index.spec.js
@@ -65,7 +65,7 @@ describe('Plugin', () => {
 
           agent.assertSomeTraces(() => {}) // wait for initial info command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
@@ -121,7 +121,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom-test')
             })
             .then(done)
@@ -133,7 +133,7 @@ describe('Plugin', () => {
         it('should be able to filter commands', done => {
           agent.assertSomeTraces(() => {}) // wait for initial command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)
@@ -167,7 +167,7 @@ describe('Plugin', () => {
         it('should be able to filter commands', done => {
           agent.assertSomeTraces(() => {}) // wait for initial command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)

--- a/packages/datadog-plugin-iovalkey/test/index.spec.js
+++ b/packages/datadog-plugin-iovalkey/test/index.spec.js
@@ -30,8 +30,8 @@ describe('Plugin', () => {
         afterEach(() => agent.close({ ritmReset: false }))
 
         it('should do automatic instrumentation when using callbacks', async () => {
-          agent.use(() => {}) // wait for initial info command
-          const promise = agent.use(traces => {
+          agent.assertSomeTraces(() => {}) // wait for initial info command
+          const promise = agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', 'get')
@@ -63,7 +63,7 @@ describe('Plugin', () => {
         it('should handle errors', done => {
           let error
 
-          agent.use(() => {}) // wait for initial info command
+          agent.assertSomeTraces(() => {}) // wait for initial info command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
@@ -82,8 +82,8 @@ describe('Plugin', () => {
         })
 
         it('should work with userland promises', done => {
-          agent.use(() => {}) // wait for initial info command
-          agent.use(traces => {
+          agent.assertSomeTraces(() => {}) // wait for initial info command
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', 'get')
@@ -131,7 +131,7 @@ describe('Plugin', () => {
         })
 
         it('should be able to filter commands', done => {
-          agent.use(() => {}) // wait for initial command
+          agent.assertSomeTraces(() => {}) // wait for initial command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
@@ -165,7 +165,7 @@ describe('Plugin', () => {
         after(() => agent.close({ ritmReset: false }))
 
         it('should be able to filter commands', done => {
-          agent.use(() => {}) // wait for initial command
+          agent.assertSomeTraces(() => {}) // wait for initial command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')

--- a/packages/datadog-plugin-jest/test/circus.spec.js
+++ b/packages/datadog-plugin-jest/test/circus.spec.js
@@ -133,7 +133,7 @@ describe('Plugin', function () {
           ]
 
           const assertionPromises = tests.map(({ name, status, error, parameters, extraTags }) => {
-            return agent.use(trace => {
+            return agent.assertSomeTraces(trace => {
               const testSpan = trace[0][0]
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta).to.contain({
@@ -199,7 +199,7 @@ describe('Plugin', function () {
             { name: 'jest-hook-failure-after will not run', error: 'hey, hook error after' }
           ]
           const assertionPromises = tests.map(({ name, error }) => {
-            return agent.use(trace => {
+            return agent.assertSomeTraces(trace => {
               const testSpan = trace[0][0]
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta).to.contain({
@@ -250,7 +250,7 @@ describe('Plugin', function () {
           ]
 
           const assertionPromises = tests.map(({ name, status }) => {
-            return agent.use(trace => {
+            return agent.assertSomeTraces(trace => {
               const testSpan = trace[0].find(span => span.type === 'test')
               expect(testSpan.parent_id.toString()).to.equal('0')
               expect(testSpan.meta[ORIGIN_KEY]).to.equal(CI_APP_ORIGIN)
@@ -287,7 +287,7 @@ describe('Plugin', function () {
         // https://github.com/facebook/jest/blob/7f2731ef8bebac7f226cfc0d2446854603a557a9/CHANGELOG.md#2650
         if (semver.intersects(version, '>=26.5.0')) {
           it('does not crash when injectGlobals is false', (done) => {
-            agent.use(trace => {
+            agent.assertSomeTraces(trace => {
               const testSpan = trace[0].find(span => span.type === 'test')
               expect(testSpan.meta).to.contain({
                 [TEST_NAME]: 'jest-inject-globals will be run',
@@ -346,7 +346,7 @@ describe('Plugin', function () {
             ]
 
             const assertionPromises = events.map(({ name, suite, status, type, spanResourceMatch }) => {
-              return agent.use((agentlessPayload, request) => {
+              return agent.assertSomeTraces((agentlessPayload, request) => {
                 if (option === 'evp proxy') {
                   expect(request.headers['x-datadog-evp-subdomain']).to.equal('citestcycle-intake')
                   expect(request.path).to.equal('/evp_proxy/v2/api/v2/citestcycle')

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -112,7 +112,7 @@ describe('Plugin', () => {
 
             let error
 
-            const expectedSpanPromise = agent.use(traces => {
+            const expectedSpanPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.include({
@@ -145,7 +145,7 @@ describe('Plugin', () => {
           // Dynamic broker list support added in 1.14/2.0 (https://github.com/tulios/kafkajs/commit/62223)
           if (semver.intersects(version, '>=1.14')) {
             it('should not extract bootstrap servers when initialized with a function', async () => {
-              const expectedSpanPromise = agent.use(traces => {
+              const expectedSpanPromise = agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span.meta).to.not.have.any.keys(['messaging.kafka.bootstrap.servers'])
               })
@@ -281,7 +281,7 @@ describe('Plugin', () => {
           })
 
           it('should propagate context', async () => {
-            const expectedSpanPromise = agent.use(traces => {
+            const expectedSpanPromise = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(span).to.include({

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -52,7 +52,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('name', 'koa.request')
@@ -92,7 +92,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('name', 'koa.request')
@@ -241,7 +241,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 expect(spans[0].meta).to.have.property('http.client_ip', '8.8.8.8')
               })
@@ -267,7 +267,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
                 expect(spans[0].meta).to.not.have.property('http.client_ip')
               })
@@ -303,7 +303,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -342,7 +342,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
                   expect(spans[0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
@@ -378,7 +378,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -409,7 +409,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -439,7 +439,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -471,7 +471,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /public/plop')
@@ -505,7 +505,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /forums/:fid/discussions/:did/posts/:pid')
@@ -542,7 +542,7 @@ describe('Plugin', () => {
                 const port = appListener.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = sort(traces[0])
 
                     expect(spans[0]).to.have.property('resource', 'GET /first/child')
@@ -579,7 +579,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /forums/:fid/posts/:pid')
@@ -612,7 +612,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -647,7 +647,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -734,7 +734,7 @@ describe('Plugin', () => {
               const port = appListener.address().port
 
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = sort(traces[0])
 
                   expect(spans[0]).to.have.property('name', 'koa.request')
@@ -771,7 +771,7 @@ describe('Plugin', () => {
                 const port = appListener.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = sort(traces[0])
 
                     expect(spans[0]).to.have.property('name', 'koa.request')
@@ -905,7 +905,7 @@ describe('Plugin', () => {
                 const port = appListener.address().port
 
                 agent
-                  .use(traces => {
+                  .assertSomeTraces(traces => {
                     const spans = sort(traces[0])
 
                     expect(spans[0]).to.have.property('resource', 'GET /user/:id')

--- a/packages/datadog-plugin-langchain/test/index.spec.js
+++ b/packages/datadog-plugin-langchain/test/index.spec.js
@@ -94,7 +94,7 @@ describe('Plugin', () => {
           nock('https://api.openai.com').post('/v1/completions').reply(403)
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
 
               const span = traces[0][0]
@@ -134,7 +134,7 @@ describe('Plugin', () => {
 
           const llm = new langchainOpenai.OpenAI({ model: 'gpt-3.5-turbo-instruct' })
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -183,7 +183,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -227,7 +227,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -254,7 +254,7 @@ describe('Plugin', () => {
           nock('https://api.openai.com').post('/v1/chat/completions').reply(403)
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
 
               const span = traces[0][0]
@@ -298,7 +298,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -353,7 +353,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -402,7 +402,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -458,7 +458,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -523,7 +523,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(1)
               const span = traces[0][0]
 
@@ -556,7 +556,7 @@ describe('Plugin', () => {
           nock('https://api.openai.com').post('/v1/chat/completions').reply(403)
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0].length).to.equal(2)
 
               const chainSpan = traces[0][0]
@@ -605,7 +605,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
               expect(spans).to.have.length(2)
 
@@ -679,7 +679,7 @@ describe('Plugin', () => {
           ])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
               expect(spans).to.have.length(2)
 
@@ -753,7 +753,7 @@ describe('Plugin', () => {
           ])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
               expect(spans).to.have.length(3) // 1 chain + 2 chat model
 
@@ -796,7 +796,7 @@ describe('Plugin', () => {
           })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
               expect(spans).to.have.length(2) // 1 chain + 1 chat model
 
@@ -831,7 +831,7 @@ describe('Plugin', () => {
             nock('https://api.openai.com').post('/v1/embeddings').reply(403)
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0].length).to.equal(1)
 
                 const span = traces[0][0]
@@ -874,7 +874,7 @@ describe('Plugin', () => {
             const embeddings = new langchainOpenai.OpenAIEmbeddings()
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0].length).to.equal(1)
                 const span = traces[0][0]
 
@@ -924,7 +924,7 @@ describe('Plugin', () => {
             }
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0].length).to.equal(1)
                 const span = traces[0][0]
 
@@ -986,7 +986,7 @@ describe('Plugin', () => {
             })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0].length).to.equal(1)
 
                 const span = traces[0][0]

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -98,7 +98,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
@@ -121,7 +121,7 @@ describe('Plugin', () => {
         if (semver.intersects(version, '>=3')) {
           it('should support prepared statement shorthand', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                 expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                 expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
@@ -143,7 +143,7 @@ describe('Plugin', () => {
 
           it('should support prepared statements', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                 expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                 expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
@@ -174,7 +174,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -190,7 +190,7 @@ describe('Plugin', () => {
 
         it('should work without a callback', done => {
           agent
-            .use(() => {})
+            .assertSomeTraces(() => {})
             .then(done)
             .catch(done)
 
@@ -230,7 +230,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
             .then(done)
@@ -336,7 +336,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -300,7 +300,7 @@ describe('Plugin', () => {
         )
 
         it('should be configured with the correct values', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('service', 'custom')
             sinon.assert.calledWith(serviceSpy, sinon.match({
               host: 'localhost',
@@ -395,7 +395,7 @@ describe('Plugin', () => {
         })
 
         it('should not instrument connections to avoid leaks from internal queue', done => {
-          agent.use((traces) => {
+          agent.assertSomeTraces((traces) => {
             expect(traces).to.have.length(1)
             expect(traces[0].find(span => span.name === 'tcp.connect')).to.be.undefined
           }).then(done, done)

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -37,7 +37,7 @@ describe('Plugin', () => {
           memcached = new Memcached('localhost:11211', { retries: 0 })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'get')
@@ -77,7 +77,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
@@ -96,7 +96,7 @@ describe('Plugin', () => {
           memcached = new Memcached(['localhost:11211'], { retries: 0 })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
               expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
               expect(traces[0][0].meta).to.have.property('component', 'memcached')
@@ -114,7 +114,7 @@ describe('Plugin', () => {
           }, { retries: 0 })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
               expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
               expect(traces[0][0].meta).to.have.property('component', 'memcached')
@@ -138,7 +138,7 @@ describe('Plugin', () => {
             memcached.del('test', err => err && done(err))
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
                 expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
                 expect(traces[0][0].meta).to.have.property('component', 'memcached')
@@ -166,7 +166,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
             .then(done)
@@ -192,7 +192,7 @@ describe('Plugin', () => {
 
           it('trace should contain memcached.command', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('memcached.command', 'version')
               })
               .then(done)
@@ -217,7 +217,7 @@ describe('Plugin', () => {
 
           it('trace should not contain memcached.command', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.not.have.property('memcached.command')
               })
               .then(done)

--- a/packages/datadog-plugin-microgateway-core/test/index.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/index.spec.js
@@ -75,7 +75,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
 
               expect(spans[0]).to.have.property('name', 'microgateway.request')
@@ -127,7 +127,7 @@ describe('Plugin', () => {
           }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
 
               expect(spans[0]).to.have.property('name', 'microgateway.request')
@@ -156,7 +156,7 @@ describe('Plugin', () => {
           }
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
 
               expect(spans[0]).to.have.property('name', 'microgateway.request')

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -120,7 +120,7 @@ describe('Plugin', () => {
           'mocha-test-pass-two can pass two'
         ]
         const assertionPromises = testNames.map(testName => {
-          return agent.use(trace => {
+          return agent.assertSomeTraces(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.parent_id.toString()).to.equal('0')
             expect(testSpan.meta[TEST_STATUS]).to.equal('pass')
@@ -190,7 +190,7 @@ describe('Plugin', () => {
           'mocha-test-programmatic-skip can skip too'
         ]
         const assertionPromises = testNames.map(testName => {
-          return agent.use(trace => {
+          return agent.assertSomeTraces(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.parent_id.toString()).to.equal('0')
             expect(testSpan.meta[TEST_STATUS]).to.equal('skip')
@@ -288,7 +288,7 @@ describe('Plugin', () => {
         const testFilePath = path.join(__dirname, 'mocha-test-integration.js')
         const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
 
-        agent.use(trace => {
+        agent.assertSomeTraces(trace => {
           const httpSpan = trace[0].find(span => span.name === 'http.request')
           const testSpan = trace[0].find(span => span.type === 'test')
           expect(testSpan.parent_id.toString()).to.equal('0')
@@ -319,7 +319,7 @@ describe('Plugin', () => {
       it('works with sync errors in the hooks', (done) => {
         const testFilePath = path.join(__dirname, 'mocha-fail-hook-sync.js')
 
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const testSpan = traces[0][0]
           expect(testSpan.meta).to.contain({
             [ERROR_TYPE]: 'TypeError'
@@ -352,7 +352,7 @@ describe('Plugin', () => {
         ]
 
         const assertionPromises = testNames.map(({ name, status }) => {
-          return agent.use(trace => {
+          return agent.assertSomeTraces(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.meta[TEST_NAME]).to.equal(name)
             expect(testSpan.meta[TEST_STATUS]).to.equal(status)
@@ -403,7 +403,7 @@ describe('Plugin', () => {
         ]
 
         const assertionPromises = testNames.map(({ name, status, errorMsg }) => {
-          return agent.use(trace => {
+          return agent.assertSomeTraces(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.meta[TEST_NAME]).to.equal(name)
             expect(testSpan.meta[TEST_STATUS]).to.equal(status)
@@ -433,7 +433,7 @@ describe('Plugin', () => {
         // first and not the one for mocha-test-done-fail-badly.js (test we are testing).
         process.removeAllListeners('uncaughtException')
         const testFilePath = path.join(__dirname, 'mocha-test-done-fail-badly.js')
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           const testSpan = traces[0][0]
           expect(testSpan.meta[ERROR_TYPE]).to.equal('AssertionError')
           expect(testSpan.meta[ERROR_MESSAGE]).to.equal('expected true to equal false')
@@ -472,7 +472,7 @@ describe('Plugin', () => {
         const testFilePath = path.join(__dirname, 'mocha-test-retries.js')
 
         const assertionPromises = testNames.map(([testName, status]) => {
-          return agent.use(trace => {
+          return agent.assertSomeTraces(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.meta[TEST_STATUS]).to.equal(status)
             expect(testSpan.meta[TEST_NAME]).to.equal(testName)
@@ -500,7 +500,7 @@ describe('Plugin', () => {
         ]
 
         const assertionPromises = testNames.map(([testName, status]) => {
-          return agent.use(trace => {
+          return agent.assertSomeTraces(trace => {
             const testSpan = trace[0][0]
             expect(testSpan.meta[TEST_STATUS]).to.equal(status)
             expect(testSpan.meta[TEST_NAME]).to.equal(testName)
@@ -535,7 +535,7 @@ describe('Plugin', () => {
               'packages/datadog-plugin-mocha/test/mocha-test-suite-level-pass.js'
             ]
 
-            agent.use((agentlessPayload, request) => {
+            agent.assertSomeTraces((agentlessPayload, request) => {
               if (option === 'evp proxy') {
                 expect(request.headers['x-datadog-evp-subdomain']).to.equal('citestcycle-intake')
                 expect(request.path).to.equal('/evp_proxy/v2/api/v2/citestcycle')

--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -148,7 +148,7 @@ describe('Plugin', () => {
         const testFilePath = path.join(__dirname, 'mocha-test-fail.js')
         const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             const testSpan = traces[0][0]
             expect(testSpan.meta).to.contain({
               [COMPONENT]: 'mocha',
@@ -215,7 +215,7 @@ describe('Plugin', () => {
           const testFilePath = path.join(__dirname, test.fileName)
           const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const testSpan = traces[0][0]
               expect(testSpan.meta).to.contain({
                 language: 'javascript',
@@ -255,7 +255,7 @@ describe('Plugin', () => {
         const testFilePath = path.join(__dirname, 'mocha-test-parameterized.js')
         const testSuite = testFilePath.replace(`${process.cwd()}/`, '')
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             const testSpan = traces[0][0]
             expect(testSpan.meta).to.contain({
               language: 'javascript',

--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -55,7 +55,7 @@ describe('Plugin', () => {
           after(() => agent.close({ ritmReset: false }))
 
           it('should do automatic instrumentation', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('name', expectedSchema.server.opName)
@@ -108,7 +108,7 @@ describe('Plugin', () => {
           after(() => agent.close({ ritmReset: false }))
 
           it('should have the configured service name', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             }).then(done, done)
 
@@ -160,7 +160,7 @@ describe('Plugin', () => {
           )
 
           it('should do automatic instrumentation', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('name', expectedSchema.client.opName)
@@ -201,7 +201,7 @@ describe('Plugin', () => {
           after(() => agent.close({ ritmReset: false }))
 
           it('should have the configured service name', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             }).then(done, done)
 
@@ -237,7 +237,7 @@ describe('Plugin', () => {
           let spanId
           let parentId
 
-          const clientPromise = agent.use(traces => {
+          const clientPromise = agent.assertSomeTraces(traces => {
             const spans = sort(traces[0])
 
             expect(spans[0]).to.have.property('name', expectedSchema.client.opName)
@@ -245,7 +245,7 @@ describe('Plugin', () => {
             spanId = spans[0].span_id
           })
 
-          const serverPromise = agent.use(traces => {
+          const serverPromise = agent.assertSomeTraces(traces => {
             const spans = sort(traces[0])
 
             expect(spans[0]).to.have.property('name', expectedSchema.server.opName)
@@ -305,7 +305,7 @@ describe('Plugin', () => {
           let spanId
           let parentId
 
-          const clientPromise = agent.use(traces => {
+          const clientPromise = agent.assertSomeTraces(traces => {
             const spans = sort(traces[0])
 
             expect(spans[0]).to.have.property('name', expectedSchema.client.opName)
@@ -315,7 +315,7 @@ describe('Plugin', () => {
             spanId = spans[0].span_id
           })
 
-          const serverPromise = agent.use(traces => {
+          const serverPromise = agent.assertSomeTraces(traces => {
             const spans = sort(traces[0])
 
             expect(spans[0]).to.have.property('name', expectedSchema.server.opName)

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -81,7 +81,7 @@ describe('Plugin', () => {
         describe('server', () => {
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `insert test.${collection}`
 
@@ -102,7 +102,7 @@ describe('Plugin', () => {
 
           it('should use the correct resource name for arbitrary commands', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `planCacheListPlans test.${collection}`
 
@@ -119,7 +119,7 @@ describe('Plugin', () => {
 
           it('should sanitize buffers as values and not as objects', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collection}`
                 const query = '{"_id":"?"}'
@@ -140,7 +140,7 @@ describe('Plugin', () => {
 
           it('should serialize BigInt without erroring', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collection}`
                 const query = '{"_id":"9999999999999999999999"}'
@@ -176,7 +176,7 @@ describe('Plugin', () => {
             const id = '123456781234567812345678'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collection}`
                 const query = `{"_id":"${id}"}`
@@ -197,7 +197,7 @@ describe('Plugin', () => {
 
           it('should skip functions when sanitizing', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collection}`
                 const query = '{"_id":"1234"}'
@@ -228,7 +228,7 @@ describe('Plugin', () => {
             let error
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
                 expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
                 expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -258,15 +258,15 @@ describe('Plugin', () => {
 
             Promise.all([
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].resource).to.equal(`find test.${collection}`)
                 }),
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].resource).to.equal(`getMore test.${collection}`)
                 }),
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0].resource).to.equal(`killCursors test.${collection}`)
                 })
             ])
@@ -286,7 +286,7 @@ describe('Plugin', () => {
 
           it('should sanitize the query as the resource', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collection}`
                 const query = '{"foo":1,"bar":{"baz":[1,2,3]}}'
@@ -326,7 +326,7 @@ describe('Plugin', () => {
             let error
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
                 expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
                 expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -378,7 +378,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
@@ -435,7 +435,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should not inject comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(startSpy.called).to.be.true
               const ops = startSpy.getCall(0).args[0].ops
               expect(ops).to.not.have.property('comment')
@@ -479,7 +479,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should not inject comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(startSpy.called).to.be.true
               const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.be.undefined
@@ -492,7 +492,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should not alter existing comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(startSpy.called).to.be.true
               const { comment } = startSpy.getCall(0).args[0].ops
               expect(comment).to.equal('test comment')
@@ -542,7 +542,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should inject service mode as comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(startSpy.called).to.be.true
@@ -565,7 +565,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should inject service mode after eixsting str comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(startSpy.called).to.be.true
@@ -595,7 +595,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should inject service mode after eixsting array comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(startSpy.called).to.be.true
@@ -656,7 +656,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should inject full mode with traceparent as comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
               const traceId = span.meta['_dd.p.tid'] + span.trace_id.toString(16).padStart(16, '0')
               const spanId = span.span_id.toString(16).padStart(16, '0')

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -90,7 +90,7 @@ describe('Plugin', () => {
 
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `insert test.${collectionName}`
 
@@ -111,7 +111,7 @@ describe('Plugin', () => {
 
           it('should use the correct resource name for arbitrary commands', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = 'planCacheListPlans test.$cmd'
                 const query = '{}'
@@ -130,7 +130,7 @@ describe('Plugin', () => {
 
           it('should sanitize buffers as values and not as objects', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = '{"_id":"?"}'
@@ -148,7 +148,7 @@ describe('Plugin', () => {
 
           it('should sanitize BSON binary', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = '{"_bin":"?"}'
@@ -168,7 +168,7 @@ describe('Plugin', () => {
             const id = '123456781234567812345678'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = `{"_id":"${id}"}`
@@ -186,7 +186,7 @@ describe('Plugin', () => {
 
           it('should stringify BSON objects', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = '{"_time":{"$timestamp":"0"}}'
@@ -204,7 +204,7 @@ describe('Plugin', () => {
 
           it('should stringify BSON internal types', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = '{"_id":"?"}'
@@ -222,7 +222,7 @@ describe('Plugin', () => {
 
           it('should skip functions when sanitizing', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = '{"_id":"1234"}'
@@ -241,7 +241,7 @@ describe('Plugin', () => {
 
           it('should log the aggregate pipeline in mongodb.query', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = 'aggregate test.$cmd'
                 const query = '[{"$match":{"_id":"1234"}},{"$project":{"_id":1}}]'
@@ -262,7 +262,7 @@ describe('Plugin', () => {
             const id = '123456781234567812345678'
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 const resource = `find test.${collectionName}`
                 const query = `{"_id":"${id}"}`
@@ -318,7 +318,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
@@ -330,7 +330,7 @@ describe('Plugin', () => {
 
         it('should include sanitized query in resource when configured', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
               const resource = `find test.${collectionName} {"_bin":"?"}`
 
@@ -384,7 +384,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should inject service mode as comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
 
               expect(startSpy.called).to.be.true
@@ -433,7 +433,7 @@ describe('Plugin', () => {
 
         it('DBM propagation should inject full mode with traceparent as comment', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
               const traceId = span.meta['_dd.p.tid'] + span.trace_id.toString(16).padStart(16, '0')
               const spanId = span.span_id.toString(16).padStart(16, '0')
@@ -481,7 +481,7 @@ describe('Plugin', () => {
             const parentSpan = tracer.startSpan('test.parent')
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 // Should only receive the trace for the parent span
                 expect(traces[0]).to.have.length(1)
                 const span = traces[0][0]
@@ -522,7 +522,7 @@ describe('Plugin', () => {
             const parentSpan = tracer.startSpan('test.parent')
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0]).to.have.length.at.least(2)
                 const rootSpan = traces[0][0]
 
@@ -569,7 +569,7 @@ describe('Plugin', () => {
             const parentSpan = tracer.startSpan('test.parent')
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 // Should only receive the trace for the parent span
                 expect(traces[0]).to.have.length(1)
                 const span = traces[0][0]
@@ -609,7 +609,7 @@ describe('Plugin', () => {
             const parentSpan = tracer.startSpan('test.parent')
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0]).to.have.length.at.least(2)
                 const rootSpan = traces[0][0]
 

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -73,7 +73,7 @@ describe('Plugin', () => {
         })
 
         it('should do automatic instrumentation', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
@@ -95,7 +95,7 @@ describe('Plugin', () => {
         it('should handle errors', done => {
           let error
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
             expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -110,7 +110,7 @@ describe('Plugin', () => {
         })
 
         it('should work without a callback', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             done()
           })
 
@@ -154,7 +154,7 @@ describe('Plugin', () => {
         )
 
         it('should be configured with the correct values', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', 'custom')
             done()
@@ -201,7 +201,7 @@ describe('Plugin', () => {
         )
 
         it('should be configured with the correct values', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', 'custom')
             sinon.assert.calledWith(serviceSpy, sinon.match({
@@ -244,7 +244,7 @@ describe('Plugin', () => {
           'db', 'db.name')
 
         it('should do automatic instrumentation', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
@@ -390,7 +390,7 @@ describe('Plugin', () => {
         })
 
         it('trace query resource should not be changed when propagation is enabled', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
             done()
           })
@@ -459,7 +459,7 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           let queryText = ''
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -474,7 +474,7 @@ describe('Plugin', () => {
         })
 
         it('query should inject _dd.dbm_trace_injected into span', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
             done()
           })
@@ -539,7 +539,7 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           let queryText = ''
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -554,7 +554,7 @@ describe('Plugin', () => {
         })
 
         it('query should inject _dd.dbm_trace_injected into span', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
             done()
           })

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -88,7 +88,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
@@ -109,7 +109,7 @@ describe('Plugin', () => {
 
         it('should support prepared statement shorthand', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
@@ -132,7 +132,7 @@ describe('Plugin', () => {
 
         it('should support prepared statements', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
@@ -161,7 +161,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -177,7 +177,7 @@ describe('Plugin', () => {
 
         it('should work without a callback', done => {
           agent
-            .use(() => {})
+            .assertSomeTraces(() => {})
             .then(done)
             .catch(done)
 
@@ -223,7 +223,7 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
             .then(done)
@@ -307,7 +307,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -271,7 +271,7 @@ describe('Plugin', () => {
         )
 
         it('should be configured with the correct values', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('service', 'custom')
             sinon.assert.calledWith(serviceSpy, sinon.match({
               host: 'localhost',
@@ -377,7 +377,7 @@ describe('Plugin', () => {
         })
 
         it('trace query resource should not be changed when propagation is enabled', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
             done()
           })
@@ -446,7 +446,7 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           let queryText = ''
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -461,7 +461,7 @@ describe('Plugin', () => {
         })
 
         it('query should inject _dd.dbm_trace_injected into span', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
             done()
           })
@@ -526,7 +526,7 @@ describe('Plugin', () => {
 
         it('query text should contain traceparent', done => {
           let queryText = ''
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -541,7 +541,7 @@ describe('Plugin', () => {
         })
 
         it('query should inject _dd.dbm_trace_injected into span', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
             done()
           })

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -186,7 +186,7 @@ describe('Plugin', () => {
         let error = null
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.deep.include({
               name: 'tcp.connect',
               service: 'test',

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -156,7 +156,7 @@ describe('Plugin', function () {
         describe('for api routes', () => {
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -184,7 +184,7 @@ describe('Plugin', function () {
           pathTests.forEach(([url, expectedPath]) => {
             it(`should infer the correct resource path (${expectedPath})`, done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[1]).to.have.property('resource', `GET ${expectedPath}`)
@@ -210,7 +210,7 @@ describe('Plugin', function () {
 
           it('should handle routes not found', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -231,7 +231,7 @@ describe('Plugin', function () {
 
           it('should handle invalid catch all parameters', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -253,7 +253,7 @@ describe('Plugin', function () {
 
           it('should pass resource path to parent span', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'web.request')
@@ -271,7 +271,7 @@ describe('Plugin', function () {
         describe('for pages', () => {
           it('should do automatic instrumentation', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -301,7 +301,7 @@ describe('Plugin', function () {
           pathTests.forEach(([url, expectedPath, statusCode]) => {
             it(`should infer the correct resource (${expectedPath})`, done => {
               agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[1]).to.have.property('resource', `GET ${expectedPath}`)
@@ -316,7 +316,7 @@ describe('Plugin', function () {
 
           it('should handle pages not found', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -337,7 +337,7 @@ describe('Plugin', function () {
 
           it('should pass resource path to parent span', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'web.request')
@@ -353,7 +353,7 @@ describe('Plugin', function () {
 
           it('should attach errors by default', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -374,7 +374,7 @@ describe('Plugin', function () {
         describe('for static files', () => {
           it('should do automatic instrumentation for assets', () => {
             const tracingPromise = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -395,7 +395,7 @@ describe('Plugin', function () {
             const file = readdirSync(path.join(__dirname, '.next/static/chunks'))[0]
 
             const tracingPromise = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -410,7 +410,7 @@ describe('Plugin', function () {
 
           it('should pass resource path to parent span', () => {
             const tracingPromise = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[0]).to.have.property('name', 'web.request')
@@ -424,7 +424,7 @@ describe('Plugin', function () {
         describe('when an error happens', () => {
           it('should not die', done => {
             agent
-              .use(_traces => { })
+              .assertSomeTraces(_traces => { })
               .then(done)
               .catch(done)
 
@@ -443,7 +443,7 @@ describe('Plugin', function () {
 
           it('should infer the correct resource path for appDir routes', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('resource', 'GET /api/appDir/[name]')
@@ -458,7 +458,7 @@ describe('Plugin', function () {
 
           it('should infer the correct resource path for appDir pages', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('resource', 'GET /appDir/[name]')
@@ -477,7 +477,7 @@ describe('Plugin', function () {
 
         it('should execute the hook and validate the status only once', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const spans = traces[0]
 
               expect(spans[1]).to.have.property('name', 'next.request')
@@ -506,7 +506,7 @@ describe('Plugin', function () {
         if (satisfies(pkg.version, '>=13.3.0')) {
           it('should attach the error to the span from a NextRequest', done => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = traces[0]
 
                 expect(spans[1]).to.have.property('name', 'next.request')
@@ -546,7 +546,7 @@ describe('Plugin', function () {
           standaloneTests.forEach(([test, resource, expectedResource]) => {
             it(`should do automatic instrumentation for ${test}`, () => {
               const promise = agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const spans = traces[0]
 
                   expect(spans[1]).to.have.property('name', 'next.request')

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -95,7 +95,7 @@ describe('Plugin', () => {
             })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property('openai.request.messages.0.content',
                 '...')
               expect(traces[0][0].meta).to.have.property('openai.request.messages.1.content',
@@ -173,7 +173,7 @@ describe('Plugin', () => {
 
         it('should attach the error to the span', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('error', 1)
               // the message content differs on OpenAI version, even between patches
               expect(traces[0][0].meta['error.message']).to.exist
@@ -323,7 +323,7 @@ describe('Plugin', () => {
             ])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -450,7 +450,7 @@ describe('Plugin', () => {
             ])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
             })
 
@@ -503,7 +503,7 @@ describe('Plugin', () => {
             ])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -579,7 +579,7 @@ describe('Plugin', () => {
             ])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -652,7 +652,7 @@ describe('Plugin', () => {
             }, [])
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].metrics).to.have.property('openai.response.usage.prompt_tokens', 0)
               expect(traces[0][0].metrics).to.not.have.property('openai.response.usage.completion_tokens')
               expect(traces[0][0].metrics).to.not.have.property('openai.response.usage.total_tokens')
@@ -753,7 +753,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -827,7 +827,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -915,7 +915,7 @@ describe('Plugin', () => {
           // `edits.create` was deprecated and removed after 4.0.0
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 expect(traces[0][0]).to.have.property('resource', 'createEdit')
@@ -1027,7 +1027,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -1092,7 +1092,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -1161,7 +1161,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -1226,7 +1226,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -1289,7 +1289,7 @@ describe('Plugin', () => {
         // TODO: issues with content being async arraybuffer, how to compute byteLength before promise resolves?
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0 <4.17.1') && DD_MAJOR < 6) {
@@ -1407,7 +1407,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
@@ -1499,7 +1499,7 @@ describe('Plugin', () => {
 
         it('does not throw when missing classification betas', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
             })
 
@@ -1672,7 +1672,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
@@ -1818,7 +1818,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
@@ -1953,7 +1953,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
@@ -2021,7 +2021,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -2136,7 +2136,7 @@ describe('Plugin', () => {
 
         it('makes a successful call', async () => {
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', 'openai.request')
               expect(traces[0][0]).to.have.property('type', 'openai')
               if (semver.satisfies(realVersion, '>=4.1.0') && DD_MAJOR < 6) {
@@ -2248,7 +2248,7 @@ describe('Plugin', () => {
 
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -2347,7 +2347,7 @@ describe('Plugin', () => {
 
           it('makes a successful call using a string prompt', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -2407,7 +2407,7 @@ describe('Plugin', () => {
 
           it('makes a successful call using an array of tokens prompt', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('openai.request.prompt', '[999, 888, 777, 666, 555]')
               })
 
@@ -2446,7 +2446,7 @@ describe('Plugin', () => {
 
           it('makes a successful call using an array of string prompts', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('openai.request.prompt.0', 'foo')
                 expect(traces[0][0].meta).to.have.property('openai.request.prompt.1', 'bar')
               })
@@ -2486,7 +2486,7 @@ describe('Plugin', () => {
 
           it('makes a successful call using an array of tokens prompts', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('openai.request.prompt.0', '[111, 222, 333]')
                 expect(traces[0][0].meta).to.have.property('openai.request.prompt.1', '[444, 555, 666]')
               })
@@ -2558,7 +2558,7 @@ describe('Plugin', () => {
 
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -2655,7 +2655,7 @@ describe('Plugin', () => {
 
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -2755,7 +2755,7 @@ describe('Plugin', () => {
 
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -2887,7 +2887,7 @@ describe('Plugin', () => {
 
           it('does not error with invalid .messages or missing .logit_bias', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
               })
 
@@ -2908,7 +2908,7 @@ describe('Plugin', () => {
 
           it('should tag image_url', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 // image_url is only relevant on request/input, output has the same shape as a normal chat completion
                 expect(span.meta).to.have.property('openai.request.messages.0.content.0.type', 'text')
@@ -3017,7 +3017,7 @@ describe('Plugin', () => {
 
           it('tags the tool calls successfully', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta)
                   .to.have.property('openai.response.choices.0.message.tool_calls.0.function.name',
                     'extract_fictional_info')
@@ -3143,7 +3143,7 @@ describe('Plugin', () => {
 
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -3249,7 +3249,7 @@ describe('Plugin', () => {
 
           it('makes a successful call', async () => {
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'openai.request')
                 expect(traces[0][0]).to.have.property('type', 'openai')
                 if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
@@ -3327,7 +3327,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', 'openai.request')
                 expect(span).to.have.property('type', 'openai')
@@ -3383,7 +3383,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', 'openai.request')
                 expect(span).to.have.property('type', 'openai')
@@ -3422,7 +3422,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.have.property('name', 'openai.request')
                 expect(span).to.have.property('type', 'openai')
@@ -3488,7 +3488,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span.meta).to.have.property('openai.response.choices.0.message.content', 'I\'m just a computer')
@@ -3536,7 +3536,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 // we shouldn't be trying to capture the image_url tokens
@@ -3584,7 +3584,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span).to.have.property('name', 'openai.request')
@@ -3636,7 +3636,7 @@ describe('Plugin', () => {
               })
 
             const checkTraces = agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 expect(span.meta).to.have.property('openai.response.choices.0.text', '\\n\\nI am an AI')
@@ -3685,7 +3685,7 @@ describe('Plugin', () => {
                 })
 
               const checkTraces = agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   expect(span).to.have.property('name', 'openai.request')
@@ -3756,7 +3756,7 @@ describe('Plugin', () => {
                 })
 
               const checkTraces = agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   const span = traces[0][0]
 
                   expect(span).to.have.property('name', 'openai.request')
@@ -3828,7 +3828,7 @@ describe('Plugin', () => {
             })
 
           const checkTraces = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span).to.have.property('name', 'openai.request')
             })

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
 
         it('should sanitize the resource name', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'POST /logstash-?.?.?/_search')
             })
             .then(done)
@@ -56,7 +56,7 @@ describe('Plugin', () => {
 
         it('should set the correct tags', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0].meta).to.have.property('db.type', 'opensearch')
@@ -87,7 +87,7 @@ describe('Plugin', () => {
 
         it('should set the correct tags on msearch', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0].meta).to.have.property('db.type', 'opensearch')
@@ -125,7 +125,7 @@ describe('Plugin', () => {
 
         it('should skip tags for unavailable fields', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.not.have.property('opensearch.body')
             })
             .then(done)
@@ -136,7 +136,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'HEAD /')
@@ -151,7 +151,7 @@ describe('Plugin', () => {
 
         it('should propagate context', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('parent_id')
               expect(traces[0][0].parent_id).to.not.be.null
             })
@@ -197,7 +197,7 @@ describe('Plugin', () => {
 
         it('should work with userland promises', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'HEAD /')
@@ -270,7 +270,7 @@ describe('Plugin', () => {
           })
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', 'custom')
               expect(traces[0][0].meta).to.have.property('opensearch.params', 'foo')

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -170,7 +170,7 @@ describe('Plugin', () => {
         it('should handle errors', done => {
           let error
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
             expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -80,7 +80,7 @@ describe('Plugin', () => {
 
         function connectionTests (url) {
           it('should be instrumented for promise API', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', dbQuery)
@@ -106,7 +106,7 @@ describe('Plugin', () => {
           })
 
           it('should be instrumented for callback API', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', dbQuery)
@@ -140,7 +140,7 @@ describe('Plugin', () => {
           it('should instrument errors', done => {
             let error
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'invalid')
@@ -209,7 +209,7 @@ describe('Plugin', () => {
 
         function poolTests (url) {
           it('should be instrumented correctly with correct tags', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', dbQuery)
@@ -234,7 +234,7 @@ describe('Plugin', () => {
           it('should instrument errors', () => {
             let error
 
-            const promise = agent.use(traces => {
+            const promise = agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'invalid')
@@ -294,7 +294,7 @@ describe('Plugin', () => {
           )
 
           it('should set the service name', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', 'custom')
             }).then(done, done)
@@ -335,7 +335,7 @@ describe('Plugin', () => {
           )
 
           it('should set the service name', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', config.connectString)
             }).then(done, done)

--- a/packages/datadog-plugin-paperplane/test/index.spec.js
+++ b/packages/datadog-plugin-paperplane/test/index.spec.js
@@ -79,7 +79,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'test')
@@ -116,7 +116,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -158,7 +158,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -194,7 +194,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /user/:id')
@@ -223,7 +223,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app')
@@ -250,7 +250,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET')
@@ -283,7 +283,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /app/user/:id')
@@ -408,7 +408,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -480,7 +480,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('service', 'custom')
@@ -509,7 +509,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('error', 1)
@@ -540,7 +540,7 @@ describe('Plugin', () => {
             const port = server.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0].meta).to.have.property('http.request.headers.user-agent', 'test')

--- a/packages/datadog-plugin-paperplane/test/index.spec.js
+++ b/packages/datadog-plugin-paperplane/test/index.spec.js
@@ -310,7 +310,7 @@ describe('Plugin', () => {
           server.listen(0, 'localhost', () => {
             const port = server.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0].trace_id.toString()).to.equal('1234')
@@ -345,7 +345,7 @@ describe('Plugin', () => {
           server.listen(0, 'localhost', () => {
             const port = server.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('error', 1)
@@ -378,7 +378,7 @@ describe('Plugin', () => {
           server.listen(0, 'localhost', () => {
             const port = server.address().port
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const spans = sort(traces[0])
 
               expect(spans[0]).to.have.property('error', 0)

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -68,7 +68,7 @@ describe('Plugin', () => {
           )
 
           it('should do automatic instrumentation when using callbacks', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
@@ -97,7 +97,7 @@ describe('Plugin', () => {
           })
 
           it('should send long queries to agent', done => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', `SELECT '${'x'.repeat(5000)}'::text as message`)
 
               done()
@@ -114,7 +114,7 @@ describe('Plugin', () => {
 
           if (semver.intersects(version, '>=5.1')) { // initial promise support
             it('should do automatic instrumentation when using promises', done => {
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                 expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                 expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
@@ -142,7 +142,7 @@ describe('Plugin', () => {
           it('should handle errors', done => {
             let error
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -164,7 +164,7 @@ describe('Plugin', () => {
           it('should handle errors', done => {
             let error
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
 
@@ -229,7 +229,7 @@ describe('Plugin', () => {
                 })
 
                 it('should instrument cursor-based streaming with pg-cursor', async () => {
-                  const tracingPromise = agent.use(traces => {
+                  const tracingPromise = agent.assertSomeTraces(traces => {
                     expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                     expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                     expect(traces[0][0]).to.have.property('resource', 'SELECT * FROM generate_series(0, 1) num')
@@ -259,7 +259,7 @@ describe('Plugin', () => {
                 })
 
                 it('should instrument stream-based queries with pg-query-stream', async () => {
-                  const agentPromise = agent.use(traces => {
+                  const agentPromise = agent.assertSomeTraces(traces => {
                     expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                     expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                     expect(traces[0][0]).to.have.property('resource', 'SELECT * FROM generate_series(0, 1) num')
@@ -288,7 +288,7 @@ describe('Plugin', () => {
                 })
 
                 it('should instrument stream-based queries with pg-query-stream and catch errors', async () => {
-                  const agentPromise = agent.use(traces => {
+                  const agentPromise = agent.assertSomeTraces(traces => {
                     expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                     expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
                     expect(traces[0][0]).to.have.property('resource', 'SELECT * FROM generate_series(0, 1) num')
@@ -348,7 +348,7 @@ describe('Plugin', () => {
         })
 
         it('should be configured with the correct values', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', 'custom')
             expect(traces[0][0]).to.have.property('resource', 'SELECT $1...')
@@ -405,7 +405,7 @@ describe('Plugin', () => {
         })
 
         it('should be configured with the correct service', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', '127.0.0.1-postgres')
           })
@@ -488,7 +488,7 @@ describe('Plugin', () => {
         })
 
         it('trace query resource should not be changed when propagation is enabled', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'SELECT $1::text as message')
             done()
           })
@@ -591,7 +591,7 @@ describe('Plugin', () => {
         })
 
         it('query text should contain traceparent', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -609,7 +609,7 @@ describe('Plugin', () => {
         })
 
         it('query should inject _dd.dbm_trace_injected into span', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property('_dd.dbm_trace_injected', 'true')
             done()
           })
@@ -624,7 +624,7 @@ describe('Plugin', () => {
         })
 
         it('service should default to tracer service name', done => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             done()
           })
@@ -671,7 +671,7 @@ describe('Plugin', () => {
             text: 'SELECT $1::text as message'
           }
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
             const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
             const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
@@ -705,7 +705,7 @@ describe('Plugin', () => {
             })
           })
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(query).to.have.property(
               'name', 'pgSelectQuery')
           }).then(done, done)
@@ -719,7 +719,7 @@ describe('Plugin', () => {
             text: 'SELECT $1::text as message'
           }
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(queryText).to.equal(
               `/*dddb='postgres',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}'` +
               '*/ SELECT $1::text as message')
@@ -743,7 +743,7 @@ describe('Plugin', () => {
             get text () { return 'SELECT $1::text as message' }
           }
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(queryText).to.equal(
               `/*dddb='postgres',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}'` +
               '*/ SELECT $1::text as message')
@@ -777,7 +777,7 @@ describe('Plugin', () => {
 
           const query = new Query('pgSelectQuery', 'SELECT $1::text as greeting')
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(queryText).to.equal(
               `/*dddb='postgres',dddbs='post',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='${ddpv}'` +
               '*/ SELECT $1::text as greeting')

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation when using callbacks', async () => {
           const promise = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -87,7 +87,7 @@ describe('Plugin', () => {
 
         it('should work with userland promises', async () => {
           const promise = agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'GET')

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -69,7 +69,7 @@ describe('Plugin', () => {
         it('should handle errors', async () => {
           let error
 
-          const promise = agent.use(traces => {
+          const promise = agent.assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
             expect(traces[0][0].meta).to.have.property('component', 'redis')
@@ -135,7 +135,7 @@ describe('Plugin', () => {
         })
 
         it('should be configured with the correct values', async () => {
-          const promise = agent.use(traces => {
+          const promise = agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('service', 'custom')
             expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
             expect(traces[0][0].metrics).to.have.property('network.destination.port', 6379)
@@ -152,7 +152,7 @@ describe('Plugin', () => {
           'localhost', 'out.host')
 
         it('should be able to filter commands', async () => {
-          const promise = agent.use(traces => {
+          const promise = agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'GET')
           })
 
@@ -201,7 +201,7 @@ describe('Plugin', () => {
         })
 
         it('should be able to filter commands on a case-insensitive basis', async () => {
-          const promise = agent.use(traces => {
+          const promise = agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'GET')
           })
 

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -112,7 +112,7 @@ describe('Legacy Plugin', () => {
         // TODO: This test is flakey. I've seen it affect 2.6.0, 2.5.3, 3.1.2, 0.12.0
         // Increasing the test timeout does not help.
         // Error will be set but span will not.
-        // agent.use is called a dozen times per test in legacy.spec but once per test in client.spec
+        // agent.assertSomeTraces is called a dozen times per test in legacy.spec but once per test in client.spec
         it.skip('should handle errors', done => {
           const assertError = () => {
             if (!error || !span) return
@@ -132,7 +132,7 @@ describe('Legacy Plugin', () => {
           let error
           let span
 
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'set')
             span = traces[0][0]
             assertError()
@@ -182,7 +182,7 @@ describe('Legacy Plugin', () => {
         })
 
         it('should be able to filter commands', done => {
-          agent.use(() => {}) // wait for initial command
+          agent.assertSomeTraces(() => {}) // wait for initial command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
@@ -225,7 +225,7 @@ describe('Legacy Plugin', () => {
         })
 
         it('should be able to filter commands', done => {
-          agent.use(() => {}) // wait for initial command
+          agent.assertSomeTraces(() => {}) // wait for initial command
           agent
             .use(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -51,7 +51,7 @@ describe('Legacy Plugin', () => {
         it('should do automatic instrumentation when using callbacks', done => {
           client.on('error', done)
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
               expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
               expect(traces[0][0]).to.have.property('resource', 'get')
@@ -171,7 +171,7 @@ describe('Legacy Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'custom')
             })
             .then(done)
@@ -184,7 +184,7 @@ describe('Legacy Plugin', () => {
         it('should be able to filter commands', done => {
           agent.assertSomeTraces(() => {}) // wait for initial command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)
@@ -227,7 +227,7 @@ describe('Legacy Plugin', () => {
         it('should be able to filter commands', done => {
           agent.assertSomeTraces(() => {}) // wait for initial command
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('resource', 'get')
             })
             .then(done)

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -39,7 +39,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', 'restify.request')
                 expect(traces[0][0]).to.have.property('service', 'test')
                 expect(traces[0][0]).to.have.property('type', 'web')
@@ -71,7 +71,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
                 expect(traces[0][0].meta).to.have.property('component', 'restify')
@@ -100,7 +100,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
                 expect(traces[0][0].meta).to.have.property('component', 'restify')
@@ -139,7 +139,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(warningSpy).to.not.have.been.called
               })
               .then(done)
@@ -205,7 +205,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /user/:id')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user/123`)
                 expect(traces[0][0].meta).to.have.property('component', 'restify')
@@ -268,7 +268,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('resource', 'GET /error')
                 expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, 'uncaught')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/error`)

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -54,7 +54,7 @@ describe('Plugin', () => {
 
           it('Should set pathway hash tag on a span when producing', (done) => {
             let produceSpanMeta = {}
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               if (span.meta['span.kind'] === 'producer') {
@@ -74,7 +74,7 @@ describe('Plugin', () => {
 
             container.once('message', msg => {
               let consumeSpanMeta = {}
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
                 if (span.meta['span.kind'] === 'consumer') {
@@ -137,7 +137,7 @@ describe('Plugin', () => {
             )
 
             it('should automatically instrument', (done) => {
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.include({
                   name: expectedSchema.send.opName,
@@ -193,7 +193,7 @@ describe('Plugin', () => {
 
           describe('receiving a message', () => {
             it('should automatically instrument', done => {
-              agent.use(traces => {
+              agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
                 expect(span).to.include({
                   name: expectedSchema.receive.opName,
@@ -266,7 +266,7 @@ describe('Plugin', () => {
           )
 
           it('should use the configuration for the receiver', (done) => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span).to.have.property('name', expectedSchema.receive.opName)
               expect(span).to.have.property('service', 'a_test_service')
@@ -276,7 +276,7 @@ describe('Plugin', () => {
           })
 
           it('should use the configuration for the sender', (done) => {
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span).to.have.property('name', expectedSchema.send.opName)
               expect(span).to.have.property('service', 'a_test_service')
@@ -315,7 +315,7 @@ describe('Plugin', () => {
         })
 
         it('should automatically instrument', (done) => {
-          agent.use(traces => {
+          agent.assertSomeTraces(traces => {
             const beforeFinishContext = rheaInstumentation.contexts.get(spy.firstCall.firstArg)
             expect(spy).to.have.been.called
             expect(beforeFinishContext).to.have.property('connection')
@@ -436,7 +436,7 @@ describe('Plugin', () => {
                   throw error
                 })
 
-                agent.use(traces => {
+                agent.assertSomeTraces(traces => {
                   const span = traces[0][0]
                   expect(span.error).to.equal(1)
                   expect(span.meta).to.include({
@@ -636,7 +636,7 @@ describe('Plugin', () => {
 
           it('sender span should get closed', (done) => {
             const err = new Error('fake protocol error')
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span).to.include({
                 name: expectedSchema.send.opName,
@@ -668,7 +668,7 @@ describe('Plugin', () => {
 
           it('receiver span should closed', (done) => {
             const err = new Error('fake protocol error')
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               expect(span).to.include({
                 name: expectedSchema.receive.opName,
@@ -703,7 +703,7 @@ describe('Plugin', () => {
 function expectReceiving (agent, expectedSchema, deliveryState, topic) {
   deliveryState = deliveryState || deliveryState === false ? undefined : 'accepted'
   topic = topic || 'amq.topic'
-  return Promise.resolve().then(() => agent.use(traces => {
+  return Promise.resolve().then(() => agent.assertSomeTraces(traces => {
     const span = traces[0][0]
     expect(span).to.include({
       name: expectedSchema.receive.opName,
@@ -728,7 +728,7 @@ function expectReceiving (agent, expectedSchema, deliveryState, topic) {
 function expectSending (agent, expectedSchema, deliveryState, topic) {
   deliveryState = deliveryState || deliveryState === false ? undefined : 'accepted'
   topic = topic || 'amq.topic'
-  return Promise.resolve().then(() => agent.use(traces => {
+  return Promise.resolve().then(() => agent.assertSomeTraces(traces => {
     const span = traces[0][0]
     expect(span).to.include({
       name: expectedSchema.send.opName,

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -91,7 +91,7 @@ describe('Plugin', () => {
             const port = appListener.address().port
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const spans = sort(traces[0])
 
                 expect(spans[0]).to.have.property('resource', 'GET /parent/child/:id')

--- a/packages/datadog-plugin-router/test/index.spec.js
+++ b/packages/datadog-plugin-router/test/index.spec.js
@@ -115,7 +115,7 @@ describe('Plugin', () => {
             res.end()
           })
 
-          const agentPromise = agent.use(traces => {
+          const agentPromise = agent.assertSomeTraces(traces => {
             for (const span of traces[0]) {
               expect(span.error).to.equal(0)
             }
@@ -139,7 +139,7 @@ describe('Plugin', () => {
             res.end()
           })
 
-          const agentPromise = agent.use(traces => {
+          const agentPromise = agent.assertSomeTraces(traces => {
             for (const span of traces[0]) {
               expect(span.error).to.equal(0)
             }

--- a/packages/datadog-plugin-sharedb/test/index.spec.js
+++ b/packages/datadog-plugin-sharedb/test/index.spec.js
@@ -41,7 +41,7 @@ describe('Plugin', () => {
           doc.fetch(function (err) {
             if (err) { throw err }
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('resource', 'fetch some-collection')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')
@@ -68,7 +68,7 @@ describe('Plugin', () => {
           doc.fetch(function (err) {
             if (err) { throw err }
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(receiveSpy).to.have.been.calledWithMatch(sinon.match.object, sinon.match.func)
               expect(replySpy).to.have.been.calledWithMatch(sinon.match.object, sinon.match.func)
               expect(traces[0][0]).to.have.property('service', 'test')
@@ -87,7 +87,7 @@ describe('Plugin', () => {
           }, {}, function (err) {
             if (err) { throw err }
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0])
                 .to
@@ -190,7 +190,7 @@ describe('Plugin', () => {
           doc.fetch(function (err) {
             if (err) { throw err }
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'test-sharedb')
               expect(receiveHookSpy).to.have.been.calledWithMatch(sinon.match.object, sinon.match.object)
               expect(replyHookSpy).to.have.been.calledWithMatch(
@@ -249,7 +249,7 @@ describe('Plugin', () => {
             expect(err).not.to.be.null
             expect(err.message).to.equal('Snapshot Fetch Failure')
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               expect(traces[0][0]).to.have.property('service', 'test')
               expect(traces[0][0]).to.have.property('resource', 'fetch some-collection')
               expect(traces[0][0].meta).to.have.property('span.kind', 'server')

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -136,7 +136,7 @@ describe('Plugin', () => {
         const query = 'SELECT 1 + 1 AS solution'
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
@@ -161,7 +161,7 @@ describe('Plugin', () => {
         const query = 'SELECT 1 + @num AS solution'
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
@@ -180,7 +180,7 @@ describe('Plugin', () => {
                       'SELECT 1 + 2 AS solution2'
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
@@ -197,7 +197,7 @@ describe('Plugin', () => {
         const query = 'SELECT 1 + @num AS solution'
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
@@ -215,7 +215,7 @@ describe('Plugin', () => {
         const query = 'SELECT 1 + @num AS solution'
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
@@ -236,7 +236,7 @@ describe('Plugin', () => {
         const query = 'SELECT 1 + @num AS solution'
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', query)
@@ -257,7 +257,7 @@ describe('Plugin', () => {
         const procedure = 'dbo.ddTestProc'
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
             expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
             expect(traces[0][0]).to.have.property('resource', procedure)
@@ -276,7 +276,7 @@ describe('Plugin', () => {
         let error
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
             expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
@@ -297,7 +297,7 @@ describe('Plugin', () => {
         let error
 
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(error.message).to.equal('Canceled.')
             expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
             expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -348,7 +348,7 @@ describe('Plugin', () => {
             const bulkLoad = buildBulkLoad()
 
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                 expect(traces[0][0]).to.have.property('resource', bulkLoad.getBulkInsertSql())
               })
@@ -364,7 +364,7 @@ describe('Plugin', () => {
               const rowStream = bulkLoad.getRowStream()
 
               const promise = agent
-                .use(traces => {
+                .assertSomeTraces(traces => {
                   expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
                   expect(traces[0][0]).to.have.property('resource', bulkLoad.getBulkInsertSql())
                 })
@@ -453,7 +453,7 @@ describe('Plugin', () => {
         })
 
         const promise = agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
             expect(request.sqlTextOrProcedure).to.equal("/*dddb='master',dddbs='custom',dde='tester'," +
               "ddh='localhost',ddps='test',ddpv='10.8.2'*/ SELECT 1 + 1 AS solution")

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -78,7 +78,7 @@ describe('Plugin', () => {
           })
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', 'test')
                 expect(traces[0][0]).to.have.property('type', 'http')
                 expect(traces[0][0]).to.have.property('resource', 'GET')
@@ -103,7 +103,7 @@ describe('Plugin', () => {
           })
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
                 expect(traces[0][0]).to.have.property('type', 'http')
                 expect(traces[0][0]).to.have.property('resource', 'POST')
@@ -145,7 +145,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
                 expect(traces[0][0].meta).to.have.property('http.url', `http://localhost:${port}/user`)
               })
@@ -168,7 +168,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               })
               .then(done)
@@ -191,7 +191,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('http.status_code', '200')
               })
               .then(done)
@@ -205,7 +205,7 @@ describe('Plugin', () => {
           let error
 
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
               expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message || error.code)
               expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
@@ -228,7 +228,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 0)
               })
               .then(done)
@@ -247,7 +247,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 1)
               })
               .then(done)
@@ -264,7 +264,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('error', 0)
                 expect(traces[0][0].meta).to.not.have.property('http.status_code')
               })
@@ -290,7 +290,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', SERVICE_NAME)
               })
               .then(done)
@@ -330,7 +330,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0]).to.have.property('service', 'custom')
               })
               .then(done)
@@ -365,7 +365,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const meta = traces[0][0].meta
                 expect(meta).to.have.property(`${HTTP_REQUEST_HEADERS}.x-baz`, 'qux')
                 expect(meta).to.have.property(`${HTTP_RESPONSE_HEADERS}.x-foo`, 'bar')
@@ -409,7 +409,7 @@ describe('Plugin', () => {
 
           appListener = server(app, port => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 expect(traces[0][0].meta).to.have.property('foo', '/foo')
               })
               .then(done)
@@ -483,7 +483,7 @@ describe('Plugin', () => {
             const timer = setTimeout(done, 100)
 
             agent
-              .use(() => {
+              .assertSomeTraces(() => {
                 clearTimeout(timer)
                 done(new Error('Blocklisted requests should not be recorded.'))
               })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.express.plugin.spec.js
@@ -68,7 +68,7 @@ withVersions('express', 'express', expressVersion => {
         }
       )
 
-      await agent.use((traces) => {
+      await agent.assertSomeTraces((traces) => {
         const span = traces[0][0]
         assert.property(span.meta, '_dd.appsec.fp.http.header')
         assert.equal(span.meta['_dd.appsec.fp.http.header'], 'hdr-0110000110-74c2908f-5-55682ec1')

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
@@ -91,7 +91,7 @@ withVersions('passport-http', 'passport-http', version => {
         )
       } catch (e) {}
 
-      await agent.use(assertFingerprintInTraces)
+      await agent.assertSomeTraces(assertFingerprintInTraces)
     })
 
     it('should report http fingerprints on login successful', async () => {
@@ -104,7 +104,7 @@ withVersions('passport-http', 'passport-http', version => {
         }
       )
 
-      await agent.use(assertFingerprintInTraces)
+      await agent.assertSomeTraces(assertFingerprintInTraces)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
@@ -90,7 +90,7 @@ withVersions('passport-local', 'passport-local', version => {
         )
       } catch (e) {}
 
-      await agent.use(assertFingerprintInTraces)
+      await agent.assertSomeTraces(assertFingerprintInTraces)
     })
 
     it('should report http fingerprints on login successful', async () => {
@@ -102,7 +102,7 @@ withVersions('passport-local', 'passport-local', version => {
         }
       )
 
-      await agent.use(assertFingerprintInTraces)
+      await agent.assertSomeTraces(assertFingerprintInTraces)
     })
   })
 })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.spec.js
@@ -54,7 +54,7 @@ describe('Attacker fingerprinting', () => {
         res.end()
       }
 
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.header')
         assert.equal(traces[0][0].meta['_dd.appsec.fp.http.header'], 'hdr-0110000010-74c2908f-3-98425651')
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.network')
@@ -74,7 +74,7 @@ describe('Attacker fingerprinting', () => {
         res.end()
       }
 
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.header')
         assert.equal(traces[0][0].meta['_dd.appsec.fp.http.header'], 'hdr-0110000010-74c2908f-3-98425651')
         assert.property(traces[0][0].meta, '_dd.appsec.fp.http.network')

--- a/packages/dd-trace/test/appsec/graphq.test-utils.js
+++ b/packages/dd-trace/test/appsec/graphq.test-utils.js
@@ -102,7 +102,7 @@ function graphqlCommonTests (config) {
     })
 
     it('Should set appsec.blocked on blocked attack', (done) => {
-      agent.use(payload => {
+      agent.assertSomeTraces(payload => {
         expect(payload[0][0].meta['appsec.blocked']).to.be.equal('true')
         done()
       })
@@ -201,7 +201,7 @@ function graphqlCommonTests (config) {
     })
 
     it('Should set appsec.blocked on blocked attack', (done) => {
-      agent.use(payload => {
+      agent.assertSomeTraces(payload => {
         expect(payload[0][0].meta['appsec.blocked']).to.be.equal('true')
         done()
       })

--- a/packages/dd-trace/test/appsec/iast/analyzers/hardcoded-password-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hardcoded-password-analyzer.spec.js
@@ -146,7 +146,7 @@ describe('Hardcoded Password Analyzer', () => {
 
       it('should detect vulnerability', (done) => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].meta['_dd.iast.json']).to.include('"HARDCODED_PASSWORD"')
             expect(traces[0][0].meta['_dd.iast.json']).to.include('"evidence":{"value":"pswd"}')
           })

--- a/packages/dd-trace/test/appsec/iast/analyzers/hardcoded-secret-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/hardcoded-secret-analyzer.spec.js
@@ -116,7 +116,7 @@ describe('Hardcoded Secret Analyzer', () => {
 
       it('should detect vulnerability', (done) => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].meta['_dd.iast.json']).to.include('"HARDCODED_SECRET"')
           })
           .then(done)

--- a/packages/dd-trace/test/appsec/iast/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/index.spec.js
@@ -28,7 +28,7 @@ describe('IAST Index', () => {
 
         it('should not have any vulnerability', (done) => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta['_dd.iast.json']).to.be.undefined
             })
             .then(done)
@@ -60,7 +60,7 @@ describe('IAST Index', () => {
 
         it('should detect vulnerability', (done) => {
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta['_dd.iast.json']).to.include('"WEAK_HASH"')
             })
             .then(done)
@@ -72,7 +72,7 @@ describe('IAST Index', () => {
           const mockedCleanIastContext = sinon.stub()
           iastContextFunctions.cleanIastContext = mockedCleanIastContext
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta['_dd.iast.json']).to.include('"WEAK_HASH"')
               expect(mockedCleanIastContext).to.have.been.calledOnce
             })
@@ -85,7 +85,7 @@ describe('IAST Index', () => {
           const releaseRequest = sinon.stub().callsFake(originalReleaseRequest)
           overheadController.releaseRequest = releaseRequest
           agent
-            .use(traces => {
+            .assertSomeTraces(traces => {
               expect(traces[0][0].meta['_dd.iast.json']).to.include('"WEAK_HASH"')
               expect(releaseRequest).to.have.been.calledOnce
             })

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/graphql.sources.test-utils.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/graphql.sources.test-utils.js
@@ -82,7 +82,7 @@ function graphqlCommonTests (config) {
     })
 
     it('Should detect COMMAND_INJECTION vulnerability with hardcoded query', (done) => {
-      agent.use(payload => {
+      agent.assertSomeTraces(payload => {
         expect(payload[0][0].meta).to.have.property('_dd.iast.json')
 
         const iastJson = JSON.parse(payload[0][0].meta['_dd.iast.json'])
@@ -94,7 +94,7 @@ function graphqlCommonTests (config) {
     })
 
     it('Should detect COMMAND_INJECTION vulnerability with query and variables', (done) => {
-      agent.use(payload => {
+      agent.assertSomeTraces(payload => {
         expect(payload[0][0].meta).to.have.property('_dd.iast.json')
 
         const iastJson = JSON.parse(payload[0][0].meta['_dd.iast.json'])

--- a/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/index.spec.js
@@ -189,7 +189,7 @@ describe('Telemetry', () => {
     function tests (config) {
       it('should have header source execution metric', (done) => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].metrics['_dd.iast.telemetry.executed.source.http_request_header']).to.be.equal(1)
           })
           .then(done)
@@ -203,7 +203,7 @@ describe('Telemetry', () => {
 
       it('should have url source execution metric', (done) => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             expect(traces[0][0].metrics['_dd.iast.telemetry.executed.source.http_request_uri']).to.be.equal(1)
           })
           .then(done)

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -89,7 +89,7 @@ function testOutsideRequestHasVulnerability (fnToTest, vulnerability, plugins, t
       this.timeout(timeout)
     }
     agent
-      .use(traces => {
+      .assertSomeTraces(traces => {
         expect(traces[0][0].meta['_dd.iast.json']).to.include(`"${vulnerability}"`)
         expect(traces[0][0].metrics['_dd.iast.enabled']).to.be.equal(1)
       }, { timeoutMs: 10000 })
@@ -144,7 +144,7 @@ function endResponse (res, appResult) {
 
 function checkNoVulnerabilityInRequest (vulnerability, config, done, makeRequest) {
   agent
-    .use(traces => {
+    .assertSomeTraces(traces => {
       if (traces[0][0].type !== 'web') throw new Error('Not a web span')
       // iastJson == undefiend is valid
       const iastJson = traces[0][0].meta['_dd.iast.json'] || ''
@@ -175,7 +175,7 @@ function checkVulnerabilityInRequest (
     occurrences = occurrencesAndLocation.occurrences
   }
   agent
-    .use(traces => {
+    .assertSomeTraces(traces => {
       expect(traces[0][0].metrics['_dd.iast.enabled']).to.be.equal(1)
       expect(traces[0][0].meta).to.have.property('_dd.iast.json')
 

--- a/packages/dd-trace/test/appsec/index.body-parser.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.body-parser.plugin.spec.js
@@ -90,7 +90,7 @@ withVersions('body-parser', 'body-parser', version => {
         expect(e.response.data).to.be.deep.equal(JSON.parse(json))
         expect(requestBody).not.to.be.called
 
-        await agent.use((traces) => {
+        await agent.assertSomeTraces((traces) => {
           const span = traces[0][0]
           expect(span.metrics['_dd.appsec.truncated.string_length']).to.equal(5000)
           expect(span.metrics['_dd.appsec.truncated.container_size']).to.equal(300)

--- a/packages/dd-trace/test/appsec/index.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.express.plugin.spec.js
@@ -318,7 +318,7 @@ withVersions('express', 'express', version => {
 
         const res = await axios.post('/', { key: 'value' })
 
-        await agent.use((traces) => {
+        await agent.assertSomeTraces((traces) => {
           const span = traces[0][0]
           assert.property(span.meta, '_dd.appsec.s.req.body')
           assert.notProperty(span.meta, '_dd.appsec.s.res.body')
@@ -333,7 +333,7 @@ withVersions('express', 'express', version => {
         const expectedResponseBodySchema = formatSchema([{ sendResKey: [8] }])
         const res = await axios.post('/sendjson', { key: 'value' })
 
-        await agent.use((traces) => {
+        await agent.assertSomeTraces((traces) => {
           const span = traces[0][0]
           assert.equal(span.meta['_dd.appsec.s.res.body'], expectedResponseBodySchema)
         })
@@ -346,7 +346,7 @@ withVersions('express', 'express', version => {
         const expectedResponseBodySchema = formatSchema([{ jsonResKey: [8] }])
         const res = await axios.post('/json', { key: 'value' })
 
-        await agent.use((traces) => {
+        await agent.assertSomeTraces((traces) => {
           const span = traces[0][0]
           assert.equal(span.meta['_dd.appsec.s.res.body'], expectedResponseBodySchema)
         })
@@ -359,7 +359,7 @@ withVersions('express', 'express', version => {
         const expectedResponseBodySchema = formatSchema([{ jsonpResKey: [8] }])
         const res = await axios.post('/jsonp', { key: 'value' })
 
-        await agent.use((traces) => {
+        await agent.assertSomeTraces((traces) => {
           const span = traces[0][0]
           assert.equal(span.meta['_dd.appsec.s.res.body'], expectedResponseBodySchema)
         })
@@ -376,7 +376,7 @@ withVersions('express', 'express', version => {
 
       const res = await axios.post('/', { key: 'value' })
 
-      await agent.use((traces) => {
+      await agent.assertSomeTraces((traces) => {
         const span = traces[0][0]
         assert.notProperty(span.meta, '_dd.appsec.s.req.body')
         assert.notProperty(span.meta, '_dd.appsec.s.res.body')

--- a/packages/dd-trace/test/appsec/rasp/utils.js
+++ b/packages/dd-trace/test/appsec/rasp/utils.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const { getWebSpan } = require('../utils')
 
 function checkRaspExecutedAndNotThreat (agent, checkRuleEval = true) {
-  return agent.use((traces) => {
+  return agent.assertSomeTraces((traces) => {
     const span = getWebSpan(traces)
     assert.notProperty(span.meta, '_dd.appsec.json')
     assert.notProperty(span.meta_struct || {}, '_dd.stack')
@@ -15,7 +15,7 @@ function checkRaspExecutedAndNotThreat (agent, checkRuleEval = true) {
 }
 
 function checkRaspExecutedAndHasThreat (agent, ruleId, ruleEvalCount = 1) {
-  return agent.use((traces) => {
+  return agent.assertSomeTraces((traces) => {
     const span = getWebSpan(traces)
     assert.property(span.meta, '_dd.appsec.json')
     assert(span.meta['_dd.appsec.json'].includes(ruleId))

--- a/packages/dd-trace/test/appsec/sdk/set_user.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/set_user.spec.js
@@ -142,7 +142,7 @@ describe('set_user', () => {
           })
           res.end()
         }
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
           expect(traces[0][0].meta).to.have.property('usr.email', 'a@b.c')
           expect(traces[0][0].meta).to.have.property('usr.custom', 'hello')
@@ -161,7 +161,7 @@ describe('set_user', () => {
           tracer.appsec.setUser({ id: 'blockedUser' })
           res.end()
         }
-        agent.use(traces => {
+        agent.assertSomeTraces(traces => {
           expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
           expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
           expect(traces[0][0].meta).to.have.property('appsec.event', 'true')

--- a/packages/dd-trace/test/appsec/sdk/track_event-integration.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/track_event-integration.spec.js
@@ -44,7 +44,7 @@ describe('track_event - Integration with the tracer', () => {
         }, { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.success.track', 'true')
         expect(traces[0][0].meta).to.have.property('usr.id', 'test_user_id')
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.success.metakey', 'metaValue')
@@ -58,7 +58,7 @@ describe('track_event - Integration with the tracer', () => {
         tracer.appsec.trackUserLoginSuccessEvent(undefined, { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.success.track', 'true')
       }).then(done).catch(done)
       axios.get(`http://localhost:${port}/`)
@@ -68,7 +68,7 @@ describe('track_event - Integration with the tracer', () => {
       controller = (req, res) => {
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.success.track', 'true')
       }).then(done).catch(done)
       axios.get(`http://localhost:${port}/`)
@@ -81,7 +81,7 @@ describe('track_event - Integration with the tracer', () => {
         tracer.appsec.trackUserLoginFailureEvent('test_user_id', true, { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.track', 'true')
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.id', 'test_user_id')
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.exists', 'true')
@@ -96,7 +96,7 @@ describe('track_event - Integration with the tracer', () => {
         tracer.appsec.trackUserLoginFailureEvent('test_user_id', false, { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.track', 'true')
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.id', 'test_user_id')
         expect(traces[0][0].meta).to.have.property('appsec.events.users.login.failure.usr.exists', 'false')
@@ -111,7 +111,7 @@ describe('track_event - Integration with the tracer', () => {
         tracer.appsec.trackUserLoginFailureEvent(undefined, false, { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.failure.track', 'true')
       }).then(done).catch(done)
       axios.get(`http://localhost:${port}/`)
@@ -121,7 +121,7 @@ describe('track_event - Integration with the tracer', () => {
       controller = (req, res) => {
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.not.have.property('appsec.events.users.login.failure.track', 'true')
       }).then(done).catch(done)
       axios.get(`http://localhost:${port}/`)
@@ -134,7 +134,7 @@ describe('track_event - Integration with the tracer', () => {
         tracer.appsec.trackCustomEvent('my-custom-event', { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.events.my-custom-event.track', 'true')
         expect(traces[0][0].meta).to.have.property('appsec.events.my-custom-event.metakey', 'metaValue')
         expect(traces[0][0].metrics).to.have.property('_sampling_priority_v1', USER_KEEP)
@@ -148,7 +148,7 @@ describe('track_event - Integration with the tracer', () => {
         tracer.appsec.trackCustomEvent({ event: 'name' }, { metakey: 'metaValue' })
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].metrics).to.not.have.property('_sampling_priority_v1', USER_KEEP)
       }).then(done).catch(done)
       axios.get(`http://localhost:${port}/`)

--- a/packages/dd-trace/test/appsec/sdk/user_blocking-integration.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking-integration.spec.js
@@ -57,7 +57,7 @@ describe('user_blocking - Integration with the tracer', () => {
         expect(ret).to.be.false
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('usr.id', 'testUser3')
         expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
       }).then(done).catch(done)
@@ -72,7 +72,7 @@ describe('user_blocking - Integration with the tracer', () => {
         expect(ret).to.be.false
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('usr.id', 'testUser')
         expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
       }).then(done).catch(done)
@@ -85,7 +85,7 @@ describe('user_blocking - Integration with the tracer', () => {
         expect(ret).to.be.true
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
         expect(traces[0][0].meta).to.have.property('_dd.appsec.user.collection_mode', 'sdk')
       }).then(done).catch(done)
@@ -99,7 +99,7 @@ describe('user_blocking - Integration with the tracer', () => {
         expect(ret).to.be.true
         res.end()
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('usr.id', 'blockedUser')
       }).then(done).catch(done)
       axios.get(`http://localhost:${port}/`)
@@ -122,7 +122,7 @@ describe('user_blocking - Integration with the tracer', () => {
         const ret = tracer.appsec.blockRequest(req, res)
         expect(ret).to.be.true
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
         expect(traces[0][0].meta).to.have.property('http.status_code', '403')
       }).then(done).catch(done)
@@ -134,7 +134,7 @@ describe('user_blocking - Integration with the tracer', () => {
         const ret = tracer.appsec.blockRequest()
         expect(ret).to.be.true
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
         expect(traces[0][0].meta).to.have.property('http.status_code', '403')
       }).then(done).catch(done)
@@ -147,7 +147,7 @@ describe('user_blocking - Integration with the tracer', () => {
         const ret = tracer.appsec.blockRequest()
         expect(ret).to.be.false
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.not.have.property('appsec.blocked', 'true')
         expect(traces[0][0].meta).to.have.property('http.status_code', '200')
         expect(traces[0][0].metrics).to.have.property('_dd.appsec.block.failed', 1)
@@ -176,7 +176,7 @@ describe('user_blocking - Integration with the tracer', () => {
         const ret = tracer.appsec.blockRequest(req, res)
         expect(ret).to.be.true
       }
-      agent.use(traces => {
+      agent.assertSomeTraces(traces => {
         expect(traces[0][0].meta).to.have.property('appsec.blocked', 'true')
         expect(traces[0][0].meta).to.have.property('http.status_code', '302')
       }).then(done).catch(done)

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -27,7 +27,7 @@ describe('dd-trace', () => {
 
     span.finish()
 
-    return agent.use((payload) => {
+    return agent.assertSomeTraces((payload) => {
       expect(payload[0][0].trace_id.toString()).to.equal(span.context()._traceId.toString(10))
       expect(payload[0][0].span_id.toString()).to.equal(span.context()._spanId.toString(10))
       expect(payload[0][0].service).to.equal('test')

--- a/packages/dd-trace/test/git_metadata_tagger.spec.js
+++ b/packages/dd-trace/test/git_metadata_tagger.spec.js
@@ -45,7 +45,7 @@ describe('git metadata tagging', () => {
     childSpan.finish()
     span.finish()
 
-    return agent.use((payload) => {
+    return agent.assertSomeTraces((payload) => {
       const firstSpan = payload[0][0]
       expect(firstSpan.meta[SCI_COMMIT_SHA]).to.equal(DUMMY_GIT_SHA)
       expect(firstSpan.meta[SCI_REPOSITORY_URL]).to.equal(DUMMY_REPOSITORY_URL)

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -89,7 +89,7 @@ describe('lambda', () => {
       expect(body.message).to.equal('hello!')
 
       // Expect traces to be correct.
-      const checkTraces = agent.use((_traces) => {
+      const checkTraces = agent.assertSomeTraces((_traces) => {
         const traces = _traces[0]
         expect(traces).lengthOf(1)
         traces.forEach((trace) => {
@@ -126,7 +126,7 @@ describe('lambda', () => {
       expect(body.message).to.equal('hello!')
 
       // Expect traces to be correct.
-      const checkTraces = agent.use((_traces) => {
+      const checkTraces = agent.assertSomeTraces((_traces) => {
         const traces = _traces[0]
         expect(traces).lengthOf(1)
         traces.forEach((trace) => {
@@ -160,7 +160,7 @@ describe('lambda', () => {
       }
 
       // Expect traces to be correct.
-      const checkTraces = agent.use((_traces) => {
+      const checkTraces = agent.assertSomeTraces((_traces) => {
         const traces = _traces[0]
         expect(traces).lengthOf(1)
         traces.forEach((trace) => {
@@ -191,7 +191,7 @@ describe('lambda', () => {
       const body = JSON.parse(result.body)
       expect(body.message).to.equal('hello!')
 
-      const checkTraces = agent.use((_traces) => {
+      const checkTraces = agent.assertSomeTraces((_traces) => {
         const traces = _traces[0]
         expect(traces).lengthOf(1)
         traces.forEach((trace) => {
@@ -239,7 +239,7 @@ describe('lambda', () => {
       datadog = require('./fixtures/datadog-lambda')
       const result = datadog(app.finishSpansEarlyTimeoutHandler)(_event, _context)
 
-      const checkTraces = agent.use((_traces) => {
+      const checkTraces = agent.assertSomeTraces((_traces) => {
         const traces = _traces[0]
         traces.forEach((trace) => {
           expect(trace.error).to.equal(0)
@@ -286,7 +286,7 @@ describe('lambda', () => {
 
           const result = datadog(app.timeoutHandler)(_event, _context)
 
-          const checkTraces = agent.use(_traces => {
+          const checkTraces = agent.assertSomeTraces(_traces => {
             // First trace, since errors are tagged at root span level.
             const trace = _traces[0][0]
             expect(trace.error).to.equal(1)

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -91,7 +91,7 @@ describe('Plugin', () => {
             const expectedOutput = { content: model.output }
             if (model.outputRole) expectedOutput.role = model.outputRole
 
-            agent.use(traces => {
+            agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
               const expected = expectedLLMObsLLMSpanEvent({

--- a/packages/dd-trace/test/llmobs/plugins/google-cloud-vertexai/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/google-cloud-vertexai/index.spec.js
@@ -130,7 +130,7 @@ describe('integrations', () => {
         useScenario({ scenario: 'generate-content-single-response' })
 
         it('makes a successful call', async () => {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -170,7 +170,7 @@ describe('integrations', () => {
         useScenario({ scenario: 'generate-content-single-response-with-tools' })
 
         it('makes a successful call', async () => {
-          const checkTraces = agent.use(traces => {
+          const checkTraces = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -220,7 +220,7 @@ describe('integrations', () => {
           useScenario({ scenario: 'generate-content-single-response' })
 
           it('makes a successful call', async () => {
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -138,7 +138,7 @@ describe('integrations', () => {
 
             const llm = new langchainOpenai.OpenAI({ model: 'gpt-3.5-turbo-instruct' })
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -166,7 +166,7 @@ describe('integrations', () => {
           it('does not tag output if there is an error', async () => {
             nock('https://api.openai.com').post('/v1/completions').reply(500)
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -223,7 +223,7 @@ describe('integrations', () => {
               }
             })
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
 
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
@@ -270,7 +270,7 @@ describe('integrations', () => {
 
             const chat = new langchainOpenai.ChatOpenAI({ model: 'gpt-3.5-turbo' })
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -298,7 +298,7 @@ describe('integrations', () => {
           it('does not tag output if there is an error', async () => {
             nock('https://api.openai.com').post('/v1/chat/completions').reply(500)
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -349,7 +349,7 @@ describe('integrations', () => {
               }
             })
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -402,7 +402,7 @@ describe('integrations', () => {
               }
             })
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -479,7 +479,7 @@ describe('integrations', () => {
 
             const embeddings = new langchainOpenai.OpenAIEmbeddings()
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -506,7 +506,7 @@ describe('integrations', () => {
           it('does not tag output if there is an error', async () => {
             nock('https://api.openai.com').post('/v1/embeddings').reply(500)
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -564,7 +564,7 @@ describe('integrations', () => {
 
             const embeddings = new langchainOpenai.OpenAIEmbeddings()
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -612,7 +612,7 @@ describe('integrations', () => {
 
             const chain = prompt.pipe(llm)
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const spans = traces[0]
               const workflowSpan = spans[0]
               const llmSpan = spans[1]
@@ -661,7 +661,7 @@ describe('integrations', () => {
           it('does not tag output if there is an error', async () => {
             nock('https://api.openai.com').post('/v1/completions').reply(500)
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const spans = traces[0]
 
               const workflowSpan = spans[0]
@@ -744,7 +744,7 @@ describe('integrations', () => {
               secondChain
             ])
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const spans = traces[0]
 
               const topLevelWorkflow = spans[0]
@@ -883,7 +883,7 @@ describe('integrations', () => {
               parser
             ])
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const spans = traces[0]
 
               const workflowSpan = spans[0]
@@ -975,7 +975,7 @@ describe('integrations', () => {
             const model = new langchainOpenai.ChatOpenAI({ model: 'gpt-3.5-turbo' })
             const chain = prompt.pipe(model)
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const spans = traces[0]
 
               const workflowSpan = spans[0]
@@ -1090,7 +1090,7 @@ describe('integrations', () => {
               .pipe(model)
               .pipe(new langchainOutputParsers.StringOutputParser())
 
-            const checkTraces = agent.use(traces => {
+            const checkTraces = agent.assertSomeTraces(traces => {
               const spans = traces[0]
               expect(spans.length).to.equal(3)
 

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv3.spec.js
@@ -82,7 +82,7 @@ describe('integrations', () => {
             usage: { prompt_tokens: 3, completion_tokens: 16, total_tokens: 19 }
           }, [])
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -138,7 +138,7 @@ describe('integrations', () => {
               }]
             }, [])
 
-          const checkSpan = agent.use(traces => {
+          const checkSpan = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -192,7 +192,7 @@ describe('integrations', () => {
             }
           }, [])
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -250,7 +250,7 @@ describe('integrations', () => {
               }]
             }, [])
 
-          const checkSpan = agent.use(traces => {
+          const checkSpan = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -299,7 +299,7 @@ describe('integrations', () => {
           .reply(400, {})
 
         let error
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -342,7 +342,7 @@ describe('integrations', () => {
             .reply(400, {})
 
           let error
-          const checkSpan = agent.use(traces => {
+          const checkSpan = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 

--- a/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/openai/openaiv4.spec.js
@@ -108,7 +108,7 @@ describe('integrations', () => {
             usage: { prompt_tokens: 3, completion_tokens: 16, total_tokens: 19 }
           }, [])
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -163,7 +163,7 @@ describe('integrations', () => {
             }]
           }, [])
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -216,7 +216,7 @@ describe('integrations', () => {
             }
           }, [])
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -281,7 +281,7 @@ describe('integrations', () => {
               }]
             }, [])
 
-          const checkSpan = agent.use(traces => {
+          const checkSpan = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -339,7 +339,7 @@ describe('integrations', () => {
               'openai-organization': 'kill-9'
             })
 
-          const checkSpan = agent.use(traces => {
+          const checkSpan = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -390,7 +390,7 @@ describe('integrations', () => {
               'openai-organization': 'kill-9'
             })
 
-          const checkSpan = agent.use(traces => {
+          const checkSpan = agent.assertSomeTraces(traces => {
             const span = traces[0][0]
             const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -441,7 +441,7 @@ describe('integrations', () => {
                 'openai-organization': 'kill-9'
               })
 
-            const checkSpan = agent.use(traces => {
+            const checkSpan = agent.assertSomeTraces(traces => {
               const span = traces[0][0]
               const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -496,7 +496,7 @@ describe('integrations', () => {
           .reply(400, {})
 
         let error
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -538,7 +538,7 @@ describe('integrations', () => {
           .reply(400, {})
 
         let error
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const span = traces[0][0]
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
@@ -588,7 +588,7 @@ describe('integrations', () => {
           .query(query)
           .reply(200, {})
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
           expect(spanEvent).to.have.property('name', 'AzureOpenAI.createChatCompletion')
@@ -608,7 +608,7 @@ describe('integrations', () => {
           .post('/chat/completions')
           .reply(200, {})
 
-        const checkSpan = agent.use(traces => {
+        const checkSpan = agent.assertSomeTraces(traces => {
           const spanEvent = LLMObsSpanWriter.prototype.append.getCall(0).args[0]
 
           expect(spanEvent).to.have.property('name', 'DeepSeek.createChatCompletion')

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -279,8 +279,8 @@ module.exports = {
   async load (pluginName, config, tracerConfig = {}) {
     tracer = require('../..')
     agent = express()
-    agent.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
-    agent.use((req, res, next) => {
+    agent.assertSomeTraces(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
+    agent.assertSomeTraces((req, res, next) => {
       if (req.is('application/msgpack')) {
         if (!req.body.length) return res.status(200).send()
         req.body = msgpack.decode(req.body, { useBigInt64: true })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -394,7 +394,7 @@ module.exports = {
   /**
    * Register a callback with expectations to be run on every tracing payload sent to the agent.
    */
-  use (callback, options) {
+  assertSomeTraces (callback, options) {
     return runCallback(callback, options, traceHandlers)
   },
 

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -279,8 +279,8 @@ module.exports = {
   async load (pluginName, config, tracerConfig = {}) {
     tracer = require('../..')
     agent = express()
-    agent.assertSomeTraces(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
-    agent.assertSomeTraces((req, res, next) => {
+    agent.use(bodyParser.raw({ limit: Infinity, type: 'application/msgpack' }))
+    agent.use((req, res, next) => {
       if (req.is('application/msgpack')) {
         if (!req.body.length) return res.status(200).send()
         req.body = msgpack.decode(req.body, { useBigInt64: true })

--- a/packages/dd-trace/test/plugins/helpers.js
+++ b/packages/dd-trace/test/plugins/helpers.js
@@ -15,7 +15,7 @@ function resolveNaming (namingSchema) {
 }
 
 function expectSomeSpan (agent, expected, timeout) {
-  return agent.use(traces => {
+  return agent.assertSomeTraces(traces => {
     const scoredErrors = []
     for (const trace of traces) {
       for (const span of trace) {

--- a/packages/dd-trace/test/plugins/tracing.spec.js
+++ b/packages/dd-trace/test/plugins/tracing.spec.js
@@ -78,7 +78,7 @@ describe('common Plugin behaviour', () => {
 
       agent.reload(pluginName, pluginConf)
 
-      agent.use(
+      agent.assertSomeTraces(
         traces => {
           const span = traces[0][0]
           spanExpectations(span)

--- a/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js
+++ b/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js
@@ -67,7 +67,7 @@ describe('Inferred Proxy Spans', function () {
         headers: inferredHeaders
       })
 
-      await agent.use(traces => {
+      await agent.assertSomeTraces(traces => {
         for (const trace of traces) {
           try {
             const spans = trace
@@ -115,7 +115,7 @@ describe('Inferred Proxy Spans', function () {
         }
       })
 
-      await agent.use(traces => {
+      await agent.assertSomeTraces(traces => {
         for (const trace of traces) {
           try {
             const spans = trace
@@ -159,7 +159,7 @@ describe('Inferred Proxy Spans', function () {
         headers: {}
       })
 
-      await agent.use(traces => {
+      await agent.assertSomeTraces(traces => {
         for (const trace of traces) {
           try {
             const spans = trace
@@ -194,7 +194,7 @@ describe('Inferred Proxy Spans', function () {
         headers: newHeaders
       })
 
-      await agent.use(traces => {
+      await agent.assertSomeTraces(traces => {
         for (const trace of traces) {
           try {
             const spans = trace
@@ -228,7 +228,7 @@ describe('Inferred Proxy Spans', function () {
         headers: inferredHeaders
       })
 
-      await agent.use(traces => {
+      await agent.assertSomeTraces(traces => {
         for (const trace of traces) {
           try {
             const spans = trace

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -57,7 +57,7 @@ function withNamingSchema (
           this.timeout(10000)
           return new Promise((resolve, reject) => {
             agent
-              .use(traces => {
+              .assertSomeTraces(traces => {
                 const span = selectSpan(traces)
                 const expectedOpName = typeof opName === 'function'
                   ? opName()
@@ -97,7 +97,7 @@ function withNamingSchema (
 
       it('should pass service name through', done => {
         agent
-          .use(traces => {
+          .assertSomeTraces(traces => {
             const span = traces[0][0]
             const expectedServiceName = typeof serviceName === 'function'
               ? serviceName()
@@ -128,7 +128,7 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
 
     it('should compute peer service', done => {
       agent
-        .use(traces => {
+        .assertSomeTraces(traces => {
           const span = traces[0][0]
           expect(span.meta).to.have.property('peer.service', typeof service === 'function' ? service() : service)
           expect(span.meta).to.have.property('_dd.peer.service.source', serviceSource)


### PR DESCRIPTION
### What does this PR do?
- renames the test helper `agent.use()` to something more descriptive

### Motivation
- the current name makes it look like some sort of middleware and isn't descriptive'

### Replacements
```
# simple one liners
agent\.use\(
agent.assertSomeTraces(

# multi line
agent(\W+)\.use\(
agent$1.assertSomeTraces(
```