### PR TITLE
Emit span IDs in profiles as 64-bit numbers instead of as strings.

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -389,8 +389,8 @@ describe('profiler', () => {
         for (const label of sample.label) {
           switch (label.key) {
             case tsKey: ts = label.num; break
-            case spanKey: spanId = label.str; break
-            case rootSpanKey: rootSpanId = label.str; break
+            case spanKey: spanId = label.num; break
+            case rootSpanKey: rootSpanId = label.num; break
             case endpointKey: endpoint = label.str; break
             case threadNameKey: threadName = label.str; break
             case threadIdKey: threadId = label.str; break

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -59,6 +59,10 @@ class DatadogSpanContext {
     return this._spanId.toString(10)
   }
 
+  toBigIntSpanId () {
+    return this._spanId.toBigInt()
+  }
+
   toTraceparent () {
     const flags = this._sampling.priority >= AUTO_KEEP ? '01' : '00'
     const traceId = this.toTraceId(true)

--- a/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
+++ b/packages/dd-trace/src/profiling/profilers/event_plugins/event.js
@@ -52,8 +52,8 @@ class EventPlugin extends TracingPlugin {
     }
 
     const context = (ctx.currentStore?.span || this.activeSpan)?.context()
-    event._ddSpanId = context?.toSpanId()
-    event._ddRootSpanId = context?._trace.started[0]?.context().toSpanId() || event._ddSpanId
+    event._ddSpanId = context?.toBigIntSpanId()
+    event._ddRootSpanId = context?._trace.started[0]?.context().toBigIntSpanId() || event._ddSpanId
 
     this.#eventHandler(this.extendEvent(event, ctx))
   }

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -273,10 +273,11 @@ class EventSerializer {
       new Label({ key: this.timestampLabelKey, num: dateOffset + BigInt(Math.round(endTime * MS_TO_NS)) })
     ]
     if (_ddSpanId) {
-      label.push(labelFromStr(this.stringTable, this.spanIdKey, _ddSpanId))
+      label.push(
+        new Label({ key: this.spanIdKey, num: _ddSpanId }))
     }
     if (_ddRootSpanId) {
-      label.push(labelFromStr(this.stringTable, this.rootSpanIdKey, _ddRootSpanId))
+      label.push(new Label({ key: this.rootSpanIdKey, num: _ddRootSpanId }))
     }
 
     const sampleInput = {

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -215,10 +215,10 @@ class NativeWallProfiler {
 
   _updateContext (context) {
     if (context.spanId !== null && typeof context.spanId === 'object') {
-      context.spanId = context.spanId.toString(10)
+      context.spanId = context.spanId.toBigInt()
     }
     if (context.rootSpanId !== null && typeof context.rootSpanId === 'object') {
-      context.rootSpanId = context.rootSpanId.toString(10)
+      context.rootSpanId = context.rootSpanId.toBigInt()
     }
     if (context.webTags !== undefined && context.endpoint === undefined) {
       // endpoint may not be determined yet, but keep it as fallback

--- a/packages/dd-trace/test/profiling/profilers/events.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/events.spec.js
@@ -17,7 +17,7 @@ describe('profilers/events', () => {
     // Set up a mock span to simulate tracing context
     const span = {
       context: () => ({
-        toSpanId: () => '1234',
+        toBigIntSpanId: () => 1234n,
         _trace: {
           started: [span]
         }


### PR DESCRIPTION
### What does this PR do?
Changes the profiler code so it now emits span IDs in profiles as 64-bit numbers instead of as strings.

### Motivation
A typical profile will have thousands of span IDs, many of them unique. By not carrying strings with decimal encoding of the span IDs this will significantly reduce the maximum memory use of profile serializations as well as the size of the serialized profiles.

libdatadog has been encoding span IDs as 64-bit ints for a very long time now. The backend can work with either strings or ints.

Jira: [PROF-12326]

[PROF-12326]: https://datadoghq.atlassian.net/browse/PROF-12326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