### PR TITLE
[test optimization] Fix crash when `error` is empty and failed test replay is enabled

### DIFF
--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -435,6 +435,10 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   addDiProbe (err) {
+    if (!err?.stack) {
+      log.warn('Can not add breakpoint if the test error does not have a stack')
+      return
+    }
     const [file, line, stackIndex] = getFileAndLineNumberFromError(err, this.repositoryRoot)
 
     if (!file || !Number.isInteger(line)) {


### PR DESCRIPTION
### What does this PR do?
Fix case where `error` is empty when failed test replay is enabled

### Motivation
Fix https://github.com/DataDog/test-visibility-install-script/issues/21

### Plugin Checklist
I couldn't find a way to reproduce `error` being empty for `ci:vitest:test:error` so I couldn't add a test 😞 