### PR TITLE
test: speed up DI integration tests

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -10,7 +10,7 @@ const { version } = require('../../package.json')
 
 describe('Dynamic Instrumentation', function () {
   describe('Default env', function () {
-    const t = setup()
+    const t = setup({ dependencies: ['fastify'] })
 
     it('base case: target app should work as expected if no test probe has been added', async function () {
       const response = await t.axios.get(t.breakpoint.url)
@@ -727,7 +727,10 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=true', function () {
-    const t = setup({ env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: true } })
+    const t = setup({
+      env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: true },
+      dependencies: ['fastify']
+    })
 
     describe('input messages', function () {
       it(
@@ -738,7 +741,10 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=false', function () {
-    const t = setup({ env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: false } })
+    const t = setup({
+      env: { DD_TRACING_ENABLED: true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED: false },
+      dependencies: ['fastify']
+    })
 
     describe('input messages', function () {
       it(
@@ -749,7 +755,10 @@ describe('Dynamic Instrumentation', function () {
   })
 
   describe('DD_TRACING_ENABLED=false', function () {
-    const t = setup({ env: { DD_TRACING_ENABLED: false } })
+    const t = setup({
+      env: { DD_TRACING_ENABLED: false },
+      dependencies: ['fastify']
+    })
 
     describe('input messages', function () {
       it(

--- a/integration-tests/debugger/ddtags.spec.js
+++ b/integration-tests/debugger/ddtags.spec.js
@@ -16,7 +16,8 @@ describe('Dynamic Instrumentation', function () {
           DD_GIT_COMMIT_SHA: 'test-commit-sha',
           DD_GIT_REPOSITORY_URL: 'test-repository-url'
         },
-        testApp: 'target-app/basic.js'
+        testApp: 'target-app/basic.js',
+        dependencies: ['fastify']
       })
 
       it('should add the expected ddtags as a query param to /debugger/v1/input', function (done) {
@@ -51,7 +52,7 @@ describe('Dynamic Instrumentation', function () {
     })
 
     describe('with undefined values', function () {
-      const t = setup({ testApp: 'target-app/basic.js' })
+      const t = setup({ testApp: 'target-app/basic.js', dependencies: ['fastify'] })
 
       it('should not include undefined values in the ddtags query param', function (done) {
         t.triggerBreakpoint()

--- a/integration-tests/debugger/redact.spec.js
+++ b/integration-tests/debugger/redact.spec.js
@@ -7,7 +7,10 @@ const { once } = require('node:events')
 // Default settings is tested in unit tests, so we only need to test the env vars here
 describe('Dynamic Instrumentation snapshot PII redaction', function () {
   describe('DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS=foo,bar', function () {
-    const t = setup({ env: { DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS: 'foo,bar' } })
+    const t = setup({
+      env: { DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS: 'foo,bar' },
+      dependencies: ['fastify']
+    })
 
     it('should respect DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS', async function () {
       t.triggerBreakpoint()
@@ -29,7 +32,10 @@ describe('Dynamic Instrumentation snapshot PII redaction', function () {
   })
 
   describe('DD_DYNAMIC_INSTRUMENTATION_REDACTION_EXCLUDED_IDENTIFIERS=secret', function () {
-    const t = setup({ env: { DD_DYNAMIC_INSTRUMENTATION_REDACTION_EXCLUDED_IDENTIFIERS: 'secret' } })
+    const t = setup({
+      env: { DD_DYNAMIC_INSTRUMENTATION_REDACTION_EXCLUDED_IDENTIFIERS: 'secret' },
+      dependencies: ['fastify']
+    })
 
     it('should respect DD_DYNAMIC_INSTRUMENTATION_REDACTED_IDENTIFIERS', async function () {
       t.triggerBreakpoint()

--- a/integration-tests/debugger/snapshot-global-sample-rate.spec.js
+++ b/integration-tests/debugger/snapshot-global-sample-rate.spec.js
@@ -5,7 +5,8 @@ const { setup } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
   const t = setup({
-    testApp: 'target-app/basic.js'
+    testApp: 'target-app/basic.js',
+    dependencies: ['fastify']
   })
 
   describe('input messages', function () {

--- a/integration-tests/debugger/snapshot-pruning.spec.js
+++ b/integration-tests/debugger/snapshot-pruning.spec.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const { setup } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
-  const t = setup()
+  const t = setup({ dependencies: ['fastify'] })
 
   describe('input messages', function () {
     describe('with snapshot', function () {

--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const { setup } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
-  const t = setup()
+  const t = setup({ dependencies: ['fastify'] })
 
   describe('input messages', function () {
     describe('with snapshot', function () {

--- a/integration-tests/debugger/template.spec.js
+++ b/integration-tests/debugger/template.spec.js
@@ -6,7 +6,7 @@ const { NODE_MAJOR } = require('../../version')
 
 describe('Dynamic Instrumentation', function () {
   describe('template evaluation', function () {
-    const t = setup()
+    const t = setup({ dependencies: ['fastify'] })
 
     beforeEach(t.triggerBreakpoint)
 

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -18,7 +18,7 @@ module.exports = {
   setup
 }
 
-function setup ({ env, testApp, testAppSource } = {}) {
+function setup ({ env, testApp, testAppSource, dependencies } = {}) {
   let sandbox, cwd, appPort
   const breakpoints = getBreakpointInfo({
     deployedFile: testApp,
@@ -74,7 +74,7 @@ function setup ({ env, testApp, testAppSource } = {}) {
   }
 
   before(async function () {
-    sandbox = await createSandbox(['fastify']) // TODO: Make this dynamic
+    sandbox = await createSandbox(dependencies)
     cwd = sandbox.folder
     // The sandbox uses the `integration-tests` folder as its root
     t.appFile = join(cwd, 'debugger', breakpoints[0].deployedFile)


### PR DESCRIPTION
### What does this PR do?

Makes the dependencies installed in sanbox used in the Dynamic Instrumentation integration tests configurable. Previously `fastify` would always be installed, even if the sandbox didn't require it. This has now been fixed.

### Motivation

Speed up integration tests.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


