### PR TITLE
chore: upgrade eslint-plugin-unicorn to v60.0.0

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -408,6 +408,9 @@ export default [
       'unicorn/prefer-at': 'off', // 17 errors | Difficult to fix
       'unicorn/prevent-abbreviations': 'off', // too strict
 
+      // These rules require a newer Node.js version than we support
+      'unicorn/no-array-reverse': 'off', // Node.js 20
+
       // These rules could potentially evaluated again at a much later point
       'unicorn/no-array-callback-reference': 'off',
       'unicorn/no-for-loop': 'off', // Activate if this is resolved https://github.com/sindresorhus/eslint-plugin-unicorn/issues/2664

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "eslint-plugin-mocha": "^10.5.0",
     "eslint-plugin-n": "^17.20.0",
     "eslint-plugin-promise": "^7.2.1",
-    "eslint-plugin-unicorn": "^59.0.1",
+    "eslint-plugin-unicorn": "^60.0.0",
     "express": "^5.1.0",
     "get-port": "^5.1.1",
     "glob": "^7.2.3",
@@ -187,8 +187,5 @@
     "workerpool": "^9.2.0",
     "yaml": "^2.8.0",
     "yarn-deduplicate": "^6.0.2"
-  },
-  "resolutions": {
-    "eslint-plugin-unicorn/@eslint/plugin-kit": "0.3.3"
   }
 }

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -223,10 +223,31 @@ function getSuiteStatus (suiteStats) {
 }
 
 class CypressPlugin {
-  constructor () {
-    this._isInit = false
-    this.testEnvironmentMetadata = getTestEnvironmentMetadata(TEST_FRAMEWORK_NAME)
+  _isInit = false
+  testEnvironmentMetadata = getTestEnvironmentMetadata(TEST_FRAMEWORK_NAME)
 
+  finishedTestsByFile = {}
+  testStatuses = {}
+
+  isTestsSkipped = false
+  isSuitesSkippingEnabled = false
+  isCodeCoverageEnabled = false
+  isFlakyTestRetriesEnabled = false
+  isEarlyFlakeDetectionEnabled = false
+  isKnownTestsEnabled = false
+  earlyFlakeDetectionNumRetries = 0
+  testsToSkip = []
+  skippedTests = []
+  hasForcedToRunSuites = false
+  hasUnskippableSuites = false
+  unskippableSuites = []
+  knownTests = []
+  isTestManagementTestsEnabled = false
+  testManagementAttemptToFixRetries = 0
+  isImpactedTestsEnabled = false
+  modifiedTests = []
+
+  constructor () {
     const {
       [GIT_REPOSITORY_URL]: repositoryUrl,
       [GIT_COMMIT_SHA]: sha,
@@ -265,26 +286,6 @@ class CypressPlugin {
       commitHeadSha,
       commitHeadMessage
     }
-    this.finishedTestsByFile = {}
-    this.testStatuses = {}
-
-    this.isTestsSkipped = false
-    this.isSuitesSkippingEnabled = false
-    this.isCodeCoverageEnabled = false
-    this.isFlakyTestRetriesEnabled = false
-    this.isEarlyFlakeDetectionEnabled = false
-    this.isKnownTestsEnabled = false
-    this.earlyFlakeDetectionNumRetries = 0
-    this.testsToSkip = []
-    this.skippedTests = []
-    this.hasForcedToRunSuites = false
-    this.hasUnskippableSuites = false
-    this.unskippableSuites = []
-    this.knownTests = []
-    this.isTestManagementTestsEnabled = false
-    this.testManagementAttemptToFixRetries = 0
-    this.isImpactedTestsEnabled = false
-    this.modifiedTests = []
   }
 
   // Init function returns a promise that resolves with the Cypress configuration

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/index.js
@@ -4,9 +4,7 @@ const sensitiveHandler = require('./evidence-redaction/sensitive-handler')
 const { stringifyWithRanges } = require('./utils')
 
 class VulnerabilityFormatter {
-  constructor () {
-    this._redactVulnearbilities = true
-  }
+  _redactVulnearbilities = true
 
   setRedactVulnerabilities (shouldRedactVulnerabilities, redactionNamePattern, redactionValuePattern) {
     this._redactVulnearbilities = shouldRedactVulnerabilities

--- a/packages/dd-trace/src/datastreams/schemas/schema_builder.js
+++ b/packages/dd-trace/src/datastreams/schemas/schema_builder.js
@@ -66,17 +66,13 @@ class SchemaBuilder {
 }
 
 class OpenApiSchema {
-  constructor () {
-    this.openapi = '3.0.0'
-    this.components = new OpenApiComponents()
-  }
+  openapi = '3.0.0'
+  components = new OpenApiComponents()
 }
 
 OpenApiSchema.SCHEMA = class {
-  constructor () {
-    this.type = 'object'
-    this.properties = {}
-  }
+  type = 'object'
+  properties = {}
 }
 
 OpenApiSchema.PROPERTY = class {

--- a/packages/dd-trace/src/datastreams/schemas/schema_sampler.js
+++ b/packages/dd-trace/src/datastreams/schemas/schema_sampler.js
@@ -3,10 +3,8 @@
 const SAMPLE_INTERVAL_MILLIS = 30 * 1000
 
 class SchemaSampler {
-  constructor () {
-    this.weight = 0
-    this.lastSampleMs = 0
-  }
+  weight = 0
+  lastSampleMs = 0
 
   trySample (currentTimeMs) {
     if (currentTimeMs >= this.lastSampleMs + SAMPLE_INTERVAL_MILLIS) {

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -375,10 +375,10 @@ function createPossionProcessSamplingFilter (samplingIntervalMillis) {
  * source with a sampling event filter and an event serializer.
  */
 class EventsProfiler {
-  constructor (options = {}) {
-    this.type = 'events'
-    this.eventSerializer = new EventSerializer()
+  type = 'events'
+  eventSerializer = new EventSerializer()
 
+  constructor (options = {}) {
     const eventHandler = event => this.eventSerializer.addEvent(event)
     const eventFilter = options.timelineSamplingEnabled
       // options.samplingInterval comes in microseconds, we need millis

--- a/packages/dd-trace/src/profiling/profilers/space.js
+++ b/packages/dd-trace/src/profiling/profilers/space.js
@@ -8,13 +8,14 @@ function strategiesToCallbackMode (strategies, callbackMode) {
 }
 
 class NativeSpaceProfiler {
+  type = 'space'
+  _pprof
+  _started = false
+
   constructor (options = {}) {
-    this.type = 'space'
     this._samplingInterval = options.heapSamplingInterval || 512 * 1024
     this._stackDepth = options.stackDepth || 64
-    this._pprof = undefined
     this._oomMonitoring = options.oomMonitoring || {}
-    this._started = false
   }
 
   start ({ mapper, nearOOMCallback } = {}) {

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -69,8 +69,12 @@ function ensureChannelsActivated () {
 }
 
 class NativeWallProfiler {
+  type = 'wall'
+  _mapper
+  _pprof
+  _started = false
+
   constructor (options = {}) {
-    this.type = 'wall'
     this._samplingIntervalMicros = options.samplingInterval || 1e6 / 99 // 99hz
     this._flushIntervalMillis = options.flushInterval || 60 * 1e3 // 60 seconds
     this._codeHotspotsEnabled = !!options.codeHotspotsEnabled
@@ -86,8 +90,6 @@ class NativeWallProfiler {
     // cpu profiling is enabled.
     this._withContexts = this._captureSpanData || this._timelineEnabled || this._cpuProfilingEnabled
     this._v8ProfilerBugWorkaroundEnabled = !!options.v8ProfilerBugWorkaroundEnabled
-    this._mapper = undefined
-    this._pprof = undefined
 
     // Bind these to this so they can be used as callbacks
     if (this._withContexts && this._captureSpanData) {
@@ -97,7 +99,6 @@ class NativeWallProfiler {
     this._generateLabels = this._generateLabels.bind(this)
 
     this._logger = options.logger
-    this._started = false
   }
 
   codeHotspotsEnabled () {

--- a/packages/dd-trace/src/remote_config/scheduler.js
+++ b/packages/dd-trace/src/remote_config/scheduler.js
@@ -1,8 +1,9 @@
 'use strict'
 
 class Scheduler {
+  _timer = null
+
   constructor (callback, interval) {
-    this._timer = null
     this._callback = callback
     this._interval = interval
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,7 +106,7 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
-"@babel/helper-validator-identifier@^7.25.9", "@babel/helper-validator-identifier@^7.27.1":
+"@babel/helper-validator-identifier@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
   integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
@@ -265,7 +265,7 @@
     module-details-from-path "^1.0.3"
     node-gyp-build "^4.5.0"
 
-"@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.0", "@eslint-community/eslint-utils@^4.5.1", "@eslint-community/eslint-utils@^4.7.0":
+"@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0", "@eslint-community/eslint-utils@^4.5.0", "@eslint-community/eslint-utils@^4.7.0":
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz#607084630c6c033992a082de6e6fbc1a8b52175a"
   integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
@@ -323,15 +323,7 @@
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.6.tgz#58369ab5b5b3ca117880c0f6c0b0f32f6950f24f"
   integrity sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==
 
-"@eslint/plugin-kit@0.3.3", "@eslint/plugin-kit@^0.2.7":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz#32926b59bd407d58d817941e48b2a7049359b1fd"
-  integrity sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==
-  dependencies:
-    "@eslint/core" "^0.15.1"
-    levn "^0.4.1"
-
-"@eslint/plugin-kit@^0.3.1":
+"@eslint/plugin-kit@^0.3.1", "@eslint/plugin-kit@^0.3.3":
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz#c6b9f165e94bf4d9fdd493f1c028a94aaf5fc1cc"
   integrity sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==
@@ -1307,6 +1299,11 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+change-case@^5.4.4:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.4.4.tgz#0d52b507d8fb8f204343432381d1a6d7bff97a02"
+  integrity sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==
+
 check-error@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
@@ -1341,7 +1338,7 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^4.2.0:
+ci-info@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.3.0.tgz#c39b1013f8fdbd28cd78e62318357d02da160cd7"
   integrity sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==
@@ -1503,7 +1500,7 @@ cookie@^0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-core-js-compat@^3.41.0:
+core-js-compat@^3.44.0:
   version "3.44.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.44.0.tgz#62b9165b97e4cbdb8bca16b14818e67428b4a0f8"
   integrity sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==
@@ -1944,27 +1941,28 @@ eslint-plugin-promise@^7.2.1:
   dependencies:
     "@eslint-community/eslint-utils" "^4.4.0"
 
-eslint-plugin-unicorn@^59.0.1:
-  version "59.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-59.0.1.tgz#e76ca18f6b92633440973e5442923a36544a1422"
-  integrity sha512-EtNXYuWPUmkgSU2E7Ttn57LbRREQesIP1BiLn7OZLKodopKfDXfBUkC/0j6mpw2JExwf43Uf3qLSvrSvppgy8Q==
+eslint-plugin-unicorn@^60.0.0:
+  version "60.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-60.0.0.tgz#68f712bcb17e94bd176cce7312647ba1d1409c3c"
+  integrity sha512-QUzTefvP8stfSXsqKQ+vBQSEsXIlAiCduS/V1Em+FKgL9c21U/IIm20/e3MFy1jyCf14tHAhqC1sX8OTy6VUCg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.25.9"
-    "@eslint-community/eslint-utils" "^4.5.1"
-    "@eslint/plugin-kit" "^0.2.7"
-    ci-info "^4.2.0"
+    "@babel/helper-validator-identifier" "^7.27.1"
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@eslint/plugin-kit" "^0.3.3"
+    change-case "^5.4.4"
+    ci-info "^4.3.0"
     clean-regexp "^1.0.0"
-    core-js-compat "^3.41.0"
+    core-js-compat "^3.44.0"
     esquery "^1.6.0"
     find-up-simple "^1.0.1"
-    globals "^16.0.0"
+    globals "^16.3.0"
     indent-string "^5.0.0"
     is-builtin-module "^5.0.0"
     jsesc "^3.1.0"
     pluralize "^8.0.0"
     regexp-tree "^0.1.27"
     regjsparser "^0.12.0"
-    semver "^7.7.1"
+    semver "^7.7.2"
     strip-indent "^4.0.0"
 
 eslint-scope@^8.4.0:
@@ -2447,7 +2445,7 @@ globals@^15.11.0, globals@^15.15.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-15.15.0.tgz#7c4761299d41c32b075715a4ce1ede7897ff72a8"
   integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
 
-globals@^16.0.0, globals@^16.2.0:
+globals@^16.2.0, globals@^16.3.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-16.3.0.tgz#66118e765ddaf9e2d880f7e17658543f93f1f667"
   integrity sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==
@@ -4155,7 +4153,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.1, semver@^7.7.2:
+semver@^7.5.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.3, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==


### PR DESCRIPTION
### What does this PR do?

This PR does two things:
1. Upgrade `eslint-plugin-unicorn` from v59.x to v60.x.
2. Fix any linting rule errors that resulted from the upgrade.

### Motivation

This upgrades a vulnerable dependency, so that we no longer have to use the `resolutions` field in `package.json` to force-upgrade it.

### Additional Notes

The minimum support Node.js version of `eslint-plugin-unicorn` v60 is changed from v18.20.0 is to v20.10.0. However, this shouldn't be an problem, since we run the linter on the currently active LTS version of Node.js (which as of this writing is version 22).