### PR TITLE
add workflow to auto-retry main and release branches

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -6,8 +6,6 @@ on:
       - master
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -23,5 +21,6 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@e22f45a4f25f4cf821d1273705ac233355400db1 # v1.2.0
         with:
-          retries: 20 # once per minute, some checks take up to 15 min
+          retries: 30 # once per minute, some checks take up to 15 min, retries are possible
           checks_exclude: devflow.*
+          fail_fast: false

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -6,8 +6,6 @@ on:
     branches: [master]
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,0 +1,31 @@
+name: Retry
+description: |
+  Retry failed workflows to mitigate the impact of flaky jobs.
+
+on:
+  workflow_run:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.[0-9]+-proposal
+      - v[0-9]+.x
+    types:
+      - completed
+    workflows:
+      - APM Capabilities
+      - APM Integrations
+      - AppSec
+      - Debugger
+      - LLMObs
+      - Project
+      - Platform
+      - Test Optimization
+
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1
+    steps:
+      - run: |
+          gh run rerun ${{ github.event.workflow_run.id }} --failed || exit 0

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 jobs:
   build-artifacts:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -7,8 +7,6 @@ on:
       - master
   schedule:
     - cron: 0 4 * * *
-    - cron: 20 4 * * *
-    - cron: 40 4 * * *
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add workflow to auto-retry main and release branches.

### Motivation
<!-- What inspired you to submit this pull request? -->

These branches often fail because of flaky tests, which has a few unfortunate side-effects:

1) For the main branch, it ends up simply failing, because we have no reason to rerun it. This hides real failures.
2) For release proposals, it means that once a release is approved, it might get stuck until someone reruns the tests.
3) For release lines, it doesn't really matter right now but I still added them as if/when we decide to run tests again in release branches they'd have a similar issue as both of the above.

I ignored regular PRs for now as these need some special handling as they are a lot more likely to have real failures since they are work in progress.

I also removed the daily full reruns as these are no longer needed to figure out flakiness if we systematically rerun failed tests as part of the pipeline.