### PR TITLE
[test optimization] Improve logic for base branch detection

### DIFF
--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -278,6 +278,7 @@ function checkAndFetchBranch (branch, remoteName) {
       { stdio: 'pipe' }
     )
     // branch exists locally, so we finish
+    return true
   } catch {
     // branch does not exist locally, so we will check the remote
     try {
@@ -297,11 +298,13 @@ function checkAndFetchBranch (branch, remoteName) {
           ['fetch', '--depth', '1', remoteName, branch],
           { stdio: 'pipe', timeout: 5000 }
         )
+        return true
       }
     } catch (e) {
       // branch does not exist or couldn't be fetched, so we can't do anything
       log.error('Git plugin error checking and fetching branch', e)
     }
+    return false
   }
 }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -1001,7 +1001,10 @@ function getPullRequestBaseBranch (pullRequestBaseBranch) {
     candidateBranches.push(pullRequestBaseBranch)
   } else {
     for (const branch of POSSIBLE_BASE_BRANCHES) {
-      checkAndFetchBranch(branch, remoteName)
+      const isSuccess = checkAndFetchBranch(branch, remoteName)
+      if (isSuccess) {
+        break
+      }
     }
 
     const localBranches = getLocalBranches(remoteName)


### PR DESCRIPTION
### What does this PR do?
Make it so that `checkAndFetchBranch` is not called for multiple possible base branches if one of them is already found.

### Motivation
We don't need to constantly look for base branches if we have already found one.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
