### PR TITLE
feat(aws/sqs): add queue url as resource tag

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -101,7 +101,8 @@ class Sqs extends BaseAwsSdkPlugin {
     const tags = {
       'resource.name': `${operation} ${params.QueueName || params.QueueUrl}`,
       'aws.sqs.queue_name': params.QueueName || params.QueueUrl,
-      queuename: queueName
+      queuename: queueName,
+      queue_url: params.QueueUrl
     }
 
     switch (operation) {

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -146,7 +146,8 @@ describe('Plugin', () => {
 
             expect(span.resource.startsWith('sendMessage')).to.equal(true)
             expect(span.meta).to.include({
-              queuename: queueName
+              queuename: queueName,
+              queue_url: QueueUrl
             })
 
             parentId = span.span_id.toString()
@@ -196,7 +197,8 @@ describe('Plugin', () => {
 
             expect(span.resource.startsWith('sendMessageBatch')).to.equal(true)
             expect(span.meta).to.include({
-              queuename: queueName
+              queuename: queueName,
+              queue_url: QueueUrl
             })
 
             parentId = span.span_id.toString()
@@ -369,6 +371,7 @@ describe('Plugin', () => {
 
             expect(span.meta).to.include({
               queuename: queueName,
+              queue_url: QueueUrl,
               aws_service: 'SQS',
               region: 'us-east-1'
             })


### PR DESCRIPTION
### What does this PR do?
This PR attaches a `queue_url` tag to AWS SQS spans, which is already available within the tracer since the queue url is a parameter to the SQS operations via AWS SDK.

### Motivation
Part of a larger effort to better link cloud resources within Datadog. Currently the way in which sqs resources are tagged are inconsistent across different trace libraries, and we need a consistent tag key with the same value format to support this linkage.

[Jira Ticket](https://datadoghq.atlassian.net/browse/CLP-1074) and more [context](https://datadoghq.atlassian.net/wiki/x/toGyLwE) around this effort

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml