### PR TITLE
[MLOB-3170] add prompt caching metrics for bedrock

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime/utils.js
@@ -45,6 +45,8 @@ function extractTextAndResponseReasonFromStream (chunks, modelProvider, modelNam
   let message = ''
   let inputTokens = 0
   let outputTokens = 0
+  let cacheReadTokens = 0
+  let cacheWriteTokens = 0
 
   for (const { chunk: { bytes } } of chunks) {
     const body = JSON.parse(Buffer.from(bytes).toString('utf8'))
@@ -100,6 +102,8 @@ function extractTextAndResponseReasonFromStream (chunks, modelProvider, modelNam
     if (invocationMetrics) {
       inputTokens = invocationMetrics.inputTokenCount
       outputTokens = invocationMetrics.outputTokenCount
+      cacheReadTokens = invocationMetrics.cacheReadInputTokenCount
+      cacheWriteTokens = invocationMetrics.cacheWriteInputTokenCount
     }
   }
 
@@ -107,7 +111,9 @@ function extractTextAndResponseReasonFromStream (chunks, modelProvider, modelNam
     message,
     role: 'assistant',
     inputTokens,
-    outputTokens
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens
   })
 }
 
@@ -118,7 +124,9 @@ class Generation {
     choiceId = '',
     role,
     inputTokens,
-    outputTokens
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens
   } = {}) {
     // stringify message as it could be a single generated message as well as a list of embeddings
     this.message = typeof message === 'string' ? message : JSON.stringify(message) || ''
@@ -127,7 +135,9 @@ class Generation {
     this.role = role
     this.usage = {
       inputTokens,
-      outputTokens
+      outputTokens,
+      cacheReadTokens,
+      cacheWriteTokens
     }
   }
 }

--- a/packages/datadog-plugin-aws-sdk/test/fixtures/bedrockruntime.js
+++ b/packages/datadog-plugin-aws-sdk/test/fixtures/bedrockruntime.js
@@ -288,7 +288,8 @@ bedrockruntime.cacheWriteRequest = {
     cacheReadTokens: 0,
     cacheWriteTokens: 1209,
     text: 'The capital of France is Paris.\n\nParis is'
-  }
+  },
+  outputRole: 'assistant'
 }
 bedrockruntime.cacheReadRequest = {
   provider: PROVIDER.ANTHROPIC,
@@ -319,7 +320,8 @@ bedrockruntime.cacheReadRequest = {
     cacheReadTokens: 1209,
     cacheWriteTokens: 0,
     text: 'The capital of Italy is Rome (Roma in Italian'
-  }
+  },
+  outputRole: 'assistant'
 }
 
 module.exports = bedrockruntime

--- a/packages/datadog-plugin-aws-sdk/test/fixtures/bedrockruntime.js
+++ b/packages/datadog-plugin-aws-sdk/test/fixtures/bedrockruntime.js
@@ -30,6 +30,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 7,
       outputTokens: 98,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: '\nParis is the capital of France. France is a country in Western Europe, and Paris ' +
         'is its capital. Paris is one of the most populous cities in the European Union, ' +
         'with a population of more than 2 million people. It is also one of the most ' +
@@ -62,6 +64,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 17,
       outputTokens: 8,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: ' The capital of France is Paris.'
     },
     outputRole: 'assistant'
@@ -78,6 +82,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 16,
       outputTokens: 11,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: ' The capital of France is Paris.'
     }
   },
@@ -104,6 +110,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 14,
       outputTokens: 10,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: 'The capital of France is Paris.'
     }
   },
@@ -119,6 +127,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 7,
       outputTokens: 335,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: 'The current capital of France is Paris. It has been the capital since 1958 and' +
         ' is also the most populous city in the country. Paris has a rich history and' +
         ' is known for its iconic landmarks and cultural significance.\n\nThe history' +
@@ -161,6 +171,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 7,
       outputTokens: 512,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: '**\nA) Berlin\nB) Paris\nC) London\nD) Rome\n\nAnswer: ' +
         'B) Paris\n\n**What is the largest planet in our solar system?**\nA) Earth\nB) ' +
         'Saturn\nC) Jupiter\nD) Uranus\n\nAnswer: C) Jupiter\n\n**What is the smallest ' +
