### PR TITLE
[DI] Improve internal timer performance

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -165,9 +165,12 @@ session.on('Debugger.scriptParsed', ({ params }) => {
       loadedScripts.push(params)
     }
 
-    clearTimeout(reEvaluateProbesTimer)
-    reEvaluateProbesTimer = setTimeout(() => {
-      session.emit('scriptLoadingStabilized')
-    }, 500)
+    if (reEvaluateProbesTimer === null) {
+      reEvaluateProbesTimer = setTimeout(() => {
+        session.emit('scriptLoadingStabilized')
+      }, 500).unref()
+    } else {
+      reEvaluateProbesTimer.refresh()
+    }
   }
 })


### PR DESCRIPTION
### What does this PR do?

Instead of using `clearTimeout` to stop a timeout, only to set it again right afterwards, use `timer.refresh()` to restart it.

As a bonus, this PR also un-refs the timer so it doesn't hang the process (though in this case, that would only ever hang it for 500ms).

### Motivation

Reduce resource usage.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


