### PR TITLE
docs: fix typo `primsa` to `prisma`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -148,7 +148,7 @@ tracer.use('pg', {
 * [oracledb](./interfaces/export_.plugins.oracledb.html)
 * [pino](./interfaces/export_.plugins.pino.html)
 * [pg](./interfaces/export_.plugins.pg.html)
-* [primsa](./interfaces/export_.plugins.prisma.html)
+* [prisma](./interfaces/export_.plugins.prisma.html)
 * [promise](./interfaces/export_.plugins.promise.html)
 * [promise-js](./interfaces/export_.plugins.promise_js.html)
 * [protobufjs](./interfaces/export_.plugins.protobufjs.html)


### PR DESCRIPTION
### What does this PR do?

fix typo `primsa`to `prisma`.

_This is clone the community PR #6005, in order to be able to land it_

### Motivation

Correct typo to avoid confusion.
