### PR TITLE
test: make sandbox package installation work offline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,13 @@ $ yarn test:instrumentations
 Several other components have test commands as well. See `package.json` for
 details.
 
+### Integration Tests
+
+When running integration tests, some packages are installed from npm into temporary sandboxes.
+If running locally without an internet connection,
+it's possible to use the environment variable `OFFLINE=true` to make `yarn` use the `--prefer-offline` flag,
+which will use the local yarn cache instead of fecthing packages from npm.
+
 ### Adding a Plugin Test to CI
 
 The plugin tests run on pull requests in Github Actions. Each plugin test suite has its own Github job, so adding a new suite to CI

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -185,7 +185,7 @@ async function createSandbox (dependencies = [], isGitRepo = false,
   const allDependencies = [`file:${out}`].concat(dependencies)
 
   fs.mkdirSync(folder)
-  const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines`
+  const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines --prefer-offline`
   const addOptions = { cwd: folder, env: restOfEnv }
   await exec(`yarn pack --filename ${out}`, { env: restOfEnv }) // TODO: cache this
 

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -185,7 +185,8 @@ async function createSandbox (dependencies = [], isGitRepo = false,
   const allDependencies = [`file:${out}`].concat(dependencies)
 
   fs.mkdirSync(folder)
-  const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines --prefer-offline`
+  const preferOfflineFlag = process.env.OFFLINE === '1' || process.env.OFFLINE === 'true' ? ' --prefer-offline' : ''
+  const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines${preferOfflineFlag}`
   const addOptions = { cwd: folder, env: restOfEnv }
   await exec(`yarn pack --filename ${out}`, { env: restOfEnv }) // TODO: cache this
 


### PR DESCRIPTION
### What does this PR do?

Ensure it's possible to create sandboxes during integration tests if you're offline.

### Motivation

Sometimes you don't have internet

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


