### PR TITLE
Fix service name in metadata

### DIFF
--- a/packages/dd-trace/src/tracer_metadata.js
+++ b/packages/dd-trace/src/tracer_metadata.js
@@ -14,7 +14,7 @@ function storeConfig (config) {
     config.tags['runtime-id'],
     tracerVersion,
     config.hostname,
-    config.server || null,
+    config.service || null,
     config.env || null,
     config.version || null
   )


### PR DESCRIPTION
### What does this PR do?

Use the correct field which contains the service name when filling the tracer metadata.

### Motivation

Noticed that the field was not set correctly.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


