### PR TITLE
remove async storage from fastify instrumentation

### DIFF
--- a/packages/datadog-plugin-fastify/src/tracing.js
+++ b/packages/datadog-plugin-fastify/src/tracing.js
@@ -17,7 +17,6 @@ class FastifyTracingPlugin extends RouterPlugin {
 
     this.addBind('datadog:fastify:pre-parsing:start', getParentStore)
     this.addBind('datadog:fastify:pre-validation:start', getParentStore)
-    this.addBind('datadog:fastify:add-hook:start', getParentStore)
 
     this.addSub('datadog:fastify:pre-parsing:finish', (ctx) => {
       return ctx.parentStore
@@ -25,9 +24,7 @@ class FastifyTracingPlugin extends RouterPlugin {
     this.addSub('datadog:fastify:pre-validation:finish', (ctx) => {
       return ctx.parentStore
     })
-    this.addSub('datadog:fastify:add-hook:finish', (ctx) => {
-      return ctx.parentStore
-    })
+    this.addSub('datadog:fastify:callback:execute', getParentStore)
   }
 }
 


### PR DESCRIPTION
### What does this PR do?
removes async resource storage usage from fastify instrumentation for Node24 compatibility

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


