### PR TITLE
chore: fix script for running CI on a community PR

### DIFF
--- a/scripts/run-ci-on-community-pr.sh
+++ b/scripts/run-ci-on-community-pr.sh
@@ -37,15 +37,16 @@ git worktree add $WORKTREE_DIR
 cd $WORKTREE_DIR
 
 git fetch origin
-gh pr checkout $PR_ID
+gh pr checkout $PR_ID --repo DataDog/dd-trace-js
 git rebase --gpg-sign $BASE_COMMIT
 git push --force
 git push origin HEAD:$TEMP_BRANCH
 
 gh pr create \
+  --repo DataDog/dd-trace-js \
   --head $TEMP_BRANCH \
   --draft \
   --label "semver-patch" \
   --title "Temp: Run CI on community PR #$PR_ID" \
   --body "This is a temporary PR to allow running CI on the community PR #$PR_ID. It should be closed after CI has completed running."
-gh pr view $TEMP_BRANCH --web
+gh pr view $TEMP_BRANCH --web --repo DataDog/dd-trace-js


### PR DESCRIPTION
The script would under some circomstances fail for the `gh` command if it couldn't determine the remote repository. This has been fixed by hardcoding it.
    
This could happen if the PR ID passed to the script was from a repository already added as a remote in the local `.git/config`, in which case `gh` wouldn't know which one to use.
