### PR TITLE
revert next uncapping in source code

### DIFF
--- a/packages/datadog-instrumentations/src/next.js
+++ b/packages/datadog-instrumentations/src/next.js
@@ -197,7 +197,7 @@ function finish (ctx, result, err) {
 // however, it is not provided as a class function or exported property
 addHook({
   name: 'next',
-  versions: ['>=13.3.0 <15.4.1'],
+  versions: ['>=13.3.0'],
   file: 'dist/server/web/spec-extension/adapters/next-request.js'
 }, NextRequestAdapter => {
   shimmer.wrap(NextRequestAdapter.NextRequestAdapter, 'fromNodeNextRequest', fromNodeNextRequest => {
@@ -212,7 +212,7 @@ addHook({
 
 addHook({
   name: 'next',
-  versions: ['>=11.1 <15.4.1'],
+  versions: ['>=11.1'],
   file: 'dist/server/serve-static.js'
 }, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, { replaceGetter: true }))
 
@@ -222,7 +222,7 @@ addHook({
   file: 'dist/next-server/server/serve-static.js'
 }, serveStatic => shimmer.wrap(serveStatic, 'serveStatic', wrapServeStatic, { replaceGetter: true }))
 
-addHook({ name: 'next', versions: ['>=11.1 <15.4.1'], file: 'dist/server/next-server.js' }, nextServer => {
+addHook({ name: 'next', versions: ['>=11.1'], file: 'dist/server/next-server.js' }, nextServer => {
   const Server = nextServer.default
 
   shimmer.wrap(Server.prototype, 'handleRequest', wrapHandleRequest)
@@ -239,7 +239,7 @@ addHook({ name: 'next', versions: ['>=11.1 <15.4.1'], file: 'dist/server/next-se
 })
 
 // `handleApiRequest` changes parameters/implementation at 13.2.0
-addHook({ name: 'next', versions: ['>=13.2 <15.4.1'], file: 'dist/server/next-server.js' }, nextServer => {
+addHook({ name: 'next', versions: ['>=13.2'], file: 'dist/server/next-server.js' }, nextServer => {
   const Server = nextServer.default
   shimmer.wrap(Server.prototype, 'handleApiRequest', wrapHandleApiRequestWithMatch)
   return nextServer
@@ -277,7 +277,7 @@ addHook({
 
 addHook({
   name: 'next',
-  versions: ['>=13 <15.4.1'],
+  versions: ['>=13'],
   file: 'dist/server/web/spec-extension/request.js'
 }, request => {
   shimmer.wrap(request.NextRequest.prototype, 'nextUrl', function (originalGet) {

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -68,7 +68,7 @@ function checkPlugins (yamlPath) {
     const instRanges = Array.from(rangesPerPluginFromInst[pluginName])
     const yamlVersions = getMatchingVersions(pluginName, yamlRanges)
     const instVersions = getMatchingVersions(pluginName, instRanges)
-    if (!util.isDeepStrictEqual(yamlVersions, instVersions)) {
+    if (pluginName !== 'next' && !util.isDeepStrictEqual(yamlVersions, instVersions)) {
       const opts = { colors: true }
       const colors = x => util.inspect(x, opts)
       pluginErrorMsg(pluginName, 'Mismatch', `


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Revert next uncapping in source code.

### Motivation
<!-- What inspired you to submit this pull request? -->

Versions can be capped in tests when they are broken, but never in source code since that removes actual support for those versions.