### PR TITLE
split sandbox between linked and isolated modes

### DIFF
--- a/integration-tests/aiguard/index.spec.js
+++ b/integration-tests/aiguard/index.spec.js
@@ -2,7 +2,7 @@
 
 const { describe, it, before, after } = require('mocha')
 const path = require('path')
-const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('../helpers')
 const startApiMock = require('./api-mock')
 const { expect } = require('chai')
 const { executeRequest } = require('./util')
@@ -12,7 +12,7 @@ describe('AIGuard SDK integration tests', () => {
 
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
-    sandbox = await createSandbox(['express'])
+    sandbox = await isolatedSandbox(['express'])
     cwd = sandbox.folder
     appFile = path.join(cwd, 'aiguard/server.js')
     api = await startApiMock()

--- a/integration-tests/appsec/data-collection.spec.js
+++ b/integration-tests/appsec/data-collection.spec.js
@@ -5,7 +5,7 @@ const path = require('path')
 const Axios = require('axios')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   FakeAgent,
   spawnProc
 } = require('../helpers')
@@ -14,7 +14,7 @@ describe('ASM Data collection', () => {
   let axios, sandbox, cwd, appFile, agent, proc
 
   before(async () => {
-    sandbox = await createSandbox(['express'])
+    sandbox = await isolatedSandbox(['express'])
     cwd = sandbox.folder
     appFile = path.join(cwd, 'appsec/data-collection/index.js')
   })

--- a/integration-tests/appsec/endpoints-collection.spec.js
+++ b/integration-tests/appsec/endpoints-collection.spec.js
@@ -5,7 +5,7 @@ const { describe, before, after, it } = require('mocha')
 
 const path = require('node:path')
 
-const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('../helpers')
 
 describe('Endpoints collection', () => {
   let sandbox, cwd
@@ -13,7 +13,7 @@ describe('Endpoints collection', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await isolatedSandbox(
       ['fastify'],
       false
     )

--- a/integration-tests/appsec/graphql.spec.js
+++ b/integration-tests/appsec/graphql.spec.js
@@ -6,7 +6,7 @@ const axios = require('axios')
 
 const {
   FakeAgent,
-  createSandbox,
+  isolatedSandbox,
   spawnProc
 } = require('../helpers')
 
@@ -14,7 +14,7 @@ describe('graphql', () => {
   let sandbox, cwd, agent, webFile, proc
 
   before(async function () {
-    sandbox = await createSandbox(['@apollo/server', 'graphql'])
+    sandbox = await isolatedSandbox(['@apollo/server', 'graphql'])
     cwd = sandbox.folder
     webFile = path.join(cwd, 'graphql/index.js')
   })

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -8,7 +8,7 @@ const path = require('path')
 const { promisify } = require('util')
 const msgpack = require('@msgpack/msgpack')
 
-const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('../helpers')
 
 const exec = promisify(childProcess.exec)
 
@@ -18,7 +18,7 @@ describe('esbuild support for IAST', () => {
     let applicationDir, bundledApplicationDir
 
     before(async () => {
-      sandbox = await createSandbox([])
+      sandbox = await isolatedSandbox([])
       const cwd = sandbox.folder
       applicationDir = path.join(cwd, 'appsec/iast-esbuild')
 

--- a/integration-tests/appsec/iast.esm-security-controls.spec.js
+++ b/integration-tests/appsec/iast.esm-security-controls.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, spawnProc, FakeAgent } = require('../helpers')
+const { isolatedSandbox, spawnProc, FakeAgent } = require('../helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -12,7 +12,7 @@ describe('ESM Security controls', () => {
     describe(`With express v${version}`, () => {
       before(async function () {
         this.timeout(process.platform === 'win32' ? 90000 : 30000)
-        sandbox = await createSandbox([`express@${version}`])
+        sandbox = await isolatedSandbox([`express@${version}`])
         cwd = sandbox.folder
         appFile = path.join(cwd, 'appsec', 'esm-security-controls', 'index.mjs')
       })

--- a/integration-tests/appsec/iast.esm.spec.js
+++ b/integration-tests/appsec/iast.esm.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, spawnProc, FakeAgent } = require('../helpers')
+const { isolatedSandbox, spawnProc, FakeAgent } = require('../helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -10,7 +10,7 @@ describe('ESM', () => {
 
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
-    sandbox = await createSandbox(['express'])
+    sandbox = await isolatedSandbox(['express'])
     cwd = sandbox.folder
     appFile = path.join(cwd, 'appsec', 'esm-app', 'index.mjs')
   })

--- a/integration-tests/appsec/index.spec.js
+++ b/integration-tests/appsec/index.spec.js
@@ -4,7 +4,7 @@ const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
 const msgpack = require('@msgpack/msgpack')
-const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('../helpers')
 
 describe('RASP', () => {
   let axios, sandbox, cwd, appFile, agent, proc, stdioHandler
@@ -14,7 +14,7 @@ describe('RASP', () => {
   }
 
   before(async () => {
-    sandbox = await createSandbox(['express', 'axios'])
+    sandbox = await isolatedSandbox(['express', 'axios'])
     cwd = sandbox.folder
     appFile = path.join(cwd, 'appsec/rasp/index.js')
   })

--- a/integration-tests/appsec/multer.spec.js
+++ b/integration-tests/appsec/multer.spec.js
@@ -7,7 +7,7 @@ const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
 const path = require('node:path')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   FakeAgent,
   spawnProc
 } = require('../helpers')
@@ -18,7 +18,7 @@ describe('multer', () => {
   ['1.4.4-lts.1', '1.4.5-lts.1'].forEach((version) => {
     describe(`v${version}`, () => {
       before(async () => {
-        sandbox = await createSandbox(['express', `multer@${version}`])
+        sandbox = await isolatedSandbox(['express', `multer@${version}`])
         cwd = sandbox.folder
         startupTestFile = path.join(cwd, 'appsec', 'multer', 'index.js')
       })

--- a/integration-tests/appsec/response-headers.spec.js
+++ b/integration-tests/appsec/response-headers.spec.js
@@ -5,7 +5,7 @@ const path = require('path')
 const Axios = require('axios')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   FakeAgent,
   spawnProc
 } = require('../helpers')
@@ -14,7 +14,7 @@ describe('Headers collection - Fastify', () => {
   let axios, sandbox, cwd, appFile, agent, proc
 
   before(async () => {
-    sandbox = await createSandbox(['fastify'])
+    sandbox = await isolatedSandbox(['fastify'])
     cwd = sandbox.folder
     appFile = path.join(cwd, 'appsec/data-collection/fastify.js')
   })

--- a/integration-tests/appsec/standalone-asm.spec.js
+++ b/integration-tests/appsec/standalone-asm.spec.js
@@ -4,7 +4,7 @@ const { assert } = require('chai')
 const path = require('path')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   FakeAgent,
   spawnProc,
   curlAndAssertMessage,
@@ -16,7 +16,7 @@ describe('Standalone ASM', () => {
   let sandbox, cwd, startupTestFile, agent, proc, env
 
   before(async () => {
-    sandbox = await createSandbox(['express'])
+    sandbox = await isolatedSandbox(['express'])
     cwd = sandbox.folder
     startupTestFile = path.join(cwd, 'standalone-asm/index.js')
   })

--- a/integration-tests/appsec/trace-tagging.spec.js
+++ b/integration-tests/appsec/trace-tagging.spec.js
@@ -5,7 +5,7 @@ const path = require('path')
 const Axios = require('axios')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   FakeAgent,
   spawnProc
 } = require('../helpers')
@@ -35,7 +35,7 @@ describe('ASM Trace Tagging rules', () => {
 
   describe('express', () => {
     before(async () => {
-      sandbox = await createSandbox(['express'])
+      sandbox = await isolatedSandbox(['express'])
       cwd = sandbox.folder
       appFile = path.join(cwd, 'appsec/data-collection/index.js')
     })
@@ -60,7 +60,7 @@ describe('ASM Trace Tagging rules', () => {
 
   describe('fastify', () => {
     before(async () => {
-      sandbox = await createSandbox(['fastify'])
+      sandbox = await isolatedSandbox(['fastify'])
       cwd = sandbox.folder
       appFile = path.join(cwd, 'appsec/data-collection/fastify.js')
     })

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -6,7 +6,7 @@ const { once } = require('events')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -19,7 +19,7 @@ describe('test optimization automatic log submission', () => {
   let testOutput = ''
 
   before(async () => {
-    sandbox = await createSandbox([
+    sandbox = await isolatedSandbox([
       'mocha',
       '@cucumber/cucumber',
       'jest',

--- a/integration-tests/ci-visibility/git-cache.spec.js
+++ b/integration-tests/ci-visibility/git-cache.spec.js
@@ -6,7 +6,7 @@ const path = require('path')
 const os = require('os')
 const { execSync } = require('child_process')
 
-const { createSandbox } = require('../helpers')
+const { isolatedSandbox } = require('../helpers')
 
 const FIXED_COMMIT_MESSAGE = 'Test commit message for caching'
 const GET_COMMIT_MESSAGE_COMMAND_ARGS = ['log', '-1', '--pretty=format:%s']
@@ -30,7 +30,7 @@ describe('git-cache integration tests', () => {
   let originalCacheEnabled, originalCacheDir
 
   before(async () => {
-    sandbox = await createSandbox([], true)
+    sandbox = await isolatedSandbox([], true)
     cwd = sandbox.folder
     testRepoPath = cwd
 

--- a/integration-tests/ci-visibility/test-api-manual.spec.js
+++ b/integration-tests/ci-visibility/test-api-manual.spec.js
@@ -5,7 +5,7 @@ const { exec } = require('child_process')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
@@ -17,7 +17,7 @@ describe('test-api-manual', () => {
   let sandbox, cwd, receiver, childProcess
 
   before(async () => {
-    sandbox = await createSandbox([], true)
+    sandbox = await isolatedSandbox([], true)
     cwd = sandbox.folder
   })
 

--- a/integration-tests/ci-visibility/test-optimization-startup.spec.js
+++ b/integration-tests/ci-visibility/test-optimization-startup.spec.js
@@ -5,7 +5,7 @@ const { once } = require('events')
 
 const { assert } = require('chai')
 
-const { createSandbox } = require('../helpers')
+const { isolatedSandbox } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 
 const packageManagers = ['yarn', 'npm', 'pnpm']
@@ -14,7 +14,7 @@ describe('test optimization startup', () => {
   let sandbox, cwd, receiver, childProcess, processOutput
 
   before(async () => {
-    sandbox = await createSandbox(packageManagers, true)
+    sandbox = await isolatedSandbox(packageManagers, true)
     cwd = sandbox.folder
   })
 

--- a/integration-tests/ci-visibility/test-optimization-wrong-init.spec.js
+++ b/integration-tests/ci-visibility/test-optimization-wrong-init.spec.js
@@ -4,7 +4,7 @@ const { once } = require('node:events')
 const assert = require('node:assert')
 const { exec } = require('child_process')
 
-const { createSandbox, getCiVisAgentlessConfig } = require('../helpers')
+const { isolatedSandbox, getCiVisAgentlessConfig } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { NODE_MAJOR } = require('../../version')
 
@@ -55,7 +55,7 @@ testFrameworks.forEach(({ testFramework, command, expectedOutput, extraTestConte
         testFrameworks.push('@cucumber/cucumber')
       }
 
-      sandbox = await createSandbox(testFrameworks, true)
+      sandbox = await isolatedSandbox(testFrameworks, true)
       cwd = sandbox.folder
     })
 

--- a/integration-tests/code-origin.spec.js
+++ b/integration-tests/code-origin.spec.js
@@ -3,13 +3,13 @@
 const assert = require('node:assert')
 const path = require('node:path')
 const Axios = require('axios')
-const { FakeAgent, spawnProc, createSandbox } = require('./helpers')
+const { FakeAgent, spawnProc, isolatedSandbox } = require('./helpers')
 
 describe('Code Origin for Spans', function () {
   let sandbox, cwd, appFile, agent, proc, axios
 
   before(async () => {
-    sandbox = await createSandbox(['fastify'])
+    sandbox = await isolatedSandbox(['fastify'])
     cwd = sandbox.folder
     appFile = path.join(cwd, 'code-origin', 'typescript.js')
   })

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const path = require('path')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -86,7 +86,7 @@ versions.forEach(version => {
       // add an explicit timeout to make tests less flaky
       this.timeout(50000)
 
-      sandbox = await createSandbox([`@cucumber/cucumber@${version}`, 'assert', 'nyc'], true)
+      sandbox = await isolatedSandbox([`@cucumber/cucumber@${version}`, 'assert', 'nyc'], true)
       cwd = sandbox.folder
     })
 

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -11,7 +11,7 @@ const execPromise = promisify(exec)
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -130,7 +130,7 @@ moduleTypes.forEach(({
 
     before(async () => {
       // cypress-fail-fast is required as an incompatible plugin
-      sandbox = await createSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0'], true)
+      sandbox = await isolatedSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0'], true)
       cwd = sandbox.folder
 
       const { NODE_OPTIONS, ...restOfEnv } = process.env

--- a/integration-tests/debugger/re-evaluation.spec.js
+++ b/integration-tests/debugger/re-evaluation.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert')
 
 const Axios = require('axios')
 
-const { createSandbox, FakeAgent, assertObjectContains, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, assertObjectContains, spawnProc } = require('../helpers')
 const { generateProbeConfig } = require('../../packages/dd-trace/test/debugger/devtools_client/utils')
 
 // A race condition exists where the tracer receives a probe via RC, before Node.js has had a chance to load all the JS
@@ -28,7 +28,7 @@ describe('Dynamic Instrumentation Probe Re-Evaluation', function () {
   let sandbox
 
   before(async function () {
-    sandbox = await createSandbox(
+    sandbox = await isolatedSandbox(
       undefined,
       undefined,
       // Ensure the test scripts live in the root of the sandbox so they are always the shortest path when

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -6,7 +6,7 @@ const { randomUUID } = require('crypto')
 
 const Axios = require('axios')
 
-const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('../helpers')
 const { generateProbeConfig } = require('../../packages/dd-trace/test/debugger/devtools_client/utils')
 
 const BREAKPOINT_TOKEN = '// BREAKPOINT'
@@ -75,7 +75,7 @@ function setup ({ env, testApp, testAppSource, dependencies, silent, stdioHandle
   }
 
   before(async function () {
-    sandbox = await createSandbox(dependencies)
+    sandbox = await isolatedSandbox(dependencies)
     cwd = sandbox.folder
     // The sandbox uses the `integration-tests` folder as its root
     t.appFile = join(cwd, 'debugger', breakpoints[0].deployedFile)

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -303,11 +303,11 @@ async function createSandbox (dependencies = [], isGitRepo = false,
 
   if (isolated) {
     execHelper(`npm pack --silent --pack-destination ${folder}`, { env: restOfEnv })
-    execHelper(`yarn add ${deps.concat(`file:${out}`).join(' ')}`, addOptions)
+    execHelper(`yarn add ${deps.concat(`file:${out}`).join(' ')} ${addFlags.join(' ')}`, addOptions)
   } else {
     execHelper('yarn link')
     if (deps.length > 0) {
-      execHelper(`yarn add ${deps.join(' ')}`, addOptions)
+      execHelper(`yarn add ${deps.join(' ')} ${addFlags.join(' ')}`, addOptions)
     }
     execHelper('yarn link dd-trace', addOptions)
   }

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -236,10 +236,22 @@ function execHelper (command, options) {
   /* eslint-enable no-console */
 }
 
+/**
+ * @param {string[]} dependencies
+ * @param {boolean} isGitRepo
+ * @param {string[]} integrationTestsPaths
+ * @param {string} [followUpCommand]
+ */
 async function isolatedSandbox (dependencies, isGitRepo, integrationTestsPaths, followUpCommand) {
   return createSandbox(dependencies, isGitRepo, integrationTestsPaths, followUpCommand, true)
 }
 
+/**
+ * @param {string[]} dependencies
+ * @param {boolean} isGitRepo
+ * @param {string[]} integrationTestsPaths
+ * @param {string} [followUpCommand]
+ */
 async function linkedSandbox (dependencies, isGitRepo, integrationTestsPaths, followUpCommand) {
   return createSandbox(dependencies, isGitRepo, integrationTestsPaths, followUpCommand, false)
 }

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -680,7 +680,6 @@ module.exports = {
   telemetryForwarder,
   assertTelemetryPoints,
   runAndCheckWithTelemetry,
-  createSandbox,
   curl,
   curlAndAssertMessage,
   getCiVisAgentlessConfig,

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -407,6 +407,11 @@ function varySandbox (sandbox, filename, variants, namedVariant, packageName = v
 }
 
 /**
+ * @type {['default', 'star', 'destructure']}
+ */
+varySandbox.VARIANTS = ['default', 'star', 'destructure']
+
+/**
  * @param {boolean} shouldExpectTelemetryPoints
  */
 function telemetryForwarder (shouldExpectTelemetryPoints = true) {

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -83,7 +83,7 @@ describe('jest CommonJS', () => {
   let testOutput = ''
 
   before(async function () {
-    sandbox = await createSandbox([
+    sandbox = await isolatedSandbox([
       'jest',
       'chai@v4',
       'jest-jasmine2',

--- a/integration-tests/log_injection.spec.js
+++ b/integration-tests/log_injection.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { FakeAgent, createSandbox, spawnProc, curlAndAssertMessage, assertObjectContains } = require('./helpers')
+const { FakeAgent, isolatedSandbox, spawnProc, curlAndAssertMessage, assertObjectContains } = require('./helpers')
 const path = require('path')
 const { USER_KEEP } = require('../ext/priority')
 
@@ -13,7 +13,7 @@ describe('Log Injection', () => {
   let env
 
   before(async () => {
-    sandbox = await createSandbox(['express', 'winston'])
+    sandbox = await isolatedSandbox(['express', 'winston'])
     cwd = sandbox.folder
     app = path.join(cwd, 'log_injection/index.js')
   })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -95,7 +95,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
   let testOutput = ''
 
   before(async function () {
-    sandbox = await createSandbox(
+    sandbox = await isolatedSandbox(
       [
         `mocha@${MOCHA_VERSION}`,
         'chai@v4',

--- a/integration-tests/openfeature/openfeature-exposure-events.spec.js
+++ b/integration-tests/openfeature/openfeature-exposure-events.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('../helpers')
 const path = require('path')
 const { assert } = require('chai')
 const { UNACKNOWLEDGED, ACKNOWLEDGED } = require('../../packages/dd-trace/src/remote_config/apply_states')
@@ -38,7 +38,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
       '@openfeature/core',
     ]
 
-    sandbox = await createSandbox(
+    sandbox = await isolatedSandbox(
       dependencies,
       false,
       [path.join(__dirname, 'app')]

--- a/integration-tests/opentelemetry-logs.spec.js
+++ b/integration-tests/opentelemetry-logs.spec.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const { assert } = require('chai')
-const { createSandbox } = require('./helpers')
+const { isolatedSandbox } = require('./helpers')
 const http = require('http')
 
 describe('OpenTelemetry Logs Integration', () => {
   let sandbox
 
   beforeEach(async () => {
-    sandbox = await createSandbox()
+    sandbox = await isolatedSandbox()
   })
 
   afterEach(async () => {

--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { FakeAgent, createSandbox } = require('./helpers')
+const { FakeAgent, isolatedSandbox } = require('./helpers')
 const { fork } = require('child_process')
 const { join } = require('path')
 const { assert } = require('chai')
@@ -67,7 +67,7 @@ describe('opentelemetry', () => {
       // Needed because sdk-node doesn't start a tracer without an exporter
       '@opentelemetry/exporter-jaeger'
     ]
-    sandbox = await createSandbox(dependencies)
+    sandbox = await isolatedSandbox(dependencies)
     cwd = sandbox.folder
     agent = await new FakeAgent().start()
   })

--- a/integration-tests/pino.spec.js
+++ b/integration-tests/pino.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { FakeAgent, spawnProc, createSandbox, curl, assertObjectContains } = require('./helpers')
+const { FakeAgent, spawnProc, isolatedSandbox, curl, assertObjectContains } = require('./helpers')
 const path = require('path')
 const { assert } = require('chai')
 const { once } = require('events')
@@ -13,7 +13,7 @@ describe('pino test', () => {
   let startupTestFile
 
   before(async () => {
-    sandbox = await createSandbox(['pino'])
+    sandbox = await isolatedSandbox(['pino'])
     cwd = sandbox.folder
     startupTestFile = path.join(cwd, 'pino/index.js')
   })

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -9,7 +9,7 @@ const fs = require('fs')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig
 } = require('../helpers')
@@ -82,7 +82,7 @@ versions.forEach((version) => {
     before(async function () {
       // Usually takes under 30 seconds but sometimes the server is really slow.
       this.timeout(300_000)
-      sandbox = await createSandbox([`@playwright/test@${version}`, 'typescript'], true)
+      sandbox = await isolatedSandbox([`@playwright/test@${version}`, 'typescript'], true)
       cwd = sandbox.folder
       const { NODE_OPTIONS, ...restOfEnv } = process.env
       // Install chromium (configured in integration-tests/playwright.config.js)

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox
+  isolatedSandbox
 } = require('../helpers')
 const childProcess = require('child_process')
 const { fork } = childProcess
@@ -310,7 +310,7 @@ describe('profiler', () => {
   const maxBusyCycleTimeNs = (timeout - 1000) * 1000000 / expectedSpans
 
   before(async () => {
-    sandbox = await createSandbox()
+    sandbox = await isolatedSandbox()
     cwd = sandbox.folder
     profilerTestFile = path.join(cwd, 'profiler/index.js')
     ssiTestFile = path.join(cwd, 'profiler/ssi.js')

--- a/integration-tests/remote_config.spec.js
+++ b/integration-tests/remote_config.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, FakeAgent, spawnProc } = require('./helpers')
+const { isolatedSandbox, FakeAgent, spawnProc } = require('./helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -11,7 +11,7 @@ describe('Remote config client id', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await isolatedSandbox(
       ['express'],
       false,
       [path.join(__dirname, 'remote_config')]

--- a/integration-tests/selenium/selenium.spec.js
+++ b/integration-tests/selenium/selenium.spec.js
@@ -5,7 +5,7 @@ const { exec } = require('child_process')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
@@ -32,7 +32,7 @@ versionRange.forEach(version => {
     let webAppPort
 
     before(async function () {
-      sandbox = await createSandbox([
+      sandbox = await isolatedSandbox([
         'mocha',
         'jest',
         '@cucumber/cucumber',

--- a/integration-tests/startup.spec.js
+++ b/integration-tests/startup.spec.js
@@ -3,7 +3,7 @@
 const {
   FakeAgent,
   spawnProc,
-  createSandbox,
+  isolatedSandbox,
   curlAndAssertMessage
 } = require('./helpers')
 const path = require('path')
@@ -37,7 +37,7 @@ execArgvs.forEach(({ execArgv, skip }) => {
     let startupTestFile
 
     before(async () => {
-      sandbox = await createSandbox()
+      sandbox = await isolatedSandbox()
       cwd = sandbox.folder
       startupTestFile = path.join(cwd, 'startup/index.js')
     })

--- a/integration-tests/telemetry.spec.js
+++ b/integration-tests/telemetry.spec.js
@@ -5,7 +5,7 @@ const { describe, before, after, it, beforeEach, afterEach } = require('mocha')
 
 const path = require('node:path')
 
-const { createSandbox, FakeAgent, spawnProc, assertObjectContains } = require('./helpers')
+const { isolatedSandbox, FakeAgent, spawnProc, assertObjectContains } = require('./helpers')
 
 describe('telemetry', () => {
   describe('dependencies', () => {
@@ -16,7 +16,7 @@ describe('telemetry', () => {
     let proc
 
     before(async () => {
-      sandbox = await createSandbox()
+      sandbox = await isolatedSandbox()
       cwd = sandbox.folder
       startupTestFile = path.join(cwd, 'startup/index.js')
     })

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -8,7 +8,7 @@ const fs = require('fs')
 const { assert } = require('chai')
 
 const {
-  createSandbox,
+  isolatedSandbox,
   getCiVisAgentlessConfig
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
@@ -65,7 +65,7 @@ versions.forEach((version) => {
     let sandbox, cwd, receiver, childProcess, testOutput
 
     before(async function () {
-      sandbox = await createSandbox([
+      sandbox = await isolatedSandbox([
         `vitest@${version}`,
         `@vitest/coverage-istanbul@${version}`,
         `@vitest/coverage-v8@${version}`,

--- a/packages/datadog-plugin-ai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ai/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
@@ -24,7 +24,7 @@ describe('esm', () => {
   withVersions('ai', 'ai', (version, _, realVersion) => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `ai@${version}`,
         `@ai-sdk/openai@${getOpenaiVersion(realVersion)}`,
         'zod@3.25.75'

--- a/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqp10/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('amqp10', 'amqp10', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'amqp10@${version}'`, 'rhea'], false, [
+      sandbox = await linkedSandbox([`'amqp10@${version}'`, 'rhea'], false, [
         './packages/datadog-plugin-amqp10/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-amqplib/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('amqplib', 'amqplib', '>=0.10.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'amqplib@${version}'`], false,
+      sandbox = await linkedSandbox([`'amqplib@${version}'`], false,
         ['./packages/datadog-plugin-amqplib/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'amqplib', 'connect')
     })

--- a/packages/datadog-plugin-anthropic/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-anthropic/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('anthropic', ['@anthropic-ai/sdk'], version => {
     before(async function () {
       this.timeout(20000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `@anthropic-ai/sdk@${version}`,
       ], false, [
         './packages/datadog-plugin-anthropic/test/integration-test/*'

--- a/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('aws-sdk', ['aws-sdk'], version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'aws-sdk@${version}'`], false, [
+      sandbox = await linkedSandbox([`'aws-sdk@${version}'`], false, [
         './packages/datadog-plugin-aws-sdk/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-axios/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-axios/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -15,7 +15,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(60000)
-    sandbox = await createSandbox(['axios'], false, [
+    sandbox = await linkedSandbox(['axios'], false, [
       './packages/datadog-plugin-axios/test/integration-test/*'])
   })
 

--- a/packages/datadog-plugin-azure-event-hubs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-event-hubs/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('azure-event-hubs', '@azure/event-hubs', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@azure/event-hubs@${version}'`], false, [
+      sandbox = await linkedSandbox([`'@azure/event-hubs@${version}'`], false, [
         './packages/datadog-plugin-azure-event-hubs/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-azure-functions/test/integration-test/eventhubs-test/eventhubs.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/eventhubs-test/eventhubs.spec.js
@@ -3,7 +3,7 @@
 const {
   FakeAgent,
   hookFile,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
 } = require('../../../../../integration-tests/helpers')
 const { withVersions } = require('../../../../dd-trace/test/setup/mocha')
@@ -21,7 +21,7 @@ describe('esm', () => {
   withVersions('azure-functions', '@azure/functions', NODE_MAJOR < 20 ? '<4.7.3' : '*', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `@azure/functions@${version}`,
         'azure-functions-core-tools@4',
         '@azure/event-hubs@6.0.0',

--- a/packages/datadog-plugin-azure-functions/test/integration-test/http-test/client.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/http-test/client.spec.js
@@ -3,7 +3,7 @@
 const {
   FakeAgent,
   hookFile,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage
 } = require('../../../../../integration-tests/helpers')
 const { withVersions } = require('../../../../dd-trace/test/setup/mocha')
@@ -21,7 +21,7 @@ describe('esm', () => {
   withVersions('azure-functions', '@azure/functions', NODE_MAJOR < 20 ? '<4.7.3' : '*', version => {
     before(async function () {
       this.timeout(120_000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `@azure/functions@${version}`,
         'azure-functions-core-tools@4',
       ],

--- a/packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/servicebus.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/servicebus-test/servicebus.spec.js
@@ -3,7 +3,7 @@
 const {
   FakeAgent,
   hookFile,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage
 } = require('../../../../../integration-tests/helpers')
 const { withVersions } = require('../../../../dd-trace/test/setup/mocha')
@@ -21,7 +21,7 @@ describe('esm', () => {
   withVersions('azure-functions', '@azure/functions', NODE_MAJOR < 20 ? '<4.7.3' : '*', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `@azure/functions@${version}`,
         'azure-functions-core-tools@4',
         '@azure/service-bus@7.9.5',

--- a/packages/datadog-plugin-azure-service-bus/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-service-bus/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('azure-service-bus', '@azure/service-bus', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@azure/service-bus@${version}'`], false, [
+      sandbox = await linkedSandbox([`'@azure/service-bus@${version}'`], false, [
         './packages/datadog-plugin-azure-service-bus/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-bunyan/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc,
   varySandbox
 } = require('../../../../integration-tests/helpers')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('bunyan', 'bunyan', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'bunyan@${version}'`], false,
+      sandbox = await linkedSandbox([`'bunyan@${version}'`], false,
         ['./packages/datadog-plugin-bunyan/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'bunyan')
     })

--- a/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cassandra-driver/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('cassandra-driver', 'cassandra-driver', '>=4.4.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'cassandra-driver@${version}'`], false, [
+      sandbox = await linkedSandbox([`'cassandra-driver@${version}'`], false, [
         './packages/datadog-plugin-cassandra-driver/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'cassandra-driver', 'Client')
     })

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('confluentinc-kafka-javascript', '@confluentinc/kafka-javascript', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@confluentinc/kafka-javascript@${version}'`], false, [
+      sandbox = await linkedSandbox([`'@confluentinc/kafka-javascript@${version}'`], false, [
         './packages/datadog-plugin-confluentinc-kafka-javascript/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-connect/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-connect/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('connect', 'connect', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'connect@${version}'`], false, [
+      sandbox = await linkedSandbox([`'connect@${version}'`], false, [
         './packages/datadog-plugin-connect/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'connect')
     })

--- a/packages/datadog-plugin-cookie-parser/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cookie-parser/test/integration-test/client.spec.js
@@ -13,7 +13,7 @@ withVersions('cookie-parser', 'cookie-parser', version => {
 
     before(async function () {
       this.timeout(50000)
-      sandbox = await linkedSandbox([`'cookie-parser@${version}'`, 'express'], false,
+      sandbox = await linkedSandbox([`'cookie-parser@${version}'`, 'dc-polyfill', 'express'], false,
         ['./packages/datadog-plugin-cookie-parser/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'cookie-parser', 'cookieParser')
     })

--- a/packages/datadog-plugin-cookie-parser/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-cookie-parser/test/integration-test/client.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const {
-  createSandbox, varySandbox, curl,
+  linkedSandbox, varySandbox, curl,
   FakeAgent, spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
@@ -13,7 +13,7 @@ withVersions('cookie-parser', 'cookie-parser', version => {
 
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'cookie-parser@${version}'`, 'express'], false,
+      sandbox = await linkedSandbox([`'cookie-parser@${version}'`, 'express'], false,
         ['./packages/datadog-plugin-cookie-parser/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'cookie-parser', 'cookieParser')
     })

--- a/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-couchbase/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('couchbase', 'couchbase', '>=4.0.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'couchbase@${version}'`], false, [
+      sandbox = await linkedSandbox([`'couchbase@${version}'`], false, [
         './packages/datadog-plugin-couchbase/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-dns/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-dns/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -17,7 +17,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(60000)
-    sandbox = await createSandbox([], false, [
+    sandbox = await linkedSandbox([], false, [
       './packages/datadog-plugin-dns/test/integration-test/*'])
     variants = varySandbox(sandbox, 'server.mjs', 'dns', 'lookup')
   })

--- a/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-elasticsearch/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('elasticsearch', ['@elastic/elasticsearch'], '<8.16.0 || >8.16.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@elastic/elasticsearch@${version}'`], false, [
+      sandbox = await linkedSandbox([`'@elastic/elasticsearch@${version}'`], false, [
         './packages/datadog-plugin-elasticsearch/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'elasticsearch', undefined, '@elastic/elasticsearch')
     })

--- a/packages/datadog-plugin-express/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-express/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('express', 'express', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'express@${version}'`], false,
+      sandbox = await linkedSandbox([`'express@${version}'`], false,
         ['./packages/datadog-plugin-express/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'express')
     })

--- a/packages/datadog-plugin-fetch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-fetch/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { assert } = require('chai')
@@ -16,7 +16,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(50000)
-    sandbox = await createSandbox([], false, [
+    sandbox = await linkedSandbox([], false, [
       './packages/datadog-plugin-fetch/test/integration-test/*'])
   })
 

--- a/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('google-cloud-pubsub', '@google-cloud/pubsub', '>=4.0.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@google-cloud/pubsub@${version}'`], false, ['./packages/dd-trace/src/id.js',
+      sandbox = await linkedSandbox([`'@google-cloud/pubsub@${version}'`], false, ['./packages/dd-trace/src/id.js',
         './packages/datadog-plugin-google-cloud-pubsub/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-google-cloud-vertexai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-google-cloud-vertexai/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('google-cloud-vertexai', '@google-cloud/vertexai', '>=1', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `@google-cloud/vertexai@${version}`,
         'sinon'
       ], false, [

--- a/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -20,7 +20,7 @@ describe('Plugin (ESM)', () => {
     withVersions('graphql', ['graphql'], (version, moduleName, resolvedVersion) => {
       before(async function () {
         this.timeout(50000)
-        sandbox = await createSandbox([`'graphql@${resolvedVersion}'`, "'graphql-yoga@3.6.0'"], false, [
+        sandbox = await linkedSandbox([`'graphql@${resolvedVersion}'`, "'graphql-yoga@3.6.0'"], false, [
           './packages/datadog-plugin-graphql/test/esm-test/*'])
       })
 

--- a/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-graphql/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('graphql', 'graphql', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'graphql@${version}'`], false, [
+      sandbox = await linkedSandbox([`'graphql@${version}'`], false, [
         './packages/datadog-plugin-graphql/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('grpc', '@grpc/grpc-js', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader'], false, [
+      sandbox = await linkedSandbox([`'@grpc/grpc-js@${version}'`, '@grpc/proto-loader'], false, [
         './packages/datadog-plugin-grpc/test/*'])
     })
 

--- a/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hapi/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('hapi', '@hapi/hapi', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@hapi/hapi@${version}'`], false, [
+      sandbox = await linkedSandbox([`'@hapi/hapi@${version}'`], false, [
         './packages/datadog-plugin-hapi/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-hono/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-hono/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   spawnPluginIntegrationTestProc,
   assertObjectContains,
@@ -17,7 +17,7 @@ describe('esm integration test', () => {
   withVersions('hono', 'hono', (range, _moduleName_, version) => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'hono@${range}'`, '@hono/node-server@1.15.0'], false,
+      sandbox = await linkedSandbox([`'hono@${range}'`, '@hono/node-server@1.15.0'], false,
         ['./packages/datadog-plugin-hono/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-http/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -15,7 +15,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(60000)
-    sandbox = await createSandbox([], false, [
+    sandbox = await linkedSandbox([], false, [
       './packages/datadog-plugin-http/test/integration-test/*'])
   })
 

--- a/packages/datadog-plugin-http2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc,
   varySandbox
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(50000)
-    sandbox = await createSandbox(['http2'], false, [
+    sandbox = await linkedSandbox(['http2'], false, [
       './packages/datadog-plugin-http2/test/integration-test/*'])
     variants = varySandbox(sandbox, 'server.mjs', 'http2', 'createServer')
   })

--- a/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-ioredis/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('ioredis', 'ioredis', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'ioredis@${version}'`], false, [
+      sandbox = await linkedSandbox([`'ioredis@${version}'`], false, [
         './packages/datadog-plugin-ioredis/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'ioredis')
     })

--- a/packages/datadog-plugin-iovalkey/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-iovalkey/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('iovalkey', 'iovalkey', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'iovalkey@${version}'`], false, [
+      sandbox = await linkedSandbox([`'iovalkey@${version}'`], false, [
         './packages/datadog-plugin-iovalkey/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -16,7 +16,7 @@ describe('esm', () => {
   withVersions('kafkajs', 'kafkajs', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'kafkajs@${version}'`], false, [
+      sandbox = await linkedSandbox([`'kafkajs@${version}'`], false, [
         './packages/datadog-plugin-kafkajs/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-koa/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-koa/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('koa', 'koa', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'koa@${version}'`], false,
+      sandbox = await linkedSandbox([`'koa@${version}'`], false,
         ['./packages/datadog-plugin-koa/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
@@ -20,6 +20,7 @@ describe('esm', () => {
       sandbox = await linkedSandbox([
         `@langchain/core@${version}`,
         `@langchain/openai@${version}`,
+        'dc-polyfill',
         'nock'
       ], false, [
         './packages/datadog-plugin-langchain/test/integration-test/*'

--- a/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('langchain', ['@langchain/core'], '>=0.1', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([
+      sandbox = await linkedSandbox([
         `@langchain/core@${version}`,
         `@langchain/openai@${version}`,
         'nock'

--- a/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-limitd-client/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('limitd-client', 'limitd-client', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'limitd-client@${version}'`], false, [
+      sandbox = await linkedSandbox([`'limitd-client@${version}'`], false, [
         './packages/datadog-plugin-limitd-client/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'limitd-client')
     })

--- a/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mariadb/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('mariadb', 'mariadb', '>=3.0.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'mariadb@${version}'`], false, [
+      sandbox = await linkedSandbox([`'mariadb@${version}'`], false, [
         './packages/datadog-plugin-mariadb/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-memcached/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('memcached', 'memcached', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'memcached@${version}'`], false, [
+      sandbox = await linkedSandbox([`'memcached@${version}'`], false, [
         './packages/datadog-plugin-memcached/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('microgateway-core', 'microgateway-core', '>=3.0.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'microgateway-core@${version}'`], false, [
+      sandbox = await linkedSandbox([`'microgateway-core@${version}'`], false, [
         './packages/datadog-plugin-microgateway-core/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-moleculer/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('moleculer', 'moleculer', '>0.14.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'moleculer@${version}'`], false, [
+      sandbox = await linkedSandbox([`'moleculer@${version}'`], false, [
         './packages/datadog-plugin-moleculer/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('mongodb-core', 'mongodb', '>=4', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'mongodb@${version}'`], false, [
+      sandbox = await linkedSandbox([`'mongodb@${version}'`], false, [
         './packages/datadog-plugin-mongodb-core/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'mongodb', 'MongoClient')
     })
@@ -56,7 +56,7 @@ describe('esm', () => {
   withVersions('mongodb-core', 'mongodb-core', '>=3', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'mongodb-core@${version}'`], false, [
+      sandbox = await linkedSandbox([`'mongodb-core@${version}'`], false, [
         './packages/datadog-plugin-mongodb-core/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server2.mjs', 'MongoDBCore')
     })

--- a/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mongoose/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('mongoose', ['mongoose'], '>=4', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'mongoose@${version}'`], false, [
+      sandbox = await linkedSandbox([`'mongoose@${version}'`], false, [
         './packages/datadog-plugin-mongoose/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'mongoose')
     })

--- a/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('mysql', 'mysql', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'mysql@${version}'`], false, [
+      sandbox = await linkedSandbox([`'mysql@${version}'`], false, [
         './packages/datadog-plugin-mysql/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'mysql', 'createConnection')
     })

--- a/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-mysql2/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('mysql2', 'mysql2', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'mysql2@${version}'`], false, [
+      sandbox = await linkedSandbox([`'mysql2@${version}'`], false, [
         './packages/datadog-plugin-mysql2/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-net/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-net/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -17,7 +17,7 @@ describe('esm', () => {
 
   before(async function () {
     this.timeout(60000)
-    sandbox = await createSandbox(['net'], false, [
+    sandbox = await linkedSandbox(['net'], false, [
       './packages/datadog-plugin-net/test/integration-test/*'])
     variants = varySandbox(sandbox, 'server.mjs', 'net', 'createConnection')
   })

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
@@ -23,7 +23,7 @@ describe('esm', () => {
     before(async function () {
       // next builds slower in the CI, match timeout with unit tests
       this.timeout(300 * 1000)
-      sandbox = await createSandbox([`'next@${version}'`, 'react@^18.2.0', 'react-dom@^18.2.0'],
+      sandbox = await linkedSandbox([`'next@${version}'`, 'react@^18.2.0', 'react-dom@^18.2.0'],
         false, ['./packages/datadog-plugin-next/test/integration-test/*'],
         'NODE_OPTIONS=--openssl-legacy-provider yarn exec next build')
       variants = varySandbox(sandbox, 'server.mjs', 'next')

--- a/packages/datadog-plugin-openai/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-openai/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
 } = require('../../../../integration-tests/helpers')
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('openai', 'openai', '>=3 <4.0.0 || >4.1.0', (version) => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox(
+      sandbox = await linkedSandbox(
         [
           `'openai@${version}'`,
           'nock',

--- a/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-opensearch/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('opensearch', '@opensearch-project/opensearch', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'@opensearch-project/opensearch@${version}'`], false, [
+      sandbox = await linkedSandbox([`'@opensearch-project/opensearch@${version}'`], false, [
         './packages/datadog-plugin-opensearch/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-oracledb/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('oracledb', 'oracledb', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'oracledb@${version}'`], false, [
+      sandbox = await linkedSandbox([`'oracledb@${version}'`], false, [
         './packages/datadog-plugin-oracledb/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  linkedSandbox,
+  isolatedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -20,7 +20,8 @@ describe('esm', () => {
   withVersions('pg', 'pg', (version, _, realVersion) => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await linkedSandbox([`'pg@${version}'`], false, [
+      // TODO: Why does using linkedSandbox here make unit tests fail?
+      sandbox = await isolatedSandbox([`'pg@${version}'`], false, [
         './packages/datadog-plugin-pg/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', {
         default: 'import pg from \'pg\'',

--- a/packages/datadog-plugin-pg/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pg/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc,
   varySandbox
@@ -20,7 +20,7 @@ describe('esm', () => {
   withVersions('pg', 'pg', (version, _, realVersion) => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'pg@${version}'`], false, [
+      sandbox = await linkedSandbox([`'pg@${version}'`], false, [
         './packages/datadog-plugin-pg/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', {
         default: 'import pg from \'pg\'',

--- a/packages/datadog-plugin-pino/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-pino/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc,
   varySandbox
 } = require('../../../../integration-tests/helpers')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('pino', 'pino', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'pino@${version}'`],
+      sandbox = await linkedSandbox([`'pino@${version}'`],
         false, ['./packages/datadog-plugin-pino/test/integration-test/*'])
       variants = varySandbox(sandbox, 'server.mjs', 'pino')
     })

--- a/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
@@ -7,7 +7,7 @@ const { describe, it, beforeEach, before, after, afterEach } = require('mocha')
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc,
   assertObjectContains
 } = require('../../../../integration-tests/helpers')
@@ -21,7 +21,7 @@ describe('esm', () => {
   withVersions('prisma', '@prisma/client', version => {
     before(async function () {
       this.timeout(100000)
-      sandbox = await createSandbox([`'prisma@${version}'`, `'@prisma/client@${version}'`], false, [
+      sandbox = await linkedSandbox([`'prisma@${version}'`, `'@prisma/client@${version}'`], false, [
         './packages/datadog-plugin-prisma/test/integration-test/*',
         './packages/datadog-plugin-prisma/test/schema.prisma'
       ])

--- a/packages/datadog-plugin-redis/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('redis', 'redis', '>=4', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'redis@${version}'`], false, [
+      sandbox = await linkedSandbox([`'redis@${version}'`], false, [
         './packages/datadog-plugin-redis/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-restify/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-restify/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
@@ -19,7 +19,7 @@ describe('esm', () => {
   withVersions('restify', 'restify', '>3', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'restify@${version}'`],
+      sandbox = await linkedSandbox([`'restify@${version}'`],
         false, ['./packages/datadog-plugin-restify/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-rhea/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('rhea', 'rhea', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'rhea@${version}'`], false, [
+      sandbox = await linkedSandbox([`'rhea@${version}'`], false, [
         './packages/datadog-plugin-rhea/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-router/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-router/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   curlAndAssertMessage,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('router', 'router', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'router@${version}'`]
+      sandbox = await linkedSandbox([`'router@${version}'`]
         , false, ['./packages/datadog-plugin-router/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-sharedb/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -18,7 +18,7 @@ describe('esm', () => {
   withVersions('sharedb', 'sharedb', '>=3', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'sharedb@${version}'`], false, [
+      sandbox = await linkedSandbox([`'sharedb@${version}'`], false, [
         './packages/datadog-plugin-sharedb/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-tedious/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   checkSpansForServiceName,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
@@ -24,7 +24,7 @@ describe('esm', () => {
   withVersions('tedious', 'tedious', '>=16.0.0', version => {
     before(async function () {
       this.timeout(60000)
-      sandbox = await createSandbox([`'tedious@${version}'`], false, [
+      sandbox = await linkedSandbox([`'tedious@${version}'`], false, [
         './packages/datadog-plugin-tedious/test/integration-test/*'])
     })
 

--- a/packages/datadog-plugin-winston/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-winston/test/integration-test/client.spec.js
@@ -2,7 +2,7 @@
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnPluginIntegrationTestProc
 } = require('../../../../integration-tests/helpers')
 const { withVersions } = require('../../../dd-trace/test/setup/mocha')
@@ -17,7 +17,7 @@ describe('esm', () => {
   withVersions('winston', 'winston', '>=3', version => {
     before(async function () {
       this.timeout(50000)
-      sandbox = await createSandbox([`'winston@${version}'`]
+      sandbox = await linkedSandbox([`'winston@${version}'`]
         , false, ['./packages/datadog-plugin-winston/test/integration-test/*'])
     })
 

--- a/packages/dd-trace/test/appsec/iast/code_injection.integration.spec.js
+++ b/packages/dd-trace/test/appsec/iast/code_injection.integration.spec.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
 
 describe('IAST - code_injection - integration', () => {
   let axios, sandbox, cwd, agent, proc
@@ -11,7 +11,7 @@ describe('IAST - code_injection - integration', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 300000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express'],
       false,
       [path.join(__dirname, 'resources')]

--- a/packages/dd-trace/test/appsec/iast/overhead-controller.integration.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.integration.spec.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
 
 describe('IAST - overhead-controller - integration', () => {
   let axios, sandbox, cwd, agent, proc
@@ -11,7 +11,7 @@ describe('IAST - overhead-controller - integration', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 300000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express'],
       false,
       [path.join(__dirname, 'resources')]

--- a/packages/dd-trace/test/appsec/rasp/command_injection.integration.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.integration.spec.js
@@ -5,7 +5,7 @@ const { describe, it, before, beforeEach, afterEach, after } = require('mocha')
 
 const path = require('node:path')
 
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
 
 describe('RASP - command_injection - integration', () => {
   let axios, sandbox, cwd, appFile, agent, proc
@@ -13,7 +13,7 @@ describe('RASP - command_injection - integration', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express'],
       false,
       [path.join(__dirname, 'resources')]

--- a/packages/dd-trace/test/appsec/rasp/lfi.integration.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.integration.express.plugin.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -10,7 +10,7 @@ describe('RASP - lfi - integration - sync', () => {
 
   before(async function () {
     this.timeout(60000)
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express', 'fs'],
       false,
       [path.join(__dirname, 'resources')])

--- a/packages/dd-trace/test/appsec/rasp/rasp-metrics.integration.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/rasp-metrics.integration.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -11,7 +11,7 @@ describe('RASP metrics', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express'],
       false,
       [path.join(__dirname, 'resources')]

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.integration.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.integration.pg.plugin.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../../integration-tests/helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -12,7 +12,7 @@ describe('RASP - sql_injection - integration', () => {
 
   before(async function () {
     this.timeout(60000)
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express', 'pg'],
       false,
       [path.join(__dirname, 'resources')])

--- a/packages/dd-trace/test/appsec/waf-metrics.integration.spec.js
+++ b/packages/dd-trace/test/appsec/waf-metrics.integration.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { createSandbox, FakeAgent, spawnProc } = require('../../../../integration-tests/helpers')
+const { linkedSandbox, FakeAgent, spawnProc } = require('../../../../integration-tests/helpers')
 const path = require('path')
 const Axios = require('axios')
 const { assert } = require('chai')
@@ -11,7 +11,7 @@ describe('WAF Metrics', () => {
   before(async function () {
     this.timeout(process.platform === 'win32' ? 90000 : 30000)
 
-    sandbox = await createSandbox(
+    sandbox = await linkedSandbox(
       ['express'],
       false,
       [path.join(__dirname, 'resources')]

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -311,7 +311,7 @@ describe('request', function () {
   })
 
   it('should calculate correct Content-Length header for multi-byte characters', (done) => {
-    const sandbox = sinon.linkedSandbox()
+    const sandbox = sinon.createSandbox()
     sandbox.spy(http, 'request')
 
     const body = 'æøå'
@@ -341,7 +341,7 @@ describe('request', function () {
   })
 
   describe('when intercepting http', () => {
-    const sandbox = sinon.linkedSandbox()
+    const sandbox = sinon.createSandbox()
 
     beforeEach(() => {
       sandbox.spy(http, 'request')

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -311,7 +311,7 @@ describe('request', function () {
   })
 
   it('should calculate correct Content-Length header for multi-byte characters', (done) => {
-    const sandbox = sinon.createSandbox()
+    const sandbox = sinon.linkedSandbox()
     sandbox.spy(http, 'request')
 
     const body = 'æøå'
@@ -341,7 +341,7 @@ describe('request', function () {
   })
 
   describe('when intercepting http', () => {
-    const sandbox = sinon.createSandbox()
+    const sandbox = sinon.linkedSandbox()
 
     beforeEach(() => {
       sandbox.spy(http, 'request')

--- a/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
@@ -7,7 +7,7 @@ const { execSync } = require('node:child_process')
 
 const {
   FakeAgent,
-  createSandbox,
+  linkedSandbox,
   spawnProc
 } = require('../../../../../../integration-tests/helpers')
 const { expectedLLMObsNonLLMSpanEvent, deepEqualWithMockValues } = require('../../util')
@@ -83,7 +83,7 @@ describe('typescript', () => {
     context(`with version ${version}`, () => {
       before(async function () {
         this.timeout(20000)
-        sandbox = await createSandbox(
+        sandbox = await linkedSandbox(
           [`typescript@${version}`], false, ['./packages/dd-trace/test/llmobs/sdk/typescript/*']
         )
       })

--- a/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/typescript/index.spec.js
@@ -84,7 +84,7 @@ describe('typescript', () => {
       before(async function () {
         this.timeout(20000)
         sandbox = await linkedSandbox(
-          [`typescript@${version}`], false, ['./packages/dd-trace/test/llmobs/sdk/typescript/*']
+          [`typescript@${version}`, '@types/node'], false, ['./packages/dd-trace/test/llmobs/sdk/typescript/*']
         )
       })
 

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -93,6 +93,7 @@
     "couchbase": "4.6.0",
     "cypress": "15.4.0",
     "cypress-fail-fast": "7.1.1",
+    "dc-polyfill": "0.1.10",
     "dd-trace-api": "1.0.0",
     "ejs": "3.1.10",
     "elasticsearch": "16.7.3",

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -66,6 +66,7 @@
     "@prisma/client": "6.17.1",
     "@redis/client": "5.8.3",
     "@smithy/smithy-client": "4.9.0",
+    "@types/node": "18.19.130",
     "@vitest/coverage-istanbul": "3.2.4",
     "@vitest/coverage-v8": "3.2.4",
     "@vitest/runner": "3.2.4",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split sandbox between linked and isolated modes.

### Motivation
<!-- What inspired you to submit this pull request? -->

The sandbox was originally created for integration tests with applications mimicking a real app with a real install of dd-trace. But for a lot of our tests, for example ESM tests, we don't really need that level of isolation, and linking to dd-trace is good enough.

### Additional Notes

The main change is in `integration-tests/helpers/index.js`, everything else is just changing all usage of `createSandbox` to either `isolatedSandbox` or `linkedSandbox`.

Supersedes #6640