### PR TITLE
Add support for profiler upload compression methods and levels

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -220,8 +220,6 @@ class Config {
         if (level > maxLevel) {
           logger.warn(`Invalid compression level ${level}. Will use ${maxLevel}.`)
           level = maxLevel
-        } else {
-          level |= 0
         }
       }
     }

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -212,16 +212,17 @@ class Config {
         logger.warn(
           `Invalid compression level "${level0}". Will use default level.`)
         level = undefined
-      } else if (level < 0) {
-        // Best I can tell this can't happen due to splitting the env var at
-        // minus sign, but let's be exhaustive.
-        logger.warn(`Invalid compression level ${level}. Will use 0.`)
-        level = 0
-      } else if (level > 9) {
-        logger.warn(`Invalid compression level ${level}. Will use 9.`)
-        level = 9
+      } else if (level < 1) {
+        logger.warn(`Invalid compression level ${level}. Will use 1.`)
+        level = 1
       } else {
-        level |= 0
+        const maxLevel = { gzip: 9, zstd: 22 }[uploadCompression]
+        if (level > maxLevel) {
+          logger.warn(`Invalid compression level ${level}. Will use ${maxLevel}.`)
+          level = maxLevel
+        } else {
+          level |= 0
+        }
       }
     }
 

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -15,6 +15,7 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../plugins/util/tags')
 const { tagger } = require('./tagger')
 const { isFalse, isTrue } = require('../util')
 const { getAzureTagsFromMetadata, getAzureAppMetadata } = require('../azure_metadata')
