### PR TITLE
Creating Anthropic SDK integration for Datadog tracer

### DIFF
--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -1,0 +1,137 @@
+'use strict'
+
+const { addHook } = require('./helpers/instrument')
+const shimmer = require('../../datadog-shimmer')
+
+const dc = require('dc-polyfill')
+const ch = dc.tracingChannel('apm:anthropic:request')
+const onStreamedChunkCh = dc.channel('apm:anthropic:request:chunk')
+
+const ANTHROPIC_PACKAGE_SHIMS = [
+  {
+    file: 'resources/messages',
+    targetClass: 'Messages',
+    baseResource: 'messages',
+    methods: ['create'],
+    streamedResponse: true
+  }
+]
+
+/**
+ * For streamed responses, we need to accumulate all of the content in
+ * the chunks, and let the combined content be the final response.
+ * This way, spans look the same as when not streamed.
+ */
+function wrapStreamIterator (response, options, ctx) {
+  return function (itr) {
+    return function () {
+      const iterator = itr.apply(this, arguments)
+      shimmer.wrap(iterator, 'next', next => function () {
+        return next.apply(this, arguments)
+          .then(res => {
+            const { done, value: chunk } = res
+            onStreamedChunkCh.publish({ ctx, chunk, done })
+
+            if (done) {
+              finish(ctx, {
+                headers: response.headers,
+                request: {
+                  path: response.url,
+                  method: options.method
+                }
+              })
+            }
+
+            return res
+          })
+          .catch(err => {
+            finish(ctx, undefined, err)
+
+            throw err
+          })
+      })
+      return iterator
+    }
+  }
+}
+
+const extensions = ['.js', '.mjs']
+
+for (const extension of extensions) {
+  for (const shim of ANTHROPIC_PACKAGE_SHIMS) {
+    const { file, targetClass, baseResource, methods, versions, streamedResponse } = shim
+    addHook({ name: '@anthropic-ai/sdk', file: file + extension, versions: versions || ['>=0.6.0'] }, exports => {
+      const targetPrototype = exports[targetClass].prototype
+
+      for (const methodName of methods) {
+        shimmer.wrap(targetPrototype, methodName, methodFn => function () {
+          if (!ch.start.hasSubscribers) {
+            return methodFn.apply(this, arguments)
+          }
+
+          // The Anthropic library lets you set `stream: true` on the options arg
+          const stream = streamedResponse && getOption(arguments, 'stream', false)
+
+          const client = this._client || this.client
+
+          const ctx = {
+            methodName: `${baseResource}.${methodName}`,
+            args: arguments,
+            basePath: client.baseURL || 'https://api.anthropic.com',
+          }
+
+          return ch.start.runStores(ctx, () => {
+            const apiProm = methodFn.apply(this, arguments)
+
+            return apiProm
+              .then(response => {
+                if (stream) {
+                  // Handle streaming response
+                  if (response.body && response.body[Symbol.asyncIterator]) {
+                    shimmer.wrap(
+                      response.body, Symbol.asyncIterator, wrapStreamIterator(response, { method: 'POST' }, ctx)
+                    )
+                  }
+                } else {
+                  // Handle non-streaming response
+                  finish(ctx, {
+                    headers: response.response?.headers || {},
+                    data: response,
+                    request: {
+                      path: ctx.basePath + '/v1/messages',
+                      method: 'POST'
+                    }
+                  })
+                }
+
+                return response
+              })
+              .catch(error => {
+                finish(ctx, undefined, error)
+                throw error
+              })
+          })
+        })
+      }
+      return exports
+    })
+  }
+}
+
+function finish (ctx, response, error) {
+  if (error) {
+    ctx.error = error
+    ch.error.publish(ctx)
+  }
+
+  // for successful streamed responses, we've already set the result on ctx.body,
+  // so we don't want to override it here
+  ctx.result ??= {}
+  Object.assign(ctx.result, response)
+
+  ch.asyncEnd.publish(ctx)
+}
+
+function getOption (args, option, defaultValue) {
+  return args[0]?.[option] || defaultValue
+}

--- a/packages/datadog-plugin-anthropic/src/index.js
+++ b/packages/datadog-plugin-anthropic/src/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const CompositePlugin = require('../../dd-trace/src/plugins/composite')
+const AnthropicTracingPlugin = require('./tracing')
+const AnthropicLLMObsPlugin = require('../../dd-trace/src/llmobs/plugins/anthropic')
+
+class AnthropicPlugin extends CompositePlugin {
+  static id = 'anthropic'
+  static get plugins () {
+    return {
+      llmobs: AnthropicLLMObsPlugin,
+      tracing: AnthropicTracingPlugin
+    }
+  }
+}
+
+module.exports = AnthropicPlugin

