### PR TITLE
test: remove get-port usage in grpc and molecular tests

### DIFF
--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('grpc', '@grpc/grpc-js', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader', 'get-port@^3.2.0'], false, [
+      sandbox = await createSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader'], false, [
         './packages/datadog-plugin-grpc/test/*'])
     })
 

--- a/packages/datadog-plugin-grpc/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-grpc/test/integration-test/server.mjs
@@ -2,13 +2,12 @@ import 'dd-trace/init.js'
 import * as grpc from '@grpc/grpc-js'
 import * as protoLoader from '@grpc/proto-loader'
 import path from 'path'
-import getPort from 'get-port'
 
 const currentDirectoryPath = path.dirname(new URL(import.meta.url).pathname)
 const parentDirectoryPath = path.resolve(currentDirectoryPath, '..')
 
 let server
-const port = await getPort()
+let port
 
 function buildClient (service, callback) {
   service = Object.assign(
@@ -28,8 +27,9 @@ function buildClient (service, callback) {
 
   return new Promise((resolve, reject) => {
     if (server.bindAsync) {
-      server.bindAsync(`127.0.0.1:${port}`, grpc.ServerCredentials.createInsecure(), (err) => {
+      server.bindAsync('127.0.0.1:0', grpc.ServerCredentials.createInsecure(), (err, boundPort) => {
         if (err) return reject(err)
+        port = boundPort
 
         server.addService(TestService.service, service)
         server.start()
@@ -37,7 +37,7 @@ function buildClient (service, callback) {
         resolve(new TestService(`127.0.0.1:${port}`, grpc.credentials.createInsecure()))
       })
     } else {
-      server.bind(`127.0.0.1:${port}`, grpc.ServerCredentials.createInsecure())
+      port = server.bind('127.0.0.1:0', grpc.ServerCredentials.createInsecure())
       server.addService(TestService.service, service)
       server.start()
 

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -16,11 +16,10 @@ const pkgs = nodeMajor > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
 describe('Plugin', () => {
   let grpc
-  let port
+  let port = 0
   let server
   let tracer
   let call
-  let getPort
 
   function buildClient (service, callback) {
     service = Object.assign({
@@ -38,8 +37,9 @@ describe('Plugin', () => {
 
     return new Promise((resolve, reject) => {
       if (server.bindAsync) {
-        server.bindAsync(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure(), (err) => {
+        server.bindAsync('0.0.0.0:0', grpc.ServerCredentials.createInsecure(), (err, boundPort) => {
           if (err) return reject(err)
+          port = boundPort
 
           server.addService(TestService.service, service)
           server.start()
@@ -47,7 +47,7 @@ describe('Plugin', () => {
           resolve(new TestService(`localhost:${port}`, grpc.credentials.createInsecure()))
         })
       } else {
-        server.bind(`0.0.0.0:${port}`, grpc.ServerCredentials.createInsecure())
+        port = server.bind('0.0.0.0:0', grpc.ServerCredentials.createInsecure())
         server.addService(TestService.service, service)
         server.start()
 
@@ -56,16 +56,9 @@ describe('Plugin', () => {
     })
   }
 
-  before(async () => {
-    getPort = (await import('get-port')).default
-  })
-
   describe('grpc/server', () => {
     beforeEach(() => {
       call = null
-      return getPort().then(newPort => {
-        port = newPort
-      })
     })
 
     afterEach(() => {

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('moleculer', 'moleculer', '>0.14.0', version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([`'moleculer@${version}'`, 'get-port'], false, [
+      sandbox = await createSandbox([`'moleculer@${version}'`], false, [
         './packages/datadog-plugin-moleculer/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-moleculer/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-moleculer/test/integration-test/server.mjs
@@ -1,14 +1,11 @@
 import 'dd-trace/init.js'
 import { ServiceBroker } from 'moleculer'
-import getPort from 'get-port'
-
-const port = await getPort()
 
 const broker = new ServiceBroker({
   namespace: 'multi',
   nodeID: `server-${process.pid}`,
   logger: false,
-  transporter: `tcp://127.0.0.1:${port}/server-${process.pid}`
+  transporter: `tcp://127.0.0.1:0/server-${process.pid}`
 })
 
 broker.createService({


### PR DESCRIPTION
The tests instead rely on native port assignment.