### PR TITLE
Remove Async Resource from knex

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/sql-injection-analyzer.js
@@ -36,14 +36,12 @@ class SqlInjectionAnalyzer extends StoredInjectionAnalyzer {
     this.addBind('datadog:knex:raw:start', (context) => {
       const { sql, dialect: knexDialect } = context
       const dialect = this.normalizeKnexDialect(knexDialect)
-      const newStore = this.getStoreAndAnalyze(sql, dialect)
-      context.currentStore = newStore
-      return newStore
+      const currentStore = this.getStoreAndAnalyze(sql, dialect)
+      context.currentStore = currentStore
+      return currentStore
     })
 
-    this.addBind('datadog:knex:raw:subscribes', (context) => {
-      return context.currentStore
-    })
+    this.addBind('datadog:knex:raw:subscribes', ({ currentStore }) => currentStore)
     this.addBind('datadog:knex:raw:finish', ({ currentStore }) => currentStore?.sqlParentStore)
   }
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/resources/knex-sql-injection-methods.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/resources/knex-sql-injection-methods.js
@@ -35,10 +35,25 @@ function executeKnexNestedRawQueryAsCallback (knex, taintedSql, sqlToFail, cb) {
   })
 }
 
+async function executeKnexAsyncNestedRawQuery (knex, taintedSql, notTaintedSql) {
+  await knex.raw(notTaintedSql)
+  await knex.raw(taintedSql)
+}
+
+async function executeKnexAsyncNestedRawQueryAsAsyncTryCatch (knex, taintedSql, sqlToFail) {
+  try {
+    await knex.raw(sqlToFail)
+  } catch (e) {
+    await knex.raw(taintedSql)
+  }
+}
+
 module.exports = {
   executeKnexRawQuery,
   executeKnexNestedRawQuery,
+  executeKnexAsyncNestedRawQuery,
   executeKnexNestedRawQueryOnRejectedInThen,
   executeKnexNestedRawQueryWitCatch,
-  executeKnexNestedRawQueryAsCallback
+  executeKnexNestedRawQueryAsCallback,
+  executeKnexAsyncNestedRawQueryAsAsyncTryCatch
 }

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.knex.plugin.spec.js
@@ -14,8 +14,7 @@ describe('sql-injection-analyzer with knex', () => {
   withVersions('knex', 'knex', knexVersion => {
     if (!semver.satisfies(knexVersion, '>=2')) return
 
-    withVersions('pg', 'pg', pgVersion => {
-      if (pgVersion !== '8.0.3') return
+    withVersions('pg', 'pg', () => {
       let knex
 
       prepareTestServerForIast('knex + pg',

--- a/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/sql-injection-analyzer.spec.js
@@ -64,7 +64,7 @@ describe('sql-injection-analyzer', () => {
   sqlInjectionAnalyzer.configure(true)
 
   it('should subscribe to mysql, mysql2 and pg start query channel', () => {
-    expect(sqlInjectionAnalyzer._subscriptions).to.have.lengthOf(9)
+    expect(sqlInjectionAnalyzer._subscriptions).to.have.lengthOf(7)
     expect(sqlInjectionAnalyzer._subscriptions[0]._channel.name).to.equals('apm:mysql:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[1]._channel.name).to.equals('datadog:mysql2:outerquery:start')
     expect(sqlInjectionAnalyzer._subscriptions[2]._channel.name).to.equals('apm:pg:query:start')
@@ -72,12 +72,13 @@ describe('sql-injection-analyzer', () => {
     expect(sqlInjectionAnalyzer._subscriptions[4]._channel.name).to.equals('datadog:pg:pool:query:finish')
     expect(sqlInjectionAnalyzer._subscriptions[5]._channel.name).to.equals('datadog:mysql:pool:query:start')
     expect(sqlInjectionAnalyzer._subscriptions[6]._channel.name).to.equals('datadog:mysql:pool:query:finish')
-    expect(sqlInjectionAnalyzer._subscriptions[7]._channel.name).to.equals('datadog:knex:raw:start')
-    expect(sqlInjectionAnalyzer._subscriptions[8]._channel.name).to.equals('datadog:knex:raw:finish')
 
-    expect(sqlInjectionAnalyzer._bindings).to.have.lengthOf(2)
+    expect(sqlInjectionAnalyzer._bindings).to.have.lengthOf(5)
     expect(sqlInjectionAnalyzer._bindings[0]._channel.name).to.equals('datadog:sequelize:query:start')
     expect(sqlInjectionAnalyzer._bindings[1]._channel.name).to.equals('datadog:pg:pool:query:start')
+    expect(sqlInjectionAnalyzer._bindings[2]._channel.name).to.equals('datadog:knex:raw:start')
+    expect(sqlInjectionAnalyzer._bindings[3]._channel.name).to.equals('datadog:knex:raw:subscribes')
+    expect(sqlInjectionAnalyzer._bindings[4]._channel.name).to.equals('datadog:knex:raw:finish')
   })
 
   it('should not detect vulnerability when no query', () => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removes the usage of AsyncResource rom knex and uses `channel.runStores()`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Fix node 24 compatibility.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


