### PR TITLE
docs: fix bug in docs related to running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Before running _plugin_ tests, the supporting docker containers need to be runni
 
 Instead, you can follow this procedure for the plugin you want to run tests for:
 
-1. Check the CI config in `.github/workflows/plugins.yml` to see what the appropriate values for the `SERVICES` and `PLUGINS` environment variables are for the plugin you're trying to test (noting that not all plugins require `SERVICES`). For example, for the `amqplib` plugin, the `SERVICES` value is `rabbitmq`, and the `PLUGINS` value is `amqplib`.
+1. Check the CI config in `.github/workflows/*.yml` to see what the appropriate values for the `SERVICES` and `PLUGINS` environment variables are for the plugin you're trying to test (noting that not all plugins require `SERVICES`). For example, for the `amqplib` plugin, the `SERVICES` value is `rabbitmq`, and the `PLUGINS` value is `amqplib`.
 2. Run the appropriate docker-compose command to start the required services. For example, for the `amqplib` plugin, you would run: `docker compose up -d rabbitmq`.
 3. Run `yarn services`, with the environment variables set above. This will install any versions of the library to be tested against into the `versions` directory, and check that the appropriate services are running prior to running the test.
 4. Now, you can run `yarn test:plugins` with the environment variables set above to run the tests for the plugin you're interested in.
@@ -117,8 +117,8 @@ To wrap that all up into a simple few lines of shell commands, here is all of th
 
 ```sh
 # These are exported for simplicity, but you can also just set them inline.
-export SERVICES="rabbitmq" # retrieved from .github/workflows/plugins.yml
-export PLUGINS="amqplib" # retrieved from .github/workflows/plugins.yml
+export SERVICES="rabbitmq" # retrieved from .github/workflows/apm-integrations.yml
+export PLUGINS="amqplib" # retrieved from .github/workflows/apm-integrations.yml
 
 docker compose up -d $SERVICES
 yarn services


### PR DESCRIPTION
The reference to `plugins.yml` is no longer valid, because this file has been split up into multiple files. Update the docs to match.
