### PR TITLE
fix: make Object.assign compatible with non-extensible headers in Bun runtime

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -387,7 +387,7 @@ const web = {
 
     return function (statusCode, statusMessage, headers) {
       headers = typeof statusMessage === 'string' ? headers : statusMessage
-      headers = Object.assign(res.getHeaders(), headers)
+      headers = Object.assign({}, res.getHeaders(), headers)
 
       if (req.method.toLowerCase() === 'options' && isOriginAllowed(req, headers)) {
         addAllowHeaders(req, res, headers)


### PR DESCRIPTION
### What does this PR do?
make Object.assign compatible with non-extensible headers in Bun runtime

### Motivation
The `res.getHeaders()` method in Bun returns a non-extensible object, causing
`Object.assign(res.getHeaders(), headers)` to throw `TypeError: Attempting to 
define property on object that is not extensible`.

This fix creates a new extensible object as the target for Object.assign,
ensuring compatibility with both Node.js and Bun runtimes.

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes

Related issues: 
- https://github.com/DataDog/dd-trace-js/issues/5324
- https://github.com/DataDog/dd-trace-js/issues/3749


