### PR TITLE
[test optimization] Support `vitest` programmatic API

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests-programmatic-api/run-programmatic-api.mjs
+++ b/integration-tests/ci-visibility/vitest-tests-programmatic-api/run-programmatic-api.mjs
@@ -1,0 +1,19 @@
+import { startVitest } from 'vitest/node'
+
+async function runProgrammaticTests () {
+  try {
+    const vitest = await startVitest('test', [], {
+      test: {
+        environment: 'node',
+      },
+      run: true,
+      watch: false
+    })
+
+    await vitest.close()
+  } catch (error) {
+    process.exit(1)
+  }
+}
+
+runProgrammaticTests()

--- a/integration-tests/ci-visibility/vitest-tests-programmatic-api/test-programmatic-api.mjs
+++ b/integration-tests/ci-visibility/vitest-tests-programmatic-api/test-programmatic-api.mjs
@@ -1,0 +1,15 @@
+import { describe, test, expect } from 'vitest'
+
+describe('programmatic api', () => {
+  test('can report passed test', () => {
+    expect(1 + 1).toBe(2)
+  })
+
+  test('can report failed test', () => {
+    expect(1 + 1).toBe(3)
+  })
+
+  test.skip('can report skipped test', () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -375,7 +375,7 @@ versions.forEach((version) => {
           const testSuite = events.find(event => event.type === 'test_suite_end').content
           assert.equal(test.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
           assert.equal(testSuite.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
-        })
+        }, 25000)
 
       childProcess = exec(
         '../../node_modules/.bin/vitest run',
@@ -383,7 +383,7 @@ versions.forEach((version) => {
           cwd: `${cwd}/ci-visibility/subproject`,
           env: {
             ...getCiVisAgentlessConfig(receiver.port),
-            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init', // ESM requires more flags
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
             TEST_DIR: './vitest-test.mjs'
           },
           stdio: 'inherit'
@@ -2103,6 +2103,51 @@ versions.forEach((version) => {
           })
           runImpactedTest(done, { isModified: true, isEfd: true, isNew: true })
         })
+      })
+    })
+
+    context('programmatic api', () => {
+      it('can report data using the vitest programmatic api', async () => {
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const testSessionEvent = events.find(event => event.type === 'test_session_end')
+            const testModuleEvent = events.find(event => event.type === 'test_module_end')
+            const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            assert.equal(testSessionEvent.content.meta[TEST_STATUS], 'fail')
+            assert.equal(testModuleEvent.content.meta[TEST_STATUS], 'fail')
+            assert.equal(testSessionEvent.content.meta[TEST_TYPE], 'test')
+            assert.equal(testModuleEvent.content.meta[TEST_TYPE], 'test')
+
+            const testSuite = testSuiteEvents.find(
+              suite => suite.content.resource ===
+                'test_suite.ci-visibility/vitest-tests-programmatic-api/test-programmatic-api.mjs'
+            )
+            assert.equal(testSuite.content.meta[TEST_STATUS], 'fail')
+
+            assert.equal(testEvents.length, 3)
+          })
+
+        childProcess = exec(
+          'node run-programmatic-api.mjs',
+          {
+            cwd: `${cwd}/ci-visibility/vitest-tests-programmatic-api`,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              TEST_DIR: './test-programmatic-api*'
+            },
+            stdio: 'pipe'
+          }
+        )
+
+        await Promise.all([
+          eventsPromise,
+          once(childProcess, 'exit')
+        ])
       })
     })
   })

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -791,7 +791,13 @@ addHook({
 
 addHook({
   name: 'vitest',
-  versions: ['>=1.6.0'],
+  versions: ['>=1.6.0 <2.0.5'],
+  filePattern: 'dist/vendor/cli-api.*'
+}, getStartVitestWrapper)
+
+addHook({
+  name: 'vitest',
+  versions: ['>=2.0.5'],
   filePattern: 'dist/chunks/cli-api.*'
 }, getStartVitestWrapper)
 


### PR DESCRIPTION
### What does this PR do?

* Support this API by adding the necessary hook

### Motivation
Allow users to use the `vitest` programmatic API:

```javascript
import { startVitest } from 'vitest/node'

async function runProgrammaticTests () {
  try {
    const vitest = await startVitest('test', [], {
      test: {
        environment: 'node',
      },
      run: true,
      watch: false
    })

    await vitest.close()
  } catch (error) {
    process.exit(1)
  }
}

runProgrammaticTests()
```

https://vitest.dev/advanced/api/#startvitest

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Integration tests.
