### PR TITLE
remove deprecated lambda executor from localstack config

### DIFF
--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -81,6 +81,8 @@ jobs:
           START_WEB: '0'
         ports:
           - 4566:4566
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock:rw
       # we have two localstacks since upgrading localstack was causing lambda & S3 tests to fail
       # To-Do: Debug localstack / lambda and localstack / S3
       localstack-legacy:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove deprecated Lambda executor from Localstack config.

### Motivation
<!-- What inspired you to submit this pull request? -->

The Localstack container sometimes fails to start with an error about this: https://github.com/DataDog/dd-trace-js/actions/runs/18574973811/job/52993257939

### Additional Notes

I also mounted the Docker socket to the Localstack container as it's another error seen in the example above.