### PR TITLE
ci(langchain): skip latest langchain in ci until mocking is fixed

### DIFF
--- a/packages/datadog-plugin-langchain/test/index.spec.js
+++ b/packages/datadog-plugin-langchain/test/index.spec.js
@@ -46,7 +46,8 @@ describe('Plugin', () => {
   })
 
   describe('langchain', () => {
-    withVersions('langchain', ['@langchain/core'], version => {
+    // TODO(sabrenner): remove this once we have the more robust mocking merged
+    withVersions('langchain', ['@langchain/core'], '<0.3.60', version => {
       before(() => {
         iastFilter.isDdTrace = file => {
           if (file.includes('dd-trace-js/versions/')) {

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -99,7 +99,8 @@ describe('integrations', () => {
       return agent.close({ ritmReset: false, wipe: true })
     })
 
-    withVersions('langchain', ['@langchain/core'], version => {
+    // TODO(sabrenner): remove this once we have the more robust mocking merged
+    withVersions('langchain', ['@langchain/core'], '<0.3.60', version => {
       describe('langchain', () => {
         beforeEach(() => {
           langchainOpenai = require(`../../../../../../versions/@langchain/openai@${version}`).get()


### PR DESCRIPTION
### What does this PR do?
Does not test against latest `langchain` until we have our more robust mocking solution in place (snapshot server). I am currently updating tests for OpenAI, and will migrate langchain tests over after as well.

Tests are failing not due to instrumentation, but that langchain updated their OpenAI SDK under the hood to v5, which we cannot currently mock nicely. We have a shared snapshot server we're finishing up that should resolve both integrations' tests.

### Motivation
Unblock CI.


