### PR TITLE
Inline eslint-config-standard config/rules in eslint.config.mjs

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -44,7 +44,6 @@ dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David D
 dev,body-parser,MIT,Copyright 2014 Jonathan Ong 2014-2015 Douglas Christopher Wilson
 dev,chai,MIT,Copyright 2017 Chai.js Assertion Library
 dev,eslint,MIT,Copyright JS Foundation and other contributors https://js.foundation
-dev,eslint-config-standard,MIT,Copyright Feross Aboukhadijeh
 dev,eslint-plugin-import,MIT,Copyright 2015 Ben Mosher
 dev,eslint-plugin-mocha,MIT,Copyright 2014 Mathias Schreck
 dev,eslint-plugin-n,MIT,Copyright 2015 Toru Nagashima

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,22 +1,15 @@
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-
-import { FlatCompat } from '@eslint/eslintrc'
 import eslintPluginJs from '@eslint/js'
 import eslintPluginStylistic from '@stylistic/eslint-plugin'
 import eslintPluginImport from 'eslint-plugin-import'
 import eslintPluginMocha from 'eslint-plugin-mocha'
 import eslintPluginN from 'eslint-plugin-n'
+import eslintPluginPromise from 'eslint-plugin-promise'
 import eslintPluginUnicorn from 'eslint-plugin-unicorn'
 import globals from 'globals'
 
 import eslintProcessEnv from './eslint-rules/eslint-process-env.mjs'
 import eslintEnvAliases from './eslint-rules/eslint-env-aliases.mjs'
 import eslintSafeTypeOfObject from './eslint-rules/eslint-safe-typeof-object.mjs'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-const compat = new FlatCompat({ baseDirectory: __dirname })
 
 const SRC_FILES = [
   '*.js',
@@ -59,7 +52,236 @@ export default [
     ]
   },
   { name: '@eslint/js/recommended', ...eslintPluginJs.configs.recommended },