--- a/packages/datadog-plugin-anthropic/src/services.js
+++ b/packages/datadog-plugin-anthropic/src/services.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const { DogStatsDClient } = require('../../dd-trace/src/dogstatsd')
+const NoopDogStatsDClient = require('../../dd-trace/src/noop/dogstatsd')
+const { ExternalLogger, NoopExternalLogger } = require('../../dd-trace/src/external-logger/src')
+
+const FLUSH_INTERVAL = 10 * 1000
+
+let metrics = null
+let logger = null
+let interval = null
+
+module.exports.init = function (tracerConfig) {
+  metrics = tracerConfig && tracerConfig.dogstatsd
+    ? new DogStatsDClient({
+        host: tracerConfig.dogstatsd.hostname,
+        port: tracerConfig.dogstatsd.port,
+        tags: [
+          `service:${tracerConfig.tags.service}`,
+          `env:${tracerConfig.tags.env}`,
+          `version:${tracerConfig.tags.version}`
+        ]
+      })
+    : new NoopDogStatsDClient()
+
+  logger = tracerConfig && tracerConfig.apiKey
+    ? new ExternalLogger({
+        ddsource: 'anthropic',
+        hostname: tracerConfig.hostname,
+        service: tracerConfig.service,
+        apiKey: tracerConfig.apiKey,
+        interval: FLUSH_INTERVAL
+      })
+    : new NoopExternalLogger()
+
+  interval = setInterval(() => {
+    metrics.flush()
+  }, FLUSH_INTERVAL).unref()
+
+  return { metrics, logger }
+}
+
+module.exports.shutdown = function () {
+  clearInterval(interval)
+  metrics = null
+  logger = null
+  interval = null
+}

