### PR TITLE
feat(tracer): add `recordException` API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -271,6 +271,15 @@ declare namespace tracer {
      * @returns {void}
      */
     addLink (context: SpanContext, attributes?: Object): void;
+
+    /**
+     * Records an exception as a span event.
+     *
+     * @param exception the exception to record.
+     * @param [attributes] additional attributes to add to the span event.
+     */
+    recordException(exception: Error | Object, attributes?: SpanAttributes): this;
+
   }
 
   /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -273,12 +273,21 @@ declare namespace tracer {
     addLink (context: SpanContext, attributes?: Object): void;
 
     /**
+     * Represents an exception object that can be recorded on a span.
+     */
+    Exception?: {
+      message: string;
+      name?: string;
+      stack?: string;
+    };
+
+    /**
      * Records an exception as a span event.
      *
-     * @param exception the exception to record.
-     * @param [attributes] additional attributes to add to the span event.
+     * @param {Error | Span['Exception']} exception the exception to record.
+     * @param {SpanAttributes} [attributes] additional attributes to add to the span event.
      */
-    recordException(exception: Error | Object, attributes?: SpanAttributes): this;
+    recordException(exception: Error | Span['Exception'], attributes?: SpanAttributes): this;
 
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -285,9 +285,9 @@ declare namespace tracer {
      * Records an exception as a span event.
      *
      * @param {Error | Span['Exception']} exception the exception to record.
-     * @param {SpanAttributes} [attributes] additional attributes to add to the span event.
+     * @param {otel.Attributes} [attributes] additional attributes to add to the span event.
      */
-    recordException(exception: Error | Span['Exception'], attributes?: SpanAttributes): this;
+    recordException(exception: Error | Span['Exception'], attributes?: otel.Attributes): this;
 
   }
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -321,7 +321,8 @@ class DatadogSpan {
       }
 
       for (let i = 0; i < value.length; i++) {
-        if (typeof value[i] !== expectedType || !this._validateScalar(key, value[i])) {
+        const currentType = typeof value[i]
+        if (currentType !== expectedType || !this._validateScalar(key, value[i])) {
           log.warn(`Dropping span event attribute. Attribute ${key} array values are not homogenous or valid: ${value}`)
           return false
         }

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -27,9 +27,8 @@ const finishedRegistry = createRegistry('finished')
 const OTEL_ENABLED = !!getEnvironmentVariable('DD_TRACE_OTEL_ENABLED')
 const ALLOWED = new Set(['string', 'number', 'boolean'])
 
-const MIN_INT_64BITS = -(2n ** 63n);
-const MAX_INT_64BITS = (2n ** 63n) - 1n;
-
+const MIN_INT_64BITS = -(2n ** 63n)
+const MAX_INT_64BITS = (2n ** 63n) - 1n
 
 const integrationCounters = {
   spans_created: {},
@@ -235,16 +234,16 @@ class DatadogSpan {
     this._events.push(event)
   }
 
-  recordException(exception, attributes={}) {
+  recordException (exception, attributes = {}) {
     if (!isError(exception)) return
 
-    const event_attributes = {
-      "exception.type": exception.name,
-      "exception.message": exception.message,
-      "exception.stacktrace": exception.stack
+    const eventAttributes = {
+      'exception.type': exception.name,
+      'exception.message': exception.message,
+      'exception.stacktrace': exception.stack
     }
 
-    this.addEvent('exception', {...event_attributes, ...attributes})
+    this.addEvent('exception', { ...eventAttributes, ...attributes })
   }
 
   finish (finishTime) {
@@ -307,7 +306,6 @@ class DatadogSpan {
     return sanitizedAttributes
   }
 
-
   _validateEventAttributes (key, value) {
     if (ALLOWED.has(typeof value)) {
       return this._validateScalar(key, value)
@@ -341,7 +339,8 @@ class DatadogSpan {
     }
 
     if (Number.isInteger(value) && (value < MIN_INT_64BITS || value > MAX_INT_64BITS)) {
-      log.warn(`Dropping span event attribute. Attribute ${key} must be within the range of a signed 64-bit integer: ${value}`)
+      log.warn(`Dropping span event attribute. Attribute ${key} must be within the range of a
+        signed 64-bit integer: ${value}`)
       return false
     } else if (!Number.isFinite(value)) {
       log.warn(`Dropping span event attribute. Attribute ${key} must be a finite number: ${value}`)

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -503,7 +503,7 @@ describe('OTel Span', () => {
     const span2 = makeSpan('span2')
     const datenow = Date.now()
     span1.addEvent('Web page unresponsive',
-      { 'error.code': '403', 'unknown values': [1, ['h', 'a', [false]]] }, datenow)
+      { 'error.code': '403', 'unknown values': [1] }, datenow)
     span2.addEvent('Web page loaded')
     span2.addEvent('Button changed color', { colors: [112, 215, 70], 'response.time': 134.3, success: true })
     const events1 = span1._ddSpan._events

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -403,6 +403,19 @@ describe('Span', () => {
       expect(events[1].attributes).to.have.property('exception.message', 'bar')
     })
 
+    it('should record exception when error is not an error object', async () => {
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      await Promise.reject({ message: "something went wrong" }).catch(error => span.recordException(error));
+
+      const events = span._events
+      expect(events).to.have.lengthOf(1)
+
+      expect(events[0].name).to.equal('exception')
+      expect(Object.keys(events[0].attributes)).to.have.lengthOf(1)
+      expect(events[0].attributes).to.have.property('exception.message', 'something went wrong')
+    })
+
     it('should record exception with custom attributes', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -380,14 +380,14 @@ describe('Span', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
       try {
-        throw new TypeError("foo")
-      } catch(error) {
+        throw new TypeError('foo')
+      } catch (error) {
         span.recordException(error)
       }
 
       try {
-        throw new Error("bar")
-      } catch(error) {
+        throw new Error('bar')
+      } catch (error) {
         span.recordException(error)
       }
 
@@ -406,7 +406,7 @@ describe('Span', () => {
     it('should record exception when error is not an error object', async () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
-      await Promise.reject({ message: "something went wrong" }).catch(error => span.recordException(error));
+      span.recordException({ message: 'something went wrong' })
 
       const events = span._events
       expect(events).to.have.lengthOf(1)
@@ -420,9 +420,9 @@ describe('Span', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
       try {
-        throw new TypeError("foo")
-      } catch(error) {
-        span.recordException(error, {'foo': 'bar'})
+        throw new TypeError('foo')
+      } catch (error) {
+        span.recordException(error, { foo: 'bar' })
       }
 
       const events = span._events
@@ -438,15 +438,16 @@ describe('Span', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
 
       try {
-        throw new TypeError("foo")
-      } catch(error) {
+        throw new TypeError('foo')
+      } catch (error) {
         span.recordException(error,
-          {'foo': 'bar',
-           'invalid1': [1, false],
-           'invalid2': [[1]],
-           'invalid3': {"foo": "bar"},
-           "invalid4": NaN,
-           "invalid5": 9223372036854775808n,
+          {
+            foo: 'bar',
+            invalid1: [1, false],
+            invalid2: [[1]],
+            invalid3: { foo: 'bar' },
+            invalid4: NaN,
+            invalid5: 9223372036854775808n,
           })
       }
 
@@ -460,11 +461,23 @@ describe('Span', () => {
       expect(events[0].attributes).to.have.property('foo', 'bar')
 
       // Check that warning logs were called for invalid attributes
-      expect(log.warn).to.have.been.calledWith('Dropping span event attribute. Attribute invalid1 array values are not homogenous or valid: 1,false')
-      expect(log.warn).to.have.been.calledWith('Dropping span event attribute. List values invalid2 must be string, number, or boolean: 1')
-      expect(log.warn).to.have.been.calledWith('Dropping span event attribute. Attribute invalid3 must be (array of) string, number, or boolean: [object Object]')
-      expect(log.warn).to.have.been.calledWith('Dropping span event attribute. Attribute invalid4 must be a finite number: NaN')
-      expect(log.warn).to.have.been.calledWith('Dropping span event attribute. Attribute invalid5 must be (array of) string, number, or boolean: 9223372036854775808')
+      expect(log.warn).to.have.been.calledWith(
+        'Dropping span event attribute. Attribute invalid1 array values are not homogenous or valid: 1,false'
+      )
+      expect(log.warn).to.have.been.calledWith(
+        'Dropping span event attribute. List values invalid2 must be string, number, or boolean: 1'
+      )
+      expect(log.warn).to.have.been.calledWith(
+        'Dropping span event attribute. Attribute invalid3 must be (array of) string, number, or boolean: ' +
+        '[object Object]'
+      )
+      expect(log.warn).to.have.been.calledWith(
+        'Dropping span event attribute. Attribute invalid4 must be a finite number: NaN'
+      )
+      expect(log.warn).to.have.been.calledWith(
+        'Dropping span event attribute. Attribute invalid5 must be (array of) string, number, or boolean: ' +
+        '9223372036854775808'
+      )
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
- Adds `recordException` API following this [RFC](https://docs.google.com/document/d/1-7CsG8GZVnNU198FfzavCNMI6IF0cGzFfS8cIz6Pu1g/edit?tab=t.0#heading=h.i8a6l13dr0px). `recordException` attaches error information to span through a span event.
- Refactor `sanitizeEventAttributes()`. Now if an attribute values does not follow the requirements (defined [here](https://docs.google.com/document/d/1cVod_VI7Yruq8U9dfMRFJd7npDu-uBpste2IB04GyaQ/edit?pli=1&tab=t.0#heading=h.z8rsw69ccced), the key is fully dropped.

### Motivation
We want to add a recordException API in every tracers so customers can use the feature without using the OpenTelemetry one which is not consistent across tracers. Note that the function is similar to the OpenTelemetry function but is not meant to be a replica.

About the second change, while implementing the API, I found out that `sanitizeEventAttributes` was not complete (lacking of check for integer range for instance) and not following the RFC.
Example:
[1, [1]] is not accepted and currently the function was only removing [1].



