### PR TITLE
ci: move older Node.js versions to integration-guardrails-unsupported

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -307,7 +307,7 @@ jobs:
   integration-guardrails:
     strategy:
       matrix:
-        version: [14.0.0, 14, 16.0.0, 18.0.0, 20.0.0, 22.0.0, 24.0.0]
+        version: [18.0.0, 20.0.0, 22.0.0, 24.0.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -323,7 +323,7 @@ jobs:
   integration-guardrails-unsupported:
     strategy:
       matrix:
-        version: ['0.8', '0.10', '0.12', '4', '6', '8', '10', '12']
+        version: ['0.8', '0.10', '0.12', '4', '6', '8', '10', '12', '14', '16']
     runs-on: ubuntu-latest
     env:
       DD_TRACE_DEBUG: 'true' # This exercises more of the guardrails code


### PR DESCRIPTION
### What does this PR do?

Move Node.js versions no longer supported by the `dd-trace` project from the `integration-guardrails` section to the `integration-guardrails-unsupported` section.

### Motivation

Node.js version 14 and 16 have never been supported in the v5.x branch of the `dd-trace` project and should probably have been moved there a while ago.

