### PR TITLE
test: use fs.rm instead of rimraf

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -62,7 +62,6 @@ dev,nock,MIT,Copyright 2017 Pedro Teixeira and other contributors
 dev,nyc,ISC,Copyright 2015 Contributors
 dev,octokit,MIT,Copyright 2023 Octokit contributors
 dev,proxyquire,MIT,Copyright 2013 Thorsten Lorenz
-dev,rimraf,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,semver,ISC,Copyright Isaac Z. Schlueter and Contributors
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen
 dev,sinon-chai,WTFPL and BSD-2-Clause,Copyright 2004 Sam Hocevar 2012–2017 Domenic Denicola

--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -65,7 +65,6 @@ if (Number(process.env.EVERYTHING)) {
     'proxyquire',
     'retry',
     'rfdc',
-    'rimraf',
     'semifies',
     'semver',
     'shell-quote',

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -11,7 +11,6 @@ const { builtinModules } = require('module')
 const os = require('os')
 const path = require('path')
 const assert = require('assert')
-const rimraf = promisify(require('rimraf'))
 const FakeAgent = require('./fake-agent')
 const id = require('../../packages/dd-trace/src/id')
 const { version } = require('../../package.json')
@@ -270,7 +269,7 @@ async function createSandbox (dependencies = [], isGitRepo = false,
 
   return {
     folder,
-    remove: async () => rimraf(folder)
+    remove: async () => fs.rm(folder, { force: true, recursive: true })
   }
 }
 

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -269,7 +269,15 @@ async function createSandbox (dependencies = [], isGitRepo = false,
 
   return {
     folder,
-    remove: async () => fs.rm(folder, { force: true, recursive: true })
+    remove: () => {
+      // Use `exec` below, instead of `fs.rm` to keep support for older Node.js versions, since this code is called in
+      // our `integration-guardrails` GitHub Actions workflow
+      if (process.platform === 'win32') {
+        return exec(`Remove-Item -Recurse -Path "${folder}"`, { shell: 'powershell.exe' })
+      } else {
+        return exec(`rm -rf ${folder}`)
+      }
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
     "nyc": "^15.1.0",
     "octokit": "^5.0.3",
     "proxyquire": "^2.1.3",
-    "rimraf": "^3.0.2",
     "semver": "^7.7.2",
     "sinon": "^18.0.1",
     "sinon-chai": "^3.7.0",

--- a/packages/datadog-plugin-fs/test/index.spec.js
+++ b/packages/datadog-plugin-fs/test/index.spec.js
@@ -3,7 +3,6 @@
 const { expect } = require('chai')
 const { channel } = require('dc-polyfill')
 const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
-const rimraf = require('rimraf')
 
 const util = require('node:util')
 const os = require('node:os')
@@ -90,7 +89,7 @@ describe('Plugin', () => {
     })
 
     after((done) => {
-      rimraf(tmpdir, realFS, done)
+      realFS.rm(tmpdir, { force: true, recursive: true }, done)
       delete plugins.fs
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4072,7 +4072,7 @@ rfdc@^1.4.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
### What does this PR do?

As the title says...

### Motivation

This feature is now part of Node.js core - no need to rely on an external dependency any more.

