### PR TITLE
test: speed up DI integration tests

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -5,7 +5,7 @@ const os = require('os')
 const { assert } = require('chai')
 const { pollInterval, setup } = require('./utils')
 const { assertObjectContains, assertUUID } = require('../helpers')
-const { ACKNOWLEDGED, ERROR } = require('../../packages/dd-trace/src/remote_config/apply_states')
+const { UNACKNOWLEDGED, ACKNOWLEDGED, ERROR } = require('../../packages/dd-trace/src/remote_config/apply_states')
 const { version } = require('../../package.json')
 
 describe('Dynamic Instrumentation', function () {
@@ -37,6 +37,10 @@ describe('Dynamic Instrumentation', function () {
         }]
 
         t.agent.on('remote-config-ack-update', (id, version, state, error) => {
+          // Due to the very short DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS, there's a race condition in which we might
+          // get an UNACKNOWLEDGED state first before the ACKNOWLEDGED state.
+          if (state === UNACKNOWLEDGED) return
+
           assert.strictEqual(id, t.rcConfig.id)
           assert.strictEqual(version, 1)
           assert.strictEqual(state, ACKNOWLEDGED)
@@ -101,6 +105,10 @@ describe('Dynamic Instrumentation', function () {
         ]
 
         t.agent.on('remote-config-ack-update', (id, version, state, error) => {
+          // Due to the very short DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS, there's a race condition in which we might
+          // get an UNACKNOWLEDGED state first before the ACKNOWLEDGED state.
+          if (state === UNACKNOWLEDGED) return
+
           assert.strictEqual(id, t.rcConfig.id)
           assert.strictEqual(version, ++receivedAckUpdates)
           assert.strictEqual(state, ACKNOWLEDGED)
@@ -141,6 +149,10 @@ describe('Dynamic Instrumentation', function () {
         }]
 
         t.agent.on('remote-config-ack-update', (id, version, state, error) => {
+          // Due to the very short DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS, there's a race condition in which we might
+          // get an UNACKNOWLEDGED state first before the ACKNOWLEDGED state.
+          if (state === UNACKNOWLEDGED) return
+
           assert.strictEqual(id, t.rcConfig.id)
           assert.strictEqual(version, 1)
           assert.strictEqual(state, ACKNOWLEDGED)

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -10,7 +10,7 @@ const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
 const { generateProbeConfig } = require('../../packages/dd-trace/test/debugger/devtools_client/utils')
 
 const BREAKPOINT_TOKEN = '// BREAKPOINT'
-const pollInterval = 1
+const pollInterval = 0.1
 
 module.exports = {
   pollInterval,


### PR DESCRIPTION
### What does this PR do?

Increase the RC poll interval in the Dynamic Instrumentation integration tests, so that they run faster.

Debugger CI run performance improvement:

| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/a7a921af-b3d7-4b62-8aa5-98e7437c2c16) | ![image](https://github.com/user-attachments/assets/9cd1620d-0980-40de-8133-e7c6be7a357b) |

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


