### PR TITLE
ci: disable legacy Gitlab exec in order to fix jobs failing with green status

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -23,10 +23,6 @@ variables:
     paths:
       - platform/artifacts/
     expire_in: 3 months
-  variables:
-    # Gitlab and BP specific env vars. Do not modify.
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment
@@ -38,9 +34,6 @@ benchmarks-pr-comment:
     - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js)
     - bp-runner bp-runner.pr-comment.yml --debug
   allow_failure: true
-  variables:
-    # Gitlab and BP specific env vars. Do not modify.
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
 
 check-big-regressions:
   stage: benchmarks-pr-comment
@@ -51,9 +44,6 @@ check-big-regressions:
   script:
     - cd platform && (git init && git remote add origin https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform && git pull origin dd-trace-js)
     - bp-runner bp-runner.fail-on-regression.yml --debug
-  variables:
-    # Gitlab and BP specific env vars. Do not modify.
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-js
 
 benchmark:
   extends: .benchmarks

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -19,8 +19,6 @@
       - platform/artifacts/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
     K6_OPTIONS_WARMUP_RATE: 500
     K6_OPTIONS_WARMUP_DURATION: 1m
     K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s


### PR DESCRIPTION
### What does this PR do?

Disables FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY that we used before to ensure build containers have QoS guaranteed. As of now, it doesn't seem to be necessary anymore, but leads to problems like https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4119.

### Motivation

Fix issue with GItlab CI jobs silently randomly failing with a green status.

