### PR TITLE
feat(llmobs): add ability to tag tool id on tool messages

### DIFF
--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -281,6 +281,7 @@ class LLMObsTagger {
 
       const { content = '', role } = message
       const toolCalls = message.toolCalls
+      const toolId = message.toolId
       const messageObj = { content }
 
       const valid = typeof content === 'string'
@@ -288,13 +289,21 @@ class LLMObsTagger {
         this.#handleFailure('Message content must be a string.', 'invalid_io_messages')
       }
 
-      const condition = this.#tagConditionalString(role, 'Message role', messageObj, 'role')
+      let condition = this.#tagConditionalString(role, 'Message role', messageObj, 'role')
 
       if (toolCalls) {
         const filteredToolCalls = this.#filterToolCalls(toolCalls)
 
         if (filteredToolCalls.length) {
           messageObj.tool_calls = filteredToolCalls
+        }
+      }
+
+      if (toolId) {
+        if (role === 'tool') {
+          condition = this.#tagConditionalString(toolId, 'Tool ID', messageObj, 'tool_id')
+        } else {
+          log.warn(`Tool ID for tool message not associated with a "tool" role, instead got "${role}"`)
         }
       }
 

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -391,6 +391,44 @@ describe('tagger', () => {
           expect(() => tagger.tagLLMIO(span, messages, undefined)).to.throw()
         })
       })
+
+      describe('tool message tagging', () => {
+        it('tags a span with a tool message', () => {
+          const messages = [
+            { role: 'tool', content: 'The weather in San Francisco is sunny', toolId: '123' }
+          ]
+
+          tagger._register(span)
+          tagger.tagLLMIO(span, messages, undefined)
+          expect(Tagger.tagMap.get(span)).to.deep.equal({
+            '_ml_obs.meta.input.messages': [
+              { role: 'tool', content: 'The weather in San Francisco is sunny', tool_id: '123' }
+            ]
+          })
+        })
+
+        it('throws if the tool id is not a string', () => {
+          const messages = [
+            { role: 'tool', content: 'The weather in San Francisco is sunny', toolId: 123 }
+          ]
+
+          expect(() => tagger.tagLLMIO(span, messages, undefined)).to.throw()
+        })
+
+        it('logs a warning if the tool id is not associated with a tool role', () => {
+          const messages = [
+            { role: 'user', content: 'The weather in San Francisco is sunny', toolId: '123' }
+          ]
+
+          tagger._register(span)
+          tagger.tagLLMIO(span, messages, undefined)
+
+          const messageTags = Tagger.tagMap.get(span)['_ml_obs.meta.input.messages']
+          expect(messageTags[0]).to.not.have.property('tool_id')
+
+          expect(logger.warn).to.have.been.calledOnce
+        })
+      })
     })
 
     describe('tagEmbeddingIO', () => {
@@ -639,6 +677,20 @@ describe('tagger', () => {
           tagger.tagLLMIO(span, messages, undefined)
           expect(logger.warn.callCount).to.equal(5) // 4 for tool call + 1 for role
         })
+      })
+
+      it('logs a warning when a tool message is not associated with a tool role', () => {
+        const messages = [
+          { role: 'user', content: 'The weather in San Francisco is sunny', toolId: '123' }
+        ]
+
+        tagger._register(span)
+        tagger.tagLLMIO(span, messages, undefined)
+
+        const messageTags = Tagger.tagMap.get(span)['_ml_obs.meta.input.messages']
+        expect(messageTags[0]).to.not.have.property('tool_id')
+
+        expect(logger.warn).to.have.been.calledOnce
       })
     })
   })


### PR DESCRIPTION
### What does this PR do?
Adds ability to tag tool id on tool messages, ie

```
{ role: 'tool', content: 'The weather in New York City is sunny', toolId: 'call_graYdzCUM03gt7butonGSOnN' }
```

Additionally:
1. If the role is not `tool`, we log a warning
2. If the `toolId` is not a string, we handle failures with respect to if the tagger should soft fail or not.

### Motivation
MLOB-3212