### PR TITLE
Log JSON parse errors for DD_SPAN_SAMPLING_RULES_FILE

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -151,6 +151,16 @@ function maybeFile (filepath) {
   }
 }
 
+function maybeJsonFile (filepath) {
+  const file = maybeFile(filepath)
+  if (!file) return
+  try {
+    return JSON.parse(file)
+  } catch (e) {
+    log.error('Error parsing JSON file %s', filepath, e)
+  }
+}
+
 function safeJsonParse (input) {
   try {
     return JSON.parse(input)
@@ -944,7 +954,7 @@ class Config {
     otelSetRuntimeMetrics)
     this._setBoolean(env, 'runtimeMetricsRuntimeId', DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED)
     this._setArray(env, 'sampler.spanSamplingRules', reformatSpanSamplingRules(coalesce(
-      safeJsonParse(maybeFile(DD_SPAN_SAMPLING_RULES_FILE)),
+      maybeJsonFile(DD_SPAN_SAMPLING_RULES_FILE),
       safeJsonParse(DD_SPAN_SAMPLING_RULES)
     )))
     this._setUnit(env, 'sampleRate', DD_TRACE_SAMPLE_RATE ||


### PR DESCRIPTION
### What does this PR do?

Log error if `DD_SPAN_SAMPLING_RULES_FILE` is provided, but it doesn't contain valid JSON.

### Motivation

Makes debugging issues with `DD_SPAN_SAMPLING_RULES_FILE` easier.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


