### PR TITLE
tracing: add support for graphql esm applications 

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -359,6 +359,15 @@ function finishResolvers ({ fields }) {
   })
 }
 
+addHook({ name: '@graphql-tools/executor', versions: ['>=0.0.14'] }, executor => {
+  // graphql-yoga uses the normalizedExecutor function, so we need to wrap both. There is no risk in wrapping both
+  // since the functions are closely related, and our wrappedExecute function prevents double calls with the
+  // contexts.has(contextValue) check.
+  shimmer.wrap(executor, 'execute', wrapExecute(executor))
+  shimmer.wrap(executor, 'normalizedExecutor', wrapExecute(executor))
+  return executor
+})
+
 addHook({ name: '@graphql-tools/executor', file: 'cjs/execution/execute.js', versions: ['>=0.0.14'] }, execute => {
   shimmer.wrap(execute, 'execute', wrapExecute(execute))
   return execute

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
@@ -1,0 +1,60 @@
+import 'dd-trace/init.js'
+import graphql from 'graphql'
+import { createServer } from 'node:http'
+
+const schema = new graphql.GraphQLSchema({
+  query: new graphql.GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      hello: {
+        type: graphql.GraphQLString,
+        args: {
+          name: { type: graphql.GraphQLString }
+        },
+        resolve (obj, args) {
+          return `Hello, ${args.name || 'world'}!`
+        }
+      }
+    }
+  })
+})
+
+const server = createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/graphql') {
+    let body = ''
+    req.on('data', chunk => {
+      body += chunk.toString()
+    })
+    req.on('end', async () => {
+      try {
+        const { query, variables } = JSON.parse(body)
+        const result = await graphql.graphql({
+          schema,
+          source: query,
+          variableValues: variables
+        })
+
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify(result))
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: error.message }))
+      }
+    })
+  } else {
+    res.writeHead(404)
+    res.end('Not Found')
+  }
+})
+
+const port = process.env.PORT || 0
+
+server.listen(port, () => {
+  const actualPort = server.address().port
+  process.stdout.write(`Server is running on http://localhost:${actualPort}/graphql\n`)
+
+  // Send port to parent process for integration tests
+  if (process.send) {
+    process.send({ port: actualPort })
+  }
+})

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
@@ -51,8 +51,6 @@ const port = process.env.PORT || 0
 
 server.listen(port, () => {
   const actualPort = server.address().port
-  process.stdout.write(`Server is running on http://localhost:${actualPort}/graphql\n`)
-
   // Send port to parent process for integration tests
   if (process.send) {
     process.send({ port: actualPort })

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-yoga-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-yoga-server.mjs
@@ -32,8 +32,6 @@ const port = process.env.PORT || 0
 
 server.listen(port, () => {
   const actualPort = server.address().port
-  process.stdout.write(`GraphQL Yoga server is running on http://localhost:${actualPort}/graphql\n`)
-
   // Send port to parent process for integration tests
   if (process.send) {
     process.send({ port: actualPort })

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-yoga-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-yoga-server.mjs
@@ -1,0 +1,41 @@
+import 'dd-trace/init.js'
+import { createSchema, createYoga } from 'graphql-yoga'
+import { createServer } from 'node:http'
+
+const typeDefs = /* GraphQL */ `
+  type Query {
+    hello(name: String): String
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: (_, { name }) => {
+      return `Hello, ${name || 'world'}!`
+    }
+  }
+}
+
+const schema = createSchema({
+  typeDefs,
+  resolvers
+})
+
+const yoga = createYoga({
+  schema,
+  graphqlEndpoint: '/graphql'
+})
+
+const server = createServer(yoga)
+
+const port = process.env.PORT || 0
+
+server.listen(port, () => {
+  const actualPort = server.address().port
+  process.stdout.write(`GraphQL Yoga server is running on http://localhost:${actualPort}/graphql\n`)
+
+  // Send port to parent process for integration tests
+  if (process.send) {
+    process.send({ port: actualPort })
+  }
+})

--- a/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const {
+  FakeAgent,
+  createSandbox,
+  checkSpansForServiceName,
+  spawnPluginIntegrationTestProc
+} = require('../../../../integration-tests/helpers')
+const { assert } = require('chai')
+const { withVersions } = require('../../../dd-trace/test/setup/mocha')
+const axios = require('axios')
+const semver = require('semver')
+
+describe('Plugin (ESM)', () => {
+  describe('graphql (ESM)', () => {
+    let agent
+    let proc
+    let sandbox
+
+    withVersions('graphql', ['graphql'], version => {
+      before(async function () {
+        this.timeout(50000)
+        sandbox = await createSandbox([`'graphql@${version}'`, "'graphql-yoga@3.6.0'"], false, [
+          './packages/datadog-plugin-graphql/test/esm-test/*'])
+      })
+
+      after(async function () {
+        await sandbox.remove()
+      })
+
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+      })
+
+      afterEach(async () => {
+        proc && proc.kill()
+        await agent.stop()
+      })
+
+      it('should instrument GraphQL execution with ESM', async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+          assert.isArray(payload)
+          assert.strictEqual(checkSpansForServiceName(payload, 'graphql.execute'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'esm-graphql-server.mjs', agent.port)
+
+        // Make a GraphQL request
+        const query = `
+          query MyQuery {
+            hello(name: "world")
+          }
+        `
+
+        try {
+          await axios.post(`${proc.url}/graphql`, {
+            query
+          })
+        } catch (error) {
+          // Server might not respond correctly, but we care about tracing
+        }
+
+        await res
+      }).timeout(50000)
+
+      // Only run GraphQL Yoga test for newer GraphQL versions (>= 15.0.0)
+      // GraphQL Yoga 3.6.0 requires newer GraphQL versions that have versionInfo export
+      // Extract version number from range strings like ">=0.10" or "^15.2.0"
+      const cleanVersion = version.replace(/^[>=^~]+/, '')
+      const coercedVersion = semver.coerce(cleanVersion)
+      if (coercedVersion && semver.gte(coercedVersion, '15.0.0')) {
+        it('should instrument GraphQL Yoga execution with ESM', async () => {
+          const res = agent.assertMessageReceived(({ headers, payload }) => {
+            assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
+            assert.isArray(payload)
+            assert.strictEqual(checkSpansForServiceName(payload, 'graphql.execute'), true)
+          })
+
+          proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'esm-graphql-yoga-server.mjs', agent.port)
+
+          // Make a GraphQL request to Yoga server
+          const query = `
+            query MyQuery {
+              hello(name: "yoga")
+            }
+          `
+
+          try {
+            await axios.post(`${proc.url}/graphql`, {
+              query
+            })
+          } catch (error) {
+            // Server might not respond correctly, but we care about tracing
+          }
+
+          await res
+        }).timeout(50000)
+      }
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
`graphql-yoga`, a package used for building graphql servers, uses `graphql-tools/executor` under the hood. `graphql-tools/executor` has separate code paths for `cjs` versus `esm` code. We already had tracing for the `cjs` code path, this PR adds tracing for the `esm` code path as well. Also adds esm tests for both a pure graphql server and a graphql-yoga server.

### Motivation
escalation

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


