### PR TITLE
Fix iast mysql2

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -15,7 +15,7 @@ class SqlInjectionAnalyzer extends StoredInjectionAnalyzer {
 
   onConfigure () {
     this.addSub('apm:mysql:query:start', ({ sql }) => this.analyze(sql, undefined, 'MYSQL'))
-    this.addSub('apm:mysql2:query:start', ({ sql }) => this.analyze(sql, undefined, 'MYSQL'))
+    this.addSub('datadog:mysql2:outerquery:start', ({ sql }) => this.analyze(sql, undefined, 'MYSQL'))
     this.addSub('apm:pg:query:start', ({ query }) => this.analyze(query.text, undefined, 'POSTGRES'))
 
     this.addSub(

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/mysql2-vulnerable-method.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/mysql2-vulnerable-method.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = function vulnerableMethod (connection, sql) {
+  return new Promise((resolve, reject) => {
+    connection.query(sql, function (err) {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+}

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.mysql2.plugin.spec.js
@@ -1,5 +1,9 @@
 'use strict'
 
+const path = require('path')
+const os = require('os')
+const fs = require('fs')
+const { assert } = require('chai')
 const { prepareTestServerForIast } = require('../utils')
 const { storage } = require('../../../../../datadog-core')
 const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
@@ -9,6 +13,7 @@ const vulnerabilityReporter = require('../../../../src/appsec/iast/vulnerability
 describe('sql-injection-analyzer with mysql2', () => {
   let mysql2
   let connection
+
   withVersions('mysql2', 'mysql2', version => {
     prepareTestServerForIast('mysql2', (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
       beforeEach(() => {
@@ -26,22 +31,43 @@ describe('sql-injection-analyzer with mysql2', () => {
         connection.end(done)
       })
 
-      describe('has vulnerability', () => {
+      describe('has vulnerability in the right file/line', () => {
+        let tmpFilePath
+        const vulnerableMethodFilename = 'mysql2-vulnerable-method.js'
+
+        beforeEach(() => {
+          tmpFilePath = path.join(os.tmpdir(), vulnerableMethodFilename)
+
+          try {
+            fs.unlinkSync(tmpFilePath)
+          } catch (e) {
+            // ignore the error
+          }
+          const src = path.join(__dirname, 'resources', vulnerableMethodFilename)
+
+          fs.copyFileSync(src, tmpFilePath)
+        })
+
+        afterEach(() => {
+          try {
+            fs.unlinkSync(tmpFilePath)
+          } catch (e) {
+            // ignore the error
+          }
+        })
+
         testThatRequestHasVulnerability(() => {
-          return new Promise((resolve, reject) => {
-            const store = storage('legacy').getStore()
-            const iastCtx = iastContextFunctions.getIastContext(store)
-            let sql = 'SELECT 1'
-            sql = newTaintedString(iastCtx, sql, 'param', 'Request')
-            connection.query(sql, function (err) {
-              if (err) {
-                reject(err)
-              } else {
-                resolve()
-              }
-            })
-          })
-        }, 'SQL_INJECTION')
+          const store = storage('legacy').getStore()
+          const iastCtx = iastContextFunctions.getIastContext(store)
+          let sql = 'SELECT 1'
+          sql = newTaintedString(iastCtx, sql, 'param', 'Request')
+          const vulnerableMethod = require(tmpFilePath)
+
+          return vulnerableMethod(connection, sql)
+        }, 'SQL_INJECTION', 1, function ([vulnerability]) {
+          assert.isTrue(vulnerability.location.path.endsWith(vulnerableMethodFilename))
+          assert.equal(vulnerability.location.line, 5)
+        })
       })
 
       describe('has no vulnerability', () => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
@@ -66,7 +66,7 @@ describe('sql-injection-analyzer', () => {
   it('should subscribe to mysql, mysql2 and pg start query channel', () => {
     expect(sqlInjectionAnalyzer._subscriptions).to.have.lengthOf(11)
     expect(sqlInjectionAnalyzer._subscriptions[0]._channel.name).to.equals('apm:mysql:query:start')
-    expect(sqlInjectionAnalyzer._subscriptions[1]._channel.name).to.equals('apm:mysql2:query:start')
+    expect(sqlInjectionAnalyzer._subscriptions[1]._channel.name).to.equals('datadog:mysql2:outerquery:start')
     expect(sqlInjectionAnalyzer._subscriptions[2]._channel.name).to.equals('apm:pg:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[3]._channel.name).to.equals('datadog:sequelize:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[4]._channel.name).to.equals('datadog:sequelize:query:finish')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the behaviour of the IAST with mysql2, where we were detecting incorrect file/lines.
Also pretends to fix the flaky test related with mysql2.

### Motivation
<!-- What inspired you to submit this pull request? -->
Bug and flaky fix

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


