### PR TITLE
use dynamic queue name for aws sqs tests

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -333,7 +333,6 @@ describe('Plugin', () => {
           )
         })
 
-
         before(() => {
           AWS = require(`../../../versions/${sqsClientName}@${version}`).get()
           sqs = new AWS.SQS({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1' })

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -406,7 +406,7 @@ describe('Plugin', () => {
         })
       })
 
-      describe.only('data stream monitoring', () => {
+      describe('data stream monitoring', () => {
         let expectedProducerHash
         let expectedConsumerHash
         let nowStub


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use dynamic queue name for AWS SQS tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

We currently have a lot of flaky tests for SQS, for example:

https://github.com/DataDog/dd-trace-js/actions/runs/16112243292/job/45458174668
https://github.com/DataDog/dd-trace-js/actions/runs/16034849399/job/45244027750

I tried reproducing these locally and wasn't able to. My theory is that there are side-effects between tests which makes them flaky. This has happened with several other message queues in the past, and usually, isolating individual queues/topics has worked to solve the problem, so I am attempting the same here as well. If this works well, I will open additional PRs for the other AWS products.