### PR TITLE
[Code Origin for Spans] Refactor Fastify implementation

### DIFF
--- a/packages/datadog-plugin-fastify/src/code_origin.js
+++ b/packages/datadog-plugin-fastify/src/code_origin.js
@@ -4,8 +4,6 @@ const { entryTags } = require('../../datadog-code-origin')
 const Plugin = require('../../dd-trace/src/plugins/plugin')
 const web = require('../../dd-trace/src/plugins/util/web')
 
-const kCodeOriginForSpansTagsSym = Symbol('datadog.codeOriginForSpansTags')
-
 class FastifyCodeOriginForSpansPlugin extends Plugin {
   static get id () {
     return 'fastify'
@@ -14,16 +12,18 @@ class FastifyCodeOriginForSpansPlugin extends Plugin {
   constructor (...args) {
     super(...args)
 
+    const routeTags = new WeakMap()
+
     this.addSub('apm:fastify:request:handle', ({ req, routeConfig }) => {
-      const tags = routeConfig?.[kCodeOriginForSpansTagsSym]
+      const tags = routeTags.get(routeConfig)
       if (!tags) return
-      const context = web.getContext(req)
-      context.span?.addTags(tags)
+      web.getContext(req).span?.addTags(tags)
     })
 
     this.addSub('apm:fastify:route:added', ({ routeOptions, onRoute }) => {
       if (!routeOptions.config) routeOptions.config = {}
-      routeOptions.config[kCodeOriginForSpansTagsSym] = entryTags(onRoute)
+      if (routeTags.has(routeOptions.config)) return
+      routeTags.set(routeOptions.config, entryTags(onRoute))
     })
   }
 }

--- a/packages/datadog-plugin-fastify/test/code_origin.spec.js
+++ b/packages/datadog-plugin-fastify/test/code_origin.spec.js
@@ -56,7 +56,7 @@ describe('Plugin', () => {
         })
 
         describe('code origin for spans enabled', () => {
-          if (semver.satisfies(specificVersion, '<4')) return // TODO: Why doesn't it work on older versions?
+          if (semver.satisfies(specificVersion, '<4.10.0')) return // TODO: Support older versions (DEBUG-3941)
 
           const configs = [{}, { codeOriginForSpans: { enabled: true } }]
 


### PR DESCRIPTION
### What does this PR do?
    
Use a WeakMap to store the Code Origin Entry Span location instead of polluting the Fastify route options config object.
    
Also limit when the `onRoute` handler is added, to only be when the version of Fastify supports getting the proper stack trace (requires v4.10.0+).

### Motivation

Unfortunately DEBUG-3941 can't easily be fixed, but while working on that JIRA ticket, I refactored a few areas of the Fastify Code Origin implementation. This PR contains those refactorings. The rest of the work related to DEBUG-3941 has been tabled for now, until we know if enough users running versions of Fastify older than 4.10.0 wants the Code Origin for Spans feature (no need to spend time on that unless it's needed).

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes

If we ever continue with the work to support Code Origin for Spans below v4.10.0, we'll need this patch, which was developed as part of this work, but was excluded from this PR:

```diff
diff --git a/packages/datadog-instrumentations/src/fastify.js b/packages/datadog-instrumentations/src/fastify.js
index 3957c6795..58099f243 100644
--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -148,7 +148,9 @@ function getRes (reply) {
 }
 
 function getRouteConfig (request) {
-  return request?.routeOptions?.config
+  // The `request.routerOptions` object was added in Fastify v4.10.0.
+  // If not present, fallback to use the now deprecated `request.context` object to access the `config` object.
+  return request?.routeOptions?.config ?? request?.context?.config
 }
 
 function publishError (error, req) {
```


