### PR TITLE
Revert "ci: add paths config to workflows for github & pull_request trigger (#5891)"

### DIFF
--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -2,21 +2,6 @@ name: APM Capabilities
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/apm-capabilities.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -2,21 +2,6 @@ name: APM Integrations
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/apm-integrations.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -2,21 +2,6 @@ name: AppSec
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/appsec.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -2,21 +2,6 @@ name: Debugger
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/debugger.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -2,21 +2,6 @@ name: Lambda
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/lambda.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -2,21 +2,6 @@ name: LLMObs
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/llmobs.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -2,21 +2,6 @@ name: Platform
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/platform.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -2,21 +2,6 @@ name: Profiling
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/profiling.yml'
   push:
     branches: [master]
   schedule:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -2,21 +2,6 @@ name: Project
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/**'
   push:
     branches: [master]
 

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -2,21 +2,6 @@ name: System Tests
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/system-tests.yml'
   push:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -2,21 +2,6 @@ name: Test Optimization
 
 on:
   pull_request:
-    paths:
-      # Paths for whole project (should be same in all workflows)
-      - '**'
-      - '!.github/workflows/**'
-      - '!.gitlab/**'
-      - '!.vscode/**'
-      - '!devdocs/**'
-      - '!examples/**'
-      - '!*.md'
-      - '!.gitlab-ci.yml'
-      - '!LICENSE*'
-      - 'LICENSE-3rdparty.csv'
-      - '!NOTICE'
-      # Paths for this workflow only
-      - '.github/workflows/test-optimization.yml'
   push:
     branches:
       - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,56 +16,8 @@ stages:
 
 include:
   - local: ".gitlab/one-pipeline.locked.yml"
-    rules:
-      - changes:
-          paths:
-            # Paths for whole project (should be same in all workflows)
-            - '**'
-            - '!.github/workflows/**'
-            - '!.gitlab/**'
-            - '!.vscode/**'
-            - '!devdocs/**'
-            - '!examples/**'
-            - '!*.md'
-            - '!LICENSE*'
-            - 'LICENSE-3rdparty.csv'
-            - '!NOTICE'
-            # Paths for this workflow only
-            - '.gitlab/one-pipeline.locked.yml'
   - local: ".gitlab/benchmarks.yml"
-    rules:
-      - changes:
-          paths:
-            # Paths for whole project (should be same in all workflows)
-            - '**'
-            - '!.github/workflows/**'
-            - '!.gitlab/**'
-            - '!.vscode/**'
-            - '!devdocs/**'
-            - '!examples/**'
-            - '!*.md'
-            - '!LICENSE*'
-            - 'LICENSE-3rdparty.csv'
-            - '!NOTICE'
-            # Paths for this workflow only
-            - '.gitlab/benchmarks.yml'
   - local: ".gitlab/macrobenchmarks.yml"
-    rules:
-      - changes:
-          paths:
-            # Paths for whole project (should be same in all workflows)
-            - '**'
-            - '!.github/workflows/**'
-            - '!.gitlab/**'
-            - '!.vscode/**'
-            - '!devdocs/**'
-            - '!examples/**'
-            - '!*.md'
-            - '!LICENSE*'
-            - 'LICENSE-3rdparty.csv'
-            - '!NOTICE'
-            # Paths for this workflow only
-            - '.gitlab/macrobenchmarks.yml'
 
 workflow:
   rules:

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -174,6 +174,7 @@ const IGNORED_WORKFLOWS = {
     'retry.yml'
   ],
   trigger_pull_request: [
+    'audit.yml',
     'eslint-rules.yml',
     'stale.yml'
   ],
@@ -200,10 +201,9 @@ for (const workflow of workflows) {
   const yamlPath = path.join(__dirname, '..', '.github', 'workflows', workflow)
   const yamlContent = yaml.parse(fs.readFileSync(yamlPath, 'utf8'))
   const triggers = yamlContent.on
-  if (!IGNORED_WORKFLOWS.trigger_pull_request.includes(workflow)) {
-    if (triggers?.pull_request !== null && Object.keys(triggers.pull_request).toString() !== 'paths') {
-      triggersError(workflow, 'The `pull_request` trigger should be blank or only include paths')
-    }
+  if (!IGNORED_WORKFLOWS.trigger_pull_request.includes(workflow) &&
+      triggers?.pull_request !== null) {
+    triggersError(workflow, 'The `pull_request` trigger should be blank')
   }
   if (!IGNORED_WORKFLOWS.trigger_push.includes(workflow) &&
       triggers?.push?.branches?.[0] !== 'master') {


### PR DESCRIPTION
This reverts commit d65e48671129662e9a671a376c8fed7c424126c3.

This commit [broke](https://github.com/DataDog/dd-trace-js/actions/runs/16283941766/job/45978925102) our ability to release to npm. For now, I think it's best to revert it.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


