### PR TITLE
test: remove loading of tap where not needed

### DIFF
--- a/packages/dd-trace/test/crashtracking/worker.js
+++ b/packages/dd-trace/test/crashtracking/worker.js
@@ -4,7 +4,7 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noCallThru()
 
-require('../setup/tap')
+require('../setup/core')
 
 const crashtracker = {
   start: sinon.stub(),
@@ -19,7 +19,6 @@ const noop = {
 const crashtracking = proxyquire('../../src/crashtracking', {
   './crashtracker': crashtracker,
   './noop': noop
-
 })
 
 crashtracking.start()


### PR DESCRIPTION
### What does this PR do?

This file doesn't use tap, so no need to require it. Instead just require the setup core functionality which was previously loaded by tap.

### Motivation

This is a step in the process of removing the `setup/tap.js` file.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