--- a/packages/datadog-plugin-anthropic/src/tracing.js
+++ b/packages/datadog-plugin-anthropic/src/tracing.js
@@ -1,0 +1,238 @@
+'use strict'
+
+const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
+const { storage } = require('../../datadog-core')
+const services = require('./services')
+const { MEASURED } = require('../../../ext/tags')
+const { DD_MAJOR } = require('../../../version')
+
+class AnthropicTracingPlugin extends TracingPlugin {
+  static id = 'anthropic'
+  static operation = 'request'
+  static system = 'anthropic'
+  static prefix = 'tracing:apm:anthropic:request'
+
+  constructor (...args) {
+    super(...args)
+
+    const { metrics, logger } = services.init(this._tracerConfig)
+    this.metrics = metrics
+    this.logger = logger
+
+    this.addSub('apm:anthropic:request:chunk', ({ ctx, chunk, done }) => {
+      if (!ctx.chunks) ctx.chunks = []
+      
+      if (chunk) ctx.chunks.push(chunk)
+      if (!done) return
+
+      const chunks = ctx.chunks
+      if (chunks.length === 0) return
+
+      // Construct complete response from streamed chunks
+      const response = this.constructResponseFromChunks(chunks)
+      ctx.result = { data: response }
+    })
+  }
+
+  configure (config) {
+    if (config.enabled === false) {
+      services.shutdown()
+    }
+
+    super.configure(config)
+  }
+
+  bindStart (ctx) {
+    const { methodName, args } = ctx
+    const payload = normalizeRequestPayload(methodName, args)
+    const normalizedMethodName = normalizeMethodName(methodName)
+
+    const store = storage('legacy').getStore() || {}
+    store.originalMethodName = methodName
+    store.normalizedMethodName = normalizedMethodName
+
+    const span = this.startSpan('anthropic.request', {
+      service: this.config.service,
+      resource: DD_MAJOR >= 6 ? normalizedMethodName : methodName,
+      type: 'anthropic',
+      kind: 'client',
+      meta: {
+        [MEASURED]: 1,
+        'anthropic.request.model': payload.model
+      }
+    }, false)
+
+    const anthropicStore = Object.create(null)
+    const tags = {}
+
+    if (payload.stream) {
+      tags['anthropic.request.stream'] = payload.stream
+    }
+
+    if (normalizedMethodName === 'createMessage') {
+      createMessageRequestExtraction(tags, payload, anthropicStore)
+    }
+
+    span.addTags(tags)
+    ctx.currentStore = { ...store, span, anthropic: anthropicStore }
+
+    return ctx.currentStore
+  }
+
+  asyncEnd (ctx) {
+    const { result } = ctx
+    const store = ctx.currentStore
+
+    const span = store?.span
+    if (!span) return
+
+    const error = !!span.context()._tags.error
+
+    let headers, body, method, path
+    if (!error) {
+      headers = result.headers
+      body = result.data
+      method = result.request?.method
+      path = result.request?.path
+    }
+
+    if (!error && headers?.constructor.name === 'Headers') {
+      headers = Object.fromEntries(headers)
+    }
+
+    const normalizedMethodName = store.normalizedMethodName
+    const anthropicStore = store.anthropic
+
+    const tags = error
+      ? {}
+      : {
+          'anthropic.request.endpoint': '/v1/messages',
+          'anthropic.request.method': method ? method.toUpperCase() : 'POST',
+          'anthropic.response.model': body.model,
+          'anthropic.response.id': body.id,
+          'anthropic.response.type': body.type,
+          'anthropic.response.role': body.role,
+          'anthropic.response.stop_reason': body.stop_reason
+        }
+
+    if (!error) {
+      responseDataExtractionByMethod(normalizedMethodName, tags, body, anthropicStore)
+    }
+
+    span.addTags(tags)
+    span.finish()
+
+    this.sendLog(normalizedMethodName, span, tags, anthropicStore, error)
+    this.sendMetrics(headers, body, span._duration, error, tags)
+  }
+
+  sendMetrics (headers, body, duration, error, spanTags) {
+    const tags = [`error:${Number(!!error)}`]
+    
+    if (error) {
+      this.metrics.increment('anthropic.request.error', 1, tags)
+    } else {
+      tags.push(
+        `endpoint:/v1/messages`,
+        `model:${body.model}`
+      )
+    }
+
+    this.metrics.distribution('anthropic.request.duration', duration * 1000, tags)
+
+    const inputTokens = spanTags['anthropic.response.usage.input_tokens']
+    const outputTokens = spanTags['anthropic.response.usage.output_tokens']
+
+    if (!error) {
+      if (inputTokens != null) {
+        this.metrics.distribution('anthropic.tokens.input', inputTokens, tags)
+      }
+
+      if (outputTokens != null) {
+        this.metrics.distribution('anthropic.tokens.output', outputTokens, tags)
+      }
+    }
+  }
+
+  sendLog (operation, span, tags, anthropicStore, error) {
+    if (error || !this.logger) return
+    
+    const log = {
+      timestamp: new Date().toISOString(),
+      operation,
+      span_id: span.context().toSpanId(),
+      trace_id: span.context().toTraceId(),
+      ...tags
+    }
+
+    this.logger.info(JSON.stringify(log))
+  }
+
+  constructResponseFromChunks (chunks) {
+    // Basic implementation for streaming response reconstruction
+    let content = ''
+    let model = null
+    let id = null
+
+    for (const chunk of chunks) {
+      if (chunk.content && chunk.content[0] && chunk.content[0].text) {
+        content += chunk.content[0].text
+      }
+      if (!model && chunk.model) model = chunk.model
+      if (!id && chunk.id) id = chunk.id
+    }
+
+    return {
+      id,
+      model,
+      content: [{ text: content }],
+      role: 'assistant',
+      type: 'message'
+    }
+  }
+}
+
+function normalizeMethodName (methodName) {
+  if (methodName === 'messages.create') {
+    return 'createMessage'
+  }
+  return methodName
+}
+
+function normalizeRequestPayload (methodName, args) {
+  return args[0] || {}
+}
+
+function createMessageRequestExtraction (tags, payload, anthropicStore) {
+  if (payload.max_tokens) {
+    tags['anthropic.request.max_tokens'] = payload.max_tokens
+  }
+
+  if (payload.temperature !== undefined) {
+    tags['anthropic.request.temperature'] = payload.temperature
+  }
+
+  if (payload.messages && Array.isArray(payload.messages)) {
+    tags['anthropic.request.messages.count'] = payload.messages.length
+  }
+
+  anthropicStore.requestPayload = payload
+}
+
+function responseDataExtractionByMethod (normalizedMethodName, tags, body, anthropicStore) {
+  if (normalizedMethodName === 'createMessage' && body) {
+    if (body.usage) {
+      tags['anthropic.response.usage.input_tokens'] = body.usage.input_tokens
+      tags['anthropic.response.usage.output_tokens'] = body.usage.output_tokens
+    }
+
+    if (body.content && Array.isArray(body.content) && body.content[0]) {
+      const textContent = body.content.find(c => c.type === 'text')
+      if (textContent) {
+        tags['anthropic.response.content.length'] = textContent.text ? textContent.text.length : 0
+      }
+    }
+  }
+}
+
+module.exports = AnthropicTracingPlugin

