### PR TITLE
ci(openai): remove flaky configuration test

### DIFF
--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -7,7 +7,6 @@ const semver = require('semver')
 const nock = require('nock')
 const sinon = require('sinon')
 const { spawn } = require('child_process')
-const { useEnv } = require('../../../integration-tests/helpers')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { DogStatsDClient } = require('../../dd-trace/src/dogstatsd')
@@ -31,16 +30,13 @@ describe('Plugin', () => {
     withVersions('openai', 'openai', '<5.0.0', version => {
       const moduleRequirePath = `../../../versions/openai@${version}`
 
-      beforeEach(() => {
+      before(() => {
         tracer = require(tracerRequirePath)
-      })
-
-      beforeEach(() => {
         return agent.load('openai')
       })
 
-      afterEach(() => {
-        return agent.close({ ritmReset: false, wipe: true })
+      after(() => {
+        return agent.close({ ritmReset: false })
       })
 
       beforeEach(() => {
@@ -74,67 +70,6 @@ describe('Plugin', () => {
       afterEach(() => {
         clock.restore()
         sinon.restore()
-      })
-
-      describe('with configuration', () => {
-        useEnv({
-          DD_OPENAI_SPAN_CHAR_LIMIT: 0
-        })
-
-        it('should truncate both inputs and outputs', async () => {
-          if (version === '3.0.0') return
-          nock('https://api.openai.com:443')
-            .post('/v1/chat/completions')
-            .reply(200, {
-              model: 'gpt-3.5-turbo-0301',
-              choices: [{
-                message: {
-                  role: 'assistant',
-                  content: "In that case, it's best to avoid peanut"
-                }
-              }]
-            })
-
-          const checkTraces = agent
-            .assertSomeTraces(traces => {
-              expect(traces[0][0].meta).to.have.property('openai.request.messages.0.content',
-                '...')
-              expect(traces[0][0].meta).to.have.property('openai.request.messages.1.content',
-                '...')
-              expect(traces[0][0].meta).to.have.property('openai.request.messages.2.content', '...')
-              expect(traces[0][0].meta).to.have.property('openai.response.choices.0.message.content',
-                '...')
-            })
-
-          const params = {
-            model: 'gpt-3.5-turbo',
-            messages: [
-              {
-                role: 'user',
-                content: 'Peanut Butter or Jelly?',
-                name: 'hunter2'
-              },
-              {
-                role: 'assistant',
-                content: 'Are you allergic to peanuts?',
-                name: 'hal'
-              },
-              {
-                role: 'user',
-                content: 'Deathly allergic!',
-                name: 'hunter2'
-              }
-            ]
-          }
-
-          if (semver.satisfies(realVersion, '>=4.0.0')) {
-            await openai.chat.completions.create(params)
-          } else {
-            await openai.createChatCompletion(params)
-          }
-
-          await checkTraces
-        })
       })
 
       describe('without initialization', () => {


### PR DESCRIPTION
### What does this PR do?
Removes a flaky configuration test that will soon be removed anyways because we will get rid of I/O tags on APM spans entirely for LLM-based integrations in favor of more specific data access controls on LLM Observability instead.

If we did want to keep this test around, we could just move it to a different file/`describe` suite, but honestly from an LLMObs standpoint I think we're OK with this.

### Motivation
Improve CI

MLOB-2947