### PR TITLE
[test optimization] Improve flakiness in cypress (even more)

### DIFF
--- a/integration-tests/ci-visibility/subproject/cypress-config.json
+++ b/integration-tests/ci-visibility/subproject/cypress-config.json
@@ -4,6 +4,6 @@
   "pluginsFile": "cypress/plugins-old/index.js",
   "supportFile": "cypress/support/e2e.js",
   "integrationFolder": "cypress/e2e",
-  "defaultCommandTimeout": 5000,
+  "defaultCommandTimeout": 1000,
   "nodeVersion": "system"
 }

--- a/integration-tests/ci-visibility/subproject/cypress.config.js
+++ b/integration-tests/ci-visibility/subproject/cypress.config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 module.exports = {
-  defaultCommandTimeout: 5000,
+  defaultCommandTimeout: 1000,
   e2e: {
     setupNodeEvents (on, config) {
       return require('dd-trace/ci/cypress/plugin')(on, config)

--- a/integration-tests/cypress-config.json
+++ b/integration-tests/cypress-config.json
@@ -4,6 +4,6 @@
   "pluginsFile": "cypress/plugins-old/index.js",
   "supportFile": "cypress/support/e2e.js",
   "integrationFolder": "cypress/e2e",
-  "defaultCommandTimeout": 5000,
+  "defaultCommandTimeout": 1000,
   "nodeVersion": "system"
 }

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -3,7 +3,7 @@ import cypress from 'cypress'
 async function runCypress () {
   const results = await cypress.run({
     config: {
-      defaultCommandTimeout: 5000,
+      defaultCommandTimeout: 1000,
       e2e: {
         setupNodeEvents (on, config) {
           if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -6,7 +6,7 @@ const cypressFailFast = require('cypress-fail-fast/plugin')
 const ddTracePlugin = require('dd-trace/ci/cypress/plugin')
 
 module.exports = {
-  defaultCommandTimeout: 5000,
+  defaultCommandTimeout: 1000,
   e2e: {
     setupNodeEvents (on, config) {
       if (process.env.CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN) {


### PR DESCRIPTION
### What does this PR do?
* Increase `receiver.gatherPayloadsMaxTimeout` timeout, which is the time we give cypress to report data. 
* Increase timeout for cypress itself

### Motivation
Try to make the CI greener. 

### Plugin Checklist
Just check that the tests pass