### PR TITLE
benchmark: do not skip failing require calls

### DIFF
--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -81,8 +81,6 @@ if (Number(process.env.EVERYTHING)) {
     'yarn-deduplicate'
   ]
   for (const pkg of packages) {
-    try {
-      require(pkg)
-    } catch {}
+    require(pkg)
   }
 }


### PR DESCRIPTION
Instead, just fail so that the entry will be removed from the list.