### PR TITLE
fix indeterministic request id failing di snapshot test

### DIFF
--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -87,7 +87,8 @@ describe('Dynamic Instrumentation', function () {
           // There's no reason to test the `request` object 100%, instead just check its fingerprint
           assert.deepEqual(Object.keys(request), ['type', 'fields'])
           assert.equal(request.type, 'Request')
-          assert.deepEqual(request.fields.id, { type: 'string', value: 'req-1' })
+          assert.equal(request.fields.id.type, 'string')
+          assert.match(request.fields.id.value, /^req-\d+$/)
           assert.deepEqual(request.fields.params, {
             type: 'NullObject', fields: { name: { type: 'string', value: 'foo' } }
           })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix indeterministic request ID failing DI snapshot test.

### Motivation
<!-- What inspired you to submit this pull request? -->

The request ID is determined by Fastify and is not always 1, which can cause the test to flake.
