### PR TITLE
fix: handle edge case with no req context (code origin)

### DIFF
--- a/packages/datadog-plugin-express/src/code_origin.js
+++ b/packages/datadog-plugin-express/src/code_origin.js
@@ -15,7 +15,7 @@ class ExpressCodeOriginForSpansPlugin extends Plugin {
     this.addSub('apm:express:middleware:enter', ({ req, layer }) => {
       const tags = layerTags.get(layer)
       if (!tags) return
-      web.getContext(req).span?.addTags(tags)
+      web.getContext(req)?.span?.addTags(tags)
     })
 
     this.addSub('apm:express:route:added', ({ topOfStackFunc, layer }) => {
@@ -26,7 +26,7 @@ class ExpressCodeOriginForSpansPlugin extends Plugin {
     this.addSub('apm:router:middleware:enter', ({ req, layer }) => {
       const tags = layerTags.get(layer)
       if (!tags) return
-      web.getContext(req).span?.addTags(tags)
+      web.getContext(req)?.span?.addTags(tags)
     })
 
     this.addSub('apm:router:route:added', ({ topOfStackFunc, layer }) => {

--- a/packages/datadog-plugin-fastify/src/code_origin.js
+++ b/packages/datadog-plugin-fastify/src/code_origin.js
@@ -15,8 +15,7 @@ class FastifyCodeOriginForSpansPlugin extends Plugin {
     this.addSub('apm:fastify:request:handle', ({ req, routeConfig }) => {
       const tags = routeConfig?.[kCodeOriginForSpansTagsSym]
       if (!tags) return
-      const context = web.getContext(req)
-      context.span?.addTags(tags)
+      web.getContext(req)?.span?.addTags(tags)
     })
 
     this.addSub('apm:fastify:route:added', ({ routeOptions, onRoute }) => {


### PR DESCRIPTION
### What does this PR do?

In some of our system test logs, we've seen that there might not be a request context available when trying to set the code origin tags for Express. This adds a guard to ensure we don't throw in that case.
    
### Motivation

It's worth noting that we haven't seen this issue in the wild, but better safe than sorry.

### Additional Notes

I have not spend time trying to figure out when this issue occurs. But I wanted to just land this since I saw it in some debug logs while investigating other issues.


