### PR TITLE
retry mocha tests automatically on the main branch

### DIFF
--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   tracing-macos:
     runs-on: macos-latest

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 # TODO: upstream jobs
 
 jobs:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   macos:
     runs-on: macos-latest

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   ubuntu:
     strategy:

--- a/.github/workflows/lambda.yml
+++ b/.github/workflows/lambda.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   sdk:
     strategy:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 # TODO: upstream jobs
 
 jobs:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   macos:
     runs-on: macos-latest

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  MOCHA_OPTIONS: ${{ github.ref == 'refs/head/master' && '-- retries 1' }}
+
 jobs:
   benchmarks-e2e:
     name: Performance and correctness tests

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -92,7 +92,7 @@ describe('Plugin', () => {
           express = require(`../../../versions/express@${version}`).get()
         })
 
-        it('should do automatic instrumentation on app routes', done => {
+        it.only('should do automatic instrumentation on app routes', done => {
           const app = express()
 
           app.get('/user', (req, res) => {
@@ -123,6 +123,8 @@ describe('Plugin', () => {
               .get(`http://localhost:${port}/user`)
               .catch(done)
           })
+
+          throw new Error('kaboom')
         })
 
         it('should do automatic instrumentation on routers', done => {

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -92,7 +92,7 @@ describe('Plugin', () => {
           express = require(`../../../versions/express@${version}`).get()
         })
 
-        it.only('should do automatic instrumentation on app routes', done => {
+        it('should do automatic instrumentation on app routes', done => {
           const app = express()
 
           app.get('/user', (req, res) => {
@@ -123,8 +123,6 @@ describe('Plugin', () => {
               .get(`http://localhost:${port}/user`)
               .catch(done)
           })
-
-          throw new Error('kaboom')
         })
 
         it('should do automatic instrumentation on routers', done => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Retry mocha tests automatically on the main branch.

### Motivation
<!-- What inspired you to submit this pull request? -->

I originally added automatic retries on the whole workflows. However, this pollutes the output a lot as each retry is also its own workflow run which always happens even if not needed. It can also cause a race condition with All Green depending on when the API polling happens, and it takes longer since all tests must be finished for the workflow to complete.

Basically, the only advantage of retrying at the workflow level is to retry any infrastructure related failure, for example a Docker Hub outage, but this should be the exception and not the norm, and retrying at the test level would be faster and a better user experience. We will still be able to capture flakiness from any retries in PRs instead, which is actually where there is a real impact.

I will leave the Retry workflow enabled for now to observe the effect for a few days and will then open a PR to remove it.