### PR TITLE
Make get-port wait between retries in tests

### DIFF
--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon')
 const chai = require('chai')
 const sinonChai = require('sinon-chai')
+const { setTimeout } = require('timers/promises')
 const proxyquire = require('../proxyquire')
 const { NODE_MAJOR } = require('../../../../version')
 
@@ -13,14 +14,17 @@ const { NODE_MAJOR } = require('../../../../version')
   // because it's used in all sorts of places.
   const getPort = require('get-port')
   require.cache[require.resolve('get-port')].exports = async function (...args) {
-    let tries = 0
+    let tries = 10
     let err = null
-    while (tries++ < 10) {
+    while (tries-- > 0) {
       try {
         return await getPort(...args)
       } catch (e) {
         if (e.code !== 'EADDRINUSE') {
           throw e
+        }
+        if (tries) {
+          await setTimeout(5)
         }
         err = e
       }


### PR DESCRIPTION
Just a small PR to hopefully make our tests less flaky.