### PR TITLE
feat(aws): rename partition tag to aws.partition

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -118,7 +118,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
 
       const partition = getPartition(region)
       if (partition) {
-        span.setTag('partition', partition)
+        span.setTag('aws.partition', partition)
       }
 
       if (!this._tracerConfig?._isInServerlessEnvironment()) return

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -59,7 +59,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         'aws.operation': operation,
         'aws.region': awsRegion,
         region: awsRegion,
-        partition: getPartition(awsRegion),
+        'aws.partition': getPartition(awsRegion),
         aws_service: awsService,
         'aws.service': awsService,
         component: 'aws-sdk'

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
               component: 'aws-sdk',
               'aws.region': 'us-east-1',
               region: 'us-east-1',
-              partition: 'aws',
+              'aws.partition': 'aws',
               'aws.service': 'S3',
               aws_service: 'S3',
               'aws.operation': 'listBuckets'
@@ -110,7 +110,7 @@ describe('Plugin', () => {
               component: 'aws-sdk',
               'aws.region': 'us-east-1',
               region: 'us-east-1',
-              partition: 'aws',
+              'aws.partition': 'aws',
               'aws.service': 'S3',
               aws_service: 'S3',
               'aws.operation': 'listBuckets'
@@ -237,7 +237,7 @@ describe('Plugin', () => {
               expect(span.meta).to.include({
                 'aws.region': region,
                 region,
-                partition
+                'aws.partition': partition
               })
 
               if (++completed === total) {


### PR DESCRIPTION
### What does this PR do?
Follow up from https://github.com/DataDog/dd-trace-js/pull/6432, aligned internally that the partition tag should have the `aws.partition` key.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


