### PR TITLE
fix(llmobs): do not submit spans without an ml application specified

### DIFF
--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -61,19 +61,6 @@ class LLMObsTagger {
     if (!this._config.llmobs.enabled) return
     if (!kind) return // do not register it in the map if it doesn't have an llmobs span kind
 
-    this._register(span)
-
-    if (name) this._setTag(span, NAME, name)
-
-    this._setTag(span, SPAN_KIND, kind)
-    if (modelName) this._setTag(span, MODEL_NAME, modelName)
-    if (modelProvider) this._setTag(span, MODEL_PROVIDER, modelProvider)
-
-    sessionId = sessionId || registry.get(parent)?.[SESSION_ID]
-    if (sessionId) this._setTag(span, SESSION_ID, sessionId)
-    if (integration) this._setTag(span, INTEGRATION, integration)
-    if (_decorator) this._setTag(span, DECORATOR, _decorator)
-
     const spanMlApp =
       mlApp ||
       registry.get(parent)?.[ML_APP] ||
@@ -87,7 +74,20 @@ class LLMObsTagger {
       )
     }
 
+    this._register(span)
+
     this._setTag(span, ML_APP, spanMlApp)
+
+    if (name) this._setTag(span, NAME, name)
+
+    this._setTag(span, SPAN_KIND, kind)
+    if (modelName) this._setTag(span, MODEL_NAME, modelName)
+    if (modelProvider) this._setTag(span, MODEL_PROVIDER, modelProvider)
+
+    sessionId = sessionId || registry.get(parent)?.[SESSION_ID]
+    if (sessionId) this._setTag(span, SESSION_ID, sessionId)
+    if (integration) this._setTag(span, INTEGRATION, integration)
+    if (_decorator) this._setTag(span, DECORATOR, _decorator)
 
     const parentId =
       parent?.context().toSpanId() ??

--- a/packages/dd-trace/test/llmobs/sdk/integration.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/integration.spec.js
@@ -294,4 +294,33 @@ describe('end to end sdk integration tests', () => {
       expect(getTag(llmobsSpans[2], 'ml_app')).to.equal('test')
     })
   })
+
+  describe('with no global mlApp', () => {
+    let originalMlApp
+
+    before(() => {
+      originalMlApp = tracer._tracer._config.llmobs.mlApp
+      tracer._tracer._config.llmobs.mlApp = null
+    })
+
+    after(() => {
+      tracer._tracer._config.llmobs.mlApp = originalMlApp
+    })
+
+    it('does not submit a span if there is no mlApp', () => {
+      payloadGenerator = function () {
+        let error
+        try {
+          llmobs.trace({ kind: 'workflow', name: 'myWorkflow' }, () => {})
+        } catch (e) {
+          error = e
+        }
+
+        expect(error).to.exist
+      }
+
+      const { llmobsSpans } = run(payloadGenerator)
+      expect(llmobsSpans).to.have.lengthOf(0)
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where spans could be submitted without an ml application. This happened because we still register the span as an LLMObs span before potentially throwing an error when registering the span, and the traced operation was try/catched and the span processor still detected the span was an LLMObs span.

Fixes the issue by moving any operations (for now, just the ml application check) that could throw to before we register the span as an LLMObs span.

### Motivation
MLOB-3182