### PR TITLE
adjust performance gate warning to 1% for low stddev scenarios

### DIFF
--- a/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
+++ b/.gitlab/benchmarks/bp-runner.fail-on-breach.yml
@@ -12,12 +12,12 @@ experiments:
           - name: normal_operation/only-tracing
             thresholds:
               - threshold: agg_http_req_duration_p50 < 2 ms
-                warning_range: 3
+                warning_range: 1
               - agg_http_req_duration_p99 < 15 ms
           - name: normal_operation/only-tracing-with-runtime-metrics-enabled
             thresholds:
               - threshold: agg_http_req_duration_p50 < 2 ms
-                warning_range: 3
+                warning_range: 1
               - agg_http_req_duration_p99 < 16 ms
           - name: high_load/only-tracing
             thresholds:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adjust performance gate warning to 1% for low standard deviation scenarios.

### Motivation
<!-- What inspired you to submit this pull request? -->

We get a lot of warnings because the standard deviation is really low and sometimes there is an outlier.