@@ -220,6 +232,8 @@ bedrockruntime.models = [
     response: {
       inputTokens: 8,
       outputTokens: 129,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
       text: ' Paris is the capital city of France. It ' +
         'is the most populous city in France and is considered one of the cultural, ' +
         'artistic, and intellectual centers of Europe. Paris is known for its iconic ' +
@@ -243,6 +257,69 @@ bedrockruntime.models = [
 bedrockruntime.modelConfig = {
   temperature,
   maxTokens
+}
+
+bedrockruntime.cacheWriteRequest = {
+  provider: PROVIDER.ANTHROPIC,
+  modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  userPrompt: prompt,
+  requestBody: {
+    temperature,
+    anthropic_version: 'bedrock-2023-05-31',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a geography expert'.repeat(200) + prompt,
+            cache_control: {
+              type: 'ephemeral'
+            }
+          }
+        ],
+      }
+    ],
+    max_tokens: 10,
+  },
+  response: {
+    inputTokens: 1213,
+    outputTokens: 10,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 1209,
+    text: 'The capital of France is Paris.\n\nParis is'
+  }
+}
+bedrockruntime.cacheReadRequest = {
+  provider: PROVIDER.ANTHROPIC,
+  modelId: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+  userPrompt: 'What is the capital of Italy?',
+  requestBody: {
+    temperature,
+    anthropic_version: 'bedrock-2023-05-31',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'You are a geography expert'.repeat(200) + 'What is the capital of Italy?',
+            cache_control: {
+              type: 'ephemeral'
+            }
+          }
+        ],
+      }
+    ],
+    max_tokens: 10,
+  },
+  response: {
+    inputTokens: 1213,
+    outputTokens: 10,
+    cacheReadTokens: 1209,
+    cacheWriteTokens: 0,
+    text: 'The capital of Italy is Rome (Roma in Italian'
+  }
 }
 
 module.exports = bedrockruntime

--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -32,7 +32,8 @@ module.exports = {
   INPUT_TOKENS_METRIC_KEY: 'input_tokens',
   OUTPUT_TOKENS_METRIC_KEY: 'output_tokens',
   TOTAL_TOKENS_METRIC_KEY: 'total_tokens',
-  CACHED_TOKENS_METRIC_KEY: 'cache_read_input_tokens',
+  CACHE_READ_INPUT_TOKENS_METRIC_KEY: 'cache_read_input_tokens',
+  CACHE_WRITE_INPUT_TOKENS_METRIC_KEY: 'cache_write_input_tokens',
 
   DROPPED_IO_COLLECTION_ERROR: 'dropped_io'
 }

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -119,8 +119,8 @@ function extractTokens ({ requestId, usage }) {
 
   const inputTokens = usage.inputTokens || inputTokensFromHeaders || 0
   const outputTokens = usage.outputTokens || outputTokensFromHeaders || 0
-  const cacheReadTokens = cacheReadTokensFromHeaders || 0
-  const cacheWriteTokens = cacheWriteTokensFromHeaders || 0
+  const cacheReadTokens = usage.cacheReadTokens || cacheReadTokensFromHeaders || 0
+  const cacheWriteTokens = usage.cacheWriteTokens || cacheWriteTokensFromHeaders || 0
 
   // adjust for the fact that bedrock input tokens only count non-cached tokens
   const normalizedInputTokens = inputTokens + cacheReadTokens + cacheWriteTokens

--- a/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
+++ b/packages/dd-trace/src/llmobs/plugins/bedrockruntime.js
@@ -42,10 +42,14 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
       const requestId = headers['x-amzn-requestid']
       const inputTokenCount = headers['x-amzn-bedrock-input-token-count']
       const outputTokenCount = headers['x-amzn-bedrock-output-token-count']
+      const cacheReadTokenCount = headers['x-amzn-bedrock-cache-read-input-token-count']
+      const cacheWriteTokenCount = headers['x-amzn-bedrock-cache-write-input-token-count']
 
       requestIdsToTokens[requestId] = {
         inputTokensFromHeaders: inputTokenCount && Number.parseInt(inputTokenCount),
-        outputTokensFromHeaders: outputTokenCount && Number.parseInt(outputTokenCount)
+        outputTokensFromHeaders: outputTokenCount && Number.parseInt(outputTokenCount),
+        cacheReadTokensFromHeaders: cacheReadTokenCount && Number.parseInt(cacheReadTokenCount),
+        cacheWriteTokensFromHeaders: cacheWriteTokenCount && Number.parseInt(cacheWriteTokenCount)
       }
     })
 
@@ -90,14 +94,16 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
     )
 
     // add token metrics
