### PR TITLE
test: clean up algorithm to create `versions/*` folders

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -92,17 +92,7 @@ async function assertModules (name, version, external) {
 }
 
 function assertFolder (name, version) {
-  if (!fs.existsSync(folder())) {
-    fs.mkdirSync(folder())
-  }
-
-  if (name && name.includes(path.sep)) {
-    name.split(path.sep).reduce(parent => assertFolder(parent))
-  }
-
-  if (!fs.existsSync(folder(name, version))) {
-    fs.mkdirSync(folder(name, version))
-  }
+  fs.mkdirSync(folder(name, version), { recursive: true })
 }
 
 async function assertPackage (name, version, dependencyVersionRange, external) {


### PR DESCRIPTION
### What does this PR do?

When running `yarn services`, a number of folders are created in the project, if they do not already exist. The algorithm to ensure these folders were present had a few bugs (which luckily didn't affect the outcome), and were overly complicated. This cleans all that up.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


