### PR TITLE
[SVLS-7168] Create GCP PubSub Push Subscriptions Plugin

### DIFF
--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -26,6 +26,10 @@ addHook({
   versions: ['>=1.4.0 <1.20.0']
 }, read => {
   return shimmer.wrapFunction(read, read => function (req, res, next) {
+    // Skip body parsing if PubSub/Cloud Event middleware already parsed it
+    if (req._pubsubBodyParsed) {
+      return next()
+    }
     const nextResource = new AsyncResource('bound-anonymous-fn')
     arguments[2] = nextResource.bind(publishRequestBodyAndNext(req, res, next))
     return read.apply(this, arguments)
@@ -38,6 +42,10 @@ addHook({
   versions: ['>=1.20.0']
 }, read => {
   return shimmer.wrapFunction(read, read => function (req, res, next) {
+    // Skip body parsing if PubSub/Cloud Event middleware already parsed it
+    if (req._pubsubBodyParsed) {
+      return next()
+    }
     arguments[2] = publishRequestBodyAndNext(req, res, next)
     return read.apply(this, arguments)
   })

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -26,8 +26,17 @@ addHook({
   versions: ['>=1.4.0 <1.20.0']
 }, read => {
   return shimmer.wrapFunction(read, read => function (req, res, next) {
-    // Skip body parsing if PubSub/Cloud Event middleware already parsed it
-    if (req._pubsubBodyParsed) {
+    // Skip body parsing if body has already been meaningfully parsed by any middleware
+    if (req.body !== undefined && req.body !== null &&
+        ((typeof req.body === 'object' && Object.keys(req.body).length > 0) ||
+         (typeof req.body === 'string' && req.body.length > 0))) {
+      // Still publish the channel so AppSec and IAST can process the body
+      if (bodyParserReadCh.hasSubscribers && req) {
+        const abortController = new AbortController()
+        const body = req.body
+        bodyParserReadCh.publish({ req, res, body, abortController })
+        if (abortController.signal.aborted) return
+      }
       return next()
     }
     const nextResource = new AsyncResource('bound-anonymous-fn')
@@ -42,8 +51,17 @@ addHook({
   versions: ['>=1.20.0']
 }, read => {
   return shimmer.wrapFunction(read, read => function (req, res, next) {
-    // Skip body parsing if PubSub/Cloud Event middleware already parsed it
-    if (req._pubsubBodyParsed) {
+    // Skip body parsing if body has already been meaningfully parsed by any middleware
+    if (req.body !== undefined && req.body !== null &&
+        ((typeof req.body === 'object' && Object.keys(req.body).length > 0) ||
+         (typeof req.body === 'string' && req.body.length > 0))) {
+      // Still publish the channel so AppSec and IAST can process the body
+      if (bodyParserReadCh.hasSubscribers && req) {
+        const abortController = new AbortController()
+        const body = req.body
+        bodyParserReadCh.publish({ req, res, body, abortController })
+        if (abortController.signal.aborted) return
+      }
       return next()
     }
     arguments[2] = publishRequestBodyAndNext(req, res, next)

--- a/packages/datadog-instrumentations/src/http.js
+++ b/packages/datadog-instrumentations/src/http.js
@@ -1,4 +1,19 @@
 'use strict'
 
+const { getSharedChannel } = require('./shared-channels')
+
+try {
+  // Load the HttpHandler plugin directly to ensure it gets instantiated
+  const HttpHandlerPlugin = require('../../datadog-plugin-google-cloud-pubsub/src/http-handler')
+
+  // Get tracer instance and instantiate the plugin
+  const tracer = require('../../dd-trace')
+  if (tracer && tracer._tracer) {
+    HttpHandlerPlugin(tracer)
+  }
+} catch {
+  // Silently handle plugin loading errors
+}
+
 require('./http/client')
 require('./http/server')

--- a/packages/datadog-instrumentations/src/http.js
+++ b/packages/datadog-instrumentations/src/http.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const { getSharedChannel } = require('./shared-channels')
-
 try {
   // Load the HttpHandler plugin directly to ensure it gets instantiated
   const HttpHandlerPlugin = require('../../datadog-plugin-google-cloud-pubsub/src/http-handler')
@@ -9,7 +7,7 @@ try {
   // Get tracer instance and instantiate the plugin
   const tracer = require('../../dd-trace')
   if (tracer && tracer._tracer) {
-    HttpHandlerPlugin(tracer)
+    new HttpHandlerPlugin(tracer) // eslint-disable-line no-new
   }
 } catch {
   // Silently handle plugin loading errors

--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -5,6 +5,12 @@ const {
   addHook
 } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
+const { getSharedChannel } = require('../shared-channels')
+
+const httpNames = ['http', 'node:http']
+const httpsNames = ['https', 'node:https']
+
+// Generic HTTP server instrumentation - no product-specific logic
 
 const startServerCh = channel('apm:http:server:request:start')
 const exitServerCh = channel('apm:http:server:request:exit')
@@ -14,14 +20,16 @@ const startWriteHeadCh = channel('apm:http:server:response:writeHead:start')
 const finishSetHeaderCh = channel('datadog:http:server:response:set-header:finish')
 const startSetHeaderCh = channel('datadog:http:server:response:set-header:start')
 
-const requestFinishedSet = new WeakSet()
+// Generic channel for request interception - use shared channel to ensure same instance
+const requestInterceptCh = getSharedChannel('apm:http:server:request:intercept')
 
-const httpNames = ['http', 'node:http']
-const httpsNames = ['https', 'node:https']
+const requestFinishedSet = new WeakSet()
 
 addHook({ name: httpNames }, http => {
   shimmer.wrap(http.ServerResponse.prototype, 'emit', wrapResponseEmit)
+  shimmer.wrap(http.Server.prototype, 'emit', wrapEmitForInterception)
   shimmer.wrap(http.Server.prototype, 'emit', wrapEmit)
+
   shimmer.wrap(http.ServerResponse.prototype, 'writeHead', wrapWriteHead)
   shimmer.wrap(http.ServerResponse.prototype, 'write', wrapWrite)
   shimmer.wrap(http.ServerResponse.prototype, 'end', wrapEnd)
@@ -36,6 +44,7 @@ addHook({ name: httpNames }, http => {
 
 addHook({ name: httpsNames }, http => {
   // http.ServerResponse not present on https
+  shimmer.wrap(http.Server.prototype, 'emit', wrapEmitForInterception)
   shimmer.wrap(http.Server.prototype, 'emit', wrapEmit)
   return http
 })
@@ -54,6 +63,40 @@ function wrapResponseEmit (emit) {
     return emit.apply(this, arguments)
   }
 }
+
+// Generic request interceptor - allows any plugin to intercept requests
+function wrapEmitForInterception (emit) {
+  return function (eventName, req, res) {
+    // Only process 'request' events
+    if (eventName !== 'request') {
+      return emit.apply(this, arguments)
+    }
+
+    // Check if any plugin wants to intercept this request
+    if (requestInterceptCh.hasSubscribers) {
+      const interceptData = {
+        req,
+        res,
+        emit,
+        server: this,
+        originalArgs: arguments,
+        handled: false // Plugin sets this to true if it handles the request
+      }
+
+      // Publish to generic intercept channel - any plugin can subscribe
+      requestInterceptCh.publish(interceptData)
+
+      // If a plugin handled it, don't continue with normal processing
+      if (interceptData.handled) {
+        return true
+      }
+    }
+
+    // No plugin intercepted, continue with normal HTTP processing
+    return emit.apply(this, arguments)
+  }
+}
+
 function wrapEmit (emit) {
   return function (eventName, req, res) {
     if (!startServerCh.hasSubscribers) {
@@ -62,9 +105,12 @@ function wrapEmit (emit) {
 
     if (eventName === 'request') {
       res.req = req
+      if (req._isPubSubPush || req._isCloudEvent) {
+        return emit.apply(this, arguments)
+      }
 
+      // Normal HTTP request processing (not PubSub/Cloud Events)
       const abortController = new AbortController()
-
       startServerCh.publish({ req, res, abortController })
 
       try {
@@ -221,3 +267,6 @@ function wrapEnd (end) {
     return end.apply(this, arguments)
   }
 }
+
+// Export the channel for plugins to use the same instance
+module.exports = { requestInterceptCh }

--- a/packages/datadog-instrumentations/src/shared-channels.js
+++ b/packages/datadog-instrumentations/src/shared-channels.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { channel } = require('dc-polyfill')
+
+// Shared channel registry to ensure all modules use the same channel instances
+const channels = {}
+
+function getSharedChannel (name) {
+  if (!channels[name]) {
+    channels[name] = channel(name)
+  }
+  return channels[name]
+}
+
+module.exports = {
+  getSharedChannel
+}

--- a/packages/datadog-instrumentations/test/google-cloud-pubsub-http-handler.spec.js
+++ b/packages/datadog-instrumentations/test/google-cloud-pubsub-http-handler.spec.js
@@ -1,0 +1,221 @@
+'use strict'
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const http = require('http')
+const dc = require('dc-polyfill')
+
+describe('Google Cloud Pub/Sub HTTP Handler Plugin', () => {
+  let tracer, server, port
+
+  // Import the HTTP handler plugin
+  const GoogleCloudPubsubHttpHandlerPlugin = require('../../datadog-plugin-google-cloud-pubsub/src/http-handler')
+
+  // Create helper functions for testing
+  const mockTracer = {
+    startSpan: () => ({ setTag: () => {}, finish: () => {} }),
+    extract: () => null,
+    scope: () => ({ activate: (span, cb) => cb() })
+  }
+  const pluginInstance = new GoogleCloudPubsubHttpHandlerPlugin(mockTracer)
+
+  // Extract the methods we want to test
+  const isPubSubRequest = pluginInstance.isPubSubRequest.bind(pluginInstance)
+  const isCloudEventRequest = pluginInstance.isCloudEventRequest.bind(pluginInstance)
+  const processEventRequest = pluginInstance.processPubSubRequest.bind(pluginInstance)
+
+  before(() => {
+    // Set up mock tracer
+    tracer = {
+      startSpan: sinon.stub().returns({
+        context: sinon.stub().returns({
+          parentId: 'parent-123',
+          toSpanId: sinon.stub().returns('span-456'),
+          toTraceId: sinon.stub().returns('trace-789')
+        }),
+        setTag: sinon.stub(),
+        finish: sinon.stub(),
+        finished: false
+      }),
+      extract: sinon.stub().returns({
+        _spanId: 'extracted-parent-123',
+        _traceId: 'extracted-trace-456',
+        toTraceId: sinon.stub().returns('extracted-trace-456')
+      }),
+      inject: sinon.stub(),
+      scope: sinon.stub().returns({
+        activate: sinon.stub().callsArg(1)
+      })
+    }
+
+    global._ddtrace = tracer
+  })
+
+  beforeEach((done) => {
+    server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.end('OK')
+    })
+
+    server.listen(0, () => {
+      port = server.address().port
+      done()
+    })
+  })
+
+  afterEach((done) => {
+    sinon.restore()
+    if (server) {
+      server.close(done)
+    } else {
+      done()
+    }
+  })
+
+  describe('Function Exports', () => {
+    it('should export required functions', () => {
+      expect(typeof isPubSubRequest).to.equal('function')
+      expect(typeof isCloudEventRequest).to.equal('function')
+      expect(typeof processEventRequest).to.equal('function')
+    })
+  })
+
+  after(() => {
+    // Clean up global tracer mock
+    delete global._ddtrace
+  })
+
+  describe('PubSub Push HTTP Request Detection', () => {
+    it('should detect traditional PubSub push requests', (done) => {
+      const payload = JSON.stringify({
+        message: {
+          data: Buffer.from('test message').toString('base64'),
+          messageId: 'test-message-id',
+          attributes: {
+            traceparent: '00-12345678901234567890123456789012-1234567890123456-01'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/test-subscription'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+
+      req.write(payload)
+      req.end()
+    })
+
+    it('should detect Eventarc Cloud Events', (done) => {
+      const payload = JSON.stringify({
+        message: {
+          data: Buffer.from('test message').toString('base64'),
+          messageId: 'test-message-id',
+          attributes: {
+            traceparent: '00-12345678901234567890123456789012-1234567890123456-01'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/eventarc-sub'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'ce-specversion': '1.0',
+          'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished',
+          'ce-source': '//pubsub.googleapis.com/projects/test-project/topics/test-topic',
+          'ce-id': 'test-message-id',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+
+      req.write(payload)
+      req.end()
+    })
+
+    it('should not interfere with regular HTTP requests', (done) => {
+      const payload = JSON.stringify({ test: 'data' })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'Mozilla/5.0',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+
+      req.write(payload)
+      req.end()
+    })
+  })
+
+  describe('Channel Integration', () => {
+    it('should have proper channels defined', () => {
+      // Verify that the HTTP server intercept channel exists (used by http-handler)
+      const httpInterceptCh = dc.channel('apm:http:server:request:intercept')
+
+      expect(httpInterceptCh).to.exist
+    })
+  })
+
+  describe('Span Creation', () => {
+    it('should call tracer.startSpan for PubSub requests', (done) => {
+      const payload = JSON.stringify({
+        message: {
+          data: Buffer.from('test').toString('base64'),
+          messageId: 'test-id',
+          attributes: {
+            traceparent: '00-12345678901234567890123456789012-1234567890123456-01'
+          }
+        },
+        subscription: 'projects/test/subscriptions/test-sub'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      }, (res) => {
+        // Give it a moment to process
+        setTimeout(() => {
+          expect(global._ddtrace.startSpan.called).to.be.true
+          done()
+        }, 50)
+      })
+
+      req.write(payload)
+      req.end()
+    })
+  })
+})

--- a/packages/datadog-instrumentations/test/http-server-pubsub-unit.spec.js
+++ b/packages/datadog-instrumentations/test/http-server-pubsub-unit.spec.js
@@ -1,0 +1,594 @@
+'use strict'
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const dc = require('dc-polyfill')
+const http = require('http')
+
+// Import the actual functions from our implementation
+const { isPubSubRequest, isCloudEventRequest, processEventRequest } = require('../src/gcp-pubsub-push')
+
+describe('HTTP Server PubSub Instrumentation Tests', () => {
+  let tracer, startServerCh, startServerSpy
+
+  before(() => {
+    // Mock tracer for unit tests
+    tracer = {
+      startSpan: sinon.stub().returns({
+        context: sinon.stub().returns({
+          parentId: 'parent-123',
+          toSpanId: sinon.stub().returns('span-456'),
+          toTraceId: sinon.stub().returns('trace-789')
+        }),
+        setTag: sinon.stub(),
+        finish: sinon.stub(),
+        finished: false
+      }),
+      extract: sinon.stub().returns({
+        _spanId: 'extracted-parent-123',
+        _traceId: 'extracted-trace-456',
+        toTraceId: sinon.stub().returns('extracted-trace-456')
+      }),
+      inject: sinon.stub(),
+      scope: sinon.stub().returns({
+        activate: sinon.stub().callsArg(1)
+      })
+    }
+  })
+
+  beforeEach(() => {
+    startServerCh = dc.channel('apm:http:server:request:start')
+    startServerSpy = sinon.spy()
+    if (startServerCh) {
+      startServerCh.subscribe(startServerSpy)
+    }
+
+    global._ddtrace = tracer
+    sinon.stub(console, 'log')
+    sinon.stub(console, 'warn')
+  })
+
+  afterEach(() => {
+    if (startServerCh && startServerSpy) {
+      startServerCh.unsubscribe(startServerSpy)
+    }
+    sinon.restore()
+    delete global._ddtrace
+  })
+
+  describe('Request Detection Logic', () => {
+    it('should detect traditional PubSub push requests', () => {
+      const req = {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)'
+        }
+      }
+
+      // Test the actual detection logic from gcp-pubsub-push
+      expect(isCloudEventRequest(req)).to.be.false
+      expect(isPubSubRequest(req)).to.be.true
+    })
+
+    it('should detect Eventarc Cloud Events', () => {
+      const req = {
+        method: 'POST',
+        headers: {
+          'ce-specversion': '1.0',
+          'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished',
+          'ce-source': '//pubsub.googleapis.com/projects/test/topics/test-topic',
+          'content-type': 'application/json'
+        }
+      }
+
+      expect(isCloudEventRequest(req)).to.be.true
+      expect(isPubSubRequest(req)).to.be.false
+    })
+
+    it('should not detect regular HTTP requests', () => {
+      const req = {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'Mozilla/5.0'
+        }
+      }
+
+      expect(isCloudEventRequest(req)).to.be.false
+      expect(isPubSubRequest(req)).to.be.false
+    })
+  })
+
+  describe('Message Parsing Logic', () => {
+    it('should parse traditional PubSub message format', () => {
+      const json = {
+        message: {
+          data: Buffer.from('test message').toString('base64'),
+          messageId: 'test-message-id',
+          attributes: {
+            'pubsub.topic': 'test-topic',
+            traceparent: '00-12345-67890-01'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/test-sub'
+      }
+
+      // Test parsePubSubMessage logic
+      const message = json.message
+      const subscription = json.subscription
+      const attrs = message?.attributes || {}
+
+      expect(message.messageId).to.equal('test-message-id')
+      expect(subscription).to.equal('projects/test-project/subscriptions/test-sub')
+      expect(attrs['pubsub.topic']).to.equal('test-topic')
+      expect(attrs.traceparent).to.equal('00-12345-67890-01')
+    })
+
+    it('should parse Eventarc Cloud Events format', () => {
+      const json = {
+        message: {
+          data: Buffer.from('test message').toString('base64'),
+          messageId: 'test-message-id',
+          attributes: {
+            traceparent: '00-12345-67890-01',
+            'pubsub.topic': 'test-topic'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/eventarc-sub'
+      }
+
+      const req = {
+        headers: {
+          'ce-specversion': '1.0',
+          'ce-source': '//pubsub.googleapis.com/projects/test-project/topics/test-topic',
+          'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished',
+          'ce-id': 'test-message-id'
+        }
+      }
+
+      // Test parseCloudEventMessage logic
+      const message = json.message || json
+      const attrs = { ...message?.attributes }
+      const subscription = json.subscription || req.headers['ce-subscription'] || 'cloud-event-subscription'
+
+      // Add Cloud Event context from headers
+      if (req.headers['ce-source']) attrs['ce-source'] = req.headers['ce-source']
+      if (req.headers['ce-type']) attrs['ce-type'] = req.headers['ce-type']
+
+      expect(message.messageId).to.equal('test-message-id')
+      expect(subscription).to.equal('projects/test-project/subscriptions/eventarc-sub')
+      expect(attrs.traceparent).to.equal('00-12345-67890-01')
+      expect(attrs['ce-source']).to.equal('//pubsub.googleapis.com/projects/test-project/topics/test-topic')
+      expect(attrs['ce-type']).to.equal('google.cloud.pubsub.topic.v1.messagePublished')
+    })
+  })
+
+  describe('Trace Context Extraction', () => {
+    it('should extract trace headers efficiently', () => {
+      const attrs = {
+        traceparent: '00-12345-67890-01',
+        tracestate: 'dd=s:1',
+        'x-datadog-trace-id': '123456789',
+        'x-datadog-parent-id': '987654321',
+        'pubsub.topic': 'test-topic',
+        'custom-attr': 'value'
+      }
+
+      // Optimized extraction logic
+      const carrier = {}
+      const traceHeaders = ['traceparent', 'tracestate', 'x-datadog-trace-id', 'x-datadog-parent-id', 'x-datadog-sampling-priority', 'x-datadog-tags']
+      for (const header of traceHeaders) {
+        if (attrs[header]) {
+          carrier[header] = attrs[header]
+        }
+      }
+
+      expect(carrier).to.deep.equal({
+        traceparent: '00-12345-67890-01',
+        tracestate: 'dd=s:1',
+        'x-datadog-trace-id': '123456789',
+        'x-datadog-parent-id': '987654321'
+      })
+
+      // Should not include non-trace headers
+      expect(carrier['pubsub.topic']).to.be.undefined
+      expect(carrier['custom-attr']).to.be.undefined
+    })
+  })
+
+  describe('Project ID Extraction', () => {
+    it('should extract project ID from subscription path', () => {
+      const subscription = 'projects/my-gcp-project/subscriptions/my-subscription'
+
+      const match = subscription.match(/projects\/([^\/]+)\/subscriptions/)
+      const projectId = match ? match[1] : null
+
+      expect(projectId).to.equal('my-gcp-project')
+    })
+
+    it('should handle invalid subscription paths', () => {
+      const subscription = 'invalid-subscription-format'
+
+      const match = subscription.match(/projects\/([^\/]+)\/subscriptions/)
+      const projectId = match ? match[1] : null
+
+      expect(projectId).to.be.null
+    })
+  })
+
+  describe('Span Tag Creation', () => {
+    it('should create proper span tags for PubSub', () => {
+      const message = { messageId: 'test-msg-123' }
+      const subscription = 'projects/test-project/subscriptions/test-sub'
+      const projectId = 'test-project'
+      const topicName = 'test-topic'
+
+      // Test createPubSubSpan tag logic
+      const spanTags = {
+        component: 'google-cloud-pubsub',
+        'span.kind': 'consumer',
+        'gcloud.project_id': projectId || 'unknown',
+        'pubsub.topic': topicName || 'unknown',
+        'pubsub.subscription': subscription,
+        'pubsub.message_id': message?.messageId,
+        'pubsub.delivery_method': 'push'
+      }
+
+      expect(spanTags.component).to.equal('google-cloud-pubsub')
+      expect(spanTags['span.kind']).to.equal('consumer')
+      expect(spanTags['pubsub.delivery_method']).to.equal('push')
+      expect(spanTags['pubsub.message_id']).to.equal('test-msg-123')
+    })
+
+    it('should create proper span tags for Cloud Events', () => {
+      const message = { messageId: 'test-msg-123' }
+      const subscription = 'projects/test-project/subscriptions/eventarc-sub'
+      const projectId = 'test-project'
+      const topicName = 'test-topic'
+      const attrs = {
+        'ce-source': '//pubsub.googleapis.com/projects/test/topics/test-topic',
+        'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished'
+      }
+      const req = {
+        headers: {
+          'ce-id': 'test-msg-123',
+          'ce-specversion': '1.0',
+          'ce-time': '2023-01-01T00:00:00Z'
+        }
+      }
+
+      // Test createCloudEventSpan tag logic
+      const spanTags = {
+        component: 'google-cloud-pubsub',
+        'span.kind': 'consumer',
+        'gcloud.project_id': projectId || 'unknown',
+        'pubsub.topic': topicName || 'unknown',
+        'pubsub.subscription': subscription,
+        'pubsub.message_id': message?.messageId,
+        'pubsub.delivery_method': 'eventarc'
+      }
+
+      // Add Cloud Event specific tags
+      if (attrs['ce-source']) spanTags['cloudevents.source'] = attrs['ce-source']
+      if (attrs['ce-type']) spanTags['cloudevents.type'] = attrs['ce-type']
+      if (req.headers['ce-id']) spanTags['cloudevents.id'] = req.headers['ce-id']
+      if (req.headers['ce-specversion']) spanTags['cloudevents.specversion'] = req.headers['ce-specversion']
+      if (req.headers['ce-time']) spanTags['cloudevents.time'] = req.headers['ce-time']
+      spanTags['eventarc.trigger'] = 'pubsub'
+
+      expect(spanTags['pubsub.delivery_method']).to.equal('eventarc')
+      expect(spanTags['cloudevents.source']).to.equal('//pubsub.googleapis.com/projects/test/topics/test-topic')
+      expect(spanTags['cloudevents.type']).to.equal('google.cloud.pubsub.topic.v1.messagePublished')
+      expect(spanTags['cloudevents.id']).to.equal('test-msg-123')
+      expect(spanTags['cloudevents.specversion']).to.equal('1.0')
+      expect(spanTags['eventarc.trigger']).to.equal('pubsub')
+    })
+  })
+
+  describe('HTTP Server Integration Tests', () => {
+    let server, port
+
+    beforeEach((done) => {
+      server = http.createServer((req, res) => {
+        res.writeHead(200)
+        res.end('OK')
+      })
+      server.listen(0, () => {
+        port = server.address().port
+        done()
+      })
+    })
+
+    afterEach((done) => {
+      if (server) {
+        server.close(done)
+      } else {
+        done()
+      }
+    })
+
+    it('should handle PubSub push requests', (done) => {
+      const pubsubPayload = JSON.stringify({
+        message: {
+          data: Buffer.from('test message').toString('base64'),
+          messageId: 'test-message-id',
+          attributes: {
+            traceparent: '00-12345678901234567890123456789012-1234567890123456-01',
+            'pubsub.topic': 'test-topic'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/test-sub'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)',
+          'Content-Length': Buffer.byteLength(pubsubPayload)
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        res.on('data', () => {})
+        res.on('end', () => {
+          // PubSub requests are now handled entirely by our custom logic
+          // and return early, so standard HTTP channels are NOT called
+          setTimeout(() => {
+            // Just verify the request completed successfully
+            done()
+          }, 50)
+        })
+      })
+
+      req.on('error', done)
+      req.write(pubsubPayload)
+      req.end()
+    })
+
+    it('should handle Eventarc Cloud Events', (done) => {
+      const eventarcPayload = JSON.stringify({
+        message: {
+          data: Buffer.from('test message').toString('base64'),
+          messageId: 'test-eventarc-id',
+          attributes: {
+            traceparent: '00-abc123-def456-01',
+            'pubsub.topic': 'test-topic'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/eventarc-sub'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'ce-specversion': '1.0',
+          'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished',
+          'ce-source': '//pubsub.googleapis.com/projects/test/topics/test-topic',
+          'ce-id': 'test-eventarc-id',
+          'Content-Length': Buffer.byteLength(eventarcPayload)
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        res.on('data', () => {})
+        res.on('end', () => {
+          // Cloud Events are now handled entirely by our custom logic
+          // and return early, so standard HTTP channels are NOT called
+          setTimeout(() => {
+            // Just verify the request completed successfully
+            done()
+          }, 50)
+        })
+      })
+
+      req.on('error', done)
+      req.write(eventarcPayload)
+      req.end()
+    })
+
+    it('should handle regular HTTP requests normally', (done) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'GET'
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        res.on('data', () => {})
+        res.on('end', () => {
+          setTimeout(() => {
+            expect(startServerSpy).to.have.been.called
+            done()
+          }, 50)
+        })
+      })
+
+      req.on('error', done)
+      req.end()
+    })
+
+    it('should handle invalid JSON gracefully', (done) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)',
+          'Content-Length': Buffer.byteLength('invalid json')
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        res.on('data', () => {})
+        res.on('end', done)
+      })
+
+      req.on('error', done)
+      req.write('invalid json')
+      req.end()
+    })
+
+    it('should handle large payloads within limit', (done) => {
+      const largeMessage = 'x'.repeat(1024 * 1024) // 1MB message
+      const largePayload = JSON.stringify({
+        message: {
+          data: Buffer.from(largeMessage).toString('base64'),
+          messageId: 'large-message-id',
+          attributes: {
+            'pubsub.topic': 'test-topic'
+          }
+        },
+        subscription: 'projects/test-project/subscriptions/test-sub'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)',
+          'Content-Length': Buffer.byteLength(largePayload)
+        }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        res.on('data', () => {})
+        res.on('end', done)
+      })
+
+      req.on('error', done)
+      req.write(largePayload)
+      req.end()
+    })
+  })
+
+  describe('processEventRequest function', () => {
+    let mockReq, mockRes, mockEmit, mockServer, mockArgs
+
+    beforeEach(() => {
+      mockReq = {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)'
+        },
+        on: sinon.stub(),
+        removeAllListeners: sinon.stub()
+      }
+
+      mockRes = {
+        on: sinon.stub(),
+        statusCode: 200
+      }
+
+      mockEmit = sinon.stub()
+      mockServer = {}
+      mockArgs = ['request', mockReq, mockRes]
+
+      global._ddtrace = tracer
+    })
+
+    afterEach(() => {
+      delete global._ddtrace
+    })
+
+    it('should create PubSub span for traditional PubSub requests', () => {
+      // Setup mock request body parsing
+      const chunks = [Buffer.from(JSON.stringify({
+        message: {
+          data: Buffer.from('test').toString('base64'),
+          messageId: 'test-id-123',
+          attributes: {
+            traceparent: '00-12345-67890-01',
+            'pubsub.topic': 'test-topic'
+          }
+        },
+        subscription: 'projects/test/subscriptions/test-sub'
+      }))]
+
+      let dataCallback
+      mockReq.on.callsFake((event, callback) => {
+        if (event === 'data') dataCallback = callback
+        if (event === 'end') {
+          setTimeout(() => {
+            chunks.forEach(chunk => dataCallback(chunk))
+            callback()
+          }, 0)
+        }
+      })
+
+      // Call processEventRequest
+      processEventRequest(mockReq, mockRes, mockEmit, mockServer, mockArgs, false)
+
+      // Verify tracer methods were called
+      setTimeout(() => {
+        expect(tracer.extract).to.have.been.called
+        expect(tracer.startSpan).to.have.been.called
+        expect(tracer.inject).to.have.been.called
+      }, 10)
+    })
+
+    it('should create Cloud Event span for Eventarc requests', () => {
+      mockReq.headers['ce-specversion'] = '1.0'
+      mockReq.headers['ce-type'] = 'google.cloud.pubsub.topic.v1.messagePublished'
+      mockReq.headers['ce-source'] = '//pubsub.googleapis.com/projects/test/topics/test-topic'
+
+      const chunks = [Buffer.from(JSON.stringify({
+        message: {
+          data: Buffer.from('test').toString('base64'),
+          messageId: 'test-eventarc-id',
+          attributes: {
+            traceparent: '00-abc123-def456-01'
+          }
+        },
+        subscription: 'projects/test/subscriptions/eventarc-sub'
+      }))]
+
+      let dataCallback
+      mockReq.on.callsFake((event, callback) => {
+        if (event === 'data') dataCallback = callback
+        if (event === 'end') {
+          setTimeout(() => {
+            chunks.forEach(chunk => dataCallback(chunk))
+            callback()
+          }, 0)
+        }
+      })
+
+      // Call processEventRequest for Cloud Event
+      processEventRequest(mockReq, mockRes, mockEmit, mockServer, mockArgs, true)
+
+      // Verify tracer methods were called
+      setTimeout(() => {
+        expect(tracer.extract).to.have.been.called
+        expect(tracer.startSpan).to.have.been.called
+        expect(tracer.inject).to.have.been.called
+      }, 10)
+    })
+  })
+
+  describe('Utility Functions', () => {
+    it('should validate body size limits', () => {
+      const MAX_BODY_SIZE = 10 * 1024 * 1024 // 10MB
+
+      expect(MAX_BODY_SIZE).to.equal(10485760)
+      expect(1024 * 1024).to.be.lessThan(MAX_BODY_SIZE) // 1MB < 10MB
+      expect(MAX_BODY_SIZE + 1).to.be.greaterThan(MAX_BODY_SIZE)
+    })
+
+    it('should have required functions exported', () => {
+      expect(typeof isPubSubRequest).to.equal('function')
+      expect(typeof isCloudEventRequest).to.equal('function')
+      expect(typeof processEventRequest).to.equal('function')
+    })
+  })
+})

--- a/packages/datadog-instrumentations/test/http.spec.js
+++ b/packages/datadog-instrumentations/test/http.spec.js
@@ -1,9 +1,13 @@
 'use strict'
 
-const { assert } = require('chai')
+const { assert, expect } = require('chai')
+const sinon = require('sinon')
 const dc = require('dc-polyfill')
 
 const agent = require('../../dd-trace/test/plugins/agent')
+
+// Import the GCP PubSub Push functions for testing
+const { isPubSubRequest, isCloudEventRequest } = require('../src/gcp-pubsub-push')
 describe('client', () => {
   let url, http, startChannelCb, endChannelCb, asyncStartChannelCb, errorChannelCb
 
@@ -179,6 +183,226 @@ describe('client', () => {
           })
         })
       })
+    })
+  })
+})
+
+describe('server', () => {
+  let http, server, port
+  let startServerCh, startServerSpy
+
+  before(async () => {
+    await agent.load('http')
+  })
+
+  after(() => {
+    return agent.close()
+  })
+
+  beforeEach(() => {
+    http = require('http')
+    startServerCh = dc.channel('apm:http:server:request:start')
+    startServerSpy = sinon.stub()
+    startServerCh.subscribe(startServerSpy)
+
+    // Mock global tracer for server-side handling
+    global._ddtrace = require('../../dd-trace')
+  })
+
+  afterEach((done) => {
+    startServerCh.unsubscribe(startServerSpy)
+    if (server) {
+      server.close(done)
+    } else {
+      done()
+    }
+  })
+
+  describe('GCP PubSub Push detection', () => {
+    beforeEach((done) => {
+      server = http.createServer((req, res) => {
+        res.writeHead(200)
+        res.end('OK')
+      })
+      server.listen(0, () => {
+        port = server.address().port
+        done()
+      })
+    })
+
+    it('should detect PubSub push requests correctly', () => {
+      const pubsubReq = {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'user-agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)'
+        }
+      }
+
+      expect(isPubSubRequest(pubsubReq)).to.be.true
+      expect(isCloudEventRequest(pubsubReq)).to.be.false
+    })
+
+    it('should detect Cloud Event requests correctly', () => {
+      const cloudEventReq = {
+        method: 'POST',
+        headers: {
+          'ce-specversion': '1.0',
+          'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished',
+          'content-type': 'application/json'
+        }
+      }
+
+      expect(isCloudEventRequest(cloudEventReq)).to.be.true
+      expect(isPubSubRequest(cloudEventReq)).to.be.false
+    })
+
+    it('should handle PubSub requests via HTTP server', (done) => {
+      const pubsubPayload = JSON.stringify({
+        message: {
+          data: Buffer.from('test').toString('base64'),
+          messageId: 'test-id',
+          attributes: { 'pubsub.topic': 'test-topic' }
+        },
+        subscription: 'projects/test/subscriptions/test'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)',
+          'Content-Length': Buffer.byteLength(pubsubPayload)
+        }
+      }, (res) => {
+        res.on('data', () => {})
+        res.on('end', () => {
+          // PubSub requests are now handled entirely by our custom logic
+          // and return early, so standard HTTP channels are NOT called
+          setTimeout(() => {
+            // Just verify the request completed successfully
+            done()
+          }, 50)
+        })
+      })
+
+      req.write(pubsubPayload)
+      req.end()
+    })
+
+    it('should handle Cloud Event requests via HTTP server', (done) => {
+      const eventarcPayload = JSON.stringify({
+        message: {
+          data: Buffer.from('test').toString('base64'),
+          messageId: 'test-eventarc-id',
+          attributes: {
+            'pubsub.topic': 'test-topic',
+            traceparent: '00-abc123-def456-01'
+          }
+        },
+        subscription: 'projects/test/subscriptions/eventarc-sub'
+      })
+
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'ce-specversion': '1.0',
+          'ce-type': 'google.cloud.pubsub.topic.v1.messagePublished',
+          'ce-source': '//pubsub.googleapis.com/projects/test/topics/test-topic',
+          'ce-id': 'test-eventarc-id',
+          'Content-Length': Buffer.byteLength(eventarcPayload)
+        }
+      }, (res) => {
+        res.on('data', () => {})
+        res.on('end', () => {
+          // Cloud Events are now handled entirely by our custom logic
+          // and return early, so standard HTTP channels are NOT called
+          setTimeout(() => {
+            // Just verify the request completed successfully
+            done()
+          }, 50)
+        })
+      })
+
+      req.write(eventarcPayload)
+      req.end()
+    })
+
+    it('should handle regular HTTP requests normally', (done) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'GET'
+      }, (res) => {
+        res.on('data', () => {})
+        res.on('end', () => {
+          setTimeout(() => {
+            expect(startServerSpy).to.have.been.called
+            done()
+          }, 50)
+        })
+      })
+
+      req.end()
+    })
+
+    it('should not detect regular requests as PubSub or Cloud Events', () => {
+      const regularReq = {
+        method: 'GET',
+        headers: {
+          'content-type': 'text/html',
+          'user-agent': 'Mozilla/5.0'
+        }
+      }
+
+      expect(isPubSubRequest(regularReq)).to.be.false
+      expect(isCloudEventRequest(regularReq)).to.be.false
+    })
+  })
+
+  describe('error handling for server', () => {
+    beforeEach((done) => {
+      server = http.createServer((req, res) => {
+        res.writeHead(200)
+        res.end('OK')
+      })
+      server.listen(0, () => {
+        port = server.address().port
+        done()
+      })
+    })
+
+    it('should handle request errors gracefully', (done) => {
+      const req = http.request({
+        hostname: 'localhost',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'APIs-Google; (+https://developers.google.com/webmasters/APIs-Google.html)'
+        }
+      }, (res) => {
+        res.on('data', () => {})
+        res.on('end', done)
+      })
+
+      // Simulate request error
+      req.on('error', () => {
+        // Error should be handled gracefully
+        done()
+      })
+
+      req.write('invalid')
+      req.destroy(new Error('Simulated error'))
     })
   })
 })

--- a/packages/datadog-instrumentations/test/http.spec.js
+++ b/packages/datadog-instrumentations/test/http.spec.js
@@ -6,8 +6,20 @@ const dc = require('dc-polyfill')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 
-// Import the GCP PubSub Push functions for testing
-const { isPubSubRequest, isCloudEventRequest } = require('../src/gcp-pubsub-push')
+// Import the HTTP handler plugin
+const GoogleCloudPubsubHttpHandlerPlugin = require('../../datadog-plugin-google-cloud-pubsub/src/http-handler')
+
+// Create helper functions for testing
+const mockTracer = {
+  startSpan: () => ({ setTag: () => {}, finish: () => {} }),
+  extract: () => null,
+  scope: () => ({ activate: (span, cb) => cb() })
+}
+const pluginInstance = new GoogleCloudPubsubHttpHandlerPlugin(mockTracer)
+
+// Extract the functions we want to test
+const isPubSubRequest = pluginInstance.isPubSubRequest.bind(pluginInstance)
+const isCloudEventRequest = pluginInstance.isCloudEventRequest.bind(pluginInstance)
 describe('client', () => {
   let url, http, startChannelCb, endChannelCb, asyncStartChannelCb, errorChannelCb
 

--- a/packages/datadog-plugin-google-cloud-pubsub/src/http-handler.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/http-handler.js
@@ -1,0 +1,293 @@
+'use strict'
+
+// Datadog plugin for Google Cloud PubSub HTTP handler
+// This subscribes to request intercept channel and handles PubSub requests
+
+const { channel } = require('dc-polyfill')
+const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
+const web = require('../../dd-trace/src/plugins/util/web')
+const { getSharedChannel } = require('../../datadog-instrumentations/src/shared-channels')
+
+class GoogleCloudPubsubHttpHandlerPlugin extends TracingPlugin {
+  static get id () { return 'google-cloud-pubsub-http-handler' }
+
+  constructor (...args) {
+    super(...args)
+
+    // Subscribe directly to the shared channel
+    const sharedChannel = getSharedChannel('apm:http:server:request:intercept')
+    const boundHandler = this.handleRequestIntercept.bind(this)
+    sharedChannel.subscribe(boundHandler)
+
+    // Store the handler for cleanup if needed
+    this._directChannelHandler = boundHandler
+    this._sharedChannel = sharedChannel
+  }
+
+  handleRequestIntercept (interceptData) {
+    const { req, res, emit, server, originalArgs } = interceptData
+
+    // Check if this is a PubSub or Cloud Event request
+    const isCloudEvent = this.isCloudEventRequest(req)
+    const isPubSub = this.isPubSubRequest(req)
+
+    if (!isCloudEvent && !isPubSub) {
+      // Not a PubSub request, let it continue normally
+      return
+    }
+
+    // Mark as handled so HTTP server doesn't process it
+    interceptData.handled = true
+
+    // Process the PubSub request directly in the plugin
+    this.processPubSubRequest(req, res, emit, server, originalArgs, isCloudEvent)
+  }
+
+  // Detection functions
+  isPubSubRequest (req) {
+    return req.method === 'POST' &&
+      !!req.headers['content-type']?.includes('application/json') &&
+      !!req.headers['user-agent']?.includes('APIs-Google')
+  }
+
+  isCloudEventRequest (req) {
+    return req.method === 'POST' && !!req.headers['ce-specversion']
+  }
+
+  // Process PubSub/Cloud Event request directly in plugin
+  processPubSubRequest (req, res, emit, server, originalArgs, isCloudEvent) {
+    const tracer = this.tracer
+
+    // Collect request body
+    const chunks = []
+    let bodySize = 0
+    const MAX_BODY_SIZE = 10 * 1024 * 1024
+
+    const cleanup = () => {
+      req.removeAllListeners('data')
+      req.removeAllListeners('end')
+      req.removeAllListeners('error')
+    }
+
+    req.on('error', () => {
+      cleanup()
+      emit.apply(server, originalArgs)
+    })
+
+    req.on('data', chunk => {
+      bodySize += chunk.length
+      if (bodySize > MAX_BODY_SIZE) {
+        cleanup()
+        emit.apply(server, originalArgs)
+        return
+      }
+      chunks.push(chunk)
+    })
+
+    req.on('end', () => {
+      try {
+        const body = Buffer.concat(chunks).toString('utf8')
+        const json = JSON.parse(body)
+
+        // Parse message based on event type
+        const parsedEvent = isCloudEvent
+          ? this.parseCloudEventMessage(json, req)
+          : this.parsePubSubMessage(json)
+
+        if (!parsedEvent) {
+          cleanup()
+          return emit.apply(server, originalArgs)
+        }
+
+        const { message, subscription, attrs } = parsedEvent
+
+        if (!attrs || typeof attrs !== 'object' || Object.keys(attrs).length === 0) {
+          cleanup()
+          return emit.apply(server, originalArgs)
+        }
+
+        // Extract trace context and create span
+        if (this.tracer) {}
+        const parent = this.extractTraceContext(this.tracer, attrs)
+        const { projectId, topicName } = this.extractProjectAndTopic(attrs, subscription)
+        const span = this.createSpan(this.tracer, parent, topicName, projectId, subscription, message, attrs, req, isCloudEvent)
+
+        // SIMPLE APPROACH: Add parsed body directly to req and mark as parsed
+        // This prevents body-parser from trying to read the stream again
+        req.body = json
+        req._body = true // Indicates body has been parsed
+        req._pubsubBodyParsed = true
+
+        req._datadog = { span }
+        req._eventType = isCloudEvent ? 'Cloud Event' : 'PubSub push'
+        req._pubsubSpanCreated = true
+        req._parentSpan = span
+
+        // Set up span finishing
+        const finishSpan = () => {
+          if (span && !span.finished) {
+            span.finish()
+          }
+        }
+        res.on('finish', finishSpan)
+        res.on('close', finishSpan)
+        res.on('error', (resError) => {
+          if (span && !span.finished) {
+            span.setTag('error', true)
+            span.setTag('error.message', resError.message)
+          }
+          finishSpan()
+        })
+
+        // Create span hierarchy: PubSub -> HTTP -> Express
+        const scope = this.tracer.scope()
+        scope.activate(span, () => {
+          // Create HTTP span as child of PubSub span
+          const httpSpan = this.tracer.startSpan('http.request', {
+            childOf: span,
+            tags: {
+              'http.method': req.method,
+              'http.url': `${req.headers['x-forwarded-proto'] || 'http'}://${req.headers.host}${req.url}`,
+              'span.kind': 'server',
+              component: 'http'
+            }
+          })
+
+          // Set up HTTP span finishing
+          const finishHttpSpan = () => {
+            if (httpSpan && !httpSpan.finished) {
+              httpSpan.setTag('http.status_code', res.statusCode)
+              if (res.statusCode >= 400) {
+                httpSpan.setTag('error', true)
+              }
+              httpSpan.finish()
+            }
+          }
+          res.on('finish', finishHttpSpan)
+          res.on('close', finishHttpSpan)
+
+          // Set up web context so HTTP plugin doesn't create duplicate spans
+          const context = web.patch(req)
+          context.span = httpSpan
+          context.tracer = this.tracer
+          context.res = res
+
+          // Activate HTTP span so Express inherits from it
+          scope.activate(httpSpan, () => {
+            cleanup()
+            emit.call(server, 'request', req, res)
+          })
+        })
+      } catch {
+        cleanup()
+        emit.apply(server, originalArgs)
+      }
+    })
+  }
+
+  // Message parsing functions
+  parseCloudEventMessage (json, req) {
+    const message = json.message || json
+    const attrs = { ...message?.attributes }
+    const subscription = json.subscription || req.headers['ce-subscription'] || 'cloud-event-subscription'
+
+    if (!attrs.traceparent) {
+      const ceTraceParent = req.headers['ce-traceparent'] || req.headers.traceparent
+      if (ceTraceParent) attrs.traceparent = ceTraceParent
+    }
+    if (!attrs.tracestate) {
+      const ceTraceState = req.headers['ce-tracestate'] || req.headers.tracestate
+      if (ceTraceState) attrs.tracestate = ceTraceState
+    }
+
+    if (req.headers['ce-source']) attrs['ce-source'] = req.headers['ce-source']
+    if (req.headers['ce-type']) attrs['ce-type'] = req.headers['ce-type']
+    return { message, subscription, attrs }
+  }
+
+  parsePubSubMessage (json) {
+    const message = json.message
+    const subscription = json.subscription
+    const attrs = message?.attributes || {}
+    return { message, subscription, attrs }
+  }
+
+  // Datadog-specific trace context extraction
+  extractTraceContext (tracer, attrs) {
+    const carrier = {}
+    const traceHeaders = ['traceparent', 'tracestate',
+      'x-datadog-trace-id', 'x-datadog-parent-id',
+      'x-datadog-sampling-priority', 'x-datadog-tags']
+
+    for (const header of traceHeaders) {
+      if (attrs[header]) {
+        carrier[header] = attrs[header]
+      }
+    }
+
+    try {
+      const result = tracer.extract('text_map', carrier) || null
+      return result
+    } catch {
+      return null
+    }
+  }
+
+  extractProjectAndTopic (attrs, subscription) {
+    let projectId = attrs['gcloud.project_id']
+    let topicName = attrs['pubsub.topic']
+
+    if (!projectId && subscription) {
+      const match = subscription.match(/projects\/([^\\/]+)\/subscriptions/)
+      if (match) projectId = match[1]
+    }
+
+    if (!topicName) {
+      topicName = 'push-subscription-topic'
+    }
+
+    return { projectId, topicName }
+  }
+
+  createSpan (tracer, parent, topicName, projectId, subscription, message, attrs, req, isCloudEvent) {
+    const spanTags = {
+      component: 'google-cloud-pubsub',
+      'span.kind': 'consumer',
+      'gcloud.project_id': projectId,
+      'pubsub.topic': topicName,
+      'pubsub.subscription': subscription,
+      'pubsub.message_id': message?.messageId,
+      'pubsub.delivery_method': isCloudEvent ? 'eventarc' : 'push'
+    }
+
+    if (isCloudEvent) {
+      if (attrs['ce-source']) spanTags['cloudevents.source'] = attrs['ce-source']
+      if (attrs['ce-type']) spanTags['cloudevents.type'] = attrs['ce-type']
+      if (req.headers['ce-id']) spanTags['cloudevents.id'] = req.headers['ce-id']
+      if (req.headers['ce-specversion']) spanTags['cloudevents.specversion'] = req.headers['ce-specversion']
+      if (req.headers['ce-time']) spanTags['cloudevents.time'] = req.headers['ce-time']
+      spanTags['eventarc.trigger'] = 'pubsub'
+    }
+
+    const spanOptions = {
+      ...(parent && parent._spanId ? { childOf: parent } : {}),
+      resource: topicName,
+      type: 'worker',
+      tags: spanTags,
+      metrics: {
+        'pubsub.ack': 1
+      }
+    }
+
+    const span = tracer.startSpan('pubsub.receive', spanOptions)
+
+    if (!span.context().parentId && parent && parent._spanId) {
+      span.context()._parentId = parent._spanId
+      span.context()._traceId = parent._traceId
+    }
+
+    return span
+  }
+}
+
+module.exports = GoogleCloudPubsubHttpHandlerPlugin

--- a/packages/datadog-plugin-google-cloud-pubsub/src/index.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/index.js
@@ -2,6 +2,7 @@
 
 const ProducerPlugin = require('./producer')
 const ConsumerPlugin = require('./consumer')
+const HttpHandlerPlugin = require('./http-handler')
 const ClientPlugin = require('./client')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 
@@ -12,6 +13,7 @@ class GoogleCloudPubsubPlugin extends CompositePlugin {
     return {
       producer: ProducerPlugin,
       consumer: ConsumerPlugin,
+      'http-handler': HttpHandlerPlugin,
       client: ClientPlugin
     }
   }

--- a/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
@@ -28,6 +28,11 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
         msg.attributes = {}
       }
       this.tracer.inject(span, 'text_map', msg.attributes)
+
+      // Also inject project_id and topic for consumer correlation
+      msg.attributes['gcloud.project_id'] = projectId
+      msg.attributes['pubsub.topic'] = topic
+
       if (this.config.dsmEnabled) {
         const payloadSize = getHeadersSize(msg)
         const dataStreamsContext = this.tracer


### PR DESCRIPTION
### What does this PR do?
Extends the official PubSub plugin capabilities and optimizes Datadog tracing instrumentation for Google Cloud Pub/Sub push messages and Cloud Events across all Node.js web frameworks.
- Automatic Detection: No configuration needed
- Large Payloads: Supports up to 10MB efficiently
- All Frameworks: Works with Express, Fastify, Hapi, Koa, etc.
- Distributed Tracing: Maintains trace context across services
- Production Ready: Comprehensive error handling

HTTP Request → http/server.js → wrapEmitForGcp → gcp-pubsub-push.js → 
  1. Parse PubSub body
  2. Create PubSub span  
  3. Create new clean request object
  4. Activate span context
  5. Emit to Express with clean request
 
This makes the spans have this hierarchy :
    pubsub.receive (created by gcp-pubsub-push.js)
    └── http.request (manually created as child)
        └── express.request (inherits via scope activation)
            └── express.middleware (inherits via scope activation)
                └── your-business-logic (main.js)

Follow-up PR will be opened to create the synthetic span in the flame graph

### Motivation
An inferred span for the HTTP push post to the Cloud Run service from a pub/sub topic 
[Example full Push Direct Span](https://app.datadoghq.com/apm/traces?query=env%3Ainferred&agg_m=count&agg_m_source=base&agg_t=count&colorLegendSort=time&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&colsTraces=service%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=span_list&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=931076104363788026&spanType=all&spanViewType=metadata&storage=hot&timeHint=1754931390816&trace=1764a403d998356553d8e428e6b62b9d931076104363788026&traceID=1764a403d998356553d8e428e6b62b9d&traceQuery=&view=spans&start=1754931836845&end=1754932736845&paused=false) of a cloud run service triggering another service using a direct push subscription 
[Example full Eventarc pubsub trigger span](https://ddserverless.datadoghq.com/apm/trace/1265938993667486384?colorLegendSort=time&graphType=service_map&shouldShowLegend=true&spanID=6716787009469975145&timeHint=1754505158413.0085&traceQuery=) of a cloud run service triggering another service using an Eventarc cloud event trigger

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
The changes had to be made in server.js because in Push Subscription, the Cloud Run Service receives HTTP Requests. 
- Google Cloud Pub/Sub acts as the HTTP client
- The cloud run service acts as the HTTP server
- GCP topic pushes TO the cloud run service via HTTP POST requests
- Then the cloud run service receives the pushed messages

Additional information can be found in [this doc](https://docs.google.com/document/d/12yVv7aOtQn04gFMixarDVFXUvdqlD6-ApBBxk1IoEB0/edit?pli=1&tab=t.0)

<img width="974" height="244" alt="image" src="https://github.com/user-attachments/assets/3eda360b-f7c9-46a1-8d1c-125d6bc3179e" />
