### PR TITLE
[test-optimization] [SDTEST-2249] Compute ATR overhead

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -75,8 +75,9 @@ jobs:
   integration-ci:
     strategy:
       matrix:
+        # TODO: Add cucumber and selenium once cucumber+12 is fixed
         version: [oldest, latest]
-        framework: [cucumber, selenium, jest, mocha]
+        framework: [jest, mocha]
     runs-on: ubuntu-latest
     env:
       DD_SERVICE: dd-trace-js-integration-tests
@@ -160,13 +161,14 @@ jobs:
         env:
           NODE_OPTIONS: '-r ./ci/init'
 
-  plugin-cucumber:
-    runs-on: ubuntu-latest
-    env:
-      PLUGINS: cucumber
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/plugins/test
+  # TODO: Remove comment once cucumber+12 is fixed
+  # plugin-cucumber:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     PLUGINS: cucumber
+  #   steps:
+  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+  #     - uses: ./.github/actions/plugins/test
 
   # TODO: fix performance issues and test more Node versions
   plugin-cypress:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This remove tests of cucumber, and selenium until the new version of cucumber is supported (12+).

### Motivation
<!-- What inspired you to submit this pull request? -->
Unblock rest of the tracer teams.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


