### PR TITLE
Reduce false positives when unvalidated redirect vulnerability is detected

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
@@ -39,11 +39,11 @@ class UnvalidatedRedirectAnalyzer extends InjectionAnalyzer {
     if (!value) return false
 
     const ranges = getRanges(iastContext, value)
-    return ranges && ranges.length > 0 && this._hasUnsafeRange(ranges)
+    return ranges?.length > 0 && this._hasUnsafeRange(ranges)
   }
 
   _hasUnsafeRange (ranges) {
-    return ranges && ranges.some(
+    return ranges.some(
       range => this._isVulnerableRange(range)
     )
   }

--- a/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
@@ -5,12 +5,18 @@ const { UNVALIDATED_REDIRECT } = require('../vulnerabilities')
 const { getNodeModulesPaths } = require('../path-line')
 const { getRanges } = require('../taint-tracking/operations')
 const {
-  HTTP_REQUEST_HEADER_VALUE,
-  HTTP_REQUEST_PATH_PARAM,
-  HTTP_REQUEST_URI
+  HTTP_REQUEST_BODY,
+  HTTP_REQUEST_PARAMETER,
+  HTTP_REQUEST_PATH
 } = require('../taint-tracking/source-types')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('express/lib/response.js')
+
+const VULNERABLE_SOURCE_TYPES = new Set([
+  HTTP_REQUEST_BODY,
+  HTTP_REQUEST_PARAMETER,
+  HTTP_REQUEST_PATH
+])
 
 class UnvalidatedRedirectAnalyzer extends InjectionAnalyzer {
   constructor () {
@@ -35,28 +41,17 @@ class UnvalidatedRedirectAnalyzer extends InjectionAnalyzer {
     if (!value) return false
 
     const ranges = getRanges(iastContext, value)
-    return ranges && ranges.length > 0 && !this._areSafeRanges(ranges)
+    return ranges && ranges.length > 0 && this._hasUnsafeRange(ranges)
   }
 
-  // Do not report vulnerability if ranges sources are exclusively url,
-  // path params or referer header to avoid false positives.
-  _areSafeRanges (ranges) {
-    return ranges && ranges.every(
-      range => this._isPathParam(range) || this._isUrl(range) || this._isRefererHeader(range)
+  _hasUnsafeRange (ranges) {
+    return ranges && ranges.some(
+      range => this._isVulnerableRange(range)
     )
   }
 
-  _isRefererHeader (range) {
-    return range.iinfo.type === HTTP_REQUEST_HEADER_VALUE &&
-      range.iinfo.parameterName && range.iinfo.parameterName.toLowerCase() === 'referer'
-  }
-
-  _isPathParam (range) {
-    return range.iinfo.type === HTTP_REQUEST_PATH_PARAM
-  }
-
-  _isUrl (range) {
-    return range.iinfo.type === HTTP_REQUEST_URI
+  _isVulnerableRange (range) {
+    return VULNERABLE_SOURCE_TYPES.has(range.iinfo.type)
   }
 
   _getExcludedPaths () {

--- a/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
@@ -6,16 +6,14 @@ const { getNodeModulesPaths } = require('../path-line')
 const { getRanges } = require('../taint-tracking/operations')
 const {
   HTTP_REQUEST_BODY,
-  HTTP_REQUEST_PARAMETER,
-  HTTP_REQUEST_PATH
+  HTTP_REQUEST_PARAMETER
 } = require('../taint-tracking/source-types')
 
 const EXCLUDED_PATHS = getNodeModulesPaths('express/lib/response.js')
 
 const VULNERABLE_SOURCE_TYPES = new Set([
   HTTP_REQUEST_BODY,
-  HTTP_REQUEST_PARAMETER,
-  HTTP_REQUEST_PATH
+  HTTP_REQUEST_PARAMETER
 ])
 
 class UnvalidatedRedirectAnalyzer extends InjectionAnalyzer {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/source-types.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/source-types.js
@@ -7,7 +7,6 @@ module.exports = {
   HTTP_REQUEST_HEADER_NAME: 'http.request.header.name',
   HTTP_REQUEST_HEADER_VALUE: 'http.request.header',
   HTTP_REQUEST_PARAMETER: 'http.request.parameter',
-  HTTP_REQUEST_PATH: 'http.request.path',
   HTTP_REQUEST_PATH_PARAM: 'http.request.path.parameter',
   HTTP_REQUEST_URI: 'http.request.uri',
   KAFKA_MESSAGE_KEY: 'kafka.message.key',

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
@@ -77,7 +77,7 @@ describe('Unvalidated Redirect vulnerability', () => {
             line: 12
           }
         }, null, (done, config) => {
-          getAxiosInstance(config).post({
+          getAxiosInstance(config).post('', {
             location: 'http://user@app.com/'
           }).catch(done)
         })
@@ -95,7 +95,7 @@ describe('Unvalidated Redirect vulnerability', () => {
         testThatRequestHasNoVulnerability((req, res) => {
           redirectFunctions.insecureWithResLocationMethod(req.headers.redirectlocation, res)
         }, UNVALIDATED_REDIRECT, (done, config) => {
-          getAxiosInstance(config).get({
+          getAxiosInstance(config).get('', {
             headers: {
               redirectlocation: 'http://user@app.com/'
             }

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
@@ -6,9 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
-const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
-const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
+const axios = require('axios')
 
 describe('Unvalidated Redirect vulnerability', () => {
   let redirectFunctions
@@ -28,9 +26,7 @@ describe('Unvalidated Redirect vulnerability', () => {
     prepareTestServerForIastInExpress('in express', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage('legacy').getStore()
-          const iastCtx = iastContextFunctions.getIastContext(store)
-          const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
+          const location = req.query.location// newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
           redirectFunctions.insecureWithResHeaderMethod('location', location, res)
         }, UNVALIDATED_REDIRECT, {
           occurrences: 1,
@@ -38,44 +34,53 @@ describe('Unvalidated Redirect vulnerability', () => {
             path: redirectFunctionsFilename,
             line: 4
           }
+        }, null, (done, config) => {
+          axios.get(`http://localhost:${config.port}/?location=https://app.com?id=tron`).catch(done)
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage('legacy').getStore()
-          const iastCtx = iastContextFunctions.getIastContext(store)
-          const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
-          redirectFunctions.insecureWithResRedirectMethod(location, res)
+          redirectFunctions.insecureWithResRedirectMethod(req.query.location, res)
         }, UNVALIDATED_REDIRECT, {
           occurrences: 1,
           location: {
             path: redirectFunctionsFilename,
             line: 8
           }
+        }, null, (done, config) => {
+          axios.get(`http://localhost:${config.port}/?location=http://user@app.com/`).catch(done)
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage('legacy').getStore()
-          const iastCtx = iastContextFunctions.getIastContext(store)
-          const location = newTaintedString(iastCtx, 'http://user@app.com/', 'param', 'Request')
-          redirectFunctions.insecureWithResLocationMethod(location, res)
+          redirectFunctions.insecureWithResLocationMethod(req.query.location, res)
         }, UNVALIDATED_REDIRECT, {
           occurrences: 1,
           location: {
             path: redirectFunctionsFilename,
             line: 12
           }
+        }, null, (done, config) => {
+          axios.get(`http://localhost:${config.port}/?location=http://user@app.com/`).catch(done)
         })
 
         testThatRequestHasNoVulnerability((req, res) => {
-          const store = storage('legacy').getStore()
-          const iastCtx = iastContextFunctions.getIastContext(store)
-          const location = newTaintedString(iastCtx, 'http://user@app.com/', 'pathParam', 'Request')
-          res.header('X-test', location)
-        }, UNVALIDATED_REDIRECT)
+          res.header('X-test', req.query.location)
+        }, UNVALIDATED_REDIRECT, (done, config) => {
+          axios.get(`http://localhost:${config.port}/?location=http://user@app.com/'`).catch(done)
+        })
 
         testThatRequestHasNoVulnerability((req, res) => {
           redirectFunctions.insecureWithResHeaderMethod('location', 'http://user@app.com/', res)
         }, UNVALIDATED_REDIRECT)
+
+        testThatRequestHasNoVulnerability((req, res) => {
+          redirectFunctions.insecureWithResLocationMethod(req.headers.redirectlocation, res)
+        }, UNVALIDATED_REDIRECT, (done, config) => {
+          axios.get(`http://localhost:${config.port}/`, {
+            headers: {
+              redirectlocation: 'http://user@app.com/'
+            }
+          }).catch(done)
+        })
       })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/unvalidated-redirect-analyzer.express.plugin.spec.js
@@ -62,6 +62,20 @@ describe('Unvalidated Redirect vulnerability', () => {
           axios.get(`http://localhost:${config.port}/?location=http://user@app.com/`).catch(done)
         })
 
+        testThatRequestHasVulnerability((req, res) => {
+          redirectFunctions.insecureWithResLocationMethod(req.body.location, res)
+        }, UNVALIDATED_REDIRECT, {
+          occurrences: 1,
+          location: {
+            path: redirectFunctionsFilename,
+            line: 12
+          }
+        }, null, (done, config) => {
+          axios.post(`http://localhost:${config.port}/`, {
+            location: 'http://user@app.com/'
+          }).catch(done)
+        })
+
         testThatRequestHasNoVulnerability((req, res) => {
           res.header('X-test', req.query.location)
         }, UNVALIDATED_REDIRECT, (done, config) => {

--- a/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/vulnerability-analyzer.express.plugin.spec.js
@@ -6,9 +6,7 @@ const path = require('path')
 
 const { UNVALIDATED_REDIRECT } = require('../../../../src/appsec/iast/vulnerabilities')
 const { prepareTestServerForIastInExpress } = require('../utils')
-const { storage } = require('../../../../../datadog-core')
-const iastContextFunctions = require('../../../../src/appsec/iast/iast-context')
-const { newTaintedString } = require('../../../../src/appsec/iast/taint-tracking/operations')
+const axios = require('axios')
 
 describe('Vulnerability Analyzer plugin', () => {
   let redirectFunctions
@@ -45,29 +43,27 @@ describe('Vulnerability Analyzer plugin', () => {
     prepareTestServerForIastInExpress('should find original source line minified or not', version,
       (testThatRequestHasVulnerability, testThatRequestHasNoVulnerability) => {
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage('legacy').getStore()
-          const iastCtx = iastContextFunctions.getIastContext(store)
-          const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
-          redirectMinFunctions.insecureWithResHeaderMethod('location', location, res)
+          redirectMinFunctions.insecureWithResHeaderMethod('location', req.query.location, res)
         }, UNVALIDATED_REDIRECT, {
           occurrences: 1,
           location: {
             path: redirectFunctionsFilename, // original source code file indicated in sourceMappingURL
             line: 4 // line in not minified source file
           }
+        }, null, (done, config) => {
+          axios.get(`http://localhost:${config.port}/?location=https://app.com?id=tron`).catch(done)
         })
 
         testThatRequestHasVulnerability((req, res) => {
-          const store = storage('legacy').getStore()
-          const iastCtx = iastContextFunctions.getIastContext(store)
-          const location = newTaintedString(iastCtx, 'https://app.com?id=tron', 'param', 'Request')
-          redirectFunctions.insecureWithResHeaderMethod('location', location, res)
+          redirectFunctions.insecureWithResHeaderMethod('location', req.query.location, res)
         }, UNVALIDATED_REDIRECT, {
           occurrences: 1,
           location: {
             path: redirectFunctionsFilename,
             line: 4
           }
+        }, null, (done, config) => {
+          axios.get(`http://localhost:${config.port}/?location=https://app.com?id=tron`).catch(done)
         })
       })
   })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Reduce false positives when unvalidated redirect vulnerability is detected

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->
[APPSEC-57443]



[APPSEC-57443]: https://datadoghq.atlassian.net/browse/APPSEC-57443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