### PR TITLE
telemetry: fix ssi instrumentation source

### DIFF
--- a/init.js
+++ b/init.js
@@ -5,8 +5,5 @@
 var guard = require('./packages/dd-trace/src/guardrails')
 
 module.exports = guard(function () {
-  var INSTRUMENTED_BY_SSI = require('./packages/dd-trace/src/constants').INSTRUMENTED_BY_SSI
-  var obj = {}
-  obj[INSTRUMENTED_BY_SSI] = 'ssi'
-  return require('.').init(obj)
+  return require('.').init()
 })

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -18,7 +18,7 @@ const hookFile = 'dd-trace/loader-hook.mjs'
 // This is set by the setShouldKill function
 let shouldKill
 
-async function runAndCheckOutput (filename, cwd, expectedOut, expectedSource) {
+async function runAndCheckOutput (filename, cwd, expectedOut) {
   const proc = spawn(process.execPath, [filename], { cwd, stdio: 'pipe' })
   const pid = proc.pid
   let out = await new Promise((resolve, reject) => {
@@ -42,12 +42,7 @@ async function runAndCheckOutput (filename, cwd, expectedOut, expectedSource) {
       // Debug adds this, which we don't care about in these tests
       out = out.replace('Flushing 0 metrics via HTTP\n', '')
     }
-    assert.match(out, new RegExp(expectedOut), `output "${out} does not contain expected output "${expectedOut}"`)
-  }
-
-  if (expectedSource) {
-    assert.match(out, new RegExp(`instrumentation source: ${expectedSource}`),
-    `Expected the process to output "${expectedSource}", but logs only contain: "${out}"`)
+    assert.strictEqual(out, expectedOut)
   }
   return pid
 }
@@ -56,10 +51,10 @@ async function runAndCheckOutput (filename, cwd, expectedOut, expectedSource) {
 let sandbox
 
 // This _must_ be used with the useSandbox function
-async function runAndCheckWithTelemetry (filename, expectedOut, expectedTelemetryPoints, expectedSource) {
+async function runAndCheckWithTelemetry (filename, expectedOut, ...expectedTelemetryPoints) {
   const cwd = sandbox.folder
   const cleanup = telemetryForwarder(expectedTelemetryPoints)
-  const pid = await runAndCheckOutput(filename, cwd, expectedOut, expectedSource)
+  const pid = await runAndCheckOutput(filename, cwd, expectedOut)
   const msgs = await cleanup()
   if (expectedTelemetryPoints.length === 0) {
     // assert no telemetry sent
@@ -185,8 +180,7 @@ async function createSandbox (dependencies = [], isGitRepo = false,
   const allDependencies = [`file:${out}`].concat(dependencies)
 
   fs.mkdirSync(folder)
-  const preferOfflineFlag = process.env.OFFLINE === '1' || process.env.OFFLINE === 'true' ? ' --prefer-offline' : ''
-  const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines${preferOfflineFlag}`
+  const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines`
   const addOptions = { cwd: folder, env: restOfEnv }
   await exec(`yarn pack --filename ${out}`, { env: restOfEnv }) // TODO: cache this
 
@@ -391,31 +385,6 @@ function setShouldKill (value) {
 }
 
 const assertObjectContains = assert.partialDeepStrictEqual || function assertObjectContains (actual, expected) {
-  if (Array.isArray(expected)) {
-    assert.ok(Array.isArray(actual), `Expected array but got ${typeof actual}`)
-    let startIndex = 0
-    for (const expectedItem of expected) {
-      let found = false
-      for (let i = startIndex; i < actual.length; i++) {
-        const actualItem = actual[i]
-        try {
-          if (expectedItem !== null && typeof expectedItem === 'object') {
-            assertObjectContains(actualItem, expectedItem)
-          } else {
-            assert.strictEqual(actualItem, expectedItem)
-          }
-          startIndex = i + 1
-          found = true
-          break
-        } catch {
-          continue
-        }
-      }
-      assert.ok(found, `Expected array to contain ${JSON.stringify(expectedItem)}`)
-    }
-    return
-  }
-
   for (const [key, val] of Object.entries(expected)) {
     if (val !== null && typeof val === 'object') {
       assert.ok(Object.hasOwn(actual, key))

--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -36,18 +36,18 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
 
       if (currentVersionIsSupported) {
         context('without DD_INJECTION_ENABLED', () => {
-          it('should initialize the tracer', () => doTest('init/trace.js', 'true\n', [], 'ssi'))
-          it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n', [], 'ssi'))
+          it('should initialize the tracer', () => doTest('init/trace.js', 'true\n'))
+          it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n'))
           it(`should ${esmWorks ? '' : 'not '}initialize ESM instrumentation`, () =>
-            doTest('init/instrument.mjs', `${esmWorks}\n`, []))
+            doTest('init/instrument.mjs', `${esmWorks}\n`))
         })
       }
       context('with DD_INJECTION_ENABLED', () => {
         useEnv({ DD_INJECTION_ENABLED })
 
-        it('should not initialize the tracer', () => doTest('init/trace.js', 'false\n', []))
-        it('should not initialize instrumentation', () => doTest('init/instrument.js', 'false\n', []))
-        it('should not initialize ESM instrumentation', () => doTest('init/instrument.mjs', 'false\n', []))
+        it('should not initialize the tracer', () => doTest('init/trace.js', 'false\n'))
+        it('should not initialize instrumentation', () => doTest('init/instrument.js', 'false\n'))
+        it('should not initialize ESM instrumentation', () => doTest('init/instrument.mjs', 'false\n'))
       })
     })
     context('when dd-trace in the app dir', () => {
@@ -55,18 +55,18 @@ function testInjectionScenarios (arg, filename, esmWorks = false) {
       useEnv({ NODE_OPTIONS })
 
       context('without DD_INJECTION_ENABLED', () => {
-        it('should initialize the tracer', () => doTest('init/trace.js', 'true\n', [], 'ssi'))
-        it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n', [], 'ssi'))
+        it('should initialize the tracer', () => doTest('init/trace.js', 'true\n'))
+        it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n'))
         it(`should ${esmWorks ? '' : 'not '}initialize ESM instrumentation`, () =>
-          doTest('init/instrument.mjs', `${esmWorks}\n`, []))
+          doTest('init/instrument.mjs', `${esmWorks}\n`))
       })
       context('with DD_INJECTION_ENABLED', () => {
-        useEnv({ DD_INJECTION_ENABLED, DD_TRACE_DEBUG })
+        useEnv({ DD_INJECTION_ENABLED })
 
-        it('should initialize the tracer', () => doTest('init/trace.js', 'true\n', telemetryGood, 'ssi'))
-        it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n', telemetryGood, 'ssi'))
+        it('should initialize the tracer', () => doTest('init/trace.js', 'true\n', ...telemetryGood))
+        it('should initialize instrumentation', () => doTest('init/instrument.js', 'true\n', ...telemetryGood))
         it(`should ${esmWorks ? '' : 'not '}initialize ESM instrumentation`, () =>
-          doTest('init/instrument.mjs', `${esmWorks}\n`, telemetryGood, 'ssi'))
+          doTest('init/instrument.mjs', `${esmWorks}\n`, ...telemetryGood))
       })
     })
   })
@@ -90,13 +90,13 @@ function testRuntimeVersionChecks (arg, filename) {
         useEnv({ NODE_OPTIONS })
 
         it('should not initialize the tracer', () =>
-          doTest('false\n', []))
+          doTest('false\n'))
         context('with DD_INJECTION_ENABLED', () => {
           useEnv({ DD_INJECTION_ENABLED })
 
           context('without debug', () => {
-            it('should not initialize the tracer', () => doTest('false\n', telemetryAbort))
-            it('should initialize the tracer, if DD_INJECT_FORCE', () => doTestForced('true\n', telemetryForced))
+            it('should not initialize the tracer', () => doTest('false\n', ...telemetryAbort))
+            it('should initialize the tracer, if DD_INJECT_FORCE', () => doTestForced('true\n', ...telemetryForced))
           })
           context('with debug', () => {
             useEnv({ DD_TRACE_DEBUG })
@@ -106,7 +106,7 @@ function testRuntimeVersionChecks (arg, filename) {
 Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs \
 >=18.
 false
-`, telemetryAbort))
+`, ...telemetryAbort))
             it('should initialize the tracer, if DD_INJECT_FORCE', () =>
               doTestForced(`Aborting application instrumentation due to incompatible_runtime.
 Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs \
@@ -114,7 +114,7 @@ Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: 
 DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.
 Application instrumentation bootstrapping complete
 true
-`, telemetryForced))
+`, ...telemetryForced))
           })
         })
       })
@@ -122,22 +122,22 @@ true
       context('when node version is more than engines field', () => {
         useEnv({ NODE_OPTIONS })
 
-        it('should initialize the tracer, if no DD_INJECTION_ENABLED', () => doTest('true\n', [], 'ssi'))
+        it('should initialize the tracer, if no DD_INJECTION_ENABLED', () => doTest('true\n'))
         context('with DD_INJECTION_ENABLED', () => {
           useEnv({ DD_INJECTION_ENABLED })
 
           context('without debug', () => {
-            it('should initialize the tracer', () => doTest('true\n', telemetryGood, 'ssi'))
+            it('should initialize the tracer', () => doTest('true\n', ...telemetryGood))
             it('should initialize the tracer, if DD_INJECT_FORCE', () =>
-              doTestForced('true\n', telemetryGood, 'ssi'))
+              doTestForced('true\n', ...telemetryGood))
           })
           context('with debug', () => {
             useEnv({ DD_TRACE_DEBUG })
 
             it('should initialize the tracer', () =>
-              doTest('Application instrumentation bootstrapping complete\ntrue\n', telemetryGood, 'ssi'))
+              doTest('Application instrumentation bootstrapping complete\ntrue\n', ...telemetryGood))
             it('should initialize the tracer, if DD_INJECT_FORCE', () =>
-              doTestForced('Application instrumentation bootstrapping complete\ntrue\n', telemetryGood, 'ssi'))
+              doTestForced('Application instrumentation bootstrapping complete\ntrue\n', ...telemetryGood))
           })
         })
       })

--- a/integration-tests/init/instrument.js
+++ b/integration-tests/init/instrument.js
@@ -15,8 +15,6 @@ const server = http.createServer((req, res) => {
       server.close()
       // eslint-disable-next-line no-console
       console.log(gotEvent)
-      // eslint-disable-next-line no-console
-      console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
       process.exit()
     })
   })

--- a/integration-tests/init/instrument.mjs
+++ b/integration-tests/init/instrument.mjs
@@ -15,8 +15,6 @@ const server = http.createServer((req, res) => {
       server.close()
       // eslint-disable-next-line no-console
       console.log(gotEvent)
-      // eslint-disable-next-line no-console
-      console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
       process.exit()
     })
   })

--- a/integration-tests/init/trace.js
+++ b/integration-tests/init/trace.js
@@ -1,5 +1,3 @@
 // eslint-disable-next-line no-console
 console.log(!!global._ddtrace)
-// eslint-disable-next-line no-console
-console.log('instrumentation source:', global._ddtrace._tracer._config.instrumentationSource)
 process.exit()

--- a/integration-tests/package-guardrails.spec.js
+++ b/integration-tests/package-guardrails.spec.js
@@ -29,13 +29,12 @@ describe('package guardrails', () => {
       useEnv({ DD_INJECTION_ENABLED })
       it('should not instrument the package, and send telemetry', () =>
         runTest('false\n',
-          ['complete', 'injection_forced:false',
-            'abort.integration', 'integration:bluebird,integration_version:1.0.0'
-          ]
+          'complete', 'injection_forced:false',
+          'abort.integration', 'integration:bluebird,integration_version:1.0.0'
         ))
     })
     context('with logging disabled', () => {
-      it('should not instrument the package', () => runTest('false\n', []))
+      it('should not instrument the package', () => runTest('false\n'))
     })
     context('with logging enabled', () => {
       useEnv({ DD_TRACE_DEBUG })
@@ -43,31 +42,31 @@ describe('package guardrails', () => {
         runTest(`Application instrumentation bootstrapping complete
 Found incompatible integration version: bluebird@1.0.0
 false
-`, []))
+`))
     })
   })
 
   context('when package is in range', () => {
     context('when bluebird is 2.9.0', () => {
       useSandbox(['bluebird@2.9.0'])
-      it('should instrument the package', () => runTest('true\n', [], 'ssi'))
+      it('should instrument the package', () => runTest('true\n'))
     })
     context('when bluebird is 3.7.2', () => {
       useSandbox(['bluebird@3.7.2'])
-      it('should instrument the package', () => runTest('true\n', [], 'ssi'))
+      it('should instrument the package', () => runTest('true\n'))
     })
   })
 
   context('when package is in range (fastify)', () => {
     context('when fastify is latest', () => {
       useSandbox(['fastify'])
-      it('should instrument the package', () => runTest('true\n', [], 'ssi'))
+      it('should instrument the package', () => runTest('true\n'))
     })
     context('when fastify is latest and logging enabled', () => {
       useSandbox(['fastify'])
       useEnv({ DD_TRACE_DEBUG })
       it('should instrument the package', () =>
-        runTest('Application instrumentation bootstrapping complete\ntrue\n', [], 'ssi'))
+        runTest('Application instrumentation bootstrapping complete\ntrue\n'))
     })
   })
 
