### PR TITLE
[test-optimization] [SDTEST-2548] Fix playwright in `v5`

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -149,7 +149,7 @@ function getPlaywrightConfig (playwrightRunner) {
 }
 
 function getRootDir (playwrightRunner, configArg) {
-  const config = configArg ? configArg.config : getPlaywrightConfig(playwrightRunner)
+  const config = configArg?.config || getPlaywrightConfig(playwrightRunner)
   if (config.rootDir) {
     return config.rootDir
   }
@@ -163,7 +163,7 @@ function getRootDir (playwrightRunner, configArg) {
 }
 
 function getProjectsFromRunner (runner, configArg) {
-  const config = configArg || getPlaywrightConfig(runner)
+  const config = configArg?.projects ? configArg : getPlaywrightConfig(runner)
   return config.projects?.map((project) => {
     if (project.project) {
       return project.project


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
With this fix we correctly setup the instrumentation for versions lower to `1.38.0` in Playwright.

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to keep supporting old versions in `v5`

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.


