### PR TITLE
Encode Javascript hashes with little-endian to be compatible with other languages in DSM

### DIFF
--- a/packages/datadog-plugin-amqplib/test/index.spec.js
+++ b/packages/datadog-plugin-amqplib/test/index.spec.js
@@ -320,20 +320,20 @@ describe('Plugin', () => {
               'type:rabbitmq'
             ], ENTRY_PARENT_HASH)
 
-            expectedProducerHashWithTopic = producerHashWithTopic.readBigUInt64BE(0).toString()
+            expectedProducerHashWithTopic = producerHashWithTopic.readBigUInt64LE(0).toString()
 
             expectedProducerHashWithExchange = computePathwayHash('test', 'tester', [
               'direction:out',
               'exchange:namedExchange',
               'has_routing_key:true',
               'type:rabbitmq'
-            ], ENTRY_PARENT_HASH).readBigUInt64BE(0).toString()
+            ], ENTRY_PARENT_HASH).readBigUInt64LE(0).toString()
 
             expectedConsumerHash = computePathwayHash('test', 'tester', [
               'direction:in',
               `topic:${queue}`,
               'type:rabbitmq'
-            ], producerHashWithTopic).readBigUInt64BE(0).toString()
+            ], producerHashWithTopic).readBigUInt64LE(0).toString()
           })
 
           it('Should emit DSM stats to the agent when sending a message on an unnamed exchange', done => {

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -210,13 +210,13 @@ describe('Kinesis', function () {
           ENTRY_PARENT_HASH
         )
 
-        expectedProducerHash = producerHash.readBigUInt64BE(0).toString()
+        expectedProducerHash = producerHash.readBigUInt64LE(0).toString()
         expectedConsumerHash = computePathwayHash(
           'test',
           'tester',
           ['direction:in', 'topic:' + streamNameDSM, 'type:kinesis'],
           producerHash
-        ).readBigUInt64BE(0).toString()
+        ).readBigUInt64LE(0).toString()
 
         createResources(streamNameDSM, done)
       })

