### PR TITLE
instrumentation: fix oracle db connection string

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -771,14 +771,12 @@ jobs:
       SERVICES: oracledb
       DD_TEST_AGENT_URL: http://testagent:9126
       DD_INJECT_FORCE: 'true'
-      # Needed to fix issue with `actions/checkout@v3: https://github.com/actions/checkout/issues/1590
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       # https://github.com/actions/runner/issues/2906#issuecomment-2109514798
       - name: Install Node for runner (with glibc 2.17 compatibility)
         run: |
-          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
-          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.19.3/node-v20.19.3-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.19.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/node
         with:

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -44,14 +44,21 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
 
         const details = this.hostName ? this : this._impl
 
-        const hostname = details?.nscon?.ntAdapter?.hostName ?? details.hostName
-        const port = details?.nscon?.ntAdapter?.port ?? details.port
+        let hostname
+        let port
+        let dbInstance
+
+        if (details) {
+          dbInstance = details.serviceName
+          hostname = details.nscon?.ntAdapter?.hostName ?? details.hostName
+          port = String(details.nscon?.ntAdapter?.port ?? details.port ?? '')
+        }
 
         startChannel.publish({
           query: dbQuery,
           connAttrs,
-          dbInstance: details.serviceName,
-          port: String(port),
+          dbInstance,
+          port,
           hostname,
         })
         try {

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -7,9 +7,6 @@ const {
 } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
 
-const connectionAttributes = new WeakMap()
-const poolAttributes = new WeakMap()
-
 const startChannel = channel('apm:oracledb:query:start')
 const errorChannel = channel('apm:oracledb:query:error')
 const finishChannel = channel('apm:oracledb:query:finish')
@@ -38,12 +35,17 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
       }
 
       return new AsyncResource('apm:oracledb:inner-scope').runInAsyncScope(() => {
-        const connAttrs = connectionAttributes.get(this)
-        startChannel.publish({ query: dbQuery, connAttrs })
+        startChannel.publish({
+          query: dbQuery,
+          connAttrs: {
+            dbInstance: this.serviceName,
+            dbRemoteAddress: this.remoteAddress,
+          }
+        })
         try {
           let result = execute.apply(this, arguments)
 
-          if (result && typeof result.then === 'function') {
+          if (typeof result?.then === 'function') {
             result = result.then(
               x => {
                 finish()
@@ -62,66 +64,6 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
           throw err
         }
       })
-    }
-  })
-  shimmer.wrap(oracledb, 'getConnection', getConnection => {
-    return function wrappedGetConnection (connAttrs, callback) {
-      if (callback) {
-        arguments[1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
-          if (connection) {
-            connectionAttributes.set(connection, connAttrs)
-          }
-          callback(err, connection)
-        })
-
-        getConnection.apply(this, arguments)
-      } else {
-        return getConnection.apply(this, arguments).then((connection) => {
-          connectionAttributes.set(connection, connAttrs)
-          return connection
-        })
-      }
-    }
-  })
-  shimmer.wrap(oracledb, 'createPool', createPool => {
-    return function wrappedCreatePool (poolAttrs, callback) {
-      if (callback) {
-        arguments[1] = shimmer.wrapFunction(callback, callback => (err, pool) => {
-          if (pool) {
-            poolAttributes.set(pool, poolAttrs)
-          }
-          callback(err, pool)
-        })
-
-        createPool.apply(this, arguments)
-      } else {
-        return createPool.apply(this, arguments).then((pool) => {
-          poolAttributes.set(pool, poolAttrs)
-          return pool
-        })
-      }
-    }
-  })
-  shimmer.wrap(oracledb.Pool.prototype, 'getConnection', getConnection => {
-    return function wrappedGetConnection () {
-      let callback
-      if (typeof arguments[arguments.length - 1] === 'function') {
-        callback = arguments[arguments.length - 1]
-      }
-      if (callback) {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
-          if (connection) {
-            connectionAttributes.set(connection, poolAttributes.get(this))
-          }
-          callback(err, connection)
-        })
-        getConnection.apply(this, arguments)
-      } else {
-        return getConnection.apply(this, arguments).then((connection) => {
-          connectionAttributes.set(connection, poolAttributes.get(this))
-          return connection
-        })
-      }
     }
   })
   return oracledb

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -38,11 +38,12 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
       }
 
       return new AsyncResource('apm:oracledb:inner-scope').runInAsyncScope(() => {
-        // The connAttrs are only used to pass through the argument to the potential
-        // serviceName method a user might have passed through.
+        // The connAttrs are used to pass through the argument to the potential
+        // serviceName method a user might have passed through as well as parsing
+        // the connection string in v5.
         const connAttrs = connectionAttributes.get(this)
 
-        const details = this.hostName ? this : this._impl
+        const details = typeof this.hostName === 'string' ? this : this._impl
 
         let hostname
         let port
@@ -50,8 +51,8 @@ addHook({ name: 'oracledb', versions: ['>=5'] }, oracledb => {
 
         if (details) {
           dbInstance = details.serviceName
-          hostname = details.nscon?.ntAdapter?.hostName ?? details.hostName
-          port = String(details.nscon?.ntAdapter?.port ?? details.port ?? '')
+          hostname = details.hostName ?? details.nscon?.ntAdapter?.hostName
+          port = String(details.port ?? details.nscon?.ntAdapter?.port ?? '')
         }
 
         startChannel.publish({

--- a/packages/datadog-plugin-oracledb/src/connection-parser.js
+++ b/packages/datadog-plugin-oracledb/src/connection-parser.js
@@ -1,0 +1,35 @@
+const { URL } = require('url')
+const log = require('../../dd-trace/src/log')
+
+function parseOracleDescriptor (descriptor) {
+  const hostnameMatch = descriptor.match(/HOST\s*=\s*([^)]+)/i)
+  const hostname = hostnameMatch?.[1]
+
+  const portMatch = descriptor.match(/PORT\s*=\s*([^)]+)/i)
+  const port = portMatch?.[1]
+
+  const sidMatch = descriptor.match(/SID\s*=\s*([^)]+)/i)
+
+  const dbInstance = sidMatch?.[1] ?? descriptor.match(/SERVICE_NAME\s*=\s*([^)]+)/i)?.[1] ?? ''
+
+  return { hostname, port, dbInstance }
+}
+
+module.exports = function getDBInformation (connAttrs) {
+  // Users can pass either connectString or connectionString
+  const connectString = (connAttrs.connectString || connAttrs.connectionString).trim()
+  if (connectString.startsWith('(')) {
+    return parseOracleDescriptor(connectString)
+  }
+  try {
+    const url = new URL(`oracle://${connectString}`)
+    return {
+      hostname: url.hostname || 'localhost', // Default Oracle hostname
+      port: url.port || '1521', // Default Oracle port
+      dbInstance: url.pathname && url.pathname.slice(1) || 'XEPDB1' // Default Oracle service name
+    }
+  } catch (error) {
+    log.error('Invalid oracle connection string', error)
+    return {}
+  }
+}

--- a/packages/datadog-plugin-oracledb/src/connection-parser.js
+++ b/packages/datadog-plugin-oracledb/src/connection-parser.js
@@ -3,21 +3,21 @@ const log = require('../../dd-trace/src/log')
 
 function parseOracleDescriptor (descriptor) {
   const hostnameMatch = descriptor.match(/HOST\s*=\s*([^)]+)/i)
-  const hostname = hostnameMatch?.[1]
+  const hostname = hostnameMatch?.[1] || 'localhost' // Default Oracle hostname
 
   const portMatch = descriptor.match(/PORT\s*=\s*([^)]+)/i)
-  const port = portMatch?.[1]
+  const port = portMatch?.[1] || '1521' // Default Oracle port
 
   const sidMatch = descriptor.match(/SID\s*=\s*([^)]+)/i)
 
