### PR TITLE
fix store binding transform not executing with undefined current store

### DIFF
--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -34,7 +34,7 @@ class StoreBinding {
     this._transform = data => {
       const store = storage('legacy').getStore()
 
-      return !store || !store.noop || data?.currentStore
+      return !store || !store.noop || data?.hasOwnProperty('currentStore')
         ? transform(data)
         : store
     }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix store binding transform not executing with undefined current store.

### Motivation
<!-- What inspired you to submit this pull request? -->

This check was originally added to allow running transforms for bindings when the current store has `noop: true` so that the previous store (without noop) would be restored. When I implemented the check I didn't consider cases where the current store is `undefined`.