### PR TITLE
[test optimization] Improve `afterEach` in cypress integration tests

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -156,7 +156,7 @@ moduleTypes.forEach(({
     })
 
     // Cypress child processes can sometimes hang or take longer to
-    // terminate. This can cause `FakeCiVisIntake` stop to be delayed
+    // terminate. This can cause `FakeCiVisIntake#stop` to be delayed
     // because there are pending connections.
     afterEach(async () => {
       childProcess.kill()

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -65,6 +65,7 @@ const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
+const RECEIVER_STOP_TIMEOUT = 20000
 const version = process.env.CYPRESS_VERSION
 const hookFile = 'dd-trace/loader-hook.mjs'
 const NUM_RETRIES_EFD = 3
@@ -154,9 +155,24 @@ moduleTypes.forEach(({
       receiver = await new FakeCiVisIntake().start()
     })
 
+    // Cypress child processes can sometimes hang or take longer to
+    // terminate. This can cause `FakeCiVisIntake` stop to be delayed
+    // because there are pending connections.
     afterEach(async () => {
       childProcess.kill()
-      await receiver.stop()
+
+      // Add timeout to prevent hanging
+      const stopPromise = receiver.stop()
+      const timeoutPromise = new Promise((resolve, reject) =>
+        setTimeout(() => reject(new Error('Receiver stop timeout')), RECEIVER_STOP_TIMEOUT)
+      )
+
+      try {
+        await Promise.race([stopPromise, timeoutPromise])
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Receiver stop timed out:', error.message)
+      }
     })
 
     if (version === '6.7.0') {


### PR DESCRIPTION
### What does this PR do?
Add a timeout to the `afterEach` hook in cypress integration tests.

### Motivation
It seems there are _still_ some `afterEach` errors in cypress 😢 , such as https://github.com/DataDog/dd-trace-js/actions/runs/17915311400/job/50936027656 

```
  1) cypress@14.5.4 commonJS
       "after each" hook for "disables early flake detection if known tests response is invalid":
     Error: Timeout of 80000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/dd-trace-js/dd-trace-js/integration-tests/cypress/cypress.spec.js)
```

I'm not sure (this was an AI suggestion), but it seems likely that `FakeCiVisIntake#stop` never resolves because there are pending connections. By adding a timeout we should avoid this issue altogether. 
