### PR TITLE
report waf config errors action

### DIFF
--- a/packages/dd-trace/src/appsec/telemetry/waf.js
+++ b/packages/dd-trace/src/appsec/telemetry/waf.js
@@ -96,7 +96,7 @@ function incrementWafInit (wafVersion, rulesVersion, success) {
   appsecMetrics.count('waf.init', { ...versionsTags, success }).inc()
 
   if (!success) {
-    appsecMetrics.count('waf.config_errors', versionsTags).inc()
+    appsecMetrics.count('waf.config_errors', { ...versionsTags, action: 'init' }).inc()
   }
 }
 
@@ -107,7 +107,7 @@ function incrementWafUpdates (wafVersion, rulesVersion, success) {
 
 function incrementWafConfigErrors (wafVersion, rulesVersion) {
   const versionsTags = getVersionsTags(wafVersion, rulesVersion)
-  appsecMetrics.count('waf.config_errors', versionsTags).inc()
+  appsecMetrics.count('waf.config_errors', { ...versionsTags, action: 'update' }).inc()
 }
 
 function incrementWafRequests (store) {

--- a/packages/dd-trace/test/appsec/telemetry/waf.spec.js
+++ b/packages/dd-trace/test/appsec/telemetry/waf.spec.js
@@ -242,6 +242,7 @@ describe('Appsec Waf Telemetry metrics', () => {
         expect(metrics.series[2].metric).to.be.eq('waf.config_errors')
         expect(metrics.series[2].tags).to.include('waf_version:0.0.1')
         expect(metrics.series[2].tags).to.include('event_rules_version:0.0.2')
+        expect(metrics.series[2].tags).to.include('action:init')
       })
     })
 
@@ -281,7 +282,8 @@ describe('Appsec Waf Telemetry metrics', () => {
 
         expect(count).to.have.been.calledOnceWithExactly('waf.config_errors', {
           waf_version: wafVersion,
-          event_rules_version: rulesVersion
+          event_rules_version: rulesVersion,
+          action: 'update'
         })
         expect(inc).to.have.been.calledOnce
       })
@@ -300,6 +302,7 @@ describe('Appsec Waf Telemetry metrics', () => {
         expect(metrics.series[1].points[0][1]).to.be.eq(3)
         expect(metrics.series[1].tags).to.include('waf_version:0.0.1')
         expect(metrics.series[1].tags).to.include('event_rules_version:0.0.2')
+        expect(metrics.series[1].tags).to.include('action:update')
       })
     })
 


### PR DESCRIPTION
### What does this PR do?
Add action: `init` | `update` tag to `waf.config_errors` telemetry metric as mentioned on RFC 1012.

[APPSEC-59077]

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->




[APPSEC-59077]: https://datadoghq.atlassian.net/browse/APPSEC-59077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