### PR TITLE
ci: skip guardrail telemetry unit tests if DD_INJECT_FORCE is used

### DIFF
--- a/packages/dd-trace/test/guardrails/telemetry.spec.js
+++ b/packages/dd-trace/test/guardrails/telemetry.spec.js
@@ -7,6 +7,13 @@ const { telemetryForwarder, assertTelemetryPoints } = require('../../../../integ
 describe('sendTelemetry', () => {
   let cleanup, sendTelemetry
 
+  before(function () {
+    if (['1', 'true', 'True'].includes(process.env.DD_INJECT_FORCE)) {
+      // When DD_INJECT_FORCE is set, only telemetry with the name `error` or `complete` is sent
+      this.skip()
+    }
+  })
+
   beforeEach(() => {
     cleanup = telemetryForwarder()
     sendTelemetry = proxyquire('../src/guardrails/telemetry', {})


### PR DESCRIPTION
### What does this PR do?

If the `DD_INJECT_FORCE` environment variable is set to `true`, skip the guardrail telemetry tests. This is the case in CI for PRs targeting a release branch, as can be seen here:
    
https://github.com/DataDog/dd-trace-js/blob/2caa6151a133fb782a51fa3c2c96f1a8d88da2ac/packages/dd-trace/test/setup/core.js#L24-L28

### Motivation

Allow CI to complete in release PRs.