### PR TITLE
[] [] Fix support for Cucumber 12+

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -75,9 +75,8 @@ jobs:
   integration-ci:
     strategy:
       matrix:
-        # TODO: Add cucumber and selenium once cucumber+12 is fixed
         version: [oldest, latest]
-        framework: [jest, mocha]
+        framework: [cucumber, selenium, jest, mocha]
     runs-on: ubuntu-latest
     env:
       DD_SERVICE: dd-trace-js-integration-tests
@@ -161,14 +160,13 @@ jobs:
         env:
           NODE_OPTIONS: '-r ./ci/init'
 
-  # TODO: Remove comment once cucumber+12 is fixed
-  # plugin-cucumber:
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     PLUGINS: cucumber
-  #   steps:
-  #     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-  #     - uses: ./.github/actions/plugins/test
+  plugin-cucumber:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: cucumber
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/plugins/test
 
   # TODO: fix performance issues and test more Node versions
   plugin-cypress:

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -11,6 +11,7 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const webAppServer = require('./web-app-server')
+const { NODE_MAJOR } = require('../../version')
 
 describe('test visibility automatic log submission', () => {
   let sandbox, cwd, receiver, childProcess, webAppPort
@@ -75,6 +76,8 @@ describe('test visibility automatic log submission', () => {
   ]
 
   testFrameworks.forEach(({ name, command, getExtraEnvVars = () => ({}) }) => {
+    if ((NODE_MAJOR === 18 || NODE_MAJOR === 23) && name === 'cucumber') return
+
     context(`with ${name}`, () => {
       it('can automatically submit logs', (done) => {
         let logIds, testIds

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -59,11 +59,10 @@ describe('test visibility automatic log submission', () => {
       name: 'jest',
       command: 'node ./node_modules/jest/bin/jest --config ./ci-visibility/automatic-log-submission/config-jest.js'
     },
-    // TODO: Uncomment once cucumber+12 is fixed
-    // {
-    //   name: 'cucumber',
-    //   command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature'
-    // },
+    {
+      name: 'cucumber',
+      command: './node_modules/.bin/cucumber-js ci-visibility/automatic-log-submission-cucumber/*.feature'
+    },
     {
       name: 'playwright',
       command: './node_modules/.bin/playwright test -c playwright.config.js',

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -63,6 +63,7 @@ const {
   DD_CAPABILITIES_IMPACTED_TESTS
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
+const { NODE_MAJOR } = require('../../version')
 
 const versions = ['7.0.0', 'latest']
 
@@ -74,6 +75,8 @@ const featuresPath = 'ci-visibility/features/'
 const fileExtension = 'js'
 
 versions.forEach(version => {
+  if ((NODE_MAJOR === 18 || NODE_MAJOR === 23) && version === 'latest') return
+
   // TODO: add esm tests
   describe(`cucumber@${version} commonJS`, () => {
     let sandbox, cwd, receiver, childProcess, testOutput

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -17,6 +17,7 @@ const {
   TEST_IS_RUM_ACTIVE,
   TEST_TYPE
 } = require('../../packages/dd-trace/src/plugins/util/test')
+const { NODE_MAJOR } = require('../../version')
 
 const webAppServer = require('../ci-visibility/web-app-server')
 
@@ -74,6 +75,7 @@ versionRange.forEach(version => {
       }
     ]
     testFrameworks.forEach(({ name, command }) => {
+      if ((NODE_MAJOR === 18 || NODE_MAJOR === 23) && name === 'cucumber') return
       context(`with ${name}`, () => {
         it('identifies tests using selenium as browser tests', (done) => {
           const assertionPromise = receiver

--- a/packages/datadog-plugin-cucumber/test/index.spec.js
+++ b/packages/datadog-plugin-cucumber/test/index.spec.js
@@ -24,6 +24,7 @@ const {
 } = require('../../dd-trace/src/plugins/util/test')
 
 const { version: ddTraceVersion } = require('../../../package.json')
+const { NODE_MAJOR } = require('../../../version')
 
 const runCucumber = (version, Cucumber, requireName, featureName, testName) => {
   const stdout = new PassThrough()
@@ -54,6 +55,8 @@ describe('Plugin', function () {
   let Cucumber
   this.timeout(10000)
   withVersions('cucumber', '@cucumber/cucumber', (version, _, specificVersion) => {
+    if ((NODE_MAJOR === 18 || NODE_MAJOR === 23) && version >= '12.0.0') return
+
     afterEach(() => {
       // > If you want to run tests multiple times, you may need to clear Node's require cache
       // before subsequent calls in whichever manner best suits your needs.

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -150,8 +150,7 @@ checkPlugins(path.join(__dirname, '..', '.github', 'workflows', 'test-optimizati
     .filter(file => fs.existsSync(path.join(__dirname, '..', 'packages', file, 'test')))
     .map(file => file.replace('datadog-plugin-', ''))
   for (const plugin of allPlugins) {
-    // TODO: Remove check of cucumber once cucumber+12 is fixed
-    if (!allTestedPlugins.has(plugin) && plugin !== 'cucumber') {
+    if (!allTestedPlugins.has(plugin)) {
       pluginErrorMsg(plugin, 'ERROR', 'Plugin is tested but not in at least one GitHub workflow')
     }
   }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
From `Cucumber 12+`, `Node 18` and `Node 23` are not supported. In order to make it work we must make sure we don't run tests with `Node 18` and `Cucumber 12+` together.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to make sure we support the latests versions of the test frameworks we support.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
[Cucumber 12.0.0 Release Notes](https://github.com/cucumber/cucumber-js/releases/tag/v12.0.0)


