### PR TITLE
ci(azure-functions): install azure-functions-core-tools outside of test suite

### DIFF
--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -97,6 +97,12 @@ jobs:
   azure-functions:
     runs-on: ubuntu-latest
     services:
+        azurite:
+          image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+          ports:
+              - "127.0.0.1:10000:10000"
+              - "127.0.0.1:10001:10001"
+              - "127.0.0.1:10002:10002"
         azureservicebusemulator:
           image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
           ports:

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -118,13 +118,9 @@ jobs:
       SERVICES: azureservicebusemulator,azuresqledge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ca-certificates curl gpg
-      - run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
-          && sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
-          && sudo bash -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-noble-prod noble main" > /etc/apt/sources.list.d/dotnetdev.list' \
-          && sudo apt-get update \
-          && sudo apt-get install -y --no-install-recommends azure-functions-core-tools-4=4.1.0-1
+      - uses: ./.github/actions/node
+      - run: npm install -g azure-functions-core-tools@4.1.0
+      - run: echo "$(dirname $(which func))" >> $GITHUB_PATH
       - uses: ./.github/actions/plugins/test
 
   azure-service-bus:

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -118,6 +118,13 @@ jobs:
       SERVICES: azureservicebusemulator,azuresqledge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ca-certificates curl gpg
+      - run: |
+          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg \
+          && sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg \
+          && sudo bash -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-noble-prod noble main" > /etc/apt/sources.list.d/dotnetdev.list' \
+          && sudo apt-get update \
+          && sudo apt-get install -y --no-install-recommends azure-functions-core-tools-4=4.1.0-1
       - uses: ./.github/actions/plugins/test
 
   azure-service-bus:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,12 @@ services:
     image: aerospike:ce-6.4.0.3
     ports:
       - "127.0.0.1:3000-3002:3000-3002"
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+    ports:
+        - "127.0.0.1:10000:10000"
+        - "127.0.0.1:10001:10001"
+        - "127.0.0.1:10002:10002"
   azureservicebusemulator:
     image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
     ports:

--- a/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
@@ -44,7 +44,7 @@ describe('esm', () => {
 
     it('is instrumented', async () => {
       const envArgs = {
-        PATH: `/usr/bin:${process.env.PATH}`
+        PATH: process.env.PATH
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
@@ -60,7 +60,7 @@ describe('esm', () => {
 
     it('propagates context to child http requests', async () => {
       const envArgs = {
-        PATH: `/usr/bin:${process.env.PATH}`
+        PATH: process.env.PATH
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
@@ -72,7 +72,7 @@ describe('esm', () => {
 
     it('propagates context through a service bus queue', async () => {
       const envArgs = {
-        PATH: `/usr/bin:${process.env.PATH}`
+        PATH: process.env.PATH
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
@@ -90,7 +90,7 @@ describe('esm', () => {
 
     it('propagates context through a service bus topic', async () => {
       const envArgs = {
-        PATH: `/usr/bin:${process.env.PATH}`
+        PATH: process.env.PATH
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 

--- a/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
@@ -22,7 +22,6 @@ describe('esm', () => {
       this.timeout(120_000)
       sandbox = await createSandbox([
         `@azure/functions@${version}`,
-        'azure-functions-core-tools@4.1.0',
         '@azure/service-bus@7.9.2'
       ],
       false,
@@ -45,7 +44,7 @@ describe('esm', () => {
 
     it('is instrumented', async () => {
       const envArgs = {
-        PATH: `${sandbox.folder}/node_modules/azure-functions-core-tools/bin:${process.env.PATH}`
+        PATH: `/usr/bin:${process.env.PATH}`
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
@@ -61,7 +60,7 @@ describe('esm', () => {
 
     it('propagates context to child http requests', async () => {
       const envArgs = {
-        PATH: `${sandbox.folder}/node_modules/azure-functions-core-tools/bin:${process.env.PATH}`
+        PATH: `/usr/bin:${process.env.PATH}`
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
@@ -73,7 +72,7 @@ describe('esm', () => {
 
     it('propagates context through a service bus queue', async () => {
       const envArgs = {
-        PATH: `${sandbox.folder}/node_modules/azure-functions-core-tools/bin:${process.env.PATH}`
+        PATH: `/usr/bin:${process.env.PATH}`
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
@@ -91,7 +90,7 @@ describe('esm', () => {
 
     it('propagates context through a service bus topic', async () => {
       const envArgs = {
-        PATH: `${sandbox.folder}/node_modules/azure-functions-core-tools/bin:${process.env.PATH}`
+        PATH: `/usr/bin:${process.env.PATH}`
       }
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 


### PR DESCRIPTION
### What does this PR do?

- Install azure-functions-core-tools outside of azure-functions test sandbox
- Add azurite service for azure-functions tests

### Motivation

Flaky tests, presumed to be caused by long installation times of azure-functions-core-tools

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes

These errors are likely not the cause of the flaky timeouts but the azurite service was added just in case to resolve these errors.
```
[2025-08-06T20:09:54.046Z] We couldn’t reach the Table service endpoint specified in the 'AzureWebJobsStorage' setting. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please confirm network connectivity and endpoint accessibility.

[2025-08-06T20:09:54.046Z] Azure.Core: Connection refused (127.0.0.1:10002). System.Net.Http: Connection refused (127.0.0.1:10002). System.Private.CoreLib: Connection refused.
```


