### PR TITLE
Tag profiles with a sequence number

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -22,16 +22,16 @@ if (process.platform !== 'win32') {
 const TIMEOUT = 30000
 
 function checkProfiles (agent, proc, timeout,
-  expectedProfileTypes = DEFAULT_PROFILE_TYPES, expectBadExit = false
+  expectedProfileTypes = DEFAULT_PROFILE_TYPES, expectBadExit = false, expectSeq = true
 ) {
   return Promise.all([
     processExitPromise(proc, timeout, expectBadExit),
-    expectProfileMessagePromise(agent, timeout, expectedProfileTypes)
+    expectProfileMessagePromise(agent, timeout, expectedProfileTypes, expectSeq)
   ])
 }
 
 function expectProfileMessagePromise (agent, timeout,
-  expectedProfileTypes = DEFAULT_PROFILE_TYPES
+  expectedProfileTypes = DEFAULT_PROFILE_TYPES, expectSeq = true
 ) {
   const fileNames = expectedProfileTypes.map(type => `${type}.pprof`)
   return agent.assertMessageReceived(({ headers, _, files }) => {
@@ -49,6 +49,9 @@ function expectProfileMessagePromise (agent, timeout,
       assert.sameMembers(attachments, fileNames)
       for (const [index, fileName] of attachments.entries()) {
         assert.propertyVal(files[index + 1], 'originalname', fileName)
+      }
+      if (expectSeq) {
+        assert(event.tags_profiler.indexOf(',profile_seq:') !== -1)
       }
     } catch (e) {
       e.message += ` ${JSON.stringify({ headers, files, event })}`
@@ -560,7 +563,7 @@ describe('profiler', () => {
           execArgv: oomExecArgv,
           env: oomEnv
         })
-        return checkProfiles(agent, proc, timeout, ['space'], true)
+        return checkProfiles(agent, proc, timeout, ['space'], true, false)
       })
 
       it('sends a heap profile on OOM in worker thread and exits successfully', () => {
@@ -584,7 +587,7 @@ describe('profiler', () => {
             DD_PROFILING_EXPERIMENTAL_OOM_MAX_HEAP_EXTENSION_COUNT: 3
           }
         })
-        return checkProfiles(agent, proc, timeout, ['space'], false)
+        return checkProfiles(agent, proc, timeout, ['space'], false, false)
       }).retries(3)
 
       it('sends a heap profile on OOM with async callback', () => {

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -124,11 +124,12 @@ class Profiler extends EventEmitter {
 
     try {
       const start = new Date()
+      const nearOOMCallback = this._nearOOMExport.bind(this)
       for (const profiler of config.profilers) {
         // TODO: move this out of Profiler when restoring sourcemap support
         profiler.start({
           mapper,
-          nearOOMCallback: this._nearOOMExport.bind(this)
+          nearOOMCallback
         })
         this._logger.debug(`Started ${profiler.type} profiler in ${threadNamePrefix} thread`)
       }

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -50,6 +50,7 @@ class Profiler extends EventEmitter {
     this._timer = undefined
     this._lastStart = undefined
     this._timeoutInterval = undefined
+    this._profile_seq = 0
     this.endpointCounts = new Map()
   }
 
@@ -292,6 +293,7 @@ class Profiler extends EventEmitter {
     this.endpointCounts.clear()
 
     tags.snapshot = snapshotKind
+    tags.profile_seq = this._profile_seq++
     const exportSpec = { profiles, start, end, tags, endpointCounts }
     const tasks = this._config.exporters.map(exporter =>
       exporter.export(exportSpec).catch(err => {


### PR DESCRIPTION
### What does this PR do?
Adds a `profile_seq` tag to profiles. It starts at 0 for a specific `runtime-id` and increments each time a profile is emitted.

### Motivation
Go and .NET profilers already emit `profile_seq` and Ruby profiler just recently [introduced it](https://github.com/DataDog/dd-trace-rb/pull/4794), so we're bringing it up to feature parity. The feature can be used to e.g. exclude profiles from application startup in analysis, or to easily compare profiles with a set difference of sequence number for e.g. memory leak analysis. It can also be used to detect missing profiles if there are gaps in the sequence number.

### Additional info
Jira: [PROF-12136]

