### PR TITLE
test: fix runtime metric flakiness

### DIFF
--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -521,7 +521,7 @@ function createGarbage (count = 50) {
               }
               if (metric === 'runtime.node.cpu.total') {
                 assert(
-                  // Lower numbers can happen due to rounding issues.
+                  // Subtracting 0.02 since lower numbers can happen due to rounding issues.
                   number >= expected - 0.02 && number <= expected + 1,
                   `${metric} sanity check failed (increase CPU load above with more ticks): ${number} ${expected}`
                 )


### PR DESCRIPTION
The cpu metric could have a rounding issue. This is fixed by accepting slightly lower values.