### PR TITLE
[test optimization] Add faulty logic to EFD in playwright

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -7,7 +7,8 @@ const shimmer = require('../../datadog-shimmer')
 const {
   parseAnnotations,
   getTestSuitePath,
-  PLAYWRIGHT_WORKER_TRACE_PAYLOAD_CODE
+  PLAYWRIGHT_WORKER_TRACE_PAYLOAD_CODE,
+  getIsFaultyEarlyFlakeDetection
 } = require('../../dd-trace/src/plugins/util/test')
 const log = require('../../dd-trace/src/log')
 const { DD_MAJOR } = require('../../../version')
@@ -52,6 +53,7 @@ let isKnownTestsEnabled = false
 let isEarlyFlakeDetectionEnabled = false
 let earlyFlakeDetectionNumRetries = 0
 let isEarlyFlakeDetectionFaulty = false
+let earlyFlakeDetectionFaultyThreshold = 0
 let isFlakyTestRetriesEnabled = false
 let flakyTestRetriesCount = 0
 let knownTests = {}
@@ -542,6 +544,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
         isKnownTestsEnabled = libraryConfig.isKnownTestsEnabled
         isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
         earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
+        earlyFlakeDetectionFaultyThreshold = libraryConfig.earlyFlakeDetectionFaultyThreshold
         isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
         flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
         isTestManagementTestsEnabled = libraryConfig.isTestManagementEnabled
@@ -846,40 +849,52 @@ addHook({
     if (isKnownTestsEnabled) {
       const newTests = allTests.filter(isNewTest)
 
-      /**
-       * We could repeat the logic of `applyRepeatEachIndex` here, but it'd be more risky
-       * as playwright could change it at any time.
-       *
-       * `applyRepeatEachIndex` goes through all the tests in a suite and applies the "repeat" logic
-       * for a single repeat index.
-       *
-       * This means that the clone logic is cumbersome:
-       * - we grab the unique file suites that have new tests
-       * - we store its project suite
-       * - we clone each of these file suites for each repeat index
-       * - we execute `applyRepeatEachIndex` for each of these cloned file suites
-       * - we add the cloned file suites to the project suite
-       */
+      const isFaulty = getIsFaultyEarlyFlakeDetection(
+        allTests.map(test => getTestSuitePath(test._requireFile, rootDir)),
+        knownTests.playwright,
+        earlyFlakeDetectionFaultyThreshold
+      )
 
-      const fileSuitesWithNewTestsToProjects = new Map()
-      newTests.forEach(newTest => {
-        newTest._ddIsNew = true
-        if (isEarlyFlakeDetectionEnabled && newTest.expectedStatus !== 'skipped' && !newTest._ddIsModified) {
-          const fileSuite = getSuiteType(newTest, 'file')
-          if (!fileSuitesWithNewTestsToProjects.has(fileSuite)) {
-            fileSuitesWithNewTestsToProjects.set(fileSuite, getSuiteType(newTest, 'project'))
+      if (isFaulty) {
+        isEarlyFlakeDetectionEnabled = false
+        isKnownTestsEnabled = false
+        isEarlyFlakeDetectionFaulty = true
+      } else {
+        /**
+         * We could repeat the logic of `applyRepeatEachIndex` here, but it'd be more risky
+         * as playwright could change it at any time.
+         *
+         * `applyRepeatEachIndex` goes through all the tests in a suite and applies the "repeat" logic
+         * for a single repeat index.
+         *
+         * This means that the clone logic is cumbersome:
+         * - we grab the unique file suites that have new tests
+         * - we store its project suite
+         * - we clone each of these file suites for each repeat index
+         * - we execute `applyRepeatEachIndex` for each of these cloned file suites
+         * - we add the cloned file suites to the project suite
+         */
+
+        const fileSuitesWithNewTestsToProjects = new Map()
+        newTests.forEach(newTest => {
+          newTest._ddIsNew = true
+          if (isEarlyFlakeDetectionEnabled && newTest.expectedStatus !== 'skipped' && !newTest._ddIsModified) {
+            const fileSuite = getSuiteType(newTest, 'file')
+            if (!fileSuitesWithNewTestsToProjects.has(fileSuite)) {
+              fileSuitesWithNewTestsToProjects.set(fileSuite, getSuiteType(newTest, 'project'))
+            }
           }
-        }
-      })
+        })
 
-      for (const [fileSuite, projectSuite] of fileSuitesWithNewTestsToProjects.entries()) {
-        for (let repeatEachIndex = 1; repeatEachIndex <= earlyFlakeDetectionNumRetries; repeatEachIndex++) {
-          const copyFileSuite = deepCloneSuite(fileSuite, isNewTest, [
-            '_ddIsNew',
-            '_ddIsEfdRetry'
-          ])
-          applyRepeatEachIndex(projectSuite._fullProject, copyFileSuite, repeatEachIndex + 1)
-          projectSuite._addSuite(copyFileSuite)
+        for (const [fileSuite, projectSuite] of fileSuitesWithNewTestsToProjects.entries()) {
+          for (let repeatEachIndex = 1; repeatEachIndex <= earlyFlakeDetectionNumRetries; repeatEachIndex++) {
+            const copyFileSuite = deepCloneSuite(fileSuite, isNewTest, [
+              '_ddIsNew',
+              '_ddIsEfdRetry'
+            ])
+            applyRepeatEachIndex(projectSuite._fullProject, copyFileSuite, repeatEachIndex + 1)
+            projectSuite._addSuite(copyFileSuite)
+          }
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?
Add faulty logic to EFD in playwright: if the number of new tests is too high, we'll stop detecting new tests and retrying.

Let's wait for #6736 to be merged.

### Motivation
It wasn't there for some reason. Most likely oversight

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Integration tests.
