### PR TITLE
Fix startuplog crashing by serializing bigint

### DIFF
--- a/packages/dd-trace/src/sampler.js
+++ b/packages/dd-trace/src/sampler.js
@@ -21,6 +21,8 @@ class Sampler {
    * @param {number} rate
    */
   constructor (rate) {
+    // TODO: Should this be moved up to the calling parts?
+    rate = Math.min(Math.max(rate, 0), 1)
     this._rate = rate
     this.#threshold = BigInt(Math.floor(rate * MAX_TRACE_ID))
   }

--- a/packages/dd-trace/src/sampler.js
+++ b/packages/dd-trace/src/sampler.js
@@ -16,12 +16,13 @@ const SAMPLING_KNUTH_FACTOR = 1_111_111_111_111_111_111n
  * This class uses a deterministic sampling algorithm that is consistent across all languages.
  */
 class Sampler {
+  #threshold = BigInt(0)
   /**
    * @param {number} rate
    */
   constructor (rate) {
     this._rate = rate
-    this._threshold = BigInt(Math.floor(rate * MAX_TRACE_ID))
+    this.#threshold = BigInt(Math.floor(rate * MAX_TRACE_ID))
   }
 
   /**
@@ -29,6 +30,10 @@ class Sampler {
    */
   rate () {
     return this._rate
+  }
+
+  get threshold () {
+    return this.#threshold
   }
 
   /**
@@ -48,7 +53,7 @@ class Sampler {
 
     span = typeof span.context === 'function' ? span.context() : span
 
-    return (span._traceId.toBigInt() * SAMPLING_KNUTH_FACTOR) % UINT64_MODULO <= this._threshold
+    return (span._traceId.toBigInt() * SAMPLING_KNUTH_FACTOR) % UINT64_MODULO <= this.#threshold
   }
 }
 

--- a/packages/dd-trace/src/sampler.js
+++ b/packages/dd-trace/src/sampler.js
@@ -16,7 +16,8 @@ const SAMPLING_KNUTH_FACTOR = 1_111_111_111_111_111_111n
  * This class uses a deterministic sampling algorithm that is consistent across all languages.
  */
 class Sampler {
-  #threshold = BigInt(0)
+  #threshold = 0n
+
   /**
    * @param {number} rate
    */

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -61,7 +61,9 @@ function tracerInfo () {
       return String(this)
     },
     toString () {
-      return JSON.stringify(this)
+      return JSON.stringify(this, (_key_, value) => {
+        return typeof value === 'bigint' || typeof value === 'symbol' ? String(value) : value
+      })
     }
   }
 

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -13,13 +13,9 @@ let samplingRules = []
 let alreadyRan = false
 
 function getIntegrationsAndAnalytics () {
-  const integrations = new Set()
-  const extras = {}
-  for (const pluginName in pluginManager._pluginsByName) {
-    integrations.add(pluginName)
+  return {
+    integrations_loaded: Object.keys(pluginManager._pluginsByName)
   }
-  extras.integrations_loaded = [...integrations]
-  return extras
 }
 
 function startupLog ({ agentError } = {}) {
@@ -93,16 +89,6 @@ function tracerInfo () {
   Object.assign(out, getIntegrationsAndAnalytics())
 
   out.appsec_enabled = !!config.appsec.enabled
-
-  // // This next bunch is for features supported by other tracers, but not this
-  // // one. They may be implemented in the future.
-
-  // out.enabled_cli
-  // out.sampling_rules_error
-  // out.integration_XXX_analytics_enabled
-  // out.integration_XXX_sample_rate
-  // out.service_mapping
-  // out.service_mapping_error
 
   return out
 }

--- a/packages/dd-trace/test/sampler.spec.js
+++ b/packages/dd-trace/test/sampler.spec.js
@@ -40,7 +40,7 @@ describe('Sampler', () => {
 
       rates.forEach(([rate, expected]) => {
         sampler = new Sampler(rate)
-        expect(sampler._threshold).to.equal(expected)
+        expect(sampler.threshold).to.equal(expected)
       })
     })
   })

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -68,7 +68,7 @@ describe('startup logging', () => {
       date: info.date,
       os_name: os.type(),
       os_version: os.release(),
-      architecture: 'arm64',
+      architecture: os.arch(),
       version: tracerVersion,
       lang: 'nodejs',
       lang_version: process.versions.node,

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -5,10 +5,13 @@ require('./setup/tap')
 const os = require('os')
 const tracerVersion = require('../../../package.json').version
 const Config = require('../src/config')
+const SamplingRule = require('../src/sampling_rule')
+const assert = require('node:assert')
 
 describe('startup logging', () => {
   let firstStderrCall
   let secondStderrCall
+  let tracerInfoMethod
 
   before(() => {
     sinon.stub(console, 'info')
@@ -18,8 +21,10 @@ describe('startup logging', () => {
       setStartupLogConfig,
       setStartupLogPluginManager,
       setSamplingRules,
-      startupLog
+      startupLog,
+      tracerInfo
     } = require('../src/startup-log')
+    tracerInfoMethod = tracerInfo
     setStartupLogPluginManager({
       _pluginsByName: {
         http: { _enabled: true },
@@ -44,7 +49,11 @@ describe('startup logging', () => {
       startupLogs: true,
       appsec: { enabled: true }
     })
-    setSamplingRules(['rule1', 'rule2'])
+    setSamplingRules([
+      new SamplingRule({ name: 'rule1', sampleRate: 0.4 }),
+      'rule2',
+      new SamplingRule({ name: 'rule3', sampleRate: 1.4 })
+    ])
     startupLog({ agentError: { message: 'Error: fake error' } })
     firstStderrCall = console.info.firstCall /* eslint-disable-line no-console */
     secondStderrCall = console.warn.firstCall /* eslint-disable-line no-console */
@@ -54,15 +63,12 @@ describe('startup logging', () => {
 
   it('startupLog should be formatted correctly', () => {
     expect(firstStderrCall.args[0].startsWith('DATADOG TRACER CONFIGURATION - ')).to.equal(true)
-    const logObj = JSON.parse(firstStderrCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    expect(typeof logObj).to.equal('object')
-    expect(typeof logObj.date).to.equal('string')
-    expect(logObj.date.length).to.equal(new Date().toISOString().length)
-    expect(logObj.tags).to.deep.equal({ version: '1.2.3' })
-    expect(logObj.sampling_rules).to.deep.equal(['rule1', 'rule2'])
-    expect(logObj).to.deep.include({
+    const info = JSON.parse(String(tracerInfoMethod()))
+    assert.deepStrictEqual(info, {
+      date: info.date,
       os_name: os.type(),
       os_version: os.release(),
+      architecture: 'arm64',
       version: tracerVersion,
       lang: 'nodejs',
       lang_version: process.versions.node,
@@ -70,26 +76,25 @@ describe('startup logging', () => {
       enabled: true,
       service: 'test',
       agent_url: 'http://example.com:4321',
-      agent_error: 'Error: fake error',
       debug: true,
       sample_rate: 1,
+      sampling_rules: [
+        { matchers: [{ pattern: 'rule1' }], _sampler: { _rate: 0.4 } },
+        'rule2',
+        { matchers: [{ pattern: 'rule3' }], _sampler: { _rate: 1 } }
+      ],
+      tags: { version: '1.2.3' },
       dd_version: '1.2.3',
       log_injection_enabled: true,
       runtime_metrics_enabled: true,
+      profiling_enabled: false,
+      integrations_loaded: ['http', 'fs', 'semver'],
       appsec_enabled: true
     })
   })
 
   it('startupLog should correctly also output the diagnostic message', () => {
     expect(secondStderrCall.args[0]).to.equal('DATADOG TRACER DIAGNOSTIC - Agent Error: Error: fake error')
-  })
-
-  it('setStartupLogPlugins should add plugins to integrations_loaded', () => {
-    const logObj = JSON.parse(firstStderrCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    const integrationsLoaded = logObj.integrations_loaded
-    expect(integrationsLoaded).to.include('fs')
-    expect(integrationsLoaded).to.include('http')
-    expect(integrationsLoaded).to.include('semver')
   })
 })
 

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -2,11 +2,12 @@
 
 require('./setup/tap')
 
-const os = require('os')
-const tracerVersion = require('../../../package.json').version
+const assert = require('node:assert')
+const os = require('node:os')
+
 const Config = require('../src/config')
 const SamplingRule = require('../src/sampling_rule')
-const assert = require('node:assert')
+const tracerVersion = require('../../../package.json').version
 
 describe('startup logging', () => {
   let firstStderrCall

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -43,7 +43,7 @@ describe('startup logging', () => {
       sampler: {
         sampleRate: 1
       },
-      tags: { version: '1.2.3' },
+      tags: { version: '1.2.3', invalid_but_listed_due_to_mocking: 42n },
       logInjection: true,
       runtimeMetrics: true,
       startupLogs: true,
@@ -83,7 +83,7 @@ describe('startup logging', () => {
         'rule2',
         { matchers: [{ pattern: 'rule3' }], _sampler: { _rate: 1 } }
       ],
-      tags: { version: '1.2.3' },
+      tags: { version: '1.2.3', invalid_but_listed_due_to_mocking: '42' },
       dd_version: '1.2.3',
       log_injection_enabled: true,
       runtime_metrics_enabled: true,


### PR DESCRIPTION
Instead, handle bigint and symbols in the future.
Also make the bigint which caused it private and use a getter for
tests instead.

Fixes #5829