### PR TITLE
ESLint: Scope certain files to other Node.js versions than v18.0.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,8 +51,7 @@ export default [
       'integration-tests/esbuild/aws-sdk-out.js', // Generated
       'packages/datadog-plugin-graphql/src/tools/index.js', // Inlined from apollo-graphql
       'packages/datadog-plugin-graphql/src/tools/signature.js', // Inlined from apollo-graphql
-      'packages/datadog-plugin-graphql/src/tools/transforms.js', // Inlined from apollo-graphql
-      'packages/dd-trace/src/guardrails/**/*' // Guardrails contain very old JS
+      'packages/datadog-plugin-graphql/src/tools/transforms.js' // Inlined from apollo-graphql
     ]
   },
   { name: '@eslint/js/recommended', ...eslintPluginJs.configs.recommended },
@@ -301,21 +300,17 @@ export default [
   },
   {
     name: 'dd-trace/defaults',
-
     plugins: {
       '@stylistic': eslintPluginStylistic,
       import: eslintPluginImport,
       n: eslintPluginN
     },
-
     languageOptions: {
       globals: {
         ...globals.node
       },
-
       ecmaVersion: 2022
     },
-
     settings: {
       node: {
         // Used by `eslint-plugin-n` to determine the minimum version of Node.js to support.
@@ -325,7 +320,6 @@ export default [
         version: '>=18.0.0'
       }
     },
-
     rules: {
       '@stylistic/max-len': ['error', { code: 120, tabWidth: 2, ignoreUrls: true, ignoreRegExpLiterals: true }],
       '@stylistic/object-curly-newline': ['error', { multiline: true, consistent: true }],
@@ -436,6 +430,81 @@ export default [
     }
   },
   {
+    name: 'dd-trace/defaults/v0.8-oldest',
+    plugins: {
+      n: eslintPluginN
+    },
+    files: [
+      'init.js',
+      'packages/dd-trace/src/guardrails/**/*',
+      'version.js'
+    ],
+    settings: {
+      node: {
+        version: '>=0.8.0'
+      }
+    },
+    rules: {
+      'eslint-rules/eslint-process-env': 'off', // Would require us to load a module outside the guardrails directory
+      'n/no-unsupported-features/es-builtins': ['error', {
+        // The following are false positives that are supported in Node.js 0.8.0
+        ignores: [
+          'JSON',
+          'JSON.stringify',
+          'parseInt',
+          'String'
+        ]
+      }],
+      'n/no-unsupported-features/es-syntax': ['error', {
+        // The following are false positives that are supported in Node.js 0.8.0
+        ignores: [
+          'array-prototype-indexof',
+          'json'
+        ]
+      }],
+      'no-var': 'off', // Only supported in Node.js 6+
+      'object-shorthand': 'off', // Only supported in Node.js 4+
+      'unicorn/prefer-includes': 'off', // Only supported in Node.js 6+
+      'unicorn/prefer-number-properties': 'off', // Only supported in Node.js 0.12+
+      'unicorn/prefer-optional-catch-binding': 'off', // Only supported in Node.js 10+
+      'unicorn/prefer-set-has': 'off', // Only supported in Node.js 0.12+
+      'unicorn/prefer-string-replace-all': 'off' // Only supported in Node.js 15+
+    }
+  },
+  {
+    name: 'dd-trace/defaults/v16-oldest',
+    plugins: {
+      n: eslintPluginN
+    },
+    files: [
+      'packages/datadog-plugin-cypress/src/support.js'
+    ],
+    settings: {
+      node: {
+        version: '>=16.0.0'
+      }
+    }
+  },
+  {
+    name: 'dd-trace/defaults/v18-latest',
+    plugins: {
+      n: eslintPluginN
+    },
+    files: [
+      'benchmark/**/*',
+      'scripts/**/*',
+      ...TEST_FILES
+    ],
+    settings: {
+      node: {
+        version: '>=18' // These files don't have to support the oldest v18 release
+      }
+    },
+    rules: {
+      'n/no-unsupported-features/node-builtins': ['error', { allowExperimental: true }]
+    }
+  },
+  {
     ...eslintPluginCypress.configs.recommended,
     files: [
       'packages/datadog-plugin-cypress/src/support.js'
@@ -461,9 +530,7 @@ export default [
       'scripts/**/*'
     ],
     rules: {
-      'n/no-unsupported-features/node-builtins': ['error', {
-        allowExperimental: true
-      }]
+      'n/no-unsupported-features/node-builtins': ['error', { allowExperimental: true }]
     }
   },
   {
@@ -493,9 +560,7 @@ export default [
       'mocha/no-top-level-hooks': 'off',
       'n/handle-callback-err': 'off',
       'n/no-missing-require': 'off',
-      'n/no-unsupported-features/node-builtins': ['error', {
-        allowExperimental: true
-      }],
+      'n/no-unsupported-features/node-builtins': ['error', { allowExperimental: true }],
       'require-await': 'off'
     }
   },

--- a/init.js
+++ b/init.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint-disable no-var */
-
 // TODO: It shouldn't be necessary to disable n/no-unpublished-require - Research
 // eslint-disable-next-line n/no-unpublished-require
 var guard = require('./packages/dd-trace/src/guardrails')

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -28,8 +28,8 @@ function isNewTest (test) {
 }
 
 function getTestProperties (testName) {
-  // We neeed to do it in this way because of compatibility with older versions as '?' is not supported in older
-  // versions of Cypress
+  // TODO: Use optional chaining when we drop support for older Cypress versions, which will happen when dd-trace@5 is
+  // EoL. Until then, this files needs to support Node.js 16.
   const properties = testManagementTests[testName] && testManagementTests[testName].properties || {}
 
   const { attempt_to_fix: isAttemptToFix, disabled: isDisabled, quarantined: isQuarantined } = properties

--- a/packages/dd-trace/src/guardrails/index.js
+++ b/packages/dd-trace/src/guardrails/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint-disable no-var */
-
 var path = require('path')
 var Module = require('module')
 var isTrue = require('./util').isTrue
@@ -54,8 +52,7 @@ function guard (fn) {
   }
 
   if (!clobberBailout && (!initBailout || forced)) {
-    // Ensure the instrumentation source is set for the current process and potential 
-    // child processes.
+    // Ensure the instrumentation source is set for the current process and potential child processes.
     var result = fn()
     telemetry('complete', ['injection_forced:' + (forced && initBailout ? 'true' : 'false')])
     log.info('Application instrumentation bootstrapping complete')

--- a/packages/dd-trace/src/guardrails/log.js
+++ b/packages/dd-trace/src/guardrails/log.js
@@ -1,6 +1,5 @@
 'use strict'
 
-/* eslint-disable no-var */
 /* eslint-disable no-console */
 
 var isTrue = require('./util').isTrue
@@ -23,7 +22,8 @@ var logLevel = isTrue(DD_TRACE_DEBUG)
   : logLevels.off
 
 var log = {
-  debug: logLevel <= 20 ? console.debug.bind(console) : function () {},
+  /* eslint n/no-unsupported-features/node-builtins: ['error', { ignores: ['console.debug'] }] */
+  debug: logLevel <= 20 ? (console.debug || console.log).bind(console) : function () {},
   info: logLevel <= 30 ? console.info.bind(console) : function () {},
   warn: logLevel <= 40 ? console.warn.bind(console) : function () {},
   error: logLevel <= 50 ? console.error.bind(console) : function () {}

--- a/packages/dd-trace/src/guardrails/telemetry.js
+++ b/packages/dd-trace/src/guardrails/telemetry.js
@@ -1,8 +1,5 @@
 'use strict'
 
-/* eslint-disable no-var */
-/* eslint-disable object-shorthand */
-
 var fs = require('fs')
 var spawn = require('child_process').spawn
 var tracerVersion = require('../../../../package.json').version
@@ -11,12 +8,12 @@ var log = require('./log')
 module.exports = sendTelemetry
 
 if (!process.env.DD_INJECTION_ENABLED) {
-  module.exports = function () {}
+  module.exports = function noop () {}
 }
 
 var telemetryForwarderPath = process.env.DD_TELEMETRY_FORWARDER_PATH
 if (typeof telemetryForwarderPath !== 'string' || !fs.existsSync(telemetryForwarderPath)) {
-  module.exports = function () {}
+  module.exports = function noop () {}
 }
 
 var metadata = {
@@ -32,12 +29,12 @@ var seen = []
 function hasSeen (point) {
   if (point.name === 'abort') {
     // This one can only be sent once, regardless of tags
-    return seen.includes('abort')
+    return seen.indexOf('abort') !== -1
   }
   if (point.name === 'abort.integration') {
     // For now, this is the only other one we want to dedupe
     var compiledPoint = point.name + point.tags.join('')
-    return seen.includes(compiledPoint)
+    return seen.indexOf(compiledPoint) !== -1
   }
   return false
 }
@@ -48,7 +45,7 @@ function sendTelemetry (name, tags) {
     points = [{ name: name, tags: tags || [] }]
   }
   if (['1', 'true', 'True'].indexOf(process.env.DD_INJECT_FORCE) !== -1) {
-    points = points.filter(function (p) { return ['error', 'complete'].includes(p.name) })
+    points = points.filter(function (p) { return ['error', 'complete'].indexOf(p.name) !== -1 })
   }
   points = points.filter(function (p) { return !hasSeen(p) })
   for (var i = 0; i < points.length; i++) {

--- a/packages/dd-trace/src/guardrails/util.js
+++ b/packages/dd-trace/src/guardrails/util.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint-disable object-shorthand */
-
 function isTrue (str) {
   str = String(str).toLowerCase()
   return str === 'true' || str === '1'

--- a/version.js
+++ b/version.js
@@ -1,8 +1,5 @@
 'use strict'
 
-/* eslint-disable no-var */
-/* eslint-disable unicorn/prefer-number-properties */
-
 var version = require('./package.json').version
 var ddMatches = version.match(/^(\d+)\.(\d+)\.(\d+)/)
 var nodeMatches = process.versions.node.match(/^(\d+)\.(\d+)\.(\d+)/)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


