### PR TITLE
test: speed up DI integration tests even more

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -97,6 +97,7 @@ function setup ({ env, testApp, testAppSource, dependencies } = {}) {
       env: {
         DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true',
         DD_DYNAMIC_INSTRUMENTATION_UPLOAD_INTERVAL_SECONDS: '0',
+        _DD_INTERNAL_DYNAMIC_INSTRUMENTATION_SCRIPT_LOADING_STABILIZATION_DELAY_MS: '0',
         DD_TRACE_AGENT_PORT: t.agent.port,
         DD_TRACE_DEBUG: process.env.DD_TRACE_DEBUG, // inherit to make debugging the sandbox easier
         DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: pollInterval,

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -4,9 +4,14 @@ const { join, dirname } = require('path')
 const { normalize } = require('source-map/lib/util')
 const { loadSourceMapSync } = require('./source-maps')
 const session = require('./session')
+const { getEnvironmentVariable } = require('../../config-helper')
 const log = require('../../log')
 
 const WINDOWS_DRIVE_LETTER_REGEX = /[a-zA-Z]/
+const SCRIPT_LOADING_STABILIZATION_DELAY =
+  getEnvironmentVariable('_DD_INTERNAL_DYNAMIC_INSTRUMENTATION_SCRIPT_LOADING_STABILIZATION_DELAY_MS') === undefined
+    ? 500
+    : Number(getEnvironmentVariable('_DD_INTERNAL_DYNAMIC_INSTRUMENTATION_SCRIPT_LOADING_STABILIZATION_DELAY_MS'))
 
 const loadedScripts = []
 const scriptUrls = new Map()
@@ -168,6 +173,6 @@ session.on('Debugger.scriptParsed', ({ params }) => {
     clearTimeout(reEvaluateProbesTimer)
     reEvaluateProbesTimer = setTimeout(() => {
       session.emit('scriptLoadingStabilized')
-    }, 500)
+    }, SCRIPT_LOADING_STABILIZATION_DELAY)
   }
 })


### PR DESCRIPTION
### What does this PR do?

Don't wait for script loading to stabilize in Dynamic Instrumentation integration tests.
    
This might make them temporarily set the test breakpoint in the wrong location, but it will quickly get moved to the right location and the test should still trigger as expected.

Debugger CI run performance improvement:

| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/9cd1620d-0980-40de-8133-e7c6be7a357b) | ![image](https://github.com/user-attachments/assets/2da1c8d3-399a-468b-9b26-8deb7101549d) |

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


