### PR TITLE
wip(vercel-ai): add vercel ai integration

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -28,6 +28,7 @@ module.exports = {
   '@smithy/smithy-client': () => require('../aws-sdk'),
   '@vitest/runner': { esmFirst: true, fn: () => require('../vitest') },
   aerospike: () => require('../aerospike'),
+  ai: { esmFirst: true, fn: () => require('../vercel-ai') },
   amqp10: () => require('../amqp10'),
   amqplib: () => require('../amqplib'),
   avsc: () => require('../avsc'),

--- a/packages/datadog-instrumentations/src/vercel-ai.js
+++ b/packages/datadog-instrumentations/src/vercel-ai.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const { addHook } = require('./helpers/instrument')
+const tracer = require('../../dd-trace')
+const shimmer = require('../../datadog-shimmer')
+
+const { TracerProvider } = tracer
+const provider = new TracerProvider()
+provider.register()
+
+const { channel } = require('dc-polyfill')
+const toolCreationChannel = channel('dd-trace:vercel-ai:tool')
+
+const TRACED_FUNCTIONS = {
+  generateText: wrapWithTracer,
+  streamText: wrapWithTracer,
+  generateObject: wrapWithTracer,
+  streamObject: wrapWithTracer,
+  embed: wrapWithTracer,
+  embedMany: wrapWithTracer,
+  tool: wrapTool
+}
+
+function wrapWithTracer (fn) {
+  return function () {
+    const options = arguments[0]
+    if (options.experimental_telemetry != null) return fn.apply(this, arguments)
+
+    options.experimental_telemetry = {
+      isEnabled: true,
+      // TODO(sabrenner): need to figure out how a user can configure this tracer
+      // maybe we advise they do this manually?
+      tracer: provider.getTracer()
+    }
+
+    return fn.apply(this, arguments)
+  }
+}
+
+function wrapTool (tool) {
+  return function () {
+    const args = arguments[0]
+    toolCreationChannel.publish(args)
+
+    return tool.apply(this, arguments)
+  }
+}
+
+addHook({
+  name: 'ai',
+  versions: ['>=4.0.0'],
+}, exports => {
+  // the exports from this package are not configurable
+  // to return wrapped functions with the tracer provided above,
+  // we need to copy the exports
+  const wrappedExports = {}
+
+  for (const [fnName, patchingFn] of Object.entries(TRACED_FUNCTIONS)) {
+    const original = exports[fnName]
+    wrappedExports[fnName] = shimmer.wrapFunction(original, patchingFn)
+  }
+
+  Object.getOwnPropertyNames(exports).forEach(prop => {
+    if (!Object.keys(TRACED_FUNCTIONS).includes(prop)) {
+      wrappedExports[prop] = exports[prop]
+    }
+  })
+
+  return wrappedExports
+})

--- a/packages/datadog-plugin-vercel-ai/src/index.js
+++ b/packages/datadog-plugin-vercel-ai/src/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const CompositePlugin = require('../../dd-trace/src/plugins/composite')
+const VercelAILLMObsPlugin = require('../../dd-trace/src/llmobs/plugins/vercel-ai')
+const VercelAITracingPlugin = require('./tracing')
+
+class VercelAIPlugin extends CompositePlugin {
+  static get id () { return 'vercel-ai' }
+  static get plugins () {
+    return {
+      llmobs: VercelAILLMObsPlugin,
+      tracing: VercelAITracingPlugin
+    }
+  }
+}
+
+module.exports = VercelAIPlugin

--- a/packages/datadog-plugin-vercel-ai/src/tracing.js
+++ b/packages/datadog-plugin-vercel-ai/src/tracing.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const Plugin = require('../../dd-trace/src/plugins/plugin')
+
+const { channel } = require('dc-polyfill')
+const spanFinishCh = channel('dd-trace:otel:span:finish')
+
+const { isVercelAISpan } = require('./util')
+
+// filter input/output based tags for APM spans
+// this is for data access controls and for sensitive data
+// the LLM Observability feature is recommended in its place for better
+// data access controls and sensitive data scrubbing
+const TAG_PATTERNS_TO_FILTER = [
+  'prompt', // TODO(sabrenner): we need to refine this so it doesn't filter out prompt tokens
+  'messages',
+  'response.text',
+  'toolCalls',
+  'toolCall.args',
+  'toolCall.result',
+  'values',
+  'embedding'
+]
+
+/**
+ * Determines if an OpenTelemetry span tag should be filtered out on the final DD span
+ *
+ * @param {String} key
+ * @returns {Boolean}
+ */
+function shouldFilterTag (key) {
+  return TAG_PATTERNS_TO_FILTER.some(pattern => key.includes(pattern))
+}
+
+class VercelAITracingPlugin extends Plugin {
+  static get id () { return 'ai' }
+
+  constructor (...args) {
+    super(...args)
+
+    spanFinishCh.subscribe(({ ddSpan }) => {
+      if (!isVercelAISpan(ddSpan)) {
+        return
+      }
+
+      for (const key of Object.keys(ddSpan.context()._tags)) {
+        if (shouldFilterTag(key)) {
+          ddSpan.setTag(key, undefined)
+        }
+      }
+    })
+  }
+}
+
+module.exports = VercelAITracingPlugin

--- a/packages/datadog-plugin-vercel-ai/src/util.js
+++ b/packages/datadog-plugin-vercel-ai/src/util.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/**
+ * Determines if an OpenTelemetry span is a Vercel AI span
+ *
+ * @param {import('../../dd-trace/src/opentracing/span') | null} span
+ * @returns {Boolean}
+ */
+function isVercelAISpan (span) {
+  return span._name?.startsWith('ai') && span.context()._tags?.['resource.name']?.startsWith('ai')
+}
+
+module.exports = {
+  isVercelAISpan
+}

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -182,6 +182,6 @@ function writeUInt32BE (buffer, value, offset) {
   buffer[0 + offset] = value & 255
 }
 
-module.exports = function createIdentifier (value, radix) {
+module.exports = Object.assign(function createIdentifier (value, radix) {
   return new Identifier(value, radix)
-}
+}, { Identifier })

--- a/packages/dd-trace/src/llmobs/plugins/vercel-ai.js
+++ b/packages/dd-trace/src/llmobs/plugins/vercel-ai.js
@@ -1,0 +1,423 @@
+'use strict'
+
+const BaseLLMObsPlugin = require('./base')
+
+const { channel } = require('dc-polyfill')
+
+const otelSpanStartCh = channel('dd-trace:otel:span:start')
+const otelSpanFinishCh = channel('dd-trace:otel:span:finish')
+const toolCreationCh = channel('dd-trace:vercel-ai:tool')
+
+const { isVercelAISpan } = require('../../../../datadog-plugin-vercel-ai/src/util')
+const { MODEL_NAME, MODEL_PROVIDER, NAME } = require('../constants/tags')
+
+const SPANS_TO_USE_LLMOBS_PARENT = new Set([
+  'generateText',
+  'streamText',
+  'embed',
+  'embedMany',
+  'generateObject',
+  'streamObject'
+])
+
+const SPAN_NAME_TO_KIND_MAPPING = {
+  // embeddings
+  embed: 'workflow',
+  embedMany: 'workflow',
+  doEmbed: 'embedding',
+  // object generation
+  generateObject: 'workflow',
+  streamObject: 'workflow',
+  // text generation
+  generateText: 'workflow',
+  streamText: 'workflow',
+  // llm operations
+  doGenerate: 'llm',
+  doStream: 'llm',
+  // tools
+  toolCall: 'tool'
+}
+
+const MODEL_PROVIDER_MAPPING = {
+  'amazon-bedrock': 'bedrock',
+  vertex: 'vertexai',
+  'generative-ai': 'genai' // TODO(sabrenner): double check this
+}
+
+const MODEL_METADATA_KEYS = new Set([
+  'frequency_penalty',
+  'max_tokens',
+  'presence_penalty',
+  'temperature',
+  'top_p',
+  'top_k',
+  'stop_sequences'
+])
+
+/**
+ * @param {import('../../../../dd-trace/src/opentracing/span')} span
+ * @param {string} tag
+ * @returns {string}
+ */
+function getSpanTag (span, tag) {
+  const value = span.context()._tags[tag]
+  if (!value) return
+
+  return value
+}
+
+/**
+ * @param {import('../../../../dd-trace/src/opentracing/span')} span
+ * @returns {string}
+ */
+function getOperation (span) {
+  const name = span._name
+  if (!name) return
+
+  return name.split('.').pop()
+}
+
+function getUsage (span) {
+  const inputTokens = getSpanTag(span, 'ai.usage.promptTokens')
+  const outputTokens = getSpanTag(span, 'ai.usage.completionTokens')
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens
+  }
+}
+
+/**
+ * @param {import('../../../../dd-trace/src/opentracing/span')} span
+ * @returns {string}
+ */
+function getModelProvider (span) {
+  const modelProviderTag = span.context()._tags['ai.model.provider']
+  const providerParts = modelProviderTag?.split('.')
+  const provider = providerParts?.[0]
+
+  // TODO(sabrenner): explain or simplify this logic
+  switch (provider) {
+    case 'google':
+      return MODEL_PROVIDER_MAPPING[providerParts?.[1]] ?? provider
+    default:
+      return MODEL_PROVIDER_MAPPING[provider] ?? provider
+  }
+}
+
+function getJsonStringValue (str, defaultValue) {
+  let maybeValue = defaultValue
+  try {
+    maybeValue = JSON.parse(str)
+  } catch {
+    // do nothing
+  }
+
+  return maybeValue
+}
+
+function getModelMetadata (span) {
+  const modelMetadata = {}
+  for (const metadata of MODEL_METADATA_KEYS) {
+    const metadataTagKey = `gen_ai.request.${metadata}`
+    const metadataValue = getSpanTag(span, metadataTagKey)
+    if (metadataValue) {
+      modelMetadata[metadata] = metadataValue
+    }
+  }
+
+  return modelMetadata
+}
+
+function getGenerationMetadata (span) {
+  const metadata = {}
+  for (const tag of Object.keys(span.context()._tags)) {
+    if (!tag.startsWith('ai.settings')) continue
+
+    const settingKey = tag.split('.').pop()
+    const transformedKey = settingKey.replaceAll(/[A-Z]/g, letter => '_' + letter.toLowerCase())
+    if (MODEL_METADATA_KEYS.has(transformedKey)) continue
+
+    const settingValue = getSpanTag(span, tag)
+    metadata[settingKey] = settingValue
+  }
+
+  return metadata
+}
+
+class VercelAILLMObsPlugin extends BaseLLMObsPlugin {
+  static get id () { return 'vercel-ai' }
+  static get integration () { return 'vercel-ai' }
+
+  /** @type {Set<Record<string, any>>} */
+  #availableTools
+
+  /** @type {Record<string, string>} */
+  #toolCallIdsToName
+
+  constructor (...args) {
+    super(...args)
+
+    otelSpanStartCh.subscribe(({ ddSpan }) => {
+      if (!isVercelAISpan(ddSpan)) return
+
+      // holding context for llmobs parentage
+      const ctx = {
+        currentStore: { span: ddSpan }
+      }
+
+      const operation = getOperation(ddSpan)
+      const useLlmObsParent = SPANS_TO_USE_LLMOBS_PARENT.has(operation)
+
+      this.start(ctx, {
+        useLlmObsParent,
+        enterIntoLlmObsStorage: false
+      }) // triggers the getLLMObsSpanRegisterOptions
+    })
+
+    otelSpanFinishCh.subscribe(({ ddSpan }) => {
+      if (!isVercelAISpan(ddSpan)) return
+
+      const ctx = {
+        currentStore: { span: ddSpan }
+      }
+
+      this.asyncEnd(ctx) // triggers the setLLMObsTags
+    })
+
+    this.#toolCallIdsToName = {}
+    this.#availableTools = new Set()
+    toolCreationCh.subscribe(toolArgs => {
+      this.#availableTools.add(toolArgs)
+    })
+  }
+
+  findToolName (toolDescription) {
+    for (const availableTool of this.#availableTools) {
+      const description = availableTool.description
+      if (description === toolDescription) {
+        return availableTool.id
+      }
+    }
+  }
+
+  getLLMObsSpanRegisterOptions (ctx) {
+    const span = ctx.currentStore.span
+    const operation = getOperation(span)
+    const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
+    if (!kind) return
+
+    return { kind, name: operation }
+  }
+
+  setLLMObsTags (ctx) {
+    const span = ctx.currentStore.span
+    if (!span) return
+
+    const operation = getOperation(span)
+    const kind = SPAN_NAME_TO_KIND_MAPPING[operation]
+    if (!kind) return
+
+    if (['embedding', 'llm'].includes(kind)) {
+      this._tagger._setTag(span, MODEL_NAME, getSpanTag(span, 'ai.model.id'))
+      this._tagger._setTag(span, MODEL_PROVIDER, getModelProvider(span))
+    }
+
+    switch (operation) {
+      case 'embed':
+      case 'embedMany':
+        this.setEmbeddingWorkflowTags(span)
+        break
+      case 'doEmbed':
+        this.setEmbeddingTags(span)
+        break
+      case 'generateObject':
+      case 'streamObject':
+        this.setObjectGenerationTags(span)
+        break
+      case 'generateText':
+      case 'streamText':
+        this.setTextGenerationTags(span)
+        break
+      case 'doGenerate':
+      case 'doStream':
+        this.setLLMOperationTags(span)
+        break
+      case 'toolCall':
+        this.setToolTags(span)
+        break
+      default:
+        break
+    }
+  }
+
+  setEmbeddingWorkflowTags (span) {
+    const inputs = getSpanTag(span, 'ai.value') ?? getSpanTag(span, 'ai.values')
+    const parsedInputs = Array.isArray(inputs)
+      ? inputs.map(input => getJsonStringValue(input, ''))
+      : getJsonStringValue(inputs, '')
+
+    const embeddingsOutput = getSpanTag(span, 'ai.embedding') ?? getSpanTag(span, 'ai.embeddings')
+    const isSingleEmbedding = !Array.isArray(embeddingsOutput)
+    const numberOfEmbeddings = isSingleEmbedding ? 1 : embeddingsOutput.length
+    const embeddingsLength = getJsonStringValue(isSingleEmbedding ? embeddingsOutput : embeddingsOutput?.[0], []).length
+    const output = `[${numberOfEmbeddings} embedding(s) returned with size ${embeddingsLength}]`
+
+    this._tagger.tagTextIO(span, parsedInputs, output)
+
+    const metadata = getGenerationMetadata(span)
+    this._tagger.tagMetadata(span, metadata)
+  }
+
+  setEmbeddingTags (span) {
+    const inputs = getSpanTag(span, 'ai.values')
+    const parsedInputs = inputs.map(input => getJsonStringValue(input, ''))
+
+    const embeddingsOutput = getSpanTag(span, 'ai.embeddings')
+    const numberOfEmbeddings = embeddingsOutput?.length
+    const embeddingsLength = getJsonStringValue(embeddingsOutput?.[0], []).length
+    const output = `[${numberOfEmbeddings} embedding(s) returned with size ${embeddingsLength}]`
+
+    this._tagger.tagEmbeddingIO(span, parsedInputs, output)
+
+    const usage = getSpanTag(span, 'ai.usage.tokens')
+    this._tagger.tagMetrics(span, {
+      inputTokens: usage,
+      totalTokens: usage
+    })
+  }
+
+  setObjectGenerationTags (span) {
+    const promptInfo = getJsonStringValue(getSpanTag(span, 'ai.prompt'), {})
+    const lastUserPrompt =
+      promptInfo.prompt ??
+      promptInfo.messages.reverse().find(message => message.role === 'user')?.content
+    const prompt = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+
+    const output = getSpanTag(span, 'ai.response.object')
+
+    this._tagger.tagTextIO(span, prompt, output)
+
+    const metadata = getGenerationMetadata(span)
+    metadata.schema = getSpanTag(span, 'ai.schema')
+    this._tagger.tagMetadata(span, metadata)
+  }
+
+  setTextGenerationTags (span) {
+    const promptInfo = getJsonStringValue(getSpanTag(span, 'ai.prompt'), {})
+    const lastUserPrompt =
+      promptInfo.prompt ??
+      promptInfo.messages.reverse().find(message => message.role === 'user')?.content
+    const prompt = Array.isArray(lastUserPrompt) ? lastUserPrompt.map(part => part.text ?? '').join('') : lastUserPrompt
+
+    const output = getSpanTag(span, 'ai.response.text')
+
+    this._tagger.tagTextIO(span, prompt, output)
+
+    const metadata = getGenerationMetadata(span)
+    this._tagger.tagMetadata(span, metadata)
+  }
+
+  setLLMOperationTags (span) {
+    const toolsForModel = getSpanTag(span, 'ai.prompt.tools')?.map(getJsonStringValue)
+    const inputMessages = getJsonStringValue(getSpanTag(span, 'ai.prompt.messages'), [])?.map(
+      message => this.formatMessage(message, toolsForModel)
+    )
+    const outputMessage = this.formatOutputMessage(span, toolsForModel)
+
+    this._tagger.tagLLMIO(span, inputMessages, outputMessage)
+
+    const metadata = getModelMetadata(span)
+    this._tagger.tagMetadata(span, metadata)
+
+    const usage = getUsage(span)
+    this._tagger.tagMetrics(span, usage)
+  }
+
+  setToolTags (span) {
+    const toolCallId = getSpanTag(span, 'ai.toolCall.id')
+    const name = this.#toolCallIdsToName[toolCallId]
+    if (name) this._tagger._setTag(span, NAME, name)
+
+    const input = getJsonStringValue(getSpanTag(span, 'ai.toolCall.args'))
+    const output = getJsonStringValue(getSpanTag(span, 'ai.toolCall.result'))
+
+    this._tagger.tagTextIO(span, input, output)
+  }
+
+  formatOutputMessage (span, toolsForModel) {
+    const outputMessageText = getSpanTag(span, 'ai.response.text') ?? getSpanTag(span, 'ai.response.object')
+    const outputMessageToolCalls = getJsonStringValue(getSpanTag(span, 'ai.response.toolCalls'), [])
+
+    const formattedToolCalls = []
+    for (const toolCall of outputMessageToolCalls) {
+      const toolCallArgs = getJsonStringValue(toolCall.args, {})
+      const toolDescription = toolsForModel?.find(tool => toolCall.toolName === tool.name)?.description
+      const name = this.findToolName(toolDescription)
+      this.#toolCallIdsToName[toolCall.toolCallId] = name
+
+      formattedToolCalls.push({
+        arguments: toolCallArgs,
+        name,
+        toolId: toolCall.toolCallId,
+        type: 'function'
+      })
+    }
+
+    return {
+      role: 'assistant',
+      content: outputMessageText,
+      toolCalls: formattedToolCalls
+    }
+  }
+
+  formatMessage (message, toolsForModel) {
+    const { role, content } = message
+    const toolCalls = []
+
+    const finalMessage = {
+      role,
+      content: ''
+    }
+
+    if (role === 'system') {
+      finalMessage.content = content
+    } else if (role === 'user') {
+      for (const part of content) {
+        const { type } = part
+        if (type === 'text') {
+          finalMessage.content += part.text
+        }
+      }
+    } else if (role === 'assistant') {
+      for (const part of content) {
+        const { type } = part
+        if (['text', 'reasoning', 'redacted-reasoning'].includes(type)) {
+          finalMessage.content += part.text ?? part.data
+        } else if (type === 'tool-call') {
+          const toolDescription = toolsForModel?.find(tool => part.toolName === tool.name)?.description
+          const name = this.findToolName(toolDescription)
+
+          toolCalls.push({
+            arguments: part.args,
+            name,
+            toolId: part.toolCallId,
+            type: 'function'
+          })
+        }
+      }
+
+      if (toolCalls.length) {
+        finalMessage.toolCalls = toolCalls
+      }
+    }
+
+    // TODO(sabrenner): add support for tool messages in a follow-up once BE supports it
+    // role === 'tool'
+
+    return finalMessage
+  }
+}
+
+module.exports = VercelAILLMObsPlugin

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -1,6 +1,8 @@
 'use strict'
 
 const log = require('../log')
