### PR TITLE
Improve agent.assertFirstTraceSpan to accept an object

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -360,10 +360,10 @@ function setShouldKill (value) {
   })
 }
 
-function assertObjectContains (actual, expected) {
+const assertObjectContains = assert.partialDeepStrictEqual || function assertObjectContains (actual, expected) {
   for (const [key, val] of Object.entries(expected)) {
     if (val !== null && typeof val === 'object') {
-      assert.ok(key in actual)
+      assert.ok(Object.hasOwn(actual, key))
       assert.notStrictEqual(actual[key], null)
       assert.strictEqual(typeof actual[key], 'object')
       assertObjectContains(actual[key], val)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 
 describe('Plugin', () => {
   let aerospike
@@ -73,7 +74,7 @@ describe('Plugin', () => {
                   'aerospike.namespace': ns,
                   'aerospike.setname': set,
                   'aerospike.userkey': userKey,
-                  'component': 'aerospike'
+                  component: 'aerospike'
                 }
               })
               .then(done)
@@ -96,7 +97,7 @@ describe('Plugin', () => {
                 type: 'aerospike',
                 meta: {
                   'span.kind': 'client',
-                  'component': 'aerospike'
+                  component: 'aerospike'
                 }
               })
               .then(done)
@@ -118,7 +119,7 @@ describe('Plugin', () => {
                   'aerospike.namespace': ns,
                   'aerospike.setname': set,
                   'aerospike.userkey': userKey,
-                  'component': 'aerospike'
+                  component: 'aerospike'
                 }
               })
               .then(done)
@@ -143,7 +144,7 @@ describe('Plugin', () => {
                   'aerospike.namespace': ns,
                   'aerospike.setname': set,
                   'aerospike.userkey': userKey,
-                  'component': 'aerospike'
+                  component: 'aerospike'
                 }
               })
               .then(done)
@@ -175,7 +176,7 @@ describe('Plugin', () => {
                   'aerospike.setname': 'demo',
                   'aerospike.bin': 'tags',
                   'aerospike.index': 'tags_idx',
-                  'component': 'aerospike'
+                  component: 'aerospike'
                 }
               })
               .then(done)
@@ -206,7 +207,7 @@ describe('Plugin', () => {
                   'span.kind': 'client',
                   'aerospike.namespace': ns,
                   'aerospike.setname': set,
-                  'component': 'aerospike'
+                  component: 'aerospike'
                 }
               })
               .then(done)
@@ -252,13 +253,15 @@ describe('Plugin', () => {
             let error
 
             agent
-              .assertFirstTraceSpan({
-                meta: {
-                  [ERROR_TYPE]: error.name,
-                  [ERROR_MESSAGE]: error.message,
-                  [ERROR_STACK]: error.stack,
-                  'component': 'aerospike'
-                }
+              .assertFirstTraceSpan((trace) => {
+                assertObjectContains(trace, {
+                  meta: {
+                    [ERROR_TYPE]: error.name,
+                    [ERROR_MESSAGE]: error.message,
+                    [ERROR_STACK]: error.stack,
+                    component: 'aerospike'
+                  }
+                })
               })
               .then(done)
               .catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -62,18 +62,19 @@ describe('Plugin', () => {
 
           it('should instrument put', done => {
             agent
-              .assertSomeTraces(traces => {
-                const span = traces[0][0]
-                expect(span).to.have.property('name', expectedSchema.command.opName)
-                expect(span).to.have.property('service', expectedSchema.command.serviceName)
-                expect(span).to.have.property('resource', 'Put')
-                expect(span).to.have.property('type', 'aerospike')
-                expect(span.meta).to.have.property('span.kind', 'client')
-                expect(span.meta).to.have.property('aerospike.key', keyString)
-                expect(span.meta).to.have.property('aerospike.namespace', ns)
-                expect(span.meta).to.have.property('aerospike.setname', set)
-                expect(span.meta).to.have.property('aerospike.userkey', userKey)
-                expect(span.meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                name: expectedSchema.command.opName,
+                service: expectedSchema.command.serviceName,
+                resource: 'Put',
+                type: 'aerospike',
+                meta: {
+                  'span.kind': 'client',
+                  'aerospike.key': keyString,
+                  'aerospike.namespace': ns,
+                  'aerospike.setname': set,
+                  'aerospike.userkey': userKey,
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -88,14 +89,15 @@ describe('Plugin', () => {
 
           it('should instrument connect', done => {
             agent
-              .assertSomeTraces(traces => {
-                const span = traces[0][0]
-                expect(span).to.have.property('name', expectedSchema.command.opName)
-                expect(span).to.have.property('service', expectedSchema.command.serviceName)
-                expect(span).to.have.property('resource', 'Connect')
-                expect(span).to.have.property('type', 'aerospike')
-                expect(span.meta).to.have.property('span.kind', 'client')
-                expect(span.meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                name: expectedSchema.command.opName,
+                service: expectedSchema.command.serviceName,
+                resource: 'Connect',
+                type: 'aerospike',
+                meta: {
+                  'span.kind': 'client',
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -105,18 +107,19 @@ describe('Plugin', () => {
 
           it('should instrument get', done => {
             agent
-              .assertSomeTraces(traces => {
-                const span = traces[0][0]
-                expect(span).to.have.property('name', expectedSchema.command.opName)
-                expect(span).to.have.property('service', expectedSchema.command.serviceName)
-                expect(span).to.have.property('resource', 'Get')
-                expect(span).to.have.property('type', 'aerospike')
-                expect(span.meta).to.have.property('span.kind', 'client')
-                expect(span.meta).to.have.property('aerospike.key', keyString)
-                expect(span.meta).to.have.property('aerospike.namespace', ns)
-                expect(span.meta).to.have.property('aerospike.setname', set)
-                expect(span.meta).to.have.property('aerospike.userkey', userKey)
-                expect(span.meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                name: expectedSchema.command.opName,
+                service: expectedSchema.command.serviceName,
+                resource: 'Get',
+                type: 'aerospike',
+                meta: {
+                  'span.kind': 'client',
+                  'aerospike.key': keyString,
+                  'aerospike.namespace': ns,
+                  'aerospike.setname': set,
+                  'aerospike.userkey': userKey,
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -129,18 +132,19 @@ describe('Plugin', () => {
 
           it('should instrument operate', done => {
             agent
-              .assertSomeTraces(traces => {
-                const span = traces[0][0]
-                expect(span).to.have.property('name', expectedSchema.command.opName)
-                expect(span).to.have.property('service', expectedSchema.command.serviceName)
-                expect(span).to.have.property('resource', 'Operate')
-                expect(span).to.have.property('type', 'aerospike')
-                expect(span.meta).to.have.property('span.kind', 'client')
-                expect(span.meta).to.have.property('aerospike.key', keyString)
-                expect(span.meta).to.have.property('aerospike.namespace', ns)
-                expect(span.meta).to.have.property('aerospike.setname', set)
-                expect(span.meta).to.have.property('aerospike.userkey', userKey)
-                expect(span.meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                name: expectedSchema.command.opName,
+                service: expectedSchema.command.serviceName,
+                resource: 'Operate',
+                type: 'aerospike',
+                meta: {
+                  'span.kind': 'client',
+                  'aerospike.key': keyString,
+                  'aerospike.namespace': ns,
+                  'aerospike.setname': set,
+                  'aerospike.userkey': userKey,
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -160,18 +164,19 @@ describe('Plugin', () => {
 
           it('should instrument createIndex', done => {
             agent
-              .assertSomeTraces(traces => {
-                const span = traces[0][0]
-                expect(span).to.have.property('name', expectedSchema.command.opName)
-                expect(span).to.have.property('service', expectedSchema.command.serviceName)
-                expect(span).to.have.property('resource', 'IndexCreate')
-                expect(span).to.have.property('type', 'aerospike')
-                expect(span.meta).to.have.property('span.kind', 'client')
-                expect(span.meta).to.have.property('aerospike.namespace', ns)
-                expect(span.meta).to.have.property('aerospike.setname', 'demo')
-                expect(span.meta).to.have.property('aerospike.bin', 'tags')
-                expect(span.meta).to.have.property('aerospike.index', 'tags_idx')
-                expect(span.meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                name: expectedSchema.command.opName,
+                service: expectedSchema.command.serviceName,
+                resource: 'IndexCreate',
+                type: 'aerospike',
+                meta: {
+                  'span.kind': 'client',
+                  'aerospike.namespace': ns,
+                  'aerospike.setname': 'demo',
+                  'aerospike.bin': 'tags',
+                  'aerospike.index': 'tags_idx',
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -192,16 +197,17 @@ describe('Plugin', () => {
 
           it('should instrument query', done => {
             agent
-              .assertSomeTraces(traces => {
-                const span = traces[0][0]
-                expect(span).to.have.property('name', expectedSchema.command.opName)
-                expect(span).to.have.property('service', expectedSchema.command.serviceName)
-                expect(span).to.have.property('resource', 'Query')
-                expect(span).to.have.property('type', 'aerospike')
-                expect(span.meta).to.have.property('span.kind', 'client')
-                expect(span.meta).to.have.property('aerospike.namespace', ns)
-                expect(span.meta).to.have.property('aerospike.setname', set)
-                expect(span.meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                name: expectedSchema.command.opName,
+                service: expectedSchema.command.serviceName,
+                resource: 'Query',
+                type: 'aerospike',
+                meta: {
+                  'span.kind': 'client',
+                  'aerospike.namespace': ns,
+                  'aerospike.setname': set,
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -246,11 +252,13 @@ describe('Plugin', () => {
             let error
 
             agent
-              .assertSomeTraces(traces => {
-                expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
-                expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-                expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
-                expect(traces[0][0].meta).to.have.property('component', 'aerospike')
+              .assertFirstTraceSpan({
+                meta: {
+                  [ERROR_TYPE]: error.name,
+                  [ERROR_MESSAGE]: error.message,
+                  [ERROR_STACK]: error.stack,
+                  'component': 'aerospike'
+                }
               })
               .then(done)
               .catch(done)
@@ -293,9 +301,9 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.command.opName)
-              expect(traces[0][0]).to.have.property('service', 'custom')
+            .assertFirstTraceSpan({
+              name: expectedSchema.command.opName,
+              service: 'custom'
             })
             .then(done)
             .catch(done)

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -53,19 +53,21 @@ describe('Plugin', () => {
         it('should do automatic instrumentation', done => {
           const query = 'SELECT now() FROM local;'
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0]).to.have.property('resource', query)
-              expect(traces[0][0]).to.have.property('type', 'cassandra')
-              expect(traces[0][0].meta).to.have.property('db.type', 'cassandra')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
-              expect(traces[0][0].meta).to.have.property('cassandra.query', query)
-              expect(traces[0][0].meta).to.have.property('cassandra.keyspace', 'system')
-              expect(traces[0][0].meta).to.have.property('component', 'cassandra-driver')
-              expect(traces[0][0].meta).to.have.property('network.destination.port', '9042')
-              expect(traces[0][0].meta).to.have.property('db.cassandra.contact.points', '127.0.0.1')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: query,
+              type: 'cassandra',
+              meta: {
+                'db.type': 'cassandra',
+                'span.kind': 'client',
+                'out.host': '127.0.0.1',
+                'cassandra.query': query,
+                'cassandra.keyspace': 'system',
+                'component': 'cassandra-driver',
+                'network.destination.port': '9042',
+                'db.cassandra.contact.points': '127.0.0.1'
+              }
             })
             .then(done)
             .catch(done)
@@ -81,8 +83,8 @@ describe('Plugin', () => {
           ]
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
+            .assertFirstTraceSpan({
+              resource: `${queries[0].query}; ${queries[1]}`
             })
             .then(done)
             .catch(done)
@@ -98,8 +100,8 @@ describe('Plugin', () => {
           ]
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
+            .assertFirstTraceSpan({
+              resource: `${queries[0].query}; ${queries[1]}`
             })
             .then(done)
             .catch(done)
@@ -115,11 +117,13 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
-              expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-              expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
-              expect(traces[0][0].meta).to.have.property('component', 'cassandra-driver')
+            .assertFirstTraceSpan({
+              meta: {
+                [ERROR_TYPE]: error.name,
+                [ERROR_MESSAGE]: error.message,
+                [ERROR_STACK]: error.stack,
+                'component': 'cassandra-driver'
+              }
             })
             .then(done)
             .catch(done)
@@ -189,10 +193,11 @@ describe('Plugin', () => {
         })
 
         it('should be configured with the correct values', done => {
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0]).to.have.property('service', 'custom')
-            done()
+          agent.assertFirstTraceSpan({
+            service: 'custom'
           })
+          .then(done)
+          .catch(done)
 
           client.execute('SELECT now() FROM local;', err => err && done(err))
         })
@@ -247,18 +252,20 @@ describe('Plugin', () => {
             const query = 'SELECT now() FROM local;'
 
             agent
-              .assertSomeTraces(traces => {
-                expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-                expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-                expect(traces[0][0]).to.have.property('resource', query)
-                expect(traces[0][0]).to.have.property('type', 'cassandra')
-                expect(traces[0][0].meta).to.have.property('db.type', 'cassandra')
-                expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-                expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
-                expect(traces[0][0].meta).to.have.property('cassandra.query', query)
-                expect(traces[0][0].meta).to.have.property('cassandra.keyspace', 'system')
-                expect(traces[0][0].meta).to.have.property('component', 'cassandra-driver')
-                expect(traces[0][0].meta).to.have.property('network.destination.port', '9042')
+              .assertFirstTraceSpan({
+                name: expectedSchema.outbound.opName,
+                service: expectedSchema.outbound.serviceName,
+                resource: query,
+                type: 'cassandra',
+                meta: {
+                  'db.type': 'cassandra',
+                  'span.kind': 'client',
+                  'out.host': '127.0.0.1',
+                  'cassandra.query': query,
+                  'cassandra.keyspace': 'system',
+                  'component': 'cassandra-driver',
+                  'network.destination.port': '9042'
+                }
               })
               .then(done)
               .catch(done)
@@ -275,8 +282,8 @@ describe('Plugin', () => {
             ]
 
             agent
-              .assertSomeTraces(traces => {
-                expect(traces[0][0]).to.have.property('resource', `${queries[0].query}; ${queries[1]}`)
+              .assertFirstTraceSpan({
+                resource: `${queries[0].query}; ${queries[1]}`
               })
               .then(done)
               .catch(done)

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -4,6 +4,7 @@ const semver = require('semver')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_TYPE, ERROR_MESSAGE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 
 describe('Plugin', () => {
   let cassandra
@@ -64,7 +65,7 @@ describe('Plugin', () => {
                 'out.host': '127.0.0.1',
                 'cassandra.query': query,
                 'cassandra.keyspace': 'system',
-                'component': 'cassandra-driver',
+                component: 'cassandra-driver',
                 'network.destination.port': '9042',
                 'db.cassandra.contact.points': '127.0.0.1'
               }
@@ -117,13 +118,15 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertFirstTraceSpan({
-              meta: {
-                [ERROR_TYPE]: error.name,
-                [ERROR_MESSAGE]: error.message,
-                [ERROR_STACK]: error.stack,
-                'component': 'cassandra-driver'
-              }
+            .assertFirstTraceSpan((trace) => {
+              assertObjectContains(trace, {
+                meta: {
+                  [ERROR_TYPE]: error.name,
+                  [ERROR_MESSAGE]: error.message,
+                  [ERROR_STACK]: error.stack,
+                  component: 'cassandra-driver'
+                }
+              })
             })
             .then(done)
             .catch(done)
@@ -196,8 +199,8 @@ describe('Plugin', () => {
           agent.assertFirstTraceSpan({
             service: 'custom'
           })
-          .then(done)
-          .catch(done)
+            .then(done)
+            .catch(done)
 
           client.execute('SELECT now() FROM local;', err => err && done(err))
         })
@@ -263,7 +266,7 @@ describe('Plugin', () => {
                   'out.host': '127.0.0.1',
                   'cassandra.query': query,
                   'cassandra.keyspace': 'system',
-                  'component': 'cassandra-driver',
+                  component: 'cassandra-driver',
                   'network.destination.port': '9042'
                 }
               })

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -32,18 +32,22 @@ describe('Plugin', () => {
         it('should do automatic instrumentation when using callbacks', async () => {
           await redis.get('foo')
 
-          await agent.assertFirstTraceSpan(span => {
-            expect(span).to.have.property('name', expectedSchema.outbound.opName)
-            expect(span).to.have.property('service', expectedSchema.outbound.serviceName)
-            expect(span).to.have.property('resource', 'get')
-            expect(span).to.have.property('type', 'redis')
-            expect(span.meta).to.have.property('component', 'ioredis')
-            expect(span.meta).to.have.property('db.name', '0')
-            expect(span.meta).to.have.property('db.type', 'redis')
-            expect(span.meta).to.have.property('span.kind', 'client')
-            expect(span.meta).to.have.property('out.host', 'localhost')
-            expect(span.meta).to.have.property('redis.raw_command', 'GET foo')
-            expect(span.metrics).to.have.property('network.destination.port', 6379)
+          await agent.assertFirstTraceSpan({
+            name: expectedSchema.outbound.opName,
+            service: expectedSchema.outbound.serviceName,
+            resource: 'get',
+            type: 'redis',
+            meta: {
+              'component': 'ioredis',
+              'db.name': '0',
+              'db.type': 'redis',
+              'span.kind': 'client',
+              'out.host': 'localhost',
+              'redis.raw_command': 'GET foo',
+            },
+            metrics: {
+              'network.destination.port': 6379
+            }
           })
         })
 
@@ -65,12 +69,14 @@ describe('Plugin', () => {
             error = err
           }
 
-          await agent.assertFirstTraceSpan(span => {
-            expect(span).to.have.property('error', 1)
-            expect(span.meta).to.have.property(ERROR_TYPE, error.name)
-            expect(span.meta).to.have.property(ERROR_MESSAGE, error.message)
-            expect(span.meta).to.have.property(ERROR_STACK, error.stack)
-            expect(span.meta).to.have.property('component', 'ioredis')
+          await agent.assertFirstTraceSpan({
+            error: 1,
+            meta: {
+              [ERROR_TYPE]: error.name,
+              [ERROR_MESSAGE]: error.message,
+              [ERROR_STACK]: error.stack,
+              component: 'ioredis',
+            },
           })
         })
 
@@ -79,18 +85,22 @@ describe('Plugin', () => {
 
           await redis.get('foo')
 
-          await agent.assertFirstTraceSpan(span => {
-            expect(span).to.have.property('name', expectedSchema.outbound.opName)
-            expect(span).to.have.property('service', expectedSchema.outbound.serviceName)
-            expect(span).to.have.property('resource', 'get')
-            expect(span).to.have.property('type', 'redis')
-            expect(span.meta).to.have.property('db.name', '0')
-            expect(span.meta).to.have.property('db.type', 'redis')
-            expect(span.meta).to.have.property('span.kind', 'client')
-            expect(span.meta).to.have.property('out.host', 'localhost')
-            expect(span.meta).to.have.property('redis.raw_command', 'GET foo')
-            expect(span.meta).to.have.property('component', 'ioredis')
-            expect(span.metrics).to.have.property('network.destination.port', 6379)
+          await agent.assertFirstTraceSpan({
+            name: expectedSchema.outbound.opName,
+            service: expectedSchema.outbound.serviceName,
+            resource: 'get',
+            type: 'redis',
+            meta: {
+              'db.name': '0',
+              'db.type': 'redis',
+              'span.kind': 'client',
+              'out.host': 'localhost',
+              'redis.raw_command': 'GET foo',
+              'component': 'ioredis'
+            },
+            metrics: {
+              'network.destination.port': 6379
+            }
           })
         })
 
@@ -112,16 +122,16 @@ describe('Plugin', () => {
         it('should be configured with the correct values', async () => {
           await redis.get('foo')
 
-          agent.assertFirstTraceSpan(span => {
-            expect(span).to.have.property('service', 'custom-test')
+          await agent.assertFirstTraceSpan({
+            service: 'custom-test'
           })
         })
 
         it('should be able to filter commands', async () => {
           await redis.get('foo')
 
-          await agent.assertFirstTraceSpan(span => {
-            expect(span).to.have.property('resource', 'get')
+          await agent.assertFirstTraceSpan({
+            resource: 'get'
           })
         })
 
@@ -150,8 +160,8 @@ describe('Plugin', () => {
         it('should be able to filter commands', async () => {
           await redis.get('foo')
 
-          await agent.assertFirstTraceSpan(span => {
-            expect(span).to.have.property('resource', 'get')
+          await agent.assertFirstTraceSpan({
+            resource: 'get'
           })
         })
       })

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -38,12 +38,12 @@ describe('Plugin', () => {
             resource: 'get',
             type: 'redis',
             meta: {
-              'component': 'ioredis',
+              component: 'ioredis',
               'db.name': '0',
               'db.type': 'redis',
               'span.kind': 'client',
               'out.host': 'localhost',
-              'redis.raw_command': 'GET foo',
+              'redis.raw_command': 'GET foo'
             },
             metrics: {
               'network.destination.port': 6379
@@ -75,8 +75,8 @@ describe('Plugin', () => {
               [ERROR_TYPE]: error.name,
               [ERROR_MESSAGE]: error.message,
               [ERROR_STACK]: error.stack,
-              component: 'ioredis',
-            },
+              component: 'ioredis'
+            }
           })
         })
 
@@ -96,7 +96,7 @@ describe('Plugin', () => {
               'span.kind': 'client',
               'out.host': 'localhost',
               'redis.raw_command': 'GET foo',
-              'component': 'ioredis'
+              component: 'ioredis'
             },
             metrics: {
               'network.destination.port': 6379

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -37,15 +37,17 @@ describe('Plugin', () => {
           memcached = new Memcached('localhost:11211', { retries: 0 })
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0]).to.have.property('resource', 'get')
-              expect(traces[0][0]).to.have.property('type', 'memcached')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
-              expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
-              expect(traces[0][0].meta).to.have.property('component', 'memcached')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'get',
+              type: 'memcached',
+              meta: {
+                'span.kind': 'client',
+                'out.host': 'localhost',
+                'network.destination.port': '11211',
+                'component': 'memcached'
+              }
             })
             .then(done)
             .catch(done)
@@ -77,12 +79,14 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('error', 1)
-              expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
-              expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-              expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
-              expect(traces[0][0].meta).to.have.property('component', 'memcached')
+            .assertFirstTraceSpan({
+              error: 1,
+              meta: {
+                [ERROR_TYPE]: error.name,
+                [ERROR_MESSAGE]: error.message,
+                [ERROR_STACK]: error.stack,
+                'component': 'memcached'
+              }
             })
             .then(done)
             .catch(done)
@@ -96,10 +100,12 @@ describe('Plugin', () => {
           memcached = new Memcached(['localhost:11211'], { retries: 0 })
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
-              expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
-              expect(traces[0][0].meta).to.have.property('component', 'memcached')
+            .assertFirstTraceSpan({
+              meta: {
+                'out.host': 'localhost',
+                'network.destination.port': '11211',
+                'component': 'memcached'
+              }
             })
             .then(done)
             .catch(done)
@@ -114,10 +120,12 @@ describe('Plugin', () => {
           }, { retries: 0 })
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
-              expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
-              expect(traces[0][0].meta).to.have.property('component', 'memcached')
+            .assertFirstTraceSpan({
+              meta: {
+                'out.host': 'localhost',
+                'network.destination.port': '11211',
+                'component': 'memcached'
+              }
             })
             .then(done)
             .catch(done)
@@ -138,10 +146,12 @@ describe('Plugin', () => {
             memcached.del('test', err => err && done(err))
 
             agent
-              .assertSomeTraces(traces => {
-                expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
-                expect(traces[0][0].meta).to.have.property('network.destination.port', '11211')
-                expect(traces[0][0].meta).to.have.property('component', 'memcached')
+              .assertFirstTraceSpan({
+                meta: {
+                  'out.host': 'localhost',
+                  'network.destination.port': '11211',
+                  'component': 'memcached'
+                }
               })
               .then(done)
               .catch(done)
@@ -166,8 +176,8 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+            .assertFirstTraceSpan({
+              service: 'custom'
             })
             .then(done)
             .catch(done)
@@ -192,8 +202,10 @@ describe('Plugin', () => {
 
           it('trace should contain memcached.command', done => {
             agent
-              .assertSomeTraces(traces => {
-                expect(traces[0][0].meta).to.have.property('memcached.command', 'version')
+              .assertFirstTraceSpan({
+                meta: {
+                  'memcached.command': 'version'
+                }
               })
               .then(done)
               .catch(done)

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -46,7 +47,7 @@ describe('Plugin', () => {
                 'span.kind': 'client',
                 'out.host': 'localhost',
                 'network.destination.port': '11211',
-                'component': 'memcached'
+                component: 'memcached'
               }
             })
             .then(done)
@@ -79,14 +80,16 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertFirstTraceSpan({
-              error: 1,
-              meta: {
-                [ERROR_TYPE]: error.name,
-                [ERROR_MESSAGE]: error.message,
-                [ERROR_STACK]: error.stack,
-                'component': 'memcached'
-              }
+            .assertFirstTraceSpan((trace) => {
+              assertObjectContains(trace, {
+                error: 1,
+                meta: {
+                  [ERROR_TYPE]: error.name,
+                  [ERROR_MESSAGE]: error.message,
+                  [ERROR_STACK]: error.stack,
+                  component: 'memcached'
+                }
+              })
             })
             .then(done)
             .catch(done)
@@ -104,7 +107,7 @@ describe('Plugin', () => {
               meta: {
                 'out.host': 'localhost',
                 'network.destination.port': '11211',
-                'component': 'memcached'
+                component: 'memcached'
               }
             })
             .then(done)
@@ -124,7 +127,7 @@ describe('Plugin', () => {
               meta: {
                 'out.host': 'localhost',
                 'network.destination.port': '11211',
-                'component': 'memcached'
+                component: 'memcached'
               }
             })
             .then(done)
@@ -150,7 +153,7 @@ describe('Plugin', () => {
                 meta: {
                   'out.host': 'localhost',
                   'network.destination.port': '11211',
-                  'component': 'memcached'
+                  component: 'memcached'
                 }
               })
               .then(done)

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -73,19 +73,22 @@ describe('Plugin', () => {
         })
 
         it('should do automatic instrumentation', done => {
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-            expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            expect(traces[0][0]).to.have.property('type', 'sql')
-            expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-            expect(traces[0][0].meta).to.have.property('db.name', 'db')
-            expect(traces[0][0].meta).to.have.property('db.user', 'root')
-            expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
-            expect(traces[0][0].meta).to.have.property('component', 'mysql')
-
-            done()
-          })
+          agent
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'SELECT 1 + 1 AS solution',
+              type: 'sql',
+              meta: {
+                'span.kind': 'client',
+                'db.name': 'db',
+                'db.user': 'root',
+                'db.type': 'mysql',
+                'component': 'mysql'
+              }
+            })
+            .then(done)
+            .catch(done)
 
           connection.query('SELECT 1 + 1 AS solution', (error, results, fields) => {
             if (error) throw error
@@ -95,14 +98,17 @@ describe('Plugin', () => {
         it('should handle errors', done => {
           let error
 
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
-            expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-            expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
-            expect(traces[0][0].meta).to.have.property('component', 'mysql')
-
-            done()
-          })
+          agent
+            .assertFirstTraceSpan({
+              meta: {
+                [ERROR_TYPE]: error.name,
+                [ERROR_MESSAGE]: error.message,
+                [ERROR_STACK]: error.stack,
+                'component': 'mysql'
+              }
+            })
+            .then(done)
+            .catch(done)
 
           connection.query('INVALID', (err, results, fields) => {
             error = err
@@ -154,11 +160,13 @@ describe('Plugin', () => {
         )
 
         it('should be configured with the correct values', done => {
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-            expect(traces[0][0]).to.have.property('service', 'custom')
-            done()
-          })
+          agent
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: 'custom'
+            })
+            .then(done)
+            .catch(done)
 
           connection.query('SELECT 1 + 1 AS solution', () => {})
         })
@@ -244,18 +252,21 @@ describe('Plugin', () => {
           'db', 'db.name')
 
         it('should do automatic instrumentation', done => {
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-            expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            expect(traces[0][0]).to.have.property('type', 'sql')
-            expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-            expect(traces[0][0].meta).to.have.property('db.user', 'root')
-            expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
-            expect(traces[0][0].meta).to.have.property('component', 'mysql')
-
-            done()
-          })
+          agent
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'SELECT 1 + 1 AS solution',
+              type: 'sql',
+              meta: {
+                'span.kind': 'client',
+                'db.user': 'root',
+                'db.type': 'mysql',
+                'component': 'mysql'
+              }
+            })
+            .then(done)
+            .catch(done)
 
           pool.query('SELECT 1 + 1 AS solution', () => {})
         })
@@ -390,10 +401,13 @@ describe('Plugin', () => {
         })
 
         it('trace query resource should not be changed when propagation is enabled', done => {
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            done()
-          })
+          agent
+            .assertFirstTraceSpan({
+              resource: 'SELECT 1 + 1 AS solution'
+            })
+            .then(done)
+            .catch(done)
+
           connection.query('SELECT 1 + 1 AS solution', (err) => {
             if (err) return done(err)
             connection.end((err) => {

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -84,7 +85,7 @@ describe('Plugin', () => {
                 'db.name': 'db',
                 'db.user': 'root',
                 'db.type': 'mysql',
-                'component': 'mysql'
+                component: 'mysql'
               }
             })
             .then(done)
@@ -99,13 +100,15 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertFirstTraceSpan({
-              meta: {
-                [ERROR_TYPE]: error.name,
-                [ERROR_MESSAGE]: error.message,
-                [ERROR_STACK]: error.stack,
-                'component': 'mysql'
-              }
+            .assertFirstTraceSpan((trace) => {
+              assertObjectContains(trace, {
+                meta: {
+                  [ERROR_TYPE]: error.name,
+                  [ERROR_MESSAGE]: error.message,
+                  [ERROR_STACK]: error.stack,
+                  component: 'mysql'
+                }
+              })
             })
             .then(done)
             .catch(done)
@@ -262,7 +265,7 @@ describe('Plugin', () => {
                 'span.kind': 'client',
                 'db.user': 'root',
                 'db.type': 'mysql',
-                'component': 'mysql'
+                component: 'mysql'
               }
             })
             .then(done)

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -3,6 +3,7 @@
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -98,7 +99,7 @@ describe('Plugin', () => {
                 'db.name': 'db',
                 'db.user': 'root',
                 'db.type': 'mysql',
-                'component': 'mysql2'
+                component: 'mysql2'
               }
             })
             .then(done)
@@ -121,7 +122,7 @@ describe('Plugin', () => {
                 'db.name': 'db',
                 'db.user': 'root',
                 'db.type': 'mysql',
-                'component': 'mysql2'
+                component: 'mysql2'
               }
             })
             .then(done)
@@ -146,7 +147,7 @@ describe('Plugin', () => {
                 'db.name': 'db',
                 'db.user': 'root',
                 'db.type': 'mysql',
-                'component': 'mysql2'
+                component: 'mysql2'
               }
             })
             .then(done)
@@ -167,13 +168,15 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertFirstTraceSpan({
-              meta: {
-                [ERROR_TYPE]: error.name,
-                [ERROR_MESSAGE]: error.message,
-                [ERROR_STACK]: error.stack,
-                component: 'mysql2'
-              }
+            .assertFirstTraceSpan((trace) => {
+              assertObjectContains(trace, {
+                meta: {
+                  [ERROR_TYPE]: error.name,
+                  [ERROR_MESSAGE]: error.message,
+                  [ERROR_STACK]: error.stack,
+                  component: 'mysql2'
+                }
+              })
             })
             .then(done)
             .catch(done)
@@ -324,7 +327,7 @@ describe('Plugin', () => {
                 'span.kind': 'client',
                 'db.user': 'root',
                 'db.type': 'mysql',
-                'component': 'mysql2'
+                component: 'mysql2'
               }
             })
             .then(done)

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -88,16 +88,18 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('db.name', 'db')
-              expect(traces[0][0].meta).to.have.property('db.user', 'root')
-              expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
-              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'SELECT 1 + 1 AS solution',
+              type: 'sql',
+              meta: {
+                'span.kind': 'client',
+                'db.name': 'db',
+                'db.user': 'root',
+                'db.type': 'mysql',
+                'component': 'mysql2'
+              }
             })
             .then(done)
             .catch(done)
@@ -109,16 +111,18 @@ describe('Plugin', () => {
 
         it('should support prepared statement shorthand', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('db.name', 'db')
-              expect(traces[0][0].meta).to.have.property('db.user', 'root')
-              expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
-              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'SELECT ? + ? AS solution',
+              type: 'sql',
+              meta: {
+                'span.kind': 'client',
+                'db.name': 'db',
+                'db.user': 'root',
+                'db.type': 'mysql',
+                'component': 'mysql2'
+              }
             })
             .then(done)
             .catch(done)
@@ -132,16 +136,18 @@ describe('Plugin', () => {
 
         it('should support prepared statements', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0]).to.have.property('resource', 'SELECT ? + ? AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('db.name', 'db')
-              expect(traces[0][0].meta).to.have.property('db.user', 'root')
-              expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
-              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'SELECT ? + ? AS solution',
+              type: 'sql',
+              meta: {
+                'span.kind': 'client',
+                'db.name': 'db',
+                'db.user': 'root',
+                'db.type': 'mysql',
+                'component': 'mysql2'
+              }
             })
             .then(done)
             .catch(done)
@@ -161,11 +167,13 @@ describe('Plugin', () => {
           let error
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0].meta).to.have.property(ERROR_TYPE, error.name)
-              expect(traces[0][0].meta).to.have.property(ERROR_MESSAGE, error.message)
-              expect(traces[0][0].meta).to.have.property(ERROR_STACK, error.stack)
-              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
+            .assertFirstTraceSpan({
+              meta: {
+                [ERROR_TYPE]: error.name,
+                [ERROR_MESSAGE]: error.message,
+                [ERROR_STACK]: error.stack,
+                component: 'mysql2'
+              }
             })
             .then(done)
             .catch(done)
@@ -223,8 +231,8 @@ describe('Plugin', () => {
 
         it('should be configured with the correct values', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('service', 'custom')
+            .assertFirstTraceSpan({
+              service: 'custom'
             })
             .then(done)
             .catch(done)
@@ -307,15 +315,17 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-              expect(traces[0][0]).to.have.property('type', 'sql')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('db.user', 'root')
-              expect(traces[0][0].meta).to.have.property('db.type', 'mysql')
-              expect(traces[0][0].meta).to.have.property('component', 'mysql2')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'SELECT 1 + 1 AS solution',
+              type: 'sql',
+              meta: {
+                'span.kind': 'client',
+                'db.user': 'root',
+                'db.type': 'mysql',
+                'component': 'mysql2'
+              }
             })
             .then(done)
             .catch(done)
@@ -377,10 +387,13 @@ describe('Plugin', () => {
         })
 
         it('trace query resource should not be changed when propagation is enabled', done => {
-          agent.assertSomeTraces(traces => {
-            expect(traces[0][0]).to.have.property('resource', 'SELECT 1 + 1 AS solution')
-            done()
-          })
+          agent
+            .assertFirstTraceSpan({
+              resource: 'SELECT 1 + 1 AS solution'
+            })
+            .then(done)
+            .catch(done)
+
           connection.query('SELECT 1 + 1 AS solution', (err) => {
             if (err) return done(err)
             connection.end((err) => {

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -65,7 +65,7 @@ describe('Plugin', () => {
                 'opensearch.method': 'POST',
                 'opensearch.url': '/docs/_search',
                 'opensearch.body': '{"query":{"match_all":{}}}',
-                'component': 'opensearch',
+                component: 'opensearch',
                 'out.host': 'localhost'
               }
             })
@@ -275,7 +275,7 @@ describe('Plugin', () => {
               meta: {
                 'opensearch.params': 'foo',
                 'opensearch.method': 'POST',
-                'component': 'opensearch'
+                component: 'opensearch'
               }
             })
             .then(done)

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -42,8 +42,8 @@ describe('Plugin', () => {
 
         it('should sanitize the resource name', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('resource', 'POST /logstash-?.?.?/_search')
+            .assertFirstTraceSpan({
+              resource: 'POST /logstash-?.?.?/_search'
             })
             .then(done)
             .catch(done)
@@ -56,19 +56,18 @@ describe('Plugin', () => {
 
         it('should set the correct tags', done => {
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', expectedSchema.outbound.serviceName)
-              expect(traces[0][0].meta).to.have.property('db.type', 'opensearch')
-              expect(traces[0][0].meta).to.have.property('span.kind', 'client')
-              expect(traces[0][0].meta).to.have.property('opensearch.method', 'POST')
-              expect(traces[0][0].meta).to.have.property('opensearch.url', '/docs/_search')
-              expect(traces[0][0].meta).to.have.property(
-                'opensearch.body',
-                '{"query":{"match_all":{}}}'
-              )
-              expect(traces[0][0].meta).to.have.property('component', 'opensearch')
-              expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              meta: {
+                'db.type': 'opensearch',
+                'span.kind': 'client',
+                'opensearch.method': 'POST',
+                'opensearch.url': '/docs/_search',
+                'opensearch.body': '{"query":{"match_all":{}}}',
+                'component': 'opensearch',
+                'out.host': 'localhost'
+              }
             })
             .then(done)
             .catch(done)
@@ -270,12 +269,14 @@ describe('Plugin', () => {
           })
 
           agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0]).to.have.property('name', expectedSchema.outbound.opName)
-              expect(traces[0][0]).to.have.property('service', 'custom')
-              expect(traces[0][0].meta).to.have.property('opensearch.params', 'foo')
-              expect(traces[0][0].meta).to.have.property('opensearch.method', 'POST')
-              expect(traces[0][0].meta).to.have.property('component', 'opensearch')
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: 'custom',
+              meta: {
+                'opensearch.params': 'foo',
+                'opensearch.method': 'POST',
+                'component': 'opensearch'
+              }
             })
             .then(done)
             .catch(done)

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -445,13 +445,17 @@ module.exports = {
    * @param {boolean} [options.rejectFirst=false] - If true, reject the first time the callback throws.
    * @returns Promise
    */
-  assertFirstTraceSpan (callback, options) {
+  assertFirstTraceSpan (callbackOrExpected, options) {
     return runCallbackAgainstTraces(function (traces) {
-      if (typeof callback !== 'function') {
-        // TODO(BridgeAR): Log all traces if the assertion fails.
-        assertObjectContains(callback, traces[0][0])
+      if (typeof callbackOrExpected !== 'function') {
+        try {
+          assertObjectContains(traces[0][0], callbackOrExpected)
+        } catch (error) {
+          console.error('Expected span %o did not match traces:\n%o', callbackOrExpected, traces)
+          throw error
+        }
       } else {
-        return callback(traces[0][0])
+        return callbackOrExpected(traces[0][0])
       }
     }, options, traceHandlers)
   },

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -451,6 +451,7 @@ module.exports = {
         try {
           assertObjectContains(traces[0][0], callbackOrExpected)
         } catch (error) {
+          // eslint-disable-next-line no-console
           console.error('Expected span %o did not match traces:\n%o', callbackOrExpected, traces)
           throw error
         }

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -7,6 +7,7 @@ const express = require('express')
 const path = require('path')
 const ritm = require('../../src/ritm')
 const { storage } = require('../../../datadog-core')
+const { assertObjectContains } = require('../../../../integration-tests/helpers')
 
 const traceHandlers = new Set()
 const statsHandlers = new Set()
@@ -438,7 +439,7 @@ module.exports = {
    * Same as assertSomeTraces() but only provides the first span (traces[0][0])
    * This callback gets executed once for every payload received by the agent.
 
-   * @param {testAssertionSpanCallback} callback - runs once per agent payload
+   * @param {testAssertionSpanCallback|Record<string|symbol, unknown>} callbackOrExpected - runs once per agent payload
    * @param {Object} [options] - An options object
    * @param {number} [options.timeoutMs=1000] - The timeout in ms.
    * @param {boolean} [options.rejectFirst=false] - If true, reject the first time the callback throws.
@@ -446,7 +447,12 @@ module.exports = {
    */
   assertFirstTraceSpan (callback, options) {
     return runCallbackAgainstTraces(function (traces) {
-      return callback(traces[0][0])
+      if (typeof callback !== 'function') {
+        // TODO(BridgeAR): Log all traces if the assertion fails.
+        assertObjectContains(callback, traces[0][0])
+      } else {
+        return callback(traces[0][0])
+      }
     }, options, traceHandlers)
   },
 


### PR DESCRIPTION
The object is internally matched against a partial match.
The output is actually a significant improvement over our current output. It shows the hole trace and also other traces.

I implemented it for a few files while I believe we should switch to this pattern is most of our test code.

There is still significant room for further improvement while this is likely a major step forward in understanding a failure fast and improving the readability of the test cases.