### PR TITLE
[test-optimization] [SDTEST-2548] Fix Cypress tests for versions `>=15.0.0`

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -120,8 +120,9 @@ jobs:
         version: [eol, oldest, latest]
         # 6.7.0 is the minimum version we support in <=5
         # 10.2.0 is the minimum version we support in >=6
+        # 14.5.4 is the latest version that supports Node 18
         # The logic to decide whether the tests run lives in integration-tests/cypress/cypress.spec.js
-        cypress-version: [6.7.0, 10.2.0, latest]
+        cypress-version: [6.7.0, 10.2.0, 14.5.4, latest]
         module-type: ['commonJS', 'esm']
     runs-on: ubuntu-latest
     env:

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -86,7 +86,8 @@ function shouldTestsRun (type) {
       return version === '6.7.0' && type === 'commonJS'
     }
     if (NODE_MAJOR > 16) {
-      return version === 'latest'
+      // Cypress 15.0.0 has removed support for Node 18
+      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
     }
   }
   if (DD_MAJOR === 6) {
@@ -94,7 +95,11 @@ function shouldTestsRun (type) {
       return false
     }
     if (NODE_MAJOR > 16) {
-      return version === '10.2.0' || version === 'latest'
+      // Cypress 15.0.0 has removed support for Node 18
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -80,7 +80,7 @@
     "cookie": "1.0.2",
     "cookie-parser": "1.4.7",
     "couchbase": "4.5.0",
-    "cypress": "14.5.4",
+    "cypress": "15.0.0",
     "cypress-fail-fast": "7.1.1",
     "dd-trace-api": "1.0.0",
     "ejs": "3.1.10",

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -80,7 +80,7 @@
     "cookie": "1.0.2",
     "cookie-parser": "1.4.7",
     "couchbase": "4.5.0",
-    "cypress": "15.0.0",
+    "cypress": "14.5.4",
     "cypress-fail-fast": "7.1.1",
     "dd-trace-api": "1.0.0",
     "ejs": "3.1.10",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR modify tests to be able to be able to support to the latest version of Cypress (`15.0.0`). The main issue is that Cypress stopped support of Node versions (`18` and `23`) on their latest major release.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to be able to support latest versions of the frameworks that we support

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
[Cypress Release Notes (15.0.0)](https://docs.cypress.io/app/references/changelog#15-0-0)


