### PR TITLE
chore(dev-deps): don't upgrade tap major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,9 @@ updates:
       - dependency-name: "@opentelemetry/core"
         # 2.0.0 onwards only supports Node.js 18.19.0 and above
         update-types: ["version-update:semver-major"]
+      - dependency-name: "tap"
+        # Contain breaking changes that are incompatible with our test usage
+        update-types: ["version-update:semver-major"]
     groups:
       dev-minor-and-patch-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
### What does this PR do?

Add `tap` major versions to the Dependabot ignore list.

### Motivation

It contains breaking changes that are incompatible with the requirements for our tests
