### PR TITLE
tracing: fix child process bug when used with bluebird promises

### DIFF
--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -179,7 +179,7 @@ function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
       return result
     }
 
-    return Promise.prototype.then.call(result, resolve, reject)
+    return Promise.resolve(result).then(resolve, reject)
   }
 }
 

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -377,7 +377,7 @@ describe('Child process plugin', () => {
         childProcess = require('child_process')
         util = require('util')
         tracer.use('child_process', { enabled: true })
-        Bluebird = require('../../../versions/bluebird@^3').get()
+        Bluebird = require('../../../versions/bluebird').get()
 
         // Store original Promise for restoration
         originalPromise = global.Promise

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -377,7 +377,7 @@ describe('Child process plugin', () => {
         childProcess = require('child_process')
         util = require('util')
         tracer.use('child_process', { enabled: true })
-        Bluebird = require('../../../versions/bluebird@3.7.2').get()
+        Bluebird = require('../../../versions/bluebird@^3').get()
 
         // Store original Promise for restoration
         originalPromise = global.Promise

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -61,6 +61,12 @@
       "versions": ["^4"]
     }
   ],
+  "child_process": [
+    {
+      "name": "bluebird",
+      "versions": ["^3"]
+    }
+  ],
   "cookie-parser": [
     {
       "name": "express",


### PR DESCRIPTION
### What does this PR do?
Child process instrumentation throws a `TypeError: this._then is not a function` when used with bluebird promises and this PR fixes that bug along with adding a unit test.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


