### PR TITLE
add error message when latest test version cannot be found

### DIFF
--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -112,6 +112,12 @@ async function assertFolder (name, version) {
  * @param {boolean} external
  */
 async function assertPackage (name, version, dependencyVersionRange, external) {
+  if (!latests[name]) {
+    throw new Error(
+      `Latest version for '${name}' needs to be defined in 'packages/dd-trace/test/plugins/versions/package.json'.`
+    )
+  }
+
   const alreadyCapped = dependencyVersionRange.includes('-')
   const cappedVersionRange = external || alreadyCapped
     ? dependencyVersionRange


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add error message when latest test version cannot be found.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now it just sets the value to `undefined` which results in a failure and a cryptic error message if the latest version isn't set.