### PR TITLE
docs: fix default agent hostname in exposed types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -427,7 +427,7 @@ declare namespace tracer {
 
     /**
      * The address of the trace agent that the tracer will submit to.
-     * @default 'localhost'
+     * @default '127.0.0.1'
      */
     hostname?: string;
 


### PR DESCRIPTION
The default agent hostname is the loopback IP address `127.0.0.1`. Not the `localhost` hostname. Updated the exposed types in the `index.d.ts` file to match.
