### PR TITLE
change merge strategy to squash for dependabot automation

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -21,7 +21,7 @@ jobs:
           github-token: "${{ steps.octo-sts.outputs.token }}"
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.dependency-group == 'test-versions'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Change merge strategy to squash for dependabot automation.

### Motivation
<!-- What inspired you to submit this pull request? -->

Turns out `--merge` literally means the `merge` strategy which we don't support.