### PR TITLE
[test-optimization] [SDTEST-2548] Fix playwright instrumentation for versions `>=1.55.0`

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -148,8 +148,8 @@ function getPlaywrightConfig (playwrightRunner) {
   }
 }
 
-function getRootDir (playwrightRunner) {
-  const config = getPlaywrightConfig(playwrightRunner)
+function getRootDir (playwrightRunner, configArg) {
+  const config = configArg ? configArg.config : getPlaywrightConfig(playwrightRunner)
   if (config.rootDir) {
     return config.rootDir
   }
@@ -162,8 +162,8 @@ function getRootDir (playwrightRunner) {
   return process.cwd()
 }
 
-function getProjectsFromRunner (runner) {
-  const config = getPlaywrightConfig(runner)
+function getProjectsFromRunner (runner, configArg) {
+  const config = configArg || getPlaywrightConfig(runner)
   return config.projects?.map((project) => {
     if (project.project) {
       return project.project
@@ -509,11 +509,12 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
   return dispatcherExport
 }
 
-function runnerHook (runnerExport, playwrightVersion) {
-  shimmer.wrap(runnerExport.Runner.prototype, 'runAllTests', runAllTests => async function () {
+function runAllTestsWrapper (runAllTests, playwrightVersion) {
+  // Config parameter is only available from >=1.55.0
+  return async function (config) {
     let onDone
 
-    rootDir = getRootDir(this)
+    rootDir = getRootDir(this, config)
 
     const processArgv = process.argv.slice(2).join(' ')
     const command = `playwright ${processArgv}`
@@ -586,7 +587,7 @@ function runnerHook (runnerExport, playwrightVersion) {
       }
     }
 
-    const projects = getProjectsFromRunner(this)
+    const projects = getProjectsFromRunner(this, config)
 
     const shouldSetRetries = isFlakyTestRetriesEnabled &&
       flakyTestRetriesCount > 0 &&
@@ -651,6 +652,19 @@ function runnerHook (runnerExport, playwrightVersion) {
     // TODO: we can trick playwright into thinking the session passed by returning
     // 'passed' here. We might be able to use this for both EFD and Test Management tests.
     return runAllTestsReturn
+  }
+}
+
+function runnerHook (runnerExport, playwrightVersion) {
+  shimmer.wrap(runnerExport.Runner.prototype, 'runAllTests', runAllTests => runAllTestsWrapper(runAllTests, playwrightVersion))
+}
+
+function runnerHookNew (runnerExport, playwrightVersion) {
+  runnerExport = shimmer.wrap(runnerExport, 'runAllTestsWithConfig', function (originalGetter) {
+    const originalFunction = originalGetter.call(this)
+    return function () {
+      return runAllTestsWrapper(originalFunction, playwrightVersion)
+    }
   })
 
   return runnerExport
@@ -693,6 +707,12 @@ addHook({
   file: 'lib/runner/runner.js',
   versions: ['>=1.38.0']
 }, runnerHook)
+
+addHook({
+  name: 'playwright',
+  file: 'lib/runner/testRunner.js',
+  versions: ['>=1.55.0']
+}, runnerHookNew)
 
 addHook({
   name: 'playwright',

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -656,7 +656,11 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
 }
 
 function runnerHook (runnerExport, playwrightVersion) {
-  shimmer.wrap(runnerExport.Runner.prototype, 'runAllTests', runAllTests => runAllTestsWrapper(runAllTests, playwrightVersion))
+  shimmer.wrap(
+    runnerExport.Runner.prototype,
+    'runAllTests',
+    runAllTests => runAllTestsWrapper(runAllTests, playwrightVersion)
+  )
 }
 
 function runnerHookNew (runnerExport, playwrightVersion) {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
With this fix we enable Playwright instrumentation for version `>=1.55.0`

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to support latests versions of the tracers supported in our product.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.


