### PR TITLE
fix(esbuild): call the hook function properly in the bundler register

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/bundler-register.js
+++ b/packages/datadog-instrumentations/src/helpers/bundler-register.js
@@ -28,7 +28,13 @@ if (!dc.unsubscribe) {
 
 dc.subscribe(CHANNEL, (payload) => {
   try {
-    hooks[payload.package]()
+    const hook = hooks[payload.package]
+
+    if (typeof hook === 'object') {
+      hook.fn()
+    } else {
+      hook()
+    }
   } catch (err) {
     log.error('esbuild-wrapped %s missing in list of hooks', payload.package)
     throw err


### PR DESCRIPTION
### What does this PR do?
Calls the hook function properly in `bundler-register.js` - it's possible for a hook to be an object with a hook function, and not always a hook function directly.

### Motivation
Closes #5925

That issue reported the problem for OpenAI, but by looking at `hook.js`, this would also be a problem for `vitest`, `langchain`, and `@vitest/runner`.