### PR TITLE
test: clean up `yarn services` script

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -1,105 +1,122 @@
 'use strict'
 
-const fs = require('fs')
-const os = require('os')
-const path = require('path')
-const crypto = require('crypto')
+const { mkdir, writeFile, readdir } = require('fs/promises')
+const { arch } = require('os')
+const { join } = require('path')
+const { createHash } = require('crypto')
+const childProcess = require('child_process')
 const semver = require('semver')
 const exec = require('./helpers/exec')
-const childProcess = require('child_process')
-const externals = require('../packages/dd-trace/test/plugins/externals')
+const externals = require('../packages/dd-trace/test/plugins/externals.json')
 const { getInstrumentation } = require('../packages/dd-trace/test/setup/helpers/load-inst')
 
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 
 // Can remove aerospike after removing support for aerospike < 5.2.0 (for Node.js 22, v5.12.1 is required)
 // Can remove couchbase after removing support for couchbase <= 3.2.0
-const excludeList = os.arch() === 'arm64' ? ['aerospike', 'couchbase', 'grpc', 'oracledb'] : []
+const excludeList = arch() === 'arm64' ? ['aerospike', 'couchbase', 'grpc', 'oracledb'] : []
 const workspaces = new Set()
-const versionLists = {}
-const deps = {}
-const filter = process.env.hasOwnProperty('PLUGINS') && process.env.PLUGINS.split('|')
+const versionListCache = new Map()
+const externalDeps = new Map()
 
 Object.keys(externals).forEach(external => externals[external].forEach(thing => {
   if (thing.dep) {
-    if (!deps[external]) {
-      deps[external] = []
-    }
-    deps[external].push(thing.name)
+    const depsArr = externalDeps.get(external)
+    depsArr ? depsArr.push(thing.name) : externalDeps.set(external, [thing.name])
   }
 }))
-
-const names = fs.readdirSync(path.join(__dirname, '..', 'packages', 'datadog-instrumentations', 'src'))
-  .filter(file => file.endsWith('.js'))
-  .map(file => file.slice(0, -3))
-  .filter(file => !filter || filter.includes(file))
 
 run()
 
 async function run () {
-  assertFolder()
-  await assertVersions()
-  assertWorkspace()
+  await assertPrerequisites()
   install()
 }
 
