### PR TITLE
[test-optimization] [SDTEST-2282] Modify `ci.job.id` tag on BuildKite

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -522,8 +522,7 @@ module.exports = {
         BUILDKITE_MESSAGE,
         BUILDKITE_AGENT_ID,
         BUILDKITE_PULL_REQUEST,
-        BUILDKITE_PULL_REQUEST_BASE_BRANCH,
-        BUILDKITE_CI_JOB_ID
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH
       } = env
 
       const extraTags = Object.keys(env).filter(envVar =>
@@ -555,7 +554,7 @@ module.exports = {
         [CI_NODE_NAME]: BUILDKITE_AGENT_ID,
         [CI_NODE_LABELS]: JSON.stringify(extraTags),
         [PR_NUMBER]: BUILDKITE_PULL_REQUEST,
-        [CI_JOB_ID]: BUILDKITE_CI_JOB_ID
+        [CI_JOB_ID]: BUILDKITE_JOB_ID
       }
 
       if (BUILDKITE_PULL_REQUEST) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR modifies where we get the `ci.job.id`. We should return it from the `BUILDKITE_JOB_ID`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


