### PR TITLE
[test-optimization] [SDTEST-1060] Add mocked files of Jest to the list of dependencies in TIA

### DIFF
--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -318,11 +318,11 @@ class JestPlugin extends CiPlugin {
      * because this subscription happens in a different process from the one
      * fetching the ITR config.
      */
-    this.addSub('ci:jest:test-suite:code-coverage', ({ coverageFiles, testSuite }) => {
+    this.addSub('ci:jest:test-suite:code-coverage', ({ coverageFiles, testSuite, mockedFiles }) => {
       if (!coverageFiles.length) {
         this.telemetry.count(TELEMETRY_CODE_COVERAGE_EMPTY)
       }
-      const files = [...coverageFiles, testSuite]
+      const files = [...coverageFiles, ...mockedFiles, testSuite]
 
       const { _traceId, _spanId } = this.testSuiteSpan.context()
       const formattedCoverage = {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
With this change we will not longer skip tests if some of their mocked files has been changed/deleted.

### Motivation
<!-- What inspired you to submit this pull request? -->
There was an incident where we were skipping a test and one of their mocked files was deleted in that same PR. In Jest mocked files don't fail in typecheck, so there is a need to add this mocked files to the list of dependencies.
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


