### PR TITLE
chore: remove duplicate information in ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -523,7 +523,6 @@ export default [
     ]
   },
   {
-    name: 'mocha/recommended',
     ...eslintPluginMocha.configs.recommended,
     files: TEST_FILES
   },


### PR DESCRIPTION
The new version of the ESLint plugin `eslint-plugin-mocha` which was upgraded in PR #6541, now contains its own `name` property, so there's no reason to manually set it anymore.

