### PR TITLE
guardrails: bail out if esbuild bundle

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -171,7 +171,8 @@ function assertTelemetryPoints (pid, msgs, expectedTelemetryPoints) {
 
     // Check that result metadata has expected values for telemetry scenarios
     const validResults = ['success', 'abort', 'error', 'unknown']
-    const validResultClasses = ['success', 'incompatible_runtime', 'incompatible_library', 'internal_error', 'unknown']
+    const validResultClasses = ['success', 'incompatible_runtime',
+      'incompatible_library', 'incompatible_bundle', 'internal_error', 'unknown']
 
     assert(validResults.includes(actualMetadata.result), `Invalid result: ${actualMetadata.result}`)
     assert(validResultClasses.includes(actualMetadata.result_class),

--- a/integration-tests/package-guardrails.spec.js
+++ b/integration-tests/package-guardrails.spec.js
@@ -142,4 +142,33 @@ addHook({ name: 'bluebird', versions: ['*'] }, Promise => {
           }, []))
     })
   })
+
+  context('when running against an ESBuild bundle', () => {
+    useSandbox(['bluebird'])
+
+    let file
+
+    before(() => {
+      file = path.join(sandboxCwd(), 'app.js')
+      const code = `console.log('hi');\nconst __defProp = 'bar';\nvoid __defProp;\n
+        /*${'foobar'.repeat(50_000)}*/\n// Bundled license information\n\n`
+      fs.writeFileSync(file, code)
+    })
+
+    context('with DD_INJECTION_ENABLED', () => {
+      useEnv({ DD_INJECTION_ENABLED })
+
+      it('should not instrument the package, and send telemetry', () =>
+        testFile(
+          file,
+          'hi',
+          [
+            'abort', 'reason:incompatible_bundle',
+            'abort.bundle', '',
+          ],
+          undefined
+        )
+      )
+    })
+  })
 })

--- a/packages/dd-trace/src/guardrails/index.js
+++ b/packages/dd-trace/src/guardrails/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var fs = require('fs')
 var path = require('path')
 var Module = require('module')
 
@@ -8,11 +9,10 @@ var isTrue = require('./util').isTrue
 var log = require('./log')
 var telemetry = require('./telemetry')
 
