### PR TITLE
chore(lint): fix rimraf eslint suggestion

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -389,7 +389,7 @@ export default [
         },
         {
           name: 'rimraf',
-          message: 'Please use fs.rm(path, { recursive: true }) instead.'
+          message: 'Please use fs.rm(path, { recursive: true, force: true }) instead.'
         },
         {
           name: 'koalas',


### PR DESCRIPTION
### What does this PR do?

Updates the recommended way to use `fs.rm` as an alternative to `rimraf`

### Motivation

This was just added in #6568, but the `force` options was left out.
