### PR TITLE
update audit workflow to only run when lockfile is changed

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,8 @@ on:
       - yarn.lock
   push:
     branches: [master]
+    paths:
+      - yarn.lock
   schedule:
     - cron: 0 4 * * *
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update audit workflow to only run when lockfile is changed.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise the main branch can start randomly failing when a new vulnerability is detected. We already have the nightly that runs every day which should be enough to catch vulnerabilities early without causing unnecessary noise, blocked PRs and potential code freezes.