### PR TITLE
test: load helpers directly instead of using globals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -196,9 +196,6 @@ export default [
         expect: 'readonly',
         proxyquire: 'readonly',
         withVersions: 'readonly',
-        withPeerService: 'readonly',
-        withNamingSchema: 'readonly',
-        withExports: 'readonly'
       }
     },
     rules: {

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -286,9 +286,10 @@ describe('Plugin', () => {
               })
           })
           withNamingSchema(
-            () => aerospike.connect(config).then(client => {
-              return client.put(key, { i: 123 })
-                .then(() => client.close(false))
+            async () => {
+              const client = await aerospike.connect(config)
+              await client.put(key, { i: 123 })
+              return client.close(false)
             }),
             rawExpectedSchema.command
           )
@@ -320,9 +321,10 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => aerospike.connect(config).then(client => {
-            return client.put(key, { i: 123 })
-              .then(() => client.close(false))
+          async () => {
+            const client = await aerospike.connect(config)
+            await client.put(key, { i: 123 })
+            return client.close(false)
           }),
           {
             v0: {

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -54,10 +54,11 @@ describe('Plugin', () => {
           withPeerService(
             () => tracer,
             'aerospike',
-            () => aerospike.connect(config).then(client => {
-              return client.put(key, { i: 123 })
-                .then(() => client.close(false))
-            }),
+            async () => {
+              const client = await aerospike.connect(config)
+              await client.put(key, { i: 123 })
+              return client.close(false)
+            },
             'test',
             'aerospike.namespace'
           )

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -290,7 +290,7 @@ describe('Plugin', () => {
               const client = await aerospike.connect(config)
               await client.put(key, { i: 123 })
               return client.close(false)
-            }),
+            },
             rawExpectedSchema.command
           )
         })
@@ -325,7 +325,7 @@ describe('Plugin', () => {
             const client = await aerospike.connect(config)
             await client.put(key, { i: 123 })
             return client.close(false)
-          }),
+          },
           {
             v0: {
               opName: 'aerospike.command',

--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 

--- a/packages/datadog-plugin-amqp10/test/index.spec.js
+++ b/packages/datadog-plugin-amqp10/test/index.spec.js
@@ -65,7 +65,10 @@ describe('Plugin', () => {
           withPeerService(
             () => tracer,
             'amqp10',
-            () => sender.send({ key: 'value' }),
+            (done) => {
+              sender.send({ key: 'value' })
+              done()
+            },
             'localhost',
             'out.host'
           )

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')

--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -61,7 +61,7 @@ describe('Plugin', () => {
             withPeerService(
               () => tracer,
               'amqplib',
-              () => channel.assertQueue(queue, {}, () => {}),
+              (done) => channel.assertQueue(queue, {}, done),
               'localhost',
               'out.host'
             )
@@ -139,7 +139,7 @@ describe('Plugin', () => {
             withPeerService(
               () => tracer,
               'amqplib',
-              () => channel.assertQueue(queue, {}, () => {}),
+              (done) => channel.assertQueue(queue, {}, done),
               'localhost',
               'out.host'
             )

--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -444,14 +444,12 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => {
+          async () => {
             const operationName = 'MyQuery'
             const source = `query ${operationName} { hello(name: "world") }`
             const variableValues = { who: 'world' }
-            gateway()
-              .then(({ executor }) => {
-                return execute(executor, source, variableValues, operationName).then(() => {})
-              })
+            const { executor } = await gateway()
+            return execute(executor, source, variableValues, operationName)
           },
           rawExpectedSchema.server,
           {

--- a/packages/datadog-plugin-apollo/test/index.spec.js
+++ b/packages/datadog-plugin-apollo/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { expect } = require('chai')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent.js')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants.js')
 const { expectedSchema, rawExpectedSchema } = require('./naming.js')

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const sinon = require('sinon')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
 const helpers = require('./kinesis_helpers')

--- a/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/lambda.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const JSZip = require('jszip')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
 const { rawExpectedSchema } = require('./lambda-naming')

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -63,7 +63,7 @@ describe('Plugin', () => {
             Bucket: bucketName,
             Key: 'test-key',
             Body: 'test body'
-          }, (err) => err && done(err)),
+          }, done),
           bucketName, 'bucketname')
 
         withNamingSchema(

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
 const axios = require('axios')

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -3,6 +3,7 @@
 
 const sinon = require('sinon')
 const semver = require('semver')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
 const { rawExpectedSchema } = require('./sns-naming')

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -355,7 +355,7 @@ describe('Sns', function () {
         (done) => sns.publish({
           TopicArn,
           Message: 'message 1'
-        }, (err) => err && done()),
+        }, done),
         'TestTopic', 'topicname')
 
       withNamingSchema(

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const sinon = require('sinon')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { setup } = require('./spec_helpers')
 const semver = require('semver')

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -74,7 +74,7 @@ describe('Plugin', () => {
           (done) => sqs.sendMessage({
             MessageBody: 'test body',
             QueueUrl
-          }, (err) => err && done(err)),
+          }, done),
           'SQS_QUEUE_NAME',
           'queuename'
         )

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const semver = require('semver')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_TYPE, ERROR_MESSAGE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-cassandra-driver/test/index.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/index.spec.js
@@ -48,8 +48,9 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'cassandra-driver',
-          (done) => client.execute('SELECT now() FROM local;', err => err && done(err)),
-          '127.0.0.1', 'db.cassandra.contact.points'
+          (done) => client.execute('SELECT now() FROM local;', done),
+          '127.0.0.1',
+          'db.cassandra.contact.points'
         )
 
         it('should do automatic instrumentation', done => {

--- a/packages/datadog-plugin-couchbase/test/index.spec.js
+++ b/packages/datadog-plugin-couchbase/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai')
 const semver = require('semver')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -59,7 +59,7 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'elasticsearch',
-          () => client.search({
+          (done) => client.search({
             index: 'docs',
             sort: 'name',
             size: 100,
@@ -68,8 +68,9 @@ describe('Plugin', () => {
                 match_all: {}
               }
             }
-          }, hasCallbackSupport ? () => {} : undefined),
-          'localhost', 'out.host'
+          }, hasCallbackSupport ? done : undefined),
+          'localhost',
+          'out.host'
         )
 
         it('should set the correct tags', done => {

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -68,7 +68,8 @@ describe('Plugin', () => {
                 match_all: {}
               }
             }
-          }, hasCallbackSupport ? done : undefined),
+          // Ignore index_not_found_exception
+          }, hasCallbackSupport ? () => done() : undefined),
           'localhost',
           'out.host'
         )

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -69,7 +69,7 @@ describe('Plugin', () => {
               }
             }
           // Ignore index_not_found_exception
-          }, hasCallbackSupport ? () => done() : undefined),
+          }, hasCallbackSupport ? () => done() : undefined)?.catch?.(() => {}),
           'localhost',
           'out.host'
         )

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')

