### PR TITLE
add octo-sts claim for access from gitlab apm reliability

### DIFF
--- a/.github/chainguard/gitlab.github-access.read.sts.yaml
+++ b/.github/chainguard/gitlab.github-access.read.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-js:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  contents: read
+  actions: read
+  pull_requests: read


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add Octo-STS claim for access from gitlab APM reliability.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is needed for pre-release gates.