### PR TITLE
fix retry no longer working for bun

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -221,7 +221,7 @@ function execHelper (command, options) {
     console.log('Exec SUCCESS: ', command)
   } catch (error) {
     console.error('Exec ERROR: ', command, error)
-    if (command.startsWith('bun')) {
+    if (command.startsWith(BUN)) {
       try {
         console.log('Exec RETRY START: ', command)
         execSync(command, options)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix retry no longer working for Bun.

### Motivation
<!-- What inspired you to submit this pull request? -->

When switching to Bun, the retry logic for failed commands was changed from `yarn` to `bun` but that's incorrect as the commands start with the full path of the binary and not just `bun`, so retries were no longer happening.