### PR TITLE
[test-optimization] [SDTEST-1923] Fix Playwright tests in `v5`

### DIFF
--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -282,337 +282,339 @@ versions.forEach((version) => {
       )
     })
 
-    context('early flake detection', () => {
-      it('retries new tests', (done) => {
-        receiver.setSettings({
-          early_flake_detection: {
-            enabled: true,
-            slow_test_retries: {
-              '5s': NUM_RETRIES_EFD
-            }
-          },
-          known_tests_enabled: true
-        })
-
-        receiver.setKnownTests(
-          {
-            playwright: {
-              'landing-page-test.js': [
-                // it will be considered new
-                // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
-                'highest-level-describe  leading and trailing spaces    should work with skipped tests',
-                'highest-level-describe  leading and trailing spaces    should work with fixme',
-                'highest-level-describe  leading and trailing spaces    should work with annotated tests'
-              ],
-              'skipped-suite-test.js': [
-                'should work with fixme root'
-              ],
-              'todo-list-page-test.js': [
-                'playwright should work with failing tests',
-                'should work with fixme root'
-              ]
-            }
-          }
-        )
-
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_ENABLED, 'true')
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            const newTests = tests.filter(test =>
-              test.resource.endsWith('should work with passing tests')
-            )
-            newTests.forEach(test => {
-              assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
-            })
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-
-            assert.equal(retriedTests.length, NUM_RETRIES_EFD)
-
-            retriedTests.forEach(test => {
-              assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
-            })
-
-            // all but one has been retried
-            assert.equal(retriedTests.length, newTests.length - 1)
+    if (DD_MAJOR >= 6 || version === 'latest') {
+      context('early flake detection', () => {
+        it('retries new tests', (done) => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': NUM_RETRIES_EFD
+              }
+            },
+            known_tests_enabled: true
           })
 
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
-        })
-      })
-
-      it('is disabled if DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED is false', (done) => {
-        receiver.setSettings({
-          early_flake_detection: {
-            enabled: true,
-            slow_test_retries: {
-              '5s': NUM_RETRIES_EFD
+          receiver.setKnownTests(
+            {
+              playwright: {
+                'landing-page-test.js': [
+                  // it will be considered new
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
+                  'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
+                ],
+                'skipped-suite-test.js': [
+                  'should work with fixme root'
+                ],
+                'todo-list-page-test.js': [
+                  'playwright should work with failing tests',
+                  'should work with fixme root'
+                ]
+              }
             }
-          },
-          known_tests_enabled: true
-        })
+          )
 
-        receiver.setKnownTests(
-          {
-            playwright: {
-              'landing-page-test.js': [
-                // it will be considered new
-                // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
-                'highest-level-describe  leading and trailing spaces    should work with skipped tests',
-                'highest-level-describe  leading and trailing spaces    should work with fixme',
-                'highest-level-describe  leading and trailing spaces    should work with annotated tests'
-              ],
-              'skipped-suite-test.js': [
-                'should work with fixme root'
-              ],
-              'todo-list-page-test.js': [
-                'playwright should work with failing tests',
-                'should work with fixme root'
-              ]
-            }
-          }
-        )
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.propertyVal(testSession.meta, TEST_EARLY_FLAKE_ENABLED, 'true')
 
-            const newTests = tests.filter(test =>
-              test.resource.endsWith('should work with passing tests')
-            )
-            // new tests are detected but not retried
-            newTests.forEach(test => {
-              assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const newTests = tests.filter(test =>
+                test.resource.endsWith('should work with passing tests')
+              )
+              newTests.forEach(test => {
+                assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+              })
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+
+              assert.equal(retriedTests.length, NUM_RETRIES_EFD)
+
+              retriedTests.forEach(test => {
+                assert.propertyVal(test.meta, TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.efd)
+              })
+
+              // all but one has been retried
+              assert.equal(retriedTests.length, newTests.length - 1)
             })
 
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 0)
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
+
+        it('is disabled if DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED is false', (done) => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': NUM_RETRIES_EFD
+              }
+            },
+            known_tests_enabled: true
           })
 
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`,
-              DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false'
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
-        })
-      })
-
-      it('does not retry tests that are skipped', (done) => {
-        receiver.setSettings({
-          early_flake_detection: {
-            enabled: true,
-            slow_test_retries: {
-              '5s': NUM_RETRIES_EFD
+          receiver.setKnownTests(
+            {
+              playwright: {
+                'landing-page-test.js': [
+                  // it will be considered new
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
+                  'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
+                ],
+                'skipped-suite-test.js': [
+                  'should work with fixme root'
+                ],
+                'todo-list-page-test.js': [
+                  'playwright should work with failing tests',
+                  'should work with fixme root'
+                ]
+              }
             }
-          },
-          known_tests_enabled: true
-        })
+          )
 
-        receiver.setKnownTests(
-          {
-            playwright: {
-              'landing-page-test.js': [
-                'highest-level-describe  leading and trailing spaces    should work with passing tests',
-                // new but not retried because it's skipped
-                // 'highest-level-describe  leading and trailing spaces    should work with skipped tests',
-                // new but not retried because it's skipped
-                // 'highest-level-describe  leading and trailing spaces    should work with fixme',
-                'highest-level-describe  leading and trailing spaces    should work with annotated tests'
-              ],
-              'skipped-suite-test.js': [
-                'should work with fixme root'
-              ],
-              'todo-list-page-test.js': [
-                'playwright should work with failing tests',
-                'should work with fixme root'
-              ]
-            }
-          }
-        )
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const newTests = tests.filter(test =>
+                test.resource.endsWith('should work with passing tests')
+              )
+              // new tests are detected but not retried
+              newTests.forEach(test => {
+                assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+              })
 
-            const newTests = tests.filter(test =>
-              test.resource.endsWith('should work with skipped tests') ||
-              test.resource.endsWith('should work with fixme')
-            )
-            // no retries
-            assert.equal(newTests.length, 2)
-            newTests.forEach(test => {
-              assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.equal(retriedTests.length, 0)
             })
 
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false'
+              },
+              stdio: 'pipe'
+            }
+          )
 
-            assert.equal(retriedTests.length, 0)
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
+
+        it('does not retry tests that are skipped', (done) => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': NUM_RETRIES_EFD
+              }
+            },
+            known_tests_enabled: true
           })
 
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
-        })
-      })
-
-      it('does not run EFD if the known tests request fails', (done) => {
-        receiver.setSettings({
-          early_flake_detection: {
-            enabled: true,
-            slow_test_retries: {
-              '5s': NUM_RETRIES_EFD
+          receiver.setKnownTests(
+            {
+              playwright: {
+                'landing-page-test.js': [
+                  'highest-level-describe  leading and trailing spaces    should work with passing tests',
+                  // new but not retried because it's skipped
+                  // 'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  // new but not retried because it's skipped
+                  // 'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
+                ],
+                'skipped-suite-test.js': [
+                  'should work with fixme root'
+                ],
+                'todo-list-page-test.js': [
+                  'playwright should work with failing tests',
+                  'should work with fixme root'
+                ]
+              }
             }
-          },
-          known_tests_enabled: true
-        })
+          )
 
-        receiver.setKnownTestsResponseCode(500)
-        receiver.setKnownTests({})
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const newTests = tests.filter(test =>
+                test.resource.endsWith('should work with skipped tests') ||
+                test.resource.endsWith('should work with fixme')
+              )
+              // no retries
+              assert.equal(newTests.length, 2)
+              newTests.forEach(test => {
+                assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+              })
 
-            assert.equal(tests.length, 7)
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
 
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.equal(newTests.length, 0)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 0)
-          })
-
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise
-            .then(() => done())
-            .catch(done)
-        })
-      })
-
-      it('disables early flake detection if known tests should not be requested', (done) => {
-        receiver.setSettings({
-          early_flake_detection: {
-            enabled: true,
-            slow_test_retries: {
-              '5s': NUM_RETRIES_EFD
-            }
-          },
-          known_tests_enabled: false
-        })
-
-        receiver.setKnownTests(
-          {
-            playwright: {
-              'landing-page-test.js': [
-                // it will be considered new
-                // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
-                'highest-level-describe  leading and trailing spaces    should work with skipped tests',
-                'highest-level-describe  leading and trailing spaces    should work with fixme',
-                'highest-level-describe  leading and trailing spaces    should work with annotated tests'
-              ],
-              'skipped-suite-test.js': [
-                'should work with fixme root'
-              ],
-              'todo-list-page-test.js': [
-                'playwright should work with failing tests',
-                'should work with fixme root'
-              ]
-            }
-          }
-        )
-
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            const newTests = tests.filter(test =>
-              test.resource.endsWith('should work with passing tests')
-            )
-            newTests.forEach(test => {
-              assert.notProperty(test.meta, TEST_IS_NEW)
+              assert.equal(retriedTests.length, 0)
             })
 
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 0)
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
+
+        it('does not run EFD if the known tests request fails', (done) => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': NUM_RETRIES_EFD
+              }
+            },
+            known_tests_enabled: true
           })
 
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
+          receiver.setKnownTestsResponseCode(500)
+          receiver.setKnownTests({})
 
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.equal(tests.length, 7)
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
+
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.equal(newTests.length, 0)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.equal(retriedTests.length, 0)
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise
+              .then(() => done())
+              .catch(done)
+          })
+        })
+
+        it('disables early flake detection if known tests should not be requested', (done) => {
+          receiver.setSettings({
+            early_flake_detection: {
+              enabled: true,
+              slow_test_retries: {
+                '5s': NUM_RETRIES_EFD
+              }
+            },
+            known_tests_enabled: false
+          })
+
+          receiver.setKnownTests(
+            {
+              playwright: {
+                'landing-page-test.js': [
+                  // it will be considered new
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
+                  'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
+                ],
+                'skipped-suite-test.js': [
+                  'should work with fixme root'
+                ],
+                'todo-list-page-test.js': [
+                  'playwright should work with failing tests',
+                  'should work with fixme root'
+                ]
+              }
+            }
+          )
+
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const newTests = tests.filter(test =>
+                test.resource.endsWith('should work with passing tests')
+              )
+              newTests.forEach(test => {
+                assert.notProperty(test.meta, TEST_IS_NEW)
+              })
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.equal(retriedTests.length, 0)
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
         })
       })
-    })
+    }
 
     it('does not crash when maxFailures=1 and there is an error', (done) => {
       receiver.gatherPayloadsMaxTimeout(({ url }) => url.endsWith('citestcycle'), payloads => {
@@ -820,70 +822,72 @@ versions.forEach((version) => {
       })
     })
 
-    context('known tests without early flake detection', () => {
-      it('detects new tests without retrying them', (done) => {
-        receiver.setSettings({
-          known_tests_enabled: true
-        })
-
-        receiver.setKnownTests(
-          {
-            playwright: {
-              'landing-page-test.js': [
-                // it will be considered new
-                // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
-                'highest-level-describe  leading and trailing spaces    should work with skipped tests',
-                'highest-level-describe  leading and trailing spaces    should work with fixme',
-                'highest-level-describe  leading and trailing spaces    should work with annotated tests'
-              ],
-              'skipped-suite-test.js': [
-                'should work with fixme root'
-              ],
-              'todo-list-page-test.js': [
-                'playwright should work with failing tests',
-                'should work with fixme root'
-              ]
-            }
-          }
-        )
-
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            const newTests = tests.filter(test =>
-              test.resource.endsWith('should work with passing tests')
-            )
-            // new tests detected but no retries
-            newTests.forEach(test => {
-              assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
-            })
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 0)
+    if (DD_MAJOR >= 6 || version === 'latest') {
+      context('known tests without early flake detection', () => {
+        it('detects new tests without retrying them', (done) => {
+          receiver.setSettings({
+            known_tests_enabled: true
           })
 
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`
-            },
-            stdio: 'pipe'
-          }
-        )
+          receiver.setKnownTests(
+            {
+              playwright: {
+                'landing-page-test.js': [
+                  // it will be considered new
+                  // 'highest-level-describe  leading and trailing spaces    should work with passing tests',
+                  'highest-level-describe  leading and trailing spaces    should work with skipped tests',
+                  'highest-level-describe  leading and trailing spaces    should work with fixme',
+                  'highest-level-describe  leading and trailing spaces    should work with annotated tests'
+                ],
+                'skipped-suite-test.js': [
+                  'should work with fixme root'
+                ],
+                'todo-list-page-test.js': [
+                  'playwright should work with failing tests',
+                  'should work with fixme root'
+                ]
+              }
+            }
+          )
 
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const newTests = tests.filter(test =>
+                test.resource.endsWith('should work with passing tests')
+              )
+              // new tests detected but no retries
+              newTests.forEach(test => {
+                assert.propertyVal(test.meta, TEST_IS_NEW, 'true')
+              })
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.equal(retriedTests.length, 0)
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
         })
       })
