### PR TITLE
add merge option to flakiness script

### DIFF
--- a/scripts/flakiness.mjs
+++ b/scripts/flakiness.mjs
@@ -7,6 +7,7 @@ const {
   BRANCH,
   CI,
   DAYS = '1',
+  MERGE = 'true',
   OCCURRENCES = '1',
   UNTIL
 } = process.env
@@ -94,7 +95,8 @@ async function checkWorkflowJobs (id, page = 1) {
     if (job.conclusion !== 'failure') continue
 
     const workflow = job.workflow_name
-    const name = job.name.split(' ')[0] // Merge matrix runs of same job together.
+    // Merge matrix runs of same job together.
+    const name = MERGE === 'true' ? job.name.split(' ')[0] : job.name
 
     flaky[workflow] ??= {}
     flaky[workflow][name] ??= []


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add merge option to flakiness script.

### Motivation
<!-- What inspired you to submit this pull request? -->

Merging is great to know the job that was flaky instead of the specific matrix combination that was used which can be too specific. However, there are cases where the precise combination needs to be known for debugging purposes.