### PR TITLE
enable pr gates for all benchmarks and make them faster

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -13,7 +13,7 @@ variables:
   tags: ["runner:apm-k8s-tweaked-metal"]
   image: $MICROBENCHMARKS_CI_IMAGE
   interruptible: true
-  timeout: 20m
+  timeout: 10m
   script:
     - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.yml --debug

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -7,17 +7,16 @@ include:
 .macrobenchmarks:
   stage: macrobenchmarks
   rules:
-    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
-      when: always
+    - when: always
     - when: manual
   tags: ["runner:apm-k8s-same-cpu"]
   needs: []
   interruptible: true
-  timeout: 1h
+  timeout: 10m
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:js-hapi
   script:
     # TODO: Revert to js/hapi after https://github.com/DataDog/benchmarking-platform/pull/199 is merged
-    - git clone --branch rochdev/parallel-experiments https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - git clone --branch js/hapi https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.$EXPERIMENT.yml --debug -t
   artifacts:
     name: "artifacts"
@@ -27,13 +26,13 @@ include:
     expire_in: 3 months
   variables:
     K6_OPTIONS_WARMUP_RATE: 500
-    K6_OPTIONS_WARMUP_DURATION: 1m
+    K6_OPTIONS_WARMUP_DURATION: 30s
     K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
     K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
     K6_OPTIONS_WARMUP_MAX_VUS: 4
 
     K6_OPTIONS_NORMAL_OPERATION_RATE: 300
-    K6_OPTIONS_NORMAL_OPERATION_DURATION: 10m
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 3m
     K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 10s
     K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
     K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Enable PR gates for all benchmarks and make them faster.

### Motivation
<!-- What inspired you to submit this pull request? -->

Pre-release gates only exist because benchmarks are slow. By making them fast enough, we can now run them on PRs instead of only at release time, thus ensuring that our code is stable before merging and preparing for release.