### PR TITLE
remove async resource from limitd-client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1802,6 +1802,12 @@ declare namespace tracer {
 
     /**
      * This plugin automatically instruments the
+     * [limitd-client]
+     */
+    interface limitd_client extends Instrumentation {}
+
+    /**
+     * This plugin automatically instruments the
      * [mariadb](https://github.com/mariadb-corporation/mariadb-connector-nodejs) module.
      */
     interface mariadb extends mysql {}

--- a/packages/datadog-instrumentations/src/limitd-client.js
+++ b/packages/datadog-instrumentations/src/limitd-client.js
@@ -1,12 +1,29 @@
 'use strict'
 
-const { addHook, AsyncResource } = require('./helpers/instrument')
+const { addHook, channel } = require('./helpers/instrument')
 const shimmer = require('../../datadog-shimmer')
+
+const callbackStartCh = channel('apm:limitd-client:callback:start')
+const callbackFinishCh = channel('apm:limitd-client:callback:finish')
 
 function wrapRequest (original) {
   return function () {
     const id = arguments.length - 1
-    arguments[id] = AsyncResource.bind(arguments[id])
+    const callback = arguments[id]
+    const ctx = {}
+
+    if (typeof callback === 'function') {
+      let cb = callback
+      callbackStartCh.runStores(ctx, () => {
+        cb = function () {
+          return callbackFinishCh.runStores(ctx, () => {
+            return callback.apply(this, arguments)
+          })
+        }
+      })
+      arguments[id] = cb
+    }
+
     return original.apply(this, arguments)
   }
 }

--- a/packages/datadog-plugin-limitd-client/src/index.js
+++ b/packages/datadog-plugin-limitd-client/src/index.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const ServerPlugin = require('../../dd-trace/src/plugins/server')
+const { storage } = require('../../datadog-core')
+
+class LimitdClientPlugin extends ServerPlugin {
+  static get id () { return 'limitd-client' }
+  static get operation () { return 'callback' }
+
+  bindStart (ctx) {
+    ctx.parentStore = storage('legacy').getStore()
+    return ctx.parentStore
+  }
+
+  bindFinish (ctx) {
+    return ctx.parentStore
+  }
+}
+
+module.exports = LimitdClientPlugin

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -64,6 +64,7 @@ module.exports = {
   get '@confluentinc/kafka-javascript' () {
     return require('../../../datadog-plugin-confluentinc-kafka-javascript/src')
   },
+  get 'limitd-client' () { return require('../../../datadog-plugin-limitd-client/src') },
   get langchain () { return require('../../../datadog-plugin-langchain/src') },
   get mariadb () { return require('../../../datadog-plugin-mariadb/src') },
   get memcached () { return require('../../../datadog-plugin-memcached/src') },


### PR DESCRIPTION
### What does this PR do?
removes async resource usage from limitd-client instrumentation.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.
- [x] Benchmarks.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


