### PR TITLE
change config.logInjection default to true

### DIFF
--- a/integration-tests/telemetry.spec.js
+++ b/integration-tests/telemetry.spec.js
@@ -66,7 +66,7 @@ describe('telemetry', () => {
       await agent.assertTelemetryReceived(msg => {
         const { configuration } = msg.payload.payload
         assertObjectContains(configuration, [
-          { name: 'DD_LOG_INJECTION', value: 'structured', origin: 'default' },
+          { name: 'DD_LOG_INJECTION', value: true, origin: 'default' },
           { name: 'DD_LOG_INJECTION', value: true, origin: 'env_var' },
           { name: 'DD_LOG_INJECTION', value: false, origin: 'code' }
         ])

--- a/packages/datadog-plugin-bunyan/src/index.js
+++ b/packages/datadog-plugin-bunyan/src/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const StructuredLogPlugin = require('../../dd-trace/src/plugins/structured_log_plugin')
+const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
 
-class BunyanPlugin extends StructuredLogPlugin {
+class BunyanPlugin extends LogPlugin {
   static get id () {
     return 'bunyan'
   }

--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const StructuredLogPlugin = require('../../dd-trace/src/plugins/structured_log_plugin')
+const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
 
-class PinoPlugin extends StructuredLogPlugin {
+class PinoPlugin extends LogPlugin {
   static get id () {
     return 'pino'
   }

--- a/packages/datadog-plugin-winston/src/index.js
+++ b/packages/datadog-plugin-winston/src/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const StructuredLogPlugin = require('../../dd-trace/src/plugins/structured_log_plugin')
+const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
 
-class WinstonPlugin extends StructuredLogPlugin {
+class WinstonPlugin extends LogPlugin {
   static get id () {
     return 'winston'
   }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -571,7 +571,7 @@ class Config {
     defaults.testManagementAttemptToFixRetries = 20
     defaults.isTestManagementEnabled = false
     defaults.isImpactedTestsEnabled = false
-    defaults.logInjection = 'structured'
+    defaults.logInjection = true
     defaults.lookup = undefined
     defaults.inferredProxyServicesEnabled = false
     defaults.memcachedCommandEnabled = false

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -45,14 +45,10 @@ module.exports = class LogPlugin extends Plugin {
     })
   }
 
-  _isEnabled (config) {
-    return config.enabled && (config.logInjection === true || config.ciVisAgentlessLogSubmissionEnabled)
-  }
-
   configure (config) {
     return super.configure({
       ...config,
-      enabled: this._isEnabled(config)
+      enabled: config.enabled && (config.logInjection || config.ciVisAgentlessLogSubmissionEnabled)
     })
   }
 }

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -437,7 +437,7 @@ describe('Config', () => {
       { name: 'ciVisibilityTestSessionName', value: '', origin: 'default' },
       { name: 'ciVisAgentlessLogSubmissionEnabled', value: false, origin: 'default' },
       { name: 'isTestDynamicInstrumentationEnabled', value: false, origin: 'default' },
-      { name: 'logInjection', value: 'structured', origin: 'default' },
+      { name: 'logInjection', value: true, origin: 'default' },
       { name: 'lookup', value: undefined, origin: 'default' },
       { name: 'middlewareTracingEnabled', value: true, origin: 'default' },
       { name: 'openai.spanCharLimit', value: 128, origin: 'default' },

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -3,7 +3,6 @@
 require('../setup/tap')
 
 const LogPlugin = require('../../src/plugins/log_plugin')
-const BunyanPlugin = require('../../../datadog-plugin-bunyan/src/index')
 const Tracer = require('../../src/tracer')
 const Config = require('../../src/config')
 

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -30,7 +30,7 @@ const tracer = new Tracer(new Config({
   ...config
 }))
 
-let plugin = new TestLog({
+const plugin = new TestLog({
   _tracer: tracer
 })
 plugin.configure({
@@ -64,44 +64,6 @@ describe('LogPlugin', () => {
       // Should have trace/span data when none is active
       expect(message.dd).to.have.property('trace_id', span.context().toTraceId(true))
       expect(message.dd).to.have.property('span_id', span.context().toSpanId())
-    })
-  })
-
-  it('should inject logs for only structured loggers when logInjection is structured', () => {
-    plugin.configure({
-      logInjection: 'structured',
-      enabled: true
-    })
-    const unstructuredLoggerSpan = tracer.startSpan('unstructured logger')
-
-    tracer.scope().activate(unstructuredLoggerSpan, () => {
-      const data = { message: {} }
-      testLogChannel.publish(data)
-      const { message } = data
-
-      expect(message.dd).to.be.undefined
-    })
-
-    plugin = new BunyanPlugin({
-      _tracer: tracer
-    })
-    plugin.configure({
-      logInjection: 'structured',
-      enabled: true
-    })
-
-    const structuredLoggerSpan = tracer.startSpan('structured logger')
-    const structuredLogChannel = channel('apm:bunyan:log')
-
-    tracer.scope().activate(structuredLoggerSpan, () => {
-      const data = { message: {} }
-      structuredLogChannel.publish(data)
-      const { message } = data
-
-      expect(message.dd).to.contain(config)
-
-      expect(message.dd).to.have.property('trace_id', structuredLoggerSpan.context().toTraceId(true))
-      expect(message.dd).to.have.property('span_id', structuredLoggerSpan.context().toSpanId())
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?
update config.logInjection to true, following [Phase 1 of this RFC](https://docs.google.com/document/d/1Okl7hQcJgA9NdQ8msSVu5P2cPQOx139K9s9f3C_bTho/edit?pli=1&tab=t.0#heading=h.8bk1fwns0kh9)
Phase 2 is skipped since dd-trace-js currently does not support any unstructured loggers

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


