### PR TITLE
instrumentation: fix service name for oracledb

### DIFF
--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -11,7 +11,7 @@ class OracledbPlugin extends DatabasePlugin {
   static get peerServicePrecursors () { return ['db.instance', 'db.hostname'] }
 
   start ({ query, connAttrs, port, hostname, dbInstance }) {
-    let service = this.serviceName({ pluginConfig: this.config, params: connAttrs })
+    const service = this.serviceName({ pluginConfig: this.config, params: connAttrs })
 
     if (hostname === undefined) {
       // Lazy load for performance. This is not needed in v6 and up
@@ -20,11 +20,6 @@ class OracledbPlugin extends DatabasePlugin {
       hostname = dbInfo.hostname
       port ??= dbInfo.port
       dbInstance ??= dbInfo.dbInstance
-    }
-
-    if (service === undefined && hostname) {
-      // Fallback for users not providing the service properly in a serviceName method
-      service = `${hostname}:${port}/${dbInstance}`
     }
 
     this.startSpan(this.operationName(), {

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -293,11 +293,11 @@ describe('Plugin', () => {
             {
               v0: {
                 opName: 'oracle.query',
-                serviceName: config.connectString
+                serviceName: 'test-oracle'
               },
               v1: {
                 opName: 'oracle.query',
-                serviceName: config.connectString
+                serviceName: 'test'
               }
             }
           )
@@ -306,7 +306,7 @@ describe('Plugin', () => {
             await Promise.all([
               agent.assertFirstTraceSpan({
                 name: expectedSchema.outbound.opName,
-                service: config.connectString
+                service: 'test-oracle'
               }),
               connection.execute(dbQuery)
             ])

--- a/packages/dd-trace/src/service-naming/schemas/v1/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v1/storage.js
@@ -14,7 +14,8 @@ const mySQLNaming = {
 
 function withFunction ({ tracerService, pluginConfig, params }) {
   if (typeof pluginConfig.service === 'function') {
-    return pluginConfig.service(params)
+    const result = pluginConfig.service(params)
+    return typeof result === 'string' && result.length > 0 ? result : tracerService
   }
   return configWithFallback({ tracerService, pluginConfig })
 }

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -244,7 +244,7 @@ function assertIntegrationName (args) {
             if (span && span.meta && span.meta.component && span.meta.component !== span.meta['_dd.integration']) {
               expect(span.meta['_dd.integration']).to.equal(
                 currentIntegrationName,
-                 `Expected span to have "_dd.integration" tag "${currentIntegrationName}" 
+                 `Expected span to have "_dd.integration" tag "${currentIntegrationName}"
                  but found "${span.meta['_dd.integration']}" for span ID ${span.span_id}`
               )
             }

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -59,25 +59,23 @@ function withNamingSchema (
         hooks(versionName, false)
 
         const { opName, serviceName } = expected[versionName]
+        const expectedOpName = typeof opName === 'function'
+          ? opName()
+          : opName
+        const expectedServiceName = typeof serviceName === 'function'
+          ? serviceName()
+          : serviceName
 
         it('should conform to the naming schema', function () {
+          console.log(expectedServiceName, expectedOpName)
           this.timeout(10000)
           return new Promise((resolve, reject) => {
-            agent
-              .assertSomeTraces(traces => {
-                const span = selectSpan(traces)
-                const expectedOpName = typeof opName === 'function'
-                  ? opName()
-                  : opName
-                const expectedServiceName = typeof serviceName === 'function'
-                  ? serviceName()
-                  : serviceName
-
-                expect(span).to.have.property('name', expectedOpName)
-                expect(span).to.have.property('service', expectedServiceName)
-              })
-              .then(resolve)
-              .catch(reject)
+            agent.assertFirstTraceSpan({
+              name: expectedOpName,
+              service: expectedServiceName,
+            })
+            .then(resolve)
+            .catch(reject)
             spanProducerFn(reject)
           })
         })


### PR DESCRIPTION
The service name should be handled by the schema, even if undefined is passed through. Instead of falling back to the connection, use the fallback as defined in schema v1. The service method is now only accepting truthy strings as return value and will otherwise fallback.