-  ...compat.extends('standard').map((config, i) => ({ name: config.name || `standard/${i + 1}`, ...config })),
+  {
+    // The following config and rules have been inlined from `eslint-config-standard` with the following modifications:
+    // - Rules that were overridden elsewhere in this file have been removed.
+    // - Deprecated rules have been replaced with their official replacements.
+    //
+    // We've inlined these to avoid having to depend on `eslint-config-standard` as:
+    // 1. It's no longer maintained.
+    // 2. It came with an older bundled version of `eslint-plugin-n` which conflicted with our version.
+    //
+    // TODO: Move these rules to dd-trace/defaults or where they otherwise belong.
+    name: 'standard',
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      globals: {
+        ...globals.es2021,
+        ...globals.node,
+        document: 'readonly',
+        navigator: 'readonly',
+        window: 'readonly'
+      }
+    },
+    plugins: {
+      '@stylistic': eslintPluginStylistic,
+      import: eslintPluginImport,
+      n: eslintPluginN,
+      promise: eslintPluginPromise
+    },
+    rules: {
+      '@stylistic/array-bracket-spacing': ['error', 'never'],
+      '@stylistic/arrow-spacing': ['error', { before: true, after: true }],
+      '@stylistic/block-spacing': ['error', 'always'],
+      '@stylistic/comma-spacing': ['error', { before: false, after: true }],
+      '@stylistic/computed-property-spacing': ['error', 'never', { enforceForClassMembers: true }],
+      '@stylistic/dot-location': ['error', 'property'],
+      '@stylistic/eol-last': 'error',
+      '@stylistic/generator-star-spacing': ['error', { before: true, after: true }],
+      '@stylistic/key-spacing': ['error', { beforeColon: false, afterColon: true }],
+      '@stylistic/keyword-spacing': ['error', { before: true, after: true }],
+      '@stylistic/lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+      '@stylistic/multiline-ternary': ['error', 'always-multiline'],
+      '@stylistic/new-parens': 'error',
+      '@stylistic/no-extra-parens': ['error', 'functions'],
+      '@stylistic/no-floating-decimal': 'error',
+      '@stylistic/no-mixed-spaces-and-tabs': 'error',
+      '@stylistic/no-multi-spaces': 'error',
+      '@stylistic/no-multiple-empty-lines': ['error', { max: 1, maxBOF: 0, maxEOF: 0 }],
+      '@stylistic/no-tabs': 'error',
+      '@stylistic/no-trailing-spaces': 'error',
+      '@stylistic/no-whitespace-before-property': 'error',
+      '@stylistic/operator-linebreak': [
+        'error',
+        'after',
+        { overrides: { '?': 'before', ':': 'before', '|>': 'before' } }
+      ],
+      '@stylistic/padded-blocks': [
+        'error',
+        { blocks: 'never', switches: 'never', classes: 'never' }
+      ],
+      '@stylistic/quote-props': ['error', 'as-needed'],
+      '@stylistic/quotes': [
+        'error',
+        'single',
+        { avoidEscape: true, allowTemplateLiterals: false }
+      ],
+      '@stylistic/rest-spread-spacing': ['error', 'never'],
+      '@stylistic/semi': ['error', 'never'],
+      '@stylistic/semi-spacing': ['error', { before: false, after: true }],
+      '@stylistic/space-before-blocks': ['error', 'always'],
+      '@stylistic/space-before-function-paren': ['error', 'always'],
+      '@stylistic/space-in-parens': ['error', 'never'],
+      '@stylistic/space-infix-ops': 'error',
+      '@stylistic/space-unary-ops': ['error', { words: true, nonwords: false }],
+      '@stylistic/spaced-comment': [
+        'error',
+        'always',
+        {
+          line: { markers: ['*package', '!', '/', ',', '='] },
+          block: {
+            balanced: true,
+            markers: ['*package', '!', ',', ':', '::', 'flow-include'],
+            exceptions: ['*']
+          }
+        }
+      ],
+      '@stylistic/template-curly-spacing': ['error', 'never'],
+      '@stylistic/template-tag-spacing': ['error', 'never'],
+      '@stylistic/wrap-iife': ['error', 'any', { functionPrototypeMethods: true }],
+      '@stylistic/yield-star-spacing': ['error', 'both'],
+      'accessor-pairs': ['error', { setWithoutGet: true, enforceForClassMembers: true }],
+      'array-callback-return': ['error', { allowImplicit: false, checkForEach: false }],
+      'brace-style': [ // TODO: Deprecated, use @stylistic/brace-style instead
+        'error',
+        '1tbs',
+        { allowSingleLine: true }
+      ],
+      camelcase: [
+        'error',
+        {
+          allow: ['^UNSAFE_'],
+          properties: 'never',
+          ignoreGlobals: true
+        }
+      ],
+      'comma-style': ['error', 'last'], // TODO: Deprecated, use @stylistic/comma-style instead
+      curly: ['error', 'multi-line'],
+      'default-case-last': 'error',
+      'dot-notation': ['error', { allowKeywords: true }],
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      'func-call-spacing': ['error', 'never'], // TODO: Deprecated, use @stylistic/func-call-spacing instead
+      indent: [ // TODO: Deprecated, use @stylistic/indent instead
+        'error',
+        2,
+        {
+          SwitchCase: 1,
+          VariableDeclarator: 1,
+          outerIIFEBody: 1,
+          MemberExpression: 1,
+          FunctionDeclaration: { parameters: 1, body: 1 },
+          FunctionExpression: { parameters: 1, body: 1 },
+          CallExpression: { arguments: 1 },
+          ArrayExpression: 1,
+          ObjectExpression: 1,
+          ImportDeclaration: 1,
+          flatTernaryExpressions: false,
+          ignoreComments: false,
+          ignoredNodes: [
+            'TemplateLiteral *',
+            'JSXElement',
+            'JSXElement > *',
+            'JSXAttribute',
+            'JSXIdentifier',
+            'JSXNamespacedName',
+            'JSXMemberExpression',
+            'JSXSpreadAttribute',
+            'JSXExpressionContainer',
+            'JSXOpeningElement',
+            'JSXClosingElement',
+            'JSXFragment',
+            'JSXOpeningFragment',
+            'JSXClosingFragment',
+            'JSXText',
+            'JSXEmptyExpression',
+            'JSXSpreadChild'
+          ],
+          offsetTernaryExpressions: true
+        }
+      ],
+      'import/export': 'error',
+      'import/first': 'error',
+      'import/no-absolute-path': ['error', { esmodule: true, commonjs: true, amd: false }],
+      'import/no-duplicates': 'error',
+      'import/no-named-default': 'error',
+      'import/no-webpack-loader-syntax': 'error',
+      'n/handle-callback-err': ['error', '^(err|error)$'],
+      'n/no-callback-literal': 'error',
+      'n/no-deprecated-api': 'error',
+      'n/no-exports-assign': 'error',
+      'n/no-new-require': 'error',
+      'n/no-path-concat': 'error',
+      'n/process-exit-as-throw': 'error',
+      'new-cap': ['error', { newIsCap: true, capIsNew: false, properties: true }],
+      'no-array-constructor': 'error',
+      'no-caller': 'error',
+      'no-constant-condition': ['error', { checkLoops: false }], // override config from @eslint/js/recommended
+      'no-empty': ['error', { allowEmptyCatch: true }], // override config from @eslint/js/recommended
+      'no-eval': 'error',
+      'no-extend-native': 'error',
+      'no-extra-bind': 'error',
+      'no-implied-eval': 'error',
+      'no-iterator': 'error',
+      'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+      'no-lone-blocks': 'error',
+      'no-multi-str': 'error',
+      'no-new': 'error',
+      'no-new-func': 'error',
+      'no-new-wrappers': 'error',
+      'no-object-constructor': 'error',
+      'no-octal-escape': 'error',
+      'no-proto': 'error',
+      'no-redeclare': ['error', { builtinGlobals: false }], // override config from @eslint/js/recommended
+      'no-return-assign': ['error', 'except-parens'],
+      'no-self-compare': 'error',
+      'no-sequences': 'error',
+      'no-template-curly-in-string': 'error',
+      'no-throw-literal': 'error',
+      'no-undef-init': 'error',
+      'no-unmodified-loop-condition': 'error',
+      'no-unneeded-ternary': ['error', { defaultAssignment: false }],
+      'no-unreachable-loop': 'error',
+      'no-unused-vars': [ // override config from @eslint/js/recommended
+        'error',
+        {
+          args: 'none',
+          caughtErrors: 'none',
+          ignoreRestSiblings: true,
+          vars: 'all'
+        }
+      ],
+      'no-use-before-define': ['error', { functions: false, classes: false, variables: false }],
+      'no-useless-call': 'error',
+      'no-useless-computed-key': 'error',
+      'no-useless-constructor': 'error',
+      'no-useless-rename': 'error',
+      'no-useless-return': 'error',
+      'no-void': 'error',
+      'object-property-newline': [ // TODO: Deprecated, use @stylistic/object-property-newline instead
+        'error',
+        { allowMultiplePropertiesPerLine: true }
+      ],
+      'object-shorthand': ['warn', 'properties'],
+      'one-var': ['error', { initialized: 'never' }],
+      'prefer-const': ['error', { destructuring: 'all' }],
+      'prefer-promise-reject-errors': 'error',
+      'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
+      'promise/param-names': 'error',
+      'symbol-description': 'error',
+      'unicode-bom': ['error', 'never'],
+      'use-isnan': [ // override config from @eslint/js/recommended
+        'error',
+        { enforceForSwitchCase: true, enforceForIndexOf: true }
+      ],
+      yoda: ['error', 'never']
+    }
+  },
   {
     name: 'dd-trace/defaults',
 
@@ -100,14 +322,11 @@ export default [
         importAttributes: 'always-multiline',
         dynamicImports: 'always-multiline'
       }],
