### PR TITLE
[Code Origin for Spans] Only send top user frame in entry spans

### DIFF
--- a/packages/datadog-code-origin/index.js
+++ b/packages/datadog-code-origin/index.js
@@ -2,7 +2,7 @@
 
 const { getUserLandFrames } = require('../dd-trace/src/plugins/util/stacktrace')
 
-const limit = Number(process.env._DD_CODE_ORIGIN_MAX_USER_FRAMES) || 8
+const exitSpanLimit = Number(process.env._DD_CODE_ORIGIN_FOR_SPANS_EXIT_SPAN_MAX_USER_FRAMES) || 8
 
 module.exports = {
   entryTags,
@@ -10,14 +10,14 @@ module.exports = {
 }
 
 function entryTags (topOfStackFunc) {
-  return tag('entry', topOfStackFunc)
+  return tag('entry', topOfStackFunc, 1)
 }
 
 function exitTags (topOfStackFunc) {
-  return tag('exit', topOfStackFunc)
+  return tag('exit', topOfStackFunc, exitSpanLimit)
 }
 
-function tag (type, topOfStackFunc) {
+function tag (type, topOfStackFunc, limit) {
   const frames = getUserLandFrames(topOfStackFunc, limit)
   const tags = {
     '_dd.code_origin.type': type

--- a/packages/datadog-code-origin/test/helpers.js
+++ b/packages/datadog-code-origin/test/helpers.js
@@ -1,0 +1,26 @@
+'use strict'
+
+module.exports = {
+  assertCodeOriginFromTraces (traces, frame) {
+    const spans = traces[0]
+    const tags = spans[0].meta
+
+    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
+
+    expect(tags).to.have.property('_dd.code_origin.frames.0.file', frame.file)
+    expect(tags).to.have.property('_dd.code_origin.frames.0.line', String(frame.line))
+    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
+    if (frame.method) {
+      expect(tags).to.have.property('_dd.code_origin.frames.0.method', frame.method)
+    } else {
+      expect(tags).to.not.have.property('_dd.code_origin.frames.0.method')
+    }
+    if (frame.type) {
+      expect(tags).to.have.property('_dd.code_origin.frames.0.type', frame.type)
+    } else {
+      expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
+    }
+
+    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+  }
+}

--- a/packages/datadog-plugin-express/test/code_origin.spec.js
+++ b/packages/datadog-plugin-express/test/code_origin.spec.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios')
 const agent = require('../../dd-trace/test/plugins/agent')
+const { assertCodeOriginFromTraces } = require('../../datadog-code-origin/test/helpers')
 const { getNextLineNumber } = require('../../dd-trace/test/plugins/helpers')
 
 const host = 'localhost'
@@ -54,56 +55,28 @@ describe('Plugin', () => {
 
             after(() => agent.close({ ritmReset: false, wipe: true }))
 
-            it('should add code_origin tag on entry spans when feature is enabled', (done) => {
-              let routeRegisterLine
+            it('should add code_origin tag on entry spans when feature is enabled', async function testCase () {
+              let line
 
-              // Wrap in a named function to have at least one frame with a function name
-              function wrapperFunction () {
+              // Wrap in a function to have a frame without a function or type name
+              (() => {
                 app.get('/route_before', (req, res) => res.end())
-                routeRegisterLine = String(getNextLineNumber())
-                app.get('/user', function userHandler (req, res) {
+                line = getNextLineNumber()
+                app.get('/user', (req, res) => {
                   res.end()
                 })
                 app.get('/route_after', (req, res) => res.end())
-              }
+              })()
 
-              const callWrapperLine = String(getNextLineNumber())
-              wrapperFunction()
-
-              listener = app.listen(0, host, () => {
-                Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    // console.log(spans)
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'wrapperFunction')
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.line', callWrapperLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.column').to.match(/^\d+$/)
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.method')
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.type', 'Context')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.2.file')
-                  }),
-                  axios.get(`http://localhost:${listener.address().port}/user`)
-                ]).then(() => done(), done)
-              })
+              await assertCodeOrigin('/user', { line })
             })
 
-            it('should point to where actual route handler is configured, not the router', function testCase (done) {
+            it('should point to where actual route handler is configured, not the router', async function testCase () {
               const router = express.Router()
 
               router.get('/route_before', (req, res) => res.end())
-              const routeRegisterLine = String(getNextLineNumber())
-              router.get('/user', function userHandler (req, res) {
+              const line = getNextLineNumber()
+              router.get('/user', (req, res) => {
                 res.end()
               })
               router.get('/route_after', (req, res) => res.end())
@@ -111,91 +84,54 @@ describe('Plugin', () => {
               app.use('/v1', router)
               app.get('/route_after', (req, res) => res.end())
 
-              listener = app.listen(0, host, () => {
-                Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
-                  }),
-                  axios.get(`http://localhost:${listener.address().port}/v1/user`)
-                ]).then(() => done(), done)
-              })
+              await assertCodeOrigin('/v1/user', { line, method: 'testCase', type: 'Context' })
             })
 
-            it('should point to route handler even if passed through a middleware', function testCase (done) {
-              app.use(function middleware (req, res, next) {
+            it('should point to route handler even if passed through a middleware', async function testCase () {
+              app.use((req, res, next) => {
                 next()
               })
-
-              const routeRegisterLine = String(getNextLineNumber())
-              app.get('/user', function userHandler (req, res) {
+              const line = getNextLineNumber()
+              app.get('/user', (req, res) => {
                 res.end()
               })
 
-              listener = app.listen(0, host, () => {
-                Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
-                  }),
-                  axios.get(`http://localhost:${listener.address().port}/user`)
-                ]).then(() => done(), done)
-              })
+              await assertCodeOrigin('/user', { line, method: 'testCase', type: 'Context' })
             })
 
-            it('should point to middleware if middleware responds early', function testCase (done) {
-              const middlewareRegisterLine = String(getNextLineNumber())
-              app.use(function middleware (req, res, next) {
+            it('should point to middleware if middleware responds early', async function testCase () {
+              const line = getNextLineNumber()
+              app.use((req, res, next) => {
+                res.end()
+              })
+              app.get('/user', (req, res) => {
                 res.end()
               })
 
-              app.get('/user', function userHandler (req, res) {
-                res.end()
-              })
-
-              listener = app.listen(0, host, () => {
-                Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', middlewareRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
-                  }),
-                  axios.get(`http://localhost:${listener.address().port}/user`)
-                ]).then(() => done(), done)
-              })
+              await assertCodeOrigin('/user', { line, method: 'testCase', type: 'Context' })
             })
           })
         }
       })
     })
   })
