### PR TITLE
Ws is disabled by default

### DIFF
--- a/packages/dd-trace/src/config_defaults.js
+++ b/packages/dd-trace/src/config_defaults.js
@@ -171,7 +171,7 @@ module.exports = {
   'tracePropagationStyle.inject': ['datadog', 'tracecontext', 'baggage'],
   'tracePropagationStyle.extract': ['datadog', 'tracecontext', 'baggage'],
   'tracePropagationStyle.otelPropagators': false,
-  traceWebsocketMessagesEnabled: true,
+  traceWebsocketMessagesEnabled: false,
   traceWebsocketMessagesInheritSampling: true,
   traceWebsocketMessagesSeparateTraces: true,
   tracing: true,


### PR DESCRIPTION
### What does this PR do?
Ws should be set to false by default until websocket implementation is considered generally available.

We're considering this a bug fix since it wasn't intended to be enabled by default.

### Motivation
This is specified in the websocket RFC.


