### PR TITLE
Make the ddBasePath variable a static string

### DIFF
--- a/packages/dd-trace/src/appsec/iast/path-line.js
+++ b/packages/dd-trace/src/appsec/iast/path-line.js
@@ -2,13 +2,12 @@
 
 const path = require('path')
 const process = require('process')
-const { calculateDDBasePath } = require('../../util')
+const { ddBasePath } = require('../../util')
 const pathLine = {
   getNodeModulesPaths,
   getRelativePath,
   getNonDDCallSiteFrames,
-  calculateDDBasePath, // Exported only for test purposes
-  ddBasePath: calculateDDBasePath(__dirname) // Only for test purposes
+  ddBasePath // Exported only for test purposes
 }
 
 const EXCLUDED_PATHS = [

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const { calculateDDBasePath } = require('../util')
-
-const ddBasePath = calculateDDBasePath(__dirname)
+const { ddBasePath } = require('../util')
 
 const LIBRARY_FRAMES_BUFFER = 20
 

--- a/packages/dd-trace/src/telemetry/logs/log-collector.js
+++ b/packages/dd-trace/src/telemetry/logs/log-collector.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const log = require('../../log')
-const { calculateDDBasePath } = require('../../util')
+const { ddBasePath } = require('../../util')
 
 const logs = new Map() // hash -> log
 
@@ -30,7 +30,6 @@ function isValid (logEntry) {
   return logEntry?.level && logEntry.message
 }
 
-const ddBasePath = calculateDDBasePath(__dirname)
 const EOL = '\n'
 const STACK_FRAME_LINE_REGEX = /^\s*at\s/gm
 

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -86,7 +86,7 @@ module.exports = {
   isFalse,
   isError,
   globMatch,
-  calculateDDBasePath,
+  ddBasePath: calculateDDBasePath(__dirname),
   hasOwn,
   normalizeProfilingEnabledValue
 }

--- a/packages/dd-trace/test/appsec/iast/path-line.spec.js
+++ b/packages/dd-trace/test/appsec/iast/path-line.spec.js
@@ -39,27 +39,6 @@ describe('path-line', function () {
     })
   })
 
-  describe('calculateDDBasePath', () => {
-    it('/node_modules/dd-trace', () => {
-      const basePath = path.join(rootPath, 'node_modules', 'dd-trace', 'packages', path.sep)
-      const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
-      expect(result).to.be.equals(basePath)
-    })
-
-    it('/packages/project/path/node_modules/dd-trace', () => {
-      const basePath =
-        path.join(rootPath, 'packages', 'project', 'path', 'node_modules', 'dd-trace', 'packages', path.sep)
-      const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
-      expect(result).to.be.equals(basePath)
-    })
-
-    it('/project/path/node_modules/dd-trace', () => {
-      const basePath = path.join(rootPath, 'project', 'path', 'node_modules', 'dd-trace', 'packages', path.sep)
-      const result = pathLine.calculateDDBasePath(path.join(basePath, PATH_LINE_PATH))
-      expect(result).to.be.equals(basePath)
-    })
-  })
-
   describe('getNonDDCallSiteFrames', () => {
     describe('does not fail', () => {
       it('with null parameter', () => {

--- a/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
+++ b/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
@@ -2,9 +2,8 @@
 
 require('../../setup/tap')
 
-const { calculateDDBasePath } = require('../../../src/util')
+const { ddBasePath } = require('../../../src/util')
 
-const ddBasePath = calculateDDBasePath(__dirname)
 const EOL = '\n'
 
 describe('telemetry log collector', () => {
@@ -28,16 +27,14 @@ describe('telemetry log collector', () => {
     })
 
     it('should store logs with same message but different stack', () => {
-      const ddFrame =
-        `at T (${ddBasePath}packages/dd-trace/test/telemetry/logs/log-collector.spec.js:29:21)`
+      const ddFrame = `at T (${ddBasePath}path/to/dd/file.js:1:2)`
       expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `stack 1\n${ddFrame}` })).to.be.true
       expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `stack 2\n${ddFrame}` })).to.be.true
       expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `stack 3\n${ddFrame}` })).to.be.true
     })
 
     it('should store logs with same message, same stack but different level', () => {
-      const ddFrame =
-        `at T (${ddBasePath}packages/dd-trace/test/telemetry/logs/log-collector.spec.js:29:21)`
+      const ddFrame = `at T (${ddBasePath}path/to/dd/file.js:1:2)`
       expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `stack 1\n${ddFrame}` })).to.be.true
       expect(logCollector.add({ message: 'Error 1', level: 'WARN', stack_trace: `stack 1\n${ddFrame}` })).to.be.true
       expect(logCollector.add({ message: 'Error 1', level: 'DEBUG', stack_trace: `stack 1\n${ddFrame}` })).to.be.true
@@ -53,7 +50,7 @@ describe('telemetry log collector', () => {
     })
 
     it('should include original message and dd frames', () => {
-      const ddFrame = `at T (${ddBasePath}packages/dd-trace/test/telemetry/logs/log_collector.spec.js:29:21)`
+      const ddFrame = `at T (${ddBasePath}path/to/dd/file.js:1:2)`
       const stack = new TypeError('Error 1')
         .stack.replace(`Error 1${EOL}`, `Error 1${EOL}${ddFrame}${EOL}`)
 
@@ -79,7 +76,7 @@ describe('telemetry log collector', () => {
 
     it('should redact stack message if first frame is not a dd frame', () => {
       const thirdPartyFrame = `at callFn (/this/is/not/a/dd/frame/runnable.js:366:21)
-        at T (${ddBasePath}packages/dd-trace/test/telemetry/logs/log_collector.spec.js:29:21)`
+        at T (${ddBasePath}path/to/dd/file.js:1:2)`
       const stack = new TypeError('Error 1')
         .stack.replace(`Error 1${EOL}`, `Error 1${EOL}${thirdPartyFrame}${EOL}`)
 


### PR DESCRIPTION
### What does this PR do?

Instead of exporting a `calculateDDBasePath` function to dynamically calculate the `ddBasePath`, just call it once where it's defined, and expose its return value.

### Motivation

There's no reason to expose a function to re-calculate the `ddBasePath` as it will be the same throughout the run-time of the process.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes

It's worriying that the tests in `packages/dd-trace/test/telemetry/logs/log-collector.spec.js` never failed in the old state.

