### PR TITLE
Baggage update

### DIFF
--- a/packages/dd-trace/src/baggage.js
+++ b/packages/dd-trace/src/baggage.js
@@ -23,7 +23,7 @@ function removeBaggageItem (keyToRemove) {
 }
 
 function removeAllBaggageItems () {
-  storage('baggage').enterWith({})
+  storage('baggage').enterWith(undefined)
   return storage('baggage').getStore()
 }
 

--- a/packages/dd-trace/src/baggage.js
+++ b/packages/dd-trace/src/baggage.js
@@ -23,7 +23,7 @@ function removeBaggageItem (keyToRemove) {
 }
 
 function removeAllBaggageItems () {
-  storage('baggage').enterWith(undefined)
+  storage('baggage').enterWith()
   return storage('baggage').getStore()
 }
 

--- a/packages/dd-trace/src/baggage.js
+++ b/packages/dd-trace/src/baggage.js
@@ -13,7 +13,7 @@ function getBaggageItem (key) {
 }
 
 function getAllBaggageItems () {
-  return storage('baggage').getStore()
+  return storage('baggage').getStore() || {}
 }
 
 function removeBaggageItem (keyToRemove) {

--- a/packages/dd-trace/src/baggage.js
+++ b/packages/dd-trace/src/baggage.js
@@ -13,7 +13,7 @@ function getBaggageItem (key) {
 }
 
 function getAllBaggageItems () {
-  return storage('baggage').getStore() || {}
+  return storage('baggage').getStore() ?? {}
 }
 
 function removeBaggageItem (keyToRemove) {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -645,11 +645,8 @@ class TextMapPropagator {
         removeAllBaggageItems()
         return
       }
-      if (spanContext) {
-        // eslint-disable-next-line unicorn/no-lonely-if
-        if (this._config.baggageTagKeys === '*' || keysToSpanTag.has(key)) {
-          spanContext._trace.tags['baggage.' + key] = value
-        }
+      if (spanContext && (this._config.baggageTagKeys === '*' || keysToSpanTag.has(key))) {
+        spanContext._trace.tags['baggage.' + key] = value
       }
       setBaggageItem(key, value)
     }

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -646,6 +646,7 @@ class TextMapPropagator {
         return
       }
       if (spanContext) {
+        // eslint-disable-next-line unicorn/no-lonely-if
         if (this._config.baggageTagKeys === '*' || keysToSpanTag.has(key)) {
           spanContext._trace.tags['baggage.' + key] = value
         }

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -136,7 +136,7 @@ class TextMapPropagator {
       let itemCounter = 0
       let byteCounter = 0
 
-      const baggageItems = spanContext ? spanContext._baggageItems : getAllBaggageItems()
+      const baggageItems = getAllBaggageItems()
       if (!baggageItems) return
       for (const [key, value] of Object.entries(baggageItems)) {
         const item = `${this._encodeOtelBaggageKey(String(key).trim())}=${encodeURIComponent(String(value).trim())},`
@@ -629,33 +629,28 @@ class TextMapPropagator {
   _extractBaggageItems (carrier, spanContext) {
     if (!this._hasPropagationStyle('extract', 'baggage')) return
     if (!carrier || !carrier.baggage) return
-    if (!spanContext) removeAllBaggageItems()
     const baggages = carrier.baggage.split(',')
     const keysToSpanTag = this._config.baggageTagKeys === '*'
       ? undefined
       : new Set(this._config.baggageTagKeys.split(','))
     for (const keyValue of baggages) {
       if (!keyValue.includes('=')) {
-        if (spanContext) spanContext._baggageItems = {}
+        removeAllBaggageItems()
         return
       }
       let [key, value] = keyValue.split('=')
       key = this._decodeOtelBaggageKey(key.trim())
       value = decodeURIComponent(value.trim())
       if (!key || !value) {
-        if (spanContext) spanContext._baggageItems = {}
+        removeAllBaggageItems()
         return
       }
-      // the current code assumes precedence of ot-baggage- (legacy opentracing baggage) over baggage
       if (spanContext) {
-        if (Object.hasOwn(spanContext._baggageItems, key)) continue
-        spanContext._baggageItems[key] = value
         if (this._config.baggageTagKeys === '*' || keysToSpanTag.has(key)) {
           spanContext._trace.tags['baggage.' + key] = value
         }
-      } else {
-        setBaggageItem(key, value)
       }
+      setBaggageItem(key, value)
     }
   }
 

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -133,6 +133,7 @@ describe('TextMapPropagator', () => {
       expect(carrier.baggage).to.equal('raccoon=chunky')
     })
 
+
     it('should inject an existing sampling priority', () => {
       const carrier = {}
       const spanContext = createContext({
@@ -418,7 +419,7 @@ describe('TextMapPropagator', () => {
       expect(spanContext.toSpanId()).to.equal(carrier['x-datadog-parent-id'])
       expect(spanContext._baggageItems.foo).to.equal(carrier['ot-baggage-foo'])
       expect(spanContext._baggageItems).to.deep.equal({ foo: 'bar' })
-      expect(getAllBaggageItems()).to.be.undefined
+      expect(getAllBaggageItems()).to.deep.equal({})
       expect(spanContext._isRemote).to.equal(true)
     })
 
@@ -443,7 +444,7 @@ describe('TextMapPropagator', () => {
       }
       const spanContextA = propagator.extract(carrierA)
       expect(spanContextA._baggageItems).to.deep.equal({})
-      expect(getAllBaggageItems()).to.be.undefined
+      expect(getAllBaggageItems()).to.deep.equal({})
 
       const carrierB = {
         'x-datadog-trace-id': '123',
@@ -452,7 +453,7 @@ describe('TextMapPropagator', () => {
       }
       const spanContextB = propagator.extract(carrierB)
       expect(spanContextB._baggageItems).to.deep.equal({})
-      expect(getAllBaggageItems()).to.be.undefined
+      expect(getAllBaggageItems()).to.deep.equal({})
 
       const carrierC = {
         'x-datadog-trace-id': '123',
@@ -461,7 +462,7 @@ describe('TextMapPropagator', () => {
       }
       const spanContextC = propagator.extract(carrierC)
       expect(spanContextC._baggageItems).to.deep.equal({})
-      expect(getAllBaggageItems()).to.be.undefined
+      expect(getAllBaggageItems()).to.deep.equal({})
 
       const carrierD = {
         'x-datadog-trace-id': '123',
@@ -470,7 +471,7 @@ describe('TextMapPropagator', () => {
       }
       const spanContextD = propagator.extract(carrierD)
       expect(spanContextD._baggageItems).to.deep.equal({})
-      expect(getAllBaggageItems()).to.be.undefined
+      expect(getAllBaggageItems()).to.deep.equal({})
     })
 
     it('should add baggage items to span tags', () => {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -133,7 +133,6 @@ describe('TextMapPropagator', () => {
       expect(carrier.baggage).to.equal('raccoon=chunky')
     })
 
-
     it('should inject an existing sampling priority', () => {
       const carrier = {}
       const spanContext = createContext({

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -685,7 +685,7 @@ describe('TracerProxy', () => {
           proxy.setBaggageItem('key1', 'value1')
           proxy.setBaggageItem('key2', 'value2')
           const baggage = proxy.removeAllBaggageItems()
-          expect(baggage).to.deep.equal({})
+          expect(baggage).to.be.undefined
         })
       })
     })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -661,7 +661,7 @@ describe('TracerProxy', () => {
         })
 
         it('should return empty object when no items exist', () => {
-          expect(proxy.getAllBaggageItems()).to.be.undefined
+          expect(proxy.getAllBaggageItems()).to.deep.equal({})
         })
       })
 


### PR DESCRIPTION
### What does this PR do?
Use span._baggageItems only for [legacy ot-baggage](https://github.com/DataDog/dd-trace-js/commit/2faa3e4e836be19f2a801221493e62d7538b846e) to avoid breaking changes. Use storage('baggage') for otel-compatible [baggage](https://opentelemetry.io/docs/concepts/signals/baggage/) exclusively.

Baggage will pass all [weblog system tests](https://github.com/DataDog/system-tests/blob/main/tests/test_baggage.py) after the changes in this PR. We will stop using [parametric system tests](https://github.com/DataDog/system-tests/blob/main/tests/parametric/test_headers_datadog.py) for baggage.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


