### PR TITLE
add dependabot automation for test versions

### DIFF
--- a/.github/chainguard/dependabot-automation.sts.yaml
+++ b/.github/chainguard/dependabot-automation.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-js:pull_request
+
+claim_pattern:
+  event_name: pull_request_target
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/heads/master
+
+permissions:
+  contents: read
+  pull_requests: write

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -8,23 +8,30 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
+      - uses: DataDog/dd-octo-sts-action@08f2144903ced3254a3dafec2592563409ba2aa0 # v1.0.1
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-js
+          policy: dependabot-automation
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # 2.4.0
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ steps.octo-sts.outputs.token }}"
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.dependency-group == 'test-versions'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       - name: Approve a PR
         if: steps.metadata.outputs.dependency-group == 'test-versions'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -1,0 +1,30 @@
+name: 'Dependabot Automation'
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # 2.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.dependency-group == 'test-versions'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve a PR
+        if: steps.metadata.outputs.dependency-group == 'test-versions'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -2,10 +2,6 @@ name: 'Dependabot Automation'
 
 on: pull_request_target
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   dependabot:
     if: github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -3,6 +3,7 @@ name: Retry
 on:
   workflow_run:
     branches:
+      - dependabot/*
       - master
       - v[0-9]+.[0-9]+.[0-9]+-proposal
       - v[0-9]+.x

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -163,6 +163,7 @@ checkPlugins(path.join(__dirname, '..', '.github', 'workflows', 'test-optimizati
 const IGNORED_WORKFLOWS = {
   all: [
     'codeql-analysis.yml',
+    'dependabot-automation.yml',
     'flakiness.yml',
     'pr-labels.yml',
     'release-3.yml',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add dependabot automation for test versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Dependabot updates are already annoying, so this attempts to auto-merge anything that can be without human interaction for the test versions used for plugin tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

~Will only actually start running when #6169 lands.~ PR has landed.

