### PR TITLE
Code cleanup: Improve calculation of number of bytes in string

### DIFF
--- a/packages/dd-trace/src/llmobs/writers/spans.js
+++ b/packages/dd-trace/src/llmobs/writers/spans.js
@@ -35,7 +35,7 @@ class LLMObsSpanWriter extends BaseWriter {
     if (shouldTruncate) {
       logger.warn(`Dropping event input/output because its size (${eventSizeBytes}) exceeds the 1MB event size limit`)
       event = this._truncateSpanEvent(event)
-      processedEventSizeBytes = Buffer.from(JSON.stringify(event)).byteLength
+      processedEventSizeBytes = Buffer.byteLength(JSON.stringify(event))
     }
 
     telemetry.recordLLMObsSpanSize(event, processedEventSizeBytes, shouldTruncate)


### PR DESCRIPTION
### What does this PR do?

Use built-in `Buffer.byteLength` API to get the amount of bytes in a string instead of first converting the string to a buffer to then get the number of bytes. In the end, this is probably not faster, but it's best practise.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


