### PR TITLE
fix bindings not applying for noop stores

### DIFF
--- a/packages/datadog-plugin-apollo/src/gateway/fetch.js
+++ b/packages/datadog-plugin-apollo/src/gateway/fetch.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
@@ -9,8 +8,8 @@ class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
     return 'tracing:apm:apollo:gateway:fetch'
   }
 
-  bindStart (ctx) {
-    const store = storage('legacy').getStore()
+  start (ctx) {
+    const store = ctx.parentStore
     const childOf = store ? store.span : null
 
     const spanData = {
@@ -24,12 +23,7 @@ class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
 
     if (serviceName) { spanData.meta.serviceName = serviceName }
 
-    const span = this.startSpan(this.getOperationName(), spanData, false)
-
-    ctx.parentStore = store
-    ctx.currentStore = { ...store, span }
-
-    return ctx.currentStore
+    this.startSpan(this.getOperationName(), spanData, ctx)
   }
 }
 

--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 let tools
@@ -14,8 +13,8 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
     return 'tracing:apm:apollo:gateway:request'
   }
 
-  bindStart (ctx) {
-    const store = storage('legacy').getStore()
+  start (ctx) {
+    const store = ctx.parentStore
     const childOf = store ? store.span : null
     const spanData = {
       childOf,
@@ -46,12 +45,7 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
       spanData.resource = getSignature(document, name, type, this?.config?.signature)
       spanData.meta['graphql.operation.type'] = type
     }
-    const span = this.startSpan(this.operationName({ id: `${this.constructor.id}.${this.constructor.operation}` }),
-      spanData, false)
-
-    ctx.parentStore = store
-    ctx.currentStore = { ...store, span }
-    return ctx.currentStore
+    this.startSpan(this.operationName({ id: `${this.constructor.id}.${this.constructor.operation}` }), spanData, ctx)
   }
 
   asyncStart (ctx) {

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
-const { storage } = require('../../datadog-core')
 const serverless = require('../../dd-trace/src/plugins/util/serverless')
 const web = require('../../dd-trace/src/plugins/util/web')
 
@@ -22,9 +21,8 @@ class AzureFunctionsPlugin extends TracingPlugin {
 
   static get prefix () { return 'tracing:datadog:azure:functions:invoke' }
 
-  bindStart (ctx) {
+  start (ctx) {
     const { functionName, methodName } = ctx
-    const store = storage('legacy').getStore()
 
     const span = this.startSpan(this.operationName(), {
       service: this.serviceName(),
@@ -33,13 +31,9 @@ class AzureFunctionsPlugin extends TracingPlugin {
         'aas.function.name': functionName,
         'aas.function.trigger': mapTriggerTag(methodName)
       }
-    }, false)
+    }, ctx)
 
     ctx.span = span
-    ctx.parentStore = store
-    ctx.currentStore = { ...store, span }
-
-    return ctx.currentStore
   }
 
   error (ctx) {

--- a/packages/datadog-plugin-dns/src/lookup.js
+++ b/packages/datadog-plugin-dns/src/lookup.js
@@ -6,7 +6,7 @@ class DNSLookupPlugin extends ClientPlugin {
   static get id () { return 'dns' }
   static get operation () { return 'lookup' }
 
-  bindStart (ctx) {
+  start (ctx) {
     const [hostname] = ctx.args
 
     this.startSpan('dns.lookup', {
@@ -19,11 +19,9 @@ class DNSLookupPlugin extends ClientPlugin {
         'dns.addresses': ''
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 
-  bindFinish (ctx) {
+  finish (ctx) {
     const span = ctx.currentStore.span
     const result = ctx.result
 
@@ -38,7 +36,7 @@ class DNSLookupPlugin extends ClientPlugin {
       span.setTag('dns.address', result)
     }
 
-    return ctx.parentStore
+    super.finish(ctx)
   }
 }
 

--- a/packages/datadog-plugin-dns/src/lookup_service.js
+++ b/packages/datadog-plugin-dns/src/lookup_service.js
@@ -6,7 +6,7 @@ class DNSLookupServicePlugin extends ClientPlugin {
   static get id () { return 'dns' }
   static get operation () { return 'lookup_service' }
 
-  bindStart (ctx) {
+  start (ctx) {
     const [address, port] = ctx.args
 
     this.startSpan('dns.lookup_service', {
@@ -20,8 +20,6 @@ class DNSLookupServicePlugin extends ClientPlugin {
         'dns.port': port
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 }
 

--- a/packages/datadog-plugin-dns/src/resolve.js
+++ b/packages/datadog-plugin-dns/src/resolve.js
@@ -6,7 +6,7 @@ class DNSResolvePlugin extends ClientPlugin {
   static get id () { return 'dns' }
   static get operation () { return 'resolve' }
 
-  bindStart (ctx) {
+  start (ctx) {
     const [hostname, maybeType] = ctx.args
     const rrtype = typeof maybeType === 'string' ? maybeType : 'A'
 
@@ -19,8 +19,6 @@ class DNSResolvePlugin extends ClientPlugin {
         'dns.rrtype': rrtype
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 }
 

--- a/packages/datadog-plugin-dns/src/reverse.js
+++ b/packages/datadog-plugin-dns/src/reverse.js
@@ -6,7 +6,7 @@ class DNSReversePlugin extends ClientPlugin {
   static get id () { return 'dns' }
   static get operation () { return 'reverse' }
 
-  bindStart (ctx) {
+  start (ctx) {
     const [ip] = ctx.args
 
     this.startSpan('dns.reverse', {
@@ -17,8 +17,6 @@ class DNSReversePlugin extends ClientPlugin {
         'dns.ip': ip
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 }
 

--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -6,7 +6,7 @@ class FetchPlugin extends HttpClientPlugin {
   static get id () { return 'fetch' }
   static get prefix () { return 'tracing:apm:fetch:request' }
 
-  bindStart (ctx) {
+  start (ctx) {
     const req = ctx.req
     const options = new URL(req.url)
     options.headers = Object.fromEntries(req.headers.entries())
@@ -15,15 +15,13 @@ class FetchPlugin extends HttpClientPlugin {
 
     ctx.args = { options }
 
-    const store = super.bindStart(ctx)
+    super.start(ctx)
 
     for (const name in options.headers) {
       if (!req.headers.has(name)) {
         req.headers.set(name, options.headers[name])
       }
     }
-
-    return store
   }
 
   error (ctx) {

--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -10,7 +10,7 @@ class FsPlugin extends TracingPlugin {
     return super.configure(...args)
   }
 
-  bindStart (ctx) {
+  start (ctx) {
     if (!this.activeSpan) return this.skip()
 
     const { operation, ...params } = ctx
@@ -40,8 +40,6 @@ class FsPlugin extends TracingPlugin {
         'file.uid': uid || ''
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 
   bindFinish (ctx) {

--- a/packages/datadog-plugin-google-cloud-vertexai/src/tracing.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/src/tracing.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { MEASURED } = require('../../../ext/tags')
-const { storage } = require('../../datadog-core')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 const makeUtilities = require('../../dd-trace/src/plugins/util/llm')
 
@@ -22,7 +21,7 @@ class GoogleCloudVertexAITracingPlugin extends TracingPlugin {
     Object.assign(this, makeUtilities('vertexai', this._tracerConfig))
   }
 
-  bindStart (ctx) {
+  start (ctx) {
     const { instance, request, resource, stream } = ctx
 
     const span = this.startSpan('vertexai.request', {
@@ -32,15 +31,10 @@ class GoogleCloudVertexAITracingPlugin extends TracingPlugin {
       meta: {
         [MEASURED]: 1
       }
-    }, false)
+    }, ctx)
 
     const tags = this.tagRequest(request, instance, stream, span)
     span.addTags(tags)
-
-    const store = storage('legacy').getStore() || {}
-    ctx.currentStore = { ...store, span }
-
-    return ctx.currentStore
   }
 
   asyncEnd (ctx) {

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -19,8 +18,7 @@ class GrpcClientPlugin extends ClientPlugin {
     })
   }
 
-  bindStart (message) {
-    const store = storage('legacy').getStore()
+  start (message) {
     const { metadata, path, type } = message
     const metadataFilter = this.config.metadataFilter
     const method = getMethodMetadata(path, type)
@@ -40,7 +38,7 @@ class GrpcClientPlugin extends ClientPlugin {
       metrics: {
         'grpc.status.code': 0
       }
-    }, false)
+    }, message)
     // needed as precursor for peer.service
     if (method.service && method.package) {
       span.setTag('rpc.service', method.package + '.' + method.service)
@@ -52,10 +50,6 @@ class GrpcClientPlugin extends ClientPlugin {
     }
 
     message.span = span
-    message.parentStore = store
-    message.currentStore = { ...store, span }
-
-    return message.currentStore
   }
 
   bindAsyncStart ({ parentStore }) {

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { storage } = require('../../datadog-core')
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
@@ -26,8 +25,7 @@ class GrpcServerPlugin extends ServerPlugin {
     })
   }
 
-  bindStart (message) {
-    const store = storage('legacy').getStore()
+  start (message) {
     const { name, metadata, type } = message
     const metadataFilter = this.config.metadataFilter
     const childOf = extract(this.tracer, metadata)
@@ -54,10 +52,6 @@ class GrpcServerPlugin extends ServerPlugin {
     addMetadataTags(span, metadata, metadataFilter, 'request')
 
     message.span = span
-    message.parentStore = store
-    message.currentStore = { ...store, span }
-
-    return message.currentStore
   }
 
   bindAsyncStart ({ parentStore }) {

--- a/packages/datadog-plugin-langchain/src/tracing.js
+++ b/packages/datadog-plugin-langchain/src/tracing.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { MEASURED } = require('../../../ext/tags')
-const { storage } = require('../../datadog-core')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
 const API_KEY = 'langchain.request.api_key'
@@ -32,7 +31,7 @@ class BaseLangChainTracingPlugin extends TracingPlugin {
     }
   }
 
-  bindStart (ctx) {
+  start (ctx) {
     // TODO(bengl): All this renaming is just so we don't have to change the existing handlers
     ctx.args = ctx.arguments
     ctx.instance = ctx.self
@@ -56,7 +55,7 @@ class BaseLangChainTracingPlugin extends TracingPlugin {
       meta: {
         [MEASURED]: 1
       }
-    }, false)
+    }, ctx)
 
     const tags = handler.getSpanStartTags(ctx, provider, span) || []
 
@@ -66,11 +65,6 @@ class BaseLangChainTracingPlugin extends TracingPlugin {
     if (type) tags[TYPE] = type
 
     span.addTags(tags)
-
-    const store = storage('legacy').getStore() || {}
-    ctx.currentStore = { ...store, span }
-
-    return ctx.currentStore
   }
 
   asyncEnd (ctx) {

--- a/packages/datadog-plugin-net/src/ipc.js
+++ b/packages/datadog-plugin-net/src/ipc.js
@@ -6,7 +6,7 @@ class NetIPCPlugin extends ClientPlugin {
   static get id () { return 'net' }
   static get operation () { return 'ipc' }
 
-  bindStart (ctx) {
+  start (ctx) {
     this.startSpan('ipc.connect', {
       service: this.config.service,
       resource: ctx.options.path,
@@ -15,8 +15,6 @@ class NetIPCPlugin extends ClientPlugin {
         'ipc.path': ctx.options.path
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 }
 

--- a/packages/datadog-plugin-net/src/tcp.js
+++ b/packages/datadog-plugin-net/src/tcp.js
@@ -24,7 +24,7 @@ class NetTCPPlugin extends ClientPlugin {
     })
   }
 
-  bindStart (ctx) {
+  start (ctx) {
     const host = ctx.options.host || 'localhost'
     const port = ctx.options.port || 0
     const family = ctx.options.family || 4
@@ -45,8 +45,6 @@ class NetTCPPlugin extends ClientPlugin {
         [CLIENT_PORT_KEY]: port
       }
     }, ctx)
-
-    return ctx.currentStore
   }
 }
 

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -19,8 +19,8 @@ class NextPlugin extends ServerPlugin {
     this.addSub('apm:next:page:load', message => this.pageLoad(message))
   }
 
-  bindStart ({ req, res }) {
-    const store = storage('legacy').getStore()
+  start ({ parentStore, req, res }) {
+    const store = parentStore
     const childOf = store ? store.span : store
     const span = this.tracer.startSpan(this.operationName(), {
       childOf,
@@ -37,8 +37,6 @@ class NextPlugin extends ServerPlugin {
     analyticsSampler.sample(span, this.config.measured, true)
 
     this._requests.set(span, req)
-
-    return { ...store, span }
   }
 
   error ({ span, error }) {

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -1,13 +1,12 @@
 const TracingPlugin = require('./tracing')
-const { storage } = require('../../../datadog-core')
 
 class ApolloBasePlugin extends TracingPlugin {
   static get id () { return 'apollo.gateway' }
   static get type () { return 'web' }
   static get kind () { return 'server' }
 
-  bindStart (ctx) {
-    const store = storage('legacy').getStore()
+  start (ctx) {
+    const store = ctx.parentStore
     const childOf = store ? store.span : null
 
     const span = this.startSpan(this.getOperationName(), {
@@ -16,7 +15,7 @@ class ApolloBasePlugin extends TracingPlugin {
       type: this.constructor.type,
       kind: this.constructor.kind,
       meta: {}
-    }, false)
+    }, ctx)
 
     ctx.parentStore = store
     ctx.currentStore = { ...store, span }

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -31,13 +31,7 @@ class Subscription {
 class StoreBinding {
   constructor (event, transform) {
     this._channel = dc.channel(event)
-    this._transform = data => {
-      const store = storage('legacy').getStore()
-
-      return !store || !store.noop
-        ? transform(data)
-        : store
-    }
+    this._transform = transform
   }
 
   enable () {

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -114,7 +114,7 @@ class TracingPlugin extends Plugin {
   }
 
   startSpan (name, { childOf, kind, meta, metrics, service, resource, type } = {}, enterOrCtx = true) {
-    const store = storage('legacy').getStore()
+    const store = typeof enterOrCtx === 'object' ? enterOrCtx.parentStore : storage('legacy').getStore()
     if (store && childOf === undefined) {
       childOf = store.span
     }

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -51,6 +51,17 @@ class TracingPlugin extends Plugin {
     })
   }
 
+  bindStart (ctx) {
+    const store = ctx.hasOwnProperty('parentStore')
+      ? ctx.parentStore
+      : storage('legacy').getStore()
+
+    ctx.parentStore = store
+    ctx.currentStore = { ...store }
+
+    return ctx.currentStore
+  }
+
   start () {} // implemented by individual plugins
 
   finish (ctx) {
@@ -129,8 +140,12 @@ class TracingPlugin extends Plugin {
     if (enterOrCtx === true) {
       storage('legacy').enterWith({ ...store, span })
     } else if (enterOrCtx) {
-      enterOrCtx.parentStore = store
-      enterOrCtx.currentStore = { ...store, span }
+      if (enterOrCtx.currentStore) {
+        enterOrCtx.currentStore.span = span
+      } else {
+        enterOrCtx.parentStore = store
+        enterOrCtx.currentStore = { ...store, span }
+      }
     }
 
     return span


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix bindings not applying for noop stores.

### Motivation
<!-- What inspired you to submit this pull request? -->

When using `AsyncResource` to manage the binding, this would always work regardless of if `noop` is set to `true` on the store. Only the subscribers would be affected, so the binding would still apply.

With the new approach, because we've been creating the spans in `bindStart`, it means that both are either enabled or disabled at the same time. This doesn't necessarily seem like an issue at first, but the problem is that it allows a `start` to be handled, then `noop` being set to `true`, and then `finish` being ignored because `bindFinish` never has a chance to restore the context that doesn't have any `noop`.