### PR TITLE
Enable profiles' zstd compression on Node.js <23.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/libdatadog": "^0.5.1",
+    "@datadog/libdatadog": "^0.6.0",
     "@datadog/native-appsec": "8.5.2",
     "@datadog/native-iast-taint-tracking": "4.0.0",
     "@datadog/native-metrics": "^3.1.1",

--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -15,7 +15,6 @@ const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../plugins/util/tags')
 const { tagger } = require('./tagger')
 const { isFalse, isTrue } = require('../util')
 const { getAzureTagsFromMetadata, getAzureAppMetadata } = require('../azure_metadata')
-const satisfies = require('semifies')
 
 class Config {
   constructor (options = {}) {
@@ -198,10 +197,6 @@ class Config {
     let [uploadCompression, level0] = uploadCompression0.split('-')
     if (!['on', 'off', 'gzip', 'zstd'].includes(uploadCompression)) {
       logger.warn(`Invalid profile upload compression method "${uploadCompression0}". Will use "on".`)
-      uploadCompression = 'on'
-    } else if (uploadCompression === 'zstd' && !satisfies(process.versions.node, '>=23.8.0')) {
-      logger.warn(
-        'Profile upload compression method "zstd" is only supported on Node.js 23.8.0 or above. Will use "on".')
       uploadCompression = 'on'
     }
     let level = level0 ? Number.parseInt(level0, 10) : undefined

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -101,13 +101,19 @@ class Profiler extends EventEmitter {
           }
           break
         case 'zstd':
-          this._compressionFn = promisify(zlib.zstdCompress)
-          if (clevel !== undefined) {
-            this._compressionOptions = {
-              params: {
-                [zlib.constants.ZSTD_c_compressionLevel]: clevel
+          if (typeof zlib.zstdCompress === 'function') {
+            this._compressionFn = promisify(zlib.zstdCompress)
+            if (clevel !== undefined) {
+              this._compressionOptions = {
+                params: {
+                  [zlib.constants.ZSTD_c_compressionLevel]: clevel
+                }
               }
             }
+          } else {
+            const zstdCompress = require('@datadog/libdatadog').load('datadog-js-zstd').zstd_compress
+            const level = clevel ?? 0 // 0 is zstd default compression level
+            this._compressionFn = (buffer) => Promise.resolve(Buffer.from(zstdCompress(buffer, level)))
           }
           break
       }

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -5,7 +5,6 @@ require('../setup/tap')
 const { expect } = require('chai')
 const os = require('os')
 const path = require('path')
-const satisfies = require('semifies')
 
 const { AgentExporter } = require('../../src/profiling/exporters/agent')
 const { FileExporter } = require('../../src/profiling/exporters/file')
@@ -443,29 +442,21 @@ describe('config', () => {
 
       expect(config.uploadCompression).to.deep.equal({ method, level })
     }
-    const zstdSupported = satisfies(process.versions.node, '>=23.8.0')
 
     it('should accept known methods', () => {
       expectConfig(undefined, 'gzip', undefined)
       expectConfig('off', 'off', undefined)
       expectConfig('on', 'gzip', undefined)
       expectConfig('gzip', 'gzip', undefined)
-      if (zstdSupported) {
-        expectConfig('zstd', 'zstd', undefined)
-      }
+      expectConfig('zstd', 'zstd', undefined)
     })
 
     it('should reject unknown methods', () => {
-      if (!zstdSupported) {
-        expectConfig('zstd', 'gzip', undefined,
-          'Profile upload compression method "zstd" is only supported on Node.js 23.8.0 or above. Will use "on".')
-      }
       expectConfig('foo', 'gzip', undefined, 'Invalid profile upload compression method "foo". Will use "on".')
     })
 
     it('should accept supported compression levels in methods that support levels', () => {
-      const levelAcceptingMethods = zstdSupported ? [['gzip', 9], ['zstd', 22]] : [['gzip', 9]]
-      levelAcceptingMethods.forEach(([method, maxLevel]) => {
+      [['gzip', 9], ['zstd', 22]].forEach(([method, maxLevel]) => {
         for (let i = 1; i <= maxLevel; i++) {
           expectConfig(`${method}-${i}`, method, i)
         }
@@ -473,8 +464,7 @@ describe('config', () => {
     })
 
     it('should reject invalid compression levels in methods that support levels', () => {
-      const levelAcceptingMethods = zstdSupported ? ['gzip', 'zstd'] : ['gzip']
-      levelAcceptingMethods.forEach((method) => {
+      ['gzip', 'zstd'].forEach((method) => {
         expectConfig(`${method}-foo`, method, undefined,
           'Invalid compression level "foo". Will use default level.')
       })
@@ -494,11 +484,9 @@ describe('config', () => {
       expectConfig('gzip-0', 'gzip', 1, 'Invalid compression level 0. Will use 1.')
       expectConfig('gzip-10', 'gzip', 9, 'Invalid compression level 10. Will use 9.')
       expectConfig('gzip-3.14', 'gzip', 3)
-      if (zstdSupported) {
-        expectConfig('zstd-0', 'zstd', 1, 'Invalid compression level 0. Will use 1.')
-        expectConfig('zstd-23', 'zstd', 22, 'Invalid compression level 23. Will use 22.')
-        expectConfig('zstd-3.14', 'zstd', 3)
-      }
+      expectConfig('zstd-0', 'zstd', 1, 'Invalid compression level 0. Will use 1.')
+      expectConfig('zstd-23', 'zstd', 22, 'Invalid compression level 23. Will use 22.')
+      expectConfig('zstd-3.14', 'zstd', 3)
     })
   })
 })

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -4,7 +4,6 @@ require('../setup/tap')
 
 const expect = require('chai').expect
 const sinon = require('sinon')
-const satisfies = require('semifies')
 
 const SpaceProfiler = require('../../src/profiling/profilers/space')
 const WallProfiler = require('../../src/profiling/profilers/wall')
@@ -294,11 +293,7 @@ describe('profiler', function () {
     })
 
     it('should export zstd profiles', async function () {
-      if (!satisfies(process.versions.node, '>=23.8.0')) {
-        this.skip()
-      } else {
-        await shouldExportProfiles('zstd', Buffer.from([0x28, 0xb5, 0x2f, 0xfd]))
-      }
+      await shouldExportProfiles('zstd', Buffer.from([0x28, 0xb5, 0x2f, 0xfd]))
     })
 
     it('should export gzip profiles with a level', async () => {
@@ -306,11 +301,7 @@ describe('profiler', function () {
     })
 
     it('should export zstd profiles with a level', async function () {
-      if (!satisfies(process.versions.node, '>=23.8.0')) {
-        this.skip()
-      } else {
-        await shouldExportProfiles('zstd-4', Buffer.from([0x28, 0xb5, 0x2f, 0xfd]))
-      }
+      await shouldExportProfiles('zstd-4', Buffer.from([0x28, 0xb5, 0x2f, 0xfd]))
     })
 
     it('should log exporter errors', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,10 +206,10 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@datadog/libdatadog@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.5.1.tgz#fe5c101c457998b74cb66f555f63197b34cad4ba"
-  integrity sha512-KsdOxTUmtjoygaZInSS5U0+KnqoxPKGpcBjGgOHR9NDKfXzmbpy5AmoaPL7JxmMxQzwknpxSi7qzBOSB3yMoJg==
+"@datadog/libdatadog@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.6.0.tgz#299a717ca18d1ea643ecf5880095ed864ffa32a8"
+  integrity sha512-Ldu+U59LUnejtd7ceXMKJCAFZeYpNdTEEXr8PISY9HFXMa4DOwepcWMaJAAqCPU7LINJeivVwvSD1Pm14VZy7w==
 
 "@datadog/native-appsec@8.5.2":
   version "8.5.2"


### PR DESCRIPTION
### What does this PR do?
Uses WASM `datadog-js-zstd` crate from `libdatadog-nodejs` to implement zstd compression of profiles on Node.js versions below 23.8.0 that don't have built-in zstd.

### Motivation
We want to to have zstd compression of profiles on those earlier supported versions of Node.js that don't have built-in zstd.

Jira: [PROF-11878]





[PROF-11878]: https://datadoghq.atlassian.net/browse/PROF-11878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