### PR TITLE
feat: add OTLP metrics export support

### DIFF
--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_http_metric_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_http_metric_exporter.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const OtlpHttpExporterBase = require('../otlp/otlp_http_exporter_base')
+const OtlpTransformer = require('./otlp_transformer')
+
+/**
+ * @typedef {import('@opentelemetry/resources').Resource} Resource
+ */
+
+/**
+ * OtlpHttpMetricExporter exports metrics via OTLP over HTTP.
+ *
+ * This implementation follows the OTLP HTTP specification:
+ * https://opentelemetry.io/docs/specs/otlp/#otlphttp
+ *
+ * @class OtlpHttpMetricExporter
+ * @extends OtlpHttpExporterBase
+ */
+class OtlpHttpMetricExporter extends OtlpHttpExporterBase {
+  /**
+   * Creates a new OtlpHttpMetricExporter instance.
+   *
+   * @param {string} url - OTLP endpoint URL
+   * @param {string} headers - Additional HTTP headers as comma-separated key=value string
+   * @param {number} timeout - Request timeout in milliseconds
+   * @param {string} protocol - OTLP protocol (http/protobuf or http/json)
+   * @param {Resource} resource - Resource attributes
+   */
+  constructor (url, headers, timeout, protocol, resource) {
+    super(url, headers, timeout, protocol, '/v1/metrics', 'metrics')
+    this.transformer = new OtlpTransformer(resource, protocol)
+  }
+
+  /**
+   * Exports metrics via OTLP over HTTP.
+   *
+   * @param {Array} metrics - Array of metric data to export
+   * @param {Function} resultCallback - Callback function for export result
+   */
+  export (metrics, resultCallback) {
+    if (metrics.length === 0) {
+      resultCallback({ code: 0 })
+      return
+    }
+
+    const payload = this.transformer.transformMetrics(metrics)
+    this._sendPayload(payload, resultCallback)
+
+    // Count total data points across all metrics
+    let dataPointCount = 0
+    for (const metric of metrics) {
+      if (metric.data) {
+        dataPointCount += metric.data.length
+      }
+    }
+    this._recordTelemetry('otel.metric_data_points', dataPointCount)
+  }
+}
+
+module.exports = OtlpHttpMetricExporter

