### PR TITLE
fix: esbuild requirement for `@openfeature/core`

### DIFF
--- a/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
+++ b/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
@@ -13,10 +13,6 @@ module.exports = {
     '@datadog/native-iast-taint-tracking',
     '@datadog/native-iast-rewriter',
 
-    // @openfeature/core is a peer dependency of @openfeature/server-sdk
-    // which is used by @datadog/openfeature-node-server
-    '@openfeature/core',
-
     // required if you encounter graphql errors during the build step
     // see https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/#bundling
     'graphql/language/visitor',

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -115,6 +115,14 @@ module.exports.setup = function (build) {
       ${isSourceMapEnabled ? `globalThis.__DD_ESBUILD_BASEPATH = '${require('../dd-trace/src/util').ddBasePath}';` : ''}
 ${build.initialOptions.banner.js}`
   }
+
+  try {
+    require.resolve('@openfeature/core')
+  } catch (error) {
+    build.initialOptions.external ??= []
+    build.initialOptions.external.push('@openfeature/core')
+  }
+
   if (isESMBuild(build)) {
     if (!build.initialOptions.banner.js.includes('import { createRequire as $dd_createRequire } from \'module\'')) {
       build.initialOptions.banner.js = `import { createRequire as $dd_createRequire } from 'module';


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In esbuild plugin, when the dependecy `@openfeature/core` is not available, this is added to `externals` to prevent crashing build process when dependency is missing.

### Motivation
<!-- What inspired you to submit this pull request? -->
Prevent crashing build process when  `@openfeature/core` is missing.
