### PR TITLE
Link to dd-trace on npm via the GitHub Deployments page for npm

### DIFF
--- a/.github/workflows/release-3.yml
+++ b/.github/workflows/release-3.yml
@@ -12,7 +12,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: npm
+    environment:
+      name: npm
+      url: https://npmjs.com/package/dd-trace
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release-4.yml
+++ b/.github/workflows/release-4.yml
@@ -12,7 +12,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: npm
+    environment:
+      name: npm
+      url: https://npmjs.com/package/dd-trace
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -5,7 +5,9 @@ on: workflow_dispatch
 jobs:
   dev_release:
     runs-on: ubuntu-latest
-    environment: npm
+    environment:
+      name: npm
+      url: https://npmjs.com/package/dd-trace
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -12,7 +12,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: npm
+    environment:
+      name: npm
+      url: https://npmjs.com/package/dd-trace
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
### What does this PR do?

This is the page that the link will show up on:

https://github.com/DataDog/dd-trace-js/deployments/npm

### Motivation

Just makes your day a bit nicer

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


