### PR TITLE
ci(langchain): update apm test to use classic langchain for in-memory vectorstore

### DIFF
--- a/packages/datadog-plugin-langchain/test/index.spec.js
+++ b/packages/datadog-plugin-langchain/test/index.spec.js
@@ -10,6 +10,8 @@ const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
 const isDdTrace = iastFilter.isDdTrace
 
+const semifies = require('semifies')
+
 describe('Plugin', () => {
   let langchainOpenai
   let langchainAnthropic
@@ -114,9 +116,15 @@ describe('Plugin', () => {
         langchainTools = require(`../../../versions/@langchain/core@${version}`)
           .get('@langchain/core/tools')
 
-        MemoryVectorStore = require(`../../../versions/@langchain/core@${version}`)
-          .get('langchain/vectorstores/memory')
-          .MemoryVectorStore
+        if (semifies(realVersion, '>=1.0')) {
+          MemoryVectorStore = require('../../../versions/@langchain/classic@>=1.0')
+            .get('@langchain/classic/vectorstores/memory')
+            .MemoryVectorStore
+        } else {
+          MemoryVectorStore = require(`../../../versions/langchain@${version}`)
+            .get('langchain/vectorstores/memory')
+            .MemoryVectorStore
+        }
       })
 
       describe('llm', () => {


### PR DESCRIPTION
### What does this PR do?
Follow-up on #6715, which forgot to update the APM test portion

### Motivation
Unblock dependabot update PRs.

### Testing
I also verified this change by checking out the dependabot branch to make these changes, and saw that all tests pass
