### PR TITLE
test,chore: use less globals and improve linting

### DIFF
--- a/.github/workflows/eslint-rules.yml
+++ b/.github/workflows/eslint-rules.yml
@@ -20,4 +20,4 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
-      - run: yarn test:eslint-rules
+      - run: npm run test:eslint-rules

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
-      - run: yarn lint
+      - run: npm run lint
 
   package-size-report:
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -538,19 +538,12 @@ export default [
   {
     name: 'dd-trace/tests/all',
     files: TEST_FILES,
-    languageOptions: {
-      globals: {
-        sinon: 'readonly',
-        expect: 'readonly',
-        proxyquire: 'readonly',
-      }
-    },
     plugins: {
       mocha: eslintPluginMocha,
       n: eslintPluginN
     },
     rules: {
-      'mocha/max-top-level-suites': 'off',
+      'mocha/max-top-level-suites': ['error', { limit: 1 }],
       'mocha/no-exports': 'off',
       'mocha/no-global-tests': 'off',
       'mocha/no-identical-title': 'off',
@@ -565,6 +558,26 @@ export default [
     }
   },
   {
+    name: 'dd-trace/tests/all',
+    files: [
+      'integration-tests/ci-visibility/**/*.js',
+      'integration-tests/ci-visibility/**/*.mjs',
+      'packages/datadog-plugin-jest/test/**/*.js',
+      'packages/datadog-plugin-mocha/test/**/*.js',
+      'packages/datadog-plugin-cucumber/test/**/*.js',
+      'packages/datadog-plugin-cypress/test/**/*.js',
+      'packages/datadog-plugin-playwright/test/**/*.js',
+      'packages/datadog-plugin-vitest/test/**/*.js',
+    ],
+    plugins: {
+      mocha: eslintPluginMocha,
+    },
+    rules: {
+      'no-undef': 'off',
+      'mocha/max-top-level-suites': 'off',
+    }
+  },
+  {
     name: 'dd-trace/tests/integration',
     plugins: {
       import: eslintPluginImport
@@ -573,7 +586,11 @@ export default [
       'integration-tests/**/*.js',
       'integration-tests/**/*.mjs',
       'packages/*/test/integration-test/**/*.js',
-      'packages/*/test/integration-test/**/*.mjs'
+      'packages/*/test/integration-test/**/*.mjs',
+      // TODO: Move the files in esm-test to integration-test
+      'packages/datadog-plugin-graphql/test/esm-test/**/*.mjs',
+      'packages/dd-trace/test/appsec/**/*.js',
+      'packages/datadog-plugin-jest/test/jest-test.js',
     ],
     rules: {
       'import/no-extraneous-dependencies': 'off'

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -558,7 +558,7 @@ export default [
     }
   },
   {
-    name: 'dd-trace/tests/all',
+    name: 'dd-trace/test-optimization/relaxed',
     files: [
       'integration-tests/ci-visibility/**/*.js',
       'integration-tests/ci-visibility/**/*.mjs',
@@ -578,7 +578,7 @@ export default [
     }
   },
   {
-    name: 'dd-trace/tests/integration',
+    name: 'dd-trace/tests/integration-and-resources',
     plugins: {
       import: eslintPluginImport
     },
@@ -589,7 +589,8 @@ export default [
       'packages/*/test/integration-test/**/*.mjs',
       // TODO: Move the files in esm-test to integration-test
       'packages/datadog-plugin-graphql/test/esm-test/**/*.mjs',
-      'packages/dd-trace/test/appsec/**/*.js',
+      'packages/dd-trace/test/appsec/**/resources/**/*.js',
+      // TODO: Move the jest-test.js to integration-test
       'packages/datadog-plugin-jest/test/jest-test.js',
     ],
     rules: {

--- a/integration-tests/appsec/endpoints-collection.spec.js
+++ b/integration-tests/appsec/endpoints-collection.spec.js
@@ -1,7 +1,11 @@
 'use strict'
 
+const { expect } = require('chai')
+const { describe, before, after, it } = require('mocha')
+
+const path = require('node:path')
+
 const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
-const path = require('path')
 
 describe('Endpoints collection', () => {
   let sandbox, cwd
@@ -113,7 +117,7 @@ describe('Endpoints collection', () => {
         cwd,
         env: {
           DD_TRACE_AGENT_PORT: agent.port,
-          DD_TELEMETRY_HEARTBEAT_INTERVAL: 1,
+          DD_TELEMETRY_HEARTBEAT_INTERVAL: '1',
           DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT: '10'
         }
       })

--- a/integration-tests/ci-visibility/jest/mocked-test.js
+++ b/integration-tests/ci-visibility/jest/mocked-test.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// eslint-disable-next-line no-undef
 jest.mock('../test/sum.js')
 
 test('adds 1 + 2 to equal 3', () => {

--- a/integration-tests/telemetry.spec.js
+++ b/integration-tests/telemetry.spec.js
@@ -1,7 +1,11 @@
 'use strict'
 
+const { expect } = require('chai')
+const { describe, before, after, it, beforeEach, afterEach } = require('mocha')
+
+const path = require('node:path')
+
 const { createSandbox, FakeAgent, spawnProc, assertObjectContains } = require('./helpers')
-const path = require('path')
 
 describe('telemetry', () => {
   describe('dependencies', () => {
@@ -27,7 +31,7 @@ describe('telemetry', () => {
         cwd,
         env: {
           AGENT_PORT: agent.port,
-          DD_LOGS_INJECTION: true
+          DD_LOGS_INJECTION: 'true'
         }
       })
     })

--- a/packages/datadog-code-origin/test/helpers.js
+++ b/packages/datadog-code-origin/test/helpers.js
@@ -13,7 +13,6 @@ module.exports = {
       '_dd.code_origin.type': 'entry',
       '_dd.code_origin.frames.0.file': frame.file,
       '_dd.code_origin.frames.0.line': String(frame.line),
-      '_dd.code_origin.frames.0.column': frame.column,
     })
 
     assert.match(tags['_dd.code_origin.frames.0.column'], /^\d+$/)

--- a/packages/datadog-code-origin/test/helpers.js
+++ b/packages/datadog-code-origin/test/helpers.js
@@ -1,27 +1,34 @@
 'use strict'
 
+const assert = require('node:assert')
+
+const { assertObjectContains } = require('../../../integration-tests/helpers')
+
 module.exports = {
   assertCodeOriginFromTraces (traces, frame) {
     const spans = traces[0]
     const tags = spans[0].meta
 
-    expect(tags).to.have.property('_dd.code_origin.type', 'entry')
+    assertObjectContains(tags, {
+      '_dd.code_origin.type': 'entry',
+      '_dd.code_origin.frames.0.file': frame.file,
+      '_dd.code_origin.frames.0.line': String(frame.line),
+      '_dd.code_origin.frames.0.column': frame.column,
+    })
 
-    expect(tags).to.have.property('_dd.code_origin.frames.0.file', frame.file)
-    expect(tags).to.have.property('_dd.code_origin.frames.0.line', String(frame.line))
-    expect(tags).to.have.property('_dd.code_origin.frames.0.column').to.match(/^\d+$/)
+    assert.match(tags['_dd.code_origin.frames.0.column'], /^\d+$/)
     if (frame.method) {
-      expect(tags).to.have.property('_dd.code_origin.frames.0.method', frame.method)
+      assert.strictEqual(tags['_dd.code_origin.frames.0.method'], frame.method)
     } else {
-      expect(tags).to.not.have.property('_dd.code_origin.frames.0.method')
+      assert.ok(!Object.hasOwn(tags, '_dd.code_origin.frames.0.method'))
     }
     if (frame.type) {
-      expect(tags).to.have.property('_dd.code_origin.frames.0.type', frame.type)
+      assert.strictEqual(tags['_dd.code_origin.frames.0.type'], frame.type)
     } else {
-      expect(tags).to.not.have.property('_dd.code_origin.frames.0.type')
+      assert.ok(!Object.hasOwn(tags, '_dd.code_origin.frames.0.type'))
     }
 
     // The second frame should not be present, because we only collect 1 frame for entry spans
-    expect(tags).to.not.have.property('_dd.code_origin.frames.1.file')
+    assert.ok(!Object.hasOwn(tags, '_dd.code_origin.frames.1.file'))
   }
 }

--- a/packages/datadog-plugin-jest/test/jest-focus.js
+++ b/packages/datadog-plugin-jest/test/jest-focus.js
@@ -1,17 +1,19 @@
 'use strict'
 
+const assert = require('assert')
+
 describe('jest-test-focused', () => {
   it('will be skipped', () => {
-    expect(true).toEqual(true)
+    assert.strictEqual(true, true)
   })
   // eslint-disable-next-line
   it.only('can do focused test', () => {
-    expect(true).toEqual(true)
+    assert.strictEqual(true, true)
   })
 })
 
 describe('jest-test-focused-2', () => {
   it('will be skipped too', () => {
-    expect(true).toEqual(true)
+    assert.strictEqual(true, true)
   })
 })

--- a/packages/datadog-plugin-jest/test/jest-hook-failure.js
+++ b/packages/datadog-plugin-jest/test/jest-hook-failure.js
@@ -1,12 +1,14 @@
 'use strict'
 
+const assert = require('assert')
+
 describe('jest-hook-failure', () => {
   beforeEach(() => {
     throw new Error('hey, hook error before')
   })
 
   it('will not run', () => {
-    expect(true).toEqual(true)
+    assert.strictEqual(true, true)
   })
 })
 
@@ -16,6 +18,6 @@ describe('jest-hook-failure-after', () => {
   })
 
   it('will not run', () => {
-    expect(true).toEqual(true)
+    assert.strictEqual(true, true)
   })
 })

--- a/packages/datadog-plugin-jest/test/jest-test-suite.js
+++ b/packages/datadog-plugin-jest/test/jest-test-suite.js
@@ -1,7 +1,9 @@
 'use strict'
 
+const assert = require('assert')
+
 describe('jest-test-suite-visibility', () => {
   it('works', () => {
-    expect(true).toEqual(true)
+    assert.strictEqual(true, true)
   })
 })

--- a/packages/datadog-plugin-jest/test/jest-test.js
+++ b/packages/datadog-plugin-jest/test/jest-test.js
@@ -5,7 +5,6 @@ const http = require('http')
 const tracer = require('dd-trace')
 
 describe('jest-test-suite', () => {
-  // eslint-disable-next-line
   jest.setTimeout(400)
 
   it('tracer and active span are available', () => {
@@ -48,7 +47,6 @@ describe('jest-test-suite', () => {
     req.end()
   })
   // only run for jest-circus tests
-  // eslint-disable-next-line
   if (jest.retryTimes) {
     const parameters = [[1, 2, 3], [2, 3, 5]]
     it.each(parameters)('can do parameterized test', (a, b, expected) => {
@@ -76,7 +74,6 @@ describe('jest-test-suite', () => {
       }, 50)
     )
   })
-  // eslint-disable-next-line
   jest.setTimeout(200)
 
   it('timeout', () => {
@@ -110,10 +107,8 @@ describe('jest-test-suite', () => {
 })
 
 // only run for jest-circus tests
-// eslint-disable-next-line
 if (jest.retryTimes) {
   describe('jest-circus-test-retry', () => {
-    // eslint-disable-next-line
     jest.retryTimes(2)
     let retryAttempt = 0
 

--- a/packages/dd-trace/test/appsec/rasp/rasp_blocking.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/rasp_blocking.fastify.plugin.spec.js
@@ -1,12 +1,16 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const agent = require('../../plugins/agent')
 const Config = require('../../../src/config')
 const appsec = require('../../../src/appsec')
+
 const Axios = require('axios')
-const { withVersions } = require('../../setup/mocha')
 const { assert } = require('chai')
+const { describe, it, afterEach, before, after } = require('mocha')
+const sinon = require('sinon')
+
+const { withVersions } = require('../../setup/mocha')
 const { json: blockedJson } = require('../../../src/appsec/blocked_templates')
 const { checkRaspExecutedAndNotThreat, checkRaspExecutedAndHasThreat } = require('./utils')
 

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -1,22 +1,10 @@
 'use strict'
 
-const sinon = require('sinon')
 const chai = require('chai')
 const sinonChai = require('sinon-chai')
-const proxyquire = require('../proxyquire')
 
 chai.use(sinonChai)
 chai.use(require('../asserts/profile'))
-
-global.sinon = sinon
-global.expect = chai.expect
-global.proxyquire = proxyquire
-
-if (global.describe && typeof global.describe.skip !== 'function') {
-  global.describe.skip = function (name, fn, opts = {}) {
-    return global.describe(name, fn, { skip: true, ...opts })
-  }
-}
 
 process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -1,12 +1,17 @@
 'use strict'
 
-require('./core')
-
 const assert = require('node:assert')
 const util = require('node:util')
 const { platform } = require('node:os')
 const path = require('node:path')
+
+const { expect } = require('chai')
+const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
 const semver = require('semver')
+const sinon = require('sinon')
+
+require('./core')
+
 const externals = require('../plugins/externals.json')
 const runtimeMetrics = require('../../src/runtime_metrics')
 const agent = require('../plugins/agent')


### PR DESCRIPTION
The sinon, expect, and proxyquire globals were removed. This also fixes a couple more issues around the linter when run locally.