### PR TITLE
collect express endpoints

### DIFF
--- a/integration-tests/appsec/endpoints-collection/express.js
+++ b/integration-tests/appsec/endpoints-collection/express.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const tracer = require('dd-trace')
+tracer.init({
+  flushInterval: 0
+})
+
+const express = require('express')
+const app = express()
+
+// Basic routes
+app.get('/users', (_, res) => res.send('ok'))
+app.post('/users', (_, res) => res.send('ok'))
+app.put('/users/:id', (_, res) => res.send('ok'))
+app.delete('/users/:id', (_, res) => res.send('ok'))
+app.patch('/users/:id', (_, res) => res.send('ok'))
+app.options('/users', (_, res) => res.send('ok'))
+
+// Additional methods
+app.trace('/trace-test', (_, res) => res.send('ok'))
+app.head('/head-test', (_, res) => res.send('ok'))
+app.connect('/connect-test', (_, res) => res.send('ok'))
+
+// Using app.route()
+app.route('/multi-method')
+  .post((_, res) => res.send('ok'))
+  .all((_, res) => res.send('ok'))
+
+// Wildcard route
+app.all('/wildcard', (_, res) => res.send('ok'))
+
+// Nested routes with Router
+const apiRouter = express.Router()
+apiRouter.put('/nested/:id', (_, res) => res.send('ok'))
+apiRouter.all('/nested', (_, res) => res.send('ok'))
+app.use('/v1', apiRouter)
+
+// Add endpoint during runtime
+setTimeout(() => {
+  // Deeply nested routes
+  const deepRouter = express.Router()
+  const subRouter = express.Router()
+  subRouter.get('/deep', (_, res) => res.send('ok'))
+  subRouter.post('/deep/:id', (_, res) => res.send('ok'))
+  deepRouter.use('/sub', subRouter)
+  app.use('/api', deepRouter)
+}, 1_000)
+
+const server = app.listen(0, '127.0.0.1', () => {
+  const port = server.address().port
+  process.send({ port })
+})

--- a/integration-tests/appsec/endpoints-collection/fastify.js
+++ b/integration-tests/appsec/endpoints-collection/fastify.js
@@ -33,6 +33,7 @@ app.all('/wildcard', async (_, reply) => reply.send('ok'))
 // Nested routes with Router
 app.register(async function (router) {
   router.put('/nested/:id', async (_, reply) => reply.send('ok'))
+  router.all('/nested', async (_, reply) => reply.send('ok'))
 }, { prefix: '/v1' })
 
 // Deeply nested routes

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -80,6 +80,9 @@ function createWrapRouterMethod (name) {
 
       layerMatchers.set(layer, matchers)
 
+      // Save matchers to consume it later on express.js for endpoint discovery
+      layer.ddMatchers = matchers
+
       if (layer.route) {
         METHODS.forEach(method => {
           if (typeof layer.route.stack === 'function') {


### PR DESCRIPTION
- Instrumenting `express.application.all()` and `route().all()` emits a single canonical `'*'` endpoint because Router’s `.all()` wrapping is unreliable [router.js#L3](https://github.com/DataDog/dd-trace-js/blob/master/packages/datadog-instrumentations/src/router.js#L3), so we handle wildcard at the Express layer.
- Router cannot determine mount prefixes for nested routes, so we instrument `express.application.use()` to resolve full paths with prefixes (e.g., `/v1/nested/:id`) when routers are mounted.
- Router only annotates layers with `ddMatchers`; Express reads these matcher strings to join mount segments deterministically without regex parsing.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


