### PR TITLE
chore: temporarily restrict yarn audit to prod deps only in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dependencies:dedupe": "yarn-deduplicate yarn.lock",
     "type:doc": "cd docs && yarn && yarn build",
     "type:test": "cd docs && yarn && yarn test",
-    "lint": "node scripts/check_licenses.js && eslint . --max-warnings 0 && yarn audit",
+    "lint": "node scripts/check_licenses.js && eslint . --max-warnings 0 && yarn audit --groups dependencies",
     "lint:fix": "node scripts/check_licenses.js && eslint . --max-warnings 0 --fix && yarn audit",
     "lint:inspect": "npx @eslint/config-inspector@latest",
     "release:proposal": "node scripts/release/proposal",


### PR DESCRIPTION
There's a potential ReDoS vulnerability in `brace-expansion` which is a dev-sub-dependency of ours (the `dd-trace` package is not vulnerable). As of now, we don't have an upgrade path, which unfortunately means this blocks all CI.
    
Temporarily disable running `yarn audit` on dev-dependencies to allow work to be done in the repo.

Alternative approach tried and failed: https://github.com/DataDog/dd-trace-js/pull/5873
