### PR TITLE
remove async storage from http2 server instrumentation

### DIFF
--- a/packages/dd-trace/src/plugins/util/inferred_proxy.js
+++ b/packages/dd-trace/src/plugins/util/inferred_proxy.js
@@ -20,7 +20,7 @@ const supportedProxies = {
   }
 }
 
-function createInferredProxySpan (headers, childOf, tracer, context) {
+function createInferredProxySpan (headers, childOf, tracer, reqCtx, store, traceCtx) {
   if (!headers) {
     return null
   }
@@ -57,12 +57,17 @@ function createInferredProxySpan (headers, childOf, tracer, context) {
   )
 
   tracer.scope().activate(span)
-  context.inferredProxySpan = span
+  reqCtx.inferredProxySpan = span
   childOf = span
 
   log.debug('Successfully created inferred proxy span.')
 
   setInferredProxySpanTags(span, proxyContext)
+
+  if (traceCtx) {
+    traceCtx.parentStore = store
+    traceCtx.currentStore = { ...store, span }
+  }
 
   return childOf
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