--- a/packages/dd-trace/src/opentelemetry/metrics/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/otlp_transformer.js
@@ -1,0 +1,255 @@
+'use strict'
+
+const OtlpTransformerBase = require('../otlp/otlp_transformer_base')
+const { getProtobufTypes } = require('../otlp/protobuf_loader')
+
+// Get the aggregation temporality enum
+const { protoAggregationTemporality } = getProtobufTypes()
+const AGGREGATION_TEMPORALITY_DELTA = protoAggregationTemporality.values.AGGREGATION_TEMPORALITY_DELTA
+
+/**
+ * OtlpTransformer transforms metrics to OTLP format.
+ *
+ * This implementation follows the OTLP Metrics Data Model specification:
+ * https://opentelemetry.io/docs/specs/otlp/#metrics-data-model
+ *
+ * @class OtlpTransformer
+ * @extends OtlpTransformerBase
+ */
+class OtlpTransformer extends OtlpTransformerBase {
+  /**
+   * Creates a new OtlpTransformer instance.
+   *
+   * @param {import('@opentelemetry/api').Attributes} resourceAttributes - Resource attributes
+   * @param {string} protocol - OTLP protocol (http/protobuf or http/json)
+   */
+  constructor (resourceAttributes, protocol) {
+    super(resourceAttributes, protocol, 'metrics')
+  }
+
+  /**
+   * Transforms metrics to OTLP format based on the configured protocol.
+   * @param {Array} metrics - Array of metric data to transform
+   * @returns {Buffer} Transformed metrics in the appropriate format
+   */
+  transformMetrics (metrics) {
+    if (this.protocol === 'http/json') {
+      return this.#transformToJson(metrics)
+    }
+    return this.#transformToProtobuf(metrics)
+  }
+
+  /**
+   * Transforms metrics to protobuf format.
+   * @param {Array} metrics - Array of metrics to transform
+   * @returns {Buffer} Protobuf-encoded metrics
+   * @private
+   */
+  #transformToProtobuf (metrics) {
+    const { protoMetricsService } = getProtobufTypes()
+
+    const metricsData = {
+      resourceMetrics: [{
+        resource: this._transformResource(),
+        scopeMetrics: this.#transformScope(metrics),
+        schemaUrl: ''
+      }]
+    }
+
+    return this._serializeToProtobuf(protoMetricsService, metricsData)
+  }
+
+  /**
+   * Transforms metrics to JSON format.
+   * @param {Array} metrics - Array of metrics to transform
+   * @returns {Buffer} JSON-encoded metrics
+   * @private
+   */
+  #transformToJson (metrics) {
+    const metricsData = {
+      resourceMetrics: [{
+        resource: this._transformResource(),
+        scopeMetrics: this.#transformScope(metrics, true)
+      }]
+    }
+    return this._serializeToJson(metricsData)
+  }
+
+  /**
+   * Creates scope metrics grouped by instrumentation scope.
+   * @param {Array} metrics - Array of metrics to transform
+   * @param {boolean} isJson - Whether to format for JSON output
+   * @returns {Object[]} Array of scope metric objects
+   * @private
+   */
+  #transformScope (metrics, isJson = false) {
+    const groupedMetrics = this._groupByInstrumentationScope(metrics)
+    const scopeMetrics = []
+
+    for (const [key, metricsInScope] of groupedMetrics) {
+      const [name, version, schemaUrl] = key.split('@')
+
+      scopeMetrics.push({
+        scope: {
+          name,
+          version,
+          droppedAttributesCount: 0
+        },
+        schemaUrl,
+        metrics: metricsInScope.map(metric =>
+          isJson ? this.#transformMetricToJson(metric) : this.#transformMetric(metric)
+        )
+      })
+    }
+
+    return scopeMetrics
+  }
+
+  /**
+   * Transforms a single metric to protobuf format.
+   * @private
+   */
+  #transformMetric (metric) {
+    const result = {
+      name: metric.name,
+      description: metric.description || '',
+      unit: metric.unit || ''
+    }
+
+    if (metric.type === 'histogram') {
+      result.histogram = {
+        dataPoints: metric.data.map(dp => ({
+          attributes: this._transformAttributes(dp.attributes),
+          startTimeUnixNano: dp.startTimeUnixNano,
+          timeUnixNano: dp.timeUnixNano,
+          count: dp.count,
+          sum: dp.sum,
+          bucketCounts: dp.bucketCounts || [],
+          explicitBounds: dp.explicitBounds || [],
+          exemplars: [],
+          flags: 0,
+          min: dp.min,
+          max: dp.max
+        })),
+        aggregationTemporality: AGGREGATION_TEMPORALITY_DELTA
+      }
+    } else if (metric.type === 'counter') {
+      result.sum = {
+        dataPoints: metric.data.map(dp => this.#transformNumberDataPoint(dp)),
+        aggregationTemporality: AGGREGATION_TEMPORALITY_DELTA,
+        isMonotonic: true
+      }
+    } else if (metric.type === 'updowncounter') {
+      result.sum = {
+        dataPoints: metric.data.map(dp => this.#transformNumberDataPoint(dp)),
+        aggregationTemporality: AGGREGATION_TEMPORALITY_DELTA,
+        isMonotonic: false
+      }
+    } else if (metric.type === 'gauge') {
+      result.gauge = {
+        dataPoints: metric.data.map(dp => this.#transformNumberDataPoint(dp))
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Transforms a single metric to JSON format.
+   * @private
+   */
+  #transformMetricToJson (metric) {
+    const result = {
+      name: metric.name,
+      description: metric.description || '',
+      unit: metric.unit || ''
+    }
+
+    if (metric.type === 'histogram') {
+      result.histogram = {
+        dataPoints: metric.data.map(dp => ({
+          attributes: this._attributesToJson(dp.attributes),
+          startTimeUnixNano: String(dp.startTimeUnixNano),
+          timeUnixNano: String(dp.timeUnixNano),
+          count: String(dp.count),
+          sum: dp.sum,
+          bucketCounts: dp.bucketCounts?.map(String) || [],
+          explicitBounds: dp.explicitBounds || [],
+          min: dp.min,
+          max: dp.max
+        })),
+        aggregationTemporality: 'AGGREGATION_TEMPORALITY_DELTA'
+      }
+    } else if (metric.type === 'counter') {
+      result.sum = {
+        dataPoints: metric.data.map(dp => this.#numberDataPointToJson(dp)),
+        aggregationTemporality: 'AGGREGATION_TEMPORALITY_DELTA',
+        isMonotonic: true
+      }
+    } else if (metric.type === 'updowncounter') {
+      result.sum = {
+        dataPoints: metric.data.map(dp => this.#numberDataPointToJson(dp)),
+        aggregationTemporality: 'AGGREGATION_TEMPORALITY_DELTA',
+        isMonotonic: false
+      }
+    } else if (metric.type === 'gauge') {
+      result.gauge = {
+        dataPoints: metric.data.map(dp => this.#numberDataPointToJson(dp))
+      }
+    }
+
+    return result
+  }
+
+  /**
+   * Transforms a number data point to protobuf format.
+   * @private
+   */
+  #transformNumberDataPoint (dataPoint) {
+    const result = {
+      attributes: this._transformAttributes(dataPoint.attributes),
+      timeUnixNano: dataPoint.timeUnixNano,
+      exemplars: [],
+      flags: 0
+    }
+
+    if (dataPoint.startTimeUnixNano) {
+      result.startTimeUnixNano = dataPoint.startTimeUnixNano
+    }
+
+    // Determine if value is int or double
+    if (Number.isInteger(dataPoint.value)) {
+      result.asInt = dataPoint.value
+    } else {
+      result.asDouble = dataPoint.value
+    }
+
+    return result
+  }
+
+  /**
+   * Transforms a number data point to JSON format.
+   * @private
+   */
+  #numberDataPointToJson (dataPoint) {
+    const result = {
+      attributes: this._attributesToJson(dataPoint.attributes),
+      timeUnixNano: String(dataPoint.timeUnixNano)
+    }
+
+    if (dataPoint.startTimeUnixNano) {
+      result.startTimeUnixNano = String(dataPoint.startTimeUnixNano)
+    }
+
+    // Determine if value is int or double
+    if (Number.isInteger(dataPoint.value)) {
+      result.asInt = String(dataPoint.value)
+    } else {
+      result.asDouble = dataPoint.value
+    }
+
+    return result
+  }
+}
+
+module.exports = OtlpTransformer

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -1,0 +1,390 @@
+'use strict'
+
+const assert = require('assert')
+const { describe, it, beforeEach } = require('tap').mocha
+require('../setup/core')
+const OtlpTransformer = require('../../src/opentelemetry/metrics/otlp_transformer')
+const OtlpHttpMetricExporter = require('../../src/opentelemetry/metrics/otlp_http_metric_exporter')
+const { protoMetricsService } = require('../../src/opentelemetry/otlp/protobuf_loader').getProtobufTypes()
+
+describe('OpenTelemetry Metrics - OTLP Transform and Export', () => {
+  let transformer
+  let resourceAttributes
+
+  beforeEach(() => {
+    resourceAttributes = {
+      'service.name': 'test-service',
+      'service.version': '1.0.0',
+      'telemetry.sdk.name': 'dd-trace-js',
+      'telemetry.sdk.language': 'nodejs'
+    }
+  })
+
+  describe('OtlpTransformer', () => {
+    describe('Protobuf Protocol', () => {
+      beforeEach(() => {
+        transformer = new OtlpTransformer(resourceAttributes, 'http/protobuf')
+      })
+
+      it('transforms Counter metric to OTLP protobuf format', () => {
+        const metrics = [{
+          name: 'test.counter',
+          description: 'A test counter',
+          unit: 'operations',
+          type: 'counter',
+          instrumentationScope: {
+            name: 'test-meter',
+            version: '1.0.0',
+            schemaUrl: ''
+          },
+          data: [{
+            attributes: { environment: 'test' },
+            startTimeUnixNano: '1000000000',
+            timeUnixNano: '2000000000',
+            value: 42
+          }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        assert(Buffer.isBuffer(buffer), 'Should return a Buffer')
+
+        const decoded = protoMetricsService.decode(buffer)
+        const metric = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
+
+        assert.strictEqual(metric.name, 'test.counter')
+        assert.strictEqual(metric.description, 'A test counter')
+        assert.strictEqual(metric.unit, 'operations')
+        assert(metric.sum, 'Should have sum data')
+        assert.strictEqual(metric.sum.isMonotonic, true)
+        assert.strictEqual(metric.sum.dataPoints.length, 1)
+
+        const dataPoint = metric.sum.dataPoints[0]
+        const value = typeof dataPoint.asInt === 'object' ? dataPoint.asInt.toNumber() : dataPoint.asInt
+        assert.strictEqual(value, 42)
+      })
+
+      it('transforms UpDownCounter metric to OTLP protobuf format', () => {
+        const metrics = [{
+          name: 'test.updowncounter',
+          description: 'A test updowncounter',
+          unit: 'items',
+          type: 'updowncounter',
+          instrumentationScope: {
+            name: 'test-meter',
+            version: '1.0.0',
+            schemaUrl: ''
+          },
+          data: [{
+            attributes: { queue: 'main' },
+            startTimeUnixNano: '1000000000',
+            timeUnixNano: '2000000000',
+            value: -10
+          }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = protoMetricsService.decode(buffer)
+        const metric = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
+
+        assert.strictEqual(metric.name, 'test.updowncounter')
+        assert(metric.sum, 'Should have sum data')
+        assert.strictEqual(metric.sum.isMonotonic, false, 'UpDownCounter should not be monotonic')
+
+        const dataPoint = metric.sum.dataPoints[0]
+        const value = typeof dataPoint.asInt === 'object' ? dataPoint.asInt.toNumber() : dataPoint.asInt
+        assert.strictEqual(value, -10)
+      })
+
+      it('transforms Histogram metric to OTLP protobuf format', () => {
+        const metrics = [{
+          name: 'test.histogram',
+          description: 'A test histogram',
+          unit: 'ms',
+          type: 'histogram',
+          instrumentationScope: {
+            name: 'test-meter',
+            version: '1.0.0',
+            schemaUrl: ''
+          },
+          data: [{
+            attributes: { endpoint: '/api' },
+            startTimeUnixNano: '1000000000',
+            timeUnixNano: '2000000000',
+            count: 5,
+            sum: 250.5,
+            min: 10.5,
+            max: 100.0,
+            bucketCounts: [1, 2, 1, 1],
+            explicitBounds: [10, 50, 100]
+          }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = protoMetricsService.decode(buffer)
+        const metric = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
+
+        assert.strictEqual(metric.name, 'test.histogram')
+        assert(metric.histogram, 'Should have histogram data')
+        assert.strictEqual(metric.histogram.dataPoints.length, 1)
+
+        const dataPoint = metric.histogram.dataPoints[0]
+        const count = typeof dataPoint.count === 'object' ? dataPoint.count.toNumber() : dataPoint.count
+        assert.strictEqual(count, 5)
+        assert.strictEqual(dataPoint.sum, 250.5)
+        assert(Array.isArray(dataPoint.bucketCounts))
+        assert(Array.isArray(dataPoint.explicitBounds))
+      })
+
+      it('transforms Gauge metric to OTLP protobuf format', () => {
+        const metrics = [{
+          name: 'test.gauge',
+          description: 'A test gauge',
+          unit: 'percent',
+          type: 'gauge',
+          instrumentationScope: {
+            name: 'test-meter',
+            version: '1.0.0',
+            schemaUrl: ''
+          },
+          data: [{
+            attributes: { resource: 'cpu' },
+            timeUnixNano: '2000000000',
+            value: 75.5
+          }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = protoMetricsService.decode(buffer)
+        const metric = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
+
+        assert.strictEqual(metric.name, 'test.gauge')
+        assert(metric.gauge, 'Should have gauge data')
+        assert.strictEqual(metric.gauge.dataPoints.length, 1)
+
+        const dataPoint = metric.gauge.dataPoints[0]
+        assert.strictEqual(dataPoint.asDouble, 75.5)
+      })
+
+      it('validates OTLP resource structure', () => {
+        const metrics = [{
+          name: 'test.metric',
+          type: 'counter',
+          instrumentationScope: { name: 'test', version: '1.0.0', schemaUrl: '' },
+          data: [{ attributes: {}, timeUnixNano: '1000000000', value: 1 }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = protoMetricsService.decode(buffer)
+
+        assert(decoded.resourceMetrics, 'Should have resourceMetrics')
+        assert.strictEqual(decoded.resourceMetrics.length, 1)
+
+        const resource = decoded.resourceMetrics[0].resource
+        assert(resource, 'Should have resource')
+        assert(Array.isArray(resource.attributes), 'Should have resource attributes')
+
+        const serviceNameAttr = resource.attributes.find(attr => attr.key === 'service.name')
+        assert(serviceNameAttr, 'Should have service.name attribute')
+        assert.strictEqual(serviceNameAttr.value.stringValue, 'test-service')
+      })
+
+      it('validates scope metrics structure', () => {
+        const metrics = [{
+          name: 'test.metric',
+          type: 'counter',
+          instrumentationScope: {
+            name: 'custom-meter',
+            version: '2.0.0',
+            schemaUrl: 'https://example.com/schema'
+          },
+          data: [{ attributes: {}, timeUnixNano: '1000000000', value: 1 }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = protoMetricsService.decode(buffer)
+
+        const scopeMetrics = decoded.resourceMetrics[0].scopeMetrics
+        assert(Array.isArray(scopeMetrics))
+        assert.strictEqual(scopeMetrics.length, 1)
+
+        const scope = scopeMetrics[0].scope
+        assert.strictEqual(scope.name, 'custom-meter')
+        assert.strictEqual(scope.version, '2.0.0')
+      })
+
+      it('validates data point attributes', () => {
+        const metrics = [{
+          name: 'test.counter',
+          type: 'counter',
+          instrumentationScope: { name: 'test', version: '1.0.0', schemaUrl: '' },
+          data: [{
+            attributes: {
+              environment: 'production',
+              region: 'us-east-1',
+              count: 5
+            },
+            timeUnixNano: '1000000000',
+            value: 1
+          }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = protoMetricsService.decode(buffer)
+
+        const dataPoint = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0].sum.dataPoints[0]
+        assert(Array.isArray(dataPoint.attributes))
+
+        const envAttr = dataPoint.attributes.find(attr => attr.key === 'environment')
+        assert(envAttr)
+        assert.strictEqual(envAttr.value.stringValue, 'production')
+
+        const countAttr = dataPoint.attributes.find(attr => attr.key === 'count')
+        assert(countAttr)
+        const countValue = typeof countAttr.value.intValue === 'object'
+          ? countAttr.value.intValue.toNumber()
+          : countAttr.value.intValue
+        assert.strictEqual(countValue, 5)
+      })
+    })
+
+    describe('JSON Protocol', () => {
+      beforeEach(() => {
+        transformer = new OtlpTransformer(resourceAttributes, 'http/json')
+      })
+
+      it('transforms Counter metric to OTLP JSON format', () => {
+        const metrics = [{
+          name: 'test.counter',
+          description: 'A test counter',
+          unit: 'operations',
+          type: 'counter',
+          instrumentationScope: {
+            name: 'test-meter',
+            version: '1.0.0',
+            schemaUrl: ''
+          },
+          data: [{
+            attributes: { environment: 'test' },
+            startTimeUnixNano: '1000000000',
+            timeUnixNano: '2000000000',
+            value: 42
+          }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = JSON.parse(buffer.toString())
+        const metric = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
+
+        assert.strictEqual(metric.name, 'test.counter')
+        assert.strictEqual(metric.description, 'A test counter')
+        assert.strictEqual(metric.unit, 'operations')
+        assert(metric.sum)
+        assert.strictEqual(metric.sum.isMonotonic, true)
+        assert.strictEqual(metric.sum.dataPoints[0].asInt, '42')
+      })
+
+      it('validates JSON format structure', () => {
+        const metrics = [{
+          name: 'test.metric',
+          type: 'counter',
+          instrumentationScope: { name: 'test', version: '1.0.0', schemaUrl: '' },
+          data: [{ attributes: {}, timeUnixNano: '1000000000', value: 1 }]
+        }]
+
+        const buffer = transformer.transformMetrics(metrics)
+        const decoded = JSON.parse(buffer.toString())
+
+        assert(decoded.resourceMetrics)
+        assert(Array.isArray(decoded.resourceMetrics))
+        assert(decoded.resourceMetrics[0].resource)
+        assert(Array.isArray(decoded.resourceMetrics[0].scopeMetrics))
+      })
+    })
+
+    describe('Protocol Handling', () => {
+      it('defaults to protobuf protocol', () => {
+        transformer = new OtlpTransformer(resourceAttributes, 'http/protobuf')
+        assert.strictEqual(transformer.protocol, 'http/protobuf')
+      })
+
+      it('supports JSON protocol', () => {
+        transformer = new OtlpTransformer(resourceAttributes, 'http/json')
+        assert.strictEqual(transformer.protocol, 'http/json')
+      })
+
+      it('falls back to protobuf for gRPC protocol', () => {
+        transformer = new OtlpTransformer(resourceAttributes, 'grpc')
+        assert.strictEqual(transformer.protocol, 'http/protobuf')
+      })
+    })
+  })
+
+  describe('OtlpHttpMetricExporter', () => {
+    it('constructs with correct default path', () => {
+      const exporter = new OtlpHttpMetricExporter(
+        'http://localhost:4318/',
+        '',
+        10000,
+        'http/protobuf',
+        resourceAttributes
+      )
+
+      assert.strictEqual(exporter.options.hostname, 'localhost')
+      assert.strictEqual(exporter.options.port, '4318')
+      assert.strictEqual(exporter.options.path, '/v1/metrics')
+      assert.strictEqual(exporter.options.headers['Content-Type'], 'application/x-protobuf')
+    })
+
+    it('constructs with custom path', () => {
+      const exporter = new OtlpHttpMetricExporter(
+        'http://localhost:4318/custom/path',
+        '',
+        10000,
+        'http/protobuf',
+        resourceAttributes
+      )
+
+      assert.strictEqual(exporter.options.path, '/custom/path')
+    })
+
+    it('sets JSON content type for JSON protocol', () => {
+      const exporter = new OtlpHttpMetricExporter(
+        'http://localhost:4318/',
+        '',
+        10000,
+        'http/json',
+        resourceAttributes
+      )
+
+      assert.strictEqual(exporter.options.headers['Content-Type'], 'application/json')
+    })
+
+    it('parses additional headers correctly', () => {
+      const exporter = new OtlpHttpMetricExporter(
+        'http://localhost:4318/',
+        'api-key=secret123,x-custom=value',
+        10000,
+        'http/protobuf',
+        resourceAttributes
+      )
+
+      assert.strictEqual(exporter.options.headers['api-key'], 'secret123')
+      assert.strictEqual(exporter.options.headers['x-custom'], 'value')
+    })
+
+    it('handles empty metrics array', (done) => {
+      const exporter = new OtlpHttpMetricExporter(
+        'http://localhost:4318/',
+        '',
+        10000,
+        'http/protobuf',
+        resourceAttributes
+      )
+
+      exporter.export([], (result) => {
+        assert.strictEqual(result.code, 0)
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION


### What does this PR do?

- Add OtlpHttpMetricExporter extending base class
- Add metrics transformer supporting Counter, UpDownCounter, Histogram, Gauge
- Support protobuf and JSON protocols
- Add 17 comprehensive tests covering all metric types
- Enables OpenTelemetry Metrics API with Datadog SDKs

### Motivation

- ...

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


