### PR TITLE
[test optimization] Improve flakiness of test optimization tests

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1561,7 +1561,7 @@ moduleTypes.forEach(({
             assert.equal(neverPassingTest.filter(
               test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
             ).length, 5)
-          })
+          }, 30000)
 
         const {
           NODE_OPTIONS, // NODE_OPTIONS dd-trace config does not work with cypress

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:integration:playwright": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/playwright/*.spec.js\"",
     "test:integration:selenium": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/selenium/*.spec.js\"",
     "test:integration:vitest": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/vitest/*.spec.js\"",
-    "test:integration:testopt": "mocha --timeout 60000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/ci-visibility/*.spec.js\"",
+    "test:integration:testopt": "mocha --timeout 90000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/ci-visibility/*.spec.js\"",
     "test:integration:profiler": "mocha --timeout 180000 -r \"packages/dd-trace/test/setup/core.js\" \"integration-tests/profiler/*.spec.js\"",
     "test:integration:plugins": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/integration-test/**/*.spec.js\"",
     "test:unit:plugins": "mocha -r \"packages/dd-trace/test/setup/mocha.js\" \"packages/datadog-instrumentations/test/@($(echo $PLUGINS)).spec.js\" \"packages/datadog-plugin-@($(echo $PLUGINS))/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@($(echo $PLUGINS))/test/integration-test/**/*.spec.js\"",


### PR DESCRIPTION
### What does this PR do?

* Increase the time to gather events for `flaky test retries retries flaky test` test in cypress test suite: this has been failing a while lately and the most likely explanation is that cypress is just too slow. 
* Increase timeout for `testopt` tests: some `before all` hooks (where the installation of dependencies happens) have been failing. There's no other solution than to wait a bit more for the installation to finish.


### Motivation

Flakiness has gone up lately

### Plugin Checklist
Just make sure tests are still passing. 