### PR TITLE
ci: clean up code in integration tests helper

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -288,7 +288,7 @@ function telemetryForwarder (shouldExpectTelemetryPoints = true) {
   return cleanup
 }
 
-async function curl (url, useHttp2 = false) {
+async function curl (url) {
   if (url !== null && typeof url === 'object') {
     if (url.then) {
       return curl(await url)


### PR DESCRIPTION
The 2nd argument to the `curl` function was never used.