### PR TITLE
use globally installed azure function tools

### DIFF
--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -118,6 +118,8 @@ jobs:
       SERVICES: azureservicebusemulator,azuresqledge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/node
+      - run: npm install -g azure-functions-core-tools@4.1.0
       - uses: ./.github/actions/plugins/test
 
   azure-service-bus:

--- a/packages/datadog-plugin-azure-functions/test/integration-test/fixtures/package.json
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/fixtures/package.json
@@ -4,6 +4,6 @@
   "description": "",
   "main": "src/functions/server.mjs",
   "scripts": {
-    "start": "func start"
+    "start": "npx azure-functions-core-tools start"
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use globally installed Azure function tools.

### Motivation
<!-- What inspired you to submit this pull request? -->

There are timeouts happening right now in the sandbox creation, and my only theory is this module since it takes a long time to install. Removing it from the test setup and installing it globally instead will skip the Mocha timeout, and will avoid having to reinstall it for every test version.