### PR TITLE
fix sqs test race condition when deleting the queue

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -99,10 +99,10 @@ describe('Plugin', () => {
         )
 
         withNamingSchema(
-          (done) => sqs.sendMessage({
+          () => new Promise((resolve, reject) => sqs.sendMessage({
             MessageBody: 'test body',
             QueueUrl
-          }, (err) => err && done(err)),
+          }, (err) => err ? reject(err) : resolve())),
           rawExpectedSchema.producer,
           {
             desc: 'producer'
@@ -110,17 +110,17 @@ describe('Plugin', () => {
         )
 
         withNamingSchema(
-          (done) => sqs.sendMessage({
+          () => new Promise((resolve, reject) => sqs.sendMessage({
             MessageBody: 'test body',
             QueueUrl
           }, (err) => {
-            if (err) return done(err)
+            if (err) return reject(err)
 
             sqs.receiveMessage({
               QueueUrl,
               MessageAttributeNames: ['.*']
-            }, (err) => err && done(err))
-          }),
+            }, (err) => err ? reject(err) : resolve())
+          })),
           rawExpectedSchema.consumer,
           {
             desc: 'consumer'
@@ -128,7 +128,9 @@ describe('Plugin', () => {
         )
 
         withNamingSchema(
-          (done) => sqs.listQueues({}, (err) => err && done(err)),
+          () => new Promise((resolve, reject) => {
+            sqs.listQueues({}, (err) => err ? reject(err) : resolve())
+          }),
           rawExpectedSchema.client,
           {
             desc: 'client'

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -34,7 +34,7 @@ describe('Plugin', () => {
           elasticsearch = metaModule.get()
 
           client = new elasticsearch.Client({
-            node: 'http://localhost:9200'
+            node: 'http://127.0.0.1:9200'
           })
         })
 
@@ -70,7 +70,7 @@ describe('Plugin', () => {
             }
           // Ignore index_not_found_exception
           }, hasCallbackSupport ? () => done() : undefined)?.catch?.(() => {}),
-          'localhost',
+          '127.0.0.1',
           'out.host'
         )
 
@@ -85,7 +85,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('elasticsearch.method', 'POST')
               expect(traces[0][0].meta).to.have.property('elasticsearch.url', '/docs/_search')
-              expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
+              expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
 
               if (hasCallbackSupport) {
                 expect(traces[0][0].meta).to.have.property('elasticsearch.body', '{"query":{"match_all":{}}}')
@@ -304,13 +304,17 @@ describe('Plugin', () => {
             client.ping().catch(done)
           })
 
-          withNamingSchema(
-            () => client.search(
-              { index: 'logstash-2000.01.01', body: {} },
-              hasCallbackSupport ? () => {} : undefined
-            ),
-            rawExpectedSchema.outbound
-          )
+          describe('test', () => {
+            withNamingSchema(
+              () => {
+                client.search(
+                  { index: 'logstash-2000.01.01', body: {} },
+                  hasCallbackSupport ? () => {} : undefined
+                )
+              },
+              rawExpectedSchema.outbound
+            )
+          })
         })
       })
 
@@ -335,7 +339,7 @@ describe('Plugin', () => {
         beforeEach(() => {
           elasticsearch = require(`../../../versions/${moduleName}@${version}`).get()
           client = new elasticsearch.Client({
-            node: 'http://localhost:9200'
+            node: 'http://127.0.0.1:9200'
           })
         })
 
@@ -370,10 +374,12 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => client.search(
-            { index: 'logstash-2000.01.01', body: {} },
-            hasCallbackSupport ? () => {} : undefined
-          ),
+          () => {
+            client.search(
+              { index: 'logstash-2000.01.01', body: {} },
+              hasCallbackSupport ? () => {} : undefined
+            )
+          },
           {
             v0: {
               opName: 'elasticsearch.query',

--- a/packages/datadog-plugin-elasticsearch/test/index.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/index.spec.js
@@ -34,7 +34,7 @@ describe('Plugin', () => {
           elasticsearch = metaModule.get()
 
           client = new elasticsearch.Client({
-            node: 'http://127.0.0.1:9200'
+            node: 'http://localhost:9200'
           })
         })
 
@@ -70,7 +70,7 @@ describe('Plugin', () => {
             }
           // Ignore index_not_found_exception
           }, hasCallbackSupport ? () => done() : undefined)?.catch?.(() => {}),
-          '127.0.0.1',
+          'localhost',
           'out.host'
         )
 
@@ -85,7 +85,7 @@ describe('Plugin', () => {
               expect(traces[0][0].meta).to.have.property('span.kind', 'client')
               expect(traces[0][0].meta).to.have.property('elasticsearch.method', 'POST')
               expect(traces[0][0].meta).to.have.property('elasticsearch.url', '/docs/_search')
-              expect(traces[0][0].meta).to.have.property('out.host', '127.0.0.1')
+              expect(traces[0][0].meta).to.have.property('out.host', 'localhost')
 
               if (hasCallbackSupport) {
                 expect(traces[0][0].meta).to.have.property('elasticsearch.body', '{"query":{"match_all":{}}}')
@@ -339,7 +339,7 @@ describe('Plugin', () => {
         beforeEach(() => {
           elasticsearch = require(`../../../versions/${moduleName}@${version}`).get()
           client = new elasticsearch.Client({
-            node: 'http://127.0.0.1:9200'
+            node: 'http://localhost:9200'
           })
         })
 

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/server.mjs
@@ -1,6 +1,6 @@
 import 'dd-trace/init.js'
 import { Client } from '@elastic/elasticsearch'
 
-const client = new Client({ node: 'http://localhost:9200' })
+const client = new Client({ node: 'http://127.0.0.1:9200' })
 
 await client.ping()

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -34,7 +34,7 @@ describe('Plugin', () => {
           mysql2 = proxyquire(`../../../versions/mysql2@${version}`, {}).get()
 
           connection = mysql2.createConnection({
-            host: 'localhost',
+            host: '127.0.0.1',
             user: 'root',
             database: 'db'
           })
@@ -51,7 +51,9 @@ describe('Plugin', () => {
         )
 
         withNamingSchema(
-          () => connection.query('SELECT 1', (_) => {}),
+          () => new Promise((resolve) => {
+            connection.query('SELECT 1', (_) => resolve())
+          }),
           rawExpectedSchema.outbound
         )
 
@@ -213,7 +215,7 @@ describe('Plugin', () => {
           mysql2 = proxyquire(`../../../versions/mysql2@${version}`, {}).get()
 
           connection = mysql2.createConnection({
-            host: 'localhost',
+            host: '127.0.0.1',
             user: 'root',
             database: 'db'
           })
@@ -222,7 +224,9 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => connection.query('SELECT 1', (_) => {}),
+          () => new Promise((resolve) => {
+            connection.query('SELECT 1', (_) => resolve())
+          }),
           {
             v0: {
               opName: 'mysql.query',
@@ -262,7 +266,7 @@ describe('Plugin', () => {
           mysql2 = proxyquire(`../../../versions/mysql2@${version}`, {}).get()
 
           connection = mysql2.createConnection({
-            host: 'localhost',
+            host: '127.0.0.1',
             user: 'root',
             database: 'db'
           })
@@ -271,7 +275,9 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => connection.query('SELECT 1', (_) => {}),
+          () => new Promise((resolve) => {
+            connection.query('SELECT 1', (_) => resolve())
+          }),
           {
             v0: {
               opName: 'mysql.query',
@@ -288,7 +294,7 @@ describe('Plugin', () => {
           agent.assertSomeTraces(traces => {
             expect(traces[0][0]).to.have.property('service', 'custom')
             sinon.assert.calledWith(serviceSpy, sinon.match({
-              host: 'localhost',
+              host: '127.0.0.1',
               user: 'root',
               database: 'db'
             }))
@@ -314,7 +320,7 @@ describe('Plugin', () => {
 
           pool = mysql2.createPool({
             connectionLimit: 1,
-            host: 'localhost',
+            host: '127.0.0.1',
             user: 'root'
           })
         })

--- a/packages/datadog-plugin-mysql2/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-mysql2/test/integration-test/server.mjs
@@ -2,7 +2,7 @@ import 'dd-trace/init.js'
 import mysql from 'mysql2'
 
 const conn = {
-  host: 'localhost',
+  host: '127.0.0.1',
   user: 'root',
   database: 'db',
   port: 3306

--- a/packages/datadog-plugin-opensearch/test/index.spec.js
+++ b/packages/datadog-plugin-opensearch/test/index.spec.js
@@ -33,7 +33,7 @@ describe('Plugin', () => {
           opensearch = metaModule.get()
 
           client = new opensearch.Client({
-            node: 'http://localhost:9201'
+            node: 'http://127.0.0.1:9201'
           })
         })
 
@@ -67,7 +67,7 @@ describe('Plugin', () => {
                 'opensearch.url': '/docs/_search',
                 'opensearch.body': '{"query":{"match_all":{}}}',
                 component: 'opensearch',
-                'out.host': 'localhost'
+                'out.host': '127.0.0.1'
               }
             })
             .then(done)
@@ -213,7 +213,9 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => client.search({ index: 'logstash-2000.01.01', body: {} }),
+          () => {
+            client.search({ index: 'logstash-2000.01.01', body: {} })
+          },
           rawExpectedSchema.outbound
         )
       })
@@ -239,7 +241,7 @@ describe('Plugin', () => {
         beforeEach(() => {
           opensearch = require(`../../../versions/${moduleName}@${version}`).get()
           client = new opensearch.Client({
-            node: 'http://localhost:9201'
+            node: 'http://127.0.0.1:9201'
           })
         })
 
@@ -258,7 +260,7 @@ describe('Plugin', () => {
           }).catch(() => {
             // Ignore index_not_found_exception for peer service assertion
           }),
-          'localhost',
+          '127.0.0.1',
           'out.host'
         )
 
@@ -291,7 +293,9 @@ describe('Plugin', () => {
         })
 
         withNamingSchema(
-          () => client.search({ index: 'logstash-2000.01.01', body: {} }),
+          () => {
+            client.search({ index: 'logstash-2000.01.01', body: {} })
+          },
           {
             v0: {
               opName: 'opensearch.query',

--- a/packages/datadog-plugin-opensearch/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-opensearch/test/integration-test/server.mjs
@@ -1,5 +1,5 @@
 import 'dd-trace/init.js'
 import opensearch from '@opensearch-project/opensearch'
 
-const client = new opensearch.Client({ node: 'http://localhost:9201' })
+const client = new opensearch.Client({ node: 'http://127.0.0.1:9201' })
 await client.ping()

--- a/packages/dd-trace/test/setup/services/elasticsearch.js
+++ b/packages/dd-trace/test/setup/services/elasticsearch.js
@@ -9,7 +9,7 @@ function waitForElasticsearch () {
 
     operation.attempt(currentAttempt => {
       // Not using ES client because it's buggy for initial connection.
-      axios.get('http://localhost:9200/_cluster/health?wait_for_status=green&local=true&timeout=100ms')
+      axios.get('http://127.0.0.1:9200/_cluster/health?wait_for_status=green&local=true&timeout=100ms')
         .then(() => resolve())
         .catch(err => {
           if (operation.retry(err)) return

--- a/packages/dd-trace/test/setup/services/mysql.js
+++ b/packages/dd-trace/test/setup/services/mysql.js
@@ -9,7 +9,7 @@ function waitForMysql () {
 
     operation.attempt(currentAttempt => {
       const connection = mysql.createConnection({
-        host: 'localhost',
+        host: '127.0.0.1',
         user: 'root',
         database: 'db'
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix SQS test race condition when deleting the queue.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `withNamingSchema` helper wasn't waiting for the callback to be done before finishing the test. This meant that the test could be done before the underlying request to the AWS endpoint had a chance to finish, resulting in an error when trying to access the now deleted queue in the `afterEach` hook.