### PR TITLE
Remove explicit AbortSignal reason

### DIFF
--- a/packages/dd-trace/src/appsec/rasp/utils.js
+++ b/packages/dd-trace/src/appsec/rasp/utils.js
@@ -58,11 +58,6 @@ function handleResult (result, req, res, abortController, config, raspRule) {
       const abortError = new DatadogRaspAbortError(req, res, blockingAction, raspRule, ruleTriggered)
       abortController.abort(abortError)
 
-      // TODO Delete this when support for node 16 is removed
-      if (!abortController.signal.reason) {
-        abortController.signal.reason = abortError
-      }
-
       return
     }
   }


### PR DESCRIPTION
### What does this PR do?
Removes the explicit set for AbortSignal reason

### Motivation
Fully supported on Node.js 18

