### PR TITLE
[test-optimization] [SDTEST-2267] Remove `getPort` from Test Optimization tests

### DIFF
--- a/integration-tests/automatic-log-submission.spec.js
+++ b/integration-tests/automatic-log-submission.spec.js
@@ -3,7 +3,6 @@
 const { exec, execSync } = require('child_process')
 
 const { assert } = require('chai')
-const getPort = require('get-port')
 
 const {
   createSandbox,
@@ -31,8 +30,9 @@ describe('test visibility automatic log submission', () => {
     // Install chromium (configured in integration-tests/playwright.config.js)
     // *Be advised*: this means that we'll only be using chromium for this test suite
     execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
-    webAppPort = await getPort()
-    webAppServer.listen(webAppPort)
+    webAppServer.listen(0, () => {
+      webAppPort = webAppServer.address().port
+    })
   })
 
   after(async () => {
@@ -41,8 +41,7 @@ describe('test visibility automatic log submission', () => {
   })
 
   beforeEach(async function () {
-    const port = await getPort()
-    receiver = await new FakeCiVisIntake(port).start()
+    receiver = await new FakeCiVisIntake().start()
   })
 
   afterEach(async () => {

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -2,7 +2,6 @@
 
 const { exec, execSync } = require('child_process')
 
-const getPort = require('get-port')
 const { assert } = require('chai')
 const fs = require('fs')
 const path = require('path')
@@ -95,8 +94,7 @@ versions.forEach(version => {
     })
 
     beforeEach(async function () {
-      const port = await getPort()
-      receiver = await new FakeCiVisIntake(port).start()
+      receiver = await new FakeCiVisIntake().start()
     })
 
     afterEach(async () => {

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -5,7 +5,6 @@ const { exec, execSync } = require('child_process')
 const path = require('path')
 const fs = require('fs')
 
-const getPort = require('get-port')
 const { assert } = require('chai')
 
 const {
@@ -114,7 +113,7 @@ moduleTypes.forEach(({
 
     this.retries(2)
     this.timeout(60000)
-    let sandbox, cwd, receiver, childProcess, webAppPort, secondWebAppServer
+    let sandbox, cwd, receiver, childProcess, webAppPort, secondWebAppServer, secondWebAppPort
 
     if (type === 'commonJS') {
       testCommand = testCommand(version)
@@ -124,8 +123,24 @@ moduleTypes.forEach(({
       // cypress-fail-fast is required as an incompatible plugin
       sandbox = await createSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0'], true)
       cwd = sandbox.folder
-      webAppPort = await getPort()
-      webAppServer.listen(webAppPort)
+      webAppServer.listen(0, 'localhost', () => {
+        webAppPort = webAppServer.address().port
+      })
+      if (version === 'latest') {
+        secondWebAppServer = http.createServer((req, res) => {
+          res.setHeader('Content-Type', 'text/html')
+          res.writeHead(200)
+          res.end(`
+            <!DOCTYPE html>
+            <html>
+              <div class="hella-world">Hella World</div>
+            </html>
+          `)
+        })
+        secondWebAppServer.listen(0, 'localhost', () => {
+          secondWebAppPort = secondWebAppServer.address().port
+        })
+      }
     })
 
     after(async () => {
@@ -1731,21 +1746,6 @@ moduleTypes.forEach(({
           NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress
           ...restEnvVars
         } = getCiVisEvpProxyConfig(receiver.port)
-
-        const secondWebAppPort = await getPort()
-
-        secondWebAppServer = http.createServer((req, res) => {
-          res.setHeader('Content-Type', 'text/html')
-          res.writeHead(200)
-          res.end(`
-            <!DOCTYPE html>
-            <html>
-              <div class="hella-world">Hella World</div>
-            </html>
-          `)
-        })
-
-        secondWebAppServer.listen(secondWebAppPort)
 
         const specToRun = 'cypress/e2e/multi-origin.js'
 

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -5,7 +5,6 @@ const satisfies = require('semifies')
 const path = require('path')
 const fs = require('fs')
 
-const getPort = require('get-port')
 const { assert } = require('chai')
 
 const {
@@ -86,10 +85,12 @@ versions.forEach((version) => {
       // Install chromium (configured in integration-tests/playwright.config.js)
       // *Be advised*: this means that we'll only be using chromium for this test suite
       execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
-      webAppPort = await getPort()
-      webAppServer.listen(webAppPort)
-      webPortWithRedirect = await getPort()
-      webAppServerWithRedirect.listen(webPortWithRedirect)
+      webAppServer.listen(0, () => {
+        webAppPort = webAppServer.address().port
+      })
+      webAppServerWithRedirect.listen(0, () => {
+        webPortWithRedirect = webAppServerWithRedirect.address().port
+      })
     })
 
     after(async () => {
@@ -99,8 +100,7 @@ versions.forEach((version) => {
     })
 
     beforeEach(async function () {
-      const port = await getPort()
-      receiver = await new FakeCiVisIntake(port).start()
+      receiver = await new FakeCiVisIntake().start()
     })
 
     afterEach(async () => {

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -3,7 +3,6 @@
 const { exec } = require('child_process')
 
 const { assert } = require('chai')
-const getPort = require('get-port')
 
 const {
   createSandbox,
@@ -41,8 +40,9 @@ versionRange.forEach(version => {
       ])
       cwd = sandbox.folder
 
-      webAppPort = await getPort()
-      webAppServer.listen(webAppPort)
+      webAppServer.listen(0, () => {
+        webAppPort = webAppServer.address().port
+      })
     })
 
     after(async function () {
@@ -51,8 +51,7 @@ versionRange.forEach(version => {
     })
 
     beforeEach(async function () {
-      const port = await getPort()
-      receiver = await new FakeCiVisIntake(port).start()
+      receiver = await new FakeCiVisIntake().start()
     })
 
     afterEach(async () => {

--- a/integration-tests/test-api-manual.spec.js
+++ b/integration-tests/test-api-manual.spec.js
@@ -2,7 +2,6 @@
 
 const { exec } = require('child_process')
 
-const getPort = require('get-port')
 const { assert } = require('chai')
 
 const {
@@ -27,8 +26,7 @@ describe('test-api-manual', () => {
   })
 
   beforeEach(async function () {
-    const port = await getPort()
-    receiver = await new FakeCiVisIntake(port).start()
+    receiver = await new FakeCiVisIntake().start()
   })
 
   afterEach(async () => {

--- a/integration-tests/test-optimization-startup.spec.js
+++ b/integration-tests/test-optimization-startup.spec.js
@@ -2,7 +2,6 @@
 
 const { exec } = require('child_process')
 
-const getPort = require('get-port')
 const { assert } = require('chai')
 
 const { createSandbox } = require('./helpers')
@@ -24,8 +23,7 @@ describe('test optimization startup', () => {
 
   beforeEach(async function () {
     processOutput = ''
-    const port = await getPort()
-    receiver = await new FakeCiVisIntake(port).start()
+    receiver = await new FakeCiVisIntake().start()
   })
 
   afterEach(async () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
With this change we remove `getPort` method from the Test Optimization tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


