### PR TITLE
benchmark: make startup-test more stable by using fixed dep list

### DIFF
--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -5,17 +5,84 @@ if (Number(process.env.USE_TRACER)) {
 }
 
 if (Number(process.env.EVERYTHING)) {
-  const json = require('../../../package.json')
-  for (const pkg in json.dependencies) {
+  // TODO: Add a preparation step that installs these dependencies. That way we
+  // are independent from what is currently installed in case adependency is
+  // removed.
+  const packages = [
+    '@babel/helpers',
+    '@datadog/libdatadog',
+    '@datadog/native-appsec',
+    '@datadog/native-iast-taint-tracking',
+    '@datadog/native-metrics',
+    '@datadog/pprof',
+    '@datadog/sketches-js',
+    '@datadog/wasm-js-rewriter',
+    '@eslint/eslintrc',
+    '@eslint/js',
+    '@isaacs/ttlcache',
+    '@msgpack/msgpack',
+    '@opentelemetry/api',
+    '@opentelemetry/core',
+    '@stylistic/eslint-plugin',
+    'axios',
+    'benchmark',
+    'body-parser',
+    'chai',
+    'crypto-randomuuid',
+    'dc-polyfill',
+    'eslint-plugin-cypress',
+    'eslint-plugin-import',
+    'eslint-plugin-mocha',
+    'eslint-plugin-n',
+    'eslint-plugin-promise',
+    'eslint-plugin-unicorn',
+    'eslint',
+    'express',
+    'get-port',
+    'glob',
+    'globals',
+    'graphql',
+    'ignore',
+    'import-in-the-middle',
+    'istanbul-lib-coverage',
+    'jest-docblock',
+    'jsonpath-plus',
+    'jszip',
+    'limiter',
+    'lodash.sortby',
+    'lru-cache',
+    'mocha',
+    'module-details-from-path',
+    'multer',
+    'mutexify',
+    'nock',
+    'nyc',
+    'octokit',
+    'opentracing',
+    'path-to-regexp',
+    'pprof-format',
+    'protobufjs',
+    'proxyquire',
+    'retry',
+    'rfdc',
+    'rimraf',
+    'semifies',
+    'semver',
+    'shell-quote',
+    'sinon-chai',
+    'sinon',
+    'source-map',
+    'tap',
+    'tiktoken',
+    'tlhunter-sorted-set',
+    'ttl-set',
+    'workerpool',
+    'yaml',
+    'yarn-deduplicate'
+  ]
+  for (const pkg of packages) {
     try {
       require(pkg)
     } catch {}
-  }
-  for (const devPkg in json.devDependencies) {
-    if (devPkg !== '@types/node') {
-      try {
-        require(devPkg)
-      } catch {}
-    }
   }
 }


### PR DESCRIPTION
The dependency list is now a fixed subset of our currently installed dependencies. Ideally, that changes to an external set of dependencies that are installed before the benchmark is run. That way the benchmark is independent from what is currently used as actual dependencies.
This is just the first step to overcome regression reports when adding new dependencies.


