### PR TITLE
fix next test network error by removing get-port usage

### DIFF
--- a/packages/datadog-plugin-next/test/server.js
+++ b/packages/datadog-plugin-next/test/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { PORT, HOSTNAME } = process.env
+const { PORT = 0, HOSTNAME } = process.env
 
 const { createServer } = require('http')
 // eslint-disable-next-line n/no-deprecated-api


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix next test network error by removing `get-port` usage.

### Motivation
<!-- What inspired you to submit this pull request? -->

Using `get-port` causes race conditions, but relying on the kernel to provide a port doesn't. This should fix the flakiness with Next that we have been seeing for months if not years.