### PR TITLE
ci: make telemetry guardrails tests more stable

### DIFF
--- a/packages/dd-trace/test/guardrails/telemetry.spec.js
+++ b/packages/dd-trace/test/guardrails/telemetry.spec.js
@@ -8,7 +8,7 @@ describe('sendTelemetry', () => {
   let cleanup, sendTelemetry
 
   beforeEach(() => {
-    cleanup = telemetryForwarder()
+    cleanup = telemetryForwarder(true)
     sendTelemetry = proxyquire('../src/guardrails/telemetry', {})
   })
 


### PR DESCRIPTION
### What does this PR do?

Tells the mock telemetry endpoint to expect telemetry in the guardrails tests, so that it will retry up to 10 times if the `telemetry-forwarder.sh` script exits with an `ENOENT` exit code.

### Motivation

An attempt to make this test more stable in CI (though not sure if this actually will help, but it will not hurt either).

