### PR TITLE
add retry for npm/yarn install in benchmark runall script

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -27,8 +27,8 @@ fi
 
 (
   cd ../../ &&
-  npm install --global yarn \
-    && yarn install --ignore-engines \
+  npm install --global yarn || (sleep 60 && npm install --global yarn) \
+    && yarn install --ignore-engines || (sleep 60 && yarn install --ignore-engines) \
     && PLUGINS="bluebird|q|graphql|express" yarn services
 )
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

Prevents the job from failing like [this](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/jobs/1051639031) when the registry is having a small outage.