### PR TITLE
test: fix rimraf being required due to merge timing conflict

### DIFF
--- a/integration-tests/ci-visibility/git-cache.spec.js
+++ b/integration-tests/ci-visibility/git-cache.spec.js
@@ -4,7 +4,6 @@ const { expect } = require('chai')
 const fs = require('fs')
 const path = require('path')
 const os = require('os')
-const rimraf = require('rimraf')
 const { execSync } = require('child_process')
 
 const { createSandbox } = require('../helpers')
@@ -59,8 +58,12 @@ describe('git-cache integration tests', () => {
   })
 
   afterEach(() => {
-    if (cacheDir && fs.existsSync(cacheDir)) {
-      rimraf.sync(cacheDir)
+    if (cacheDir) {
+      try {
+        fs.rmSync(cacheDir, { recursive: true })
+      } catch {
+        // Ignore, if none exists
+      }
     }
     process.env.DD_EXPERIMENTAL_TEST_OPT_GIT_CACHE_ENABLED = originalCacheEnabled
     process.env.DD_EXPERIMENTAL_TEST_OPT_GIT_CACHE_DIR = originalCacheDir


### PR DESCRIPTION
The rimraf module was removed and the tests did not rerun. Due to not yet having a merge queue, this slipped through.
