### PR TITLE
Update allowed values for config.logInjection

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -40,7 +40,7 @@ let promise: Promise<void>;
 ddTrace.init();
 tracer.init({
   apmTracingEnabled: false,
-  logInjection: true,
+  logInjection: 'structured',
   startupLogs: false,
   env: 'test',
   version: '1.0.0',

--- a/index.d.ts
+++ b/index.d.ts
@@ -373,9 +373,13 @@ declare namespace tracer {
     /**
      * Whether to enable trace ID injection in log records to be able to correlate
      * traces with logs.
-     * @default false
+     * all: enable for both structured and unstructured logs
+     * structured: enable only for structured logs
+     * (same as 'all' since dd-trace does support log injection for unstructured logs)
+     * disabled: disable trace ID injection in all logs
+     * @default 'structured'
      */
-    logInjection?: boolean,
+    logInjection?: string,
 
     /**
      * Whether to enable startup logs.

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -2,6 +2,7 @@
 
 const { LOG } = require('../../../../ext/formats')
 const Plugin = require('./plugin')
+const log = require('../log')
 const { storage } = require('../../../datadog-core')
 
 function messageProxy (message, holder) {
@@ -46,10 +47,17 @@ module.exports = class LogPlugin extends Plugin {
   }
 
   _isEnabled (config) {
-    return config.enabled && (config.logInjection === true || config.ciVisAgentlessLogSubmissionEnabled)
+    return config.enabled &&
+    (config.logInjection === 'all' || config.logInjection === true || config.ciVisAgentlessLogSubmissionEnabled)
   }
 
   configure (config) {
+    if (config.logInjection === true) {
+      log.warn('Boolean value for config.logInjection is deprecated. Use "all" or "structured" instead.')
+    }
+    if (config.logInjection === false) {
+      log.warn('Boolean value for config.logInjection is deprecated. Use "disabled" instead.')
+    }
     return super.configure({
       ...config,
       enabled: this._isEnabled(config)


### PR DESCRIPTION
### What does this PR do?
ON HOLD while RFC is being updated
Update `config.logInjection` to take string values and deprecate boolean values

### Motivation
[RFC](https://docs.google.com/document/d/1Okl7hQcJgA9NdQ8msSVu5P2cPQOx139K9s9f3C_bTho/edit?usp=sharing)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


