### PR TITLE
add missing contents write permission to dependabot automation

### DIFF
--- a/.github/chainguard/dependabot-automation.sts.yaml
+++ b/.github/chainguard/dependabot-automation.sts.yaml
@@ -9,5 +9,5 @@ claim_pattern:
   job_workflow_ref: DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/heads/master
 
 permissions:
-  contents: read
+  contents: write
   pull_requests: write


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add missing contents write permission to dependabot automation.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise it fails with this error: https://github.com/DataDog/dd-trace-js/actions/runs/16587175311/job/46914714068?pr=6194

According to the docs from a similar [action](https://github.com/peter-evans/enable-pull-request-automerge?tab=readme-ov-file#action-inputs), `contents: write` is needed to enable auto-merge.