+
+  function assertCodeOrigin (path, frame) {
+    return new Promise((resolve, reject) => {
+      listener = app.listen(0, host, async () => {
+        try {
+          await Promise.all([
+            agent.assertSomeTraces((traces) => {
+              assertCodeOriginFromTraces(traces, { file: __filename, ...frame })
+            }),
+            axios.get(`http://localhost:${listener.address().port}${path}`)
+          ])
+        } catch (err) {
+          reject(err)
+        }
+
+        resolve()
+      })
+    })
+  }
 })

--- a/packages/datadog-plugin-fastify/test/code_origin.spec.js
+++ b/packages/datadog-plugin-fastify/test/code_origin.spec.js
@@ -3,28 +3,26 @@
 const axios = require('axios')
 const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
+const { assertCodeOriginFromTraces } = require('../../datadog-code-origin/test/helpers')
 const { getNextLineNumber } = require('../../dd-trace/test/plugins/helpers')
 const { NODE_MAJOR } = require('../../../version')
 
 describe('Plugin', () => {
-  let fastify
-  let app
+  let fastify, app
 
   describe('fastify', () => {
     withVersions('fastify', 'fastify', (version, _, specificVersion) => {
       if (NODE_MAJOR <= 18 && semver.satisfies(specificVersion, '>=5')) return
 
-      afterEach(() => {
-        app.close()
-      })
+      afterEach(() => app.close())
 
       withExports('fastify', version, ['default', 'fastify'], '>=3', getExport => {
-        beforeEach(() => {
+        beforeEach(async () => {
           fastify = getExport()
           app = fastify()
 
           if (semver.intersects(version, '>=3')) {
-            return app.register(require('../../../versions/middie').get())
+            await app.register(require('../../../versions/middie').get())
           }
         })
 
@@ -66,142 +64,61 @@ describe('Plugin', () => {
 
               after(() => agent.close({ ritmReset: false, wipe: true }))
 
-              it('should add code_origin tag on entry spans when feature is enabled', async () => {
-                let routeRegisterLine
+              it('should add code_origin tag on entry spans when feature is enabled', async function testCase () {
+                let line
 
-                // Wrap in a named function to have at least one frame with a function name
-                function wrapperFunction () {
-                  routeRegisterLine = String(getNextLineNumber())
-                  app.get('/user', function userHandler (request, reply) {
+                // Wrap in a function to have a frame without a function or type name
+                (() => {
+                  line = getNextLineNumber()
+                  app.get('/user', (request, reply) => {
                     reply.send()
                   })
-                }
+                })()
 
-                const callWrapperLine = String(getNextLineNumber())
-                wrapperFunction()
-
-                await app.listen(getListenOptions())
-
-                await Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'wrapperFunction')
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.line', callWrapperLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.column').to.match(/^\d+$/)
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.method')
-                    expect(tags).to.have.property('_dd.code_origin.frames.1.type', 'Context')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.2.file')
-                  }),
-                  axios.get(`http://localhost:${app.server.address().port}/user`)
-                ])
+                await assertCodeOrigin('/user', { line })
               })
 
               it('should point to where actual route handler is configured, not the prefix', async () => {
-                let routeRegisterLine
+                let line
 
                 app.register(function v1Handler (app, opts, done) {
-                  routeRegisterLine = String(getNextLineNumber())
-                  app.get('/user', function userHandler (request, reply) {
+                  line = getNextLineNumber()
+                  app.get('/user', (request, reply) => {
                     reply.send()
                   })
                   done()
                 }, { prefix: '/v1' })
 
-                await app.listen(getListenOptions())
+                await app.ready()
 
-                await Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'v1Handler')
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
-                  }),
-                  axios.get(`http://localhost:${app.server.address().port}/v1/user`)
-                ])
+                await assertCodeOrigin('/v1/user', { line, method: 'v1Handler' })
               })
 
               it('should point to route handler even if passed through a middleware', async function testCase () {
-                app.use(function middleware (req, res, next) {
+                app.use((req, res, next) => {
                   next()
                 })
-
-                const routeRegisterLine = String(getNextLineNumber())
-                app.get('/user', function userHandler (request, reply) {
+                const line = getNextLineNumber()
+                app.get('/user', (request, reply) => {
                   reply.send()
                 })
 
-                await app.listen(getListenOptions())
-
-                await Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', routeRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
-                  }),
-                  axios.get(`http://localhost:${app.server.address().port}/user`)
-                ])
+                await assertCodeOrigin('/user', { line, method: 'testCase', type: 'Context' })
               })
 
               // TODO: In Fastify, the route is resolved before the middleware is called, so we actually can get the
               // line number of where the route handler is defined. However, this might not be the right choice and it
               // might be better to point to the middleware.
               it.skip('should point to middleware if middleware responds early', async function testCase () {
-                const middlewareRegisterLine = String(getNextLineNumber())
-                app.use(function middleware (req, res, next) {
+                const line = getNextLineNumber()
+                app.use((req, res, next) => {
                   res.end()
                 })
-
-                app.get('/user', function userHandler (request, reply) {
+                app.get('/user', (request, reply) => {
                   reply.send()
                 })
 
-                await app.listen(getListenOptions())
-
-                await Promise.all([
-                  agent.assertSomeTraces(traces => {
-                    const spans = traces[0]
-                    const tags = spans[0].meta
-
-                    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
-
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.file', __filename)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.line', middlewareRegisterLine)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.method', 'testCase')
-                    expect(tags).to.have.property('_dd.code_origin.frames.0.type', 'Context')
-
-                    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
-                  }),
-                  axios.get(`http://localhost:${app.server.address().port}/user`)
-                ])
+                await assertCodeOrigin('/user', { line, method: 'testCase', type: 'Context' })
               })
             })
           }
@@ -209,6 +126,16 @@ describe('Plugin', () => {
       })
     })
   })
+
+  async function assertCodeOrigin (path, frame) {
+    await app.listen(getListenOptions())
+    await Promise.all([
+      agent.assertSomeTraces(traces => {
+        assertCodeOriginFromTraces(traces, { file: __filename, ...frame })
+      }),
+      axios.get(`http://localhost:${app.server.address().port}${path}`)
+    ])
+  }
 })
 
 // Required by Fastify 1.0.0


### PR DESCRIPTION
### What does this PR do?

Instead of sending the top 8 user frames in entry spans, this reduces the limit to just one.

### Motivation

Align implementation with the other tracers (nice way of saying that this was essentially a bug)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


