### PR TITLE
improve esbuild integration test stability

### DIFF
--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -15,19 +15,15 @@ const TEST_DIR = path.join(__dirname, '.')
 process.chdir(TEST_DIR)
 
 // This should switch to our withVersion helper. The order here currently matters.
-const esbuildVersions = ['latest', '0.16.12']
+const latestVersion = require('../../packages/dd-trace/test/plugins/versions/package.json').dependencies.esbuild
+const esbuildVersions = [latestVersion, '0.16.12']
+
+const timeout = 60_000
 
 esbuildVersions.forEach((version) => {
   describe(`esbuild ${version}`, () => {
     before(() => {
-      chproc.execSync('npm install', {
-        timeout: 1000 * 30
-      })
-      if (version !== 'latest') {
-        chproc.execSync(`npm install esbuild@${version}`, {
-          timeout: 1000 * 30
-        })
-      }
+      chproc.execSync(`npm install esbuild@${version}`, { timeout })
     })
 
     it('works', () => {
@@ -36,9 +32,7 @@ esbuildVersions.forEach((version) => {
 
       console.log('npm run built')
       try {
-        chproc.execSync('npm run built', {
-          timeout: 1000 * 30
-        })
+        chproc.execSync('npm run built', { timeout })
       } catch (err) {
         console.error(err)
         process.exit(1)
@@ -50,41 +44,31 @@ esbuildVersions.forEach((version) => {
     it('does not bundle modules listed in .external', () => {
       const command = 'node ./build-and-test-skip-external.js'
       console.log(command)
-      chproc.execSync(command, {
-        timeout: 1000 * 30
-      })
+      chproc.execSync(command, { timeout })
     })
 
     it('handles typescript apps that import without file extensions', () => {
       const command = 'node ./build-and-test-typescript.mjs'
       console.log(command)
-      chproc.execSync(command, {
-        timeout: 1000 * 30
-      })
+      chproc.execSync(command, { timeout })
     })
 
     it('handles the complex aws-sdk package with dynamic requires', () => {
       const command = 'node ./build-and-test-aws-sdk.js'
       console.log(command)
-      chproc.execSync(command, {
-        timeout: 1000 * 30
-      })
+      chproc.execSync(command, { timeout })
     })
 
     it('handles scoped node_modules', () => {
       const command = 'node ./build-and-test-koa.mjs'
       console.log(command)
-      chproc.execSync(command, {
-        timeout: 1000 * 30
-      })
+      chproc.execSync(command, { timeout })
     })
 
     it('handles instrumentations where the patching function is a property of the hook', () => {
       const command = 'node ./build-and-test-openai.js'
       console.log(command)
-      chproc.execSync(command, {
-        timeout: 1000 * 30
-      })
+      chproc.execSync(command, { timeout })
     })
 
     describe('ESM', () => {
@@ -98,17 +82,13 @@ esbuildVersions.forEach((version) => {
         console.log('npm run build:esm')
         chproc.execSync('npm run build:esm')
         console.log('npm run built:esm')
-        chproc.execSync('npm run built:esm', {
-          timeout: 1000 * 30
-        })
+        chproc.execSync('npm run built:esm', { timeout })
       })
 
       it('should not override existing js banner', () => {
         const command = 'node ./build-and-run.esm-unrelated-js-banner.mjs'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
 
         const builtFile = fs.readFileSync('./out.mjs').toString()
         assert.include(builtFile, '/* js test */')
@@ -117,9 +97,7 @@ esbuildVersions.forEach((version) => {
       it('should contain the definitions when esm is inferred from outfile', () => {
         const command = 'node ./build-and-run.esm-relying-in-extension.mjs'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
 
         const builtFile = fs.readFileSync('./out.mjs').toString()
         assert.include(builtFile, 'globalThis.__filename ??= $dd_fileURLToPath(import.meta.url);')
@@ -128,9 +106,7 @@ esbuildVersions.forEach((version) => {
       it('should contain the definitions when esm is inferred from format', () => {
         const command = 'node ./build-and-run.esm-relying-in-format.mjs'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
 
         const builtFile = fs.readFileSync('./out.mjs').toString()
         assert.include(builtFile, 'globalThis.__filename ??= $dd_fileURLToPath(import.meta.url);')
@@ -139,9 +115,7 @@ esbuildVersions.forEach((version) => {
       it('should contain the definitions when format is inferred from out extension', () => {
         const command = 'node ./build-and-run.esm-relying-in-out-extension.mjs'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
 
         const builtFile = fs.readFileSync('./basic-test.mjs').toString()
         assert.include(builtFile, 'globalThis.__filename ??= $dd_fileURLToPath(import.meta.url);')
@@ -150,9 +124,7 @@ esbuildVersions.forEach((version) => {
       it('should not contain the definitions when no esm is specified', () => {
         const command = 'node ./build.js'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
 
         const builtFile = fs.readFileSync('./out.js').toString()
         assert.notInclude(builtFile, 'globalThis.__filename ??= $dd_fileURLToPath(import.meta.url);')
@@ -161,17 +133,13 @@ esbuildVersions.forEach((version) => {
       it('should not crash when it is already patched using global', () => {
         const command = 'node ./build-and-run.esm-patched-global-banner.mjs'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
       })
 
       it('should not crash when it is already patched using const', () => {
         const command = 'node ./build-and-run.esm-patched-const-banner.mjs'
         console.log(command)
-        chproc.execSync(command, {
-          timeout: 1000 * 30
-        })
+        chproc.execSync(command, { timeout })
       })
     })
   })

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -24,7 +24,7 @@
     "@koa/router": "*",
     "aws-sdk": "*",
     "axios": "*",
-    "esbuild": "^0.16.12",
+    "esbuild": "*",
     "express": "^4.16.2",
     "knex": "*",
     "koa": "*",

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -24,7 +24,7 @@
     "@koa/router": "*",
     "aws-sdk": "*",
     "axios": "*",
-    "esbuild": "*",
+    "esbuild": "^0.16.12",
     "express": "^4.16.2",
     "knex": "*",
     "koa": "*",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:plugins:upstream": "node ./packages/dd-trace/test/plugins/suite.js",
     "test:profiler": "tap \"packages/dd-trace/test/profiling/**/*.spec.js\"",
     "test:profiler:ci": "npm run test:profiler -- --coverage --nyc-arg=--include=\"packages/dd-trace/src/profiling/**/*.js\"",
-    "test:integration": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/*.spec.js\"",
+    "test:integration": "mocha --timeout 120000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/*.spec.js\"",
     "test:integration:appsec": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/appsec/*.spec.js\"",
     "test:integration:cucumber": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/cucumber/*.spec.js\"",
     "test:integration:cypress": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/cypress/*.spec.js\"",

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -83,6 +83,7 @@
     "dd-trace-api": "1.0.0",
     "ejs": "3.1.10",
     "elasticsearch": "16.7.3",
+    "esbuild": "0.25.9",
     "express": "5.1.0",
     "express-mongo-sanitize": "2.2.0",
     "express-session": "1.18.2",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Improve esbuild integration test stability by pinning the latest version and bumping the timeout.

### Motivation
<!-- What inspired you to submit this pull request? -->

Avoid issues related to new versions of esbuild and hopefully prevent further occurrences of timeouts like https://github.com/DataDog/dd-trace-js/actions/runs/16977715214/job/48130733078