### PR TITLE
chore: remove unused code

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -262,7 +262,6 @@ const elasticsearchOptions: plugins.elasticsearch = {
 
 const awsSdkOptions: plugins.aws_sdk = {
   service: 'test',
-  splitByAwsService: false,
   batchPropagationEnabled: false,
   hooks: {
     request: (span?: Span, response?) => {},

--- a/index.d.ts
+++ b/index.d.ts
@@ -1699,12 +1699,6 @@ declare namespace tracer {
      */
     interface aws_sdk extends Instrumentation {
       /**
-       * Whether to add a suffix to the service name so that each AWS service has its own service name.
-       * @default true
-       */
-      splitByAwsService?: boolean;
-
-      /**
        * Whether to inject all messages during batch AWS SQS, Kinesis, and SNS send operations. Normal
        * behavior is to inject the first message in batch send operations.
        * @default false

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -282,7 +282,6 @@ function normalizeConfig (config, serviceIdentifier) {
   return {
     ...config,
     ...specificConfig,
-    splitByAwsService: config.splitByAwsService !== false,
     batchPropagationEnabled,
     hooks
   }

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -254,7 +254,6 @@ describe('Plugin', () => {
         before(() => {
           return agent.load(['aws-sdk', 'http'], [{
             service: 'test',
-            splitByAwsService: false,
             hooks: {
               request (span, response) {
                 span.setTag('hook.operation', response.request.operation)


### PR DESCRIPTION
This code is not used anymore and has no effect. Reintroducing it does not seem to be ideal. It is likely best to always name the services uniquely.

Fixes: https://github.com/DataDog/dd-trace-js/issues/6766

We could also implement the functionality again, it was just not requested for so long that it's probably fine as is.