### PR TITLE
add experimental flag on plugins to disable them by default

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -9,7 +9,7 @@ const log = require('../../../dd-trace/src/log')
 const checkRequireCache = require('./check-require-cache')
 const telemetry = require('../../../dd-trace/src/guardrails/telemetry')
 const { isInServerlessEnvironment } = require('../../../dd-trace/src/serverless')
-const { isFalse, isTrue, normalizePluginEnvName } = require('../../../dd-trace/src/util')
+const { isFalse } = require('../../../dd-trace/src/util')
 const { getEnvironmentVariables } = require('../../../dd-trace/src/config-helper')
 
 const envs = getEnvironmentVariables()
@@ -25,20 +25,15 @@ const names = Object.keys(hooks)
 const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
 
 const disabledInstrumentations = new Set(
-  DD_TRACE_DISABLED_INSTRUMENTATIONS?.split(',').map(name => normalizePluginEnvName(name, true)) ?? []
+  DD_TRACE_DISABLED_INSTRUMENTATIONS?.split(',') ?? []
 )
-const reenabledInstrumentations = new Set()
 
 // Check for DD_TRACE_<INTEGRATION>_ENABLED environment variables
 for (const [key, value] of Object.entries(envs)) {
   const match = key.match(/^DD_TRACE_(.+)_ENABLED$/)
-  if (match && value) {
-    const integration = normalizePluginEnvName(match[1], true)
-    if (isFalse(value)) {
-      disabledInstrumentations.add(integration)
-    } else if (isTrue(value)) {
-      reenabledInstrumentations.add(integration)
-    }
+  if (match && isFalse(value)) {
+    const integration = match[1].toLowerCase()
+    disabledInstrumentations.add(integration)
   }
 }
 
@@ -65,8 +60,7 @@ const allInstrumentations = {}
 
 // TODO: make this more efficient
 for (const packageName of names) {
-  const normalizedPackageName = normalizePluginEnvName(packageName, true)
-  if (disabledInstrumentations.has(normalizedPackageName)) continue
+  if (disabledInstrumentations.has(packageName)) continue
 
   const hookOptions = {}
 
@@ -74,10 +68,6 @@ for (const packageName of names) {
 
   if (hook !== null && typeof hook === 'object') {
     if (hook.serverless === false && isInServerlessEnvironment()) continue
-
-    // some integrations are disabled by default, but can be enabled by setting
-    // the DD_TRACE_<INTEGRATION>_ENABLED environment variable to true
-    if (hook.disabled && !reenabledInstrumentations.has(normalizedPackageName)) continue
 
     hookOptions.internals = hook.esmFirst
     hook = hook.fn

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -9,7 +9,6 @@ const log = require('../../../dd-trace/src/log')
 const checkRequireCache = require('./check-require-cache')
 const telemetry = require('../../../dd-trace/src/guardrails/telemetry')
 const { isInServerlessEnvironment } = require('../../../dd-trace/src/serverless')
-const { isFalse } = require('../../../dd-trace/src/util')
 const { getEnvironmentVariables } = require('../../../dd-trace/src/config-helper')
 
 const envs = getEnvironmentVariables()
@@ -27,15 +26,6 @@ const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
 const disabledInstrumentations = new Set(
   DD_TRACE_DISABLED_INSTRUMENTATIONS?.split(',')
 )
-
-// Check for DD_TRACE_<INTEGRATION>_ENABLED environment variables
-for (const [key, value] of Object.entries(envs)) {
-  const match = key.match(/^DD_TRACE_(.+)_ENABLED$/)
-  if (match && isFalse(value)) {
-    const integration = match[1].toLowerCase()
-    disabledInstrumentations.add(integration)
-  }
-}
 
 const loadChannel = channel('dd-trace:instrumentation:load')
 

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -25,7 +25,7 @@ const names = Object.keys(hooks)
 const pathSepExpr = new RegExp(`\\${path.sep}`, 'g')
 
 const disabledInstrumentations = new Set(
-  DD_TRACE_DISABLED_INSTRUMENTATIONS?.split(',') ?? []
+  DD_TRACE_DISABLED_INSTRUMENTATIONS?.split(',')
 )
 
 // Check for DD_TRACE_<INTEGRATION>_ENABLED environment variables

--- a/packages/datadog-instrumentations/test/helpers/register.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/register.spec.js
@@ -20,7 +20,6 @@ describe('register', () => {
 
     hooksMock = {
       '@confluentinc/kafka-javascript': {
-        disabled: true,
         fn: sinon.stub().returns('hooked')
       },
       'mongodb-core': {
@@ -71,54 +70,6 @@ describe('register', () => {
       expect(result).to.equal('original')
     }
   }
-
-  it('should skip hooks that are disabled by default and process enabled hooks', () => {
-    loadRegisterWithEnv()
-
-    expect(HookMock.callCount).to.equal(1)
-    expect(HookMock.args[0]).to.deep.include(['mongodb-core'], { internals: undefined })
-
-    runHookCallbacks(HookMock)
-
-    expect(hooksMock['@confluentinc/kafka-javascript'].fn).to.not.have.been.called
-    expect(hooksMock['mongodb-core'].fn).to.have.been.called
-  })
-
-  it('should enable disabled hooks when DD_TRACE_[pkg]_ENABLED is true', () => {
-    loadRegisterWithEnv({ DD_TRACE_CONFLUENTINC_KAFKA_JAVASCRIPT_ENABLED: 'true' })
-
-    expect(HookMock.callCount).to.equal(2)
-    expect(HookMock.args[0]).to.deep.include(['@confluentinc/kafka-javascript'], { internals: undefined })
-    expect(HookMock.args[1]).to.deep.include(['mongodb-core'], { internals: undefined })
-
-    runHookCallbacks(HookMock)
-
-    expect(hooksMock['@confluentinc/kafka-javascript'].fn).to.have.been.called
-    expect(hooksMock['mongodb-core'].fn).to.have.been.called
-  })
-
-  it('should not enable disabled hooks when DD_TRACE_[pkg]_ENABLED is false', () => {
-    loadRegisterWithEnv({ DD_TRACE_CONFLUENTINC_KAFKA_JAVASCRIPT_ENABLED: 'false' })
-
-    expect(HookMock.callCount).to.equal(1)
-    expect(HookMock.args[0]).to.deep.include(['mongodb-core'], { internals: undefined })
-
-    runHookCallbacks(HookMock)
-
-    expect(hooksMock['@confluentinc/kafka-javascript'].fn).to.not.have.been.called
-    expect(hooksMock['mongodb-core'].fn).to.have.been.called
-  })
-
-  it('should disable hooks that are disabled by DD_TRACE_[pkg]_ENABLED=false', () => {
-    loadRegisterWithEnv({ DD_TRACE_MONGODB_CORE_ENABLED: 'false' })
-
-    expect(HookMock.callCount).to.equal(0)
-
-    runHookCallbacks(HookMock)
-
-    expect(hooksMock['@confluentinc/kafka-javascript'].fn).to.not.have.been.called
-    expect(hooksMock['mongodb-core'].fn).to.not.have.been.called
-  })
 
   it('should disable hooks that are disabled by DD_TRACE_DISABLED_INSTRUMENTATIONS', () => {
     loadRegisterWithEnv({ DD_TRACE_DISABLED_INSTRUMENTATIONS: 'mongodb-core,@confluentinc/kafka-javascript' })

--- a/packages/datadog-plugin-prisma/src/index.js
+++ b/packages/datadog-plugin-prisma/src/index.js
@@ -6,6 +6,7 @@ const PrismaClientPlugin = require('./client')
 const PrismaEnginePlugin = require('./engine')
 
 class PrismaPlugin extends CompositePlugin {
+  static experimental = true
   static get id () { return 'prisma' }
   static get plugins () {
     return {

--- a/packages/datadog-plugin-prisma/src/index.js
+++ b/packages/datadog-plugin-prisma/src/index.js
@@ -6,7 +6,6 @@ const PrismaClientPlugin = require('./client')
 const PrismaEnginePlugin = require('./engine')
 
 class PrismaPlugin extends CompositePlugin {
-  static experimental = true
   static get id () { return 'prisma' }
   static get plugins () {
     return {

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -78,7 +78,7 @@ module.exports = class PluginManager {
       this._pluginsByName[name] = new Plugin(this._tracer, this._tracerConfig)
     }
     const pluginConfig = this._configsByName[name] || {
-      enabled: isTrue(getEnvEnabled(Plugin)) || (this._tracerConfig.plugins !== false && !Plugin.experimental)
+      enabled: this._tracerConfig.plugins !== false && (!Plugin.experimental || isTrue(getEnvEnabled(Plugin)))
     }
 
     // extracts predetermined configuration from tracer and combines it with plugin-specific config

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -74,7 +74,7 @@ module.exports = class PluginManager {
       this._pluginsByName[name] = new Plugin(this._tracer, this._tracerConfig)
     }
     const pluginConfig = this._configsByName[name] || {
-      enabled: this._tracerConfig.plugins !== false
+      enabled: this._tracerConfig.plugins !== false && !Plugin.experimental
     }
 
     // extracts predetermined configuration from tracer and combines it with plugin-specific config

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { channel } = require('dc-polyfill')
-const { isFalse, normalizePluginEnvName } = require('./util')
+const { isFalse, isTrue, normalizePluginEnvName } = require('./util')
 const plugins = require('./plugins')
 const log = require('./log')
 const { getEnvironmentVariable } = require('../../dd-trace/src/config-helper')
@@ -32,8 +32,7 @@ loadChannel.subscribe(({ name }) => {
 function maybeEnable (Plugin) {
   if (!Plugin || typeof Plugin !== 'function') return
   if (!pluginClasses[Plugin.id]) {
-    const envName = `DD_TRACE_${Plugin.id.toUpperCase()}_ENABLED`
-    const enabled = getEnvironmentVariable(normalizePluginEnvName(envName))
+    const enabled = getEnvEnabled(Plugin)
 
     // TODO: remove the need to load the plugin class in order to disable the plugin
     if (isFalse(enabled) || disabledPlugins.has(Plugin.id)) {
@@ -44,6 +43,11 @@ function maybeEnable (Plugin) {
       pluginClasses[Plugin.id] = Plugin
     }
   }
+}
+
+function getEnvEnabled (Plugin) {
+  const envName = `DD_TRACE_${Plugin.id.toUpperCase()}_ENABLED`
+  return getEnvironmentVariable(normalizePluginEnvName(envName))
 }
 
 // TODO this must always be a singleton.
@@ -74,7 +78,7 @@ module.exports = class PluginManager {
       this._pluginsByName[name] = new Plugin(this._tracer, this._tracerConfig)
     }
     const pluginConfig = this._configsByName[name] || {
-      enabled: this._tracerConfig.plugins !== false && !Plugin.experimental
+      enabled: isTrue(getEnvEnabled(Plugin)) || (this._tracerConfig.plugins !== false && !Plugin.experimental)
     }
 
     // extracts predetermined configuration from tracer and combines it with plugin-specific config

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -91,6 +91,7 @@ describe('Plugin Manager', () => {
 
   afterEach(() => {
     delete process.env.DD_TRACE_DISABLED_PLUGINS
+    delete process.env.DD_TRACE_EIGHT_ENABLED
     pm.destroy()
   })
 
@@ -286,6 +287,20 @@ describe('Plugin Manager', () => {
         pm.configure()
         loadChannel.publish({ name: 'eight' })
         expect(Eight.prototype.configure).to.have.been.calledWithMatch({ enabled: false })
+      })
+
+      it('should enable the plugin when configured programmatically', () => {
+        pm.configure()
+        pm.configurePlugin('eight')
+        loadChannel.publish({ name: 'eight' })
+        expect(Eight.prototype.configure).to.have.been.calledWithMatch({ enabled: true })
+      })
+
+      it('should enable the plugin when configured with an environment variable', () => {
+        process.env.DD_TRACE_EIGHT_ENABLED = 'true'
+        pm.configure()
+        loadChannel.publish({ name: 'eight' })
+        expect(Eight.prototype.configure).to.have.been.calledWithMatch({ enabled: true })
       })
     })
 

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -16,6 +16,7 @@ describe('Plugin Manager', () => {
   let Four
   let Five
   let Six
+  let Eight
   let pm
 
   beforeEach(() => {
@@ -53,7 +54,11 @@ describe('Plugin Manager', () => {
           return 'six'
         }
       },
-      seven: {}
+      seven: {},
+      eight: class Eight extends FakePlugin {
+        static experimental = true
+        static id = 'eight'
+      }
     }
 
     Two = plugins.two
@@ -66,6 +71,9 @@ describe('Plugin Manager', () => {
     Five.prototype.configure = sinon.spy()
     Six = plugins.six
     Six.prototype.configure = sinon.spy()
+
+    Eight = plugins.eight
+    Eight.prototype.configure = sinon.spy()
 
     process.env.DD_TRACE_DISABLED_PLUGINS = 'five,six,seven'
 
@@ -270,6 +278,14 @@ describe('Plugin Manager', () => {
         pm.configurePlugin('two')
         expect(instantiated).to.be.empty
         expect(Two.prototype.configure).to.not.have.been.called
+      })
+    })
+
+    describe('with an experimental plugin', () => {
+      it('should disable the plugin by default', () => {
+        pm.configure()
+        loadChannel.publish({ name: 'eight' })
+        expect(Eight.prototype.configure).to.have.been.calledWithMatch({ enabled: false })
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add experimental flag on plugins to disable them by default.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now only disabling the instrumentation is possible by default. However, this is problematic because users interact with plugins, not instrumentation, so they would only know the name for the plugins. Also, instrumentations do more than just back a single plugin, so when the goal is to disable just tracing for a library for example, it shouldn't also disable any other existing features already built on top of the same instrumentation. Doing this at the plugin level instead solves these issues and provides a better and more granular user experience that focuses only on the functionality.