+const { Identifier } = require('../id')
+const Span = require('../opentracing/span')
 const {
   MODEL_NAME,
   MODEL_PROVIDER,
@@ -89,10 +91,15 @@ class LLMObsTagger {
 
     this._setTag(span, ML_APP, spanMlApp)
 
-    const parentId =
-      parent?.context().toSpanId() ??
-      span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY] ??
-      ROOT_PARENT_ID
+    let parentId
+    if (parent instanceof Identifier) {
+      parentId = parent.toString(10)
+    } else if (parent instanceof Span) {
+      parentId = parent.context().toSpanId()
+    } else {
+      parentId = span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY] ?? ROOT_PARENT_ID
+    }
+
     this._setTag(span, PARENT_ID_KEY, parentId)
   }
 

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -16,6 +16,10 @@ const kinds = require('../../../../ext/kinds')
 const SpanContext = require('./span_context')
 const id = require('../id')
 
+const { channel } = require('dc-polyfill')
+const otelSpanStartCh = channel('dd-trace:otel:span:start')
+const otelSpanFinishCh = channel('dd-trace:otel:span:finish')
+
 // The one built into OTel rounds so we lose sub-millisecond precision.
 function hrTimeToMilliseconds (time) {
   return time[0] * 1e3 + time[1] / 1e6
@@ -165,6 +169,8 @@ class Span {
     this.startTime = hrStartTime
     this.kind = kind
     this._spanProcessor.onStart(this, context)
+
+    otelSpanStartCh.publish({ span: this, ddSpan: this._ddSpan })
   }
 
   get parentSpanId () {
@@ -257,6 +263,9 @@ class Span {
       api.diag.error('You can only call end() on a span once.')
       return
     }
+
+    // publish before span finishes and tags are potentially removed
+    otelSpanFinishCh.publish({ span: this, ddSpan: this._ddSpan })
 
     const hrEndTime = timeInputToHrTime(timeInput || (performance.now() + timeOrigin))
     const endTime = hrTimeToMilliseconds(hrEndTime)

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -24,6 +24,7 @@ module.exports = {
   get '@smithy/smithy-client' () { return require('../../../datadog-plugin-aws-sdk/src') },
   get '@vitest/runner' () { return require('../../../datadog-plugin-vitest/src') },
   get aerospike () { return require('../../../datadog-plugin-aerospike/src') },
+  get ai () { return require('../../../datadog-plugin-vercel-ai/src') },
   get amqp10 () { return require('../../../datadog-plugin-amqp10/src') },
   get amqplib () { return require('../../../datadog-plugin-amqplib/src') },
   get avsc () { return require('../../../datadog-plugin-avsc/src') },


### PR DESCRIPTION
### What does this PR do?
WIP - assessing strategy of parsing OTel spans generated from the Vercel AI SDK (which works great, but seeing if it fits into library standards/if we can set a new precedent)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


