### PR TITLE
style: change 'nodejs' spelling to 'Node.js'

### DIFF
--- a/integration-tests/init.spec.js
+++ b/integration-tests/init.spec.js
@@ -105,13 +105,13 @@ function testRuntimeVersionChecks (arg, filename) {
 
             it('should not initialize the tracer', () =>
               doTest(`Aborting application instrumentation due to incompatible_runtime.
-Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs \
+Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes: Node.js \
 >=18.
 false
 `, telemetryAbort))
             it('should initialize the tracer, if DD_INJECT_FORCE', () =>
               doTestForced(`Aborting application instrumentation due to incompatible_runtime.
-Found incompatible runtime nodejs ${process.versions.node}, Supported runtimes: nodejs \
+Found incompatible runtime Node.js ${process.versions.node}, Supported runtimes: Node.js \
 >=18.
 DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.
 Application instrumentation bootstrapping complete

--- a/node-upstream-tests/node/run_tests.js
+++ b/node-upstream-tests/node/run_tests.js
@@ -9,7 +9,7 @@ const fsUtils = require('./fs_utils')
 const NODE_BIN = process.env.NODE_BIN || '/usr/bin/node'
 const NODE_REPO_PATH = process.env.NODE_REPO_PATH
 if (NODE_REPO_PATH === undefined) {
-  throw new Error('The env variable NODE_REPO_PATH is not set. This is required to locate the root of the nodejs repo')
+  throw new Error('The env variable NODE_REPO_PATH is not set. This is required to locate the root of the Node.js repo')
 }
 const MAX_PARALLEL_TESTS = 8
 

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -33,7 +33,7 @@ function disable () {
 }
 
 function onFirstReceivedRequest () {
-  // nodejs unsubscribe during publish bug: https://github.com/nodejs/node/pull/55116
+  // Node.js unsubscribe during publish bug: https://github.com/nodejs/node/pull/55116
   process.nextTick(() => {
     incomingHttpRequestStart.unsubscribe(onFirstReceivedRequest)
   })

--- a/packages/dd-trace/src/guardrails/index.js
+++ b/packages/dd-trace/src/guardrails/index.js
@@ -48,10 +48,10 @@ function guard (fn) {
     ], undefined, {
       result: 'abort',
       result_class: 'incompatible_runtime',
-      result_reason: 'Incompatible runtime nodejs ' + version + ', supported runtimes: nodejs ' + engines.node
+      result_reason: 'Incompatible runtime Node.js ' + version + ', supported runtimes: Node.js ' + engines.node
     })
     log.info('Aborting application instrumentation due to incompatible_runtime.')
-    log.info('Found incompatible runtime nodejs %s, Supported runtimes: nodejs %s.', version, engines.node)
+    log.info('Found incompatible runtime Node.js %s, Supported runtimes: Node.js %s.', version, engines.node)
     if (forced) {
       log.info('DD_INJECT_FORCE enabled, allowing unsupported runtimes and continuing.')
     }

--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -71,7 +71,7 @@ function setStackTraceLimitFunction (fn) {
 function onError (err) {
   const { formatted, cause } = getErrorLog(err)
 
-  // calling twice logger.error() because Error cause is only available in nodejs v16.9.0
+  // calling twice logger.error() because Error cause is only available in Node.js v16.9.0
   // TODO: replace it with Error(message, { cause }) when cause has broad support
   if (formatted) {
     withNoop(() => {

--- a/packages/dd-trace/test/iitm.spec.js
+++ b/packages/dd-trace/test/iitm.spec.js
@@ -17,7 +17,7 @@ describe('iitm.js', () => {
   }
   let iitmjs
 
-  describe('with a supported nodejs version', () => {
+  describe('with a supported Node.js version', () => {
     let listener
     const moduleLoadStartChannel = dc.channel('dd-trace:moduleLoadStart')
 


### PR DESCRIPTION
Ensure consistent spelling of Node.js across the codebase
