### PR TITLE
fix missing retry on npm install of wasm-js-rewriter

### DIFF
--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 
+const { setTimeout } = require('timers/promises')
 const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
@@ -16,7 +17,7 @@ const retry = async fn => {
   try {
     await fn()
   } catch {
-    await exec('sleep 60')
+    await setTimeout(60_000)
     await fn()
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix missing retry on npm install of wasm-js-rewriter.

### Motivation
<!-- What inspired you to submit this pull request? -->

Installs often fail because of network or registry issues, so we should always wait a bit and retry.