### PR TITLE
expand endpoint wildcard on fastify

### DIFF
--- a/integration-tests/appsec/endpoints-collection.spec.js
+++ b/integration-tests/appsec/endpoints-collection.spec.js
@@ -40,8 +40,15 @@ describe('Endpoints collection', () => {
       // Using app.route()
       { method: 'POST', path: '/multi-method' },
 
-      // Wildcard route
-      { method: '*', path: '/wildcard' },
+      // Wildcard route expanded (fastify does not support CONNECT)
+      { method: 'GET', path: '/wildcard' },
+      { method: 'POST', path: '/wildcard' },
+      { method: 'PUT', path: '/wildcard' },
+      { method: 'DELETE', path: '/wildcard' },
+      { method: 'HEAD', path: '/wildcard' },
+      { method: 'PATCH', path: '/wildcard' },
+      { method: 'OPTIONS', path: '/wildcard' },
+      { method: 'TRACE', path: '/wildcard' },
 
       // Nested routes with Router
       { method: 'PUT', path: '/v1/nested/:id' },
@@ -91,7 +98,7 @@ describe('Endpoints collection', () => {
             })
           }
         }
-      }, 'app-endpoints', 5_000, 2)
+      }, 'app-endpoints', 5_000, 3)
 
       const trueCount = isFirstFlags.filter(v => v === true).length
       expect(trueCount).to.equal(1)

--- a/packages/dd-trace/src/telemetry/endpoints.js
+++ b/packages/dd-trace/src/telemetry/endpoints.js
@@ -43,13 +43,8 @@ function onFastifyRoute (routeData) {
 
   const methods = Array.isArray(routeOptions.method) ? routeOptions.method : [routeOptions.method]
 
-  // Check if this is a wildcard route fastify.all()
-  if (methods.length === 8) {
-    recordEndpoint('*', routeOptions.path)
-  } else {
-    for (const method of methods) {
-      recordEndpoint(method, routeOptions.path)
-    }
+  for (const method of methods) {
+    recordEndpoint(method, routeOptions.path)
   }
 }
 

--- a/packages/dd-trace/test/telemetry/endpoints.spec.js
+++ b/packages/dd-trace/test/telemetry/endpoints.spec.js
@@ -101,7 +101,7 @@ describe('endpoints telemetry', () => {
       expect(Boolean(secondPayload.is_first)).to.equal(false)
     })
 
-    it('should record fastify wildcard when all methods provided', () => {
+    it('should record all methods when fastify.all() is used', () => {
       fastifyRouteCh.publish({
         routeOptions: {
           method: ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'PATCH', 'OPTIONS', 'TRACE'],
@@ -114,7 +114,16 @@ describe('endpoints telemetry', () => {
       expect(sendData).to.have.been.calledOnce
       const payload = sendData.firstCall.args[4]
       const resources = payload.endpoints.map(e => e.resource_name)
-      expect(resources).to.deep.equal(['* /all'])
+      expect(resources).to.have.members([
+        'GET /all',
+        'POST /all',
+        'PUT /all',
+        'DELETE /all',
+        'HEAD /all',
+        'PATCH /all',
+        'OPTIONS /all',
+        'TRACE /all'
+      ])
     })
   })
 


### PR DESCRIPTION
### What does this PR do?
When defining a wildcard route `*`, it's important to note that `CONNECT` requests won't be matched, as Fastify does not support this http method.

With `app.all('/wildcard', async (_, reply) => reply.send('ok'))`

1. The original PR https://github.com/DataDog/dd-trace-js/pull/6258 will report `* /wildcard`
2. This PR will report all http endpoints expect `connect`

We should merge this PR only if we got a confirmation that the second option is the correct one

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


