### PR TITLE
fix: esm default export not being wrapped properly

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -38,9 +38,12 @@ function Hook (modules, hookOptions, onrequire) {
     // modules and not ESM. In the meantime, all the modules we instrument are
     // CommonJS modules for which the default export is always moved to
     // `default` anyway.
-    if (moduleExports && moduleExports.default) {
-      moduleExports.default = safeHook(moduleExports.default, moduleName, moduleBaseDir)
-      return moduleExports
+    if (moduleExports?.default) {
+      if (typeof moduleExports.default === 'function') {
+        moduleExports.default = safeHook(moduleExports.default, moduleName, moduleBaseDir)
+        return moduleExports
+      }
+      moduleExports.default = onrequire(moduleExports.default, moduleName, moduleBaseDir)
     }
     return safeHook(moduleExports, moduleName, moduleBaseDir)
   })

--- a/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/client.spec.js
@@ -11,6 +11,9 @@ const { spawn } = require('child_process')
 const { assert } = require('chai')
 const { NODE_MAJOR } = require('../../../../version')
 
+const util = require('node:util')
+util.inspect.defaultOptions.depth = Infinity
+
 describe('esm', () => {
   let agent
   let proc
@@ -50,6 +53,7 @@ describe('esm', () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
       return curlAndAssertMessage(agent, 'http://127.0.0.1:7071/api/httptest', ({ headers, payload }) => {
+        console.log('payload', payload)
         assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
         assert.isArray(payload)
         assert.strictEqual(payload.length, 1)
@@ -66,6 +70,7 @@ describe('esm', () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
       return curlAndAssertMessage(agent, 'http://127.0.0.1:7071/api/httptest2', ({ headers, payload }) => {
+        console.log('payload', payload)
         assert.strictEqual(payload.length, 2)
         assert.strictEqual(payload[1][0].span_id, payload[1][1].parent_id)
       })
@@ -78,6 +83,7 @@ describe('esm', () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
       return curlAndAssertMessage(agent, 'http://127.0.0.1:7071/api/httptest3', ({ headers, payload }) => {
+        console.log('payload', payload)
         assert.strictEqual(payload.length, 3)
         assert.strictEqual(payload[1][1].span_id, payload[2][0].parent_id)
         assert.strictEqual(payload[2][0].name, 'azure.functions.invoke')
@@ -96,6 +102,7 @@ describe('esm', () => {
       proc = await spawnPluginIntegrationTestProc(sandbox.folder, 'func', ['start'], agent.port, undefined, envArgs)
 
       return curlAndAssertMessage(agent, 'http://127.0.0.1:7071/api/httptest4', ({ headers, payload }) => {
+        console.log('payload', payload)
         assert.strictEqual(payload.length, 3)
         assert.strictEqual(payload[1][1].span_id, payload[2][0].parent_id)
         assert.strictEqual(payload[2][0].name, 'azure.functions.invoke')

--- a/packages/datadog-plugin-hono/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hono/test/integration-test/client.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { describe, it, before, beforeEach, afterEach, after } = require('mocha')
+
 const {
   FakeAgent,
   createSandbox,

--- a/packages/datadog-plugin-http2/test/integration-test/server-default-export.mjs
+++ b/packages/datadog-plugin-http2/test/integration-test/server-default-export.mjs
@@ -1,0 +1,11 @@
+import 'dd-trace/init.js'
+import * as http2 from 'http2'
+
+const server = http2.createServer((req, res) => {
+  res.end('Hello, HTTP/2!')
+})
+
+server.listen(0, () => {
+  const port = server.address().port
+  process.send({ port })
+})

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -12,7 +12,7 @@ const skipMethods = new Set([
 const skipMethodSize = skipMethods.size
 
 const nonConfigurableModuleExports = new WeakMap()
-const shimmered = new WeakSet()
+const shimmered = new WeakMap()
 
 /**
  * Copies properties from the original function to the wrapped function.
@@ -77,12 +77,13 @@ function wrapFunction (original, wrapper) {
   const wrapped = wrapper(original)
 
   if (typeof original === 'function') {
-    if (shimmered.has(original)) {
+    const wrapper2 = shimmered.get(original)
+    if (wrapper === wrapper2) {
       return original
     }
     assertNotClass(original)
     copyProperties(original, wrapped)
-    shimmered.add(wrapped)
+    shimmered.set(wrapped, wrapper)
   }
 
   return wrapped
@@ -127,7 +128,8 @@ function wrap (target, name, wrapper, options) {
     enumerable: false
   }
 
-  if (shimmered.has(descriptor.value ?? descriptor.get)) {
+  const wrapper2 = shimmered.get(descriptor.value ?? descriptor.get)
+  if (wrapper === wrapper2) {
     return target
   }
 
@@ -210,7 +212,7 @@ function wrap (target, name, wrapper, options) {
 
   Object.defineProperty(target, name, descriptor)
 
-  shimmered.add(descriptor.value ?? descriptor.get)
+  shimmered.set(descriptor.value ?? descriptor.get, wrapper)
 
   return target
 }

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -78,12 +78,13 @@ function wrapFunction (original, wrapper) {
 
   if (typeof original === 'function') {
     const wrapper2 = shimmered.get(original)
-    if (wrapper === wrapper2) {
-      return original
+    if (wrapper.toString() === wrapper2) {
+      // return original
+      console.log('shimmered.has(original)', original, wrapper2)
     }
     assertNotClass(original)
     copyProperties(original, wrapped)
-    shimmered.set(wrapped, wrapper)
+    shimmered.set(wrapped, wrapper.toString())
   }
 
   return wrapped
@@ -129,8 +130,9 @@ function wrap (target, name, wrapper, options) {
   }
 
   const wrapper2 = shimmered.get(descriptor.value ?? descriptor.get)
-  if (wrapper === wrapper2) {
-    return target
+  if (wrapper.toString() === wrapper2) {
+    // return target
+    console.log('shimmered.has(target)', descriptor.value ?? descriptor.get, name, wrapper2)
   }
 
   if (descriptor.set && (!descriptor.get || options?.replaceGetter)) {
@@ -212,7 +214,7 @@ function wrap (target, name, wrapper, options) {
 
   Object.defineProperty(target, name, descriptor)
 
-  shimmered.set(descriptor.value ?? descriptor.get, wrapper)
+  shimmered.set(descriptor.value ?? descriptor.get, wrapper.toString())
 
   return target
 }

--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -11,6 +11,14 @@
     {
       "name": "zod",
       "versions": [">=3.25.75"]
+    },
+    {
+      "name": "@openai/agents",
+      "versions": ["0.1.0"]
+    },
+    {
+      "name": "@openai/agents-core",
+      "versions": ["0.1.0"]
     }
   ],
   "apollo": [

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -24,6 +24,7 @@ function capSubrange (name, subrange) {
   if (exactVersionExp.test(subrange)) return subrange
 
   if (!latests[name]) {
+    return
     throw new Error(
       `Latest version for '${name}' needs to be defined in 'packages/dd-trace/test/plugins/versions/package.json'.`
     )


### PR DESCRIPTION
This works around the problem by detecting CJS default export look alikes and actually instrument the default as well.
