### PR TITLE
fix mongoose flaky tests

### DIFF
--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -52,9 +52,13 @@ describe('Plugin', () => {
         'mongodb-core',
         (done) => {
           const PeerCat = mongoose.model('PeerCat', { name: String })
-          new PeerCat({ name: 'PeerCat' }).save().catch(done)
+          new PeerCat({ name: 'PeerCat' }).save()
+            .then(() => done())
+            .catch(done)
         },
-        () => dbName, 'peer.service')
+        () => dbName, 'peer.service',
+        { waitForFinish: true }
+      )
 
       it('should propagate context with write operations', () => {
         const Cat = mongoose.model('Cat1', { name: String })

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -92,20 +92,16 @@ class OutboundPlugin extends TracingPlugin {
 
   finish (ctx) {
     const span = ctx?.currentStore?.span || this.activeSpan
-    this.tagPeerService(span, () => {
-      super.finish(...arguments)
-    })
+    this.tagPeerService(span)
+    super.finish(...arguments)
   }
 
-  tagPeerService (span, done) {
+  tagPeerService (span) {
     if (this._tracerConfig.spanComputePeerService) {
       const peerData = this.getPeerService(span.context()._tags)
       if (peerData !== undefined) {
         span.addTags(this.getPeerServiceRemap(peerData))
       }
-    }
-    if (done) {
-      done()
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes mongoose flakes due to race condition setting peer service tag and the span finishing.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


