### PR TITLE
switch to npm for test sandbox packaging

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -12,6 +12,7 @@ const assert = require('assert')
 const rimraf = promisify(require('rimraf'))
 const FakeAgent = require('./fake-agent')
 const id = require('../../packages/dd-trace/src/id')
+const { version } = require('../../package.json')
 
 const hookFile = 'dd-trace/loader-hook.mjs'
 
@@ -182,14 +183,14 @@ async function createSandbox (dependencies = [], isGitRepo = false,
     return { folder: path.join(process.cwd(), 'integration-tests'), remove: async () => {} }
   }
   const folder = path.join(os.tmpdir(), id().toString())
-  const out = path.join(folder, 'dd-trace.tgz')
+  const out = path.join(folder, `dd-trace-${version}.tgz`)
   const allDependencies = [`file:${out}`].concat(dependencies)
 
   fs.mkdirSync(folder)
   const preferOfflineFlag = process.env.OFFLINE === '1' || process.env.OFFLINE === 'true' ? ' --prefer-offline' : ''
   const addCommand = `yarn add ${allDependencies.join(' ')} --ignore-engines${preferOfflineFlag}`
   const addOptions = { cwd: folder, env: restOfEnv }
-  await exec(`yarn pack --filename ${out}`, { env: restOfEnv }) // TODO: cache this
+  await exec(`npm pack --silent --pack-destination ${folder}`, { env: restOfEnv }) // TODO: cache this
 
   try {
     await exec(addCommand, addOptions)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch to npm for test sandbox packaging.

### Motivation
<!-- What inspired you to submit this pull request? -->

npm is about twice faster at packaging.