### PR TITLE
feat(openai): support OpenAI v5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
       - LDAP_PASSWORDS=password1,password2
 
   testagent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.24.0
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.24.1
     ports:
         - "127.0.0.1:9126:9126"
     environment:
@@ -166,7 +166,7 @@ services:
   # Use this for local development when making new VCR cassettes to persist to the test agent
   # Do not use the above testagent service if using this one.
   testagent-vcr:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.24.0
+    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.24.1
     ports:
       - "127.0.0.1:9126:9126"
     environment:

--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -31,7 +31,21 @@ const V4_PACKAGE_SHIMS = [
     file: 'resources/files',
     targetClass: 'Files',
     baseResource: 'files',
-    methods: ['create', 'del', 'list', 'retrieve']
+    methods: ['create', 'list', 'retrieve'],
+  },
+  {
+    file: 'resources/files',
+    targetClass: 'Files',
+    baseResource: 'files',
+    methods: ['del'],
+    versions: ['>=4.0.0 <5.0.0']
+  },
+  {
+    file: 'resources/files',
+    targetClass: 'Files',
+    baseResource: 'files',
+    methods: ['delete'],
+    versions: ['>=5']
   },
   {
     file: 'resources/files',
@@ -78,7 +92,21 @@ const V4_PACKAGE_SHIMS = [
     file: 'resources/models',
     targetClass: 'Models',
     baseResource: 'models',
-    methods: ['del', 'list', 'retrieve']
+    methods: ['list', 'retrieve']
+  },
+  {
+    file: 'resources/models',
+    targetClass: 'Models',
+    baseResource: 'models',
+    methods: ['del'],
+    versions: ['>=4 <5']
+  },
+  {
+    file: 'resources/models',
+    targetClass: 'Models',
+    baseResource: 'models',
+    methods: ['delete'],
+    versions: ['>=5']
   },
   {
     file: 'resources/moderations',

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -366,6 +366,7 @@ function normalizeMethodName (methodName) {
     case 'files.retrieve':
       return 'retrieveFile'
     case 'files.del':
+    case 'files.delete':
       return 'deleteFile'
     case 'files.retrieveContent':
     case 'files.content':
@@ -410,6 +411,7 @@ function normalizeMethodName (methodName) {
     case 'models.retrieve':
       return 'retrieveModel'
     case 'models.del':
+    case 'models.delete':
       return 'deleteModel'
     default:
       return methodName
@@ -952,6 +954,7 @@ function normalizeRequestPayload (methodName, args) {
 
     case 'deleteFile':
     case 'files.del':
+    case 'files.delete':
     case 'retrieveFile':
     case 'files.retrieve':
     case 'downloadFile':
@@ -972,6 +975,7 @@ function normalizeRequestPayload (methodName, args) {
     case 'fine-tune.retrieve':
     case 'deleteModel':
     case 'models.del':
+    case 'models.delete':
     case 'cancelFineTune':
     case 'fine_tuning.jobs.cancel':
     case 'fine-tune.cancel':


### PR DESCRIPTION
### What does this PR do?
Supports OpenAI v5 buy adding proper patching support for `client.files.delete` and `client.models.delete`, previously both `.del` instead.

Additionally, there are some Node.js 20 stipulations for files that are added into the tests as well.

### Motivation
Support most recent OpenAI major, remove version cap on CI.