### PR TITLE
test: fix test name

### DIFF
--- a/packages/dd-trace/test/opentelemetry/span_context.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span_context.spec.js
@@ -76,7 +76,7 @@ describe('OTel Span Context', () => {
     }
   })
 
-  it('should get trace id as hex', () => {
+  it('should get trace state as string', () => {
     const tracestate = new TraceState()
     tracestate.forVendor('dd', vendor => {
       vendor.set('foo', 'bar')


### PR DESCRIPTION
The name of this test was copy-pasted from a previous test without renaming it.