### PR TITLE
Always redact exception messages for logs in telemetry

### DIFF
--- a/packages/dd-trace/src/telemetry/logs/log-collector.js
+++ b/packages/dd-trace/src/telemetry/logs/log-collector.js
@@ -41,8 +41,6 @@ function sanitize (logEntry) {
 
   const firstIndex = stackLines.findIndex(l => l.match(STACK_FRAME_LINE_REGEX))
 
-  const isDDCode = firstIndex !== -1 && stackLines[firstIndex].includes(ddBasePath)
-
   // Filter to keep only DD frames
   stackLines = stackLines
     .filter((line, index) => index >= firstIndex && line.includes(ddBasePath))

--- a/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
+++ b/packages/dd-trace/test/telemetry/logs/log-collector.spec.js
@@ -33,16 +33,46 @@ describe('telemetry log collector', () => {
       const ddFrame1 = `at T (${ddBasePath}path/to/dd/file1.js:1:2)`
       const ddFrame2 = `at T (${ddBasePath}path/to/dd/file2.js:3:4)`
       const ddFrame3 = `at T (${ddBasePath}path/to/dd/file3.js:5:6)`
-      expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `Error: msg\n${ddFrame1}`, errorType: 'Error' })).to.be.true
-      expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `Error: msg\n${ddFrame2}`, errorType: 'Error' })).to.be.true
-      expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `Error: msg\n${ddFrame3}`, errorType: 'Error' })).to.be.true
+      expect(logCollector.add({
+        message: 'Error 1',
+        level: 'ERROR',
+        stack_trace: `Error: msg\n${ddFrame1}`,
+        errorType: 'Error'
+      })).to.be.true
+      expect(logCollector.add({
+        message: 'Error 1',
+        level: 'ERROR',
+        stack_trace: `Error: msg\n${ddFrame2}`,
+        errorType: 'Error'
+      })).to.be.true
+      expect(logCollector.add({
+        message: 'Error 1',
+        level: 'ERROR',
+        stack_trace: `Error: msg\n${ddFrame3}`,
+        errorType: 'Error'
+      })).to.be.true
     })
 
     it('should store logs with same message, same stack but different level', () => {
       const ddFrame = `at T (${ddBasePath}path/to/dd/file.js:1:2)`
-      expect(logCollector.add({ message: 'Error 1', level: 'ERROR', stack_trace: `Error: msg\n${ddFrame}`, errorType: 'Error' })).to.be.true
-      expect(logCollector.add({ message: 'Error 1', level: 'WARN', stack_trace: `Error: msg\n${ddFrame}`, errorType: 'Error' })).to.be.true
-      expect(logCollector.add({ message: 'Error 1', level: 'DEBUG', stack_trace: `Error: msg\n${ddFrame}`, errorType: 'Error' })).to.be.true
+      expect(logCollector.add({
+        message: 'Error 1',
+        level: 'ERROR',
+        stack_trace: `Error: msg\n${ddFrame}`,
+        errorType: 'Error'
+      })).to.be.true
+      expect(logCollector.add({
+        message: 'Error 1',
+        level: 'WARN',
+        stack_trace: `Error: msg\n${ddFrame}`,
+        errorType: 'Error'
+      })).to.be.true
+      expect(logCollector.add({
+        message: 'Error 1',
+        level: 'DEBUG',
+        stack_trace: `Error: msg\n${ddFrame}`,
+        errorType: 'Error'
+      })).to.be.true
     })
 
     it('should not store logs with empty stack and \'Generic Error\' message', () => {
@@ -109,7 +139,8 @@ describe('telemetry log collector', () => {
 
     it('should redact multi-line error messages', () => {
       const ddFrame = `at cachedExec (${ddBasePath}plugins/util/git-cache.js:96:17)`
-      const multiLineError = `Error: Command failed: git rev-parse --abbrev-ref --symbolic-full-name @{upstream}${EOL}fatal: HEAD does not point to a branch${EOL}${EOL}${ddFrame}`
+      const multiLineError = 'Error: Command failed: git rev-parse --abbrev-ref ' +
+        `--symbolic-full-name @{upstream}${EOL}fatal: HEAD does not point to a branch${EOL}${EOL}${ddFrame}`
 
       const ddFrames = multiLineError
         .split(EOL)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Always redact exception messages for logs that get sent to telemetry.

### Motivation
<!-- What inspired you to submit this pull request? -->

The requirements / expectation for sending logs to telemetry is to always ensure that we have constant content (outside of DD / known stack frames).

Previously this would check the frame was ours and if so it would include the exception message, this is not allowed.

Additionally, this would populate the stack trace with multiple frames if there were new lines within the exception message logged.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Please reach out to me for more context - I drafted this with Claude as I'm unfamiliar with dd-trace-js and would like help getting this implemented, but the overall logic here looks correct.
