### PR TITLE
replace static getters with static properties

### DIFF
--- a/packages/datadog-plugin-aerospike/src/index.js
+++ b/packages/datadog-plugin-aerospike/src/index.js
@@ -6,16 +6,12 @@ const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 const AEROSPIKE_PEER_SERVICE = 'aerospike.namespace'
 
 class AerospikePlugin extends DatabasePlugin {
-  static get id () { return 'aerospike' }
-  static get operation () { return 'command' }
-  static get system () { return 'aerospike' }
-  static get prefix () {
-    return 'tracing:apm:aerospike:command'
-  }
+  static id = 'aerospike'
+  static operation = 'command'
+  static system = 'aerospike'
+  static prefix = 'tracing:apm:aerospike:command'
 
-  static get peerServicePrecursors () {
-    return [AEROSPIKE_PEER_SERVICE]
-  }
+  static peerServicePrecursors = [AEROSPIKE_PEER_SERVICE]
 
   bindStart (ctx) {
     const { commandName, commandArgs } = ctx

--- a/packages/datadog-plugin-amqp10/src/consumer.js
+++ b/packages/datadog-plugin-amqp10/src/consumer.js
@@ -4,8 +4,8 @@ const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
 const { getAddress, getShortName } = require('./util')
 
 class Amqp10ConsumerPlugin extends ConsumerPlugin {
-  static get id () { return 'amqp10' }
-  static get system () { return 'amqp' }
+  static id = 'amqp10'
+  static system = 'amqp'
 
   bindStart (ctx) {
     const { link } = ctx

--- a/packages/datadog-plugin-amqp10/src/index.js
+++ b/packages/datadog-plugin-amqp10/src/index.js
@@ -5,7 +5,7 @@ const ConsumerPlugin = require('./consumer')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class Amqp10Plugin extends CompositePlugin {
-  static get id () { return 'amqp10' }
+  static id = 'amqp10'
   static get plugins () {
     return {
       producer: ProducerPlugin,

--- a/packages/datadog-plugin-amqp10/src/producer.js
+++ b/packages/datadog-plugin-amqp10/src/producer.js
@@ -5,9 +5,9 @@ const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const { getAddress, getShortName } = require('./util')
 
 class Amqp10ProducerPlugin extends ProducerPlugin {
-  static get id () { return 'amqp10' }
-  static get operation () { return 'send' }
-  static get system () { return 'amqp' }
+  static id = 'amqp10'
+  static operation = 'send'
+  static system = 'amqp'
 
   bindStart (ctx) {
     const { link } = ctx

--- a/packages/datadog-plugin-amqplib/src/client.js
+++ b/packages/datadog-plugin-amqplib/src/client.js
@@ -6,9 +6,9 @@ const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { getResourceName } = require('./util')
 
 class AmqplibClientPlugin extends ClientPlugin {
-  static get id () { return 'amqplib' }
-  static get type () { return 'messaging' }
-  static get operation () { return 'command' }
+  static id = 'amqplib'
+  static type = 'messaging'
+  static operation = 'command'
 
   bindStart (ctx) {
     const { channel = {}, method, fields } = ctx

--- a/packages/datadog-plugin-amqplib/src/consumer.js
+++ b/packages/datadog-plugin-amqplib/src/consumer.js
@@ -6,8 +6,8 @@ const { getAmqpMessageSize } = require('../../dd-trace/src/datastreams')
 const { getResourceName } = require('./util')
 
 class AmqplibConsumerPlugin extends ConsumerPlugin {
-  static get id () { return 'amqplib' }
-  static get operation () { return 'consume' }
+  static id = 'amqplib'
+  static operation = 'consume'
 
   bindStart (ctx) {
     const { method, fields, message, queue } = ctx

--- a/packages/datadog-plugin-amqplib/src/index.js
+++ b/packages/datadog-plugin-amqplib/src/index.js
@@ -7,7 +7,7 @@ const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 // TODO: Consider splitting channels for publish/receive in the instrumentation.
 class AmqplibPlugin extends CompositePlugin {
-  static get id () { return 'amqplib' }
+  static id = 'amqplib'
   static get plugins () {
     return {
       producer: ProducerPlugin,

--- a/packages/datadog-plugin-amqplib/src/producer.js
+++ b/packages/datadog-plugin-amqplib/src/producer.js
@@ -7,8 +7,8 @@ const { DsmPathwayCodec, getAmqpMessageSize } = require('../../dd-trace/src/data
 const { getResourceName } = require('./util')
 
 class AmqplibProducerPlugin extends ProducerPlugin {
-  static get id () { return 'amqplib' }
-  static get operation () { return 'publish' }
+  static id = 'amqplib'
+  static operation = 'publish'
 
   bindStart (ctx) {
     const { channel = {}, method, fields, message } = ctx

--- a/packages/datadog-plugin-apollo/src/gateway/execute.js
+++ b/packages/datadog-plugin-apollo/src/gateway/execute.js
@@ -3,10 +3,8 @@
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayExecutePlugin extends ApolloBasePlugin {
-  static get operation () { return 'execute' }
-  static get prefix () {
-    return 'tracing:apm:apollo:gateway:execute'
-  }
+  static operation = 'execute'
+  static prefix = 'tracing:apm:apollo:gateway:execute'
 }
 
 module.exports = ApolloGatewayExecutePlugin

--- a/packages/datadog-plugin-apollo/src/gateway/fetch.js
+++ b/packages/datadog-plugin-apollo/src/gateway/fetch.js
@@ -4,10 +4,8 @@ const { storage } = require('../../../datadog-core')
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayFetchPlugin extends ApolloBasePlugin {
-  static get operation () { return 'fetch' }
-  static get prefix () {
-    return 'tracing:apm:apollo:gateway:fetch'
-  }
+  static operation = 'fetch'
+  static prefix = 'tracing:apm:apollo:gateway:fetch'
 
   bindStart (ctx) {
     const store = storage('legacy').getStore()

--- a/packages/datadog-plugin-apollo/src/gateway/index.js
+++ b/packages/datadog-plugin-apollo/src/gateway/index.js
@@ -10,7 +10,7 @@ const ApolloGatewayValidatePlugin = require('./validate')
 const ApolloGatewayFetchPlugin = require('./fetch')
 
 class ApolloGatewayPlugin extends CompositePlugin {
-  static get id () { return 'gateway' }
+  static id = 'gateway'
   static get plugins () {
     return {
       execute: ApolloGatewayExecutePlugin,

--- a/packages/datadog-plugin-apollo/src/gateway/plan.js
+++ b/packages/datadog-plugin-apollo/src/gateway/plan.js
@@ -3,10 +3,8 @@
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayPlanPlugin extends ApolloBasePlugin {
-  static get operation () { return 'plan' }
-  static get prefix () {
-    return 'tracing:apm:apollo:gateway:plan'
-  }
+  static operation = 'plan'
+  static prefix = 'tracing:apm:apollo:gateway:plan'
 }
 
 module.exports = ApolloGatewayPlanPlugin

--- a/packages/datadog-plugin-apollo/src/gateway/postprocessing.js
+++ b/packages/datadog-plugin-apollo/src/gateway/postprocessing.js
@@ -3,10 +3,8 @@
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayPostProcessingPlugin extends ApolloBasePlugin {
-  static get operation () { return 'postprocessing' }
-  static get prefix () {
-    return 'tracing:apm:apollo:gateway:postprocessing'
-  }
+  static operation = 'postprocessing'
+  static prefix = 'tracing:apm:apollo:gateway:postprocessing'
 }
 
 module.exports = ApolloGatewayPostProcessingPlugin

--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -9,10 +9,8 @@ const OPERATION_DEFINITION = 'OperationDefinition'
 const FRAGMENT_DEFINITION = 'FragmentDefinition'
 
 class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
-  static get operation () { return 'request' }
-  static get prefix () {
-    return 'tracing:apm:apollo:gateway:request'
-  }
+  static operation = 'request'
+  static prefix = 'tracing:apm:apollo:gateway:request'
 
   bindStart (ctx) {
     const store = storage('legacy').getStore()

--- a/packages/datadog-plugin-apollo/src/gateway/validate.js
+++ b/packages/datadog-plugin-apollo/src/gateway/validate.js
@@ -4,9 +4,7 @@ const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayValidatePlugin extends ApolloBasePlugin {
   static operation = 'validate'
-  static get prefix () {
-    return 'tracing:apm:apollo:gateway:validate'
-  }
+  static prefix = 'tracing:apm:apollo:gateway:validate'
 
   end (ctx) {
     const result = ctx.result

--- a/packages/datadog-plugin-apollo/src/gateway/validate.js
+++ b/packages/datadog-plugin-apollo/src/gateway/validate.js
@@ -3,7 +3,7 @@
 const ApolloBasePlugin = require('../../../dd-trace/src/plugins/apollo')
 
 class ApolloGatewayValidatePlugin extends ApolloBasePlugin {
-  static get operation () { return 'validate' }
+  static operation = 'validate'
   static get prefix () {
     return 'tracing:apm:apollo:gateway:validate'
   }

--- a/packages/datadog-plugin-apollo/src/index.js
+++ b/packages/datadog-plugin-apollo/src/index.js
@@ -4,7 +4,7 @@ const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 const ApolloGatewayPlugin = require('./gateway')
 
 class ApolloPlugin extends CompositePlugin {
-  static get id () { return 'apollo' }
+  static id = 'apollo'
   static get plugins () {
     return {
       gateway: ApolloGatewayPlugin

--- a/packages/datadog-plugin-avsc/src/index.js
+++ b/packages/datadog-plugin-avsc/src/index.js
@@ -4,8 +4,8 @@ const SchemaPlugin = require('../../dd-trace/src/plugins/schema')
 const SchemaExtractor = require('./schema_iterator')
 
 class AvscPlugin extends SchemaPlugin {
-  static get id () { return 'avsc' }
-  static get schemaExtractor () { return SchemaExtractor }
+  static id = 'avsc'
+  static schemaExtractor = SchemaExtractor
 }
 
 module.exports = AvscPlugin

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -9,8 +9,8 @@ const { tagsFromRequest, tagsFromResponse } = require('../../dd-trace/src/payloa
 const { getEnvironmentVariable } = require('../../dd-trace/src/config-helper')
 
 class BaseAwsSdkPlugin extends ClientPlugin {
-  static get id () { return 'aws' }
-  static get isPayloadReporter () { return false }
+  static id = 'aws'
+  static isPayloadReporter = false
 
   get serviceIdentifier () {
     const id = this.constructor.id.toLowerCase()

--- a/packages/datadog-plugin-aws-sdk/src/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/index.js
@@ -5,9 +5,7 @@ const Plugin = require('../../dd-trace/src/plugins/plugin')
 const services = require('./services')
 
 class AwsSdkPlugin extends Plugin {
-  static get id () {
-    return 'aws-sdk'
-  }
+  static id = 'aws-sdk'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/index.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/index.js
@@ -4,9 +4,7 @@ const CompositePlugin = require('../../../../dd-trace/src/plugins/composite')
 const BedrockRuntimeTracing = require('./tracing')
 const BedrockRuntimeLLMObsPlugin = require('../../../../dd-trace/src/llmobs/plugins/bedrockruntime')
 class BedrockRuntimePlugin extends CompositePlugin {
-  static get id () {
-    return 'bedrockruntime'
-  }
+  static id = 'bedrockruntime'
 
   static get plugins () {
     return {

--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/tracing.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/tracing.js
@@ -6,7 +6,7 @@ const { parseModelId } = require('./utils')
 const enabledOperations = new Set(['invokeModel'])
 
 class BedrockRuntime extends BaseAwsSdkPlugin {
-  static get id () { return 'bedrockruntime' }
+  static id = 'bedrockruntime'
 
   isEnabled (request) {
     const operation = request.operation

--- a/packages/datadog-plugin-aws-sdk/src/services/cloudwatchlogs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/cloudwatchlogs.js
@@ -3,7 +3,7 @@
 const BaseAwsSdkPlugin = require('../base')
 
 class CloudwatchLogs extends BaseAwsSdkPlugin {
-  static get id () { return 'cloudwatchlogs' }
+  static id = 'cloudwatchlogs'
 
   generateTags (params, operation) {
     if (!params?.logGroupName) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
@@ -6,9 +6,9 @@ const { DYNAMODB_PTR_KIND, SPAN_POINTER_DIRECTION } = require('../../../dd-trace
 const { extractPrimaryKeys, generatePointerHash } = require('../util')
 
 class DynamoDb extends BaseAwsSdkPlugin {
-  static get id () { return 'dynamodb' }
-  static get peerServicePrecursors () { return ['tablename'] }
-  static get isPayloadReporter () { return true }
+  static id = 'dynamodb'
+  static peerServicePrecursors = ['tablename']
+  static isPayloadReporter = true
 
   generateTags (params, operation, response) {
     const tags = {}

--- a/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
@@ -3,8 +3,8 @@ const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
 class EventBridge extends BaseAwsSdkPlugin {
-  static get id () { return 'eventbridge' }
-  static get isPayloadReporter () { return true }
+  static id = 'eventbridge'
+  static isPayloadReporter = true
 
   generateTags (params, operation, response) {
     if (!params?.source) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/kinesis.js
@@ -4,9 +4,9 @@ const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
 class Kinesis extends BaseAwsSdkPlugin {
-  static get id () { return 'kinesis' }
-  static get peerServicePrecursors () { return ['streamname'] }
-  static get isPayloadReporter () { return true }
+  static id = 'kinesis'
+  static peerServicePrecursors = ['streamname']
+  static isPayloadReporter = true
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-aws-sdk/src/services/lambda.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/lambda.js
@@ -4,7 +4,7 @@ const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
 class Lambda extends BaseAwsSdkPlugin {
-  static get id () { return 'lambda' }
+  static id = 'lambda'
 
   generateTags (params, operation, response) {
     if (!params?.FunctionName) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/redshift.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/redshift.js
@@ -3,7 +3,7 @@
 const BaseAwsSdkPlugin = require('../base')
 
 class Redshift extends BaseAwsSdkPlugin {
-  static get id () { return 'redshift' }
+  static id = 'redshift'
 
   generateTags (params, operation, response) {
     if (!params?.ClusterIdentifier) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/s3.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/s3.js
@@ -6,9 +6,9 @@ const { generatePointerHash } = require('../util')
 const { S3_PTR_KIND, SPAN_POINTER_DIRECTION } = require('../../../dd-trace/src/constants')
 
 class S3 extends BaseAwsSdkPlugin {
-  static get id () { return 's3' }
-  static get peerServicePrecursors () { return ['bucketname'] }
-  static get isPayloadReporter () { return true }
+  static id = 's3'
+  static peerServicePrecursors = ['bucketname']
+  static isPayloadReporter = true
 
   generateTags (params, operation, response) {
     if (!params?.Bucket) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/sfn.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sfn.js
@@ -1,7 +1,7 @@
 'use strict'
 const Stepfunctions = require('./stepfunctions')
 class Sfn extends Stepfunctions {
-  static get id () { return 'sfn' }
+  static id = 'sfn'
 }
 
 module.exports = Sfn

--- a/packages/datadog-plugin-aws-sdk/src/services/sns.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sns.js
@@ -4,9 +4,9 @@ const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
 class Sns extends BaseAwsSdkPlugin {
-  static get id () { return 'sns' }
-  static get peerServicePrecursors () { return ['topicname'] }
-  static get isPayloadReporter () { return true }
+  static id = 'sns'
+  static peerServicePrecursors = ['topicname']
+  static isPayloadReporter = true
 
   generateTags (params, operation, response) {
     if (!params) return {}

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -5,9 +5,9 @@ const BaseAwsSdkPlugin = require('../base')
 const { DsmPathwayCodec, getHeadersSize } = require('../../../dd-trace/src/datastreams')
 
 class Sqs extends BaseAwsSdkPlugin {
-  static get id () { return 'sqs' }
-  static get peerServicePrecursors () { return ['queuename'] }
-  static get isPayloadReporter () { return true }
+  static id = 'sqs'
+  static peerServicePrecursors = ['queuename']
+  static isPayloadReporter = true
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-aws-sdk/src/services/states.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/states.js
@@ -1,7 +1,7 @@
 'use strict'
 const Stepfunctions = require('./stepfunctions')
 class States extends Stepfunctions {
-  static get id () { return 'states' }
+  static id = 'states'
 }
 
 module.exports = States

--- a/packages/datadog-plugin-aws-sdk/src/services/stepfunctions.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/stepfunctions.js
@@ -3,7 +3,7 @@ const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
 class Stepfunctions extends BaseAwsSdkPlugin {
-  static get id () { return 'stepfunctions' }
+  static id = 'stepfunctions'
 
   // This is the shape of StartExecutionInput, as defined in
   // https://github.com/aws/aws-sdk-js/blob/master/apis/states-2016-11-23.normal.json

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -16,11 +16,11 @@ const triggerMap = {
 }
 
 class AzureFunctionsPlugin extends TracingPlugin {
-  static get id () { return 'azure-functions' }
-  static get operation () { return 'invoke' }
-  static get kind () { return 'server' }
-  static get type () { return 'serverless' }
-  static get prefix () { return 'tracing:datadog:azure:functions:invoke' }
+  static id = 'azure-functions'
+  static operation = 'invoke'
+  static kind = 'server'
+  static type = 'serverless'
+  static prefix = 'tracing:datadog:azure:functions:invoke'
 
   bindStart (ctx) {
     const childOf = extractTraceContext(this._tracer, ctx)

--- a/packages/datadog-plugin-azure-service-bus/src/index.js
+++ b/packages/datadog-plugin-azure-service-bus/src/index.js
@@ -4,7 +4,7 @@ const ProducerPlugin = require('./producer')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class AzureServiceBusPlugin extends CompositePlugin {
-  static get id () { return 'azure-service-bus' }
+  static id = 'azure-service-bus'
   static get plugins () {
     return {
       producer: ProducerPlugin

--- a/packages/datadog-plugin-azure-service-bus/src/producer.js
+++ b/packages/datadog-plugin-azure-service-bus/src/producer.js
@@ -3,8 +3,8 @@
 const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 
 class AzureServiceBusProducerPlugin extends ProducerPlugin {
-  static get id () { return 'azure-service-bus' }
-  static get operation () { return 'send' }
+  static id = 'azure-service-bus'
+  static operation = 'send'
 
   bindStart (ctx) {
     const { sender, msg } = ctx

--- a/packages/datadog-plugin-bunyan/src/index.js
+++ b/packages/datadog-plugin-bunyan/src/index.js
@@ -3,8 +3,6 @@
 const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
 
 class BunyanPlugin extends LogPlugin {
-  static get id () {
-    return 'bunyan'
-  }
+  static id = 'bunyan'
 }
 module.exports = BunyanPlugin

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -4,9 +4,9 @@ const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 const CASSANDRA_CONTACT_POINTS_KEY = 'db.cassandra.contact.points'
 
 class CassandraDriverPlugin extends DatabasePlugin {
-  static get id () { return 'cassandra-driver' }
-  static get system () { return 'cassandra' }
-  static get peerServicePrecursors () { return [CASSANDRA_CONTACT_POINTS_KEY] }
+  static id = 'cassandra-driver'
+  static system = 'cassandra'
+  static peerServicePrecursors = [CASSANDRA_CONTACT_POINTS_KEY]
 
   bindStart (ctx) {
     let { keyspace, query, contactPoints = {} } = ctx

--- a/packages/datadog-plugin-child_process/src/index.js
+++ b/packages/datadog-plugin-child_process/src/index.js
@@ -28,8 +28,8 @@ function truncateCommand (cmdFields) {
 }
 
 class ChildProcessPlugin extends TracingPlugin {
-  static get id () { return 'child_process' }
-  static get prefix () { return 'tracing:datadog:child_process:execution' }
+  static id = 'child_process'
+  static prefix = 'tracing:datadog:child_process:execution'
 
   get tracer () {
     return this._tracer

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/src/batch-consumer.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/src/batch-consumer.js
@@ -3,9 +3,7 @@
 const KafkajsBatchConsumerPlugin = require('../../datadog-plugin-kafkajs/src/batch-consumer')
 
 class ConfluentKafkaJsBatchConsumerPlugin extends KafkajsBatchConsumerPlugin {
-  static get id () {
-    return 'confluentinc-kafka-javascript'
-  }
+  static id = 'confluentinc-kafka-javascript'
 }
 
 module.exports = ConfluentKafkaJsBatchConsumerPlugin

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/src/consumer.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/src/consumer.js
@@ -3,9 +3,7 @@
 const KafkajsConsumerPlugin = require('../../datadog-plugin-kafkajs/src/consumer')
 
 class ConfluentKafkaJsConsumerPlugin extends KafkajsConsumerPlugin {
-  static get id () {
-    return 'confluentinc-kafka-javascript'
-  }
+  static id = 'confluentinc-kafka-javascript'
 }
 
 module.exports = ConfluentKafkaJsConsumerPlugin

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/src/index.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/src/index.js
@@ -6,7 +6,7 @@ const BatchConsumerPlugin = require('./batch-consumer')
 const KafkajsPlugin = require('../../datadog-plugin-kafkajs/src/index')
 
 class ConfluentKafkaJsPlugin extends KafkajsPlugin {
-  static get id () { return 'confluentinc-kafka-javascript' }
+  static id = 'confluentinc-kafka-javascript'
   static get plugins () {
     return {
       producer: ProducerPlugin,

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/src/producer.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/src/producer.js
@@ -3,9 +3,7 @@
 const KafkajsProducerPlugin = require('../../datadog-plugin-kafkajs/src/producer')
 
 class ConfluentKafkaJsProducerPlugin extends KafkajsProducerPlugin {
-  static get id () {
-    return 'confluentinc-kafka-javascript'
-  }
+  static id = 'confluentinc-kafka-javascript'
 }
 
 module.exports = ConfluentKafkaJsProducerPlugin

--- a/packages/datadog-plugin-connect/src/index.js
+++ b/packages/datadog-plugin-connect/src/index.js
@@ -3,9 +3,7 @@
 const RouterPlugin = require('../../datadog-plugin-router/src')
 
 class ConnectPlugin extends RouterPlugin {
-  static get id () {
-    return 'connect'
-  }
+  static id = 'connect'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -4,8 +4,8 @@ const StoragePlugin = require('../../dd-trace/src/plugins/storage')
 const { storage } = require('../../datadog-core')
 
 class CouchBasePlugin extends StoragePlugin {
-  static get id () { return 'couchbase' }
-  static get peerServicePrecursors () { return ['db.couchbase.seed.nodes'] }
+  static id = 'couchbase'
+  static peerServicePrecursors = ['db.couchbase.seed.nodes']
 
   addSubs (func, start) {
     this.addSub(`apm:couchbase:${func}:start`, start)

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -75,9 +75,7 @@ function getTestSuiteTags (testSuiteSpan) {
 }
 
 class CucumberPlugin extends CiPlugin {
-  static get id () {
-    return 'cucumber'
-  }
+  static id = 'cucumber'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-cypress/src/index.js
+++ b/packages/datadog-plugin-cypress/src/index.js
@@ -5,9 +5,7 @@ const Plugin = require('../../dd-trace/src/plugins/plugin')
 // Cypress plugin does not patch any library. This is just a placeholder to
 // follow the structure of the plugins
 class CypressPlugin extends Plugin {
-  static get id () {
-    return 'cypress'
-  }
+  static id = 'cypress'
 }
 
 module.exports = CypressPlugin

--- a/packages/datadog-plugin-dd-trace-api/src/index.js
+++ b/packages/datadog-plugin-dd-trace-api/src/index.js
@@ -12,9 +12,7 @@ const injectionEnabledTag =
   `injection_enabled:${getEnvironmentVariable('DD_INJECTION_ENABLED') ? 'yes' : 'no'}`
 
 module.exports = class DdTraceApiPlugin extends Plugin {
-  static get id () {
-    return 'dd-trace-api'
-  }
+  static id = 'dd-trace-api'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-dns/src/index.js
+++ b/packages/datadog-plugin-dns/src/index.js
@@ -9,7 +9,7 @@ const DNSReversePlugin = require('./reverse')
 // TODO: Are DNS spans really client spans?
 
 class DNSPlugin extends CompositePlugin {
-  static get id () { return 'dns' }
+  static id = 'dns'
   static get plugins () {
     return {
       lookup: DNSLookupPlugin,

--- a/packages/datadog-plugin-dns/src/lookup.js
+++ b/packages/datadog-plugin-dns/src/lookup.js
@@ -3,8 +3,8 @@
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class DNSLookupPlugin extends ClientPlugin {
-  static get id () { return 'dns' }
-  static get operation () { return 'lookup' }
+  static id = 'dns'
+  static operation = 'lookup'
 
   bindStart (ctx) {
     const [hostname] = ctx.args

--- a/packages/datadog-plugin-dns/src/lookup_service.js
+++ b/packages/datadog-plugin-dns/src/lookup_service.js
@@ -3,8 +3,8 @@
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class DNSLookupServicePlugin extends ClientPlugin {
-  static get id () { return 'dns' }
-  static get operation () { return 'lookup_service' }
+  static id = 'dns'
+  static operation = 'lookup_service'
 
   bindStart (ctx) {
     const [address, port] = ctx.args

--- a/packages/datadog-plugin-dns/src/resolve.js
+++ b/packages/datadog-plugin-dns/src/resolve.js
@@ -3,8 +3,8 @@
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class DNSResolvePlugin extends ClientPlugin {
-  static get id () { return 'dns' }
-  static get operation () { return 'resolve' }
+  static id = 'dns'
+  static operation = 'resolve'
 
   bindStart (ctx) {
     const [hostname, maybeType] = ctx.args

--- a/packages/datadog-plugin-dns/src/reverse.js
+++ b/packages/datadog-plugin-dns/src/reverse.js
@@ -3,8 +3,8 @@
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class DNSReversePlugin extends ClientPlugin {
-  static get id () { return 'dns' }
-  static get operation () { return 'reverse' }
+  static id = 'dns'
+  static operation = 'reverse'
 
   bindStart (ctx) {
     const [ip] = ctx.args

--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -3,7 +3,7 @@
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 class ElasticsearchPlugin extends DatabasePlugin {
-  static get id () { return 'elasticsearch' }
+  static id = 'elasticsearch'
 
   bindStart (ctx) {
     const { params } = ctx

--- a/packages/datadog-plugin-express/src/code_origin.js
+++ b/packages/datadog-plugin-express/src/code_origin.js
@@ -5,9 +5,7 @@ const Plugin = require('../../dd-trace/src/plugins/plugin')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class ExpressCodeOriginForSpansPlugin extends Plugin {
-  static get id () {
-    return 'express'
-  }
+  static id = 'express'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-express/src/index.js
+++ b/packages/datadog-plugin-express/src/index.js
@@ -5,7 +5,7 @@ const ExpressCodeOriginForSpansPlugin = require('./code_origin')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class ExpressPlugin extends CompositePlugin {
-  static get id () { return 'express' }
+  static id = 'express'
   static get plugins () {
     return {
       tracing: ExpressTracingPlugin,

--- a/packages/datadog-plugin-express/src/tracing.js
+++ b/packages/datadog-plugin-express/src/tracing.js
@@ -3,9 +3,7 @@
 const RouterPlugin = require('../../datadog-plugin-router/src')
 
 class ExpressTracingPlugin extends RouterPlugin {
-  static get id () {
-    return 'express'
-  }
+  static id = 'express'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-fastify/src/code_origin.js
+++ b/packages/datadog-plugin-fastify/src/code_origin.js
@@ -7,9 +7,7 @@ const web = require('../../dd-trace/src/plugins/util/web')
 const kCodeOriginForSpansTagsSym = Symbol('datadog.codeOriginForSpansTags')
 
 class FastifyCodeOriginForSpansPlugin extends Plugin {
-  static get id () {
-    return 'fastify'
-  }
+  static id = 'fastify'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-fastify/src/index.js
+++ b/packages/datadog-plugin-fastify/src/index.js
@@ -5,7 +5,7 @@ const FastifyCodeOriginForSpansPlugin = require('./code_origin')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class FastifyPlugin extends CompositePlugin {
-  static get id () { return 'fastify' }
+  static id = 'fastify'
   static get plugins () {
     return {
       tracing: FastifyTracingPlugin,

--- a/packages/datadog-plugin-fastify/src/tracing.js
+++ b/packages/datadog-plugin-fastify/src/tracing.js
@@ -3,9 +3,7 @@
 const RouterPlugin = require('../../datadog-plugin-router/src')
 
 class FastifyTracingPlugin extends RouterPlugin {
-  static get id () {
-    return 'fastify'
-  }
+  static id = 'fastify'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-fetch/src/index.js
+++ b/packages/datadog-plugin-fetch/src/index.js
@@ -3,8 +3,8 @@
 const HttpClientPlugin = require('../../datadog-plugin-http/src/client')
 
 class FetchPlugin extends HttpClientPlugin {
-  static get id () { return 'fetch' }
-  static get prefix () { return 'tracing:apm:fetch:request' }
+  static id = 'fetch'
+  static prefix = 'tracing:apm:fetch:request'
 
   bindStart (ctx) {
     const req = ctx.req

--- a/packages/datadog-plugin-find-my-way/src/index.js
+++ b/packages/datadog-plugin-find-my-way/src/index.js
@@ -4,9 +4,7 @@ const Plugin = require('../../dd-trace/src/plugins/plugin')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class FindMyWayPlugin extends Plugin {
-  static get id () {
-    return 'find-my-way'
-  }
+  static id = 'find-my-way'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-fs/src/index.js
+++ b/packages/datadog-plugin-fs/src/index.js
@@ -3,8 +3,8 @@
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
 class FsPlugin extends TracingPlugin {
-  static get id () { return 'fs' }
-  static get operation () { return 'operation' }
+  static id = 'fs'
+  static operation = 'operation'
 
   configure (...args) {
     return super.configure(...args)

--- a/packages/datadog-plugin-google-cloud-pubsub/src/client.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/client.js
@@ -3,9 +3,9 @@
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class GoogleCloudPubsubClientPlugin extends ClientPlugin {
-  static get id () { return 'google-cloud-pubsub' }
-  static get type () { return 'messaging' }
-  static get operation () { return 'request' }
+  static id = 'google-cloud-pubsub'
+  static type = 'messaging'
+  static operation = 'request'
 
   start (ctx) {
     const { request, api, projectId } = ctx

--- a/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/consumer.js
@@ -4,8 +4,8 @@ const { getMessageSize } = require('../../dd-trace/src/datastreams')
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
 
 class GoogleCloudPubsubConsumerPlugin extends ConsumerPlugin {
-  static get id () { return 'google-cloud-pubsub' }
-  static get operation () { return 'receive' }
+  static id = 'google-cloud-pubsub'
+  static operation = 'receive'
 
   bindStart (ctx) {
     const { message } = ctx

--- a/packages/datadog-plugin-google-cloud-pubsub/src/index.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/index.js
@@ -7,7 +7,7 @@ const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 // TODO: Consider splitting channels for publish/receive in the instrumentation.
 class GoogleCloudPubsubPlugin extends CompositePlugin {
-  static get id () { return 'google-cloud-pubsub' }
+  static id = 'google-cloud-pubsub'
   static get plugins () {
     return {
       producer: ProducerPlugin,

--- a/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
@@ -4,8 +4,8 @@ const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 const { DsmPathwayCodec, getHeadersSize } = require('../../dd-trace/src/datastreams')
 
 class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
-  static get id () { return 'google-cloud-pubsub' }
-  static get operation () { return 'request' }
+  static id = 'google-cloud-pubsub'
+  static operation = 'request'
 
   bindStart (ctx) {
     const { request, api, projectId } = ctx

--- a/packages/datadog-plugin-google-cloud-vertexai/src/index.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/src/index.js
@@ -5,7 +5,7 @@ const GoogleVertexAITracingPlugin = require('./tracing')
 const VertexAILLMObsPlugin = require('../../dd-trace/src/llmobs/plugins/vertexai')
 
 class GoogleCloudVertexAIPlugin extends CompositePlugin {
-  static get id () { return 'google-cloud-vertexai' }
+  static id = 'google-cloud-vertexai'
   static get plugins () {
     return {
       llmobs: VertexAILLMObsPlugin,

--- a/packages/datadog-plugin-google-cloud-vertexai/src/tracing.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/src/tracing.js
@@ -10,7 +10,7 @@ const {
 } = require('./utils')
 
 class GoogleCloudVertexAITracingPlugin extends TracingPlugin {
-  static get id () { return 'google-cloud-vertexai' }
+  static id = 'google-cloud-vertexai'
   static get prefix () {
     return 'tracing:apm:vertexai:request'
   }

--- a/packages/datadog-plugin-google-cloud-vertexai/src/tracing.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/src/tracing.js
@@ -11,9 +11,7 @@ const {
 
 class GoogleCloudVertexAITracingPlugin extends TracingPlugin {
   static id = 'google-cloud-vertexai'
-  static get prefix () {
-    return 'tracing:apm:vertexai:request'
-  }
+  static prefix = 'tracing:apm:vertexai:request'
 
   constructor () {
     super(...arguments)

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -6,10 +6,10 @@ const { extractErrorIntoSpanEvent } = require('./utils')
 let tools
 
 class GraphQLExecutePlugin extends TracingPlugin {
-  static get id () { return 'graphql' }
-  static get operation () { return 'execute' }
-  static get type () { return 'graphql' }
-  static get kind () { return 'server' }
+  static id = 'graphql'
+  static operation = 'execute'
+  static type = 'graphql'
+  static kind = 'server'
 
   bindStart (ctx) {
     const { operation, args, docSource } = ctx

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -9,7 +9,7 @@ const GraphQLValidatePlugin = require('./validate')
 const GraphQLResolvePlugin = require('./resolve')
 
 class GraphQLPlugin extends CompositePlugin {
-  static get id () { return 'graphql' }
+  static id = 'graphql'
   static get plugins () {
     return {
       execute: GraphQLExecutePlugin,

--- a/packages/datadog-plugin-graphql/src/parse.js
+++ b/packages/datadog-plugin-graphql/src/parse.js
@@ -3,8 +3,8 @@
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
 class GraphQLParsePlugin extends TracingPlugin {
-  static get id () { return 'graphql' }
-  static get operation () { return 'parser' }
+  static id = 'graphql'
+  static operation = 'parser'
 
   bindStart (ctx) {
     this.startSpan('graphql.parse', {

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -6,8 +6,8 @@ const dc = require('dc-polyfill')
 const collapsedPathSym = Symbol('collapsedPaths')
 
 class GraphQLResolvePlugin extends TracingPlugin {
-  static get id () { return 'graphql' }
-  static get operation () { return 'resolve' }
+  static id = 'graphql'
+  static operation = 'resolve'
 
   start (fieldCtx) {
     const { info, rootCtx, args } = fieldCtx

--- a/packages/datadog-plugin-graphql/src/validate.js
+++ b/packages/datadog-plugin-graphql/src/validate.js
@@ -4,8 +4,8 @@ const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 const { extractErrorIntoSpanEvent } = require('./utils')
 
 class GraphQLValidatePlugin extends TracingPlugin {
-  static get id () { return 'graphql' }
-  static get operation () { return 'validate' }
+  static id = 'graphql'
+  static operation = 'validate'
 
   bindStart (ctx) {
     const { docSource, document } = ctx

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -6,10 +6,10 @@ const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
 
 class GrpcClientPlugin extends ClientPlugin {
-  static get id () { return 'grpc' }
-  static get operation () { return 'client:request' }
-  static get prefix () { return 'apm:grpc:client:request' }
-  static get peerServicePrecursors () { return ['rpc.service'] }
+  static id = 'grpc'
+  static operation = 'client:request'
+  static prefix = 'apm:grpc:client:request'
+  static peerServicePrecursors = ['rpc.service']
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-grpc/src/index.js
+++ b/packages/datadog-plugin-grpc/src/index.js
@@ -5,7 +5,7 @@ const GrpcClientPlugin = require('./client')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class GrpcPlugin extends CompositePlugin {
-  static get id () { return 'grpc' }
+  static id = 'grpc'
   static get plugins () {
     return {
       server: GrpcServerPlugin,

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -6,9 +6,9 @@ const { TEXT_MAP } = require('../../../ext/formats')
 const { addMetadataTags, getFilter, getMethodMetadata } = require('./util')
 
 class GrpcServerPlugin extends ServerPlugin {
-  static get id () { return 'grpc' }
-  static get operation () { return 'server:request' }
-  static get prefix () { return 'apm:grpc:server:request' }
+  static id = 'grpc'
+  static operation = 'server:request'
+  static prefix = 'apm:grpc:server:request'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-hapi/src/index.js
+++ b/packages/datadog-plugin-hapi/src/index.js
@@ -5,9 +5,7 @@ const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class HapiPlugin extends RouterPlugin {
-  static get id () {
-    return 'hapi'
-  }
+  static id = 'hapi'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-hono/src/index.js
+++ b/packages/datadog-plugin-hono/src/index.js
@@ -4,9 +4,7 @@ const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class HonoPlugin extends RouterPlugin {
-  static get id () {
-    return 'hono'
-  }
+  static id = 'hono'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -16,7 +16,7 @@ const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 class HttpClientPlugin extends ClientPlugin {
-  static get id () { return 'http' }
+  static id = 'http'
   static get prefix () { return 'apm:http:client:request' }
 
   bindStart (message) {

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -17,7 +17,7 @@ const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 class HttpClientPlugin extends ClientPlugin {
   static id = 'http'
-  static get prefix () { return 'apm:http:client:request' }
+  static prefix = 'apm:http:client:request'
 
   bindStart (message) {
     const { args, http = {} } = message

--- a/packages/datadog-plugin-http/src/index.js
+++ b/packages/datadog-plugin-http/src/index.js
@@ -5,7 +5,7 @@ const HttpClientPlugin = require('./client')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class HttpPlugin extends CompositePlugin {
-  static get id () { return 'http' }
+  static id = 'http'
   static get plugins () {
     return {
       server: HttpServerPlugin,

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -7,13 +7,9 @@ const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-t
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
 class HttpServerPlugin extends ServerPlugin {
-  static get id () {
-    return 'http'
-  }
+  static id = 'http'
 
-  static get prefix () {
-    return 'apm:http:server:request'
-  }
+  static prefix = 'apm:http:server:request'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -24,8 +24,8 @@ const HTTP2_HEADER_STATUS = ':status'
 const HTTP2_METHOD_GET = 'GET'
 
 class Http2ClientPlugin extends ClientPlugin {
-  static get id () { return 'http2' }
-  static get prefix () { return 'apm:http2:client:request' }
+  static id = 'http2'
+  static prefix = 'apm:http2:client:request'
 
   bindStart (message) {
     const { authority, options, headers = {} } = message

--- a/packages/datadog-plugin-http2/src/index.js
+++ b/packages/datadog-plugin-http2/src/index.js
@@ -5,7 +5,7 @@ const Http2ClientPlugin = require('./client')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class Http2Plugin extends CompositePlugin {
-  static get id () { return 'http2' }
+  static id = 'http2'
   static get plugins () {
     return {
       server: Http2ServerPlugin,

--- a/packages/datadog-plugin-http2/src/server.js
+++ b/packages/datadog-plugin-http2/src/server.js
@@ -12,13 +12,9 @@ class Http2ServerPlugin extends ServerPlugin {
     this.addBind('apm:http2:server:response:emit', this.bindEmit)
   }
 
-  static get id () {
-    return 'http2'
-  }
+  static id = 'http2'
 
-  static get prefix () {
-    return 'apm:http2:server:request'
-  }
+  static prefix = 'apm:http2:server:request'
 
   bindStart (ctx) {
     const { req, res } = ctx

--- a/packages/datadog-plugin-ioredis/src/index.js
+++ b/packages/datadog-plugin-ioredis/src/index.js
@@ -3,9 +3,7 @@
 const RedisPlugin = require('../../datadog-plugin-redis/src')
 
 class IORedisPlugin extends RedisPlugin {
-  static get id () {
-    return 'ioredis'
-  }
+  static id = 'ioredis'
 }
 
 module.exports = IORedisPlugin

--- a/packages/datadog-plugin-iovalkey/src/index.js
+++ b/packages/datadog-plugin-iovalkey/src/index.js
@@ -7,7 +7,7 @@ class IOValkeyPlugin extends RedisPlugin {
     return 'iovalkey'
   }
 
-  static get system () { return 'valkey' }
+  static system = 'valkey'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-iovalkey/src/index.js
+++ b/packages/datadog-plugin-iovalkey/src/index.js
@@ -3,9 +3,7 @@
 const RedisPlugin = require('../../datadog-plugin-redis/src')
 
 class IOValkeyPlugin extends RedisPlugin {
-  static get id () {
-    return 'iovalkey'
-  }
+  static id = 'iovalkey'
 
   static system = 'valkey'
 

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -67,9 +67,7 @@ function withTimeout (promise, timeoutMs) {
 }
 
 class JestPlugin extends CiPlugin {
-  static get id () {
-    return 'jest'
-  }
+  static id = 'jest'
 
   // The lists are the same for every test suite, so we can cache them
   getUnskippableSuites (unskippableSuitesList) {

--- a/packages/datadog-plugin-kafkajs/src/batch-consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/batch-consumer.js
@@ -5,8 +5,8 @@ const { getMessageSize } = require('../../dd-trace/src/datastreams')
 const { convertToTextMap } = require('./utils')
 
 class KafkajsBatchConsumerPlugin extends ConsumerPlugin {
-  static get id () { return 'kafkajs' }
-  static get operation () { return 'consume-batch' }
+  static id = 'kafkajs'
+  static operation = 'consume-batch'
 
   start (ctx) {
     const { topic, messages, groupId, clusterId } = ctx.extractedArgs || ctx

--- a/packages/datadog-plugin-kafkajs/src/consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/consumer.js
@@ -10,8 +10,8 @@ const beforeFinishCh = dc.channel('dd-trace:kafkajs:consumer:beforeFinish')
 const MESSAGING_DESTINATION_KEY = 'messaging.destination.name'
 
 class KafkajsConsumerPlugin extends ConsumerPlugin {
-  static get id () { return 'kafkajs' }
-  static get operation () { return 'consume' }
+  static id = 'kafkajs'
+  static operation = 'consume'
 
   constructor () {
     super(...arguments)

--- a/packages/datadog-plugin-kafkajs/src/index.js
+++ b/packages/datadog-plugin-kafkajs/src/index.js
@@ -6,7 +6,7 @@ const BatchConsumerPlugin = require('./batch-consumer')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class KafkajsPlugin extends CompositePlugin {
-  static get id () { return 'kafkajs' }
+  static id = 'kafkajs'
   static get plugins () {
     return {
       producer: ProducerPlugin,

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -7,9 +7,9 @@ const BOOTSTRAP_SERVERS_KEY = 'messaging.kafka.bootstrap.servers'
 const MESSAGING_DESTINATION_KEY = 'messaging.destination.name'
 
 class KafkajsProducerPlugin extends ProducerPlugin {
-  static get id () { return 'kafkajs' }
-  static get operation () { return 'produce' }
-  static get peerServicePrecursors () { return [BOOTSTRAP_SERVERS_KEY] }
+  static id = 'kafkajs'
+  static operation = 'produce'
+  static peerServicePrecursors = [BOOTSTRAP_SERVERS_KEY]
 
   constructor () {
     super(...arguments)

--- a/packages/datadog-plugin-koa/src/index.js
+++ b/packages/datadog-plugin-koa/src/index.js
@@ -4,9 +4,7 @@ const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class KoaPlugin extends RouterPlugin {
-  static get id () {
-    return 'koa'
-  }
+  static id = 'koa'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-langchain/src/index.js
+++ b/packages/datadog-plugin-langchain/src/index.js
@@ -19,8 +19,8 @@ for (const Plugin of langChainTracingPlugins) {
 }
 
 class LangChainPlugin extends CompositePlugin {
-  static get id () { return 'langchain' }
-  static get plugins () { return plugins }
+  static id = 'langchain'
+  static plugins = plugins
 }
 
 module.exports = LangChainPlugin

--- a/packages/datadog-plugin-langchain/src/tracing.js
+++ b/packages/datadog-plugin-langchain/src/tracing.js
@@ -13,9 +13,9 @@ const LangChainLanguageModelHandler = require('./handlers/language_models')
 const LangChainEmbeddingHandler = require('./handlers/embedding')
 
 class BaseLangChainTracingPlugin extends TracingPlugin {
-  static get id () { return 'langchain' }
-  static get operation () { return 'invoke' }
-  static get system () { return 'langchain' }
+  static id = 'langchain'
+  static operation = 'invoke'
+  static system = 'langchain'
 
   constructor () {
     super(...arguments)
@@ -85,75 +85,57 @@ class BaseLangChainTracingPlugin extends TracingPlugin {
 }
 
 class RunnableSequenceInvokePlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_rs_invoke' }
-  static get lcType () { return 'chain' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:RunnableSequence_invoke'
-  }
+  static id = 'langchain_rs_invoke'
+  static lcType = 'chain'
+  static prefix = 'tracing:orchestrion:@langchain/core:RunnableSequence_invoke'
 }
 
 class RunnableSequenceBatchPlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_rs_batch' }
-  static get lcType () { return 'chain' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:RunnableSequence_batch'
-  }
+  static id = 'langchain_rs_batch'
+  static lcType = 'chain'
+  static prefix = 'tracing:orchestrion:@langchain/core:RunnableSequence_batch'
 }
 
 class BaseChatModelGeneratePlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_chat_model_generate' }
-  static get lcType () { return 'chat_model' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:BaseChatModel_generate'
-  }
+  static id = 'langchain_chat_model_generate'
+  static lcType = 'chat_model'
+  static prefix = 'tracing:orchestrion:@langchain/core:BaseChatModel_generate'
 }
 
 class BaseLLMGeneratePlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_llm_generate' }
-  static get lcType () { return 'llm' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:BaseLLM_generate'
-  }
+  static id = 'langchain_llm_generate'
+  static lcType = 'llm'
+  static prefix = 'tracing:orchestrion:@langchain/core:BaseLLM_generate'
 }
 
 class EmbeddingsEmbedQueryPlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_embeddings_embed_query' }
-  static get lcType () { return 'embedding' }
-  static get prefix () {
-    return 'tracing:apm:@langchain/core:Embeddings_embedQuery'
-  }
+  static id = 'langchain_embeddings_embed_query'
+  static lcType = 'embedding'
+  static prefix = 'tracing:apm:@langchain/core:Embeddings_embedQuery'
 }
 
 class EmbeddingsEmbedDocumentsPlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_embeddings_embed_documents' }
-  static get lcType () { return 'embedding' }
-  static get prefix () {
-    return 'tracing:apm:@langchain/core:Embeddings_embedDocuments'
-  }
+  static id = 'langchain_embeddings_embed_documents'
+  static lcType = 'embedding'
+  static prefix = 'tracing:apm:@langchain/core:Embeddings_embedDocuments'
 }
 
 class ToolInvokePlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_tool_invoke' }
-  static get lcType () { return 'tool' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:Tool_invoke'
-  }
+  static id = 'langchain_tool_invoke'
+  static lcType = 'tool'
+  static prefix = 'tracing:orchestrion:@langchain/core:Tool_invoke'
 }
 
 class VectorStoreSimilaritySearchPlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_vectorstore_similarity_search' }
-  static get lcType () { return 'similarity_search' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearch'
-  }
+  static id = 'langchain_vectorstore_similarity_search'
+  static lcType = 'similarity_search'
+  static prefix = 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearch'
 }
 
 class VectorStoreSimilaritySearchWithScorePlugin extends BaseLangChainTracingPlugin {
-  static get id () { return 'langchain_vectorstore_similarity_search_with_score' }
-  static get lcType () { return 'similarity_search' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearchWithScore'
-  }
+  static id = 'langchain_vectorstore_similarity_search_with_score'
+  static lcType = 'similarity_search'
+  static prefix = 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearchWithScore'
 }
 
 module.exports = [

--- a/packages/datadog-plugin-mariadb/src/index.js
+++ b/packages/datadog-plugin-mariadb/src/index.js
@@ -4,8 +4,8 @@ const { storage } = require('../../datadog-core')
 const MySQLPlugin = require('../../datadog-plugin-mysql/src')
 
 class MariadbPlugin extends MySQLPlugin {
-  static get id () { return 'mariadb' }
-  static get system () { return 'mariadb' }
+  static id = 'mariadb'
+  static system = 'mariadb'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-memcached/src/index.js
+++ b/packages/datadog-plugin-memcached/src/index.js
@@ -4,7 +4,7 @@ const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const CachePlugin = require('../../dd-trace/src/plugins/cache')
 
 class MemcachedPlugin extends CachePlugin {
-  static get id () { return 'memcached' }
+  static id = 'memcached'
 
   bindStart (ctx) {
     const { client, server, query } = ctx

--- a/packages/datadog-plugin-microgateway-core/src/index.js
+++ b/packages/datadog-plugin-microgateway-core/src/index.js
@@ -4,9 +4,7 @@ const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class MicrogatewayCorePlugin extends RouterPlugin {
-  static get id () {
-    return 'microgateway-core'
-  }
+  static id = 'microgateway-core'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -74,9 +74,7 @@ function getTestSuiteLevelVisibilityTags (testSuiteSpan) {
 }
 
 class MochaPlugin extends CiPlugin {
-  static get id () {
-    return 'mocha'
-  }
+  static id = 'mocha'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-moleculer/src/client.js
+++ b/packages/datadog-plugin-moleculer/src/client.js
@@ -4,8 +4,8 @@ const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { moleculerTags } = require('./util')
 
 class MoleculerClientPlugin extends ClientPlugin {
-  static get id () { return 'moleculer' }
-  static get operation () { return 'call' }
+  static id = 'moleculer'
+  static operation = 'call'
 
   bindStart (ctx) {
     const { actionName, opts } = ctx

--- a/packages/datadog-plugin-moleculer/src/index.js
+++ b/packages/datadog-plugin-moleculer/src/index.js
@@ -7,7 +7,7 @@ const MoleculerClientPlugin = require('./client')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class MoleculerPlugin extends CompositePlugin {
-  static get id () { return 'moleculer' }
+  static id = 'moleculer'
   static get plugins () {
     return {
       server: MoleculerServerPlugin,

--- a/packages/datadog-plugin-moleculer/src/server.js
+++ b/packages/datadog-plugin-moleculer/src/server.js
@@ -4,8 +4,8 @@ const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { moleculerTags } = require('./util')
 
 class MoleculerServerPlugin extends ServerPlugin {
-  static get id () { return 'moleculer' }
-  static get operation () { return 'action' }
+  static id = 'moleculer'
+  static operation = 'action'
 
   bindStart (ctx) {
     const { action, middlewareCtx, broker } = ctx

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -6,11 +6,11 @@ const coalesce = require('koalas')
 const { getEnvironmentVariable } = require('../../dd-trace/src/config-helper')
 
 class MongodbCorePlugin extends DatabasePlugin {
-  static get id () { return 'mongodb-core' }
-  static get component () { return 'mongodb' }
+  static id = 'mongodb-core'
+  static component = 'mongodb'
   // avoid using db.name for peer.service since it includes the collection name
   // should be removed if one day this will be fixed
-  static get peerServicePrecursors () { return [] }
+  static peerServicePrecursors = []
 
   configure (config) {
     super.configure(config)

--- a/packages/datadog-plugin-mongoose/src/index.js
+++ b/packages/datadog-plugin-mongoose/src/index.js
@@ -4,8 +4,8 @@ const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 const { storage } = require('../../datadog-core')
 
 class MongoosePlugin extends DatabasePlugin {
-  static get id () { return 'mongoose' }
-  static get operation () { return 'exec' }
+  static id = 'mongoose'
+  static operation = 'exec'
 
   bindStart (ctx) {
     ctx.parentStore = storage('legacy').getStore()

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -5,8 +5,8 @@ const CLIENT_PORT_KEY = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 class MySQLPlugin extends DatabasePlugin {
-  static get id () { return 'mysql' }
-  static get system () { return 'mysql' }
+  static id = 'mysql'
+  static system = 'mysql'
 
   constructor () {
     super(...arguments)

--- a/packages/datadog-plugin-mysql2/src/index.js
+++ b/packages/datadog-plugin-mysql2/src/index.js
@@ -4,7 +4,7 @@ const { storage } = require('../../datadog-core')
 const MySQLPlugin = require('../../datadog-plugin-mysql/src')
 
 class MySQL2Plugin extends MySQLPlugin {
-  static get id () { return 'mysql2' }
+  static id = 'mysql2'
 
   constructor () {
     super(...arguments)

--- a/packages/datadog-plugin-net/src/index.js
+++ b/packages/datadog-plugin-net/src/index.js
@@ -5,7 +5,7 @@ const NetIPCPlugin = require('./ipc')
 const NetTCPPlugin = require('./tcp')
 
 class NetPlugin extends Plugin {
-  static get id () { return 'net' }
+  static id = 'net'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-net/src/ipc.js
+++ b/packages/datadog-plugin-net/src/ipc.js
@@ -3,8 +3,8 @@
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class NetIPCPlugin extends ClientPlugin {
-  static get id () { return 'net' }
-  static get operation () { return 'ipc' }
+  static id = 'net'
+  static operation = 'ipc'
 
   bindStart (ctx) {
     this.startSpan('ipc.connect', {

--- a/packages/datadog-plugin-net/src/tcp.js
+++ b/packages/datadog-plugin-net/src/tcp.js
@@ -4,8 +4,8 @@ const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 
 class NetTCPPlugin extends ClientPlugin {
-  static get id () { return 'net' }
-  static get operation () { return 'tcp' }
+  static id = 'net'
+  static operation = 'tcp'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -9,9 +9,7 @@ const web = require('../../dd-trace/src/plugins/util/web')
 const errorPages = new Set(['/404', '/500', '/_error', '/_not-found', '/_not-found/page'])
 
 class NextPlugin extends ServerPlugin {
-  static get id () {
-    return 'next'
-  }
+  static id = 'next'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-nyc/src/index.js
+++ b/packages/datadog-plugin-nyc/src/index.js
@@ -3,9 +3,7 @@
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 
 class NycPlugin extends CiPlugin {
-  static get id () {
-    return 'nyc'
-  }
+  static id = 'nyc'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-openai/src/index.js
+++ b/packages/datadog-plugin-openai/src/index.js
@@ -5,7 +5,7 @@ const OpenAiTracingPlugin = require('./tracing')
 const OpenAiLLMObsPlugin = require('../../dd-trace/src/llmobs/plugins/openai')
 
 class OpenAiPlugin extends CompositePlugin {
-  static get id () { return 'openai' }
+  static id = 'openai'
   static get plugins () {
     return {
       llmobs: OpenAiLLMObsPlugin,

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -17,12 +17,10 @@ const {
 const { DD_MAJOR } = require('../../../version')
 
 class OpenAiTracingPlugin extends TracingPlugin {
-  static get id () { return 'openai' }
-  static get operation () { return 'request' }
-  static get system () { return 'openai' }
-  static get prefix () {
-    return 'tracing:apm:openai:request'
-  }
+  static id = 'openai'
+  static operation = 'request'
+  static system = 'openai'
+  static prefix = 'tracing:apm:openai:request'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-opensearch/src/index.js
+++ b/packages/datadog-plugin-opensearch/src/index.js
@@ -3,9 +3,7 @@
 const ElasticsearchPlugin = require('../../datadog-plugin-elasticsearch/src')
 
 class OpenSearchPlugin extends ElasticsearchPlugin {
-  static get id () {
-    return 'opensearch'
-  }
+  static id = 'opensearch'
 }
 
 module.exports = OpenSearchPlugin

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -6,9 +6,9 @@ const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 let parser
 
 class OracledbPlugin extends DatabasePlugin {
-  static get id () { return 'oracledb' }
-  static get system () { return 'oracle' }
-  static get peerServicePrecursors () { return ['db.instance', 'db.hostname'] }
+  static id = 'oracledb'
+  static system = 'oracle'
+  static peerServicePrecursors = ['db.instance', 'db.hostname']
 
   start ({ query, connAttrs, port, hostname, dbInstance }) {
     const service = this.serviceName({ pluginConfig: this.config, params: connAttrs })

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -4,9 +4,9 @@ const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 class PGPlugin extends DatabasePlugin {
-  static get id () { return 'pg' }
-  static get operation () { return 'query' }
-  static get system () { return 'postgres' }
+  static id = 'pg'
+  static operation = 'query'
+  static system = 'postgres'
 
   start ({ params = {}, query, processId, stream }) {
     const service = this.serviceName({ pluginConfig: this.config, params })

--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -3,9 +3,7 @@
 const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
 
 class PinoPlugin extends LogPlugin {
-  static get id () {
-    return 'pino'
-  }
+  static id = 'pino'
 }
 
 module.exports = PinoPlugin

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -48,9 +48,7 @@ const {
 const { appClosing: appClosingTelemetry } = require('../../dd-trace/src/telemetry')
 
 class PlaywrightPlugin extends CiPlugin {
-  static get id () {
-    return 'playwright'
-  }
+  static id = 'playwright'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-prisma/src/client.js
+++ b/packages/datadog-plugin-prisma/src/client.js
@@ -1,12 +1,10 @@
 'use strict'
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 class PrismaClientPlugin extends DatabasePlugin {
-  static get id () { return 'prisma' }
-  static get operation () { return 'client' }
-  static get system () { return 'prisma' }
-  static get prefix () {
-    return 'tracing:apm:prisma:client'
-  }
+  static id = 'prisma'
+  static operation = 'client'
+  static system = 'prisma'
+  static prefix = 'tracing:apm:prisma:client'
 
   bindStart (ctx) {
     const service = this.serviceName({ pluginConfig: this.config })

--- a/packages/datadog-plugin-prisma/src/engine.js
+++ b/packages/datadog-plugin-prisma/src/engine.js
@@ -23,9 +23,9 @@ const databaseDriverMapper = {
 }
 
 class PrismaEngine extends DatabasePlugin {
-  static get id () { return 'prisma' }
-  static get operation () { return 'engine' }
-  static get system () { return 'prisma' }
+  static id = 'prisma'
+  static operation = 'engine'
+  static system = 'prisma'
 
   start (ctx) {
     const { engineSpan, allEngineSpans, childOf, dbConfig } = ctx

--- a/packages/datadog-plugin-prisma/src/index.js
+++ b/packages/datadog-plugin-prisma/src/index.js
@@ -6,7 +6,7 @@ const PrismaClientPlugin = require('./client')
 const PrismaEnginePlugin = require('./engine')
 
 class PrismaPlugin extends CompositePlugin {
-  static get id () { return 'prisma' }
+  static id = 'prisma'
   static get plugins () {
     return {
       client: PrismaClientPlugin,

--- a/packages/datadog-plugin-protobufjs/src/index.js
+++ b/packages/datadog-plugin-protobufjs/src/index.js
@@ -4,13 +4,9 @@ const SchemaPlugin = require('../../dd-trace/src/plugins/schema')
 const SchemaExtractor = require('./schema_iterator')
 
 class ProtobufjsPlugin extends SchemaPlugin {
-  static get id () {
-    return 'protobufjs'
-  }
+  static id = 'protobufjs'
 
-  static get schemaExtractor () {
-    return SchemaExtractor
-  }
+  static schemaExtractor = SchemaExtractor
 }
 
 module.exports = ProtobufjsPlugin

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -5,8 +5,8 @@ const CachePlugin = require('../../dd-trace/src/plugins/cache')
 const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
 
 class RedisPlugin extends CachePlugin {
-  static get id () { return 'redis' }
-  static get system () { return 'redis' }
+  static id = 'redis'
+  static system = 'redis'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-restify/src/index.js
+++ b/packages/datadog-plugin-restify/src/index.js
@@ -4,9 +4,7 @@ const RouterPlugin = require('../../datadog-plugin-router/src')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class RestifyPlugin extends RouterPlugin {
-  static get id () {
-    return 'restify'
-  }
+  static id = 'restify'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-rhea/src/consumer.js
+++ b/packages/datadog-plugin-rhea/src/consumer.js
@@ -4,7 +4,7 @@ const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
 const { getAmqpMessageSize } = require('../../dd-trace/src/datastreams')
 
 class RheaConsumerPlugin extends ConsumerPlugin {
-  static get id () { return 'rhea' }
+  static id = 'rhea'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-rhea/src/index.js
+++ b/packages/datadog-plugin-rhea/src/index.js
@@ -5,7 +5,7 @@ const ConsumerPlugin = require('./consumer')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
 class RheaPlugin extends CompositePlugin {
-  static get id () { return 'rhea' }
+  static id = 'rhea'
   static get plugins () {
     return {
       producer: ProducerPlugin,

--- a/packages/datadog-plugin-rhea/src/producer.js
+++ b/packages/datadog-plugin-rhea/src/producer.js
@@ -5,8 +5,8 @@ const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 const { getAmqpMessageSize, DsmPathwayCodec } = require('../../dd-trace/src/datastreams')
 
 class RheaProducerPlugin extends ProducerPlugin {
-  static get id () { return 'rhea' }
-  static get operation () { return 'send' }
+  static id = 'rhea'
+  static operation = 'send'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -7,9 +7,7 @@ const { storage } = require('../../datadog-core')
 const { COMPONENT } = require('../../dd-trace/src/constants')
 
 class RouterPlugin extends WebPlugin {
-  static get id () {
-    return 'router'
-  }
+  static id = 'router'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-selenium/src/index.js
+++ b/packages/datadog-plugin-selenium/src/index.js
@@ -27,9 +27,7 @@ function getTestSpanFromTrace (trace) {
 }
 
 class SeleniumPlugin extends CiPlugin {
-  static get id () {
-    return 'selenium'
-  }
+  static id = 'selenium'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-sharedb/src/index.js
+++ b/packages/datadog-plugin-sharedb/src/index.js
@@ -3,7 +3,7 @@
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 
 class SharedbPlugin extends ServerPlugin {
-  static get id () { return 'sharedb' }
+  static id = 'sharedb'
 
   bindStart (ctx) {
     const { actionName, request } = ctx

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -4,9 +4,9 @@ const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 class TediousPlugin extends DatabasePlugin {
-  static get id () { return 'tedious' }
-  static get operation () { return 'request' } // TODO: change to match other database plugins
-  static get system () { return 'mssql' }
+  static id = 'tedious'
+  static operation = 'request' // TODO: change to match other database plugins
+  static system = 'mssql'
 
   bindStart (ctx) {
     const service = this.serviceName({ pluginConfig: this.config, system: this.system })

--- a/packages/datadog-plugin-undici/src/index.js
+++ b/packages/datadog-plugin-undici/src/index.js
@@ -3,10 +3,8 @@
 const FetchPlugin = require('../../datadog-plugin-fetch/src/index.js')
 
 class UndiciPlugin extends FetchPlugin {
-  static get id () { return 'undici' }
-  static get prefix () {
-    return 'tracing:apm:undici:fetch'
-  }
+  static id = 'undici'
+  static prefix = 'tracing:apm:undici:fetch'
 }
 
 module.exports = UndiciPlugin

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -47,9 +47,7 @@ const { DD_MAJOR } = require('../../../version')
 const MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION = 5
 
 class VitestPlugin extends CiPlugin {
-  static get id () {
-    return 'vitest'
-  }
+  static id = 'vitest'
 
   constructor (...args) {
     super(...args)

--- a/packages/datadog-plugin-web/src/index.js
+++ b/packages/datadog-plugin-web/src/index.js
@@ -4,9 +4,7 @@ const Plugin = require('../../dd-trace/src/plugins/plugin')
 const web = require('../../dd-trace/src/plugins/util/web')
 
 class WebPlugin extends Plugin {
-  static get id () {
-    return 'web'
-  }
+  static id = 'web'
 
   configure (config) {
     return super.configure(web.normalizeConfig(config))

--- a/packages/datadog-plugin-winston/src/index.js
+++ b/packages/datadog-plugin-winston/src/index.js
@@ -3,8 +3,6 @@
 const LogPlugin = require('../../dd-trace/src/plugins/log_plugin')
 
 class WinstonPlugin extends LogPlugin {
-  static get id () {
-    return 'winston'
-  }
+  static id = 'winston'
 }
 module.exports = WinstonPlugin

--- a/packages/dd-trace/src/appsec/waf/waf_manager.js
+++ b/packages/dd-trace/src/appsec/waf/waf_manager.js
@@ -7,7 +7,7 @@ const WAFContextWrapper = require('./waf_context_wrapper')
 const contexts = new WeakMap()
 
 class WAFManager {
-  static get defaultWafConfigPath () { return 'datadog/00/ASM_DD/default/config' }
+  static defaultWafConfigPath = 'datadog/00/ASM_DD/default/config'
 
   constructor (rules, config) {
     this.config = config

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -36,9 +36,7 @@ function getWinstonLogSubmissionParameters (config) {
 }
 
 class LogSubmissionPlugin extends Plugin {
-  static get id () {
-    return 'log-submission'
-  }
+  static id = 'log-submission'
 
   constructor (...args) {
     super(...args)

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -9,9 +9,7 @@ const {
 const { storage } = require('../../../../datadog-core')
 
 class TestApiManualPlugin extends CiPlugin {
-  static get id () {
-    return 'test-api-manual'
-  }
+  static id = 'test-api-manual'
 
   constructor (...args) {
     super(...args)

--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -25,11 +25,9 @@ const ToolHandler = require('./handlers/tool')
 const VectorStoreHandler = require('./handlers/vectorstore')
 
 class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
-  static get integration () { return 'langchain' }
-  static get id () { return 'langchain' }
-  static get prefix () {
-    return 'tracing:apm:langchain:invoke'
-  }
+  static integration = 'langchain'
+  static id = 'langchain'
+  static prefix = 'tracing:apm:langchain:invoke'
 
   constructor () {
     super(...arguments)
@@ -150,75 +148,57 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
 }
 
 class RunnableSequenceInvokePlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_rs_invoke' }
-  static get lcType () { return 'chain' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:RunnableSequence_invoke'
-  }
+  static id = 'llmobs_langchain_rs_invoke'
+  static lcType = 'chain'
+  static prefix = 'tracing:orchestrion:@langchain/core:RunnableSequence_invoke'
 }
 
 class RunnableSequenceBatchPlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_rs_batch' }
-  static get lcType () { return 'chain' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:RunnableSequence_batch'
-  }
+  static id = 'llmobs_langchain_rs_batch'
+  static lcType = 'chain'
+  static prefix = 'tracing:orchestrion:@langchain/core:RunnableSequence_batch'
 }
 
 class BaseChatModelGeneratePlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_chat_model_generate' }
-  static get lcType () { return 'chat_model' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:BaseChatModel_generate'
-  }
+  static id = 'llmobs_langchain_chat_model_generate'
+  static lcType = 'chat_model'
+  static prefix = 'tracing:orchestrion:@langchain/core:BaseChatModel_generate'
 }
 
 class BaseLLMGeneratePlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_llm_generate' }
-  static get lcType () { return 'llm' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:BaseLLM_generate'
-  }
+  static id = 'llmobs_langchain_llm_generate'
+  static lcType = 'llm'
+  static prefix = 'tracing:orchestrion:@langchain/core:BaseLLM_generate'
 }
 
 class EmbeddingsEmbedQueryPlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_embeddings_embed_query' }
-  static get lcType () { return 'embedding' }
-  static get prefix () {
-    return 'tracing:apm:@langchain/core:Embeddings_embedQuery'
-  }
+  static id = 'llmobs_langchain_embeddings_embed_query'
+  static lcType = 'embedding'
+  static prefix = 'tracing:apm:@langchain/core:Embeddings_embedQuery'
 }
 
 class EmbeddingsEmbedDocumentsPlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_embeddings_embed_documents' }
-  static get lcType () { return 'embedding' }
-  static get prefix () {
-    return 'tracing:apm:@langchain/core:Embeddings_embedDocuments'
-  }
+  static id = 'llmobs_langchain_embeddings_embed_documents'
+  static lcType = 'embedding'
+  static prefix = 'tracing:apm:@langchain/core:Embeddings_embedDocuments'
 }
 
 class ToolInvokePlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_tool_invoke' }
-  static get lcType () { return 'tool' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:Tool_invoke'
-  }
+  static id = 'llmobs_langchain_tool_invoke'
+  static lcType = 'tool'
+  static prefix = 'tracing:orchestrion:@langchain/core:Tool_invoke'
 }
 
 class VectorStoreSimilaritySearchPlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_vectorstore_similarity_search' }
-  static get lcType () { return 'similarity_search' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearch'
-  }
+  static id = 'llmobs_langchain_vectorstore_similarity_search'
+  static lcType = 'similarity_search'
+  static prefix = 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearch'
 }
 
 class VectorStoreSimilaritySearchWithScorePlugin extends BaseLangChainLLMObsPlugin {
-  static get id () { return 'llmobs_langchain_vectorstore_similarity_search_with_score' }
-  static get lcType () { return 'similarity_search' }
-  static get prefix () {
-    return 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearchWithScore'
-  }
+  static id = 'llmobs_langchain_vectorstore_similarity_search_with_score'
+  static lcType = 'similarity_search'
+  static prefix = 'tracing:orchestrion:@langchain/core:VectorStore_similaritySearchWithScore'
 }
 
 module.exports = [

--- a/packages/dd-trace/src/llmobs/plugins/openai.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai.js
@@ -10,11 +10,9 @@ function isIterable (obj) {
 }
 
 class OpenAiLLMObsPlugin extends LLMObsPlugin {
-  static get id () { return 'openai' }
-  static get integration () { return 'openai' }
-  static get prefix () {
-    return 'tracing:apm:openai:request'
-  }
+  static id = 'openai'
+  static integration = 'openai'
+  static prefix = 'tracing:apm:openai:request'
 
   getLLMObsSpanRegisterOptions (ctx) {
     const resource = ctx.methodName

--- a/packages/dd-trace/src/llmobs/plugins/vertexai.js
+++ b/packages/dd-trace/src/llmobs/plugins/vertexai.js
@@ -7,11 +7,9 @@ const {
 } = require('../../../../datadog-plugin-google-cloud-vertexai/src/utils')
 
 class VertexAILLMObsPlugin extends LLMObsPlugin {
-  static get integration () { return 'vertexai' } // used for llmobs telemetry
-  static get id () { return 'vertexai' }
-  static get prefix () {
-    return 'tracing:apm:vertexai:request'
-  }
+  static integration = 'vertexai' // used for llmobs telemetry
+  static id = 'vertexai'
+  static prefix = 'tracing:apm:vertexai:request'
 
   getLLMObsSpanRegisterOptions (ctx) {
     const history = ctx.instance?.historyInternal || []

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -4,9 +4,9 @@ const TracingPlugin = require('./tracing')
 const { storage } = require('../../../datadog-core')
 
 class ApolloBasePlugin extends TracingPlugin {
-  static get id () { return 'apollo.gateway' }
-  static get type () { return 'web' }
-  static get kind () { return 'server' }
+  static id = 'apollo.gateway'
+  static type = 'web'
+  static kind = 'server'
 
   bindStart (ctx) {
     const store = storage('legacy').getStore()

--- a/packages/dd-trace/src/plugins/cache.js
+++ b/packages/dd-trace/src/plugins/cache.js
@@ -3,7 +3,7 @@
 const StoragePlugin = require('./storage')
 
 class CachePlugin extends StoragePlugin {
-  static get operation () { return 'command' }
+  static operation = 'command'
 
   startSpan (options, ctx) {
     if (!options.kind) {

--- a/packages/dd-trace/src/plugins/client.js
+++ b/packages/dd-trace/src/plugins/client.js
@@ -3,9 +3,9 @@
 const OutboundPlugin = require('./outbound')
 
 class ClientPlugin extends OutboundPlugin {
-  static get operation () { return 'request' }
-  static get kind () { return 'client' }
-  static get type () { return 'web' } // overridden by storage and other client type plugins
+  static operation = 'request'
+  static kind = 'client'
+  static type = 'web' // overridden by storage and other client type plugins
 }
 
 module.exports = ClientPlugin

--- a/packages/dd-trace/src/plugins/consumer.js
+++ b/packages/dd-trace/src/plugins/consumer.js
@@ -3,9 +3,9 @@
 const InboundPlugin = require('./inbound')
 
 class ConsumerPlugin extends InboundPlugin {
-  static get operation () { return 'receive' }
-  static get kind () { return 'consumer' }
-  static get type () { return 'messaging' }
+  static operation = 'receive'
+  static kind = 'consumer'
+  static type = 'messaging'
 
   startSpan (options, enterOrCtx) {
     if (!options.service) {

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -4,8 +4,8 @@ const StoragePlugin = require('./storage')
 const { PEER_SERVICE_KEY, PEER_SERVICE_SOURCE_KEY } = require('../constants')
 
 class DatabasePlugin extends StoragePlugin {
-  static get operation () { return 'query' }
-  static get peerServicePrecursors () { return ['db.name'] }
+  static operation = 'query'
+  static peerServicePrecursors = ['db.name']
 
   constructor (...args) {
     super(...args)

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -17,7 +17,7 @@ const COMMON_PEER_SVC_SOURCE_TAGS = [
 
 // TODO: Exit span on finish when AsyncResource instances are removed.
 class OutboundPlugin extends TracingPlugin {
-  static get peerServicePrecursors () { return [] }
+  static peerServicePrecursors = []
 
   constructor (...args) {
     super(...args)

--- a/packages/dd-trace/src/plugins/producer.js
+++ b/packages/dd-trace/src/plugins/producer.js
@@ -3,9 +3,9 @@
 const OutboundPlugin = require('./outbound')
 
 class ProducerPlugin extends OutboundPlugin {
-  static get operation () { return 'publish' }
-  static get kind () { return 'producer' }
-  static get type () { return 'messaging' }
+  static operation = 'publish'
+  static kind = 'producer'
+  static type = 'messaging'
 
   startSpan (options, enterOrCtx) {
     const spanDefaults = {

--- a/packages/dd-trace/src/plugins/server.js
+++ b/packages/dd-trace/src/plugins/server.js
@@ -3,9 +3,9 @@
 const InboundPlugin = require('./inbound')
 
 class ServerPlugin extends InboundPlugin {
-  static get operation () { return 'request' }
-  static get kind () { return 'server' }
-  static get type () { return 'web' } // a default that may eventually be overriden by nonweb servers
+  static operation = 'request'
+  static kind = 'server'
+  static type = 'web' // a default that may eventually be overriden by nonweb servers
 }
 
 module.exports = ServerPlugin

--- a/packages/dd-trace/src/plugins/storage.js
+++ b/packages/dd-trace/src/plugins/storage.js
@@ -3,7 +3,7 @@
 const ClientPlugin = require('./client')
 
 class StoragePlugin extends ClientPlugin {
-  static get type () { return 'storage' }
+  static type = 'storage'
 
   constructor (...args) {
     super(...args)

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns.js
@@ -3,13 +3,9 @@
 const EventPlugin = require('./event')
 
 class DNSPlugin extends EventPlugin {
-  static get id () {
-    return 'dns'
-  }
+  static id = 'dns'
 
-  static get entryType () {
-    return 'dns'
-  }
+  static entryType = 'dns'
 }
 
 module.exports = DNSPlugin

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookup.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookup.js
@@ -3,9 +3,7 @@
 const DNSPlugin = require('./dns')
 
 class DNSLookupPlugin extends DNSPlugin {
-  static get operation () {
-    return 'lookup'
-  }
+  static operation = 'lookup'
 
   extendEvent (event, startEvent) {
     event.name = 'lookup'

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookupservice.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_lookupservice.js
@@ -3,9 +3,7 @@
 const DNSPlugin = require('./dns')
 
 class DNSLookupServicePlugin extends DNSPlugin {
-  static get operation () {
-    return 'lookup_service'
-  }
+  static operation = 'lookup_service'
 
   extendEvent (event, startEvent) {
     event.name = 'lookupService'

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_resolve.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_resolve.js
@@ -5,9 +5,7 @@ const DNSPlugin = require('./dns')
 const queryNames = new Map()
 
 class DNSResolvePlugin extends DNSPlugin {
-  static get operation () {
-    return 'resolve'
-  }
+  static operation = 'resolve'
 
   extendEvent (event, startEvent) {
     const rrtype = startEvent.args[1]

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/dns_reverse.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/dns_reverse.js
@@ -3,9 +3,7 @@
 const DNSPlugin = require('./dns')
 
 class DNSReversePlugin extends DNSPlugin {
-  static get operation () {
-    return 'reverse'
-  }
+  static operation = 'reverse'
 
   extendEvent (event, startEvent) {
     event.name = 'getHostByAddr'

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/fs.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/fs.js
@@ -19,17 +19,11 @@ const allowedParams = new Set([
 ])
 
 class FilesystemPlugin extends EventPlugin {
-  static get id () {
-    return 'fs'
-  }
+  static id = 'fs'
 
-  static get operation () {
-    return 'operation'
-  }
+  static operation = 'operation'
 
-  static get entryType () {
-    return 'fs'
-  }
+  static entryType = 'fs'
 
   ignoreEvent (event) {
     // Don't care about sync events, they show up in the event loop samples anyway

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/net.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/net.js
@@ -3,17 +3,11 @@
 const EventPlugin = require('./event')
 
 class NetPlugin extends EventPlugin {
-  static get id () {
-    return 'net'
-  }
+  static id = 'net'
 
-  static get operation () {
-    return 'tcp'
-  }
+  static operation = 'tcp'
 
-  static get entryType () {
-    return 'net'
-  }
+  static entryType = 'net'
 
   extendEvent (event, { options }) {
     event.name = 'connect'

--- a/packages/dd-trace/src/remote_config/manager.js
+++ b/packages/dd-trace/src/remote_config/manager.js
@@ -22,7 +22,7 @@ const kSupportsAckCallback = Symbol('kSupportsAckCallback')
 // There MUST NOT exist separate instances of RC clients in a tracer making separate ClientGetConfigsRequest
 // with their own separated Client.ClientState.
 class RemoteConfigManager extends EventEmitter {
-  static get kPreUpdate () { return kPreUpdate }
+  static kPreUpdate = kPreUpdate
 
   constructor (config) {
     super()

--- a/packages/dd-trace/test/appsec/iast/iast-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/iast-plugin.spec.js
@@ -381,7 +381,7 @@ describe('IAST Plugin', () => {
 
   describe('Add sub to iast plugin', () => {
     class BadPlugin extends IastPlugin {
-      static get id () { return 'badPlugin' }
+      static id = 'badPlugin'
 
       constructor () {
         super()
@@ -393,7 +393,7 @@ describe('IAST Plugin', () => {
       }
     }
     class GoodPlugin extends IastPlugin {
-      static get id () { return 'goodPlugin' }
+      static id = 'goodPlugin'
 
       constructor () {
         super()

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -33,25 +33,17 @@ describe('Plugin Manager', () => {
     const plugins = {
       one: {},
       two: class Two extends FakePlugin {
-        static get id () {
-          return 'two'
-        }
+        static id = 'two'
       },
       three: {},
       four: class Four extends FakePlugin {
-        static get id () {
-          return 'four'
-        }
+        static id = 'four'
       },
       five: class Five extends FakePlugin {
-        static get id () {
-          return 'five'
-        }
+        static id = 'five'
       },
       six: class Six extends FakePlugin {
-        static get id () {
-          return 'six'
-        }
+        static id = 'six'
       },
       seven: {}
     }

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -12,9 +12,7 @@ const { expect } = require('chai')
 const testLogChannel = channel('apm:test:log')
 
 class TestLog extends LogPlugin {
-  static get id () {
-    return 'test'
-  }
+  static id = 'test'
 }
 
 const config = {

--- a/packages/dd-trace/test/plugins/outbound.spec.js
+++ b/packages/dd-trace/test/plugins/outbound.spec.js
@@ -91,7 +91,7 @@ describe('OuboundPlugin', () => {
 
     it('should use specific tags in order of precedence if they are available', () => {
       class WithPrecursors extends OutboundPlugin {
-        static get peerServicePrecursors () { return ['foo', 'bar'] }
+        static peerServicePrecursors = ['foo', 'bar']
       }
       const res = new WithPrecursors().getPeerService({
         fooIsNotAPrecursor: 'bar',

--- a/packages/dd-trace/test/plugins/plugin.spec.js
+++ b/packages/dd-trace/test/plugins/plugin.spec.js
@@ -10,7 +10,7 @@ describe('Plugin', () => {
   let plugin
 
   class BadPlugin extends Plugin {
-    static get id () { return 'badPlugin' }
+    static id = 'badPlugin'
 
     constructor () {
       super()
@@ -23,7 +23,7 @@ describe('Plugin', () => {
   }
 
   class GoodPlugin extends Plugin {
-    static get id () { return 'goodPlugin' }
+    static id = 'goodPlugin'
 
     constructor () {
       super()
@@ -63,7 +63,7 @@ describe('Plugin', () => {
 
   it('should run binding transforms with an undefined current store', () => {
     class TestPlugin extends Plugin {
-      static get id () { return 'test' }
+      static id = 'test'
 
       constructor () {
         super()

--- a/packages/dd-trace/test/plugins/tracing.spec.js
+++ b/packages/dd-trace/test/plugins/tracing.spec.js
@@ -35,8 +35,8 @@ describe('common Plugin behaviour', () => {
 
   after(() => agent.close({ ritmReset: false }))
   class CommonPlugin extends TracingPlugin {
-    static get id () { return 'commonPlugin' }
-    static get operation () { return 'dothings' }
+    static id = 'commonPlugin'
+    static operation = 'dothings'
 
     start () {
       return this.startSpan('common.operation', {
@@ -46,8 +46,8 @@ describe('common Plugin behaviour', () => {
   }
 
   class SuffixPlugin extends TracingPlugin {
-    static get id () { return 'suffixPlugin' }
-    static get operation () { return 'dothings' }
+    static id = 'suffixPlugin'
+    static operation = 'dothings'
     start () {
       return this.startSpan('common.operation', {
         service: this.config.service || `${this.tracer._service}-suffix`


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Replace static getters with static properties.

### Motivation
<!-- What inspired you to submit this pull request? -->

Static properties are much more readable. Static getters were only used originally to preserve compatibility with Webpack 4, but that has never been officially supported and it was decided that we don't want to support it anyway, so we can use the cleaner syntax.