### PR TITLE
add explicit main ref when checking out system tests in workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: 'DataDog/system-tests'
+          ref: 'main'
       - name: Checkout dd-trace-js
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add explicit `main` ref when checking out system tests in workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise each job in the matrix needs an API call to figure out the default branch, and since we have hundreds of jobs in the matrix it resulted in API call limits being reached.