### PR TITLE
ci(aws-sdk): fix bedrock runtime tests failing

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
@@ -23,11 +23,15 @@ describe('Plugin', () => {
         })
 
         before(done => {
-          // TODO: Remove `<3.798.0` limit once our tests support newer versions
-          const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0 <3.798.0'
+          const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0'
           AWS = require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`).get()
+          const NodeHttpHandler =
+            require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`)
+              .get('@smithy/node-http-handler')
+              .NodeHttpHandler
+
           bedrockRuntimeClient = new AWS.BedrockRuntimeClient(
-            { endpoint: 'http://127.0.0.1:4566', region: 'us-east-1', ServiceId: serviceName }
+            { endpoint: 'http://127.0.0.1:4566', region: 'us-east-1', ServiceId: serviceName, requestHandler: new NodeHttpHandler() }
           )
           done()
         })

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -51,7 +51,7 @@ describe('Plugin', () => {
           const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0'
           AWS = require(`../../../../../../versions/${bedrockRuntimeClientName}@${requireVersion}`).get()
           const NodeHttpHandler =
-            require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`)
+            require(`../../../../../../versions/${bedrockRuntimeClientName}@${requireVersion}`)
               .get('@smithy/node-http-handler')
               .NodeHttpHandler
 

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -48,11 +48,15 @@ describe('Plugin', () => {
         })
 
         before(done => {
-          // TODO: Remove `<3.798.0` limit once our tests support newer versions
-          const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0 <3.798.0'
+          const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0'
           AWS = require(`../../../../../../versions/${bedrockRuntimeClientName}@${requireVersion}`).get()
+          const NodeHttpHandler =
+            require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`)
+              .get('@smithy/node-http-handler')
+              .NodeHttpHandler
+
           bedrockRuntimeClient = new AWS.BedrockRuntimeClient(
-            { endpoint: 'http://127.0.0.1:4566', region: 'us-east-1', ServiceId: serviceName }
+            { endpoint: 'http://127.0.0.1:4566', region: 'us-east-1', ServiceId: serviceName, requestHandler: new NodeHttpHandler() }
           )
           done()
         })

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -52,7 +52,7 @@
     },
     {
       "name": "@aws-sdk/client-bedrock-runtime",
-      "versions": [">=3.422.0 <3.798.0"]
+      "versions": [">=3.422.0"]
     }
   ],
   "body-parser": [


### PR DESCRIPTION
### What does this PR do?
Fixes AWS Bedrock Runtime tests to use a `NodeHttpHandler` from `@smithy/node-http-handler` so we can properly stub requests.

### Motivation
Test latest versions of bedrock. This fix should have been done a month ago but was deprioritized at the time. Looks like there was no regression in the time the tests were disabled.

Closes #5628
MLOB-2678


