### PR TITLE
`esbuild` support for IAST (cjs)

### DIFF
--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -32,9 +32,9 @@ describe('esbuild support for IAST', () => {
       })
 
       // Install app deps
-      await exec('npm install', {
+      await exec('npm install || npm install', {
         cwd: applicationDir,
-        timeout: 3e3
+        timeout: 6e3
       })
 
       // Bundle the application

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -32,12 +32,10 @@ describe('esbuild support for IAST', () => {
       })
 
       // Install app deps
-      const npmInstall = await exec('npm install', {
+      await exec('npm install', {
         cwd: applicationDir,
         timeout: 3e3
       })
-
-      console.log(npmInstall)
 
       // Bundle the application
       await exec('npm run build', {

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -1,0 +1,144 @@
+'use strict'
+
+const Axios = require('axios')
+const { assert } = require('chai')
+const childProcess = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const { promisify } = require('util')
+const msgpack = require('@msgpack/msgpack')
+
+const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+
+const exec = promisify(childProcess.exec)
+
+describe('esbuild support for IAST', () => {
+  describe('cjs', () => {
+    let proc, agent, sandbox, axios
+    let applicationDir, bundledApplicationDir
+
+    before(async () => {
+      sandbox = await createSandbox([])
+      const cwd = sandbox.folder
+      applicationDir = path.join(cwd, 'appsec/iast-esbuild')
+
+      // Craft node_modules directory to ship native modules
+      const craftedNodeModulesDir = path.join(applicationDir, 'tmp_node_modules')
+      fs.mkdirSync(craftedNodeModulesDir)
+      await exec('npm init -y', { cwd: craftedNodeModulesDir })
+      await exec('npm install @datadog/native-iast-rewriter @datadog/native-iast-taint-tracking', {
+        cwd: craftedNodeModulesDir,
+        timeout: 3e3
+      })
+
+      // Install app deps
+      await exec('npm install', {
+        cwd: applicationDir,
+        timeout: 3e3
+      })
+
+      // Bundle the application
+      await exec('npm run build', {
+        cwd: applicationDir,
+        timeout: 3e3
+      })
+
+      bundledApplicationDir = path.join(applicationDir, 'build')
+
+      // Copy crafted node_modules with native modules
+      fs.cpSync(path.join(craftedNodeModulesDir, 'node_modules'), bundledApplicationDir, { recursive: true })
+    })
+
+    after(async () => {
+      await sandbox.remove()
+    })
+
+    function startServer (appFile, iastEnabled) {
+      beforeEach(async () => {
+        agent = await new FakeAgent().start()
+        proc = await spawnProc(path.join(bundledApplicationDir, appFile), {
+          cwd: applicationDir,
+          env: {
+            DD_TRACE_AGENT_PORT: agent.port,
+            DD_IAST_ENABLED: String(iastEnabled),
+            DD_IAST_REQUEST_SAMPLING: '100',
+          }
+        })
+        axios = Axios.create({ baseURL: proc.url })
+      })
+
+      afterEach(async () => {
+        proc.kill()
+        await agent.stop()
+      })
+    }
+
+    describe('with IAST enabled', () => {
+      describe('with sourcemap esbuild option enabled', () => {
+        startServer('iast-enabled-with-sm.js', true)
+
+        it('should detect vulnerability with correct location', async () => {
+          await axios.get('/iast/cmdi-vulnerable?args=-la')
+
+          const expectedVulnerabilityType = 'COMMAND_INJECTION'
+          const expectedVulnerabilityLocationPath = path.join('iast', 'index.js')
+          const expectedVulnerabilityLocationLine = 9
+
+          await agent.assertMessageReceived(({ payload }) => {
+            const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
+            spans.forEach(span => {
+              assert.property(span.meta, '_dd.iast.json')
+              const spanIastData = JSON.parse(span.meta['_dd.iast.json'])
+              assert.strictEqual(spanIastData.vulnerabilities[0].type, expectedVulnerabilityType)
+              assert.strictEqual(spanIastData.vulnerabilities[0].location.path, expectedVulnerabilityLocationPath)
+              assert.strictEqual(spanIastData.vulnerabilities[0].location.line, expectedVulnerabilityLocationLine)
+
+              const ddStack = msgpack.decode(span.meta_struct['_dd.stack'])
+              assert.property(ddStack.vulnerability[0], 'frames')
+              assert.isNotEmpty(ddStack.vulnerability[0].frames)
+            })
+          }, null, 1, true)
+        })
+      })
+
+      describe('with sourcemap esbuild option disabled', () => {
+        startServer('iast-enabled-with-no-sm.js', true)
+
+        it('should detect vulnerability with first callsite location', async () => {
+          await axios.get('/iast/cmdi-vulnerable?args=-la')
+
+          const expectedVulnerabilityType = 'COMMAND_INJECTION'
+          const expectedVulnerabilityLocationPath = path.join('build', 'iast-enabled-with-no-sm.js')
+
+          await agent.assertMessageReceived(({ payload }) => {
+            const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
+            spans.forEach(span => {
+              assert.property(span.meta, '_dd.iast.json')
+              const spanIastData = JSON.parse(span.meta['_dd.iast.json'])
+              assert.strictEqual(spanIastData.vulnerabilities[0].type, expectedVulnerabilityType)
+              assert.strictEqual(spanIastData.vulnerabilities[0].location.path, expectedVulnerabilityLocationPath)
+
+              const ddStack = msgpack.decode(span.meta_struct['_dd.stack'])
+              assert.property(ddStack.vulnerability[0], 'frames')
+              assert.isNotEmpty(ddStack.vulnerability[0].frames)
+            })
+          }, null, 1, true)
+        })
+      })
+    })
+
+    describe('with IAST disabled', () => {
+      startServer('iast-disabled.js', false)
+
+      it('should not detect any vulnerability', async () => {
+        await axios.get('/iast/cmdi-vulnerable?args=-la')
+        await agent.assertMessageReceived(({ payload }) => {
+          const spans = payload.flatMap(p => p.filter(span => span.name === 'express.request'))
+          spans.forEach(span => {
+            assert.notProperty(span.meta, '_dd.iast.json')
+          })
+        }, null, 1, true)
+      })
+    })
+  })
+})

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -32,10 +32,12 @@ describe('esbuild support for IAST', () => {
       })
 
       // Install app deps
-      await exec('npm install', {
+      const npmInstall = await exec('npm install', {
         cwd: applicationDir,
         timeout: 3e3
       })
+
+      console.log(npmInstall)
 
       // Bundle the application
       await exec('npm run build', {

--- a/integration-tests/appsec/iast-esbuild/app.js
+++ b/integration-tests/appsec/iast-esbuild/app.js
@@ -1,0 +1,16 @@
+'use strict'
+
+require('dd-trace').init()
+
+const express = require('express')
+
+const iastRouter = require('./iast')
+const randomJson = require('./random.json') // eslint-disable-line no-unused-vars
+
+const app = express()
+
+app.use('/iast', iastRouter)
+
+const server = app.listen(0, () => {
+  process.send?.({ port: server.address().port })
+})

--- a/integration-tests/appsec/iast-esbuild/esbuild-no-iast.js
+++ b/integration-tests/appsec/iast-esbuild/esbuild-no-iast.js
@@ -8,17 +8,8 @@ const esbuildCommonConfig = require('./esbuild.common-config')
 
 esbuild.build({
   ...esbuildCommonConfig,
-  outfile: 'build/iast-enabled-with-sm.js',
-  sourcemap: true,
-}).catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
-
-esbuild.build({
-  ...esbuildCommonConfig,
-  outfile: 'build/iast-enabled-with-no-sm.js',
-  sourcemap: false,
+  outfile: 'build/iast-disabled.js',
+  sourcemap: false
 }).catch((err) => {
   console.error(err)
   process.exit(1)

--- a/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
+++ b/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const ddPlugin = require('dd-trace/esbuild')
+
+module.exports = {
+  entryPoints: ['app.js'],
+  bundle: true,
+  minify: true,
+  plugins: [ddPlugin],
+  platform: 'node',
+  target: ['node18'],
+  external: [
+    '@datadog/native-iast-taint-tracking',
+    '@datadog/native-iast-rewriter',
+
+    // required if you encounter graphql errors during the build step
+    // see https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/#bundling
+    'graphql/language/visitor',
+    'graphql/language/printer',
+    'graphql/utilities'
+  ]
+}

--- a/integration-tests/appsec/iast-esbuild/esbuild.js
+++ b/integration-tests/appsec/iast-esbuild/esbuild.js
@@ -1,0 +1,40 @@
+'use strict'
+
+/* eslint-disable no-console */
+
+const esbuild = require('esbuild')
+
+const esbuildCommonConfig = require('./esbuild.common-config')
+
+esbuild.build({
+  ...esbuildCommonConfig,
+  outfile: 'build/iast-enabled-with-sm.js',
+  sourcemap: true,
+  define: {
+    __DD_IAST_ENABLED__: 'true'
+  },
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+
+esbuild.build({
+  ...esbuildCommonConfig,
+  outfile: 'build/iast-enabled-with-no-sm.js',
+  sourcemap: false,
+  define: {
+    __DD_IAST_ENABLED__: 'true'
+  },
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+
+esbuild.build({
+  ...esbuildCommonConfig,
+  outfile: 'build/iast-disabled.js',
+  sourcemap: false
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/integration-tests/appsec/iast-esbuild/iast/index.js
+++ b/integration-tests/appsec/iast-esbuild/iast/index.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const express = require('express')
+const { execSync } = require('child_process')
+
+const router = express.Router()
+
+router.get('/cmdi-vulnerable', (req, res) => {
+  execSync(`ls ${req.query.args}`)
+
+  res.end()
+})
+
+module.exports = router

--- a/integration-tests/appsec/iast-esbuild/package.json
+++ b/integration-tests/appsec/iast-esbuild/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "esbuild-dd-trace-iast",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Basic application to test IAST support on a bundled app with dd-trace via esbuild",
+  "main": "app.js",
+  "scripts": {
+    "build": "node ./esbuild.js"
+  },
+  "keywords": [
+    "esbuild",
+    "iast"
+  ],
+  "author": "Carles Capell <carles.capell@datadoghq.com>",
+  "license": "ISC",
+  "dependencies": {
+    "esbuild": "^0.25.9",
+    "express": "^4.21.2"
+  }
+}

--- a/integration-tests/appsec/iast-esbuild/package.json
+++ b/integration-tests/appsec/iast-esbuild/package.json
@@ -5,7 +5,7 @@
   "description": "Basic application to test IAST support on a bundled app with dd-trace via esbuild",
   "main": "app.js",
   "scripts": {
-    "build": "node ./esbuild.js"
+    "build": "DD_IAST_ENABLED=true node ./esbuild.js && DD_IAST_ENABLED=false node ./esbuild-no-iast.js"
   },
   "keywords": [
     "esbuild",

--- a/integration-tests/appsec/iast-esbuild/random.json
+++ b/integration-tests/appsec/iast-esbuild/random.json
@@ -1,0 +1,3 @@
+{
+  "isRandom": true
+}

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -180,10 +180,6 @@ ${build.initialOptions.banner.js}`
       // It is local application code, not an instrumented package
       if (DEBUG) console.log(`APP: ${args.path}`, args)
 
-      const ext = path.extname(args.path).toLowerCase()
-      const isJs = /\.[cm]?[jt]sx?$/.test(ext)
-      if (!isJs && ext) return
-
       return {
         path: fullPathToModule,
         pluginData: {
@@ -282,6 +278,10 @@ ${build.initialOptions.banner.js}`
     }
 
     if (DD_IAST_ENABLED && args.pluginData?.applicationFile) {
+      const ext = path.extname(args.path).toLowerCase()
+      const isJs =/^\.(js|mjs|cjs)$/.test(ext)
+      if (!isJs) return
+
       if (DEBUG) console.log(`REWRITE: ${args.path}`)
       const fileCode = fs.readFileSync(args.path, 'utf8')
       const rewritten = rewriter.rewrite(fileCode, args.path, ['iast'])

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -178,7 +178,7 @@ ${build.initialOptions.banner.js}`
 
     if (args.path.startsWith('.') && !args.importer.includes('node_modules/')) {
       // It is local application code, not an instrumented package
-      if (DEBUG) console.log(`APP: ${args.path}`, args)
+      if (DEBUG) console.log(`APP: ${args.path}`)
 
       return {
         path: fullPathToModule,

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -45,7 +45,7 @@ for (const builtin of RAW_BUILTINS) {
 }
 
 const DEBUG = !!process.env.DD_TRACE_DEBUG
-const DD_IAST_ENABLED = process.env.DD_IAST_ENABLED.toLowerCase() === 'true' || process.env.DD_IAST_ENABLED === '1'
+const DD_IAST_ENABLED = process.env.DD_IAST_ENABLED?.toLowerCase() === 'true' || process.env.DD_IAST_ENABLED === '1'
 
 // We don't want to handle any built-in packages
 // Those packages will still be handled via RITM

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -240,10 +240,6 @@ ${build.initialOptions.banner.js}`
   })
 
   build.onLoad({ filter: /.*/ }, args => {
-    // if (!args.pluginData?.pkgOfInterest && !args.pluginData?.fileToRewrite) {
-    //   return
-    // }
-
     if (args.pluginData?.pkgOfInterest) {
       const data = args.pluginData
 

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -282,16 +282,14 @@ ${build.initialOptions.banner.js}`
       }
     }
 
-    if (args.pluginData?.applicationFile) {
-      if (ddIastEnabled) {
-        if (DEBUG) console.log(`REWRITE: ${args.path}`)
-        const fileCode = fs.readFileSync(args.path, 'utf8')
-        const rewritten = rewriter.rewrite(fileCode, args.path, ['iast'])
-        return {
-          contents: rewritten.content,
-          loader: 'js',
-          resolveDir: path.dirname(args.path)
-        }
+    if (ddIastEnabled && args.pluginData?.applicationFile) {
+      if (DEBUG) console.log(`REWRITE: ${args.path}`)
+      const fileCode = fs.readFileSync(args.path, 'utf8')
+      const rewritten = rewriter.rewrite(fileCode, args.path, ['iast'])
+      return {
+        contents: rewritten.content,
+        loader: 'js',
+        resolveDir: path.dirname(args.path)
       }
     }
   })

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -7,6 +7,9 @@ const hooks = require('../datadog-instrumentations/src/helpers/hooks.js')
 const extractPackageAndModulePath = require(
   '../datadog-instrumentations/src/helpers/extract-package-and-module-path.js'
 )
+const iastRewriter = require('../dd-trace/src/appsec/iast/taint-tracking/rewriter')
+
+const rewriter = iastRewriter.getRewriter()
 
 for (const hook of Object.values(hooks)) {
   if (typeof hook === 'object') {
@@ -96,10 +99,18 @@ function getGitMetadata () {
 }
 
 module.exports.setup = function (build) {
+  const ddIastEnabled = build.initialOptions.define?.__DD_IAST_ENABLED__ === 'true'
+  const isSourceMapEnabled = !!build.initialOptions.sourcemap ||
+    ['internal', 'both'].includes(build.initialOptions.sourcemap)
   const externalModules = new Set(build.initialOptions.external || [])
+  build.initialOptions.banner ??= {}
+  build.initialOptions.banner.js ??= ''
+  if (ddIastEnabled) {
+    build.initialOptions.banner.js =
+      `globalThis.__DD_ESBUILD_IAST_${isSourceMapEnabled ? 'WITH_SM' : 'WITH_NO_SM'} = true;
+${build.initialOptions.banner.js}`
+  }
   if (isESMBuild(build)) {
-    build.initialOptions.banner ??= {}
-    build.initialOptions.banner.js ??= ''
     if (!build.initialOptions.banner.js.includes('import { createRequire as $dd_createRequire } from \'module\'')) {
       build.initialOptions.banner.js = `import { createRequire as $dd_createRequire } from 'module';
 import { fileURLToPath as $dd_fileURLToPath } from 'url';
@@ -141,13 +152,6 @@ ${build.initialOptions.banner.js}`
     }
 
     // TODO: Should this also check for namespace === 'file'?
-    if (args.path.startsWith('.') && !args.importer.includes('node_modules/')) {
-      // This is local application code, not an instrumented package
-      if (DEBUG) console.log(`LOCAL: ${args.path}`)
-      return
-    }
-
-    // TODO: Should this also check for namespace === 'file'?
     if (!modulesOfInterest.has(args.path) &&
         args.path.startsWith('@') &&
         !args.importer.includes('node_modules/')) {
@@ -166,6 +170,25 @@ ${build.initialOptions.banner.js}`
       }
       return
     }
+
+    if (args.path.startsWith('.') && !args.importer.includes('node_modules/')) {
+      // It is local application code, not an instrumented package
+      if (DEBUG) console.log(`APP: ${args.path}`, args)
+
+      const ext = path.extname(args.path).toLowerCase()
+      const isJs = /\.[cm]?[jt]sx?$/.test(ext)
+      if (!isJs && ext) return
+
+      return {
+        path: fullPathToModule,
+        pluginData: {
+          path: args.path,
+          full: fullPathToModule,
+          applicationFile: true
+        }
+      }
+    }
+
     const extracted = extractPackageAndModulePath(fullPathToModule)
 
     const internal = builtins.has(args.path)
@@ -215,22 +238,23 @@ ${build.initialOptions.banner.js}`
   })
 
   build.onLoad({ filter: /.*/ }, args => {
-    if (!args.pluginData?.pkgOfInterest) {
-      return
-    }
+    // if (!args.pluginData?.pkgOfInterest && !args.pluginData?.fileToRewrite) {
+    //   return
+    // }
 
-    const data = args.pluginData
+    if (args.pluginData?.pkgOfInterest) {
+      const data = args.pluginData
 
-    if (DEBUG) console.log(`LOAD: ${data.pkg}@${data.version}, pkg "${data.path}"`)
+      if (DEBUG) console.log(`LOAD: ${data.pkg}@${data.version}, pkg "${data.path}"`)
 
-    const pkgPath = data.raw !== data.pkg
-      ? `${data.pkg}/${data.path}`
-      : data.pkg
+      const pkgPath = data.raw !== data.pkg
+        ? `${data.pkg}/${data.path}`
+        : data.pkg
 
-    // Read the content of the module file of interest
-    const fileCode = fs.readFileSync(args.path, 'utf8')
+      // Read the content of the module file of interest
+      const fileCode = fs.readFileSync(args.path, 'utf8')
 
-    const contents = `
+      const contents = `
       (function() {
         ${fileCode}
       })(...arguments);
@@ -248,12 +272,25 @@ ${build.initialOptions.banner.js}`
         module.exports = payload.module;
     }
     `
+      // https://esbuild.github.io/plugins/#on-load-results
+      return {
+        contents,
+        loader: 'js',
+        resolveDir: path.dirname(args.path)
+      }
+    }
 
-    // https://esbuild.github.io/plugins/#on-load-results
-    return {
-      contents,
-      loader: 'js',
-      resolveDir: path.dirname(args.path)
+    if (args.pluginData?.applicationFile) {
+      if (ddIastEnabled) {
+        if (DEBUG) console.log(`REWRITE: ${args.path}`)
+        const fileCode = fs.readFileSync(args.path, 'utf8')
+        const rewritten = rewriter.rewrite(fileCode, args.path, ['iast'])
+        return {
+          contents: rewritten.content,
+          loader: 'js',
+          resolveDir: path.dirname(args.path)
+        }
+      }
     }
   })
 }

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -7,6 +7,8 @@ const hooks = require('../datadog-instrumentations/src/helpers/hooks.js')
 const extractPackageAndModulePath = require(
   '../datadog-instrumentations/src/helpers/extract-package-and-module-path.js'
 )
+
+const { calculateDDBasePath } = require('../dd-trace/src/util')
 const iastRewriter = require('../dd-trace/src/appsec/iast/taint-tracking/rewriter')
 
 const rewriter = iastRewriter.getRewriter()
@@ -106,8 +108,10 @@ module.exports.setup = function (build) {
   build.initialOptions.banner ??= {}
   build.initialOptions.banner.js ??= ''
   if (ddIastEnabled) {
+    const ddBasePath = calculateDDBasePath(__dirname)
     build.initialOptions.banner.js =
       `globalThis.__DD_ESBUILD_IAST_${isSourceMapEnabled ? 'WITH_SM' : 'WITH_NO_SM'} = true;
+      ${isSourceMapEnabled ? `globalThis.__DD_ESBUILD_BASEPATH = '${ddBasePath}';` : ''}
 ${build.initialOptions.banner.js}`
   }
   if (isESMBuild(build)) {

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -279,7 +279,7 @@ ${build.initialOptions.banner.js}`
 
     if (DD_IAST_ENABLED && args.pluginData?.applicationFile) {
       const ext = path.extname(args.path).toLowerCase()
-      const isJs =/^\.(js|mjs|cjs)$/.test(ext)
+      const isJs = /^\.(js|mjs|cjs)$/.test(ext)
       if (!isJs) return
 
       if (DEBUG) console.log(`REWRITE: ${args.path}`)

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -8,7 +8,6 @@ const extractPackageAndModulePath = require(
   '../datadog-instrumentations/src/helpers/extract-package-and-module-path.js'
 )
 
-const { calculateDDBasePath } = require('../dd-trace/src/util')
 const iastRewriter = require('../dd-trace/src/appsec/iast/taint-tracking/rewriter')
 
 const rewriter = iastRewriter.getRewriter()
@@ -108,10 +107,9 @@ module.exports.setup = function (build) {
   build.initialOptions.banner ??= {}
   build.initialOptions.banner.js ??= ''
   if (ddIastEnabled) {
-    const ddBasePath = calculateDDBasePath(__dirname)
     build.initialOptions.banner.js =
       `globalThis.__DD_ESBUILD_IAST_${isSourceMapEnabled ? 'WITH_SM' : 'WITH_NO_SM'} = true;
-      ${isSourceMapEnabled ? `globalThis.__DD_ESBUILD_BASEPATH = '${ddBasePath}';` : ''}
+      ${isSourceMapEnabled ? `globalThis.__DD_ESBUILD_BASEPATH = '${require('../dd-trace/src/util').ddBasePath}';` : ''}
 ${build.initialOptions.banner.js}`
   }
   if (isESMBuild(build)) {

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -8,9 +8,7 @@ const extractPackageAndModulePath = require(
   '../datadog-instrumentations/src/helpers/extract-package-and-module-path.js'
 )
 
-const iastRewriter = require('../dd-trace/src/appsec/iast/taint-tracking/rewriter')
-
-const rewriter = iastRewriter.getRewriter()
+let rewriter
 
 for (const hook of Object.values(hooks)) {
   if (typeof hook === 'object') {
@@ -101,6 +99,12 @@ function getGitMetadata () {
 
 module.exports.setup = function (build) {
   const ddIastEnabled = build.initialOptions.define?.__DD_IAST_ENABLED__ === 'true'
+
+  if (ddIastEnabled) {
+    const iastRewriter = require('../dd-trace/src/appsec/iast/taint-tracking/rewriter')
+    rewriter = iastRewriter.getRewriter()
+  }
+
   const isSourceMapEnabled = !!build.initialOptions.sourcemap ||
     ['internal', 'both'].includes(build.initialOptions.sourcemap)
   const externalModules = new Set(build.initialOptions.external || [])

--- a/packages/dd-trace/src/appsec/iast/path-line.js
+++ b/packages/dd-trace/src/appsec/iast/path-line.js
@@ -32,9 +32,14 @@ function getNonDDCallSiteFrames (callSiteFrames, externallyExcludedPaths) {
 
   for (const callsite of callSiteFrames) {
     let filepath = callsite.file
-    callsite.path = getRelativePath(filepath)
+
     if (globalThis.__DD_ESBUILD_IAST_WITH_SM) {
-      const { path: originalPath, line, column } = getOriginalPathAndLineFromSourceMap(callsite)
+      const callsiteLocation = {
+        path: getRelativePath(filepath),
+        line: callsite.line,
+        column: callsite.column
+      }
+      const { path: originalPath, line, column } = getOriginalPathAndLineFromSourceMap(callsiteLocation)
       callsite.path = filepath = originalPath
       callsite.line = line
       callsite.column = column
@@ -42,8 +47,9 @@ function getNonDDCallSiteFrames (callSiteFrames, externallyExcludedPaths) {
 
     if (
       !isExcluded(callsite, externallyExcludedPaths) &&
-      (!filepath.includes(ddBasePath) || globalThis.__DD_ESBUILD_IAST_WITH_NO_SM)
+      (!filepath.includes(pathLine.ddBasePath) || globalThis.__DD_ESBUILD_IAST_WITH_NO_SM)
     ) {
+      callsite.path = getRelativePath(filepath)
       callsite.isInternal = !path.isAbsolute(filepath)
 
       result.push(callsite)

--- a/packages/dd-trace/src/appsec/iast/path-line.js
+++ b/packages/dd-trace/src/appsec/iast/path-line.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const process = require('process')
-const { ddBasePath, calculateDDBasePath } = require('../../util')
+const { ddBasePath } = require('../../util')
 const { getOriginalPathAndLineFromSourceMap } = require('./taint-tracking/rewriter')
 const pathLine = {
   getNodeModulesPaths,
@@ -26,15 +26,6 @@ const EXCLUDED_PATH_PREFIXES = [
 function getNonDDCallSiteFrames (callSiteFrames, externallyExcludedPaths) {
   if (!callSiteFrames) {
     return []
-  }
-
-  let { ddBasePath } = pathLine
-
-  // Recompute ddBasePath for bundled output
-  if (globalThis.__DD_ESBUILD_IAST_WITH_SM) {
-    const callsite = callSiteFrames[0]
-    callsite.path = getRelativePath(callsite.file)
-    ddBasePath = calculateDDBasePath(getOriginalPathAndLineFromSourceMap(callsite).path)
   }
 
   const result = []

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -170,7 +170,10 @@ function enableRewriter (telemetryVerbosity) {
       const rewriter = getRewriter(telemetryVerbosity)
       if (rewriter) {
         shimPrepareStackTrace()
-        shimmer.wrap(Module.prototype, '_compile', compileMethod => getCompileMethodFn(compileMethod))
+        if (!globalThis.__DD_ESBUILD_IAST_WITH_SM && !globalThis.__DD_ESBUILD_IAST_WITH_NO_SM) {
+          // Avoid rewriting twice when application has been bundled
+          shimmer.wrap(Module.prototype, '_compile', compileMethod => getCompileMethodFn(compileMethod))
+        }
       }
     }
 

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -44,7 +44,7 @@ function setGetOriginalPathAndLineFromSourceMapFunction (chainSourceMap, { getOr
     ? (path, line, column) => {
       // if --enable-source-maps is present stacktraces of the rewritten files contain the original path, file and
       // column because the sourcemap chaining is done during the rewriting process so we can skip it
-        return isPrivateModule(path) && !isDdTrace(path)
+        return !globalThis.__DD_ESBUILD_IAST_WITH_SM && isPrivateModule(path) && !isDdTrace(path)
           ? { path, line, column }
           : getOriginalPathAndLineFromSourceMap(path, line, column)
       }
@@ -264,5 +264,5 @@ function enable (configArg) {
 }
 
 module.exports = {
-  enable, disable, getOriginalPathAndLineFromSourceMap
+  enable, disable, getOriginalPathAndLineFromSourceMap, getRewriter
 }

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -32,7 +32,13 @@ function getCallSiteList (maxDepth = 100, constructorOpt) {
 }
 
 function filterOutFramesFromLibrary (callSiteList) {
-  return callSiteList.filter(callSite => !callSite.getFileName()?.startsWith(ddBasePath))
+  return callSiteList.filter(callSite => {
+    if (globalThis.__DD_ESBUILD_IAST_WITH_SM || globalThis.__DD_ESBUILD_IAST_WITH_NO_SM) {
+      // Since it is bundled, it is not possible to discriminate the frame comes from library code or not
+      return true
+    }
+    return !callSite.getFileName()?.startsWith(ddBasePath)
+  })
 }
 
 function getCallsiteFrames (maxDepth = 32, constructorOpt = getCallsiteFrames, callSiteListGetter = getCallSiteList) {

--- a/packages/dd-trace/src/appsec/stack_trace.js
+++ b/packages/dd-trace/src/appsec/stack_trace.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { ddBasePath } = require('../util')
+const { getOriginalPathAndLineFromSourceMap } = require('./iast/taint-tracking/rewriter')
 
 const LIBRARY_FRAMES_BUFFER = 20
 
@@ -33,10 +34,22 @@ function getCallSiteList (maxDepth = 100, constructorOpt) {
 
 function filterOutFramesFromLibrary (callSiteList) {
   return callSiteList.filter(callSite => {
-    if (globalThis.__DD_ESBUILD_IAST_WITH_SM || globalThis.__DD_ESBUILD_IAST_WITH_NO_SM) {
-      // Since it is bundled, it is not possible to discriminate the frame comes from library code or not
+    if (globalThis.__DD_ESBUILD_IAST_WITH_NO_SM) {
+      // bundled and no SourceMap, not possible to discriminate if the frame comes from dd-trace code or not
       return true
     }
+
+    if (globalThis.__DD_ESBUILD_IAST_WITH_SM) {
+      // bundled with SourceMap, get original file and line to discriminate if comes from dd-trace or not
+      const callSiteLocation = {
+        path: callSite.getFileName(),
+        line: callSite.getLineNumber(),
+        column: callSite.getColumnNumber()
+      }
+      const { path } = getOriginalPathAndLineFromSourceMap(callSiteLocation)
+      return !path?.startsWith(ddBasePath)
+    }
+
     return !callSite.getFileName()?.startsWith(ddBasePath)
   })
 }

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -90,6 +90,5 @@ module.exports = {
   globMatch,
   ddBasePath: globalThis.__DD_ESBUILD_BASEPATH || calculateDDBasePath(__dirname),
   normalizeProfilingEnabledValue,
-  normalizePluginEnvName,
-  calculateDDBasePath
+  normalizePluginEnvName
 }

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -88,7 +88,7 @@ module.exports = {
   isFalse,
   isError,
   globMatch,
-  ddBasePath: calculateDDBasePath(__dirname),
+  ddBasePath: globalThis.__DD_ESBUILD_BASEPATH || calculateDDBasePath(__dirname),
   normalizeProfilingEnabledValue,
   normalizePluginEnvName,
   calculateDDBasePath

--- a/packages/dd-trace/src/util.js
+++ b/packages/dd-trace/src/util.js
@@ -90,5 +90,6 @@ module.exports = {
   globMatch,
   ddBasePath: calculateDDBasePath(__dirname),
   normalizeProfilingEnabledValue,
-  normalizePluginEnvName
+  normalizePluginEnvName,
+  calculateDDBasePath
 }

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -119,6 +119,16 @@ describe('IAST Rewriter', () => {
       rewriter.disable()
     })
 
+    it('Should not wrap module compile method if applications has been bundled', () => {
+      globalThis.__DD_ESBUILD_IAST_WITH_SM = true
+
+      rewriter.enable(iastEnabledConfig)
+      expect(shimmer.wrap).to.not.have.been.called
+
+      rewriter.disable()
+      delete globalThis.__DD_ESBUILD_IAST_WITH_SM
+    })
+
     // TODO: This cannot be tested with mocking.
     it('Should unwrap module compile method on taint tracking disable')
 


### PR DESCRIPTION
### What does this PR do?
Adds `esbuild` support for IAST product in cjs.

This PR adds a new step to `esbuild` dd-trace plugin in order to rewrite with IAST pass every application code file in order to get taint tracking propagation in the output file.

It also adds some adjustments to the process of obtaining the location of detected vulnerabilities in order to report the correct location. It should be noted that this will only be reported correctly if the `esbuild` `sourcemaps` flag is set; otherwise, the location of the first frame of the stack trace will be reported.

### Motivation
Customer request

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[APPSEC-58310](https://datadoghq.atlassian.net/browse/APPSEC-58310)


[APPSEC-58310]: https://datadoghq.atlassian.net/browse/APPSEC-58310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