### PR TITLE
refactor: symplify identifier

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -168,23 +168,12 @@ class AgentEncoder {
     this._msgpack.encodeByte(bytes, value)
   }
 
-  // TODO: Use BigInt instead.
   _encodeId (bytes, id) {
     const offset = bytes.length
 
     bytes.reserve(9)
 
-    id = id.toArray()
-
-    bytes.buffer[offset] = 0xCF
-    bytes.buffer[offset + 1] = id[0]
-    bytes.buffer[offset + 2] = id[1]
-    bytes.buffer[offset + 3] = id[2]
-    bytes.buffer[offset + 4] = id[3]
-    bytes.buffer[offset + 5] = id[4]
-    bytes.buffer[offset + 6] = id[5]
-    bytes.buffer[offset + 7] = id[6]
-    bytes.buffer[offset + 8] = id[7]
+    id.writeToLast64Bits(bytes.buffer, offset)
   }
 
   _encodeNumber (bytes, value) {

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -2,184 +2,109 @@
 
 const { randomFillSync } = require('crypto')
 
-const UINT_MAX = 4_294_967_296
-
-const data = new Uint8Array(8 * 8192)
-const zeroId = new Uint8Array(8)
-
-const map = Array.prototype.map
-const pad = byte => `${byte < 16 ? '0' : ''}${byte.toString(16)}`
-
+const zeroId = Buffer.alloc(8)
+const data = Buffer.allocUnsafe(8 * 8192)
 let batch = 0
 
-// Internal representation of a trace or span ID.
 class Identifier {
+  #buffer
+
+  /**
+   * Creates a new Identifier instance.
+   *
+   * If `value` is not provided, a random ID will be generated.
+   *
+   * @param {string} [value] - The value to create the ID from. It must represent a 64 or 128 bit ID.
+   * @param {number} [radix=16] - The radix to use for the conversion.
+   */
   constructor (value, radix = 16) {
-    this._buffer = radix === 16
-      ? createBuffer(value)
-      : fromString(value, radix)
-  }
-
-  toString (radix = 16) {
-    return radix === 16
-      ? toHexString(this._buffer)
-      : toNumberString(this._buffer, radix)
-  }
-
-  toBigInt () {
-    return Buffer.from(this._buffer).readBigUInt64BE(0)
-  }
-
-  toBuffer () {
-    return this._buffer
-  }
-
-  toArray () {
-    if (this._buffer.length === 8) {
-      return this._buffer
+    if (!value) {
+      this.#buffer = pseudoRandom()
+    } else if (radix === 16) {
+      // TODO: What should we do if the value is too long?
+      this.#buffer = value === '0' ? zeroId : Buffer.from(value.padStart(value.length > 16 ? 32 : 16, '0'), 'hex')
+    } else {
+      const buffer = Buffer.alloc(8)
+      buffer.writeBigUInt64BE(BigInt(value))
+      this.#buffer = buffer
     }
-    return this._buffer.slice(-8)
+  }
+
+  is128bit () {
+    return this.#buffer.length !== 8
+  }
+
+  /**
+   * Converts the last 8 bytes of the current ID to a string.
+   * If the radix is 16, the string will be in hexadecimal format.
+   * If the radix is not 16, the string will be in decimal format.
+   *
+   * @param {number} radix - The radix to use for the conversion.
+   * @returns {string} - The string representation of the ID.
+   */
+  toString (radix = 16) {
+    if (radix === 16) {
+      return this.#buffer.toString('hex')
+    }
+    // TODO: Should we really only return the last 64 bits?
+    return this.#buffer.readBigUInt64BE(this.#buffer.length - 8).toString(radix)
+  }
+
+  toFirst64BitsBigInt () {
+    return this.#buffer.readBigUInt64BE(0)
+  }
+
+  /**
+   * Writes the last 64 bits of the current ID to a buffer.
+   *
+   * @param {Buffer} buffer - The buffer to write the ID to.
+   * @param {number} offset - The offset to write the ID to.
+   * @returns {Buffer} - The buffer with the ID written to it.
+   */
+  writeToLast64Bits (buffer, offset) {
+    buffer[offset] = 0xCF
+    const copyOffset = this.#buffer.length - 8
+    this.#buffer.copy(buffer, offset + 1, copyOffset, copyOffset + 8)
+    return buffer
+  }
+
+  get length () {
+    return this.#buffer.length
   }
 
   toJSON () {
     return this.toString()
   }
 
+  /**
+   * Checks if the current ID is equal to another ID.
+   * If either ID is longer than the other ID, the longer ID will be truncated to the length of the shorter ID.
+   * Only the last 64 bits of the longer ID will be compared in that case.
+   *
+   * @param {Identifier} other - The other ID to compare with.
+   * @returns {boolean} - `true` if the IDs are equal, otherwise `false`.
+   */
   equals (other) {
-    const length = this._buffer.length
-    const otherLength = other._buffer.length
-
-    // Only compare the bytes available in both IDs.
-    for (let i = length, j = otherLength; i >= 0 && j >= 0; i--, j--) {
-      if (this._buffer[i] !== other._buffer[j]) return false
+    let otherBuffer = other.#buffer
+    let thisBuffer = this.#buffer
+    if (other.#buffer.length > this.#buffer.length) {
+      otherBuffer = other.#buffer.subarray(-this.#buffer.length)
     }
-
-    return true
-  }
-}
-
-// Create a buffer, using an optional hexadecimal value if provided.
-function createBuffer (value) {
-  if (value === '0') return zeroId
-  if (!value) return pseudoRandom()
-
-  const size = Math.ceil(value.length / 16) * 16
-  const bytes = size / 2
-  const buffer = []
-
-  value = value.padStart(size, '0')
-
-  for (let i = 0; i < bytes; i++) {
-    buffer[i] = Number.parseInt(value.slice(i * 2, i * 2 + 2), 16)
-  }
-
-  return buffer
-}
-
-// Convert a numerical string to a buffer using the specified radix.
-function fromString (str, raddix) {
-  const buffer = new Array(8)
-  const len = str.length
-
-  let pos = 0
-  let high = 0
-  let low = 0
-
-  if (str[0] === '-') pos++
-
-  const sign = pos
-
-  while (pos < len) {
-    const chr = Number.parseInt(str[pos++], raddix)
-
-    if (!(chr >= 0)) break // NaN
-
-    low = low * raddix + chr
-    high = high * raddix + Math.floor(low / UINT_MAX)
-    low %= UINT_MAX
-  }
-
-  if (sign) {
-    high = ~high
-
-    if (low) {
-      low = UINT_MAX - low
-    } else {
-      high++
+    if (other.#buffer.length < this.#buffer.length) {
+      thisBuffer = this.#buffer.subarray(-other.#buffer.length)
     }
+    return thisBuffer.equals(otherBuffer)
   }
-
-  writeUInt32BE(buffer, high, 0)
-  writeUInt32BE(buffer, low, 4)
-
-  return buffer
 }
 
-// Convert a buffer to a numerical string.
-function toNumberString (buffer, radix) {
-  let high = readInt32(buffer, buffer.length - 8)
-  let low = readInt32(buffer, buffer.length - 4)
-  let str = ''
-
-  radix = radix || 10
-
-  while (1) {
-    const mod = (high % radix) * UINT_MAX + low
-
-    high = Math.floor(high / radix)
-    low = Math.floor(mod / radix)
-    str = (mod % radix).toString(radix) + str
-
-    if (!high && !low) break
-  }
-
-  return str
-}
-
-// Convert a buffer to a hexadecimal string.
-function toHexString (buffer) {
-  return map.call(buffer, pad).join('')
-}
-
-// Simple pseudo-random 64-bit ID generator.
 function pseudoRandom () {
-  if (batch === 0) {
-    randomFillSync(data)
-  }
-
+  if (batch === 0) randomFillSync(data)
   batch = (batch + 1) % 8192
-
   const offset = batch * 8
-
-  return [
-    data[offset] & 0x7F, // only positive int64,
-    data[offset + 1],
-    data[offset + 2],
-    data[offset + 3],
-    data[offset + 4],
-    data[offset + 5],
-    data[offset + 6],
-    data[offset + 7]
-  ]
-}
-
-// Read a buffer to unsigned integer bytes.
-function readInt32 (buffer, offset) {
-  return (buffer[offset + 0] * 16_777_216) +
-    (buffer[offset + 1] << 16) +
-    (buffer[offset + 2] << 8) +
-    buffer[offset + 3]
-}
-
-// Write unsigned integer bytes to a buffer.
-function writeUInt32BE (buffer, value, offset) {
-  buffer[3 + offset] = value & 255
-  value >>= 8
-  buffer[2 + offset] = value & 255
-  value >>= 8
-  buffer[1 + offset] = value & 255
-  value >>= 8
-  buffer[0 + offset] = value & 255
+  const buffer = Buffer.alloc(8)
+  data.copy(buffer, 0, offset, offset + 8)
+  buffer[0] &= 0x7F // Only positive int64
+  return buffer
 }
 
 module.exports = function createIdentifier (value, radix) {

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -717,11 +717,7 @@ class TextMapPropagator {
   }
 
   _extract128BitTraceId (traceId, spanContext) {
-    if (!spanContext) return
-
-    const buffer = spanContext._traceId.toBuffer()
-
-    if (buffer.length !== 16) return
+    if (!spanContext?._traceId.is128bit()) return
 
     const tid = traceId.slice(0, 16)
 
@@ -749,7 +745,7 @@ class TextMapPropagator {
   }
 
   _getB3TraceId (spanContext) {
-    if (spanContext._traceId.toBuffer().length <= 8 && spanContext._trace.tags['_dd.p.tid']) {
+    if (!spanContext._traceId.is128bit() && spanContext._trace.tags['_dd.p.tid']) {
       return spanContext._trace.tags['_dd.p.tid'] + spanContext._traceId.toString(16)
     }
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -45,7 +45,7 @@ class DatadogSpanContext {
 
   toTraceId (get128bitId = false) {
     if (get128bitId) {
-      return this._traceId.toBuffer().length <= 8 && this._trace.tags[TRACE_ID_128]
+      return !this._traceId.is128bit() && this._trace.tags[TRACE_ID_128]
         ? this._trace.tags[TRACE_ID_128] + this._traceId.toString(16).padStart(16, '0')
         : this._traceId.toString(16).padStart(32, '0')
     }
@@ -60,7 +60,7 @@ class DatadogSpanContext {
   }
 
   toBigIntSpanId () {
-    return this._spanId.toBigInt()
+    return this._spanId.toFirst64BitsBigInt()
   }
 
   toTraceparent () {

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -216,10 +216,10 @@ class NativeWallProfiler {
 
   _updateContext (context) {
     if (context.spanId !== null && typeof context.spanId === 'object') {
-      context.spanId = context.spanId.toBigInt()
+      context.spanId = context.spanId.toFirst64BitsBigInt()
     }
     if (context.rootSpanId !== null && typeof context.rootSpanId === 'object') {
-      context.rootSpanId = context.rootSpanId.toBigInt()
+      context.rootSpanId = context.rootSpanId.toFirst64BitsBigInt()
     }
     if (context.webTags !== undefined && context.endpoint === undefined) {
       // endpoint may not be determined yet, but keep it as fallback

--- a/packages/dd-trace/src/sampler.js
+++ b/packages/dd-trace/src/sampler.js
@@ -56,7 +56,7 @@ class Sampler {
 
     span = typeof span.context === 'function' ? span.context() : span
 
-    return (span._traceId.toBigInt() * SAMPLING_KNUTH_FACTOR) % UINT64_MODULO <= this.#threshold
+    return (span._traceId.toFirst64BitsBigInt() * SAMPLING_KNUTH_FACTOR) % UINT64_MODULO <= this.#threshold
   }
 }
 

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -60,6 +60,36 @@ describe('id', () => {
     expect(json).to.equal('"7f00ff00ff00ff00"')
   })
 
+  it('should return false for is128bit() for 64 bit ID', () => {
+    const spanId = id()
+
+    expect(spanId.is128bit()).to.be.false
+  })
+
+  it('should return true for is128bit() for 128 bit ID', () => {
+    const spanId = id('1234567812345678abcdef', 16)
+
+    expect(spanId.is128bit()).to.be.true
+  })
+
+  it('should write 64 bits to a buffer with writeToLast64Bits() for 64 bit ID', () => {
+    Math.random.returns(0x0000FF00 / (0xFFFFFFFF + 1))
+
+    const buffer = Buffer.alloc(16)
+    const spanId = id()
+    spanId.writeToLast64Bits(buffer, 0)
+
+    expect(buffer).to.deep.equal(Buffer.from('cf7f00ff00ff00ff0000000000000000', 'hex'))
+  })
+
+  it('should write the last 64 bits to a buffer with writeToLast64Bits() for 128 bit ID', () => {
+    const buffer = Buffer.alloc(16)
+    const spanId = id('1a2b3c4d1a2b3c4d1234567812345678', 16)
+    spanId.writeToLast64Bits(buffer, 2)
+
+    expect(buffer).to.deep.equal(Buffer.from('0000cf12345678123456780000000000', 'hex'))
+  })
+
   it('should support small hex strings', () => {
     const spanId = id('abcd', 16)
 
@@ -95,7 +125,7 @@ describe('id', () => {
     for (const [tid, expected] of ids) {
       const spanId = id(tid, 10)
 
-      expect(spanId.toBigInt()).to.equal(expected)
+      expect(spanId.toFirst64BitsBigInt()).to.equal(expected)
     }
   })
 })


### PR DESCRIPTION
This changes the current implementation to use the buffer instead of an array. That allows to use Node.js buffer methods that significantly simplify the overall logic.

On top of that, a few methods were renamed for clarity. We mix 64 and 128bit Identifiers and the new methods should make it clearer how these methods work (only on 64 bits).