### PR TITLE
Clear internal timer when manually flushing agent exporter

### DIFF
--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -31,9 +31,7 @@ class AgentExporter {
     })
 
     process.once('beforeExit', () => {
-      clearTimeout(this.#timer)
-      this.#timer = undefined
-      this._writer.flush()
+      this.flush()
     })
   }
 
@@ -63,6 +61,8 @@ class AgentExporter {
   }
 
   flush (done = () => {}) {
+    clearTimeout(this.#timer)
+    this.#timer = undefined
     this._writer.flush(done)
   }
 }


### PR DESCRIPTION
### What does this PR do?

Clear the internal flush timer, which flushes the internal queue of data waiting to be sent to the agent, if the `flush` function on the `AgentExporter` is called manually.

### Motivation

There's no reason to keep the flush timer running if the queue is empty.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


