### PR TITLE
wrapCommandQueueClass fix super call

### DIFF
--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -39,8 +39,8 @@ function wrapAddCommand (addCommand) {
 
 function wrapCommandQueueClass (cls) {
   const ret = class RedisCommandQueue extends cls {
-    constructor () {
-      super(arguments)
+    constructor (...args) {
+      super(...args)
       if (createClientUrl) {
         try {
           const parsed = new URL(createClientUrl)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix the super call on wrapCommandQueueClass

### Motivation
<!-- What inspired you to submit this pull request? -->
Currently breaks redis pub/sub on node-redis 5+ (and is probably causing other unexpected issues)




