### PR TITLE
Added manual nightly workflow

### DIFF
--- a/.github/workflows/nightly-dispatch.yml
+++ b/.github/workflows/nightly-dispatch.yml
@@ -6,45 +6,50 @@ on:
       runApmIntegrations:
         description: 'APM Integration Tests'
         required: false
-        default: 'true'
+        default: true
+        type: boolean
       runApmCapabilities:
         description: 'APM Capabilities Tests'
         required: false
-        default: 'true'
+        default: true
+        type: boolean
       runLlmobs:
         description: 'LLM-OBS Tests'
         required: false
-        default: 'true'
+        default: true
+        type: boolean
       runPlatform:
         description: 'Platform Tests'
         required: false
-        default: 'true'
+        default: true
+        type: boolean
       runServerless:
         description: 'Serverless Tests'
         required: false
-        default: 'true'
+        default: true
+        type: boolean
 
 jobs:
   nightly:
     runs-on: ubuntu-latest
     steps:
       - uses: ./.github/workflows/apm-integrations
-        if: inputs.runApmIntegrations == 'true'
+        if: inputs.runApmIntegrations
         with:
           runNightly: 'true'
       - uses: ./.github/workflows/apm-capabilities
-        if: inputs.runApmCapabilities == 'true'
+        if: inputs.runApmCapabilities
         with:
           runNightly: 'true'
       - uses: ./.github/workflows/llmobs
-        if: inputs.runLlmobs == 'true'
+        if: inputs.runLlmobs
         with:
           runNightly: 'true'
       - uses: ./.github/workflows/platform
-        if: inputs.runPlatform == 'true'
+        if: inputs.runPlatform
         with:
           runNightly: 'true'
       - uses: ./.github/workflows/serverless
-        if: inputs.runServerless == 'true'
+        if: inputs.runServerless
         with:
           runNightly: 'true'

--- a/.github/workflows/nightly-dispatch.yml
+++ b/.github/workflows/nightly-dispatch.yml
@@ -1,0 +1,50 @@
+name: Nightly Testing
+
+on:
+  workflow_dispatch:
+    inputs:
+      runApmIntegrations:
+        description: 'APM Integration Tests'
+        required: false
+        default: 'true'
+      runApmCapabilities:
+        description: 'APM Capabilities Tests'
+        required: false
+        default: 'true'
+      runLlmobs:
+        description: 'LLM-OBS Tests'
+        required: false
+        default: 'true'
+      runPlatform:
+        description: 'Platform Tests'
+        required: false
+        default: 'true'
+      runServerless:
+        description: 'Serverless Tests'
+        required: false
+        default: 'true'
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/apm-integrations
+        if: inputs.runApmIntegrations == 'true'
+        with:
+          runNightly: 'true'
+      - uses: ./.github/workflows/apm-capabilities
+        if: inputs.runApmCapabilities == 'true'
+        with:
+          runNightly: 'true'
+      - uses: ./.github/workflows/llmobs
+        if: inputs.runLlmobs == 'true'
+        with:
+          runNightly: 'true'
+      - uses: ./.github/workflows/platform
+        if: inputs.runPlatform == 'true'
+        with:
+          runNightly: 'true'
+      - uses: ./.github/workflows/serverless
+        if: inputs.runServerless == 'true'
+        with:
+          runNightly: 'true'


### PR DESCRIPTION
### What does this PR do?
This PR introduces a new dispatch workflow that triggers other workflows using the workflow_call option. It's only objective is to add the main workflow dispatcher to our GitHub Actions CI dashboard, enabling the new action so it can later be triggered (for testing) by the full set of changes in PR #6501.

### Motivation
Testing changes on #6501 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


