### PR TITLE
chore: improve script for running CI on community PRs

### DIFF
--- a/scripts/run-ci-on-community-pr.sh
+++ b/scripts/run-ci-on-community-pr.sh
@@ -2,21 +2,51 @@
 
 set -euo pipefail
 
-PR_ID=${1:-}
+check_gh() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: GitHub CLI 'gh' is not installed. Install from https://cli.github.com and run 'gh auth login'."
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: GitHub CLI 'gh' is not authenticated. Run 'gh auth login' and ensure you can access the repository."
+    exit 1
+  fi
+  if ! gh api user >/dev/null 2>&1; then
+    echo "Error: 'gh' cannot access the GitHub API. Check your network or authentication."
+    exit 1
+  fi
+}
+
+ARG=${1:-}
+if [ "${ARG}" = "--check" ] || [ "${ARG}" = "-c" ]; then
+  check_gh
+  USER_LOGIN=$(gh api user --jq .login)
+  echo "GitHub CLI is installed and authenticated as: ${USER_LOGIN}"
+  exit 0
+fi
+
+PR_ID=${ARG}
 
 if [ -z "$PR_ID" ]; then
   echo "Usage: $0 <pr-id>"
+  echo "       $0 <options>"
   echo
   echo "This will:"
   echo "1. Rebase the PR with its target branch, with each contained commit signed."
   echo "2. Create a temporary PR to allow running CI on the community PR."
   echo
+  echo "Options:"
+  echo "  --check, -c        Verify GitHub CLI installation and authentication, then exit."
+  echo
   echo "Prerequisites:"
   echo "- You must have a GPG key configured to use with git."
   echo "- You must have write access to the PR."
+  echo "- You must have the GitHub CLI installed."
   echo
   exit 1
 fi
+
+check_gh
 
 GITHUB_USER=$(gh api user --jq .login)
 BASE_COMMIT=$(gh pr view $PR_ID --json baseRefOid --jq '.baseRefOid')


### PR DESCRIPTION
The script now checks if some of the most common issues related to the prerequisites are met before continuing.
    
A new `--check` option has also been added to check these prerequisites and then exit.
