### PR TITLE
[test optimization] Fix `vitest` latest release

### DIFF
--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -53,6 +53,7 @@ const {
   DD_CAPABILITIES_IMPACTED_TESTS
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
+const { NODE_MAJOR } = require('../../version')
 
 const NUM_RETRIES_EFD = 3
 
@@ -399,7 +400,10 @@ versions.forEach((version) => {
     })
 
     // total code coverage only works for >=2.0.0
-    if (version === 'latest') {
+    // v4 dropped support for Node 18. Every test but this once passes, so we'll leave them
+    // for now. The breaking change is in https://github.com/vitest-dev/vitest/commit/9a0bf2254
+    // shipped in https://github.com/vitest-dev/vitest/releases/tag/v4.0.0-beta.12
+    if (version === 'latest' && NODE_MAJOR >= 20) {
       const coverageProviders = ['v8', 'istanbul']
 
       coverageProviders.forEach((coverageProvider) => {


### PR DESCRIPTION
### What does this PR do?

Tested the changes with `dependabot/npm_and_yarn/packages/dd-trace/test/plugins/versions/test-versions-af45cfb341` and the e2e tests pass: https://github.com/DataDog/dd-trace-js/actions/runs/18882428844/job/53888930537?pr=6773 


### Motivation
Fix vitest latest release: https://github.com/vitest-dev/vitest/releases/tag/v4.0.4. It broke in v4 but we just noticed.

### Plugin Checklist
Just make sure the tests we have pass.