### PR TITLE
chore: Remove rule for Config Inversion Validate Local File Task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,8 +8,6 @@ stages:
   - macrobenchmarks-notify
 
 validate_supported_configurations_local_file:
-  rules:
-    - when: on_success
   extends: .validate_supported_configurations_local_file
   variables:
     LOCAL_JSON_PATH: "packages/dd-trace/src/supported-configurations.json"


### PR DESCRIPTION
### What does this PR do?
Previously, the CI was manually running `validate_supported_configurations_local_file` since         `DANGEROUSLY_SKIP_SHARED_PIPELINE_TESTS` was set to `true` in dd-trace-js and Config Inversion tasks skipped the tasks when `DANGEROUSLY_SKIP_SHARED_PIPELINE_TESTS=true`. This manual execution of the task is no longer needed following the removal of the restrictions of `DANGEROUSLY_SKIP_SHARED_PIPELINE_TESTS` in https://github.com/DataDog/libdatadog-build/pull/139.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


