### PR TITLE
test: simplify vary test helper

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -275,6 +275,18 @@ async function createSandbox (dependencies = [], isGitRepo = false,
 }
 
 /**
+ * @typedef {{ default: string, star: string, destructure: string }} Variants
+ */
+/**
+ * @overload
+ * @param {object} sandbox - A `sandbox` as returned from `createSandbox`
+ * @param {string} filename - The file that will be copied and modified for each variant.
+ * @param {string} bindingName - The binding name that will be use to bind to the packageName.
+ * @param {string} [namedVariant] - The name of the named variant to use.
+ * @param {string} [packageName] - The name of the package. If not provided, the binding name will be used.
+ * @returns {Variants} A map from variant names to resulting filenames
+ */
+/**
  * Creates a bunch of files based on an original file in sandbox. Useful for varying test files
  * without having to create a bunch of them yourself.
  *
@@ -284,39 +296,43 @@ async function createSandbox (dependencies = [], isGitRepo = false,
  *
  * @param {object} sandbox - A `sandbox` as returned from `createSandbox`
  * @param {string} filename - The file that will be copied and modified for each variant.
- * @param {object} variants - The variants. If empty then a default import style will be added
- * depending on the parameters passed through.
- * @param {object} bindingName - The binding name that will be use to bind to the packageName.
- * @param {object} namedVariant - The name of the named variant to use.
- * @param {object} packageName - The name of the package.
- * @returns {object} A map from variant names to resulting filenames
+ * @param {Variants} variants - The variants.
+ * @returns {Variants} A map from variant names to resulting filenames
  */
