### PR TITLE
fix race condition in kinesis tests by swallowing irrelevant errors

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -162,7 +162,7 @@ describe('Kinesis', function () {
           expect(span.meta).to.have.property('streamname', streamName)
         }).then(done, done)
 
-        helpers.putTestRecord(kinesis, streamName, helpers.dataBuffer, e => e && done(e))
+        helpers.putTestRecord(kinesis, streamName, helpers.dataBuffer, () => {})
       })
 
       describe('Disabled', () => {
@@ -260,9 +260,7 @@ describe('Kinesis', function () {
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
           if (err) return done(err)
 
-          helpers.getTestData(kinesis, streamNameDSM, data, (err) => {
-            if (err) return done(err)
-          })
+          helpers.getTestData(kinesis, streamNameDSM, data, () => {})
         })
       })
 
@@ -280,9 +278,7 @@ describe('Kinesis', function () {
           })
         }).then(done, done)
 
-        helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
-          if (err) return done(err)
-        })
+        helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, () => {})
       })
 
       it('emits DSM stats to the agent during Kinesis putRecord', done => {
@@ -300,9 +296,7 @@ describe('Kinesis', function () {
           expect(agent.dsmStatsExist(agent, expectedProducerHash)).to.equal(true)
         }, { timeoutMs: 10000 }).then(done, done)
 
-        helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
-          if (err) return done(err)
-        })
+        helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, () => {})
       })
 
       it('emits DSM stats to the agent during Kinesis getRecord', done => {
@@ -323,9 +317,7 @@ describe('Kinesis', function () {
         helpers.putTestRecord(kinesis, streamNameDSM, helpers.dataBuffer, (err, data) => {
           if (err) return done(err)
 
-          helpers.getTestData(kinesis, streamNameDSM, data, (err) => {
-            if (err) return done(err)
-          })
+          helpers.getTestData(kinesis, streamNameDSM, data, () => {})
         })
       })
 
@@ -349,9 +341,7 @@ describe('Kinesis', function () {
           if (err) return done(err)
 
           agent.reload('aws-sdk', { kinesis: { dsmEnabled: true } }, { dsmEnabled: true })
-          helpers.getTestData(kinesis, streamNameDSM, data, (err) => {
-            if (err) return done(err)
-          })
+          helpers.getTestData(kinesis, streamNameDSM, data, () => {})
         })
       })
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix race condition in kinesis tests by swallowing irrelevant errors.

### Motivation
<!-- What inspired you to submit this pull request? -->

Errors from the underlying connection to Kinesis are irrelevant for any tracing test, and they are likely since the stream is destroyed in the `afterEach` hook which could happen before the connection is closed once the test is done.