### PR TITLE
[test-optimization] [SDTEST-2034] Send tag when there is no branch

### DIFF
--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -67,7 +67,8 @@ const {
   GIT_BRANCH,
   CI_PROVIDER_NAME,
   CI_WORKSPACE_PATH,
-  GIT_COMMIT_MESSAGE
+  GIT_COMMIT_MESSAGE,
+  GIT_TAG
 } = require('../../dd-trace/src/plugins/util/tags')
 const {
   OS_VERSION,
@@ -206,7 +207,8 @@ class CypressPlugin {
       [GIT_BRANCH]: branch,
       [CI_PROVIDER_NAME]: ciProviderName,
       [CI_WORKSPACE_PATH]: repositoryRoot,
-      [GIT_COMMIT_MESSAGE]: commitMessage
+      [GIT_COMMIT_MESSAGE]: commitMessage,
+      [GIT_TAG]: tag
     } = this.testEnvironmentMetadata
 
     this.repositoryRoot = repositoryRoot
@@ -223,7 +225,8 @@ class CypressPlugin {
       runtimeVersion,
       branch,
       testLevel: 'test',
-      commitMessage
+      commitMessage,
+      tag
     }
     this.finishedTestsByFile = {}
     this.testStatuses = {}

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -28,7 +28,8 @@ function getLibraryConfiguration ({
   runtimeVersion,
   branch,
   testLevel = 'suite',
-  custom
+  custom,
+  tag
 }, done) {
   const options = {
     path: '/api/v2/libraries/tests/services/setting',
@@ -69,7 +70,7 @@ function getLibraryConfiguration ({
         env,
         repository_url: repositoryUrl,
         sha,
-        branch
+        branch: branch || tag
       }
     }
   })

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -45,7 +45,8 @@ const {
   GIT_COMMIT_SHA,
   GIT_BRANCH,
   CI_WORKSPACE_PATH,
-  GIT_COMMIT_MESSAGE
+  GIT_COMMIT_MESSAGE,
+  GIT_TAG
 } = require('./util/tags')
 const { OS_VERSION, OS_PLATFORM, OS_ARCHITECTURE, RUNTIME_NAME, RUNTIME_VERSION } = require('./util/env')
 const getDiClient = require('../ci-visibility/dynamic-instrumentation')
@@ -253,7 +254,8 @@ module.exports = class CiPlugin extends Plugin {
       [GIT_BRANCH]: branch,
       [CI_PROVIDER_NAME]: ciProviderName,
       [CI_WORKSPACE_PATH]: repositoryRoot,
-      [GIT_COMMIT_MESSAGE]: commitMessage
+      [GIT_COMMIT_MESSAGE]: commitMessage,
+      [GIT_TAG]: tag
     } = this.testEnvironmentMetadata
 
     this.repositoryRoot = repositoryRoot || process.cwd()
@@ -272,7 +274,8 @@ module.exports = class CiPlugin extends Plugin {
       runtimeVersion,
       branch,
       testLevel: 'suite',
-      commitMessage
+      commitMessage,
+      tag
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When a GitHub is triggered with a _tag push_, the branch that we are sending is empty, resulting in an error. We want to solve this by sending the tag whenever this happen as the branch.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to avoid setting wrongly the library configurations.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.


