### PR TITLE
chore(deps-dev): limit rimraf to <=3.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,9 @@ updates:
       - dependency-name: "@opentelemetry/core"
         # 2.0.0 onwards only supports Node.js 18.19.0 and above
         update-types: ["version-update:semver-major"]
+      - dependency-name: "rimraf"
+        # 4.0.0 onwards no longer supports an API where we can pass in an fs implementation
+        update-types: ["version-update:semver-major"]
     groups:
       dev-minor-and-patch-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
### What does this PR do?

Instruct Dependabot to never upgrade `rimraf` past the v3 major.

### Motivation

Version 4 of rimraf no longer supports a custom file system, which we rely on in one of our tests.

