### PR TITLE
[test optimization] Fix `createSandbox`

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -207,7 +207,7 @@ async function createSandbox (dependencies = [], isGitRepo = false,
     await exec('git add -A', { cwd: folder })
     await exec('git commit -m "first commit" --no-verify', { cwd: folder })
     await exec(`git remote add origin ${localRemotePath}`, { cwd: folder })
-    await exec('git push', { cwd: folder })
+    await exec('git push --set-upstream origin HEAD', { cwd: folder })
   }
 
   return {


### PR DESCRIPTION
### What does this PR do?
Do not use a reference to `master`, as the default branch might be `main` locally.

### Motivation
https://github.com/DataDog/dd-trace-js/pull/5807 broke `createSandbox`

### Plugin Checklist
Just check integration tests still pass