### PR TITLE
bump dc-polyfill to 0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/core": "^1.14.0",
     "crypto-randomuuid": "^1.0.0",
-    "dc-polyfill": "0.1.8",
+    "dc-polyfill": "0.1.9",
     "ignore": "^5.2.4",
     "import-in-the-middle": "1.13.1",
     "istanbul-lib-coverage": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1332,10 +1332,10 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-dc-polyfill@0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.8.tgz#2d91dd4dd0f2e3575ce038d013f346161f5a413a"
-  integrity sha512-F9+06papa9GOFUMjxGiqM1bS98pOkinZpBF3Sygb46owrXaHdR2uLkftE6nygrqNcAurdwKjLAtX+0GJkSwIFQ==
+dc-polyfill@0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/dc-polyfill/-/dc-polyfill-0.1.9.tgz#ee594f4366a6dcf006db1c1f9d3672f57a720856"
+  integrity sha512-D5mJThEEk9hf+CJPwTf9JFsrWdlWp8Pccjxkhf7uUT/E/cU9Mx3ebWe2Bz2OawRmJ6WS9eaDPBkeBE4uOKq9uw==
 
 debug@2.6.9:
   version "2.6.9"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump dc-polyfill to 0.1.9

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix a bug where calling `runStores()` and `bindStore()` on different calls of `channel()` would result in a complete lost of context.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

See https://github.com/DataDog/dc-polyfill/pull/18