### PR TITLE
[test-optimization] [SDTEST-2282] Add `ci.job.id` tag on supported CI providers

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -27,7 +27,8 @@ const {
   GIT_COMMIT_COMMITTER_EMAIL,
   CI_NODE_LABELS,
   CI_NODE_NAME,
-  PR_NUMBER
+  PR_NUMBER,
+  CI_JOB_ID
 } = require('./tags')
 const { filterSensitiveInfoFromRepository } = require('./url')
 const { getEnvironmentVariable, getEnvironmentVariables } = require('../../config-helper')
@@ -210,7 +211,8 @@ module.exports = {
         [CI_NODE_LABELS]: CI_RUNNER_TAGS,
         [CI_NODE_NAME]: CI_RUNNER_ID,
         [GIT_PULL_REQUEST_BASE_BRANCH]: CI_MERGE_REQUEST_TARGET_BRANCH_NAME,
-        [PR_NUMBER]: CI_MERGE_REQUEST_IID
+        [PR_NUMBER]: CI_MERGE_REQUEST_IID,
+        [CI_JOB_ID]: GITLAB_CI_JOB_ID
       }
     }
 
@@ -247,7 +249,8 @@ module.exports = {
           CIRCLE_WORKFLOW_ID,
           CIRCLE_BUILD_NUM,
         }),
-        [PR_NUMBER]: CIRCLE_PR_NUMBER
+        [PR_NUMBER]: CIRCLE_PR_NUMBER,
+        [CI_JOB_ID]: CIRCLE_BUILD_NUM
       }
     }
 
@@ -298,7 +301,8 @@ module.exports = {
           GITHUB_REPOSITORY,
           GITHUB_RUN_ID,
           GITHUB_RUN_ATTEMPT
-        })
+        }),
+        [CI_JOB_ID]: GITHUB_JOB
       }
       if (GITHUB_BASE_REF) { // `pull_request` or `pull_request_target` event
         tags[GIT_PULL_REQUEST_BASE_BRANCH] = GITHUB_BASE_REF
@@ -407,7 +411,8 @@ module.exports = {
         [CI_JOB_NAME]: SYSTEM_JOBDISPLAYNAME,
         [CI_ENV_VARS]: JSON.stringify({ SYSTEM_TEAMPROJECTID, BUILD_BUILDID, SYSTEM_JOBID }),
         [PR_NUMBER]: SYSTEM_PULLREQUEST_PULLREQUESTNUMBER,
-        [GIT_PULL_REQUEST_BASE_BRANCH]: SYSTEM_PULLREQUEST_TARGETBRANCH
+        [GIT_PULL_REQUEST_BASE_BRANCH]: SYSTEM_PULLREQUEST_TARGETBRANCH,
+        [CI_JOB_ID]: SYSTEM_JOBID
       }
 
       if (SYSTEM_TEAMFOUNDATIONSERVERURI && SYSTEM_TEAMPROJECTID && BUILD_BUILDID) {
@@ -510,7 +515,8 @@ module.exports = {
         BUILDKITE_MESSAGE,
         BUILDKITE_AGENT_ID,
         BUILDKITE_PULL_REQUEST,
-        BUILDKITE_PULL_REQUEST_BASE_BRANCH
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH,
+        BUILDKITE_CI_JOB_ID
       } = env
 
       const extraTags = Object.keys(env).filter(envVar =>
@@ -542,6 +548,7 @@ module.exports = {
         [CI_NODE_NAME]: BUILDKITE_AGENT_ID,
         [CI_NODE_LABELS]: JSON.stringify(extraTags),
         [PR_NUMBER]: BUILDKITE_PULL_REQUEST,
+        [CI_JOB_ID]: BUILDKITE_CI_JOB_ID
       }
 
       if (BUILDKITE_PULL_REQUEST) {
@@ -682,7 +689,8 @@ module.exports = {
           CODEBUILD_BUILD_ARN,
           DD_PIPELINE_EXECUTION_ID,
           DD_ACTION_EXECUTION_ID
-        })
+        }),
+        [CI_JOB_ID]: DD_ACTION_EXECUTION_ID
       }
     }
 

--- a/packages/dd-trace/src/plugins/util/tags.js
+++ b/packages/dd-trace/src/plugins/util/tags.js
@@ -31,6 +31,7 @@ const CI_PROVIDER_NAME = 'ci.provider.name'
 const CI_WORKSPACE_PATH = 'ci.workspace_path'
 const CI_JOB_URL = 'ci.job.url'
 const CI_JOB_NAME = 'ci.job.name'
+const CI_JOB_ID = 'ci.job.id'
 const CI_STAGE_NAME = 'ci.stage.name'
 const CI_NODE_NAME = 'ci.node.name'
 const CI_NODE_LABELS = 'ci.node.labels'
@@ -69,6 +70,7 @@ module.exports = {
   CI_WORKSPACE_PATH,
   CI_JOB_URL,
   CI_JOB_NAME,
+  CI_JOB_ID,
   CI_STAGE_NAME,
   CI_ENV_VARS,
   CI_NODE_NAME,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds the `ci.job.id` tag for some of the CI providers that reports this data.

### Motivation
<!-- What inspired you to submit this pull request? -->
Some of our users expected to have a `ci.job.id`.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.


