### PR TITLE
Add script to allow running CI on community PRs

### DIFF
--- a/scripts/run-ci-on-community-pr.sh
+++ b/scripts/run-ci-on-community-pr.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PR_ID=${1:-}
+
+if [ -z "$PR_ID" ]; then
+  echo "Usage: $0 <pr-id>"
+  echo
+  echo "This will:"
+  echo "1. Rebase the PR with its target branch, with each contained commit signed."
+  echo "2. Create a temporary PR to allow running CI on the community PR."
+  echo
+  echo "Prerequisites:"
+  echo "- You must have a GPG key configured to use with git."
+  echo "- You must have write access to the PR."
+  echo
+  exit 1
+fi
+
+GITHUB_USER=$(gh api user --jq .login)
+BASE_COMMIT=$(gh pr view $PR_ID --json baseRefOid --jq '.baseRefOid')
+TEMP_BRANCH=$GITHUB_USER/tmp-ci-run-$PR_ID-$(date +%s)
+WORKTREE_DIR=$(mktemp -d)
+ORIGINAL_DIR=$(pwd)
+
+cleanup() {
+  if [ -n "${WORKTREE_DIR:-}" ] && [ -d "$WORKTREE_DIR" ]; then
+    cd "$ORIGINAL_DIR" 2>/dev/null || true
+    git worktree remove "$WORKTREE_DIR" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT ERR INT
+
+git worktree add $WORKTREE_DIR
+cd $WORKTREE_DIR
+
+git fetch origin
+gh pr checkout $PR_ID
+git rebase --gpg-sign $BASE_COMMIT
+git push --force
+git push origin HEAD:$TEMP_BRANCH
+
+gh pr create \
+  --head $TEMP_BRANCH \
+  --draft \
+  --label "semver-patch" \
+  --title "Temp: Run CI on community PR #$PR_ID" \
+  --body "This is a temporary PR to allow running CI on the community PR #$PR_ID. It should be closed after CI has completed running."
+gh pr view $TEMP_BRANCH --web


### PR DESCRIPTION
### What does this PR do?

The script can be executed like so:

```sh    
./scripts/run-ci-on-community-pr.sh <pr-id>
```
    
It will do the following:    
1. Rebase the community PR againt its target branch.
2. Sign all the commits in the community PR.
3. Create a temporary PR to allow running of CI in the community PR.
    
The temporary PR can be closed once CI has completed running.

### Motivation

When a community PR is opened against `dd-trace-js`, the old approach to allow CI to run, was to close the community PR and create a new one with its commits cherry-picked (since CI isn't allowed to run for community PRs).

This is has a few downsides:
1. It's a bad experience for the original author
2. It splits discussion and reviews across two PRs
3. Doing this manually was an annoyance

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes

This works due to the fact that the temp PR and the original PR shares the same commit SHAs. This allows the CI to run with the permissions of the user creating the temp PR.

