### PR TITLE
chore: remove sampling priority check to allow re sampling

### DIFF
--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -105,7 +105,6 @@ class PrioritySampler {
     const root = context._trace.started[0]
 
     // TODO: remove the decision maker tag when priority is less than AUTO_KEEP
-    if (context._sampling.priority !== undefined) return
     if (!root) return // noop span
 
     log.trace(span, auto)


### PR DESCRIPTION
### What does this PR do?
Removes check within our sampler to allow re-sampling an already sampled span. This issue came up because of a customer trying to set `MANUAL_KEEP` on a span that is normally dropped during successful calls. The span of interest is a web client request, which at the time of creation, injects the web request headers with the trace context, which also means making and setting the sampling decision (drop at the time), on both the headers and the local span. When the request returns an error, the customer is trying to set `MANUAL_KEEP` on the span, but the tag is not respected since the span already has a sampling decision. Removing this line always for re-sampling, and aligns with our sampling docs [here](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_mechanisms/?tab=nodejs#force-keep-and-drop:~:text=The%20head%2Dbased%20sampling%20mechanism,the%20trace%20to%20be%20dropped.).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


