### PR TITLE
[test optimization] Fix even more cypress flakiness

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1416,7 +1416,7 @@ moduleTypes.forEach(({
 
             const testSession = events.find(event => event.type === 'test_session_end').content
             assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
-          })
+          }, 25000)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
         childProcess = exec(
@@ -1432,6 +1432,10 @@ moduleTypes.forEach(({
             stdio: 'pipe'
           }
         )
+
+        // TODO: remove this once we have figured out flakiness
+        childProcess.stdout.pipe(process.stdout)
+        childProcess.stderr.pipe(process.stderr)
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -1478,7 +1482,7 @@ moduleTypes.forEach(({
 
             const testSession = events.find(event => event.type === 'test_session_end').content
             assert.notProperty(testSession.meta, TEST_EARLY_FLAKE_ENABLED)
-          })
+          }, 25000)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
 
@@ -1494,6 +1498,10 @@ moduleTypes.forEach(({
             stdio: 'pipe'
           }
         )
+
+        // TODO: remove this once we have figured out flakiness
+        childProcess.stdout.pipe(process.stdout)
+        childProcess.stderr.pipe(process.stderr)
 
         await Promise.all([
           once(childProcess, 'exit'),


### PR DESCRIPTION
### What does this PR do?
* Add more time for events to come
* Pipe test framework output to the main process (temporary until we figure out flakiness)

### Motivation
There's still some flakiness in some tests:

https://github.com/DataDog/dd-trace-js/actions/runs/18718566742/job/53384390279

### Plugin Checklist
Just check that tests are still passing