+var BUNDLE_THRESHOLD = 1024 * 256 // arbitrary 256 KB filesize threshold
 var NODE_MAJOR = nodeVersion.NODE_MAJOR
 
 function guard (fn) {
-  var initBailout = false
-  var clobberBailout = false
   var forced = isTrue(process.env.DD_INJECT_FORCE)
   var engines = require('../../../../package.json').engines
   var versions = engines.node.match(/^>=(\d+) <(\d+)$/)
@@ -20,56 +20,121 @@ function guard (fn) {
   var nextMajor = versions[2]
   var version = process.versions.node
 
-  if (process.env.DD_INJECTION_ENABLED) {
-    // If we're running via single-step install, and we're in the app's
-    // node_modules, then we should not initialize the tracer. This prevents
-    // single-step-installed tracer from clobbering the manually-installed tracer.
-    var resolvedInApp
-    var entrypoint = process.argv[1]
-    try {
-      // eslint-disable-next-line n/no-unsupported-features/node-builtins
-      resolvedInApp = Module.createRequire(entrypoint).resolve('dd-trace')
-    } catch (e) {
-      // Ignore. If we can't resolve the module, we assume it's not in the app.
-      // TODO: There's also the possibility that this version of Node.js doesn't have Module.createRequire (pre v12.2.0)
-    }
-    if (resolvedInApp) {
-      var ourselves = path.normalize(path.join(__dirname, '..', '..', '..', '..', 'index.js'))
-      if (ourselves !== resolvedInApp) {
-        clobberBailout = true
-      }
-    }
-  }
+  // Detect bailout conditions
+  var bailoutReason = detectBailoutReason(minMajor, nextMajor)
 
-  // If the runtime doesn't match the engines field in package.json, then we
-  // should not initialize the tracer.
-  if (!clobberBailout && (NODE_MAJOR < minMajor || NODE_MAJOR >= nextMajor)) {
-    initBailout = true
-    telemetry([
-      { name: 'abort', tags: ['reason:incompatible_runtime'] },
-      { name: 'abort.runtime', tags: [] }
-    ], undefined, {
-      result: 'abort',
-      result_class: 'incompatible_runtime',
-      result_reason: 'Incompatible runtime Node.js ' + version + ', supported runtimes: Node.js ' + engines.node
-    })
-    log.info('Aborting application instrumentation due to incompatible_runtime.')
-    log.info('Found incompatible runtime Node.js %s, Supported runtimes: Node.js %s.', version, engines.node)
-    if (forced) {
+  // Handle bailout
+  if (bailoutReason) {
+    // Clobber bailout cannot be forced - always abort
+    if (bailoutReason.type === 'clobber') {
+      return
+    }
+
+    // Log abort telemetry for runtime and bundle bailouts
+    if (bailoutReason.type === 'runtime') {
+      telemetry([
+        { name: 'abort', tags: ['reason:incompatible_runtime'] },
+        { name: 'abort.runtime', tags: [] }
+      ], undefined, {
+        result: 'abort',
+        result_class: 'incompatible_runtime',
+        result_reason: 'Incompatible runtime Node.js ' + version + ', supported runtimes: Node.js ' + engines.node
+      })
+      log.info('Aborting application instrumentation due to incompatible_runtime.')
+      log.info('Found incompatible runtime Node.js %s, Supported runtimes: Node.js %s.', version, engines.node)
+    } else if (bailoutReason.type === 'bundle') {
+      telemetry([
+        { name: 'abort', tags: ['reason:incompatible_bundle'] },
+        { name: 'abort.bundle', tags: [] }
+      ], undefined, {
+        result: 'abort',
+        result_class: 'incompatible_bundle',
+        result_reason: 'Application appears to be bundled, cannot instrument'
+      })
+      log.info('Aborting application instrumentation since application is bundled.')
+    }
+
+    // Check if forced override applies
+    if (!forced) {
+      return
+    }
+
+    // Log force override
+    if (bailoutReason.type === 'runtime') {
       log.info('DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.')
+    } else if (bailoutReason.type === 'bundle') {
+      log.info('DD_INJECT_FORCE enabled, allowing unsupported bundling and continuing.')
     }
   }
 
-  if (!clobberBailout && (!initBailout || forced)) {
-    // Ensure the instrumentation source is set for the current process and potential child processes.
-    var result = fn()
-    telemetry('complete', ['injection_forced:' + (forced && initBailout ? 'true' : 'false')], {
-      result: 'success',
-      result_class: 'success',
-      result_reason: 'Successfully configured ddtrace package'
-    })
-    log.info('Application instrumentation bootstrapping complete')
-    return result
+  // Initialize tracer
+  var result = fn()
+  telemetry('complete', ['injection_forced:' + (forced && bailoutReason ? 'true' : 'false')], {
+    result: 'success',
+    result_class: 'success',
+    result_reason: 'Successfully configured ddtrace package'
+  })
+  log.info('Application instrumentation bootstrapping complete')
+  return result
+}
+
+function detectBailoutReason (minMajor, nextMajor) {
+  // Check for incompatible runtime (always check, regardless of injection mode)
+  if (NODE_MAJOR < minMajor || NODE_MAJOR >= nextMajor) {
+    return { type: 'runtime' }
+  }
+
+  // Only check injection-specific bailouts when DD_INJECTION_ENABLED is set
+  if (!process.env.DD_INJECTION_ENABLED) {
+    return null
+  }
+
+  var entrypoint = process.argv[1]
+
+  // Check for clobber conflict (single-step vs manual install)
+  var clobberConflict = checkClobberConflict(entrypoint)
+  if (clobberConflict) {
+    return { type: 'clobber' }
+  }
+
+  // Check for bundled application
+  var isBundled = checkIfBundled(entrypoint)
+  if (isBundled) {
+    return { type: 'bundle' }
+  }
+
+  return null
+}
+
+function checkClobberConflict (entrypoint) {
+  try {
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    var resolvedInApp = Module.createRequire(entrypoint).resolve('dd-trace')
+    var ourselves = path.normalize(path.join(__dirname, '..', '..', '..', '..', 'index.js'))
+    return ourselves !== resolvedInApp
+  } catch (e) {
+    // If we can't resolve, no conflict
+    return false
+  }
+}
+
+function checkIfBundled (entrypoint) {
+  try {
+    var stats = fs.statSync(entrypoint)
+
+    // Check file size before reading to optimize performance
+    if (stats.size <= BUNDLE_THRESHOLD) {
+      return false
+    }
+
+    var contents = fs.readFileSync(entrypoint, 'utf8')
+
+    // Check for ESBuild bundle markers
+    return contents.indexOf('__defProp') !== -1 &&
+      contents.indexOf('Bundled license information') !== -1
+  } catch (_err) {
+    // If we can't access the entrypoint, assume not bundled
+    return false
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
- instructs guardrails to disable SSI if the application is an ESBuild bundle
  - we cannot properly instrument any bundle externally
  - we can only instrument ESBuild bundles and only if the user built it with our plugin

### Motivation
- if a user has bundled their application with our ESBuild plugin and...
  - included a copy of the tracer using `require('dd-trace')` then...
    - it can get into a weird double-tracer state
    - there will be an internal (bundled) copy and an external (`--require` via guardrails) tracer
    - they fight with each other
  - but without a copy of the tracer then...
    - it can get into a weird state where the bundle does emit diagnostic channel messages
    - but the external tracer doesn't properly handle them
    - we could possibly support this in the future but it will require a lot of edge case testing
- if a user has bundled their application...
  - with Webpack or with ESBuild but without our ESBuild plugin or with another bundler then...
    - it can get into a weird state where the tracer only instruments internal module `require('http')` calls
    - but doesn't instrument userland module `require('express')` calls