-    const { inputTokens, outputTokens, totalTokens } = extractTokens({
+    const { inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens } = extractTokens({
       requestId: response.$metadata.requestId,
       usage: textAndResponseReason.usage
     })
     this._tagger.tagMetrics(span, {
       inputTokens,
       outputTokens,
-      totalTokens
+      totalTokens,
+      cacheReadTokens,
+      cacheWriteTokens
     })
   }
 }
@@ -105,17 +111,26 @@ class BedrockRuntimeLLMObsPlugin extends BaseLLMObsPlugin {
 function extractTokens ({ requestId, usage }) {
   const {
     inputTokensFromHeaders,
-    outputTokensFromHeaders
+    outputTokensFromHeaders,
+    cacheReadTokensFromHeaders,
+    cacheWriteTokensFromHeaders
   } = requestIdsToTokens[requestId] || {}
   delete requestIdsToTokens[requestId]
 
   const inputTokens = usage.inputTokens || inputTokensFromHeaders || 0
   const outputTokens = usage.outputTokens || outputTokensFromHeaders || 0
+  const cacheReadTokens = cacheReadTokensFromHeaders || 0
+  const cacheWriteTokens = cacheWriteTokensFromHeaders || 0
+
+  // adjust for the fact that bedrock input tokens only count non-cached tokens
+  const normalizedInputTokens = inputTokens + cacheReadTokens + cacheWriteTokens
 
   return {
-    inputTokens,
+    inputTokens: normalizedInputTokens,
     outputTokens,
-    totalTokens: inputTokens + outputTokens
+    totalTokens: normalizedInputTokens + outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens
   }
 }
 

--- a/packages/dd-trace/src/llmobs/plugins/openai.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai.js
@@ -86,8 +86,8 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
 
       const promptTokensDetails = tokenUsage.prompt_tokens_details
       if (promptTokensDetails) {
-        const cachedReadTokens = promptTokensDetails.cached_tokens
-        if (cachedReadTokens) metrics.cachedReadTokens = cachedReadTokens
+        const cacheReadTokens = promptTokensDetails.cached_tokens
+        if (cacheReadTokens) metrics.cacheReadTokens = cacheReadTokens
       }
     }
 

