### PR TITLE
doc: remove outdated README.md about opentelemetry/api versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,3 @@ Please refer to the [SECURITY.md](https://github.com/DataDog/dd-trace-js/blob/ma
 ## Datadog With OpenTelemetery
 
 Please refer to the [Node.js Custom Instrumentation using OpenTelemetry API](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/nodejs/otel/) document. It includes information on how to use the OpenTelemetry API with dd-trace-js.
-
-Note that our internal implementation of the OpenTelemetry API is currently set within the version range `>=1.0.0 <1.9.0`. This range will be updated at a regular cadence therefore, we recommend updating your tracer to the latest release to ensure up to date support.


### PR DESCRIPTION
The version is now updated regularly again.
