### PR TITLE
chore: revert force-upgrade of form-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,6 @@
     "yarn-deduplicate": "^6.0.2"
   },
   "resolutions": {
-    "eslint-plugin-unicorn/@eslint/plugin-kit": "0.3.3",
-    "axios/form-data": "^4.0.4"
+    "eslint-plugin-unicorn/@eslint/plugin-kit": "0.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,7 +2258,7 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.0, form-data@^4.0.4:
+form-data@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==


### PR DESCRIPTION
This was added in #6144. The `resolutions` field should only be used as a last resort. In this case the `form-data` dev-sub-dependency could just have been upgraded by bumping it in `yarn.lock` as it was within the decided semver range.