### PR TITLE
test: clean up invalid code in `yarn services` script

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -40,8 +40,6 @@ async function run () {
   assertFolder()
   await assertVersions()
   assertWorkspace()
-  // Some native addon packages rely on libraries that are not supported on ARM64
-  excludeList.forEach(pkg => delete workspaces[pkg])
   install()
 }
 


### PR DESCRIPTION
### What does this PR do?

The removed code was basically a noop. It has never had any effect as you can't use the `delete` symbol to remove elements from a `Set`.

The `workspaces` set was already properly filtered because we never add anything to it that's on the `excludedList` to begin with:

https://github.com/DataDog/dd-trace-js/blob/68d5534d11b0b9272a4ca71507746974f0961abb/scripts/install_plugin_modules.js#L211

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