--- a/packages/dd-trace/src/llmobs/plugins/anthropic.js
+++ b/packages/dd-trace/src/llmobs/plugins/anthropic.js
@@ -1,0 +1,120 @@
+'use strict'
+
+const LLMObsPlugin = require('./base')
+
+class AnthropicLLMObsPlugin extends LLMObsPlugin {
+  static id = 'anthropic'
+  static integration = 'anthropic'
+  static prefix = 'tracing:apm:anthropic:request'
+
+  getLLMObsSpanRegisterOptions (ctx) {
+    const resource = ctx.methodName
+    const methodName = normalizeAnthropicResourceName(resource)
+    if (!methodName) return // we will not trace all anthropic methods for llmobs
+
+    const inputs = ctx.args[0] // message creation takes one argument
+    const operation = 'chat' // Anthropic primarily does chat completions
+    const kind = 'llm'
+
+    const { modelProvider, client } = this._getModelProviderAndClient()
+
+    const name = `${client}.${methodName}`
+
+    return {
+      modelProvider,
+      modelName: inputs.model,
+      kind,
+      name
+    }
+  }
+
+  setLLMObsTags (ctx) {
+    const span = ctx.currentStore?.span
+    const resource = ctx.methodName
+    const methodName = normalizeAnthropicResourceName(resource)
+    if (!methodName) return // we will not trace all anthropic methods for llmobs
+
+    const inputs = ctx.args[0] // message creation takes one argument
+    const response = ctx.result?.data // no result if error
+    const error = !!span.context()._tags.error
+
+    if (methodName === 'createMessage') {
+      this._tagChatCompletion(span, inputs, response, error)
+    }
+
+    if (!error) {
+      const metrics = this._extractMetrics(response)
+      this._tagger.tagMetrics(span, metrics)
+    }
+  }
+
+  _getModelProviderAndClient () {
+    return { modelProvider: 'anthropic', client: 'Anthropic' }
+  }
+
+  _extractMetrics (response) {
+    const metrics = {}
+    const tokenUsage = response.usage
+
+    if (tokenUsage) {
+      const inputTokens = tokenUsage.input_tokens
+      if (inputTokens) metrics.inputTokens = inputTokens
+
+      const outputTokens = tokenUsage.output_tokens
+      if (outputTokens) metrics.outputTokens = outputTokens
+
+      const totalTokens = inputTokens + outputTokens
+      if (totalTokens) metrics.totalTokens = totalTokens
+    }
+
+    return metrics
+  }
+
+  _tagChatCompletion (span, inputs, response, error) {
+    const { model, messages, max_tokens, temperature, ...parameters } = inputs
+
+    const metadata = {}
+    if (max_tokens) metadata.max_tokens = max_tokens
+    if (temperature !== undefined) metadata.temperature = temperature
+    if (parameters.top_p !== undefined) metadata.top_p = parameters.top_p
+    if (parameters.top_k !== undefined) metadata.top_k = parameters.top_k
+
+    this._tagger.tagMetadata(span, metadata)
+
+    if (messages) {
+      this._tagger.tagLLMIO(span, messages, 'inputs')
+    }
+
+    if (!error && response) {
+      const choices = []
+      if (response.content) {
+        // Anthropic returns content array
+        const content = response.content
+          .filter(item => item.type === 'text')
+          .map(item => item.text)
+          .join('')
+
+        choices.push({
+          message: {
+            role: response.role,
+            content: content
+          },
+          finish_reason: response.stop_reason
+        })
+      }
+
+      this._tagger.tagLLMIO(span, choices, 'outputs')
+    }
+  }
+}
+
+function normalizeAnthropicResourceName (resource) {
+  switch (resource) {
+    case 'messages.create':
+      return 'createMessage'
+    default:
+      return null
+  }
+}
+
+module.exports = AnthropicLLMObsPlugin


### PR DESCRIPTION
<!-- dd-meta {"pullId":"9dc73455-e4b0-410e-81f4-88a961696057","source":"chat","resourceId":"95bbf825-ac19-44a4-9f6d-2ef5d00cefba","workflowId":"e47dbf2f-a622-4f53-901b-0ce7cb3f9c91","codeChangeId":"e47dbf2f-a622-4f53-901b-0ce7cb3f9c91","sourceType":"chat"} -->
PR by [Bits](https://app.datadoghq.com/code?session_id=9dc73455-e4b0-410e-81f4-88a961696057) for chat [95bbf825-ac19-44a4-9f6d-2ef5d00cefba](https://app.datadoghq.com/code/95bbf825-ac19-44a4-9f6d-2ef5d00cefba).

You can ask for changes by mentioning @Datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a new tracing integration for Anthropic AI SDK (@anthropic-ai/sdk) to enable APM instrumentation and LLM observability for Anthropic API calls.

### Motivation
<!-- What inspired you to submit this pull request? -->

The Anthropic AI SDK was not previously supported by dd-trace-js, meaning users couldn't get visibility into their Anthropic API calls through DataDog APM. This integration provides comprehensive tracing support including support for streaming responses, token usage metrics, and LLM observability features.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This integration follows the same pattern as the OpenAI integration and supports:
- Tracing of `messages.create` API calls
- Streaming response handling with chunk accumulation
- Token usage metrics (input/output tokens)
- LLM observability with proper input/output tagging
- Error handling and span tagging
- Integration with DataDog's metrics and logging systems