### PR TITLE
fix: set DD_RUNTIME_METRICS_ENABLED to true on runtime metrics benchmarks

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -85,6 +85,7 @@ only-tracing-with-runtime-metrics-enabled:
   extends: .macrobenchmarks
   variables:
     DD_BENCHMARKS_CONFIGURATION: only-tracing-with-runtime-metrics-enabled
+    DD_RUNTIME_METRICS_ENABLED: "true"
     # Must be set to ensure consistent benchmark result naming and tagging
     CI_JOB_NAME: only-tracing-with-runtime-metrics-enabled
   parallel:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set `DD_RUNTIME_METRICS_ENABLED` to `true` on `only-tracing-with-runtime-metrics-enabled`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Missing environment variable on `only-tracing-with-runtime-metrics-enabled` benchmarks after https://github.com/DataDog/dd-trace-js/pull/6564/files#diff-05f7ea9af0e08df9a622f062bf18b58f480884ad31a4e4e6839258486eb89e00L77.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


