### PR TITLE
add manual checkpoint parameter to consume DSM API

### DIFF
--- a/packages/dd-trace/src/datastreams/checkpointer.js
+++ b/packages/dd-trace/src/datastreams/checkpointer.js
@@ -9,6 +9,12 @@ class DataStreamsCheckpointer {
     this.dsmProcessor = tracer._dataStreamsProcessor
   }
 
+  /**
+   * @param {string} type - The type of the checkpoint, usually the streaming technology being used.
+   *                       Examples include kafka, kinesis, sns etc.
+   * @param {string} target - The target of data. This can be a topic, exchange or stream name.
+   * @param {Object} carrier - The carrier object to inject context into.
+   */
   setProduceCheckpoint (type, target, carrier) {
     if (!this.config.dsmEnabled) return
 
@@ -23,6 +29,15 @@ class DataStreamsCheckpointer {
     this.tracer.inject(ctx, 'text_map_dsm', carrier)
   }
 
+  /**
+   * @param {string} type - The type of the checkpoint, usually the streaming technology being used.
+   *                       Examples include kafka, kinesis, sns etc.
+   * @param {string} source - The source of data. This can be a topic, exchange or stream name.
+   * @param {Object} carrier - The carrier object to extract context from.
+   * @param {boolean} [manualCheckpoint=true] - Whether this checkpoint was manually set. Keep true if manually instrumenting.
+   *                                           Manual instrumentation always overrides automatic instrumentation in the case a call is both
+   *                                           manually and automatically instrumented.
+   */
   setConsumeCheckpoint (type, source, carrier, manualCheckpoint = true) {
     if (!this.config.dsmEnabled) return
 

--- a/packages/dd-trace/src/datastreams/checkpointer.js
+++ b/packages/dd-trace/src/datastreams/checkpointer.js
@@ -23,14 +23,19 @@ class DataStreamsCheckpointer {
     this.tracer.inject(ctx, 'text_map_dsm', carrier)
   }
 
-  setConsumeCheckpoint (type, source, carrier) {
+  setConsumeCheckpoint (type, source, carrier, manualCheckpoint = true) {
     if (!this.config.dsmEnabled) return
 
     const parentCtx = this.tracer.extract('text_map_dsm', carrier)
     DataStreamsContext.setDataStreamsContext(parentCtx)
 
+    const tags = ['type:' + type, 'topic:' + source, 'direction:in']
+    if (manualCheckpoint) {
+      tags.push('manual_checkpoint:true')
+    }
+
     const ctx = this.dsmProcessor.setCheckpoint(
-      ['type:' + type, 'topic:' + source, 'direction:in', 'manual_checkpoint:true'],
+      tags,
       null,
       parentCtx,
       null

--- a/packages/dd-trace/src/datastreams/checkpointer.js
+++ b/packages/dd-trace/src/datastreams/checkpointer.js
@@ -34,9 +34,10 @@ class DataStreamsCheckpointer {
    *                       Examples include kafka, kinesis, sns etc.
    * @param {string} source - The source of data. This can be a topic, exchange or stream name.
    * @param {Object} carrier - The carrier object to extract context from.
-   * @param {boolean} [manualCheckpoint=true] - Whether this checkpoint was manually set. Keep true if manually instrumenting.
-   *                                           Manual instrumentation always overrides automatic instrumentation in the case a call is both
-   *                                           manually and automatically instrumented.
+   * @param {boolean} [manualCheckpoint=true] - Whether this checkpoint was manually set. Keep true if manually
+   *                                           instrumenting. Manual instrumentation always overrides automatic
+   *                                           instrumentation in the case a call is both manually and automatically
+   *                                           instrumented.
    */
   setConsumeCheckpoint (type, source, carrier, manualCheckpoint = true) {
     if (!this.config.dsmEnabled) return

--- a/packages/dd-trace/test/datastreams/data_streams_checkpointer.spec.js
+++ b/packages/dd-trace/test/datastreams/data_streams_checkpointer.spec.js
@@ -70,4 +70,21 @@ describe('data streams checkpointer manual api', () => {
 
     expect(DSM_CONTEXT_HEADER in headers).to.equal(true)
   })
+
+  it('should test manual checkpoint behavior', function () {
+    const headers = {}
+    const mockSetCheckpoint = sinon.stub().returns({ hash: Buffer.from([1, 2, 3, 4]) })
+
+    tracer._tracer._dataStreamsProcessor.setCheckpoint = mockSetCheckpoint
+
+    tracer.dataStreamsCheckpointer.setConsumeCheckpoint('kinesis', 'stream-123', headers)
+    let calledTags = mockSetCheckpoint.getCall(0).args[0]
+    expect(calledTags).to.include('manual_checkpoint:true')
+
+    mockSetCheckpoint.resetHistory()
+
+    tracer.dataStreamsCheckpointer.setConsumeCheckpoint('kinesis', 'stream-123', headers, false)
+    calledTags = mockSetCheckpoint.getCall(0).args[0]
+    expect(calledTags).to.not.include('manual_checkpoint:true')
+  })
 })

--- a/packages/dd-trace/test/datastreams/data_streams_checkpointer.spec.js
+++ b/packages/dd-trace/test/datastreams/data_streams_checkpointer.spec.js
@@ -71,20 +71,25 @@ describe('data streams checkpointer manual api', () => {
     expect(DSM_CONTEXT_HEADER in headers).to.equal(true)
   })
 
-  it('should test manual checkpoint behavior', function () {
+  it('should set manual checkpoint when setConsumeCheckpoint is called without additional parameters', function () {
     const headers = {}
     const mockSetCheckpoint = sinon.stub().returns({ hash: Buffer.from([1, 2, 3, 4]) })
 
     tracer._tracer._dataStreamsProcessor.setCheckpoint = mockSetCheckpoint
 
     tracer.dataStreamsCheckpointer.setConsumeCheckpoint('kinesis', 'stream-123', headers)
-    let calledTags = mockSetCheckpoint.getCall(0).args[0]
+    const calledTags = mockSetCheckpoint.getCall(0).args[0]
     expect(calledTags).to.include('manual_checkpoint:true')
+  })
 
-    mockSetCheckpoint.resetHistory()
+  it('should set an automatic checkpoint when setConsumeCheckpoint is called with manualCheckpoint:false', function () {
+    const headers = {}
+    const mockSetCheckpoint = sinon.stub().returns({ hash: Buffer.from([1, 2, 3, 4]) })
+
+    tracer._tracer._dataStreamsProcessor.setCheckpoint = mockSetCheckpoint
 
     tracer.dataStreamsCheckpointer.setConsumeCheckpoint('kinesis', 'stream-123', headers, false)
-    calledTags = mockSetCheckpoint.getCall(0).args[0]
+    const calledTags = mockSetCheckpoint.getCall(0).args[0]
     expect(calledTags).to.not.include('manual_checkpoint:true')
   })
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a manualCheckpoint parameter in the public dsm set_consume_checkpoint(), this allows one to turn off the manual_checkpoint:true tag if use of function is not for explicit purpose of manually instrumenting (default remains as manual instrumentation).

### Motivation
<!-- What inspired you to submit this pull request? -->
Wanting to use this public API in a non manual way in another repo

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


