### PR TITLE
increase timeout for dynamo and event hubs

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
@@ -27,6 +27,7 @@ async function resetLocalStackDynamo () {
 describe('Plugin', () => {
   describe('aws-sdk (dynamodb)', function () {
     setup()
+    this.timeout(10000)
 
     withVersions('aws-sdk', ['aws-sdk', '@aws-sdk/smithy-client'], (version, moduleName) => {
       let tracer

--- a/packages/datadog-plugin-azure-event-hubs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-event-hubs/test/integration-test/client.spec.js
@@ -16,7 +16,7 @@ describe('esm', () => {
 
   withVersions('azure-event-hubs', '@azure/event-hubs', version => {
     before(async function () {
-      this.timeout(20000)
+      this.timeout(60000)
       sandbox = await createSandbox([`'@azure/event-hubs@${version}'`], false, [
         './packages/datadog-plugin-azure-event-hubs/test/integration-test/*'])
     })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase timeout for Dynamo and Event Hubs.

### Motivation
<!-- What inspired you to submit this pull request? -->

After rerunning the Serverless workflow 100 times, timeouts on those were the main failures (other than infrastructure).