### PR TITLE
chore(lint): align ECMA version in ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,7 +76,7 @@ export default [
         }
       },
       globals: {
-        ...globals.es2021,
+        ...globals.es2022,
         ...globals.node,
         document: 'readonly',
         navigator: 'readonly',


### PR DESCRIPTION
### What does this PR do?

Align the `globals` with the `ecmaVersion` property above to both be 2022.
    
### Motivation

There's no differences between these two versions, but to make maintenance easier in the future, better align these versions now.