-    })
+    }
 
     it('sets _dd.test.is_user_provided_service to true if DD_SERVICE is used', (done) => {
       const receiverPromise = receiver
@@ -914,417 +918,419 @@ versions.forEach((version) => {
       })
     })
 
-    context('test management', () => {
-      context('attempt to fix', () => {
-        beforeEach(() => {
-          receiver.setTestManagementTests({
-            playwright: {
-              suites: {
-                'attempt-to-fix-test.js': {
-                  tests: {
-                    'attempt to fix should attempt to fix failed test': {
-                      properties: {
-                        attempt_to_fix: true
+    if (DD_MAJOR >= 6 || version === 'latest') {
+      context('test management', () => {
+        context('attempt to fix', () => {
+          beforeEach(() => {
+            receiver.setTestManagementTests({
+              playwright: {
+                suites: {
+                  'attempt-to-fix-test.js': {
+                    tests: {
+                      'attempt to fix should attempt to fix failed test': {
+                        properties: {
+                          attempt_to_fix: true
+                        }
                       }
                     }
                   }
                 }
               }
-            }
-          })
-        })
-
-        const getTestAssertions = ({
-          isAttemptingToFix,
-          shouldAlwaysPass,
-          shouldFailSometimes,
-          isDisabled,
-          isQuarantined
-        }) =>
-          receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const tests = events.filter(event => event.type === 'test').map(event => event.content)
-              const testSession = events.find(event => event.type === 'test_session_end').content
-
-              if (isAttemptingToFix) {
-                assert.propertyVal(testSession.meta, TEST_MANAGEMENT_ENABLED, 'true')
-              } else {
-                assert.notProperty(testSession.meta, TEST_MANAGEMENT_ENABLED)
-              }
-
-              const attemptedToFixTests = tests.filter(
-                test => test.meta[TEST_NAME] === 'attempt to fix should attempt to fix failed test'
-              )
-
-              if (isAttemptingToFix) {
-                assert.equal(attemptedToFixTests.length, 4)
-              } else {
-                assert.equal(attemptedToFixTests.length, 1)
-              }
-
-              if (isDisabled) {
-                const numDisabledTests = attemptedToFixTests.filter(test =>
-                  test.meta[TEST_MANAGEMENT_IS_DISABLED] === 'true'
-                ).length
-                assert.equal(numDisabledTests, attemptedToFixTests.length)
-              }
-
-              if (isQuarantined) {
-                const numQuarantinedTests = attemptedToFixTests.filter(test =>
-                  test.meta[TEST_MANAGEMENT_IS_QUARANTINED] === 'true'
-                ).length
-                assert.equal(numQuarantinedTests, attemptedToFixTests.length)
-              }
-
-              // Retried tests are in randomly order, so we just count number of tests
-              const countAttemptToFixTests = attemptedToFixTests.filter(test =>
-                test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true'
-              ).length
-
-              const countRetriedAttemptToFixTests = attemptedToFixTests.filter(test =>
-                test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true' &&
-                test.meta[TEST_IS_RETRY] === 'true' &&
-                test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atf
-              ).length
-
-              const testsMarkedAsFailedAllRetries = attemptedToFixTests.filter(test =>
-                test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true'
-              ).length
-
-              const testsMarkedAsPassedAllRetries = attemptedToFixTests.filter(test =>
-                test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'true'
-              ).length
-
-              const testsMarkedAsFailed = attemptedToFixTests.filter(test =>
-                test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'false'
-              ).length
-
-              if (isAttemptingToFix) {
-                assert.equal(countAttemptToFixTests, attemptedToFixTests.length)
-                assert.equal(countRetriedAttemptToFixTests, attemptedToFixTests.length - 1)
-                if (shouldAlwaysPass) {
-                  assert.equal(testsMarkedAsFailedAllRetries, 0)
-                  assert.equal(testsMarkedAsFailed, 0)
-                  assert.equal(testsMarkedAsPassedAllRetries, 1)
-                } else if (shouldFailSometimes) {
-                  assert.equal(testsMarkedAsFailedAllRetries, 0)
-                  assert.equal(testsMarkedAsFailed, 1)
-                  assert.equal(testsMarkedAsPassedAllRetries, 0)
-                } else { // always fail
-                  assert.equal(testsMarkedAsFailedAllRetries, 1)
-                  assert.equal(testsMarkedAsFailed, 1)
-                  assert.equal(testsMarkedAsPassedAllRetries, 0)
-                }
-              } else {
-                assert.equal(countAttemptToFixTests, 0)
-                assert.equal(countRetriedAttemptToFixTests, 0)
-                assert.equal(testsMarkedAsFailedAllRetries, 0)
-                assert.equal(testsMarkedAsPassedAllRetries, 0)
-              }
             })
+          })
 
-        const runAttemptToFixTest = (done, {
-          isAttemptingToFix,
-          isQuarantined,
-          extraEnvVars,
-          shouldAlwaysPass,
-          shouldFailSometimes,
-          isDisabled
-        } = {}) => {
-          const testAssertionsPromise = getTestAssertions({
+          const getTestAssertions = ({
             isAttemptingToFix,
             shouldAlwaysPass,
             shouldFailSometimes,
             isDisabled,
             isQuarantined
-          })
+          }) =>
+            receiver
+              .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const tests = events.filter(event => event.type === 'test').map(event => event.content)
+                const testSession = events.find(event => event.type === 'test_session_end').content
 
-          childProcess = exec(
-            './node_modules/.bin/playwright test -c playwright.config.js attempt-to-fix-test.js',
-            {
-              cwd,
-              env: {
-                ...getCiVisAgentlessConfig(receiver.port),
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                TEST_DIR: './ci-visibility/playwright-tests-test-management',
-                ...(shouldAlwaysPass ? { SHOULD_ALWAYS_PASS: '1' } : {}),
-                ...(shouldFailSometimes ? { SHOULD_FAIL_SOMETIMES: '1' } : {}),
-                ...extraEnvVars
-              },
-              stdio: 'pipe'
-            }
-          )
+                if (isAttemptingToFix) {
+                  assert.propertyVal(testSession.meta, TEST_MANAGEMENT_ENABLED, 'true')
+                } else {
+                  assert.notProperty(testSession.meta, TEST_MANAGEMENT_ENABLED)
+                }
 
-          childProcess.on('exit', (exitCode) => {
-            testAssertionsPromise.then(() => {
-              if (isQuarantined || isDisabled || shouldAlwaysPass) {
-                // even though a test fails, the exit code is 0 because the test is quarantined
-                assert.equal(exitCode, 0)
-              } else {
-                assert.equal(exitCode, 1)
+                const attemptedToFixTests = tests.filter(
+                  test => test.meta[TEST_NAME] === 'attempt to fix should attempt to fix failed test'
+                )
+
+                if (isAttemptingToFix) {
+                  assert.equal(attemptedToFixTests.length, 4)
+                } else {
+                  assert.equal(attemptedToFixTests.length, 1)
+                }
+
+                if (isDisabled) {
+                  const numDisabledTests = attemptedToFixTests.filter(test =>
+                    test.meta[TEST_MANAGEMENT_IS_DISABLED] === 'true'
+                  ).length
+                  assert.equal(numDisabledTests, attemptedToFixTests.length)
+                }
+
+                if (isQuarantined) {
+                  const numQuarantinedTests = attemptedToFixTests.filter(test =>
+                    test.meta[TEST_MANAGEMENT_IS_QUARANTINED] === 'true'
+                  ).length
+                  assert.equal(numQuarantinedTests, attemptedToFixTests.length)
+                }
+
+                // Retried tests are in randomly order, so we just count number of tests
+                const countAttemptToFixTests = attemptedToFixTests.filter(test =>
+                  test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true'
+                ).length
+
+                const countRetriedAttemptToFixTests = attemptedToFixTests.filter(test =>
+                  test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true' &&
+                  test.meta[TEST_IS_RETRY] === 'true' &&
+                  test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atf
+                ).length
+
+                const testsMarkedAsFailedAllRetries = attemptedToFixTests.filter(test =>
+                  test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true'
+                ).length
+
+                const testsMarkedAsPassedAllRetries = attemptedToFixTests.filter(test =>
+                  test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'true'
+                ).length
+
+                const testsMarkedAsFailed = attemptedToFixTests.filter(test =>
+                  test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED] === 'false'
+                ).length
+
+                if (isAttemptingToFix) {
+                  assert.equal(countAttemptToFixTests, attemptedToFixTests.length)
+                  assert.equal(countRetriedAttemptToFixTests, attemptedToFixTests.length - 1)
+                  if (shouldAlwaysPass) {
+                    assert.equal(testsMarkedAsFailedAllRetries, 0)
+                    assert.equal(testsMarkedAsFailed, 0)
+                    assert.equal(testsMarkedAsPassedAllRetries, 1)
+                  } else if (shouldFailSometimes) {
+                    assert.equal(testsMarkedAsFailedAllRetries, 0)
+                    assert.equal(testsMarkedAsFailed, 1)
+                    assert.equal(testsMarkedAsPassedAllRetries, 0)
+                  } else { // always fail
+                    assert.equal(testsMarkedAsFailedAllRetries, 1)
+                    assert.equal(testsMarkedAsFailed, 1)
+                    assert.equal(testsMarkedAsPassedAllRetries, 0)
+                  }
+                } else {
+                  assert.equal(countAttemptToFixTests, 0)
+                  assert.equal(countRetriedAttemptToFixTests, 0)
+                  assert.equal(testsMarkedAsFailedAllRetries, 0)
+                  assert.equal(testsMarkedAsPassedAllRetries, 0)
+                }
+              })
+
+          const runAttemptToFixTest = (done, {
+            isAttemptingToFix,
+            isQuarantined,
+            extraEnvVars,
+            shouldAlwaysPass,
+            shouldFailSometimes,
+            isDisabled
+          } = {}) => {
+            const testAssertionsPromise = getTestAssertions({
+              isAttemptingToFix,
+              shouldAlwaysPass,
+              shouldFailSometimes,
+              isDisabled,
+              isQuarantined
+            })
+
+            childProcess = exec(
+              './node_modules/.bin/playwright test -c playwright.config.js attempt-to-fix-test.js',
+              {
+                cwd,
+                env: {
+                  ...getCiVisAgentlessConfig(receiver.port),
+                  PW_BASE_URL: `http://localhost:${webAppPort}`,
+                  TEST_DIR: './ci-visibility/playwright-tests-test-management',
+                  ...(shouldAlwaysPass ? { SHOULD_ALWAYS_PASS: '1' } : {}),
+                  ...(shouldFailSometimes ? { SHOULD_FAIL_SOMETIMES: '1' } : {}),
+                  ...extraEnvVars
+                },
+                stdio: 'pipe'
               }
-              done()
-            }).catch(done)
+            )
+
+            childProcess.on('exit', (exitCode) => {
+              testAssertionsPromise.then(() => {
+                if (isQuarantined || isDisabled || shouldAlwaysPass) {
+                  // even though a test fails, the exit code is 0 because the test is quarantined
+                  assert.equal(exitCode, 0)
+                } else {
+                  assert.equal(exitCode, 1)
+                }
+                done()
+              }).catch(done)
+            })
+          }
+
+          it('can attempt to fix and mark last attempt as failed if every attempt fails', (done) => {
+            receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+
+            runAttemptToFixTest(done, { isAttemptingToFix: true })
           })
-        }
 
-        it('can attempt to fix and mark last attempt as failed if every attempt fails', (done) => {
-          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+          it('can attempt to fix and mark last attempt as passed if every attempt passes', (done) => {
+            receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 
-          runAttemptToFixTest(done, { isAttemptingToFix: true })
-        })
+            runAttemptToFixTest(done, { isAttemptingToFix: true, shouldAlwaysPass: true })
+          })
 
-        it('can attempt to fix and mark last attempt as passed if every attempt passes', (done) => {
-          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+          it('can attempt to fix and not mark last attempt if attempts both pass and fail', (done) => {
+            receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 
-          runAttemptToFixTest(done, { isAttemptingToFix: true, shouldAlwaysPass: true })
-        })
+            runAttemptToFixTest(done, { isAttemptingToFix: true, shouldFailSometimes: true })
+          })
 
-        it('can attempt to fix and not mark last attempt if attempts both pass and fail', (done) => {
-          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+          it('does not attempt to fix tests if test management is not enabled', (done) => {
+            receiver.setSettings({ test_management: { enabled: false, attempt_to_fix_retries: 3 } })
 
-          runAttemptToFixTest(done, { isAttemptingToFix: true, shouldFailSometimes: true })
-        })
+            runAttemptToFixTest(done)
+          })
 
-        it('does not attempt to fix tests if test management is not enabled', (done) => {
-          receiver.setSettings({ test_management: { enabled: false, attempt_to_fix_retries: 3 } })
+          it('does not enable attempt to fix tests if DD_TEST_MANAGEMENT_ENABLED is set to false', (done) => {
+            receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 
-          runAttemptToFixTest(done)
-        })
+            runAttemptToFixTest(done, { extraEnvVars: { DD_TEST_MANAGEMENT_ENABLED: '0' } })
+          })
 
-        it('does not enable attempt to fix tests if DD_TEST_MANAGEMENT_ENABLED is set to false', (done) => {
-          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
-
-          runAttemptToFixTest(done, { extraEnvVars: { DD_TEST_MANAGEMENT_ENABLED: '0' } })
-        })
-
-        it('does not fail retry if a test is quarantined', (done) => {
-          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
-          receiver.setTestManagementTests({
-            playwright: {
-              suites: {
-                'attempt-to-fix-test.js': {
-                  tests: {
-                    'attempt to fix should attempt to fix failed test': {
-                      properties: {
-                        attempt_to_fix: true,
-                        quarantined: true
+          it('does not fail retry if a test is quarantined', (done) => {
+            receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+            receiver.setTestManagementTests({
+              playwright: {
+                suites: {
+                  'attempt-to-fix-test.js': {
+                    tests: {
+                      'attempt to fix should attempt to fix failed test': {
+                        properties: {
+                          attempt_to_fix: true,
+                          quarantined: true
+                        }
                       }
                     }
                   }
                 }
-              }
-            }
-          })
-
-          runAttemptToFixTest(done, { isAttemptingToFix: true, isQuarantined: true })
-        })
-
-        it('does not fail retry if a test is disabled', (done) => {
-          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
-          receiver.setTestManagementTests({
-            playwright: {
-              suites: {
-                'attempt-to-fix-test.js': {
-                  tests: {
-                    'attempt to fix should attempt to fix failed test': {
-                      properties: {
-                        attempt_to_fix: true,
-                        disabled: true
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          })
-
-          runAttemptToFixTest(done, { isAttemptingToFix: true, isDisabled: true })
-        })
-      })
-
-      context('disabled', () => {
-        beforeEach(() => {
-          receiver.setTestManagementTests({
-            playwright: {
-              suites: {
-                'disabled-test.js': {
-                  tests: {
-                    'disable should disable test': {
-                      properties: {
-                        disabled: true
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          })
-        })
-
-        const getTestAssertions = (isDisabling) =>
-          receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-
-              const testSession = events.find(event => event.type === 'test_session_end').content
-              if (isDisabling) {
-                assert.propertyVal(testSession.meta, TEST_MANAGEMENT_ENABLED, 'true')
-              } else {
-                assert.notProperty(testSession.meta, TEST_MANAGEMENT_ENABLED)
-              }
-
-              const skippedTest = events.find(event => event.type === 'test').content
-
-              if (isDisabling) {
-                assert.equal(skippedTest.meta[TEST_STATUS], 'skip')
-                assert.propertyVal(skippedTest.meta, TEST_MANAGEMENT_IS_DISABLED, 'true')
-              } else {
-                assert.equal(skippedTest.meta[TEST_STATUS], 'fail')
-                assert.notProperty(skippedTest.meta, TEST_MANAGEMENT_IS_DISABLED)
               }
             })
 
-        const runDisableTest = (done, isDisabling, extraEnvVars) => {
-          const testAssertionsPromise = getTestAssertions(isDisabling)
-
-          childProcess = exec(
-            './node_modules/.bin/playwright test -c playwright.config.js disabled-test.js',
-            {
-              cwd,
-              env: {
-                ...getCiVisAgentlessConfig(receiver.port),
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                TEST_DIR: './ci-visibility/playwright-tests-test-management',
-                ...extraEnvVars
-              },
-              stdio: 'pipe'
-            }
-          )
-
-          childProcess.on('exit', (exitCode) => {
-            testAssertionsPromise.then(() => {
-              if (isDisabling) {
-                assert.equal(exitCode, 0)
-              } else {
-                assert.equal(exitCode, 1)
-              }
-              done()
-            }).catch(done)
+            runAttemptToFixTest(done, { isAttemptingToFix: true, isQuarantined: true })
           })
-        }
 
-        it('can disable tests', (done) => {
-          receiver.setSettings({ test_management: { enabled: true } })
-
-          runDisableTest(done, true)
-        })
-
-        it('fails if disable is not enabled', (done) => {
-          receiver.setSettings({ test_management: { enabled: false } })
-
-          runDisableTest(done, false)
-        })
-
-        it('does not enable disable tests if DD_TEST_MANAGEMENT_ENABLED is set to false', (done) => {
-          receiver.setSettings({ test_management: { enabled: true } })
-
-          runDisableTest(done, false, { DD_TEST_MANAGEMENT_ENABLED: '0' })
-        })
-      })
-
-      context('quarantine', () => {
-        beforeEach(() => {
-          receiver.setTestManagementTests({
-            playwright: {
-              suites: {
-                'quarantine-test.js': {
-                  tests: {
-                    'quarantine should quarantine failed test': {
-                      properties: {
-                        quarantined: true
+          it('does not fail retry if a test is disabled', (done) => {
+            receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+            receiver.setTestManagementTests({
+              playwright: {
+                suites: {
+                  'attempt-to-fix-test.js': {
+                    tests: {
+                      'attempt to fix should attempt to fix failed test': {
+                        properties: {
+                          attempt_to_fix: true,
+                          disabled: true
+                        }
                       }
                     }
                   }
                 }
               }
-            }
-          })
-        })
-
-        const getTestAssertions = (isQuarantining) =>
-          receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-
-              const testSession = events.find(event => event.type === 'test_session_end').content
-              if (isQuarantining) {
-                assert.propertyVal(testSession.meta, TEST_MANAGEMENT_ENABLED, 'true')
-              } else {
-                assert.notProperty(testSession.meta, TEST_MANAGEMENT_ENABLED)
-              }
-
-              const failedTest = events.find(event => event.type === 'test').content
-
-              if (isQuarantining) {
-                // TODO: manage to run the test
-                assert.equal(failedTest.meta[TEST_STATUS], 'skip')
-                assert.propertyVal(failedTest.meta, TEST_MANAGEMENT_IS_QUARANTINED, 'true')
-              } else {
-                assert.equal(failedTest.meta[TEST_STATUS], 'fail')
-                assert.notProperty(failedTest.meta, TEST_MANAGEMENT_IS_QUARANTINED)
-              }
             })
 
-        const runQuarantineTest = (done, isQuarantining, extraEnvVars) => {
-          const testAssertionsPromise = getTestAssertions(isQuarantining)
-
-          childProcess = exec(
-            './node_modules/.bin/playwright test -c playwright.config.js quarantine-test.js',
-            {
-              cwd,
-              env: {
-                ...getCiVisAgentlessConfig(receiver.port),
-                PW_BASE_URL: `http://localhost:${webAppPort}`,
-                TEST_DIR: './ci-visibility/playwright-tests-test-management',
-                ...extraEnvVars
-              },
-              stdio: 'pipe'
-            }
-          )
-
-          childProcess.on('exit', (exitCode) => {
-            testAssertionsPromise.then(() => {
-              if (isQuarantining) {
-                assert.equal(exitCode, 0)
-              } else {
-                assert.equal(exitCode, 1)
-              }
-              done()
-            }).catch(done)
+            runAttemptToFixTest(done, { isAttemptingToFix: true, isDisabled: true })
           })
-        }
-
-        it('can quarantine tests', (done) => {
-          receiver.setSettings({ test_management: { enabled: true } })
-
-          runQuarantineTest(done, true)
         })
 
-        it('fails if quarantine is not enabled', (done) => {
-          receiver.setSettings({ test_management: { enabled: false } })
+        context('disabled', () => {
+          beforeEach(() => {
+            receiver.setTestManagementTests({
+              playwright: {
+                suites: {
+                  'disabled-test.js': {
+                    tests: {
+                      'disable should disable test': {
+                        properties: {
+                          disabled: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            })
+          })
 
-          runQuarantineTest(done, false)
+          const getTestAssertions = (isDisabling) =>
+            receiver
+              .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+
+                const testSession = events.find(event => event.type === 'test_session_end').content
+                if (isDisabling) {
+                  assert.propertyVal(testSession.meta, TEST_MANAGEMENT_ENABLED, 'true')
+                } else {
+                  assert.notProperty(testSession.meta, TEST_MANAGEMENT_ENABLED)
+                }
+
+                const skippedTest = events.find(event => event.type === 'test').content
+
+                if (isDisabling) {
+                  assert.equal(skippedTest.meta[TEST_STATUS], 'skip')
+                  assert.propertyVal(skippedTest.meta, TEST_MANAGEMENT_IS_DISABLED, 'true')
+                } else {
+                  assert.equal(skippedTest.meta[TEST_STATUS], 'fail')
+                  assert.notProperty(skippedTest.meta, TEST_MANAGEMENT_IS_DISABLED)
+                }
+              })
+
+          const runDisableTest = (done, isDisabling, extraEnvVars) => {
+            const testAssertionsPromise = getTestAssertions(isDisabling)
+
+            childProcess = exec(
+              './node_modules/.bin/playwright test -c playwright.config.js disabled-test.js',
+              {
+                cwd,
+                env: {
+                  ...getCiVisAgentlessConfig(receiver.port),
+                  PW_BASE_URL: `http://localhost:${webAppPort}`,
+                  TEST_DIR: './ci-visibility/playwright-tests-test-management',
+                  ...extraEnvVars
+                },
+                stdio: 'pipe'
+              }
+            )
+
+            childProcess.on('exit', (exitCode) => {
+              testAssertionsPromise.then(() => {
+                if (isDisabling) {
+                  assert.equal(exitCode, 0)
+                } else {
+                  assert.equal(exitCode, 1)
+                }
+                done()
+              }).catch(done)
+            })
+          }
+
+          it('can disable tests', (done) => {
+            receiver.setSettings({ test_management: { enabled: true } })
+
+            runDisableTest(done, true)
+          })
+
+          it('fails if disable is not enabled', (done) => {
+            receiver.setSettings({ test_management: { enabled: false } })
+
+            runDisableTest(done, false)
+          })
+
+          it('does not enable disable tests if DD_TEST_MANAGEMENT_ENABLED is set to false', (done) => {
+            receiver.setSettings({ test_management: { enabled: true } })
+
+            runDisableTest(done, false, { DD_TEST_MANAGEMENT_ENABLED: '0' })
+          })
         })
 
-        it('does not enable quarantine tests if DD_TEST_MANAGEMENT_ENABLED is set to false', (done) => {
-          receiver.setSettings({ test_management: { enabled: true } })
+        context('quarantine', () => {
+          beforeEach(() => {
+            receiver.setTestManagementTests({
+              playwright: {
+                suites: {
+                  'quarantine-test.js': {
+                    tests: {
+                      'quarantine should quarantine failed test': {
+                        properties: {
+                          quarantined: true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            })
+          })
 
-          runQuarantineTest(done, false, { DD_TEST_MANAGEMENT_ENABLED: '0' })
+          const getTestAssertions = (isQuarantining) =>
+            receiver
+              .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+
+                const testSession = events.find(event => event.type === 'test_session_end').content
+                if (isQuarantining) {
+                  assert.propertyVal(testSession.meta, TEST_MANAGEMENT_ENABLED, 'true')
+                } else {
+                  assert.notProperty(testSession.meta, TEST_MANAGEMENT_ENABLED)
+                }
+
+                const failedTest = events.find(event => event.type === 'test').content
+
+                if (isQuarantining) {
+                  // TODO: manage to run the test
+                  assert.equal(failedTest.meta[TEST_STATUS], 'skip')
+                  assert.propertyVal(failedTest.meta, TEST_MANAGEMENT_IS_QUARANTINED, 'true')
+                } else {
+                  assert.equal(failedTest.meta[TEST_STATUS], 'fail')
+                  assert.notProperty(failedTest.meta, TEST_MANAGEMENT_IS_QUARANTINED)
+                }
+              })
+
+          const runQuarantineTest = (done, isQuarantining, extraEnvVars) => {
+            const testAssertionsPromise = getTestAssertions(isQuarantining)
+
+            childProcess = exec(
+              './node_modules/.bin/playwright test -c playwright.config.js quarantine-test.js',
+              {
+                cwd,
+                env: {
+                  ...getCiVisAgentlessConfig(receiver.port),
+                  PW_BASE_URL: `http://localhost:${webAppPort}`,
+                  TEST_DIR: './ci-visibility/playwright-tests-test-management',
+                  ...extraEnvVars
+                },
+                stdio: 'pipe'
+              }
+            )
+
+            childProcess.on('exit', (exitCode) => {
+              testAssertionsPromise.then(() => {
+                if (isQuarantining) {
+                  assert.equal(exitCode, 0)
+                } else {
+                  assert.equal(exitCode, 1)
+                }
+                done()
+              }).catch(done)
+            })
+          }
+
+          it('can quarantine tests', (done) => {
+            receiver.setSettings({ test_management: { enabled: true } })
+
+            runQuarantineTest(done, true)
+          })
+
+          it('fails if quarantine is not enabled', (done) => {
+            receiver.setSettings({ test_management: { enabled: false } })
+
+            runQuarantineTest(done, false)
+          })
+
+          it('does not enable quarantine tests if DD_TEST_MANAGEMENT_ENABLED is set to false', (done) => {
+            receiver.setSettings({ test_management: { enabled: true } })
+
+            runQuarantineTest(done, false, { DD_TEST_MANAGEMENT_ENABLED: '0' })
+          })
         })
       })
-    })
+    }
 
     context('libraries capabilities', () => {
       it('adds capabilities to tests', (done) => {
@@ -1367,121 +1373,125 @@ versions.forEach((version) => {
       })
     })
 
-    context('active test span', () => {
-      it('can grab the test span and add tags', (done) => {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
+    if (DD_MAJOR >= 6 || version === 'latest') {
+      context('active test span', () => {
+        it('can grab the test span and add tags', (done) => {
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
 
-            const test = events.find(event => event.type === 'test').content
+              const test = events.find(event => event.type === 'test').content
 
-            assert.equal(test.meta['test.custom_tag'], 'this is custom')
-          })
-
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js active-test-span-tags-test.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`,
-              TEST_DIR: './ci-visibility/playwright-tests-active-test-span'
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
-        })
-      })
-
-      it('can grab the test span and add spans', (done) => {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            const test = events.find(event => event.type === 'test').content
-            const spans = events.filter(event => event.type === 'span').map(event => event.content)
-
-            const customSpan = spans.find(span => span.name === 'my custom span')
-
-            assert.exists(customSpan)
-            assert.equal(customSpan.meta['test.really_custom_tag'], 'this is really custom')
-
-            // custom span is children of active test span
-            assert.equal(customSpan.trace_id.toString(), test.trace_id.toString())
-            assert.equal(customSpan.parent_id.toString(), test.span_id.toString())
-          })
-
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js active-test-span-custom-span-test.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${webAppPort}`,
-              TEST_DIR: './ci-visibility/playwright-tests-active-test-span'
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          receiverPromise.then(() => done()).catch(done)
-        })
-      })
-    })
-
-    context('correlation between tests and RUM sessions', () => {
-      const getTestAssertions = ({ isRedirecting }) =>
-        receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const playwrightTest = events.find(event => event.type === 'test').content
-            if (isRedirecting) {
-              assert.notProperty(playwrightTest.meta, TEST_IS_RUM_ACTIVE)
-              assert.notProperty(playwrightTest.meta, TEST_BROWSER_VERSION)
-            } else {
-              assert.property(playwrightTest.meta, TEST_IS_RUM_ACTIVE, 'true')
-              assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
-            }
-            assert.include(playwrightTest.meta, {
-              [TEST_BROWSER_NAME]: 'chromium',
-              [TEST_TYPE]: 'browser'
+              assert.equal(test.meta['test.custom_tag'], 'this is custom')
             })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-tags-test.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                TEST_DIR: './ci-visibility/playwright-tests-active-test-span'
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
           })
-
-      const runTest = (done, { isRedirecting }, extraEnvVars) => {
-        const testAssertionsPromise = getTestAssertions({ isRedirecting })
-
-        childProcess = exec(
-          './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
-          {
-            cwd,
-            env: {
-              ...getCiVisAgentlessConfig(receiver.port),
-              PW_BASE_URL: `http://localhost:${isRedirecting ? webPortWithRedirect : webAppPort}`,
-              TEST_DIR: './ci-visibility/playwright-tests-rum',
-              ...extraEnvVars
-            },
-            stdio: 'pipe'
-          }
-        )
-
-        childProcess.on('exit', () => {
-          testAssertionsPromise.then(() => done()).catch(done)
         })
-      }
 
-      it('can correlate tests and RUM sessions', (done) => {
-        runTest(done, { isRedirecting: false })
-      })
+        it('can grab the test span and add spans', (done) => {
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
 
-      it('do not crash when redirecting and RUM sessions are not active', (done) => {
-        runTest(done, { isRedirecting: true })
+              const test = events.find(event => event.type === 'test').content
+              const spans = events.filter(event => event.type === 'span').map(event => event.content)
+
+              const customSpan = spans.find(span => span.name === 'my custom span')
+
+              assert.exists(customSpan)
+              assert.equal(customSpan.meta['test.really_custom_tag'], 'this is really custom')
+
+              // custom span is children of active test span
+              assert.equal(customSpan.trace_id.toString(), test.trace_id.toString())
+              assert.equal(customSpan.parent_id.toString(), test.span_id.toString())
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-custom-span-test.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${webAppPort}`,
+                TEST_DIR: './ci-visibility/playwright-tests-active-test-span'
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            receiverPromise.then(() => done()).catch(done)
+          })
+        })
       })
-    })
+    }
+
+    if (DD_MAJOR >= 6 || version === 'latest') {
+      context('correlation between tests and RUM sessions', () => {
+        const getTestAssertions = ({ isRedirecting }) =>
+          receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const playwrightTest = events.find(event => event.type === 'test').content
+              if (isRedirecting) {
+                assert.notProperty(playwrightTest.meta, TEST_IS_RUM_ACTIVE)
+                assert.notProperty(playwrightTest.meta, TEST_BROWSER_VERSION)
+              } else {
+                assert.property(playwrightTest.meta, TEST_IS_RUM_ACTIVE, 'true')
+                assert.property(playwrightTest.meta, TEST_BROWSER_VERSION)
+              }
+              assert.include(playwrightTest.meta, {
+                [TEST_BROWSER_NAME]: 'chromium',
+                [TEST_TYPE]: 'browser'
+              })
+            })
+
+        const runTest = (done, { isRedirecting }, extraEnvVars) => {
+          const testAssertionsPromise = getTestAssertions({ isRedirecting })
+
+          childProcess = exec(
+            './node_modules/.bin/playwright test -c playwright.config.js active-test-span-rum-test.js',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                PW_BASE_URL: `http://localhost:${isRedirecting ? webPortWithRedirect : webAppPort}`,
+                TEST_DIR: './ci-visibility/playwright-tests-rum',
+                ...extraEnvVars
+              },
+              stdio: 'pipe'
+            }
+          )
+
+          childProcess.on('exit', () => {
+            testAssertionsPromise.then(() => done()).catch(done)
+          })
+        }
+
+        it('can correlate tests and RUM sessions', (done) => {
+          runTest(done, { isRedirecting: false })
+        })
+
+        it('do not crash when redirecting and RUM sessions are not active', (done) => {
+          runTest(done, { isRedirecting: true })
+        })
+      })
+    }
 
     context('run session status', () => {
       it('session status is not changed if it fails before running any test', (done) => {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1,3 +1,5 @@
+const satisfies = require('semifies')
+
 const { addHook, channel, AsyncResource } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 const {
@@ -54,6 +56,7 @@ let testManagementAttemptToFixRetries = 0
 let testManagementTests = {}
 const quarantinedOrDisabledTestsAttemptToFix = []
 let rootDir = ''
+const MINIMUM_SUPPORTED_VERSION_RANGE_EFD = '>=1.38.0' // TODO: remove this once we drop support for v5
 
 function getTestProperties (test) {
   const testName = getTestFullname(test)
@@ -524,7 +527,7 @@ function runnerHook (runnerExport, playwrightVersion) {
       log.error('Playwright session start error', e)
     }
 
-    if (isKnownTestsEnabled) {
+    if (isKnownTestsEnabled && satisfies(playwrightVersion, MINIMUM_SUPPORTED_VERSION_RANGE_EFD)) {
       try {
         const { err, knownTests: receivedKnownTests } = await getChannelPromise(knownTestsCh)
         if (!err) {
@@ -540,7 +543,7 @@ function runnerHook (runnerExport, playwrightVersion) {
       }
     }
 
-    if (isTestManagementTestsEnabled) {
+    if (isTestManagementTestsEnabled && satisfies(playwrightVersion, MINIMUM_SUPPORTED_VERSION_RANGE_EFD)) {
       try {
         const { err, testManagementTests: receivedTestManagementTests } = await getChannelPromise(testManagementTestsCh)
         if (!err) {
@@ -668,7 +671,7 @@ addHook({
   name: 'playwright',
   file: 'lib/runner/dispatcher.js',
   versions: ['>=1.38.0']
-}, (dispatcher, version) => dispatcherHookNew(dispatcher, dispatcherRunWrapperNew, version))
+}, (dispatcher) => dispatcherHookNew(dispatcher, dispatcherRunWrapperNew))
 
 addHook({
   name: 'playwright',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This change will exclude tests that were not supposed to be run in older versions of Playwright (`<1.38`).

### Motivation
<!-- What inspired you to submit this pull request? -->
There was a failure in the CI when the tests were run in the `v5` of the tracer.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Integration tests.


