### PR TITLE
Prevent IITM failure when there's another loader hook ahead of it.

### DIFF
--- a/integration-tests/double-loader.spec.js
+++ b/integration-tests/double-loader.spec.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const { execSync } = require('child_process')
+const path = require('path')
+const assert = require('assert')
+const { describe, it } = require('mocha')
+
+describe('double-loader scenario', () => {
+  it('does not fail', () => {
+    const l1 = path.join(__dirname, 'double-loader', 'loader1.mjs')
+    const l2 = path.join(__dirname, '..', 'loader-hook.mjs')
+    assert.doesNotThrow(() => {
+      execSync(`node --no-warnings --loader=${l1} --loader=${l2} -p 0`)
+    })
+  })
+})

--- a/integration-tests/double-loader/loader1.mjs
+++ b/integration-tests/double-loader/loader1.mjs
@@ -1,0 +1,9 @@
+import { readFile } from 'node:fs/promises'
+
+export async function load (url, context, nextLoad) {
+  const result = await nextLoad(url, context)
+  if (result.format === 'commonjs' && !result.source) {
+    result.source = await readFile(new URL(url))
+  }
+  return result
+}

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -1,1 +1,10 @@
-export * from 'import-in-the-middle/hook.mjs'
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+// TODO(bengl) This is all here because IITM imports a CommonJS module. Once
+// that's fixed in IITM, we no longer need all this.
+const iitmPath = createRequire(import.meta.url).resolve('import-in-the-middle/hook.mjs')
+const { createHook } = createRequire(iitmPath)('./hook.js')
+const iitmMeta = { url: pathToFileURL(iitmPath).toString() }
+const { initialize, load, resolve, getFormat, getSource } = createHook(iitmMeta)
+export { initialize, load, resolve, getFormat, getSource }


### PR DESCRIPTION
In cases where there's a loader hook that's loaded before IITM, and that hook does the Node.js-recommended approach for handling CommonJS modules, IITM will break because it imports a CommonJS module immediately. This workaround uses `Module.createRequire()` to bypass the loader hook logic, for now.