@@ -89,13 +88,13 @@ addHook({ name: 'bluebird', versions: ['*'] }, Promise => {
       useEnv({ DD_INJECTION_ENABLED })
       it('should not instrument the package, and send telemetry', () =>
         runTest('false\n',
-          ['complete', 'injection_forced:false',
-            'error', 'error_type:ReferenceError,integration:bluebird,integration_version:3.7.2']
+          'complete', 'injection_forced:false',
+          'error', 'error_type:ReferenceError,integration:bluebird,integration_version:3.7.2'
         ))
     })
 
     context('with logging disabled', () => {
-      it('should not instrument the package', () => runTest('false\n', []))
+      it('should not instrument the package', () => runTest('false\n'))
     })
 
     context('with logging enabled', () => {
@@ -108,7 +107,7 @@ Error during ddtrace instrumentation of application, aborting.
 ReferenceError: this is a test error
     at `))
             assert.ok(log.includes('\nfalse\n'))
-          }, []))
+          }))
     })
   })
 })

--- a/integration-tests/telemetry.spec.js
+++ b/integration-tests/telemetry.spec.js
@@ -66,6 +66,59 @@ describe('telemetry', () => {
       await agent.assertTelemetryReceived(msg => {
         const { configuration } = msg.payload.payload
         assertObjectContains(configuration, [
+          { name: 'ssi_injection_enabled', value: '', origin: 'default' },
+          { name: 'instrumentation_source', value: 'manual', origin: 'default' },
+          { name: 'ssi_forced_injection_enabled', value: null, origin: 'default' },
+          { name: 'DD_LOG_INJECTION', value: 'structured', origin: 'default' },
+          { name: 'DD_LOG_INJECTION', value: true, origin: 'env_var' },
+          { name: 'DD_LOG_INJECTION', value: false, origin: 'code' }
+        ])
+      }, 'app-started', 5_000, 1)
+    })
+  })
+
+  describe('ssi', () => {
+    let sandbox
+    let cwd
+    let startupTestFile
+    let agent
+    let proc
+
+    before(async () => {
+      sandbox = await createSandbox()
+      cwd = sandbox.folder
+      startupTestFile = path.join(cwd, 'startup/index.js')
+    })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+      proc = await spawnProc(startupTestFile, {
+        cwd,
+        env: {
+          AGENT_PORT: agent.port,
+          DD_LOGS_INJECTION: true,
+          DD_INSTRUMENTATION_INSTALL_TYPE: 'k8s_single_step'
+        }
+      })
+    })
+
+    afterEach(async () => {
+      proc.kill()
+      await agent.stop()
+    })
+
+    it('Assert configuration chaining data is sent with instrumentation install type env', async () => {
+      await agent.assertTelemetryReceived(msg => {
+        const { configuration } = msg.payload.payload
+        assertObjectContains(configuration, [
+          { name: 'ssi_injection_enabled', value: '', origin: 'default' },
+          { name: 'instrumentation_source', value: 'manual', origin: 'default' },
+          { name: 'instrumentation_source', value: 'ssi', origin: 'env_var' },
+          { name: 'ssi_forced_injection_enabled', value: null, origin: 'default' },
           { name: 'DD_LOG_INJECTION', value: 'structured', origin: 'default' },
           { name: 'DD_LOG_INJECTION', value: true, origin: 'env_var' },
           { name: 'DD_LOG_INJECTION', value: false, origin: 'code' }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -16,7 +16,7 @@ const { updateConfig } = require('./telemetry')
 const telemetryMetrics = require('./telemetry/metrics')
 const { isInServerlessEnvironment, getIsGCPFunction, getIsAzureFunction } = require('./serverless')
 const {
-  ORIGIN_KEY, GRPC_CLIENT_ERROR_STATUSES, GRPC_SERVER_ERROR_STATUSES, INSTRUMENTED_BY_SSI
+  ORIGIN_KEY, GRPC_CLIENT_ERROR_STATUSES, GRPC_SERVER_ERROR_STATUSES,
 } = require('./constants')
 const { appendRules } = require('./payload-tagging/config')
 const { getEnvironmentVariable, getEnvironmentVariables } = require('./config-helper')
@@ -1004,6 +1004,9 @@ class Config {
     // 0: disabled, 1: logging, 2: garbage collection + logging
     env.spanLeakDebug = maybeInt(DD_TRACE_SPAN_LEAK_DEBUG)
     this._setBoolean(env, 'spanRemoveIntegrationFromService', DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED)
+    if (getEnvironmentVariable('DD_INSTRUMENTATION_INSTALL_TYPE')?.endsWith('single_step')) {
+      this._setString(env, 'instrumentationSource', 'ssi')
+    }
     this._setBoolean(env, 'startupLogs', DD_TRACE_STARTUP_LOGS)
     this._setTags(env, 'tags', tags)
     env.tagsHeaderMaxLength = DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH
@@ -1150,9 +1153,6 @@ class Config {
     opts['iast.securityControlsConfiguration'] = options.iast?.securityControlsConfiguration
     this._setBoolean(opts, 'iast.stackTrace.enabled', options.iast?.stackTrace?.enabled)
     this._setString(opts, 'iast.telemetryVerbosity', options.iast && options.iast.telemetryVerbosity)
-    if (options[INSTRUMENTED_BY_SSI]) {
-      this._setString(opts, 'instrumentationSource', options[INSTRUMENTED_BY_SSI])
-    }
     this._setBoolean(opts, 'isCiVisibility', options.isCiVisibility)
     this._setBoolean(opts, 'legacyBaggageEnabled', options.legacyBaggageEnabled)
     this._setBoolean(opts, 'llmobs.agentlessEnabled', options.llmobs?.agentlessEnabled)

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -54,5 +54,4 @@ module.exports = {
     UPSTREAM: 'u',
     DOWNSTREAM: 'd'
   }),
-  INSTRUMENTED_BY_SSI: Symbol('_dd.instrumented.by.ssi')
 }


### PR DESCRIPTION
Init may be called by users as well in case they don't want to programmatically configure the SDK. In that case, SSI would have been reported, while that is obviously incorrect.
The fix now checks for the environment variable used by the agent.