### PR TITLE
Fix flake

### DIFF
--- a/packages/dd-trace/test/profiling/profilers/poisson.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/poisson.spec.js
@@ -132,7 +132,7 @@ describe('PoissonProcessSamplingFilter', () => {
     assert.ok(filter.currentSamplingInstant >= prevNextSamplingInstant)
     assert.strictEqual(typeof filter.nextSamplingInstant, 'number')
     assert.ok(filter.nextSamplingInstant < 500000)
-    assert.ok(filter.samplingInstantCount < 10)
+    assert.ok(filter.samplingInstantCount < 30)
   })
 
   it('should reset nextSamplingInstant if it is too far in the past', () => {


### PR DESCRIPTION
### What does this PR do?
Makes it less likely that a test will flake out. Poisson random processes can actually manifest any no matter how unlikely behavior, only with exponentially decaying probabilities. Tripling the number of allowed interval recalculations will hopefully make it so we never observe a flake. If this proves wrong, we can still push this number higher.

### Motivation
Test was observed as flaky.
