### PR TITLE
bug(tracing): fix moleculer client meta propagation

### DIFF
--- a/packages/datadog-instrumentations/src/moleculer/client.js
+++ b/packages/datadog-instrumentations/src/moleculer/client.js
@@ -21,7 +21,7 @@ function wrapCall (call) {
       ctx.promiseCtx = promise.ctx
       ctx.broker = broker
 
-      return promise
+      promise
         .then(
           result => {
             finishChannel.publish(ctx)
@@ -34,6 +34,7 @@ function wrapCall (call) {
             throw error
           }
         )
+      return promise
     })
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes broken promise chain for moleculer client calls. Adds regression test case. Fixes #6262 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


