### PR TITLE
[test optimization] Fix issue with `jest.mock` and bypassed modules 

### DIFF
--- a/integration-tests/ci-visibility/jest-mock-bypass-require/logger.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/logger.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const winston = require('winston')
+
+module.exports = winston.createLogger({
+  level: 'info',
+  format: winston.format.simple(),
+  transports: [
+    new winston.transports.Console()
+  ]
+})

--- a/integration-tests/ci-visibility/jest-mock-bypass-require/winston-mock-test.js
+++ b/integration-tests/ci-visibility/jest-mock-bypass-require/winston-mock-test.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const winston = require('winston')
+const logger = require('./logger')
+
+jest.mock('winston', () => ({
+  createLogger: jest.fn(() => ({
+    info: jest.fn(),
+  })),
+  format: {
+    simple: jest.fn(() => ({}))
+  },
+  transports: {
+    Console: jest.fn()
+  }
+}))
+
+describe('winston mock test', () => {
+  it('should call winston.createLogger when mocked', () => {
+    logger.info('test')
+    expect(winston.createLogger).toHaveBeenCalledTimes(1)
+    expect(logger.info).toHaveBeenCalledTimes(1)
+  })
+})

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -88,7 +88,8 @@ describe('jest CommonJS', () => {
       'jest-jasmine2',
       'jest-environment-jsdom',
       '@happy-dom/jest-environment',
-      'office-addin-mock'
+      'office-addin-mock',
+      'winston'
     ], true)
     cwd = sandbox.folder
     startupTestFile = path.join(cwd, testFile)
@@ -4088,6 +4089,25 @@ describe('jest CommonJS', () => {
         })
         runImpactedTest(done, { isModified: true, isEfd: true, isNew: true })
       })
+    })
+  })
+
+  describe('winston mocking', () => {
+    it('should allow winston to be mocked and verify createLogger is called', async () => {
+      childProcess = exec(
+        runTestsWithCoverageCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: 'jest-mock-bypass-require/winston-mock-test',
+            SHOULD_CHECK_RESULTS: '1'
+          }
+        }
+      )
+
+      const [code] = await once(childProcess, 'exit')
+      assert.equal(code, 0, `Jest should pass but failed with code ${code}`)
     })
   })
 })


### PR DESCRIPTION
### What does this PR do?

* Check if the library has been mocked before bypassing jest's require module. 


### Motivation
If the user was using `jest.mock` to mock libraries that we instrument, such as `winston`, this resulted in the library not actually being mocked:

```javascript
const winston = require('winston')
const logger = require('./logger')

jest.mock('winston', () => ({
  createLogger: jest.fn(() => ({
    info: jest.fn(),
  })),
  format: {
    simple: jest.fn(() => ({}))
  },
  transports: {
    Console: jest.fn()
  }
}))

describe('winston mock test', () => {
  it('should call winston.createLogger when mocked', () => {
    logger.info('test')
    // !! this was not a mock before the change
    expect(winston.createLogger).toHaveBeenCalledTimes(1)
    expect(logger.info).toHaveBeenCalledTimes(1)
  })
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Integration tests.
