### PR TITLE
reduce output size of flakiness report

### DIFF
--- a/scripts/flakiness.mjs
+++ b/scripts/flakiness.mjs
@@ -110,10 +110,9 @@ if (Object.keys(flaky).length === 0) {
     console.log(`* ${workflow}`)
     for (const [job, urls] of Object.entries(jobs).sort()) {
       if (urls.length < OCCURRENCES) continue
-      console.log(`    * ${job}`)
-      for (const url of urls.sort()) {
-        console.log(`        * [${url.replace('https://github.com/DataDog/', '')}](${url})`)
-      }
+      // Padding is needed because Slack doesn't show single digits as links.
+      const links = urls.map((url, idx) => `[${String(idx + 1).padStart(2, '0')}](${url})`)
+      console.log(`    * ${job} (${links.join(', ')})`)
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Reduce output size of flakiness report.

### Motivation
<!-- What inspired you to submit this pull request? -->

We have a lot of flaky tests, and the list was becoming unreadable. The new format uses a comma-separated indexed links instead of the full links with a newline for each one.
