### PR TITLE
chore(llmobs): add `ml_app` tag to llmobs enabled telemetry metric

### DIFF
--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -85,7 +85,8 @@ function recordLLMObsEnabled (startTime, config, value = 1) {
     error: 0,
     agentless: Number(config.llmobs.agentlessEnabled),
     site: config.site,
-    auto: Number(autoEnabled)
+    auto: Number(autoEnabled),
+    ml_app: config.llmobs.mlApp
   }
   llmobsMetrics.count('product_enabled', tags).inc(value)
   llmobsMetrics.distribution('init_time', tags).track(initTimeMs)


### PR DESCRIPTION
### What does this PR do?
Adds missing `ml_app` tag to the llm observability enabled telemetry metric event.

### Motivation
Better telemetry coverage for llm observability.

### Testing
Sent a couple telemetry events, with this showing
<img width="1321" height="299" alt="Screenshot 2025-09-25 at 12 51 07 PM" src="https://github.com/user-attachments/assets/2cabd602-cc88-4a94-b8d3-e19ca3bba2fd" />

