### PR TITLE
fix(llmobs): properly parse DD_TAGS onto span events' tags

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -823,8 +823,12 @@ class Config {
     const env = setHiddenProperty(this, '_env', {})
     setHiddenProperty(this, '_envUnprocessed', {})
 
+    const ddTags = {}
+    tagger.add(ddTags, parseSpaceSeparatedTags(DD_TAGS))
+    setHiddenProperty(this, '_ddTags', ddTags) // usable as a standalone tag set for other products
+
     tagger.add(tags, parseSpaceSeparatedTags(handleOtel(OTEL_RESOURCE_ATTRIBUTES)))
-    tagger.add(tags, parseSpaceSeparatedTags(DD_TAGS))
+    tagger.add(tags, ddTags)
     tagger.add(tags, DD_TRACE_TAGS)
     tagger.add(tags, DD_TRACE_GLOBAL_TAGS)
 

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -177,7 +177,10 @@ class LLMObsSpanProcessor {
   }
 
   _processTags (span, mlApp, sessionId, error) {
+    const ddTags = this._config._ddTags ?? {}
+
     let tags = {
+      ...ddTags,
       version: this._config.version,
       env: this._config.env,
       service: this._config.service,
@@ -187,6 +190,7 @@ class LLMObsSpanProcessor {
       error: Number(!!error) || 0,
       language: 'javascript'
     }
+
     const errType = span.context()._tags[ERROR_TYPE] || error?.name
     if (errType) tags.error_type = errType
     if (sessionId) tags.session_id = sessionId

--- a/packages/dd-trace/test/llmobs/sdk/integration.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/integration.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { expectedLLMObsNonLLMSpanEvent, deepEqualWithMockValues } = require('../util')
+const { useEnv } = require('../../../../../integration-tests/helpers')
 const chai = require('chai')
 
 chai.Assertion.addMethod('deepEqualWithMockValues', deepEqualWithMockValues)
@@ -20,10 +21,14 @@ function getTag (llmobsSpan, tagName) {
   return tag?.split(':')[1]
 }
 
-describe('end to end sdk integration tests', () => {
+describe.only('end to end sdk integration tests', () => {
   let tracer
   let llmobs
   let payloadGenerator
+
+  useEnv({
+    DD_TAGS: 'foo:bar',
+  })
 
   function run (payloadGenerator) {
     payloadGenerator()
@@ -112,7 +117,7 @@ describe('end to end sdk integration tests', () => {
       expectedLLMObsNonLLMSpanEvent({
         span: spans[0],
         spanKind: 'agent',
-        tags: { ...tags, bar: 'baz' },
+        tags: { ...tags, bar: 'baz', foo: 'bar' },
         metadata: { foo: 'bar' },
         inputValue: 'hello',
         outputValue: 'world'
@@ -121,7 +126,7 @@ describe('end to end sdk integration tests', () => {
         span: spans[2],
         spanKind: 'workflow',
         parentId: spans[0].context().toSpanId(),
-        tags,
+        tags: { ...tags, foo: 'bar' },
         name: 'myWorkflow',
         inputValue: 'world',
         outputValue: 'hello'
@@ -165,7 +170,7 @@ describe('end to end sdk integration tests', () => {
       expectedLLMObsNonLLMSpanEvent({
         span: spans[0],
         spanKind: 'agent',
-        tags,
+        tags: { ...tags, foo: 'bar' },
         inputValue: 'hello',
         outputValue: 'world',
         metadata: { foo: 'bar' }
@@ -174,7 +179,7 @@ describe('end to end sdk integration tests', () => {
         span: spans[2],
         spanKind: 'workflow',
         parentId: spans[0].context().toSpanId(),
-        tags,
+        tags: { ...tags, foo: 'bar' },
         name: 'myWorkflow',
         inputValue: 'my custom input',
         outputValue: 'custom'

--- a/packages/dd-trace/test/llmobs/sdk/integration.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/integration.spec.js
@@ -21,7 +21,7 @@ function getTag (llmobsSpan, tagName) {
   return tag?.split(':')[1]
 }
 
-describe.only('end to end sdk integration tests', () => {
+describe('end to end sdk integration tests', () => {
   let tracer
   let llmobs
   let payloadGenerator


### PR DESCRIPTION
### What does this PR do?
Properly parse DD_TAGS onto the llmobs span events' tags field.

Internally: sets `DD_TAGS` as a private (but accessible) member on the `config` object for the tracer, as the `tags` property gets "polluted" with other tags besides `DD_TAGS` for LLM Observability, we just want to propagate `DD_TAGS` that are set on the config.

### Motivation
We should have been grabbing these the whole time.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


