### PR TITLE
limit dependabot automation trigger to opened activity

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -1,6 +1,9 @@
 name: 'Dependabot Automation'
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   dependabot:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Limit dependabot automation trigger to `opened` activity.

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise it reapproves when anyone makes a change to a dependabot PR, and those changes should always be reviewed by someone.