### PR TITLE
Activate weekly dependabot PRs for npm and switch actions to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,28 @@ updates:
       - "/.github/actions/*"
       - "/.github/actions/*/*"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     groups:
       gh-actions-packages:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-minor-and-patch-dependencies:
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      runtime-minor-and-patch-dependencies:
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
We should be up to date with dependencies in an automated way.

I decided not to ignore anything for now to see how many PRs are incoming and potentially limit it later by ignoring a couple of pinned versions.