### PR TITLE
chore: update sinon to v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "octokit": "^5.0.3",
     "proxyquire": "^2.1.3",
     "semver": "^7.7.2",
-    "sinon": "^18.0.1",
+    "sinon": "^21.0.0",
     "sinon-chai": "^3.7.0",
     "tap": "^16.3.10",
     "tiktoken": "^1.0.21",

--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -50,7 +50,9 @@ describe('Plugin', () => {
       })
 
       beforeEach(() => {
-        clock = sinon.useFakeTimers()
+        clock = sinon.useFakeTimers({
+          toFake: ['Date']
+        })
 
         const requiredModule = require(moduleRequirePath)
         const module = requiredModule.get()

--- a/packages/dd-trace/test/appsec/api_security_sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security_sampler.spec.js
@@ -14,7 +14,10 @@ describe('API Security Sampler', () => {
   let apiSecuritySampler, webStub, span, clock, performanceNowStub
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers({ now: 10 })
+    clock = sinon.useFakeTimers({
+      now: 10,
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
     performanceNowStub = sinon.stub(performance, 'now').callsFake(() => clock.now)
 
     webStub = {

--- a/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
+++ b/packages/dd-trace/test/appsec/iast/telemetry/logs.spec.js
@@ -14,7 +14,9 @@ describe('Telemetry logs', () => {
   let start, send
 
   before(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
   })
 
   after(() => {

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -30,7 +30,9 @@ describe('input message http requests', function () {
   let clock, send, request, jsonBuffer
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
 
     request = sinon.spy()
     request['@noCallThru'] = true

--- a/packages/dd-trace/test/debugger/devtools_client/source-maps.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/source-maps.spec.js
@@ -103,7 +103,9 @@ describe('source map utils', function () {
     let clock
 
     function setup () {
-      clock = sinon.useFakeTimers()
+      clock = sinon.useFakeTimers({
+        toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+      })
       readFileSync = sinon.stub().returns(rawSourceMap)
       readFile = sinon.stub().resolves(rawSourceMap)
 

--- a/packages/dd-trace/test/debugger/devtools_client/status.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/status.spec.js
@@ -25,7 +25,9 @@ describe('diagnostic message http requests', function () {
   ]
 
   beforeEach(function () {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
 
     request = sinon.spy()
     request['@noCallThru'] = true

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -597,7 +597,9 @@ describe('dogstatsd', () => {
     })
 
     it('should flush via interval', () => {
-      const clock = sinon.useFakeTimers()
+      const clock = sinon.useFakeTimers({
+        toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+      })
 
       client = new CustomMetrics({ dogstatsd: {} })
 

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -53,7 +53,9 @@ describe('sdk', () => {
     // remove max listener warnings, we don't care about the writer anyways
     process.removeAllListeners('beforeExit')
 
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
   })
 
   afterEach(() => {

--- a/packages/dd-trace/test/llmobs/writers/base.spec.js
+++ b/packages/dd-trace/test/llmobs/writers/base.spec.js
@@ -30,7 +30,9 @@ describe('BaseLLMObsWriter', () => {
       })
     })
 
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
 
     options = {
       endpoint: '/endpoint',

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -5,8 +5,6 @@ const { describe, it, beforeEach, afterEach } = require('tap').mocha
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const { setTimeout } = require('node:timers/promises')
-
 require('../setup/core')
 
 const SpaceProfiler = require('../../src/profiling/profilers/space')
@@ -46,7 +44,9 @@ describe('profiler', function () {
 
   function setUpProfiler () {
     interval = 65 * 1000
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
     exporterPromise = Promise.resolve()
     exporter = {
       export: sinon.stub().returns(exporterPromise)
@@ -208,7 +208,7 @@ describe('profiler', function () {
       clock.tick(interval)
 
       await rejected.catch(() => {})
-      await setTimeout(1)
+      await clock.tickAsync(1)
 
       sinon.assert.notCalled(wallProfiler.stop)
       sinon.assert.notCalled(spaceProfiler.stop)
@@ -225,7 +225,7 @@ describe('profiler', function () {
       clock.tick(interval)
 
       await rejected.catch(() => {})
-      await setTimeout(1)
+      await clock.tickAsync(1)
 
       sinon.assert.notCalled(wallProfiler.stop)
       sinon.assert.notCalled(spaceProfiler.stop)
@@ -330,7 +330,7 @@ describe('profiler', function () {
       clock.tick(interval)
 
       await waitForExport()
-      await setTimeout(1)
+      await clock.tickAsync(1)
 
       const [
         startWall,

--- a/packages/dd-trace/test/rate_limiter.spec.js
+++ b/packages/dd-trace/test/rate_limiter.spec.js
@@ -13,7 +13,9 @@ describe('RateLimiter', () => {
   let rateLimiter
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
   })
 
   afterEach(() => {

--- a/packages/dd-trace/test/rate_limiter.spec.js
+++ b/packages/dd-trace/test/rate_limiter.spec.js
@@ -14,7 +14,7 @@ describe('RateLimiter', () => {
 
   beforeEach(() => {
     clock = sinon.useFakeTimers({
-      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'hrtime']
     })
   })
 

--- a/packages/dd-trace/test/remote_config/scheduler.spec.js
+++ b/packages/dd-trace/test/remote_config/scheduler.spec.js
@@ -16,7 +16,9 @@ describe('Scheduler', () => {
   let scheduler
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
     stub = sinon.stub()
     scheduler = new Scheduler(stub, INTERVAL)
   })

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -204,7 +204,9 @@ function createGarbage (count = 50) {
           }
         }
 
-        clock = sinon.useFakeTimers()
+        clock = sinon.useFakeTimers({
+          toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+        })
 
         runtimeMetrics.start(config)
       })

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -429,7 +429,10 @@ describe('sampling rule', () => {
         maxPerSecond: 1
       })
 
-      const clock = sinon.useFakeTimers(new Date())
+      const clock = sinon.useFakeTimers({
+        now: new Date(),
+        toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+      })
       expect(rule.sample(new SpanContext({ traceId: id() }))).to.equal(true)
       expect(rule.sample(new SpanContext({ traceId: id() }))).to.equal(false)
       clock.tick(1000)

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -431,7 +431,7 @@ describe('sampling rule', () => {
 
       const clock = sinon.useFakeTimers({
         now: new Date(),
-        toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+        toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'hrtime']
       })
       expect(rule.sample(new SpanContext({ traceId: id() }))).to.equal(true)
       expect(rule.sample(new SpanContext({ traceId: id() }))).to.equal(false)

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -260,7 +260,9 @@ describe('telemetry app-heartbeat', () => {
   let clock
 
   before(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
   })
 
   after(() => {
@@ -317,7 +319,9 @@ describe('Telemetry extended heartbeat', () => {
   let clock
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
   })
 
   afterEach(() => {
@@ -500,7 +504,9 @@ describe('Telemetry retry', () => {
   const HEARTBEAT_INTERVAL = 60000
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers()
+    clock = sinon.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+    })
     pluginsByName = {
       foo2: { _enabled: true },
       bar2: { _enabled: false }
@@ -896,7 +902,9 @@ describe('AVM OSS', () => {
     suite.forEach(({ scaValue, scaValueOrigin, testDescription }) => {
       describe(testDescription, () => {
         before((done) => {
-          clock = sinon.useFakeTimers()
+          clock = sinon.useFakeTimers({
+            toFake: ['Date', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval']
+          })
 
           storage('legacy').run({ noop: true }, () => {
             traceAgent = http.createServer(async (req, res) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,40 +744,27 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@sinonjs/commons@^3.0.0", "@sinonjs/commons@^3.0.1":
+"@sinonjs/commons@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
   integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@11.2.2":
-  version "11.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz#50063cc3574f4a27bd8453180a04171c85cc9699"
-  integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
-  dependencies:
-    "@sinonjs/commons" "^3.0.0"
-
-"@sinonjs/fake-timers@^13.0.1":
+"@sinonjs/fake-timers@^13.0.5":
   version "13.0.5"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz#36b9dbc21ad5546486ea9173d6bea063eb1717d5"
   integrity sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
-"@sinonjs/samsam@^8.0.0":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.2.tgz#e4386bf668ff36c95949e55a38dc5f5892fc2689"
-  integrity sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==
+"@sinonjs/samsam@^8.0.1":
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-8.0.3.tgz#eb6ffaef421e1e27783cc9b52567de20cb28072d"
+  integrity sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
-    lodash.get "^4.4.2"
     type-detect "^4.1.0"
-
-"@sinonjs/text-encoding@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz#282046f03e886e352b2d5f5da5eb755e01457f3f"
-  integrity sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==
 
 "@stylistic/eslint-plugin@^5.0.0":
   version "5.4.0"
@@ -1648,11 +1635,6 @@ diff@^4.0.1, diff@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
-diff@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.0.tgz#26ded047cd1179b78b9537d5ef725503ce1ae531"
-  integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
 diff@^7.0.0:
   version "7.0.0"
@@ -3088,11 +3070,6 @@ jszip@^3.10.1:
     readable-stream "~2.3.6"
     setimmediate "^1.0.5"
 
-just-extend@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-6.2.0.tgz#b816abfb3d67ee860482e7401564672558163947"
-  integrity sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==
-
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -3162,11 +3139,6 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
-
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -3413,17 +3385,6 @@ negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
-
-nise@^6.0.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-6.1.1.tgz#78ea93cc49be122e44cb7c8fdf597b0e8778b64a"
-  integrity sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==
-  dependencies:
-    "@sinonjs/commons" "^3.0.1"
-    "@sinonjs/fake-timers" "^13.0.1"
-    "@sinonjs/text-encoding" "^0.7.3"
-    just-extend "^6.2.0"
-    path-to-regexp "^8.1.0"
 
 nock@^13.5.6:
   version "13.5.6"
@@ -3746,7 +3707,7 @@ path-to-regexp@^0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
-path-to-regexp@^8.0.0, path-to-regexp@^8.1.0:
+path-to-regexp@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-8.2.0.tgz#73990cc29e57a3ff2a0d914095156df5db79e8b4"
   integrity sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==
@@ -4308,17 +4269,16 @@ sinon-chai@^3.7.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.7.0.tgz#cfb7dec1c50990ed18c153f1840721cf13139783"
   integrity sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==
 
-sinon@^18.0.1:
-  version "18.0.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-18.0.1.tgz#464334cdfea2cddc5eda9a4ea7e2e3f0c7a91c5e"
-  integrity sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==
+sinon@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-21.0.0.tgz#dbda73abc7e6cb803fef3368cfbecbb5936e8a9e"
+  integrity sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
-    "@sinonjs/fake-timers" "11.2.2"
-    "@sinonjs/samsam" "^8.0.0"
-    diff "^5.2.0"
-    nise "^6.0.0"
-    supports-color "^7"
+    "@sinonjs/fake-timers" "^13.0.5"
+    "@sinonjs/samsam" "^8.0.1"
+    diff "^7.0.0"
+    supports-color "^7.2.0"
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -4510,7 +4470,7 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-supports-color@^7, supports-color@^7.1.0:
+supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==


### PR DESCRIPTION
Sinon now mocks more timers and thus, our tests fail in case they rely on some timers to continue to work as before.

This allows to potentially reduce test runtime in more places in the future, while the solution for now is to just limit the mocked APIs to the old ones.