### PR TITLE
Update to libdatadog-nodejs 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@datadog/libdatadog": "^0.6.0",
+    "@datadog/libdatadog": "^0.7.0",
     "@datadog/native-appsec": "8.5.2",
     "@datadog/native-iast-taint-tracking": "4.0.0",
     "@datadog/native-metrics": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,10 +206,10 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@datadog/libdatadog@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.6.0.tgz#299a717ca18d1ea643ecf5880095ed864ffa32a8"
-  integrity sha512-Ldu+U59LUnejtd7ceXMKJCAFZeYpNdTEEXr8PISY9HFXMa4DOwepcWMaJAAqCPU7LINJeivVwvSD1Pm14VZy7w==
+"@datadog/libdatadog@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@datadog/libdatadog/-/libdatadog-0.7.0.tgz#81e07d3040c628892db697ccd01ae3c4d2a76315"
+  integrity sha512-VVZLspzQcfEU47gmGCVoRkngn7RgFRR4CHjw4YaX8eWT+xz4Q4l6PvA45b7CMk9nlt3MNN5MtGdYttYMIpo6Sg==
 
 "@datadog/native-appsec@8.5.2":
   version "8.5.2"


### PR DESCRIPTION
### What does this PR do?
Updates to libdatadog-nodejs 0.7.0

### Motivation
It updates crashtracker to 16.0.3 from 15.0.0. With this, it'll start emitting crashtracker messages in the newer format and we can filter new format on the intake for whether it's a Datadog-related crash or not.
It also brings in the bindings for service/process discovery.