### PR TITLE
fix performance gate warning triggering for acceptable range

### DIFF
--- a/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
@@ -11,14 +11,14 @@ experiments:
         scenarios:
           - name: normal_operation/only-tracing
             thresholds:
-              - agg_http_req_duration_p50 < 2 ms
+              - threshold: agg_http_req_duration_p50 < 2 ms
+                warning_range: 3
               - agg_http_req_duration_p99 < 15 ms
-            warning_range: 3
           - name: normal_operation/only-tracing-with-runtime-metrics-enabled
             thresholds:
-              - agg_http_req_duration_p50 < 2 ms
+              - threshold: agg_http_req_duration_p50 < 2 ms
+                warning_range: 3
               - agg_http_req_duration_p99 < 16 ms
-            warning_range: 3
           - name: high_load/only-tracing
             thresholds:
               - throughput > 400 op/s


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix performance gate warning triggering for acceptable range.

### Motivation
<!-- What inspired you to submit this pull request? -->

The warning calculation doesn't work well for low standard deviations and low values so we need to work around that.