### PR TITLE
[DI] Fix race condition if breakpoint is hit while being removed

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -144,6 +144,7 @@ async function removeBreakpoint ({ id }) {
   if (probesAtLocation.size === 0) {
     locationToBreakpoint.delete(locationKey)
     breakpointToProbes.delete(breakpoint.id)
+    // TODO: If anything below in this if-block throws, the state is out of sync.
     if (breakpointToProbes.size === 0) {
       await stop() // This will also remove the breakpoint
     } else {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -65,6 +65,12 @@ session.on('Debugger.paused', async ({ params }) => {
   for (let i = 0; i < params.hitBreakpoints.length; i++) {
     const probesAtLocation = breakpointToProbes.get(params.hitBreakpoints[i])
 
+    if (probesAtLocation === undefined) {
+      // This might happen due to a race condition where the breakpoint is in the process of being removed
+      log.error('[debugger:devtools_client] No probes found for breakpoint %s', params.hitBreakpoints[i])
+      continue
+    }
+
     if (probesAtLocation.size !== 1) {
       numberOfProbesOnBreakpoint = numberOfProbesOnBreakpoint + probesAtLocation.size - 1
       if (numberOfProbesOnBreakpoint > snapshotProbeIndex.length) {

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -1,0 +1,72 @@
+'use strict'
+
+require('../../setup/mocha')
+
+const breakpoint = { file: 'file.js', line: 1 }
+const breakpointId = 'breakpoint-id'
+const scriptId = 'script-id'
+const path = `/path/to/${breakpoint.file}`
+const url = `file://${path}`
+const functionName = 'myFn'
+const parentThreadId = 'my-parent-thread-id'
+const event = {
+  params: {
+    hitBreakpoints: [breakpointId],
+    callFrames: [{ functionName, location: { scriptId, lineNumber: breakpoint.line - 1, columnNumber: 0 } }]
+  }
+}
+
+describe('onPause', function () {
+  let session, send, onPaused, ackReceived
+
+  beforeEach(async function () {
+    ackReceived = sinon.spy()
+
+    session = {
+      on: sinon.spy((event, listener) => {
+        if (event === 'Debugger.scriptParsed') {
+          listener({ params: { scriptId, url } })
+        }
+      }),
+      post: sinon.spy(),
+      emit: sinon.spy(),
+      '@noCallThru': true
+    }
+
+    const config = {
+      service: 'my-service',
+      runtimeId: 'my-runtime-id',
+      parentThreadId,
+      dynamicInstrumentation: {
+        redactedIdentifiers: [],
+        redactionExcludedIdentifiers: []
+      },
+      '@noCallThru': true
+    }
+
+    send = sinon.spy()
+    send['@noCallThru'] = true
+
+    proxyquire('../src/debugger/devtools_client/state', { './session': session })
+    proxyquire('../src/debugger/devtools_client/status', { './config': config })
+    proxyquire('../src/debugger/devtools_client/snapshot/collector', { '../session': session })
+    proxyquire('../src/debugger/devtools_client/snapshot/redaction', { '../config': config })
+    proxyquire('../src/debugger/devtools_client', {
+      './config': config,
+      './session': session,
+      './send': send,
+      './status': { ackReceived },
+      './remote_config': { '@noCallThru': true }
+    })
+
+    const onPausedCall = session.on.args.find(([event]) => event === 'Debugger.paused')
+    onPaused = onPausedCall[1]
+  })
+
+  it('should not fail if there is no probe for at the breakpoint', async function () {
+    await onPaused(event)
+    expect(session.post).to.have.been.calledOnceWith('Debugger.resume')
+    expect(ackReceived).to.not.have.been.called
+    expect(send).to.not.have.been.called
+  })
+})


### PR DESCRIPTION
### What does this PR do?

The internal state kept by the DI code of which probes are active, might not be 100% in sync with the actual breakpoints configured via the Chrome DevTools Protocol (CDP).
    
This could happen if the probe is in the process of either being updated or removed while at the same time being hit in the instrumented application.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