+const satisfies = require('semifies')
 
 class Config {
   constructor (options = {}) {
@@ -25,6 +26,7 @@ class Config {
       DD_PROFILING_CODEHOTSPOTS_ENABLED,
       DD_PROFILING_CPU_ENABLED,
       DD_PROFILING_DEBUG_SOURCE_MAPS,
+      DD_PROFILING_DEBUG_UPLOAD_COMPRESSION,
       DD_PROFILING_ENDPOINT_COLLECTION_ENABLED,
       DD_PROFILING_EXPERIMENTAL_CODEHOTSPOTS_ENABLED,
       DD_PROFILING_EXPERIMENTAL_CPU_ENABLED,
@@ -190,6 +192,45 @@ class Config {
       DD_PROFILING_EXPERIMENTAL_CPU_ENABLED, samplingContextsAvailable))
     logExperimentalVarDeprecation('CPU_ENABLED')
     checkOptionWithSamplingContextAllowed(this.cpuProfilingEnabled, 'CPU profiling')
+
+    const uploadCompression0 = coalesce(options.uploadCompression, DD_PROFILING_DEBUG_UPLOAD_COMPRESSION, 'on')
+    let [uploadCompression, level0] = uploadCompression0.split('-')
+    if (!['on', 'off', 'gzip', 'zstd'].includes(uploadCompression)) {
+      logger.warn(`Invalid profile upload compression method "${uploadCompression0}". Will use "on".`)
+      uploadCompression = 'on'
+    } else if (uploadCompression === 'zstd' && !satisfies(process.versions.node, '>=23.8.0')) {
+      logger.warn(
+        'Profile upload compression method "zstd" is only supported on Node.js 23.8.0 or above. Will use "on".')
+      uploadCompression = 'on'
+    }
+    let level = level0 ? parseInt(level0, 10) : undefined
+    if (level !== undefined) {
+      if (['on', 'off'].includes(uploadCompression)) {
+        logger.warn(`Compression levels are not supported for "${uploadCompression}".`)
+        level = undefined
+      } else if (isNaN(level)) {
+        logger.warn(
+          `Invalid compression level "${level0}". Will use default level.`)
+        level = undefined
+      } else if (level < 0) {
+        // Best I can tell this can't happen due to splitting the env var at
+        // minus sign, but let's be exhaustive.
+        logger.warn(`Invalid compression level ${level}. Will use 0.`)
+        level = 0
+      } else if (level > 9) {
+        logger.warn(`Invalid compression level ${level}. Will use 9.`)
+        level = 9
+      } else {
+        level |= 0
+      }
+    }
+
+    // Default to gzip
+    if (uploadCompression === 'on') {
+      uploadCompression = 'gzip'
+    }
+
+    this.uploadCompression = { method: uploadCompression, level }
 
     this.profilers = ensureProfilers(profilers, this)
   }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -8,6 +8,9 @@ const { isWebServerSpan, endpointNameFromTags, getStartedSpans } = require('./we
 const dc = require('dc-polyfill')
 const crashtracker = require('../crashtracking')
 
+const { promisify } = require('util')
+const zlib = require('zlib')
+
 const profileSubmittedChannel = dc.channel('datadog:profiling:profile-submitted')
 const spanFinishedChannel = dc.channel('dd-trace:span:finish')
 
@@ -85,6 +88,28 @@ class Profiler extends EventEmitter {
             ? 'Found no source maps'
             : `Found source maps for following files: [${Array.from(mapper.infoMap.keys()).join(', ')}]`
         })
+      }
+
+      const clevel = config.uploadCompression.level
+      switch (config.uploadCompression.method) {
+        case 'gzip':
+          this._compressionFn = promisify(zlib.gzip)
+          if (clevel) {
+            this._compressionOptions = {
+              level: clevel
+            }
+          }
+          break
+        case 'zstd':
+          this._compressionFn = promisify(zlib.zstdCompress)
+          if (clevel) {
+            this._compressionOptions = {
+              params: {
+                [zlib.constants.ZSTD_c_compressionLevel]: clevel
+              }
+            }
+          }
+          break
       }
     } catch (err) {
       this._logError(err)
@@ -218,7 +243,14 @@ class Profiler extends EventEmitter {
       // encode and export asynchronously
       for (const { profiler, profile } of profiles) {
         try {
-          encodedProfiles[profiler.type] = await profiler.encode(profile)
+          const encoded = await profiler.encode(profile)
+          let compressed
+          if (encoded instanceof Buffer && this._compressionFn !== undefined) {
+            compressed = await this._compressionFn(encoded, this._compressionOptions)
+          } else {
+            compressed = encoded
+          }
+          encodedProfiles[profiler.type] = compressed
           this._logger.debug(() => {
             const profileJson = JSON.stringify(profile, (key, value) => {
               return typeof value === 'bigint' ? value.toString() : value

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -94,7 +94,7 @@ class Profiler extends EventEmitter {
       switch (config.uploadCompression.method) {
         case 'gzip':
           this._compressionFn = promisify(zlib.gzip)
-          if (clevel) {
+          if (clevel !== undefined) {
             this._compressionOptions = {
               level: clevel
             }
@@ -102,7 +102,7 @@ class Profiler extends EventEmitter {
           break
         case 'zstd':
           this._compressionFn = promisify(zlib.zstdCompress)
-          if (clevel) {
+          if (clevel !== undefined) {
             this._compressionOptions = {
               params: {
                 [zlib.constants.ZSTD_c_compressionLevel]: clevel

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -1,7 +1,6 @@
 const { performance, constants, PerformanceObserver } = require('perf_hooks')
-const { END_TIMESTAMP_LABEL, SPAN_ID_LABEL, LOCAL_ROOT_SPAN_ID_LABEL } = require('./shared')
+const { END_TIMESTAMP_LABEL, SPAN_ID_LABEL, LOCAL_ROOT_SPAN_ID_LABEL, encodeProfileAsync } = require('./shared')
 const { Function, Label, Line, Location, Profile, Sample, StringTable, ValueType } = require('pprof-format')
-const pprof = require('@datadog/pprof/')
 
 // perf_hooks uses millis, with fractional part representing nanos. We emit nanos into the pprof file.
 const MS_TO_NS = 1000000
@@ -412,7 +411,7 @@ class EventsProfiler {
   }
 
   encode (profile) {
-    return pprof.encode(profile())
+    return encodeProfileAsync(profile())
   }
 }
 

--- a/packages/dd-trace/src/profiling/profilers/shared.js
+++ b/packages/dd-trace/src/profiling/profilers/shared.js
@@ -36,6 +36,10 @@ function getNonJSThreadsLabels () {
   return { [THREAD_NAME_LABEL]: 'Non-JS threads', [THREAD_ID_LABEL]: 'NA', [OS_THREAD_ID_LABEL]: 'NA' }
 }
 
+function encodeProfileAsync (profile) {
+  return profile.encodeAsync().then(Buffer.from)
+}
+
 module.exports = {
   END_TIMESTAMP_LABEL,
   THREAD_NAME_LABEL,
@@ -46,5 +50,6 @@ module.exports = {
   threadNamePrefix,
   eventLoopThreadName,
   getNonJSThreadsLabels,
-  getThreadLabels: cacheThreadLabels()
+  getThreadLabels: cacheThreadLabels(),
+  encodeProfileAsync
 }

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { oomExportStrategies } = require('../constants')
-const { getThreadLabels } = require('./shared')
+const { encodeProfileAsync, getThreadLabels } = require('./shared')
 
 function strategiesToCallbackMode (strategies, callbackMode) {
   return strategies.includes(oomExportStrategies.ASYNC_CALLBACK) ? callbackMode.Async : 0
@@ -47,7 +47,7 @@ class NativeSpaceProfiler {
   }
 
   encode (profile) {
-    return this._pprof.encode(profile)
+    return encodeProfileAsync(profile)
   }
 
   stop () {

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -10,7 +10,8 @@ const {
   SPAN_ID_LABEL,
   LOCAL_ROOT_SPAN_ID_LABEL,
   getNonJSThreadsLabels,
-  getThreadLabels
+  getThreadLabels,
+  encodeProfileAsync
 } = require('./shared')
 
 const { isWebServerSpan, endpointNameFromTags, getStartedSpans } = require('../webspan-utils')
@@ -326,7 +327,7 @@ class NativeWallProfiler {
   }
 
   encode (profile) {
-    return this._pprof.encode(profile)
+    return encodeProfileAsync(profile)
   }
 
   stop () {

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -464,9 +464,9 @@ describe('config', () => {
     })
 
     it('should accept supported compression levels in methods that support levels', () => {
-      const levelAcceptingMethods = zstdSupported ? ['gzip', 'zstd'] : ['gzip']
-      levelAcceptingMethods.forEach((method) => {
-        for (let i = 0; i < 10; i++) {
+      const levelAcceptingMethods = zstdSupported ? [['gzip', 9], ['zstd', 22]] : [['gzip', 9]]
+      levelAcceptingMethods.forEach(([method, maxLevel]) => {
+        for (let i = 1; i <= maxLevel; i++) {
           expectConfig(`${method}-${i}`, method, i)
         }
       })
@@ -491,12 +491,14 @@ describe('config', () => {
     })
 
     it('should normalize compression levels', () => {
-      const levelAcceptingMethods = zstdSupported ? ['gzip', 'zstd'] : ['gzip']
-      levelAcceptingMethods.forEach((method) => {
-        expectConfig(`${method}-10`, method, 9,
-          'Invalid compression level 10. Will use 9.')
-        expectConfig(`${method}-3.14`, method, 3)
-      })
+      expectConfig('gzip-0', 'gzip', 1, 'Invalid compression level 0. Will use 1.')
+      expectConfig('gzip-10', 'gzip', 9, 'Invalid compression level 10. Will use 9.')
+      expectConfig('gzip-3.14', 'gzip', 3)
+      if (zstdSupported) {
+        expectConfig('zstd-0', 'zstd', 1, 'Invalid compression level 0. Will use 1.')
+        expectConfig('zstd-23', 'zstd', 22, 'Invalid compression level 23. Will use 22.')
+        expectConfig('zstd-3.14', 'zstd', 3)
+      }
     })
   })
 })

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -5,6 +5,8 @@ require('../setup/tap')
 const { expect } = require('chai')
 const os = require('os')
 const path = require('path')
+const satisfies = require('semifies')
+
 const { AgentExporter } = require('../../src/profiling/exporters/agent')
 const { FileExporter } = require('../../src/profiling/exporters/file')
 const WallProfiler = require('../../src/profiling/profilers/wall')
@@ -55,6 +57,8 @@ describe('config', () => {
     expect(config.profilers[1]).to.be.an.instanceof(SpaceProfiler)
     expect(config.v8ProfilerBugWorkaroundEnabled).true
     expect(config.cpuProfilingEnabled).to.equal(samplingContextsAvailable)
+    expect(config.uploadCompression.method).to.equal('gzip')
+    expect(config.uploadCompression.level).to.be.undefined
   })
 
   it('should support configuration options', () => {
@@ -412,4 +416,87 @@ describe('config', () => {
       })
     })
   }
+
+  describe('upload compression settings', () => {
+    const expectConfig = (env, method, level, warning) => {
+      process.env = {
+        DD_PROFILING_DEBUG_UPLOAD_COMPRESSION: env
+      }
+
+      const logger = {
+        warnings: [],
+        debug () {},
+        info () {},
+        warn (message) {
+          this.warnings.push(message)
+        },
+        error () {}
+      }
+      const config = new Config({ logger })
+
+      if (warning) {
+        expect(logger.warnings.length).to.equals(1)
+        expect(logger.warnings[0]).to.equal(warning)
+      } else {
+        expect(logger.warnings.length).to.equals(0)
+      }
+
+      expect(config.uploadCompression).to.deep.equal({ method, level })
+    }
+    const zstdSupported = satisfies(process.versions.node, '>=23.8.0')
+
+    it('should accept known methods', () => {
+      expectConfig(undefined, 'gzip', undefined)
+      expectConfig('off', 'off', undefined)
+      expectConfig('on', 'gzip', undefined)
+      expectConfig('gzip', 'gzip', undefined)
+      if (zstdSupported) {
+        expectConfig('zstd', 'zstd', undefined)
+      }
+    })
+
+    it('should reject unknown methods', () => {
+      if (!zstdSupported) {
+        expectConfig('zstd', 'gzip', undefined,
+          'Profile upload compression method "zstd" is only supported on Node.js 23.8.0 or above. Will use "on".')
+      }
+      expectConfig('foo', 'gzip', undefined, 'Invalid profile upload compression method "foo". Will use "on".')
+    })
+
+    it('should accept supported compression levels in methods that support levels', () => {
+      const levelAcceptingMethods = zstdSupported ? ['gzip', 'zstd'] : ['gzip']
+      levelAcceptingMethods.forEach((method) => {
+        for (let i = 0; i < 10; i++) {
+          expectConfig(`${method}-${i}`, method, i)
+        }
+      })
+    })
+
+    it('should reject invalid compression levels in methods that support levels', () => {
+      const levelAcceptingMethods = zstdSupported ? ['gzip', 'zstd'] : ['gzip']
+      levelAcceptingMethods.forEach((method) => {
+        expectConfig(`${method}-foo`, method, undefined,
+          'Invalid compression level "foo". Will use default level.')
+      })
+    })
+
+    it('should reject compression levels in methods that do not support levels', () => {
+      ['on', 'off'].forEach((method) => {
+        const effectiveMethod = method === 'on' ? 'gzip' : method
+        expectConfig(`${method}-3`, effectiveMethod, undefined,
+          `Compression levels are not supported for "${method}".`)
+        expectConfig(`${method}-foo`, effectiveMethod, undefined,
+          `Compression levels are not supported for "${method}".`)
+      })
+    })
+
+    it('should normalize compression levels', () => {
+      const levelAcceptingMethods = zstdSupported ? ['gzip', 'zstd'] : ['gzip']
+      levelAcceptingMethods.forEach((method) => {
+        expectConfig(`${method}-10`, method, 9,
+          'Invalid compression level 10. Will use 9.')
+        expectConfig(`${method}-3.14`, method, 3)
+      })
+    })
+  })
 })

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -12,7 +12,6 @@ const path = require('path')
 const { request } = require('http')
 const getPort = require('get-port')
 const proxyquire = require('proxyquire')
-const { gunzipSync } = require('zlib')
 const WallProfiler = require('../../../src/profiling/profilers/wall')
 const SpaceProfiler = require('../../../src/profiling/profilers/space')
 const logger = require('../../../src/log')
@@ -129,14 +128,14 @@ describe('exporters/agent', function () {
     expect(req.files[2]).to.have.property('mimetype', 'application/octet-stream')
     expect(req.files[2]).to.have.property('size', req.files[2].buffer.length)
 
-    const wallProfile = Profile.decode(gunzipSync(req.files[1].buffer))
-    const spaceProfile = Profile.decode(gunzipSync(req.files[2].buffer))
+    const wallProfile = Profile.decode(req.files[1].buffer)
+    const spaceProfile = Profile.decode(req.files[2].buffer)
 
     expect(wallProfile).to.be.a.profile
     expect(spaceProfile).to.be.a.profile
 
-    expect(wallProfile).to.deep.equal(Profile.decode(gunzipSync(profiles.wall)))
-    expect(spaceProfile).to.deep.equal(Profile.decode(gunzipSync(profiles.space)))
+    expect(wallProfile).to.deep.equal(Profile.decode(profiles.wall))
+    expect(spaceProfile).to.deep.equal(Profile.decode(profiles.space))
   }
 
   beforeEach(() => {

--- a/packages/dd-trace/test/profiling/profilers/space.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/space.spec.js
@@ -9,14 +9,17 @@ const sinon = require('sinon')
 describe('profilers/native/space', () => {
   let NativeSpaceProfiler
   let pprof
+  let profile0
 
   beforeEach(() => {
+    profile0 = {
+      encodeAsync: sinon.stub().returns(Promise.resolve('encoded'))
+    }
     pprof = {
-      encode: sinon.stub().returns(Promise.resolve()),
       heap: {
         start: sinon.stub(),
         stop: sinon.stub(),
-        profile: sinon.stub()
+        profile: sinon.stub().returns(profile0)
       }
     }
 
@@ -82,14 +85,14 @@ describe('profilers/native/space', () => {
     expect(profile).to.equal('profile')
   })
 
-  it('should encode profiles from the pprof space profiler', () => {
+  it('should encode profiles using their encodeAsync method', () => {
     const profiler = new NativeSpaceProfiler()
 
     profiler.start()
     const profile = profiler.profile(true)
     profiler.encode(profile)
 
-    sinon.assert.calledOnce(pprof.encode)
+    sinon.assert.calledOnce(profile0.encodeAsync)
   })
 
   it('should use mapper if given', () => {

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -9,13 +9,16 @@ const sinon = require('sinon')
 describe('profilers/native/wall', () => {
   let NativeWallProfiler
   let pprof
+  let profile0
 
   beforeEach(() => {
+    profile0 = {
+      encodeAsync: sinon.stub().returns(Promise.resolve('encoded'))
+    }
     pprof = {
-      encode: sinon.stub().returns(Promise.resolve()),
       time: {
         start: sinon.stub(),
-        stop: sinon.stub().returns('profile'),
+        stop: sinon.stub().returns(profile0),
         setContext: sinon.stub(),
         v8ProfilerStuckEventLoopDetected: sinon.stub().returns(false),
         constants: {
@@ -117,7 +120,7 @@ describe('profilers/native/wall', () => {
 
     const profile = profiler.profile(true)
 
-    expect(profile).to.equal('profile')
+    expect(profile).to.be.equal(profile0)
 
     sinon.assert.calledOnce(pprof.time.stop)
     sinon.assert.calledOnce(pprof.time.start)
@@ -134,7 +137,7 @@ describe('profilers/native/wall', () => {
 
     const profile = profiler.profile(false)
 
-    expect(profile).to.equal('profile')
+    expect(profile).to.equal(profile0)
 
     sinon.assert.calledOnce(pprof.time.stop)
     sinon.assert.calledOnce(pprof.time.start)
@@ -143,7 +146,7 @@ describe('profilers/native/wall', () => {
     sinon.assert.calledOnce(pprof.time.stop)
   })
 
-  it('should encode profiles from the pprof time profiler', () => {
+  it('should encode profiles calling their encodeAsync method', () => {
     const profiler = new NativeWallProfiler()
 
     profiler.start()
@@ -154,7 +157,7 @@ describe('profilers/native/wall', () => {
 
     profiler.stop()
 
-    sinon.assert.calledOnce(pprof.encode)
+    sinon.assert.calledOnce(profile0.encodeAsync)
   })
 
   it('should use mapper if given', () => {


### PR DESCRIPTION
### What does this PR do?
Adds a `DD_PROFILING_DEBUG_UPLOAD_COMPRESSION` environment variable that supports setting a compression method for profile uploads. Supported values are "on", "off", "gzip", and "zstd" (which only works for Node.js 23.8.0 or above currently.) Default value is "on" and "on" itself is interpreted as "gzip" (although this can change to "zstd" in the future.) Additionally, "gzip" and "zstd" can accept a level between 0 and 9 after a dash (e.g. "zstd-5") to indicate a compression level.

### Motivation
zstd offers significantly better compression than gzip and often also lower CPU use. A representative CPU profile of about 460 kiB compresses to 124 kiB in 6ms with gzip level 6 while it compresses to the same size with zstd level 3 in 1ms. We don't expect this ever to be a user-configurable option (hence `DEBUG` in the name) but want to experiment with various options ourselves.

### Additional Notes
Jira: [PROF-11828]




[PROF-11828]: https://datadoghq.atlassian.net/browse/PROF-11828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