### PR TITLE
ci(openai): resolve further test conflicts from bumping openai support and merging major changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.57.0",
+  "version": "6.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "6.0.0-pre",
+  "version": "5.57.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -550,7 +550,8 @@ describe('Plugin', () => {
             expect(traces[0][0]).to.have.property('name', 'openai.request')
             expect(traces[0][0]).to.have.property('type', 'openai')
             if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
-              expect(traces[0][0]).to.have.property('resource', 'models.del')
+              const method = semver.satisfies(realVersion, '>=5.0.0') ? 'delete' : 'del'
+              expect(traces[0][0]).to.have.property('resource', `models.${method}`)
             } else {
               expect(traces[0][0]).to.have.property('resource', 'deleteModel')
             }
@@ -740,7 +741,8 @@ describe('Plugin', () => {
             expect(traces[0][0]).to.have.property('name', 'openai.request')
             expect(traces[0][0]).to.have.property('type', 'openai')
             if (semver.satisfies(realVersion, '>=4.0.0') && DD_MAJOR < 6) {
-              expect(traces[0][0]).to.have.property('resource', 'files.del')
+              const method = semver.satisfies(realVersion, '>=5.0.0') ? 'delete' : 'del'
+              expect(traces[0][0]).to.have.property('resource', `files.${method}`)
             } else {
               expect(traces[0][0]).to.have.property('resource', 'deleteFile')
             }


### PR DESCRIPTION
### What does this PR do?
#5963 introduced new support for OpenAI v5 in which some resource names were changed and the tests did not properly pick up on them/the changes for the method names, which breaks `dd-trace@5` support, while it was working for the next `dd-trace@6`.

### Motivation
Unblock release CI.