### PR TITLE
script: add script to rerun a workflow a specific number of times

### DIFF
--- a/scripts/rerun.js
+++ b/scripts/rerun.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Example to rerun the Serverless workflow 30 times on the current branch:
+// GITHUB_TOKEN=$(ddtool auth github token) WORKFLOW=Serverless node scripts/rerun
+
+const { execSync } = require('child_process')
+
+const {
+  ATTEMPTS = 30,
+  BRANCH,
+  INTERVAL = 600,
+  WORKFLOW
+} = process.env
+
+function rerun (current = 1) {
+  const branch = BRANCH || execSync('git rev-parse --abbrev-ref HEAD').toString().trim()
+  const result = execSync(`gh run ls -b ${branch} -w ${WORKFLOW}`).toString()
+  const id = result.match(/\d{11}/)[0]
+
+  execSync(`gh run rerun ${id} --repo DataDog/dd-trace-js || exit 0`)
+
+  if (current >= ATTEMPTS) return
+
+  setTimeout(() => rerun(current + 1), INTERVAL * 1000)
+}
+
+rerun()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add script to rerun a workflow a specific number of times.

### Motivation
<!-- What inspired you to submit this pull request? -->

Debugging flakiness can be difficult. This script allows rerunning a workflow many times with no user interaction to validate the frequency of the issue or a fix.

Example: https://github.com/DataDog/dd-trace-js/actions/runs/18574973811/job/53008454770?pr=6682