### PR TITLE
Fix fs test expecting a promise returning method to throw sync

### DIFF
--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -1534,10 +1534,10 @@ describe('Plugin', () => {
             })
 
             it('should handle errors', () =>
-              testHandleErrors(fs, 'dir.read', (_1, _2, _3, cb) => {
+              testHandleErrors(fs, 'dir.read', async (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  dir.read()
+                  await dir.read()
                 } catch (e) {
                   cb(e)
                 }
@@ -1557,7 +1557,7 @@ describe('Plugin', () => {
               testHandleErrors(fs, 'dir.read', (_1, _2, _3, cb) => {
                 dir.closeSync()
                 try {
-                  dir.read(cb)
+                  dir.read(() => {})
                 } catch (e) {
                   cb(e)
                 }


### PR DESCRIPTION
That expectation does not hold, since an async method always rejects in a async manner. This improves another test to just not use the callback in the wrong spot. That would now time out, so it is also not ideal, while the test could otherwise have silently not worked as expected.