-      'comma-dangle': 'off', // Override (turned on by @eslint/js/recommended)
       'import/no-extraneous-dependencies': 'error',
       'n/no-restricted-require': ['error', ['diagnostics_channel']],
       'no-console': 'error',
-      'no-mixed-operators': 'off', // Override (turned on by standard)
       'no-prototype-builtins': 'off', // Override (turned on by @eslint/js/recommended)
-      'no-unused-expressions': 'off', // Override (turned on by standard)
-      'no-var': 'error', // Override (set to warn in standard)
+      'no-var': 'error',
       'require-await': 'error'
     }
   },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,6 @@
     "body-parser": "^2.2.0",
     "chai": "^4.5.0",
     "eslint": "^9.29.0",
-    "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-n": "^17.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,11 +1970,6 @@ eslint-compat-utils@^0.5.1:
   dependencies:
     semver "^7.5.4"
 
-eslint-config-standard@^17.1.0:
-  version "17.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz#40ffb8595d47a6b242e07cbfd49dc211ed128975"
-  integrity sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==
-
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"


### PR DESCRIPTION
### What does this PR do?

As the title says :)

### Motivation

The `eslint-config-standard` plugin has been inlined because:
    
1. It is no longer maintained.
2. It used a lot of deprecated rules (which has now been upgraded as to their recommended replacements in this PR).
3. It came with an older bundled version of `eslint-plugin-n` which conflicted with our version.
4. Blocked us from making some other changes to the ESLint config that we want to make.

### Additional Notes

The ruleset has been left where the old `eslint-config-standard` ruleset was instead of merging it into our own rulesets. It's intended to be split up and moved together with the other rulesets, but I think it's best to do that in a separate PR to keep the diff as simple as possible and better preserve the history of the change.

