### PR TITLE
Update CODEOWNERS (rename apm-sdk-api to apm-sdk-capabilities)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,9 +49,9 @@
 /integration-tests/vitest/vitest.spec.js @DataDog/ci-app-libraries
 /integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
 /integration-tests/test-api-manual.spec.js @DataDog/ci-app-libraries
-/integration-tests/telemetry.spec.js @DataDog/apm-sdk-api-js
-/integration-tests/opentelemetry/ @DataDog/apm-sdk-api-js
-/integration-tests/remote_config.spec.js @DataDog/apm-sdk-api-js
+/integration-tests/telemetry.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js
+/integration-tests/remote_config.spec.js @DataDog/apm-sdk-capabilities-js
 
 /packages/dd-trace/src/service-naming/ @Datadog/apm-idm-js
 /packages/dd-trace/test/service-naming/ @Datadog/apm-idm-js
@@ -70,28 +70,28 @@
 /packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js @DataDog/ml-observability
 
 # API SDK
-/packages/dd-trace/src/telemetry/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/telemetry/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/config.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/config.spec.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/opentelemetry/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/opentelemetry/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/opentracing/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/opentracing/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/remote_config/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/remote_config/ @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/baggage.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/sampler.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/sampler.spec.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/priority_sampler.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/priority_sampler.spec.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/sampling_rule.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/sampling_rule.spec.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/src/span_sampler.js @DataDog/apm-sdk-api-js
-/packages/dd-trace/test/span_sampler.spec.js @DataDog/apm-sdk-api-js
+/packages/dd-trace/src/telemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/telemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/config.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/config.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/opentelemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/opentelemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/opentracing/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/opentracing/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/remote_config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/remote_config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/baggage.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/priority_sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/priority_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/sampling_rule.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/sampling_rule.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/span_sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/span_sampler.spec.js @DataDog/apm-sdk-capabilities-js
 
 # CI
-/.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-api-js
+/.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
 /.github/workflows/apm-integrations.yml @Datadog/apm-idm-js
 /.github/workflows/appsec.yml @DataDog/asm-js
 /.github/workflows/codeql-analysis.yml @DataDog/dd-trace-js


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Team name changed from API to Capabilities a while ago - this change is required to reflect this in Github teams

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