-  const dbInstance = sidMatch?.[1] ?? descriptor.match(/SERVICE_NAME\s*=\s*([^)]+)/i)?.[1] ?? ''
+  const dbInstance = sidMatch?.[1] || descriptor.match(/SERVICE_NAME\s*=\s*([^)]+)/i)?.[1] || 'XEPDB1' // Default Oracle service name
 
   return { hostname, port, dbInstance }
 }
 
 module.exports = function getDBInformation (connAttrs) {
   // Users can pass either connectString or connectionString
-  const connectString = (connAttrs.connectString || connAttrs.connectionString).trim()
+  const connectString = ((connAttrs.connectString || connAttrs.connectionString) ?? '').trim()
   if (connectString.startsWith('(')) {
     return parseOracleDescriptor(connectString)
   }

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -2,7 +2,6 @@
 
 const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
-const log = require('../../dd-trace/src/log')
 
 class OracledbPlugin extends DatabasePlugin {
   static get id () { return 'oracledb' }
@@ -11,8 +10,10 @@ class OracledbPlugin extends DatabasePlugin {
 
   start ({ query, connAttrs }) {
     const service = this.serviceName({ pluginConfig: this.config, params: connAttrs })
-    // Users can pass either connectString or connectionString
-    const url = getUrl(connAttrs.connectString || connAttrs.connectionString)
+
+    const lastCollonIndex = connAttrs.dbRemoteAddress.lastIndexOf(':')
+    const port = connAttrs.dbRemoteAddress.slice(lastCollonIndex + 1)
+    const hostname = connAttrs.dbRemoteAddress.slice(0, lastCollonIndex)
 
     this.startSpan(this.operationName(), {
       service,
@@ -21,21 +22,11 @@ class OracledbPlugin extends DatabasePlugin {
       kind: 'client',
       meta: {
         'db.user': this.config.user,
-        'db.instance': url.pathname && url.pathname.slice(1),
-        'db.hostname': url.hostname,
-        [CLIENT_PORT_KEY]: url.port
+        'db.instance': connAttrs.dbInstance,
+        'db.hostname': hostname,
+        [CLIENT_PORT_KEY]: port
       }
     })
-  }
-}
-
-// TODO: Avoid creating an error since it's a heavy operation.
-function getUrl (connectString) {
-  try {
-    return new URL(`http://${connectString}`)
-  } catch (e) {
-    log.error('Invalid oracle connection string', e)
-    return {}
   }
 }
 

--- a/packages/dd-trace/src/service-naming/schemas/definition.js
+++ b/packages/dd-trace/src/service-naming/schemas/definition.js
@@ -3,20 +3,13 @@ class SchemaDefinition {
     this.schema = schema
   }
 
-  getSchemaItem (type, kind, plugin) {
-    const schema = this.schema
-    if (schema && schema[type] && schema[type][kind] && schema[type][kind][plugin]) {
-      return schema[type][kind][plugin]
-    }
-  }
-
   getOpName (type, kind, plugin, opts) {
-    const item = this.getSchemaItem(type, kind, plugin)
+    const item = this.schema[type][kind][plugin]
     return item.opName(opts)
   }
 
   getServiceName (type, kind, plugin, opts) {
-    const item = this.getSchemaItem(type, kind, plugin)
+    const item = this.schema[type][kind][plugin]
     return item.serviceName(opts)
   }
 }

--- a/packages/dd-trace/test/service-naming/schema.spec.js
+++ b/packages/dd-trace/test/service-naming/schema.spec.js
@@ -71,20 +71,6 @@ describe('Service naming', () => {
     const resolver = new SchemaDefinition(dummySchema)
     const extra = { my: { extra: 'args' } }
 
-    describe('Item resolver', () => {
-      it('should answer undefined on inexistent plugin', () => {
-        expect(resolver.getSchemaItem('messaging', 'inbound', 'foo')).to.be.equal(undefined)
-      })
-
-      it('should answer undefined on inexistent i/o dir', () => {
-        expect(resolver.getSchemaItem('messaging', 'foo', 'kafka')).to.be.equal(undefined)
-      })
-
-      it('should answer undefined on inexistent type', () => {
-        expect(resolver.getSchemaItem('foo', 'inbound', 'kafka')).to.be.equal(undefined)
-      })
-    })
-
     describe('Operation name getter', () => {
       it('should passthrough operation name arguments', () => {
         resolver.getOpName('messaging', 'inbound', 'kafka', extra)


### PR DESCRIPTION
Oracle supports three different ways to pass through conenctions. We only supported URLs so far. Others were unsupported. Instead of relying on the input, this changes the implementation to use the drivers own information to get that. This reduces the overhead of the instrumentation and we should always get the correct information, no matter how the user passes the information through.