### PR TITLE
Allow for reordering of files in the test upload

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -43,8 +43,11 @@ function expectProfileMessagePromise (agent, timeout,
       assert.propertyVal(event, 'family', 'node')
       assert.isString(event.info.profiler.activation)
       assert.isString(event.info.profiler.ssi.mechanism)
-      assert.deepPropertyVal(event, 'attachments', fileNames)
-      for (const [index, fileName] of fileNames.entries()) {
+      const attachments = event.attachments
+      assert.isArray(attachments)
+      // Profiler encodes the files with Promise.all, so their ordering is not guaranteed
+      assert.sameMembers(attachments, fileNames)
+      for (const [index, fileName] of attachments.entries()) {
         assert.propertyVal(files[index + 1], 'originalname', fileName)
       }
     } catch (e) {


### PR DESCRIPTION
### What does this PR do?
Adjusts profiler test behavior so it no longer expects the profile files to be present in the upload in a particular order.

### Motivation
Test became flaky because #5800 introduced parallelism into profile files' encoding that made their ordering nondeterministic.
