### PR TITLE
use datadog sca for vulnerability detection

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,14 +2,8 @@ name: Audit
 
 on:
   pull_request:
-    paths:
-      - yarn.lock
-  push:
-    branches: [master]
-    paths:
-      - yarn.lock
-  schedule:
-    - cron: 0 4 * * *
+    branches:
+      - dependabot/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/scripts/verify-ci-config.js
+++ b/scripts/verify-ci-config.js
@@ -162,6 +162,7 @@ checkPlugins(path.join(__dirname, '..', '.github', 'workflows', 'test-optimizati
 
 const IGNORED_WORKFLOWS = {
   all: [
+    'audit.yml',
     'codeql-analysis.yml',
     'flakiness.yml',
     'pr-labels.yml',
@@ -174,7 +175,6 @@ const IGNORED_WORKFLOWS = {
     'retry.yml'
   ],
   trigger_pull_request: [
-    'audit.yml',
     'eslint-rules.yml',
     'stale.yml'
   ],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove audit workflow in favour of Datadog SCA.

### Motivation
<!-- What inspired you to submit this pull request? -->

This has several benefits:

- Datadog SCA is a lot more powerful:
    - It collects its data from more sources than a simple `npm audit` and it keeps historical data.
    - It can detect non-npm vulnerabilities.
    - It can also be used for other types of security and code quality issues.
    - It supports alerting us immediately when the vulnerability is detected without waiting for our CI to run.
- Stop blocking PRs for unrelated changes that also touch `package.json` or `yarn.lock`.
    - This is especially true for vulnerabilities that don't have a release with a fix yet.
- Stop broadcasting vulnerabilities publicly while we work on fixing them.
- Allow ignoring specific vulnerabilities, for example if they are known to not affect us and we cannot update because of Node version support.

I kept the workflow only for Dependabot branches, because those branches should auto-merge whenever possible, and without human interaction we need some guardrail in place to block on detection.

