### PR TITLE
ci: do not update @opentelemetry/core major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,9 @@ updates:
       - dependency-name: "glob"
         # 11.0.0 onwards only supports Node.js 20 and above
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@opentelemetry/core"
+        # 2.0.0 onwards only supports Node.js 18.19.0 and above
+        update-types: ["version-update:semver-major"]
     groups:
       dev-minor-and-patch-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
`dd-trace` v5 supports Node.js 18.0.0, which core does not. This must therefore be limited.