--- a/packages/datadog-plugin-fastify/test/code_origin.spec.js
+++ b/packages/datadog-plugin-fastify/test/code_origin.spec.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios')
 const semver = require('semver')
+const { withExports, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { assertCodeOriginFromTraces } = require('../../datadog-code-origin/test/helpers')
 const { getNextLineNumber } = require('../../dd-trace/test/plugins/helpers')

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -1,8 +1,9 @@
 'use strict'
 
-const { AsyncLocalStorage } = require('async_hooks')
+const { AsyncLocalStorage } = require('node:async_hooks')
 const axios = require('axios')
 const semver = require('semver')
+const { withExports, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')

--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/helpers')
 const id = require('../../dd-trace/src/id')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai')
 const semver = require('semver')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -1,10 +1,11 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const getPort = require('get-port')
 const semver = require('semver')
-const Readable = require('stream').Readable
+const Readable = require('node:stream').Readable
 const getService = require('./service')
 const loader = require('../../../versions/@grpc/proto-loader').get()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK, GRPC_CLIENT_ERROR_STATUSES } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -101,11 +101,11 @@ describe('Plugin', () => {
             withPeerService(
               () => tracer,
               'grpc',
-              async () => {
+              async (done) => {
                 const client = await buildClient({
                   getUnary: (_, callback) => callback()
                 })
-                client.getUnary({ first: 'foobar' }, () => {})
+                client.getUnary({ first: 'foobar' }, done)
               },
               'test.TestService', 'rpc.service')
 

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const getPort = require('get-port')
-const Readable = require('stream').Readable
+const Readable = require('node:stream').Readable
 
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK, GRPC_SERVER_ERROR_STATUSES } = require('../../dd-trace/src/constants')
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -91,7 +91,7 @@ describe('Plugin', () => {
         )
 
         withNamingSchema(
-          spanProducerFn,
+          (done) => spanProducerFn((err) => err && done(err)),
           rawExpectedSchema.client
         )
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -67,7 +67,7 @@ describe('Plugin', () => {
             })
         })
 
-        const spanProducerFn = () => {
+        const spanProducerFn = (done) => {
           const app = express()
           app.get('/user', (req, res) => {
             res.status(200).send()
@@ -78,6 +78,7 @@ describe('Plugin', () => {
               res.on('data', () => {})
             })
             req.end()
+            done()
           })
         }
 

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const fs = require('fs')
 const path = require('path')

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const axios = require('axios')
 const { incomingHttpRequestStart } = require('../../dd-trace/src/appsec/channels')

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -86,7 +86,7 @@ describe('Plugin', () => {
         )
 
         withNamingSchema(
-          spanProducerFn,
+          (done) => spanProducerFn((err) => err && done(err)),
           rawExpectedSchema.client
         )
 

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -73,6 +73,7 @@ describe('Plugin', () => {
             req.on('error', done)
 
             req.end()
+            setTimeout(done, 10)
           })
         }
 

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const fs = require('fs')
 const path = require('path')

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
+const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { rawExpectedSchema } = require('./naming')
 

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-iovalkey/test/index.spec.js
+++ b/packages/datadog-plugin-iovalkey/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -103,9 +103,10 @@ describe('Plugin', () => {
           withPeerService(
             () => tracer,
             'kafkajs',
-            (done) => sendMessages(kafka, testTopic, messages).catch(done),
+            () => sendMessages(kafka, testTopic, messages),
             '127.0.0.1:9092',
-            'messaging.kafka.bootstrap.servers')
+            'messaging.kafka.bootstrap.servers'
+          )
 
           it('should be instrumented w/ error', async () => {
             const producer = kafka.producer()

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai')
 const semver = require('semver')
 const dc = require('dc-polyfill')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -59,8 +59,10 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'mariadb',
-          done => connection.query('SELECT 1', (err) => { err && done(err) }),
-          'db', 'db.name')
+          done => connection.query('SELECT 1', done),
+          'db',
+          'db.name'
+        )
 
         it('should propagate context to callbacks, with correct callback args', done => {
           const span = tracer.startSpan('test')

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const semver = require('semver')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -30,7 +30,7 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'memcached',
-          done => memcached.get('test', err => err && done(err)),
+          done => memcached.get('test', done),
           'localhost',
           'out.host'
         )

--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -2,7 +2,8 @@
 
 const { expect } = require('chai')
 const getPort = require('get-port')
-const os = require('os')
+const os = require('node:os')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 

--- a/packages/datadog-plugin-moleculer/test/index.spec.js
+++ b/packages/datadog-plugin-moleculer/test/index.spec.js
@@ -153,9 +153,7 @@ describe('Plugin', () => {
           withPeerService(
             () => tracer,
             'moleculer',
-            done => {
-              broker.call('math.add', { a: 5, b: 3 }).catch(done)
-            },
+            () => broker.call('math.add', { a: 5, b: 3 }),
             hostname,
             'out.host'
           )

--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon')
 const semver = require('semver')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -83,7 +83,7 @@ describe('Plugin', () => {
           withPeerService(
             () => tracer,
             'mongodb-core',
-            () => collection.insertOne({ a: 1 }, {}, () => {}),
+            (done) => collection.insertOne({ a: 1 }, {}, done),
             'test',
             'peer.service'
           )

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -84,7 +84,8 @@ describe('Plugin', () => {
             () => tracer,
             'mongodb-core',
             () => collection.insertOne({ a: 1 }, {}, () => {}),
-            'test', 'peer.service'
+            'test',
+            'peer.service'
           )
 
           it('should do automatic instrumentation', done => {

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon')
 const semver = require('semver')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -51,11 +51,12 @@ describe('Plugin', () => {
       withPeerService(
         () => tracer,
         'mongodb-core',
-        (done) => {
+        () => {
           const PeerCat = mongoose.model('PeerCat', { name: String })
-          new PeerCat({ name: 'PeerCat' }).save().catch(done)
+          return new PeerCat({ name: 'PeerCat' }).save()
         },
-        () => dbName, 'peer.service')
+        () => dbName,
+        'peer.service')
 
       it('should propagate context with write operations', () => {
         const Cat = mongoose.model('Cat1', { name: String })

--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const semver = require('semver')
+const { withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const id = require('../../dd-trace/src/id')
 

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -252,7 +252,7 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'mysql',
-          () => pool.query('SELECT 1', (_) => {}),
+          (done) => pool.query('SELECT 1', (_) => done()),
           'db', 'db.name')
 
         it('should do automatic instrumentation', done => {

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -253,7 +253,9 @@ describe('Plugin', () => {
           () => tracer,
           'mysql',
           (done) => pool.query('SELECT 1', (_) => done()),
-          'db', 'db.name')
+          'db',
+          'db.name'
+        )
 
         it('should do automatic instrumentation', done => {
           agent

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const proxyquire = require('proxyquire').noPreserveCache()
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -46,7 +46,9 @@ describe('Plugin', () => {
           () => tracer,
           'mysql2',
           (done) => connection.query('SELECT 1', (_) => done()),
-          'db', 'db.name')
+          'db',
+          'db.name'
+        )
 
         withNamingSchema(
           () => connection.query('SELECT 1', (_) => {}),

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const dns = require('dns')
+const dns = require('node:dns')
+const { withPeerService } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-net/test/index.spec.js
+++ b/packages/datadog-plugin-net/test/index.spec.js
@@ -93,9 +93,10 @@ describe('Plugin', () => {
       withPeerService(
         () => tracer,
         'net',
-        () => {
+        (done) => {
           const socket = new net.Socket()
           socket.connect(port, 'localhost')
+          done()
         },
         'localhost',
         'out.host'

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -2,12 +2,13 @@
 
 /* eslint import/no-extraneous-dependencies: ["error", {"packageDir": ['./']}] */
 
-const path = require('path')
+const path = require('node:path')
 const axios = require('axios')
 const getPort = require('get-port')
-const { execSync, spawn } = require('child_process')
+const { execSync, spawn } = require('node:child_process')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
-const { writeFileSync, readdirSync } = require('fs')
+const { writeFileSync, readdirSync } = require('node:fs')
 const { satisfies } = require('semver')
 const { rawExpectedSchema } = require('./naming')
 

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -255,7 +255,9 @@ describe('Plugin', () => {
               }
             }
           }),
-          'localhost', 'out.host')
+          'localhost',
+          'out.host'
+        )
 
         it('should be configured with the correct values', done => {
           client.search({

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -254,6 +254,8 @@ describe('Plugin', () => {
                 match_all: {}
               }
             }
+          }).catch(() => {
+            // Ignore index_not_found_exception for peer service assertion
           }),
           'localhost',
           'out.host'

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -61,12 +61,9 @@ describe('Plugin', () => {
           withPeerService(
             () => tracer,
             'pg',
-            (done) => client.query('SELECT 1', (err, result) => {
-              if (err) {
-                done()
-              }
-            }),
-            'postgres', 'db.name'
+            (done) => client.query('SELECT 1', done),
+            'postgres',
+            'db.name'
           )
 
           it('should do automatic instrumentation when using callbacks', done => {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -1,13 +1,15 @@
 'use strict'
 
 const { expect } = require('chai')
-const assert = require('assert')
+const assert = require('node:assert')
 const semver = require('semver')
+
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const net = require('net')
+const net = require('node:net')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
-const EventEmitter = require('events')
+const EventEmitter = require('node:events')
 
 const ddpv = require('mocha/package.json').version
 

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const Writable = require('stream').Writable
+const Writable = require('node:stream').Writable
+const { withExports, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const semver = require('semver')
 const { NODE_MAJOR } = require('../../../version')

--- a/packages/datadog-plugin-prisma/test/index.spec.js
+++ b/packages/datadog-plugin-prisma/test/index.spec.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const fs = require('fs/promises')
-const path = require('path')
+const fs = require('node:fs/promises')
+const path = require('node:path')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { execSync } = require('node:child_process')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -1,7 +1,8 @@
 'use strict'
 
-const assert = require('assert')
+const assert = require('node:assert')
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -85,7 +85,9 @@ describe('Plugin', () => {
           () => tracer,
           'redis',
           () => client.get('bar'),
-          '127.0.0.1', 'out.host')
+          '127.0.0.1',
+          'out.host'
+        )
 
         it('should handle errors', async () => {
           let error

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -84,7 +84,7 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'redis',
-          (done) => client.get('bar').catch(done),
+          () => client.get('bar'),
           '127.0.0.1', 'out.host')
 
         it('should handle errors', async () => {
@@ -169,7 +169,7 @@ describe('Plugin', () => {
         withPeerService(
           () => tracer,
           'redis',
-          (done) => client.get('bar').catch(done),
+          () => client.get('bar'),
           'localhost', 'out.host')
 
         it('should be able to filter commands', async () => {

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 

--- a/packages/datadog-plugin-redis/test/legacy.spec.js
+++ b/packages/datadog-plugin-redis/test/legacy.spec.js
@@ -44,7 +44,7 @@ describe('Legacy Plugin', () => {
         withPeerService(
           () => tracer,
           'redis',
-          () => client.get('foo'),
+          (done) => client.get('foo', done),
           '127.0.0.1',
           'out.host'
         )

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -132,7 +132,10 @@ describe('Plugin', () => {
             withPeerService(
               () => tracer,
               'rhea',
-              () => context.sender.send({ body: 'Hello World!' }),
+              (done) => {
+                context.sender.send({ body: 'Hello World!' })
+                done()
+              },
               'localhost',
               'out.host'
             )

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { expect } = require('chai')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { expectedSchema, rawExpectedSchema } = require('./naming')

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const semver = require('semver')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -81,9 +81,9 @@ describe('Plugin', () => {
       withPeerService(
         () => tracer,
         'tedious',
-        (done) => connection.execSql(new tds.Request('SELECT 1', (err) => {
-          if (err) return done(err)
-        })), 'master', 'db.name'
+        (done) => connection.execSql(new tds.Request('SELECT 1', done)),
+        'master',
+        'db.name'
       )
 
       describe('with tedious disabled', () => {

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const tags = require('../../../ext/tags')
 const { expect } = require('chai')

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -138,7 +138,9 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
       const spanGenerationPromise = useCallback
         ? new Promise((resolve, reject) => {
           const result = spanGenerationFn((err) => err ? reject(err) : resolve())
-          if (result && Object.keys(result).length === 0) {
+          // Some callback based methods are a mixture of callback and promise,
+          // depending on the module version. Await the promises as well.
+          if (util.types.isPromise(result)) {
             result.then?.(resolve, reject)
           }
         })

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -2,8 +2,10 @@
 
 require('./core')
 
-const { platform } = require('os')
-const path = require('path')
+const assert = require('node:assert')
+const util = require('node:util')
+const { platform } = require('node:os')
+const path = require('node:path')
 const semver = require('semver')
 const externals = require('../plugins/externals.json')
 const runtimeMetrics = require('../../src/runtime_metrics')
@@ -14,10 +16,13 @@ const { getInstrumentation } = require('./helpers/load-inst')
 
 const NODE_PATH_SEP = platform() === 'win32' ? ';' : ':'
 
+// TODO: Remove global
 global.withVersions = withVersions
-global.withExports = withExports
-global.withNamingSchema = withNamingSchema
-global.withPeerService = withPeerService
+
+exports.withVersions = withVersions
+exports.withExports = withExports
+exports.withNamingSchema = withNamingSchema
+exports.withPeerService = withPeerService
 
 const testedPlugins = agent.testedPlugins
 

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -136,7 +136,12 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
     it('should compute peer service', async () => {
       const useCallback = spanGenerationFn.length === 1
       const spanGenerationPromise = useCallback
-        ? new Promise((resolve, reject) => spanGenerationFn((err) => err ? reject(err) : resolve())?.then?.(resolve, reject))
+        ? new Promise((resolve, reject) => {
+          const result = spanGenerationFn((err) => err ? reject(err) : resolve())
+          if (result && Object.keys(result).length === 0) {
+            result.then?.(resolve, reject)
+          }
+        })
         : spanGenerationFn()
 
       assert.ok(

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -136,7 +136,7 @@ function withPeerService (tracer, pluginName, spanGenerationFn, service, service
     it('should compute peer service', async () => {
       const useCallback = spanGenerationFn.length === 1
       const spanGenerationPromise = useCallback
-        ? new Promise((resolve, reject) => spanGenerationFn((err) => err ? reject(err) : resolve()))
+        ? new Promise((resolve, reject) => spanGenerationFn((err) => err ? reject(err) : resolve())?.then?.(resolve, reject))
         : spanGenerationFn()
 
       assert.ok(


### PR DESCRIPTION
As drive-by also import a couple of Node.js modules with the
explicit `node:` prefix. That makes it clear it is a Node.js module
that is loaded.

The benefit over loading the helpers directly is that it allows to
read the API in an IDE and to jump to the code directly.

Closes #5959 (superseding it)