### PR TITLE
[test optimization] Improve flakiness for `plugin-mocha`

### DIFF
--- a/packages/datadog-plugin-mocha/test/index.spec.js
+++ b/packages/datadog-plugin-mocha/test/index.spec.js
@@ -79,7 +79,10 @@ const ASYNC_TESTS = [
   }
 ]
 
-describe('Plugin', () => {
+describe('Plugin', function () {
+  this.timeout(10000)
+  this.retries(1)
+
   let Mocha
   withVersions('mocha', 'mocha', (version, _, specificVersion) => {
     afterEach(() => {


### PR DESCRIPTION
### What does this PR do?
* Increase timeout of `mocha` plugin tests.
* Add a single retry

### Motivation
It fails randomly and it's mostly with a timeout:

https://github.com/DataDog/dd-trace-js/actions/runs/18403397728/job/52437725221?pr=6615
https://github.com/DataDog/dd-trace-js/actions/runs/18283372667/job/52051815976
https://github.com/DataDog/dd-trace-js/actions/runs/18215338408/job/51863321758
https://github.com/DataDog/dd-trace-js/actions/runs/18199143517/job/51815095166
https://github.com/DataDog/dd-trace-js/actions/runs/18199143517/job/51813283822
https://github.com/DataDog/dd-trace-js/actions/runs/18195607013/job/51800930790
https://github.com/DataDog/dd-trace-js/actions/runs/18096509406/job/51488682669

### Plugin Checklist
Just check that current jobs pass