### PR TITLE
Update esbuild integration test dependency

### DIFF
--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -26,7 +26,7 @@ describe('esbuild support for IAST', () => {
       const craftedNodeModulesDir = path.join(applicationDir, 'tmp_node_modules')
       fs.mkdirSync(craftedNodeModulesDir)
       await exec('npm init -y', { cwd: craftedNodeModulesDir })
-      await exec('npm install @datadog/native-iast-rewriter @datadog/native-iast-taint-tracking', {
+      await exec('npm install @datadog/wasm-js-rewriter @datadog/native-iast-taint-tracking', {
         cwd: craftedNodeModulesDir,
         timeout: 3e3
       })

--- a/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
+++ b/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
@@ -11,7 +11,7 @@ module.exports = {
   target: ['node18'],
   external: [
     '@datadog/native-iast-taint-tracking',
-    '@datadog/native-iast-rewriter',
+    '@datadog/wasm-js-rewriter',
 
     // required if you encounter graphql errors during the build step
     // see https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/#bundling


### PR DESCRIPTION
### What does this PR do?
Update esbuild integration test dependency to replace `@datadog/wasm-js-rewriter` with `@datadog/native-iast-rewriter`

### Motivation

Remove deprecated dependency

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [x] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