-function varySandbox (sandbox, filename, variants, bindingName, namedVariant, packageName) {
+function varySandbox (sandbox, filename, variants, namedVariant, packageName = variants) {
+  if (typeof variants === 'string') {
+    const bindingName = variants
+    variants = {
+      default: `import ${bindingName} from '${packageName}'`,
+      star: namedVariant
+        ? `import * as ${bindingName} from '${packageName}'`
+        : `import * as mod${bindingName} from '${packageName}'; const ${bindingName} = mod${bindingName}.default`,
+      destructure: namedVariant
+        ? `import { ${namedVariant} } from '${packageName}'; const ${bindingName} = { ${namedVariant} }`
+        : `import { default as ${bindingName}} from '${packageName}'`
+    }
+  }
+
   const origFileData = readFileSync(path.join(sandbox.folder, filename), 'utf8')
   const [prefix, suffix] = filename.split('.')
-  const variantFilenames = {}
-  packageName = packageName || bindingName
-  const defaultVariants = {
-    default: `import ${bindingName} from '${packageName}'`,
-    star: namedVariant
-      ? `import * as ${bindingName} from '${packageName}'`
-      : `import * as mod${bindingName} from '${packageName}'; const ${bindingName} = mod${bindingName}.default`,
-    destructure: namedVariant
-      ? `import { ${namedVariant} } from '${packageName}'; const ${bindingName} = { ${namedVariant} }`
-      : `import { default as ${bindingName}} from '${packageName}'`
-  }
-  variants = variants || defaultVariants
-  for (const variant in variants) {
+  const variantFilenames = /** @type {Variants} */ ({})
+
+  for (const [variant, value] of Object.entries(variants)) {
     const variantFilename = `${prefix}-${variant}.${suffix}`
     variantFilenames[variant] = variantFilename
     let newFileData = origFileData
     if (variant !== 'default') {
-      newFileData = origFileData.replace(variants.default, `${variants[variant]}`)
+      newFileData = origFileData.replace(variants.default, `${value}`)
     }
     writeFileSync(path.join(sandbox.folder, variantFilename), newFileData)
   }
   return variantFilenames
 }
+
+/**
+ * @type {string[]}
+ */
+varySandbox.variants = ['default', 'star', 'destructure']
 
 function telemetryForwarder (shouldExpectTelemetryPoints = true) {
   process.env.DD_TELEMETRY_FORWARDER_PATH =

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -318,7 +318,7 @@ function varySandbox (sandbox, filename, variants, namedVariant, packageName = v
   const variantFilenames = /** @type {Variants} */ ({})
 
   for (const [variant, value] of Object.entries(variants)) {
-    const variantFilename = `${prefix}-${variant}.${suffix}`
+    const variantFilename = `${prefix}-${variant}${suffix}`
     variantFilenames[variant] = variantFilename
     let newFileData = origFileData
     if (variant !== 'default') {

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -314,7 +314,7 @@ function varySandbox (sandbox, filename, variants, namedVariant, packageName = v
   }
 
   const origFileData = readFileSync(path.join(sandbox.folder, filename), 'utf8')
-  const [prefix, suffix] = filename.split('.')
+  const { name: prefix, ext: suffix } = path.parse(filename)
   const variantFilenames = /** @type {Variants} */ ({})
 
   for (const [variant, value] of Object.entries(variants)) {
@@ -332,7 +332,7 @@ function varySandbox (sandbox, filename, variants, namedVariant, packageName = v
 /**
  * @type {string[]}
  */
-varySandbox.variants = ['default', 'star', 'destructure']
+varySandbox.VARIANTS = ['default', 'star', 'destructure']
 
 function telemetryForwarder (shouldExpectTelemetryPoints = true) {
   process.env.DD_TELEMETRY_FORWARDER_PATH =

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -38,8 +38,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
-      it('is instrumented', async () => {
+    for (const variant of varySandbox.VARIANTS) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'amqplib@${version}'`], false,
         ['./packages/datadog-plugin-amqplib/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'amqplib', 'connect')
+      variants = varySandbox(sandbox, 'server.mjs', 'amqplib', 'connect')
     })
 
     after(async () => {
@@ -38,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'destructure', 'star']) {
+    for (const variant of varySandbox.variants) {
       it('is instrumented', async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -20,7 +20,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'bunyan@${version}'`], false,
         ['./packages/datadog-plugin-bunyan/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'bunyan')
+      variants = varySandbox(sandbox, 'server.mjs', 'bunyan')
     })
 
     after(async () => {
@@ -35,8 +35,8 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(
           sandbox.folder,
           variants[variant],

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -35,7 +35,7 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(
           sandbox.folder,

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'cassandra-driver@${version}'`], false, [
         './packages/datadog-plugin-cassandra-driver/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'cassandra-driver', 'Client')
+      variants = varySandbox(sandbox, 'server.mjs', 'cassandra-driver', 'Client')
     })
 
     after(async () => {
@@ -38,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'destructure', 'star']) {
+    for (const variant of varySandbox.variants) {
       it('is instrumented', async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -38,8 +38,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
-      it('is instrumented', async () => {
+    for (const variant of varySandbox.VARIANTS) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'connect@${version}'`], false, [
         './packages/datadog-plugin-connect/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'connect')
+      variants = varySandbox(sandbox, 'server.mjs', 'connect')
     })
 
     after(async () => {
@@ -38,8 +38,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port)
 
         return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -38,7 +38,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port)
 

--- a/packages/datadog-plugin-dns/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-dns/test/integration-test/client.spec.js
@@ -36,7 +36,7 @@ describe('esm', () => {
   })
 
   context('dns', () => {
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-dns/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-dns/test/integration-test/client.spec.js
@@ -19,7 +19,7 @@ describe('esm', () => {
     this.timeout(20000)
     sandbox = await createSandbox([], false, [
       './packages/datadog-plugin-dns/test/integration-test/*'])
-    variants = varySandbox(sandbox, 'server.mjs', null, 'dns', 'lookup')
+    variants = varySandbox(sandbox, 'server.mjs', 'dns', 'lookup')
   })
 
   after(async () => {
@@ -36,8 +36,8 @@ describe('esm', () => {
   })
 
   context('dns', () => {
-    for (const variant of ['default', 'star', 'destructure']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'@elastic/elasticsearch@${version}'`], false, [
         './packages/datadog-plugin-elasticsearch/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'elasticsearch', null, '@elastic/elasticsearch')
+      variants = varySandbox(sandbox, 'server.mjs', 'elasticsearch', undefined, '@elastic/elasticsearch')
     })
 
     after(async () => {
@@ -37,8 +37,8 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -37,7 +37,7 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -38,9 +38,9 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       describe('with DD_TRACE_MIDDLEWARE_TRACING_ENABLED unset', () => {
-        it('is instrumented', async () => {
+        it(`is instrumented loaded with ${variant}`, async () => {
           proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port)
           const numberOfSpans = semver.intersects(version, '<5.0.0') ? 4 : 2
           const whichMiddleware = semver.intersects(version, '<5.0.0')

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -22,7 +22,7 @@ describe('esm', () => {
       this.timeout(50000)
       sandbox = await createSandbox([`'express@${version}'`], false,
         ['./packages/datadog-plugin-express/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'express')
+      variants = varySandbox(sandbox, 'server.mjs', 'express')
     })
 
     after(async function () {
@@ -38,7 +38,7 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of ['default', 'star', 'destructure']) {
+    for (const variant of varySandbox.variants) {
       describe('with DD_TRACE_MIDDLEWARE_TRACING_ENABLED unset', () => {
         it('is instrumented', async () => {
           proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port)

--- a/packages/datadog-plugin-http2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/integration-test/client.spec.js
@@ -37,7 +37,7 @@ describe('esm', () => {
   })
 
   context('http2', () => {
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port)
         const resultPromise = agent.assertMessageReceived(({ headers, payload }) => {

--- a/packages/datadog-plugin-http2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/integration-test/client.spec.js
@@ -19,7 +19,7 @@ describe('esm', () => {
     this.timeout(50000)
     sandbox = await createSandbox(['http2'], false, [
       './packages/datadog-plugin-http2/test/integration-test/*'])
-    variants = varySandbox(sandbox, 'server.mjs', null, 'http2', 'createServer')
+    variants = varySandbox(sandbox, 'server.mjs', 'http2', 'createServer')
   })
 
   after(async function () {
@@ -37,8 +37,8 @@ describe('esm', () => {
   })
 
   context('http2', () => {
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port)
         const resultPromise = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -20,7 +20,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'ioredis@${version}'`], false, [
         './packages/datadog-plugin-ioredis/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'ioredis')
+      variants = varySandbox(sandbox, 'server.mjs', 'ioredis')
     })
 
     after(async () => {
@@ -36,8 +36,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'star', 'destructure']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -36,7 +36,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -21,7 +21,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'limitd-client@${version}'`], false, [
         './packages/datadog-plugin-limitd-client/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'limitd-client')
+      variants = varySandbox(sandbox, 'server.mjs', 'limitd-client')
     })
 
     after(async () => {
@@ -36,7 +36,7 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of ['default', 'star', 'destructure']) {
+    for (const variant of varySandbox.variants) {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -36,8 +36,8 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of varySandbox.variants) {
-      it(`is instrumented ${variant}`, async () => {
+    for (const variant of varySandbox.VARIANTS) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -21,7 +21,7 @@ describe('esm', () => {
       this.timeout(30000)
       sandbox = await createSandbox([`'mongodb@${version}'`], false, [
         './packages/datadog-plugin-mongodb-core/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'mongodb', 'MongoClient')
+      variants = varySandbox(sandbox, 'server.mjs', 'mongodb', 'MongoClient')
     })
 
     after(async function () {
@@ -37,8 +37,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)
@@ -58,7 +58,7 @@ describe('esm', () => {
       this.timeout(30000)
       sandbox = await createSandbox([`'mongodb-core@${version}'`], false, [
         './packages/datadog-plugin-mongodb-core/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server2.mjs', null, 'MongoDBCore')
+      variants = varySandbox(sandbox, 'server2.mjs', 'MongoDBCore')
     })
 
     after(async function () {
@@ -74,8 +74,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -37,7 +37,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
@@ -74,7 +74,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -21,7 +21,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'mongoose@${version}'`], false, [
         './packages/datadog-plugin-mongoose/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'mongoose')
+      variants = varySandbox(sandbox, 'server.mjs', 'mongoose')
     })
 
     after(async () => {
@@ -36,8 +36,8 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of ['default', 'destructure', 'star']) {
-      it(`is instrumented ${variant}`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -36,7 +36,7 @@ describe('esm', () => {
       proc && proc.kill()
       await agent.stop()
     })
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -37,7 +37,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -21,7 +21,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'mysql@${version}'`], false, [
         './packages/datadog-plugin-mysql/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'mysql', 'createConnection')
+      variants = varySandbox(sandbox, 'server.mjs', 'mysql', 'createConnection')
     })
 
     after(async () => {
@@ -37,8 +37,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['star', 'default', 'destructure']) {
-      it('is instrumented', async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-net/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-net/test/integration-test/client.spec.js
@@ -19,7 +19,7 @@ describe('esm', () => {
     this.timeout(20000)
     sandbox = await createSandbox(['net'], false, [
       './packages/datadog-plugin-net/test/integration-test/*'])
-    variants = varySandbox(sandbox, 'server.mjs', null, 'net', 'createConnection')
+    variants = varySandbox(sandbox, 'server.mjs', 'net', 'createConnection')
   })
 
   after(async () => {
@@ -36,8 +36,8 @@ describe('esm', () => {
   })
 
   context('net', () => {
-    for (const variant of ['default', 'star', 'destructure']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-net/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-net/test/integration-test/client.spec.js
@@ -36,7 +36,7 @@ describe('esm', () => {
   })
 
   context('net', () => {
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -26,7 +26,7 @@ describe('esm', () => {
       sandbox = await createSandbox([`'next@${version}'`, 'react@^18.2.0', 'react-dom@^18.2.0'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'],
         'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build')
-      variants = varySandbox(sandbox, 'server.mjs', null, 'next')
+      variants = varySandbox(sandbox, 'server.mjs', 'next')
     })
 
     after(async () => {
@@ -42,8 +42,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'star', 'destructure']) {
-      it(`is instrumented ${variant}`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port, undefined, {
           NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`
         })

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -42,7 +42,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandbox.folder, variants[variant], agent.port, undefined, {
           NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -46,7 +46,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -46,8 +46,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'star', 'destructure']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.propertyVal(headers, 'host', `127.0.0.1:${agent.port}`)
           assert.isArray(payload)

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -36,7 +36,7 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of varySandbox.variants) {
+    for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(
           sandbox.folder,

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -20,7 +20,7 @@ describe('esm', () => {
       this.timeout(20000)
       sandbox = await createSandbox([`'pino@${version}'`],
         false, ['./packages/datadog-plugin-pino/test/integration-test/*'])
-      variants = varySandbox(sandbox, 'server.mjs', null, 'pino')
+      variants = varySandbox(sandbox, 'server.mjs', 'pino')
     })
 
     after(async () => {
@@ -36,8 +36,8 @@ describe('esm', () => {
       await agent.stop()
     })
 
-    for (const variant of ['default', 'star', 'destructure']) {
-      it(`is instrumented (${variant})`, async () => {
+    for (const variant of varySandbox.variants) {
+      it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(
           sandbox.folder,
           variants[variant],


### PR DESCRIPTION
This creates an overload for the vary helper to remove the need for an additional argument. It also improves the types and makes sure the entries do not have to be written out in the tests.