### PR TITLE
Remove the APP_KEY config property from telemetry

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -286,6 +286,7 @@ class Config {
     checkIfBothOtelAndDdEnvVarSet()
 
     const DD_API_KEY = getEnvironmentVariable('DD_API_KEY')
+    const DD_APP_KEY = getEnvironmentVariable('DD_APP_KEY')
 
     if (getEnvironmentVariable('DD_TRACE_PROPAGATION_STYLE') && (
       getEnvironmentVariable('DD_TRACE_PROPAGATION_STYLE_INJECT') ||
@@ -338,6 +339,7 @@ class Config {
 
     // TODO: refactor
     this.apiKey = DD_API_KEY
+    this.appKey = DD_APP_KEY
 
     // sent in telemetry event app-started
     this.installSignature = {
@@ -495,7 +497,6 @@ class Config {
       DD_API_SECURITY_ENDPOINT_COLLECTION_ENABLED,
       DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT,
       DD_APM_TRACING_ENABLED,
-      DD_APP_KEY,
       DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE,
       DD_APPSEC_COLLECT_ALL_HEADERS,
       DD_APPSEC_ENABLED,
@@ -654,7 +655,6 @@ class Config {
       DD_APM_TRACING_ENABLED ??
         (DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED && isFalse(DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED))
     )
-    this._setString(env, 'appKey', DD_APP_KEY)
     this._setBoolean(env, 'appsec.apiSecurity.enabled', DD_API_SECURITY_ENABLED && isTrue(DD_API_SECURITY_ENABLED))
     env['appsec.apiSecurity.sampleDelay'] = maybeFloat(DD_API_SECURITY_SAMPLE_DELAY)
     this._setBoolean(env, 'appsec.apiSecurity.endpointCollectionEnabled',

--- a/packages/dd-trace/src/config_defaults.js
+++ b/packages/dd-trace/src/config_defaults.js
@@ -27,7 +27,6 @@ const service = AWS_LAMBDA_FUNCTION_NAME ||
 
 module.exports = {
   apmTracingEnabled: true,
-  appKey: undefined,
   'appsec.apiSecurity.enabled': true,
   'appsec.apiSecurity.sampleDelay': 30,
   'appsec.apiSecurity.endpointCollectionEnabled': true,

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -371,7 +371,6 @@ describe('Config', () => {
 
     expect(updateConfig.getCall(0).args[0]).to.deep.include.members([
       { name: 'apmTracingEnabled', value: true, origin: 'default' },
-      { name: 'appKey', value: undefined, origin: 'default' },
       { name: 'appsec.apiSecurity.enabled', value: true, origin: 'default' },
       { name: 'appsec.apiSecurity.sampleDelay', value: 30, origin: 'default' },
       { name: 'appsec.apiSecurity.endpointCollectionEnabled', value: true, origin: 'default' },
@@ -798,7 +797,6 @@ describe('Config', () => {
 
     expect(updateConfig.getCall(0).args[0]).to.deep.include.members([
       { name: 'apmTracingEnabled', value: false, origin: 'env_var' },
-      { name: 'appKey', value: 'myAppKey', origin: 'env_var' },
       { name: 'appsec.apiSecurity.enabled', value: true, origin: 'env_var' },
       { name: 'appsec.apiSecurity.sampleDelay', value: 25, origin: 'env_var' },
       { name: 'appsec.apiSecurity.endpointCollectionEnabled', value: false, origin: 'env_var' },


### PR DESCRIPTION
### What does this PR do?
Ensures the APP_KEY is not captured or transmitted through telemetry.

### Motivation
The `APP_KEY` must be handled like the `API_KEY` and must never be shared or transmitted via telemetry.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.
- [x] Benchmarks.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [x] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


