### PR TITLE
Use symbol instead of weak map for associating data with contexts

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -11,33 +11,28 @@ class EventPlugin extends TracingPlugin {
     super()
     this.eventHandler = eventHandler
     this.eventFilter = eventFilter
-    this.contextData = new WeakMap()
     this.entryType = this.constructor.entryType
+    this.dataSymbol = Symbol(`dd-trace.profiling.event.${this.entryType}.${this.constructor.operation}`)
   }
 
   start (ctx) {
-    this.contextData.set(ctx, {
-      startEvent: ctx,
-      startTime: performance.now()
-    })
+    ctx[this.dataSymbol] = performance.now()
   }
 
   error (ctx) {
-    const data = this.contextData.get(ctx)
-    if (data) {
-      data.error = true
-    }
+    // We don't emit perf events for failed operations
+    ctx[this.dataSymbol] = undefined
   }
 
   finish (ctx) {
-    const data = this.contextData.get(ctx)
+    const startTime = ctx[this.dataSymbol]
+    if (startTime === undefined) {
+      return
+    }
+    ctx[this.dataSymbol] = undefined
 
-    if (!data) return
-    this.contextData.delete(ctx)
-
-    const { startEvent, startTime, error } = data
-    if (error || this.ignoreEvent(startEvent)) {
-      return // don't emit perf events for failed operations or ignored events
+    if (this.ignoreEvent(ctx)) {
+      return // don't emit perf events for ignored events
     }
 
     const duration = performance.now() - startTime
@@ -55,7 +50,7 @@ class EventPlugin extends TracingPlugin {
     event._ddSpanId = context?.toSpanId()
     event._ddRootSpanId = context?._trace.started[0]?.context().toSpanId() || event._ddSpanId
 
-    this.eventHandler(this.extendEvent(event, startEvent))
+    this.eventHandler(this.extendEvent(event, ctx))
   }
 
   ignoreEvent () {


### PR DESCRIPTION
### What does this PR do?
Binds profiler event specific data into context objects using a symbol instead of using a WeakMap.

### Motivation
As discussed in #6267, the WeakMap solution strongly referenced the callback context object (the key in the map) from the value. Binding the data we need to track in a symbol property of the context object itself solves this problem.

As an additional bonus, since the context object is passed to the `finish` method we no longer need to keep track of it in `start`, reducing the data set to only the event start time. This way, we could eliminate the need for an intermediate object for storing the tuple of `{ startEvent, startTime }`.

### Additional info
I took the opportunity to also introduce private fields in the `EventPlugin` class – this is broken into its own commit for ease of review.