### PR TITLE
[test optimization] Fix cypress tests in release branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "6.0.0-pre",
+  "version": "5.0.0",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.0.0",
+  "version": "6.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/dd-trace/src/pkg.js
+++ b/packages/dd-trace/src/pkg.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const fs = require('node:fs')
-const path = require('node:path')
+const fs = require('fs')
+const path = require('path')
 
 function findRoot () {
   return require.main && require.main.filename


### PR DESCRIPTION
### What does this PR do?
* Do not use `node:fs` or `node:path` which is not available in node 12.

### Motivation

Fix v5 release line: https://github.com/DataDog/dd-trace-js/actions/runs/18219849736/job/51878362098?pr=6591

v5 still supports an old version of cypress which comes with a node.js 12 bundled. This commit is in the path of the cypress plugin so it broke it: https://github.com/DataDog/dd-trace-js/pull/6447/files#diff-b68f3948a41121c6d97bf4211aa4490bfb5c546da690dcd9e8017870cd26ca03R3

