### PR TITLE
Skip dependabot analyzer for dependabot PRs

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -67,6 +67,7 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     name: Datadog Static Analyzer
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
The job requires secrets that we do not pass to dependabot PRs. Thus, skipping them seems like the best way to handle it.

Java removed the job, dotnet also skips it https://github.com/DataDog/dd-trace-dotnet/pull/7041

TODO: Deactivate system tests and Test Automatization performance tests