### PR TITLE
ci: add cooldown time of a day to dependabot for regular dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       - "/.github/workflows/*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
+      exclude:
+        - "@datadog/*"
     groups:
       gh-actions-packages:
         patterns:
@@ -27,6 +31,10 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 1
+      exclude:
+        - "@datadog/*"
     labels:
       - dependabot
       - dependencies


### PR DESCRIPTION
All datadog dependencies may still be updated right away. This is a minor security improvement.

Instrumented libraries are still run right away to know if things are working with newer versions early. This is a trade-off, since we do not actually use these dependencies in our code and also do not use them locally.