### PR TITLE
[test optimization] Test latest release of `jest`

### DIFF
--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -2286,7 +2286,7 @@ describe('jest CommonJS', () => {
       })
     })
 
-    it('works with happy-dom', (done) => {
+    it('works with happy-dom', async () => {
       // Tests from ci-visibility/test/ci-visibility-test-2.js will be considered new
       receiver.setKnownTests({
         jest: {
@@ -2347,17 +2347,15 @@ describe('jest CommonJS', () => {
             ...getCiVisAgentlessConfig(receiver.port), // use agentless for this test, just for variety
             TESTS_TO_RUN: 'test/ci-visibility-test',
             ENABLE_HAPPY_DOM: 'true',
-            DD_TRACE_DEBUG: '1',
-            DD_TRACE_LOG_LEVEL: 'warn'
           },
           stdio: 'inherit'
         }
       )
-      childProcess.on('exit', () => {
-        eventsPromise.then(() => {
-          done()
-        }).catch(done)
-      })
+
+      await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise
+      ])
     })
 
     it('disables early flake detection if known tests should not be requested', (done) => {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -621,9 +621,18 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 function getTestEnvironment (pkg, jestVersion) {
   if (pkg.default) {
     const wrappedTestEnvironment = getWrappedEnvironment(pkg.default, jestVersion)
-    pkg.default = wrappedTestEnvironment
-    pkg.TestEnvironment = wrappedTestEnvironment
-    return pkg
+    try {
+      pkg.default = wrappedTestEnvironment
+      pkg.TestEnvironment = wrappedTestEnvironment
+      return pkg
+    } catch (e) {
+      log.warn('Failed to assign the wrappedTestEnvironment to the pkg', e)
+      return {
+        ...pkg,
+        default: wrappedTestEnvironment,
+        TestEnvironment: wrappedTestEnvironment
+      }
+    }
   }
   return getWrappedEnvironment(pkg, jestVersion)
 }


### PR DESCRIPTION
### What does this PR do?
* Make sure latest happy dom changes work with us. 

### Motivation
Latest release of `jest`: https://github.com/jestjs/jest/releases/tag/v30.2.0 broke our integration tests: https://github.com/DataDog/dd-trace-js/actions/runs/18093612861/job/51480494062?pr=6553 from https://github.com/DataDog/dd-trace-js/pull/6553

### Plugin Checklist
Just check that today's tests pass