### PR TITLE
add release proposal script based on octo-sts policy

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -2,6 +2,13 @@ name: '[Release Proposal]'
 
 on:
   workflow_dispatch:
+    inputs:
+      authentication:
+        type: choice
+        description: Authentication strategy to retrieve the GitHub token.
+        options:
+          - github-app
+          - octo-sts
   schedule:
     - cron: 0 5 * * *
 
@@ -10,7 +17,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  create-proposal:
+  # TODO: Remove this strategy entirely once Octo-STS works properly.
+  create-proposal-github-app:
+    if: inputs.authentication == 'github-app'
     strategy:
       fail-fast: false
       matrix:
@@ -38,3 +47,38 @@ jobs:
       - run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  create-proposal-octo-sts:
+    if: inputs.authentication == 'octo-sts'
+    strategy:
+      fail-fast: false
+      matrix:
+        release-line: ['5']
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      #<TESTING> Only required for debugging, remove afterwards
+      - name: Debug OIDC Claims
+        uses: github/actions-oidc-debugger@36a60c31d7af9b718b4ca7152ba24229a15241ad # main
+        with:
+          audience: "octo-debugger"
+      #</TESTING>
+      - uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-js
+          policy: release-proposal
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.octo-sts.outputs.token }}
+      - uses: ./.github/actions/node
+        with:
+          version: ''
+      - uses: ./.github/actions/install/branch-diff
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+      - run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add release proposal script based on octo-sts policy.

### Motivation
<!-- What inspired you to submit this pull request? -->

We're phasing out the GitHub app to make it easier and more secure to control permissions per workflow.

### Additional Notes

I split the workflow in 2 for now so that we can keep using the old strategy temporarily while the new strategy is being tested. This is because the YAML needs to be merged to the main branch otherwise it won't work, and I don't want to break the functionality there.