--- a/packages/dd-trace/src/llmobs/plugins/openai.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai.js
@@ -86,8 +86,8 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
 
       const promptTokensDetails = tokenUsage.prompt_tokens_details
       if (promptTokensDetails) {
-        const cachedTokens = promptTokensDetails.cached_tokens
-        if (cachedTokens) metrics.cachedTokens = cachedTokens
+        const cachedReadTokens = promptTokensDetails.cached_tokens
+        if (cachedReadTokens) metrics.cachedReadTokens = cachedReadTokens
       }
     }
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -20,7 +20,8 @@ const {
   NAME,
   PROPAGATED_PARENT_ID_KEY,
   ROOT_PARENT_ID,
-  CACHED_TOKENS_METRIC_KEY,
+  CACHE_READ_INPUT_TOKENS_METRIC_KEY,
+  CACHE_WRITE_INPUT_TOKENS_METRIC_KEY,
   INPUT_TOKENS_METRIC_KEY,
   OUTPUT_TOKENS_METRIC_KEY,
   TOTAL_TOKENS_METRIC_KEY,
@@ -145,8 +146,11 @@ class LLMObsTagger {
         case 'totalTokens':
           processedKey = TOTAL_TOKENS_METRIC_KEY
           break
-        case 'cachedTokens':
-          processedKey = CACHED_TOKENS_METRIC_KEY
+        case 'cacheReadTokens':
+          processedKey = CACHE_READ_INPUT_TOKENS_METRIC_KEY
+          break
+        case 'cacheWriteTokens':
+          processedKey = CACHE_WRITE_INPUT_TOKENS_METRIC_KEY
           break
       }
 

--- a/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke-with-response-stream_post_4b5b3e7d.yaml
+++ b/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke-with-response-stream_post_4b5b3e7d.yaml
@@ -1,0 +1,170 @@
+interactions:
+- request:
+    body: '{"temperature":0.5,"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"You
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertWhat is the capital of Italy?","cache_control":{"type":"ephemeral"}}]}],"max_tokens":10}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      ? !!python/object/apply:multidict._multidict.istr
+      - Connection
+      : - keep-alive
+      Content-Length:
+      - '5409'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      ? !!python/object/apply:multidict._multidict.istr
+      - User-Agent
+      : - aws-sdk-js/3.422.0 ua/2.0 os/darwin#24.6.0 lang/js md/nodejs#20.16.0 api/bedrock-runtime#3.422.0
+      ? !!python/object/apply:multidict._multidict.istr
+      - x-amzn-bedrock-accept
+      : - application/json
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/invoke-with-response-stream
+  response:
+    body:
+      string: !!binary |
+        AAACJwAAAEu6BRVuCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0
+        aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpj
+        MkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWFXUWlPaUp0YzJkZlltUnlhMTh3TVVkcldH
+        MU1TbE5DYVRGNFRUVjJORXhNZVVVeVZXOGlMQ0owZVhCbElqb2liV1Z6YzJGblpTSXNJbkp2YkdV
+        aU9pSmhjM05wYzNSaGJuUWlMQ0p0YjJSbGJDSTZJbU5zWVhWa1pTMXpiMjV1WlhRdE5DMHlNREkx
+        TURVeE5DSXNJbU52Ym5SbGJuUWlPbHRkTENKemRHOXdYM0psWVhOdmJpSTZiblZzYkN3aWMzUnZj
+        Rjl6WlhGMVpXNWpaU0k2Ym5Wc2JDd2lkWE5oWjJVaU9uc2lhVzV3ZFhSZmRHOXJaVzV6SWpvMExD
+        SmpZV05vWlY5amNtVmhkR2x2Ymw5cGJuQjFkRjkwYjJ0bGJuTWlPakFzSW1OaFkyaGxYM0psWVdS
+        ZmFXNXdkWFJmZEc5clpXNXpJam94TWpBNUxDSnZkWFJ3ZFhSZmRHOXJaVzV6SWpveGZYMTkiLCJw
+        IjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkMifWDU8dYAAAEBAAAAS3IQvWQLOmV2ZW50
+        LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10
+        eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOXpkR0Z5
+        ZENJc0ltbHVaR1Y0SWpvd0xDSmpiMjUwWlc1MFgySnNiMk5ySWpwN0luUjVjR1VpT2lKMFpYaDBJ
+        aXdpZEdWNGRDSTZJaUo5ZlE9PSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFCQ0RF
+        RkdISSJ960LhrAAAAO8AAABLLqgXfws6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUH
+        ABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhC
+        bElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2
+        ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lKVWFHVWlmWDA9IiwicCI6ImFi
+        Y2RlZmdoaWprbG1ub3BxIn2K/KlLAAAA7wAAAEsuqBd/CzpldmVudC10eXBlBwAFY2h1bmsNOmNv
+        bnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRl
+        cyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1WkdWNElqb3dM
+        Q0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlPaUlnWTJGd2FY
+        UmhiQ0J2WmlKOWZRPT0iLCJwIjoiYWJjZGUifaKPoX4AAAEbAAAAS1hAMkcLOmV2ZW50LXR5cGUH
+        AAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAF
+        ZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRHVnVkRjlpYkc5amExOWtaV3gwWVNJc0lt
+        bHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpvaWRHVjRkRjlrWld4MFlTSXNJblJsZUhR
+        aU9pSWdTWFJoYkhrZ2FYTWdVbTl0WlNBb0luMTkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1
+        dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTIn1oh7OBAAABCQAAAEtCYPalCzpldmVudC10eXBlBwAF
+        Y2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2
+        ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1
+        WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlP
+        aUpTYjIxaEluMTkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xN
+        Tk9QUSJ9x2gjggAAARYAAABLoND29gs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUH
+        ABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhC
+        bElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZU0k2
+        ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ2FXNGlmWDA9IiwicCI6ImFi
+        Y2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzIn20
+        X1HdAAAA/wAAAEtOSID9CzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxp
+        Y2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVky
+        OXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJbWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhC
+        bElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVIUWlPaUlnU1hSaGJHbGhiaUo5ZlE9PSIsInAiOiJh
+        YmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5In3NqupOAAAA2wAAAEt6CQk5CzpldmVudC10eXBlBwAF
+        Y2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2
+        ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEc5d0lpd2lhVzVr
+        WlhnaU9qQjkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9Q
+        UVJTVFVWV1hZWjAxMjM0In1lBo0+AAABMAAAAEvuUSxSCzpldmVudC10eXBlBwAFY2h1bmsNOmNv
+        bnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRl
+        cyI6ImV5SjBlWEJsSWpvaWJXVnpjMkZuWlY5a1pXeDBZU0lzSW1SbGJIUmhJanA3SW5OMGIzQmZj
+        bVZoYzI5dUlqb2liV0Y0WDNSdmEyVnVjeUlzSW5OMGIzQmZjMlZ4ZFdWdVkyVWlPbTUxYkd4OUxD
+        SjFjMkZuWlNJNmV5SnZkWFJ3ZFhSZmRHOXJaVzV6SWpveE1IMTkiLCJwIjoiYWJjZGVmZ2hpamts
+        bW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVCJ9AebjDgAAAbQAAABLqjc6AAs6ZXZl
+        bnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdl
+        LXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpWOXpkRzl3SWl3aVlX
+        MWhlbTl1TFdKbFpISnZZMnN0YVc1MmIyTmhkR2x2YmsxbGRISnBZM01pT25zaWFXNXdkWFJVYjJ0
+        bGJrTnZkVzUwSWpvMExDSnZkWFJ3ZFhSVWIydGxia052ZFc1MElqb3hNQ3dpYVc1MmIyTmhkR2x2
+        Ymt4aGRHVnVZM2tpT2pFME1UQXNJbVpwY25OMFFubDBaVXhoZEdWdVkza2lPakUwTURZc0ltTmhZ
+        MmhsVW1WaFpFbHVjSFYwVkc5clpXNURiM1Z1ZENJNk1USXdPU3dpWTJGamFHVlhjbWwwWlVsdWNI
+        VjBWRzlyWlc1RGIzVnVkQ0k2TUgxOSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ekFC
+        Q0RFRkdISUpLTE1OT1AifSPCDSA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/vnd.amazon.eventstream
+      Date:
+      - Wed, 24 Sep 2025 20:53:33 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Amzn-Bedrock-Content-Type:
+      - application/json
+      x-amzn-RequestId:
+      - 05059263-d49d-408d-a543-fb6d5d34e0b2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke-with-response-stream_post_920fdf6e.yaml
+++ b/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke-with-response-stream_post_920fdf6e.yaml
@@ -1,0 +1,159 @@
+interactions:
+- request:
+    body: '{"temperature":0.5,"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"You
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertWhat is the capital of France?","cache_control":{"type":"ephemeral"}}]}],"max_tokens":10}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      ? !!python/object/apply:multidict._multidict.istr
+      - Connection
+      : - keep-alive
+      Content-Length:
+      - '5410'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      ? !!python/object/apply:multidict._multidict.istr
+      - User-Agent
+      : - aws-sdk-js/3.422.0 ua/2.0 os/darwin#24.6.0 lang/js md/nodejs#20.16.0 api/bedrock-runtime#3.422.0
+      ? !!python/object/apply:multidict._multidict.istr
+      - x-amzn-bedrock-accept
+      : - application/json
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/invoke-with-response-stream
+  response:
+    body:
+      string: !!binary |
+        AAACQwAAAEvWt8TjCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0
+        aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaWJXVnpj
+        MkZuWlY5emRHRnlkQ0lzSW0xbGMzTmhaMlVpT25zaWFXUWlPaUp0YzJkZlltUnlhMTh3TVRSaFZV
+        UXhOV3MwVlVVNVJXNUljakpWVkdOU01tc2lMQ0owZVhCbElqb2liV1Z6YzJGblpTSXNJbkp2YkdV
+        aU9pSmhjM05wYzNSaGJuUWlMQ0p0YjJSbGJDSTZJbU5zWVhWa1pTMXpiMjV1WlhRdE5DMHlNREkx
+        TURVeE5DSXNJbU52Ym5SbGJuUWlPbHRkTENKemRHOXdYM0psWVhOdmJpSTZiblZzYkN3aWMzUnZj
+        Rjl6WlhGMVpXNWpaU0k2Ym5Wc2JDd2lkWE5oWjJVaU9uc2lhVzV3ZFhSZmRHOXJaVzV6SWpvMExD
+        SmpZV05vWlY5amNtVmhkR2x2Ymw5cGJuQjFkRjkwYjJ0bGJuTWlPakV5TURrc0ltTmhZMmhsWDNK
+        bFlXUmZhVzV3ZFhSZmRHOXJaVzV6SWpvd0xDSnZkWFJ3ZFhSZmRHOXJaVzV6SWpvMGZYMTkiLCJw
+        IjoiYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAx
+        MjM0In0vnFZYAAABCwAAAEs4oKXFCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcA
+        EGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJs
+        SWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTl6ZEdGeWRDSXNJbWx1WkdWNElqb3dMQ0pqYjI1MFpXNTBY
+        MkpzYjJOcklqcDdJblI1Y0dVaU9pSjBaWGgwSWl3aWRHVjRkQ0k2SWlKOWZRPT0iLCJwIjoiYWJj
+        ZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTIn2xTSSOAAAA+gAAAEuG
+        qA+NCzpldmVudC10eXBlBwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24N
+        Om1lc3NhZ2UtdHlwZQcABWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJH
+        OWphMTlrWld4MFlTSXNJbWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5
+        a1pXeDBZU0lzSW5SbGVIUWlPaUpVYUdVZ1kyRndhWFJoYkNCdlppQkdjbUZ1WTJVaWZYMD0iLCJw
+        IjoiYWJjZCJ9jnoq1QAAAPgAAABL/Ghc7Qs6ZXZlbnQtdHlwZQcABWNodW5rDTpjb250ZW50LXR5
+        cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0ZXMiOiJleUow
+        ZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5a1pXeDBZU0lzSW1sdVpHVjRJam93TENKa1pXeDBZ
+        U0k2ZXlKMGVYQmxJam9pZEdWNGRGOWtaV3gwWVNJc0luUmxlSFFpT2lJZ2FYTWdVR0Z5YVhNdUlu
+        MTkiLCJwIjoiYWJjZGVmZ2hpamtsbW5vcHFyIn1hBM9PAAAA+wAAAEu7yCY9CzpldmVudC10eXBl
+        BwAFY2h1bmsNOmNvbnRlbnQtdHlwZQcAEGFwcGxpY2F0aW9uL2pzb24NOm1lc3NhZ2UtdHlwZQcA
+        BWV2ZW50eyJieXRlcyI6ImV5SjBlWEJsSWpvaVkyOXVkR1Z1ZEY5aWJHOWphMTlrWld4MFlTSXNJ
+        bWx1WkdWNElqb3dMQ0prWld4MFlTSTZleUowZVhCbElqb2lkR1Y0ZEY5a1pXeDBZU0lzSW5SbGVI
+        UWlPaUpjYmx4dVVHRnlhWE1pZlgwPSIsInAiOiJhYmNkZWZnaGlqa2xtbm9wcXJzdHUifQ/XRIUA
+        AAD+AAAAS3MoqU0LOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBwbGljYXRp
+        b24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9pWTI5dWRH
+        VnVkRjlpYkc5amExOWtaV3gwWVNJc0ltbHVaR1Y0SWpvd0xDSmtaV3gwWVNJNmV5SjBlWEJsSWpv
+        aWRHVjRkRjlrWld4MFlTSXNJblJsZUhRaU9pSWdhWE1pZlgwPSIsInAiOiJhYmNkZWZnaGlqa2xt
+        bm9wcXJzdHV2d3h5ekFCQ0RFRiJ9Zzi1JgAAAKgAAABLxHuTJgs6ZXZlbnQtdHlwZQcABWNodW5r
+        DTpjb250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsi
+        Ynl0ZXMiOiJleUowZVhCbElqb2lZMjl1ZEdWdWRGOWliRzlqYTE5emRHOXdJaXdpYVc1a1pYZ2lP
+        akI5IiwicCI6ImFiY2RlZiJ9rc1dOgAAAQwAAABLioB51Qs6ZXZlbnQtdHlwZQcABWNodW5rDTpj
+        b250ZW50LXR5cGUHABBhcHBsaWNhdGlvbi9qc29uDTptZXNzYWdlLXR5cGUHAAVldmVudHsiYnl0
+        ZXMiOiJleUowZVhCbElqb2liV1Z6YzJGblpWOWtaV3gwWVNJc0ltUmxiSFJoSWpwN0luTjBiM0Jm
+        Y21WaGMyOXVJam9pYldGNFgzUnZhMlZ1Y3lJc0luTjBiM0JmYzJWeGRXVnVZMlVpT201MWJHeDlM
+        Q0oxYzJGblpTSTZleUp2ZFhSd2RYUmZkRzlyWlc1eklqb3hNSDE5IiwicCI6ImFiY2RlZmdoaWoi
+        fSVBeWgAAAG3AAAAS+2XQNALOmV2ZW50LXR5cGUHAAVjaHVuaw06Y29udGVudC10eXBlBwAQYXBw
+        bGljYXRpb24vanNvbg06bWVzc2FnZS10eXBlBwAFZXZlbnR7ImJ5dGVzIjoiZXlKMGVYQmxJam9p
+        YldWemMyRm5aVjl6ZEc5d0lpd2lZVzFoZW05dUxXSmxaSEp2WTJzdGFXNTJiMk5oZEdsdmJrMWxk
+        SEpwWTNNaU9uc2lhVzV3ZFhSVWIydGxia052ZFc1MElqbzBMQ0p2ZFhSd2RYUlViMnRsYmtOdmRX
+        NTBJam94TUN3aWFXNTJiMk5oZEdsdmJreGhkR1Z1WTNraU9qRXhOVFVzSW1acGNuTjBRbmwwWlV4
+        aGRHVnVZM2tpT2pFeE5USXNJbU5oWTJobFVtVmhaRWx1Y0hWMFZHOXJaVzVEYjNWdWRDSTZNQ3dp
+        WTJGamFHVlhjbWwwWlVsdWNIVjBWRzlyWlc1RGIzVnVkQ0k2TVRJd09YMTkiLCJwIjoiYWJjZGVm
+        Z2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTIn1qQwAD
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/vnd.amazon.eventstream
+      Date:
+      - Wed, 24 Sep 2025 20:31:55 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Amzn-Bedrock-Content-Type:
+      - application/json
+      x-amzn-RequestId:
+      - f888c1fa-a708-4312-a5ea-281da98bebb3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke_post_0b72aefa.yaml
+++ b/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke_post_0b72aefa.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: '{"temperature":0.5,"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"You
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertWhat is the capital of Italy?","cache_control":{"type":"ephemeral"}}]}],"max_tokens":10}'
+    headers:
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept
+      : - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      ? !!python/object/apply:multidict._multidict.istr
+      - Connection
+      : - keep-alive
+      Content-Length:
+      - '5409'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      ? !!python/object/apply:multidict._multidict.istr
+      - User-Agent
+      : - aws-sdk-js/3.422.0 ua/2.0 os/darwin#24.6.0 lang/js md/nodejs#20.16.0 api/bedrock-runtime#3.422.0
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+  response:
+    body:
+      string: '{"id":"msg_bdrk_01BxsSheRqBYWJpi9prdJozH","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"The
+        capital of Italy is Rome (Roma in Italian"}],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":4,"cache_creation_input_tokens":0,"cache_read_input_tokens":1209,"output_tokens":10}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '353'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 24 Sep 2025 18:26:05 GMT
+      X-Amzn-Bedrock-Cache-Read-Input-Token-Count:
+      - '1209'
+      X-Amzn-Bedrock-Cache-Write-Input-Token-Count:
+      - '0'
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '4'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '1152'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - 6afc4cce-e80e-4b26-8474-aeb493fd9799
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke_post_b1cbb572.yaml
+++ b/packages/dd-trace/test/llmobs/cassettes/bedrock-runtime/bedrock-runtime_model_us.anthropic.claude-sonnet-4-20250514-v1_0_invoke_post_b1cbb572.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: '{"temperature":0.5,"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":[{"type":"text","text":"You
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertYou are a geography expertYou
+      are a geography expertYou are a geography expertWhat is the capital of France?","cache_control":{"type":"ephemeral"}}]}],"max_tokens":10}'
+    headers:
+      ? !!python/object/apply:multidict._multidict.istr
+      - Accept
+      : - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      ? !!python/object/apply:multidict._multidict.istr
+      - Connection
+      : - keep-alive
+      Content-Length:
+      - '5410'
+      ? !!python/object/apply:multidict._multidict.istr
+      - Content-Type
+      : - application/json
+      ? !!python/object/apply:multidict._multidict.istr
+      - User-Agent
+      : - aws-sdk-js/3.422.0 ua/2.0 os/darwin#24.6.0 lang/js md/nodejs#20.16.0 api/bedrock-runtime#3.422.0
+    method: POST
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-20250514-v1:0/invoke
+  response:
+    body:
+      string: '{"id":"msg_bdrk_01LL4iC3KoyutR6rpYHbnHcs","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"The
+        capital of France is Paris.\n\nParis is"}],"stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":4,"cache_creation_input_tokens":1209,"cache_read_input_tokens":0,"output_tokens":10}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '351'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 24 Sep 2025 18:13:59 GMT
+      X-Amzn-Bedrock-Cache-Read-Input-Token-Count:
+      - '0'
+      X-Amzn-Bedrock-Cache-Write-Input-Token-Count:
+      - '1209'
+      X-Amzn-Bedrock-Input-Token-Count:
+      - '4'
+      X-Amzn-Bedrock-Invocation-Latency:
+      - '1180'
+      X-Amzn-Bedrock-Output-Token-Count:
+      - '10'
+      x-amzn-RequestId:
+      - f37a748f-a588-4db0-affb-1864383ef25d
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -6,7 +6,12 @@ const { describe, it, before } = require('mocha')
 const { withVersions } = require('../../../setup/mocha')
 
 const { expectedLLMObsLLMSpanEvent, deepEqualWithMockValues, useLlmObs } = require('../../util')
-const { models, modelConfig, cacheWriteRequest, cacheReadRequest } = require('../../../../../datadog-plugin-aws-sdk/test/fixtures/bedrockruntime')
+const {
+  models,
+  modelConfig,
+  cacheWriteRequest,
+  cacheReadRequest
+} = require('../../../../../datadog-plugin-aws-sdk/test/fixtures/bedrockruntime')
 const { useEnv } = require('../../../../../../integration-tests/helpers')
 
 const { expect } = chai


### PR DESCRIPTION
This PR adds prompt caching metrics (cached read / write token counts) to spans submitted from the Bedrock integration.

Note: The input token count returned as part of the Bedrock response only includes non-cached tokens. Therefore, we have to adjust this token count to include cached tokens as well (since that is what our backend expects).

## Testing

I ran the following script with `node --inspect-brk bedrock_caching_simple.js` to test these changes:
```
const tracer = require('dd-trace').init({
    llmobs: {
      mlApp: "nicole-test",
      agentlessEnabled: false,
    },
    env: "nicole-test",
  });
  const { llmobs } = tracer;
  
  const AWS = require('@aws-sdk/client-bedrock-runtime');
  const bedrockRuntimeClient = new AWS.BedrockRuntimeClient({
    region: 'us-east-1',
  });
  
  const modelId = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
  const systemPrompt = "You are an expert software developer".repeat(200);
  
  (async () => {
    const request1 = {
      body: JSON.stringify({
        system: systemPrompt,
        temperature: 0.1,
        anthropic_version: 'bedrock-2023-05-31',
        messages: [
          {
            role: 'user',
            content: [
              {
                type: 'text',
                text: 'What are the best practices for API design?',
              },
              {
                type: "text",
                text: "test",
                cache_control: {
                  type: "ephemeral"
                }
              }
            ],
          }
        ],
        max_tokens: 100,
      }),
      contentType: 'application/json',
      accept: 'application/json',
      modelId: modelId
    };
  
    const command1 = new AWS.InvokeModelCommand(request1);
    await bedrockRuntimeClient.send(command1);
})();
```


Running this script once leads to the first request where you can see that the system prompt is being written to the cache. Running the script again leads to the second request where the shared system prompt is read from the cache.


|  | span | Cached Tokens |
|----------|----------|----------|
| first request   | [span](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&sp=%5B%7B%22sp%22%3A%7B%22width%22%3A%22min%28100%25%2C%20max%28calc%28100%25%20-%20var%28--ui-page-left-offset%29%20-%2016px%29%2C%20900px%29%29%22%7D%2C%22p%22%3A%7B%22eventId%22%3A%22AwAAAZl36hAlMbKDqQAAABhBWmwzNmhBbEFBQ1EzQWVEaV9MdUFBQUEAAAAkMDE5OTc3ZWEtNGYzNi00ZjdiLTg4YmUtOGI4OGFkZjQxYTI0AAASwA%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=4133420068894346222&start=1758652800504&end=1758653700504&paused=false)  | <img width="1150" height="724" alt="image" src="https://github.com/user-attachments/assets/1bd786cd-8281-4247-a9e6-f2c3ed178301" />   |
| second request (hits the cache)   |  [span](https://app.datadoghq.com/llm/traces?query=%40ml_app%3Anicole-test%20%40event_type%3Aspan%20%40parent_id%3Aundefined&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&sp=%5B%7B%22sp%22%3A%7B%22width%22%3A%22min%28100%25%2C%20max%28calc%28100%25%20-%20var%28--ui-page-left-offset%29%20-%2016px%29%2C%20900px%29%29%22%7D%2C%22p%22%3A%7B%22eventId%22%3A%22AwAAAZl36kjopgzKJQAAABhBWmwzNmtqb0FBREVQMHZvQzk3SEFBQUEAAAAkMDE5OTc3ZWEtZWNjNi00YWY2LTkyMGYtODg0NDg3ZTFlODlkAAAUDw%22%7D%2C%22i%22%3A%22llm-obs-panel%22%7D%5D&spanId=6441125655129925386&start=1758652800504&end=1758653700504&paused=false)  | <img width="1552" height="742" alt="image" src="https://github.com/user-attachments/assets/112d5f9e-8ed5-48ce-a910-5934224d40c4" />   |



- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


