### PR TITLE
fix missing repo flag for retry workflow

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -28,4 +28,4 @@ jobs:
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1
     steps:
       - run: |
-          gh run rerun ${{ github.event.workflow_run.id }} --failed || exit 0
+          gh run rerun ${{ github.event.workflow_run.id }} --repo DataDog/dd-trace-js --failed || exit 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing repo flag for retry workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->

Since the repo is not checked out it cannot be inferred from the current folder.