### PR TITLE
add sleep between yarn install retries

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -18,7 +18,8 @@ runs:
       shell: bash
       if: inputs.cache == 'true' && steps.yarn-cache.outputs.cache-hit == 'true'
       # Retry in case of server error from registry.
-    - run: yarn install --frozen-lockfile --ignore-engines || yarn install --frozen-lockfile --ignore-engines
+      # Wait 60 seconds to give the registry server time to heal.
+    - run: yarn install --frozen-lockfile --ignore-engines || sleep 60 && yarn install --frozen-lockfile --ignore-engines
       shell: bash
     - run: tar -cf node_modules.tar node_modules
       shell: bash


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add sleep between yarn install retries.

### Motivation
<!-- What inspired you to submit this pull request? -->

There have been cases where the retry (which currently happens immediately) still gets a 503 from the npm registry, but then a retry of the entire workflow works. My theory is that when the registry returns 503, there might be a small outage that takes a bit of time to be resolved, especially since a 503 would usually come from a load balancer which may take some time to realize new instances are up and healthy. Adding 60 seconds should hopefully be enough to avoid further occurrences of these issues.