-async function assertVersions () {
-  const internals = names
-    .map(getInstrumentation)
-    .reduce((prev, next) => prev.concat(next), [])
+async function assertPrerequisites () {
+  const filter = process.env.PLUGINS?.split('|')
+
+  const moduleNames = (await readdir(join(__dirname, '..', 'packages', 'datadog-instrumentations', 'src')))
+    .filter(file => file.endsWith('.js'))
+    .map(file => file.slice(0, -3))
+    .filter(file => !filter || filter.includes(file))
+
+  const internals = moduleNames.reduce((/** @type {object[]} */ internals, moduleName) => {
+    internals.push(...getInstrumentation(moduleName))
+    return internals
+  }, [])
 
   for (const inst of internals) {
     await assertInstrumentation(inst, false)
   }
 
-  const externalNames = Object.keys(externals).filter(name => ~names.indexOf(name))
+  const externalNames = Object.keys(externals).filter(name => moduleNames.includes(name))
   for (const name of externalNames) {
     for (const inst of [].concat(externals[name])) {
       await assertInstrumentation(inst, true)
     }
   }
+
+  await assertWorkspaces()
 }
 
+/**
+ * @param {object} instrumentation
+ * @param {boolean} external
+ */
 async function assertInstrumentation (instrumentation, external) {
   const versions = process.env.PACKAGE_VERSION_RANGE && !external
     ? [process.env.PACKAGE_VERSION_RANGE]
     : [].concat(instrumentation.versions || [])
 
   for (const version of versions) {
-    if (version) {
-      if (version !== '*') {
-        await assertModules(instrumentation.name, semver.coerce(version).version, external)
-      }
+    if (!version) continue
 
-      await assertModules(instrumentation.name, version, external)
+    if (version !== '*') {
+      const result = semver.coerce(version)
+      if (!result) throw new Error(`Invalid version: ${version}`)
+      await assertModules(instrumentation.name, result.version, external)
     }
+
+    await assertModules(instrumentation.name, version, external)
   }
 }
 
+/**
+ * @param {string} name
+ * @param {string} version
+ * @param {boolean} external
+ */
 async function assertModules (name, version, external) {
   const range = process.env.RANGE
   if (range && !semver.subset(version, range)) return
-  addFolder(name)
-  addFolder(name, version)
-  assertFolder(name)
-  assertFolder(name, version)
-  await assertPackage(name, null, version, external)
-  await assertPackage(name, version, version, external)
-  assertIndex(name)
-  assertIndex(name, version)
+  await Promise.all([
+    assertPackage(name, null, version, external),
+    assertPackage(name, version, version, external)
+  ])
 }
 
-function assertFolder (name, version) {
-  fs.mkdirSync(folder(name, version), { recursive: true })
+/**
+ * @param {string|null} [name]
+ * @param {string|null} [version]
+ */
+async function assertFolder (name, version) {
+  await mkdir(folder(name, version), { recursive: true })
 }
 
+/**
+ * @param {string} name
+ * @param {string|null} version
+ * @param {string} dependencyVersionRange
+ * @param {boolean} external
+ */
 async function assertPackage (name, version, dependencyVersionRange, external) {
   const dependencies = { [name]: dependencyVersionRange }
-  if (deps[name]) {
+  if (externalDeps.has(name)) {
     await addDependencies(dependencies, name, dependencyVersionRange)
   }
   const pkg = {
-    name: [name, sha1(name).substr(0, 8), sha1(version)].filter(val => val).join('-'),
+    name: [name, sha1(name).slice(0, 8), sha1(version)].filter(val => val).join('-'),
     version: '1.0.0',
     license: 'BSD-3-Clause',
     private: true,
@@ -117,14 +134,25 @@ async function assertPackage (name, version, dependencyVersionRange, external) {
       }
     }
   }
-  fs.writeFileSync(filename(name, version, 'package.json'), JSON.stringify(pkg, null, 2) + '\n')
+
+  addFolderToWorkspaces(name, version)
+  await assertFolder(name, version)
+  await Promise.all([
+    writeFile(filename(name, version, 'package.json'), JSON.stringify(pkg, null, 2) + '\n'),
+    assertIndex(name, version)
+  ])
 }
 
+/**
+ * @param {object} dependencies
+ * @param {string} name
+ * @param {string} versionRange
+ */
 async function addDependencies (dependencies, name, versionRange) {
   const versionList = await getVersionList(name)
   const version = semver.maxSatisfying(versionList, versionRange)
   const pkgJson = await npmView(`${name}@${version}`)
-  for (const dep of deps[name]) {
+  for (const dep of externalDeps.get(name)) {
     for (const section of ['devDependencies', 'peerDependencies']) {
       if (pkgJson[section] && dep in pkgJson[section]) {
         if (pkgJson[section][dep].includes('||')) {
@@ -140,27 +168,39 @@ async function addDependencies (dependencies, name, versionRange) {
   }
 }
 
+/**
+ * @param {string} name
+ * @returns {Promise<string[]>}
+ */
 async function getVersionList (name) {
-  if (versionLists[name]) {
-    return versionLists[name]
-  }
-  const list = await npmView(`${name} versions`)
-  versionLists[name] = list
+  let list = versionListCache.get(name)
+  if (list) return list
+  list = await npmView(`${name} versions`)
+  versionListCache.set(name, list)
   return list
 }
 
+/**
+ * @param {string} input
+ * @param {boolean} [retry=true]
+ * @returns {Promise<any>}
+ */
 function npmView (input, retry = true) {
   return new Promise((resolve, reject) => {
     childProcess.exec(`npm view ${input} --json`, (err, stdout) => {
       if (err) {
         return retry ? npmView(input, false).then(resolve, reject) : reject(err)
       }
-      resolve(JSON.parse(stdout.toString('utf8')))
+      resolve(JSON.parse(stdout.toString()))
     })
   })
 }
 
-function assertIndex (name, version) {
+/**
+ * @param {string} name
+ * @param {string|null} version
+ */
+async function assertIndex (name, version) {
   const index = `'use strict'
 
 const requirePackageJson = require('${requirePackageJsonPath}')
@@ -171,11 +211,12 @@ module.exports = {
   version () { return requirePackageJson('${name}', module).version }
 }
 `
-  fs.writeFileSync(filename(name, version, 'index.js'), index)
+  await writeFile(filename(name, version, 'index.js'), index)
 }
 
-function assertWorkspace () {
-  fs.writeFileSync(filename(null, null, 'package.json'), JSON.stringify({
+async function assertWorkspaces () {
+  await assertFolder()
+  await writeFile(filename(null, null, 'package.json'), JSON.stringify({
     name: 'versions',
     version: '1.0.0',
     license: 'BSD-3-Clause',
@@ -186,32 +227,62 @@ function assertWorkspace () {
   }, null, 2) + '\n')
 }
 
-function install () {
+/**
+ * @param {boolean} [retry=true]
+ */
+function install (retry = true) {
   try {
     exec('yarn --ignore-engines', { cwd: folder() })
-  } catch (e) { // retry in case of server error from registry
-    exec('yarn --ignore-engines', { cwd: folder() })
+  } catch (err) {
+    if (!retry) throw err
+    install(false) // retry in case of server error from registry
   }
 }
 
-function addFolder (name, version) {
-  const basename = [name, version].filter(val => val).join('@')
-  if (!excludeList.includes(name)) workspaces.add(basename)
+/**
+ * @param {string} name
+ * @param {string|null} [version]
+ */
+function addFolderToWorkspaces (name, version) {
+  if (!excludeList.includes(name)) workspaces.add(basename(name, version))
 }
 
+/**
+ * @param {string|null} [name]
+ * @param {string|null} [version]
+ * @returns {string}
+ */
 function folder (name, version) {
-  const basename = [name, version].filter(val => val).join('@')
-  return path.join(__dirname, '..', 'versions', basename)
+  return join(__dirname, '..', 'versions', basename(name, version))
 }
 
+/**
+ * @param {string|null} [name]
+ * @param {string|null} [version]
+ * @returns {string}
+ */
+function basename (name, version) {
+  return name ? (version ? `${name}@${version}` : name) : ''
+}
+
+/**
+ * @param {string|null} name
+ * @param {string|null} version
+ * @param {string} file
+ * @returns {string}
+ */
 function filename (name, version, file) {
-  return path.join(folder(name, version), file)
+  return join(folder(name, version), file)
 }
 
+/**
+ * @template {string|null} T
+ * @param {T} str
+ * @returns {T extends null ? undefined : T extends string ? string : never}
+ */
 function sha1 (str) {
-  if (!str) return
-
-  const shasum = crypto.createHash('sha1')
+  if (!str) return /** @type {any} */ (undefined)
+  const shasum = createHash('sha1')
   shasum.update(str)
-  return shasum.digest('hex')
+  return /** @type {any} */ (shasum.digest('hex'))
 }


### PR DESCRIPTION
### What does this PR do?

Make several modifications to the `scripts/install_plugin_modules.js` script (without changing the behavior/result of it). The major ones are:
- Adds JSDoc to all functions within the file (makes future refactoring easier).
- Throw useful error in case version range provided via `PACKAGE_VERSION_RANGE` is invalid.
- Run async operations in parallel where possible.

### Motivation

I'm in the process of refactoring this script. Before starting to move code to other locations, I thought it was best to just get it up-to-date with modern standards and to clean up the code a bit so that it was free from edge case errors etc.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


