### PR TITLE
fix(ffe): Fix FFE_FLAGS Remote Config handler payload format mismatch (FFL-1294)

### DIFF
--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -164,7 +164,7 @@ class Tracer extends NoopProxy {
           rc.setProductHandler('FFE_FLAGS', (action, conf) => {
             // Feed UFC config directly to OpenFeature provider
             if (action === 'apply' || action === 'modify') {
-              this.openfeature._setConfiguration(conf.flag_configuration)
+              this.openfeature._setConfiguration(conf)
             }
           })
         }

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -372,7 +372,7 @@ describe('TracerProxy', () => {
         proxy.openfeature // Trigger lazy loading
 
         const flagConfig = { flags: { 'test-flag': {} } }
-        handlers.get('FFE_FLAGS')('apply', { flag_configuration: flagConfig })
+        handlers.get('FFE_FLAGS')('apply', flagConfig)
 
         expect(openfeatureProvider._setConfiguration).to.have.been.calledWith(flagConfig)
       })
@@ -384,7 +384,7 @@ describe('TracerProxy', () => {
         proxy.openfeature // Trigger lazy loading
 
         const flagConfig = { flags: { 'modified-flag': {} } }
-        handlers.get('FFE_FLAGS')('modify', { flag_configuration: flagConfig })
+        handlers.get('FFE_FLAGS')('modify', flagConfig)
 
         expect(openfeatureProvider._setConfiguration).to.have.been.calledWith(flagConfig)
       })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Changes:
- Fixed: this.openfeature._setConfiguration(conf.flag_configuration)
- To: this.openfeature._setConfiguration(conf)

### Motivation
<!-- What inspired you to submit this pull request? -->

The FFE_FLAGS RC handler was incorrectly expecting a wrapped payload with `conf.flag_configuration`, but Remote Config delivers direct UFC payloads.

system tests were also written to expect an incorrect format and are being update in parallel.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [x] Integration tests.
- [x] Benchmarks.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [x] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


