### PR TITLE
skip dependabot update for major versions of nock nyc and otel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,12 @@ updates:
         update-types: ["version-update:semver-major"]
         # The path-to-regexp version has to be the same as used in express v4.
         # Consider vendoring it instead.
+      - dependency-name: "nock"
+        # Latest version breaks our tests.
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "nyc"
+        # Latest version breaks our tests.
+        update-types: ["version-update:semver-major"]
       - dependency-name: "path-to-regexp"
       - dependency-name: "lru-cache"
         # 11.0.0 onwards only supports Node.js 20 and above
@@ -77,6 +83,7 @@ updates:
           - "@datadog/sketches-js"
           - "@datadog/wasm-js-rewriter"
           - "@opentelemetry/api"
+          - "@opentelemetry/core"
   - package-ecosystem: "npm"
     directory: "/packages/dd-trace/test/plugins/versions"
     schedule:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Skip dependabot update for major versions of nock nyc and OTel.

### Motivation
<!-- What inspired you to submit this pull request? -->

They break our tests when updated:

https://github.com/DataDog/dd-trace-js/pull/6257
https://github.com/DataDog/dd-trace-js/pull/6057
https://github.com/DataDog/dd-trace-js/pull/5999
https://github.com/DataDog/dd-trace-js/pull/5972