### PR TITLE
ESLint: Run linter on Cypress support file

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -44,6 +44,7 @@ dev,benchmark,MIT,Copyright 2010-2016 Mathias Bynens Robert Kieffer John-David D
 dev,body-parser,MIT,Copyright 2014 Jonathan Ong 2014-2015 Douglas Christopher Wilson
 dev,chai,MIT,Copyright 2017 Chai.js Assertion Library
 dev,eslint,MIT,Copyright JS Foundation and other contributors https://js.foundation
+dev,eslint-plugin-cypress,MIT,Copyright (c) 2019 Cypress.io
 dev,eslint-plugin-import,MIT,Copyright 2015 Ben Mosher
 dev,eslint-plugin-mocha,MIT,Copyright 2014 Mathias Schreck
 dev,eslint-plugin-n,MIT,Copyright 2015 Toru Nagashima

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import eslintPluginJs from '@eslint/js'
 import eslintPluginStylistic from '@stylistic/eslint-plugin'
+import eslintPluginCypress from 'eslint-plugin-cypress'
 import eslintPluginImport from 'eslint-plugin-import'
 import eslintPluginMocha from 'eslint-plugin-mocha'
 import eslintPluginN from 'eslint-plugin-n'
@@ -405,6 +406,12 @@ export default [
       'unicorn/prefer-top-level-await': 'off', // Only useful when using ESM
       'unicorn/switch-case-braces': 'off', // Questionable benefit
     }