--- a/packages/datadog-plugin-aws-sdk/test/sns.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.spec.js
@@ -496,8 +496,8 @@ describe('Sns', function () {
     })
 
     describe('Data Streams Monitoring', () => {
-      const expectedProducerHash = '5117773060236273241'
-      const expectedConsumerHash = '1353703578833511841'
+      const expectedProducerHash = '6441962419319932231'
+      const expectedConsumerHash = '11665883874244872466'
       let nowStub
 
       before(() => {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -440,13 +440,13 @@ describe('Plugin', () => {
             ENTRY_PARENT_HASH
           )
 
-          expectedProducerHash = producerHash.readBigUInt64BE(0).toString()
+          expectedProducerHash = producerHash.readBigUInt64LE(0).toString()
           expectedConsumerHash = computePathwayHash(
             'test',
             'tester',
             ['direction:in', 'topic:' + queueNameDSM, 'type:sqs'],
             producerHash
-          ).readBigUInt64BE(0).toString()
+          ).readBigUInt64LE(0).toString()
         })
 
         beforeEach(done => {

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -85,7 +85,7 @@ describe('Plugin', () => {
             const meta = {
               'span.kind': 'producer',
               component: 'kafkajs',
-              'pathway.hash': expectedProducerHash.readBigUInt64BE(0).toString(),
+              'pathway.hash': expectedProducerHash.readBigUInt64LE(0).toString(),
               'messaging.destination.name': testTopic,
               'messaging.kafka.bootstrap.servers': '127.0.0.1:9092'
             }
@@ -253,7 +253,7 @@ describe('Plugin', () => {
               meta: {
                 'span.kind': 'consumer',
                 component: 'kafkajs',
-                'pathway.hash': expectedConsumerHash.readBigUInt64BE(0).toString(),
+                'pathway.hash': expectedConsumerHash.readBigUInt64LE(0).toString(),
                 'messaging.destination.name': testTopic
               },
               resource: testTopic,

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -50,8 +50,8 @@ describe('Plugin', () => {
             connection.open_receiver('amq.topic')
           })
 
-          const expectedProducerHash = '15837999642856815456'
-          const expectedConsumerHash = '18403970455318595370'
+          const expectedProducerHash = '6952218661438409691'
+          const expectedConsumerHash = '3064432256082340095'
 
           it('Should set pathway hash tag on a span when producing', (done) => {
             let produceSpanMeta = {}

--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -17,8 +17,9 @@ const ENTRY_PARENT_HASH = Buffer.from('0000000000000000', 'hex')
 
 class StatsPoint {
   constructor (hash, parentHash, edgeTags) {
-    this.hash = hash.readBigUInt64BE()
-    this.parentHash = parentHash.readBigUInt64BE()
+    this.hash = hash.readBigUInt64LE()
+    this.parentHash = parentHash.readBigUInt64LE()
+
     this.edgeTags = edgeTags
     this.edgeLatency = new LogCollapsingLowestDenseDDSketch()
     this.pathwayLatency = new LogCollapsingLowestDenseDDSketch()
@@ -191,7 +192,7 @@ class DataStreamsProcessor {
       .addLatencies(checkpoint)
     // set DSM pathway hash on span to enable related traces feature on DSM tab, convert from buffer to uint64
     if (span) {
-      span.setTag(PATHWAY_HASH, checkpoint.hash.readBigUInt64BE(0).toString())
+      span.setTag(PATHWAY_HASH, checkpoint.hash.readBigUInt64LE(0).toString())
     }
   }
 

--- a/packages/dd-trace/test/datastreams/data_streams_checkpointer.spec.js
+++ b/packages/dd-trace/test/datastreams/data_streams_checkpointer.spec.js
@@ -4,8 +4,8 @@ require('../setup/tap')
 
 const agent = require('../plugins/agent')
 
-const expectedProducerHash = '11369286567396183453'
-const expectedConsumerHash = '11204511019589278729'
+const expectedProducerHash = '11316777716831864733'
+const expectedConsumerHash = '685328872879070794'
 const DSM_CONTEXT_HEADER = 'dd-pathway-ctx-base64'
 
 describe('data streams checkpointer manual api', () => {
@@ -34,9 +34,10 @@ describe('data streams checkpointer manual api', () => {
           }
         }
       }
+
       expect(statsPointsReceived).to.equal(1)
       expect(agent.dsmStatsExist(agent, expectedProducerHash, expectedEdgeTags)).to.equal(true)
-    }).then(done, done)
+    }, { timeoutMs: 5000 }).then(done, done)
 
     const headers = {}
 
@@ -60,10 +61,10 @@ describe('data streams checkpointer manual api', () => {
       }
       expect(statsPointsReceived).to.equal(2)
       expect(agent.dsmStatsExist(agent, expectedConsumerHash, expectedEdgeTags)).to.equal(true)
-    }).then(done, done)
+    }, { timeoutMs: 5000 }).then(done, done)
 
     const headers = {
-      [DSM_CONTEXT_HEADER]: 'tvMEiT2p8cjWzqLRnGTWzqLRnGQ=' // same context as previous produce
+      [DSM_CONTEXT_HEADER]: 'ncfR5V9FDZ3E58Cfj2LI2cOfj2I=' // same context as previous produce
     }
 
     tracer.dataStreamsCheckpointer.setConsumeCheckpoint('testConsume', 'test-queue', headers)

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -65,8 +65,8 @@ describe('StatsPoint', () => {
     payloadSize.accept(100)
 
     const encoded = aggStats.encode()
-    expect(encoded.Hash.toString(16)).to.equal(DEFAULT_CURRENT_HASH.toString('hex'))
-    expect(encoded.ParentHash.toString(16)).to.equal(DEFAULT_PARENT_HASH.toString('hex'))
+    expect(encoded.Hash).to.equal(DEFAULT_CURRENT_HASH.readBigUInt64LE())
+    expect(encoded.ParentHash).to.equal(DEFAULT_PARENT_HASH.readBigUInt64LE())
     expect(encoded.EdgeTags).to.deep.equal(aggStats.edgeTags)
     expect(encoded.EdgeLatency).to.deep.equal(edgeLatency.toProto())
     expect(encoded.PathwayLatency).to.deep.equal(pathwayLatency.toProto())
@@ -277,8 +277,8 @@ describe('DataStreamsProcessor', () => {
     payloadSize.accept(mockCheckpoint.payloadSize)
 
     const encoded = checkpointBucket.encode()
-    expect(encoded.Hash.toString(16)).to.equal(DEFAULT_CURRENT_HASH.toString('hex'))
-    expect(encoded.ParentHash.toString(16)).to.equal(DEFAULT_PARENT_HASH.toString('hex'))
+    expect(encoded.Hash).to.equal(DEFAULT_CURRENT_HASH.readBigUInt64LE())
+    expect(encoded.ParentHash).to.equal(DEFAULT_PARENT_HASH.readBigUInt64LE())
     expect(encoded.EdgeTags).to.deep.equal(mockCheckpoint.edgeTags)
     expect(encoded.EdgeLatency).to.deep.equal(edgeLatency.toProto())
     expect(encoded.PathwayLatency).to.deep.equal(pathwayLatency.toProto())
@@ -296,8 +296,8 @@ describe('DataStreamsProcessor', () => {
         Start: 1680000000000n,
         Duration: 10000000000n,
         Stats: [{
-          Hash: DEFAULT_CURRENT_HASH.readBigUInt64BE(),
-          ParentHash: DEFAULT_PARENT_HASH.readBigUInt64BE(),
+          Hash: DEFAULT_CURRENT_HASH.readBigUInt64LE(),
+          ParentHash: DEFAULT_PARENT_HASH.readBigUInt64LE(),
           EdgeTags: mockCheckpoint.edgeTags,
           EdgeLatency: edgeLatency.toProto(),
           PathwayLatency: pathwayLatency.toProto(),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This changes the encoding of hashes from big-endian to little-endian when we are sending the stats to the DSM backend.

Its a relatively small change, but this broke how DSM worked in systems with multiple languages, as every other language uses little endian. This meant that context propagation did not work across languages, the javascript producer would produce a hash in hex format of 8 bytes, broadcast a checkpoint having converted the hash to big endian and the consumer would pull that hash from the message headers, convert it to little endian and the numbers would not match. 

It was broken without a visual component for all queue technologies but in rabbitmq, it was also visually broken because of how rabbitmq associations work.


## Tests

### Before with rabbitmq
<img width="557" height="281" alt="CleanShot 2025-07-29 at 08 57 07" src="https://github.com/user-attachments/assets/55441332-fb76-42f4-9962-c13df28e3ae4" />
### After with rabbitmq
<img width="677" height="147" alt="CleanShot 2025-07-29 at 08 57 19" src="https://github.com/user-attachments/assets/ebe6acd5-e276-4a37-a247-3c5744cbeae6" />

### Kafka
<img width="829" height="232" alt="CleanShot 2025-07-29 at 08 57 32" src="https://github.com/user-attachments/assets/616faf0f-cb43-4e6e-a4c1-cf3bed4281b2" />

which i can see when I look at the checkpoints:
test 4 which doesn't work, has the following checkpoints:
```
{
"key": {
"service": "nodejs-kafka-producer-test4-eric.firth",
"hash": 12593296123675988000,
"parentHash": 0,
"edgeType": "kafka",
"edgeDirection": "out",
"group": "",
"topic": "endian-fix-validation-topic-test4",
"eventType": "",
"exchange": ""
},
"value": {}
},
{
"key": {
"service": "python-kafka-consumer-test4-eric.firth",
"hash": 15170800266638707000,
"parentHash": 11403507064061660000,
"edgeType": "kafka",
"edgeDirection": "in",
"group": "my_group",
"topic": "endian-fix-validation-topic-test4",
"eventType": "",
"exchange": ""
},
"value": {}
}
```
as you can see the hash of the producer `12593296123675988000` is not the same as the parent hash of the consumer `11403507064061660000`
where test5 which does gives the following checkpoints
```
{
"key": {
"service": "nodejs-kafka-producer-test5-eric.firth",
"hash": 7610290120735904000,
"parentHash": 0,
"edgeType": "kafka",
"edgeDirection": "out",
"group": "",
"topic": "endian-fix-validation-topic-test5",
"eventType": "",
"exchange": ""
},
"value": {}
},
{
"key": {
"service": "python-kafka-consumer-test5-eric.firth",
"hash": 17373314072852003000,
"parentHash": 7610290120735904000,
"edgeType": "kafka",
"edgeDirection": "in",
"group": "my_group",
"topic": "endian-fix-validation-topic-test5",
"eventType": "",
"exchange": ""
},
"value": {}
}
```
and in that. the hash of the producer and parent hash of the cnosumer do match (`7610290120735904000`)

### Motivation
<!-- What inspired you to submit this pull request? -->
We received a bug report https://datadoghq.atlassian.net/browse/DSMS-98

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [x] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [x] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


