### PR TITLE
Fix concurrency.group for runs on master

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -9,7 +9,10 @@ on:
     - cron: 0 4 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  # this ensures that only one workflow runs at a time for a given branch on pull requests
+  # as the group key is the workflow name and the branch name
+  # for scheduled runs and pushes to master, we use the run id to ensure that all runs are executed
+  group: ${{ (github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref)) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### What does this PR do?
Fix the concurrency for system-tests runs on main

The previous code was `${{ github.workflow }}-${{ github.ref || github.run_id }}`. But `github.ref` is always set, so `run_id` was ignored.

The new code weill set this key

* For PR : `${{ github.workflow }}-${{ github.ref }}` -> branch name, concurrency applied on PR
* for pushes/scheduled on master : `${{ github.workflow }}-${{ github.run_id }}` -> they are all executed, as run_id is unique.

### Motivation
We always want to have system-tests fully executed on each commit on main : 

* ease debugging, by better flagging the culprit
* side effect : those runs won't shows up as failure in CI health

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


