### PR TITLE
[CO] Add support for Express .use() routes

### DIFF
--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -146,7 +146,7 @@ function createWrapRouterMethod (name) {
       }
 
       if (routeAddedChannel.hasSubscribers) {
-        routeAddedChannel.publish({ topOfStackFunc: methodWithTrace, layer: this.stack[0] })
+        routeAddedChannel.publish({ topOfStackFunc: methodWithTrace, layer: this.stack.at(-1) })
       }
 
       if (this.stack.length > offset) {

--- a/packages/datadog-plugin-express/test/code_origin.spec.js
+++ b/packages/datadog-plugin-express/test/code_origin.spec.js
@@ -87,6 +87,17 @@ describe('Plugin', () => {
               await assertCodeOrigin('/v1/user', { line, method: 'testCase', type: 'Context' })
             })
 
+            it('should support .use() routes', async function testCase () {
+              app.get('/route_before', (req, res) => res.end())
+              const line = getNextLineNumber()
+              app.use('/foo', (req, res) => {
+                res.end()
+              })
+              app.get('/route_after', (req, res) => res.end())
+
+              await assertCodeOrigin('/foo/bar', { line, method: 'testCase', type: 'Context' })
+            })
+
             it('should point to route handler even if passed through a middleware', async function testCase () {
               app.use((req, res, next) => {
                 next()


### PR DESCRIPTION
### What does this PR do?

Add support in Code Origin, for Express routes added using the `.use()` method. This will indirectly also add support for a lot of 3rd party modules which uses this aproch to attach themselves with a route prefix to an Express app.

Example route definition:

```js
app.use('/foo', (res, res) => {
  res.end('hello world')
})
```

The above route is special, as it can not only be requested as `/foo`, but also `/foo/bar` etc, which is why it's often a way for 3rd party modules to attach themselves with a route prefix and do their own internal route handling.

### Motivation

Improve support for Express.
