### PR TITLE
[test optimization] Clean up handling of known tests in `vitest`

### DIFF
--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -51,6 +51,10 @@ function waitForHitProbe () {
   })
 }
 
+function isValidKnownTests (receivedKnownTests) {
+  return !!receivedKnownTests.vitest
+}
+
 function getProvidedContext () {
   try {
     const {
@@ -235,28 +239,33 @@ function getSortWrapper (sort, frameworkVersion) {
 
         const testFilepaths = await getFilePaths.call(this.ctx)
 
-        isEarlyFlakeDetectionFaultyCh.publish({
-          knownTests: knownTests.vitest || {},
-          testFilepaths,
-          onDone: (isFaulty) => {
-            isEarlyFlakeDetectionFaulty = isFaulty
+        if (isValidKnownTests(knownTests)) {
+          isEarlyFlakeDetectionFaultyCh.publish({
+            knownTests: knownTests.vitest,
+            testFilepaths,
+            onDone: (isFaulty) => {
+              isEarlyFlakeDetectionFaulty = isFaulty
+            }
+          })
+          if (isEarlyFlakeDetectionFaulty) {
+            isEarlyFlakeDetectionEnabled = false
+            log.warn('New test detection is disabled because the number of new tests is too high.')
+          } else {
+            // TODO: use this to pass session and module IDs to the worker, instead of polluting process.env
+            // Note: setting this.ctx.config.provide directly does not work because it's cached
+            try {
+              const workspaceProject = this.ctx.getCoreWorkspaceProject()
+              workspaceProject._provided._ddIsKnownTestsEnabled = isKnownTestsEnabled
+              workspaceProject._provided._ddKnownTests = knownTests
+              workspaceProject._provided._ddIsEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
+              workspaceProject._provided._ddEarlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
+            } catch {
+              log.warn('Could not send known tests to workers so Early Flake Detection will not work.')
+            }
           }
-        })
-        if (isEarlyFlakeDetectionFaulty) {
-          isEarlyFlakeDetectionEnabled = false
-          log.warn('New test detection is disabled because the number of new tests is too high.')
         } else {
-          // TODO: use this to pass session and module IDs to the worker, instead of polluting process.env
-          // Note: setting this.ctx.config.provide directly does not work because it's cached
-          try {
-            const workspaceProject = this.ctx.getCoreWorkspaceProject()
-            workspaceProject._provided._ddIsKnownTestsEnabled = isKnownTestsEnabled
-            workspaceProject._provided._ddKnownTests = knownTests.vitest || {}
-            workspaceProject._provided._ddIsEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
-            workspaceProject._provided._ddEarlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
-          } catch {
-            log.warn('Could not send known tests to workers so Early Flake Detection will not work.')
-          }
+          isEarlyFlakeDetectionFaulty = true
+          isEarlyFlakeDetectionEnabled = false
         }
       }
     }

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -55,8 +55,12 @@ class VitestPlugin extends CiPlugin {
     this.taskToFinishTime = new WeakMap()
 
     this.addSub('ci:vitest:test:is-new', ({ knownTests, testSuiteAbsolutePath, testName, onDone }) => {
+      // if for whatever reason the worker does not receive valid known tests, we don't consider it as new
+      if (!knownTests.vitest) {
+        return onDone(false)
+      }
       const testSuite = getTestSuitePath(testSuiteAbsolutePath, this.repositoryRoot)
-      const testsForThisTestSuite = knownTests[testSuite] || []
+      const testsForThisTestSuite = knownTests.vitest[testSuite] || []
       onDone(!testsForThisTestSuite.includes(testName))
     })
 


### PR DESCRIPTION
### What does this PR do?

* Check that the response at least includes a `vitest` key before considering it as valid. Otherwise, we might be detecting tests as new even though the response is invalid.

### Motivation

Make sure we err on the side of caution (no new test detected)

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Integration tests.
