### PR TITLE
Ensure buffer gets correctly stringified when logged

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -108,7 +108,7 @@ class DogStatsDClient {
     const socket = family === 6 ? this._udp6 : this._udp4
 
     queue.forEach((buffer) => {
-      log.debug('Sending to DogStatsD:', buffer)
+      log.debug('Sending to DogStatsD: %s', buffer)
       socket.send(buffer, 0, buffer.length, this._port, address)
     })
   }

--- a/packages/dd-trace/src/llmobs/writers/base.js
+++ b/packages/dd-trace/src/llmobs/writers/base.js
@@ -76,7 +76,7 @@ class BaseLLMObsWriter {
     this._bufferSize = 0
     const payload = this._encode(this.makePayload(events))
 
-    log.debug('Encoded LLMObs payload:', payload)
+    log.debug('Encoded LLMObs payload: %s', payload)
 
     const options = this._getOptions()
 


### PR DESCRIPTION
### What does this PR do?

This fixes a regression introduced in #5916 and discovered by @rochdev: https://github.com/DataDog/dd-trace-js/commit/2ce554fc817fa423a08931ba3c2975ecac6f43b1#r160904842

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


