### PR TITLE
fix(ai): add support for AI SDK v5 token properties

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/ai/util.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/util.js
@@ -45,19 +45,24 @@ function getOperation (span) {
 
 /**
  * Get the LLM token usage from the span tags
+ * Supports both AI SDK v4 (promptTokens/completionTokens) and v5 (inputTokens/outputTokens)
  * @template T extends {inputTokens: number, outputTokens: number, totalTokens: number}
  * @param {T} tags
  * @returns {Pick<T, 'inputTokens' | 'outputTokens' | 'totalTokens'>}
  */
 function getUsage (tags) {
   const usage = {}
-  const inputTokens = tags['ai.usage.promptTokens']
-  const outputTokens = tags['ai.usage.completionTokens']
+
+  // AI SDK v5 uses inputTokens/outputTokens, v4 uses promptTokens/completionTokens
+  // Check v5 properties first, fall back to v4
+  const inputTokens = tags['ai.usage.inputTokens'] ?? tags['ai.usage.promptTokens']
+  const outputTokens = tags['ai.usage.outputTokens'] ?? tags['ai.usage.completionTokens']
 
   if (inputTokens != null) usage.inputTokens = inputTokens
   if (outputTokens != null) usage.outputTokens = outputTokens
 
-  const totalTokens = inputTokens + outputTokens
+  // v5 provides totalTokens directly, v4 requires computation
+  const totalTokens = tags['ai.usage.totalTokens'] ?? (inputTokens + outputTokens)
   if (!Number.isNaN(totalTokens)) usage.totalTokens = totalTokens
 
   return usage

--- a/packages/dd-trace/test/llmobs/plugins/ai/util.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/ai/util.spec.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const { expect } = require('chai')
+const { describe, it } = require('mocha')
+
+const { getUsage } = require('../../../../src/llmobs/plugins/ai/util')
+
+describe('AI Plugin Utils', () => {
+  describe('getUsage', () => {
+    it('should extract usage from v4 token properties', () => {
+      const tags = {
+        'ai.usage.promptTokens': 10,
+        'ai.usage.completionTokens': 20
+      }
+
+      const result = getUsage(tags)
+
+      expect(result).to.deep.equal({
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30
+      })
+    })
+
+    it('should extract usage from v5 token properties', () => {
+      const tags = {
+        'ai.usage.inputTokens': 10,
+        'ai.usage.outputTokens': 20,
+        'ai.usage.totalTokens': 30
+      }
+
+      const result = getUsage(tags)
+
+      expect(result).to.deep.equal({
+        inputTokens: 10,
+        outputTokens: 20,
+        totalTokens: 30
+      })
+    })
+
+    it('should prefer v5 properties over v4', () => {
+      const tags = {
+        'ai.usage.inputTokens': 15,
+        'ai.usage.promptTokens': 10,
+        'ai.usage.outputTokens': 25,
+        'ai.usage.completionTokens': 20,
+        'ai.usage.totalTokens': 40
+      }
+
+      const result = getUsage(tags)
+
+      expect(result).to.deep.equal({
+        inputTokens: 15,
+        outputTokens: 25,
+        totalTokens: 40
+      })
+    })
+  })
+})


### PR DESCRIPTION
> AI Disclosure: the large majority of this PR is generated and I couldn't find any existing coverage for this file, so I created a new test. 

AI SDK v5 renamed token usage properties from promptTokens/completionTokens to inputTokens/outputTokens/totalTokens. This was causing token metrics to not show up for streaming operations for users on v5.

The getUsage() function now checks for v5 properties first, then falls back to v4 for backwards compatibility:
- ai.usage.inputTokens (v5) → ai.usage.promptTokens (v4)
- ai.usage.outputTokens (v5) → ai.usage.completionTokens (v4)
- ai.usage.totalTokens (v5) → computed sum (v4)

See: https://ai-sdk.dev/docs/migration-guides/migration-guide-5-0#usage-token-properties

### What does this PR do?
Updates the AI plugin to support the v5 usage names

### Motivation
Streaming text wasn't showing any token metrics