+  },
+  {
+    ...eslintPluginCypress.configs.recommended,
+    files: [
+      'packages/datadog-plugin-cypress/src/support.js'
+    ]
   },
   {
     name: 'mocha/recommended',

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "body-parser": "^2.2.0",
     "chai": "^4.5.0",
     "eslint": "^9.29.0",
+    "eslint-plugin-cypress": "^5.1.0",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-n": "^17.20.0",

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/no-abusive-eslint-disable */
-/* eslint-disable */
 let isEarlyFlakeDetectionEnabled = false
 let isKnownTestsEnabled = false
 let knownTestsForSuite = []
@@ -20,7 +18,7 @@ let originalWindow
 function safeGetRum (window) {
   try {
     return window.DD_RUM
-  } catch (e) {
+  } catch {
     return null
   }
 }
@@ -30,12 +28,13 @@ function isNewTest (test) {
 }
 
 function getTestProperties (testName) {
-  // We neeed to do it in this way because of compatibility with older versions as '?' is not supported in older versions of Cypress
-  const properties = testManagementTests[testName] && testManagementTests[testName].properties || {};
+  // We neeed to do it in this way because of compatibility with older versions as '?' is not supported in older
+  // versions of Cypress
+  const properties = testManagementTests[testName] && testManagementTests[testName].properties || {}
 
-  const { attempt_to_fix: isAttemptToFix, disabled: isDisabled, quarantined: isQuarantined } = properties;
+  const { attempt_to_fix: isAttemptToFix, disabled: isDisabled, quarantined: isQuarantined } = properties
 
-  return { isAttemptToFix, isDisabled, isQuarantined };
+  return { isAttemptToFix, isDisabled, isQuarantined }
 }
 
 function retryTest (test, suiteTests, numRetries, tags) {
@@ -63,11 +62,9 @@ Cypress.mocha.getRunner().runTests = function (suite, fn) {
 
     const { isAttemptToFix } = getTestProperties(testName)
 
-    if (isTestManagementEnabled) {
-      if (isAttemptToFix && !test.isPending()) {
-        test._ddIsAttemptToFix = true
-        retryTest(test, suite.tests, testManagementAttemptToFixRetries, ['_ddIsAttemptToFix'])
-      }
+    if (isTestManagementEnabled && isAttemptToFix && !test.isPending()) {
+      test._ddIsAttemptToFix = true
+      retryTest(test, suite.tests, testManagementAttemptToFixRetries, ['_ddIsAttemptToFix'])
     }
     if (isImpactedTestsEnabled && isModifiedTest) {
       test._ddIsModified = true
@@ -80,15 +77,13 @@ Cypress.mocha.getRunner().runTests = function (suite, fn) {
         )
       }
     }
-    if (isKnownTestsEnabled) {
-      if (!test._ddIsNew && !test.isPending() && isNewTest(test)) {
-        test._ddIsNew = true
-        if (isImpactedTestsEnabled && isModifiedTest) {
-          test._ddIsModified = true
-        }
-        if (isEarlyFlakeDetectionEnabled && !isAttemptToFix && !isModifiedTest) {
-          retryTest(test, suite.tests, earlyFlakeDetectionNumRetries, ['_ddIsNew', '_ddIsEfdRetry'])
-        }
+    if (isKnownTestsEnabled && !test._ddIsNew && !test.isPending() && isNewTest(test)) {
+      test._ddIsNew = true
+      if (isImpactedTestsEnabled && isModifiedTest) {
+        test._ddIsModified = true
+      }
+      if (isEarlyFlakeDetectionEnabled && !isAttemptToFix && !isModifiedTest) {
+        retryTest(test, suite.tests, earlyFlakeDetectionNumRetries, ['_ddIsNew', '_ddIsEfdRetry'])
       }
     }
   })
@@ -135,11 +130,10 @@ after(() => {
     if (safeGetRum(originalWindow)) {
       originalWindow.dispatchEvent(new Event('beforeunload'))
     }
-  } catch (e) {
+  } catch {
     // ignore error. It's usually a multi origin issue.
   }
 })
-
 
 afterEach(function () {
   const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
@@ -156,7 +150,7 @@ afterEach(function () {
   }
   try {
     testInfo.testSourceLine = Cypress.mocha.getRunner().currentRunnable.invocationDetails.line
-  } catch (e) {}
+  } catch {}
 
   if (safeGetRum(originalWindow)) {
     testInfo.isRUMActive = true
@@ -164,7 +158,7 @@ afterEach(function () {
   let coverage
   try {
     coverage = originalWindow.__coverage__
-  } catch (e) {
+  } catch {
     // ignore error and continue
   }
   cy.task('dd:afterEach', { test: testInfo, coverage })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1986,6 +1986,13 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
+eslint-plugin-cypress@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.0.tgz#348c63f2afb2b336ab2063bf27347c1219be64b6"
+  integrity sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==
+  dependencies:
+    globals "^16.2.0"
+
 eslint-plugin-es-x@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz#a207aa08da37a7923f2a9599e6d3eb73f3f92b74"
@@ -2580,6 +2587,11 @@ globals@^15.11.0, globals@^15.15.0:
   version "15.15.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-15.15.0.tgz#7c4761299d41c32b075715a4ce1ede7897ff72a8"
   integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
+
+globals@^16.2.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-16.3.0.tgz#66118e765ddaf9e2d880f7e17658543f93f1f667"
+  integrity sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==
 
 globalthis@^1.0.4:
   version "1.0.4"
@@ -4643,7 +4655,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4707,7 +4728,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5213,7 +5241,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.2.tgz#4c045a8b437ae1bc70c646af11929a8b4d238656"
   integrity sha512-Xz4Nm9c+LiBHhDR5bDLnNzmj6+5F+cyEAWPMkbs2awq/dYazR/efelZzUAjB/y3kNHL+uzkHvxVVpaOfGCPV7A==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -5226,6 +5254,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What does this PR do?

Enables linting of `packages/datadog-plugin-cypress/src/support.js` which was previously skipped by ESLint. This was most likely done because it accesses a lot of globals from Cypress, which ESLint doesn't know anything about by default (though the narrower `/* eslint-disable no-undef */` should have been used instead if that was the case).

This PR adds the plugin `eslint-plugin-cypress` to allow ESLint to know about these globals and enables its recommended rules for that specific file.

### Motivation

We should avoid disabling ESLint completely in a file as it allows bug and unwanted formatting to sneak in.

