### PR TITLE
fix gc pause metric using millis instead of nanos

### DIFF
--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -274,9 +274,10 @@ function startGCObserver () {
   gcObserver = new PerformanceObserver(list => {
     for (const entry of list.getEntries()) {
       const type = gcType(entry.detail?.kind || entry.kind)
+      const duration = entry.duration * 1_000_000
 
-      runtimeMetrics.histogram('runtime.node.gc.pause.by.type', entry.duration, `gc_type:${type}`)
-      runtimeMetrics.histogram('runtime.node.gc.pause', entry.duration)
+      runtimeMetrics.histogram('runtime.node.gc.pause.by.type', duration, `gc_type:${type}`)
+      runtimeMetrics.histogram('runtime.node.gc.pause', duration)
     }
   })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix GC pause metric using milliseconds instead of nanoseconds.

### Motivation
<!-- What inspired you to submit this pull request? -->

This made the metric plummet to 0 or close to it as the precision was incorrect.
