### PR TITLE
feat: add cause and props to stack output of errors

### DIFF
--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { URL } = require('url')
+
 const ClientPlugin = require('../../dd-trace/src/plugins/client')
 const { storage } = require('../../datadog-core')
 const tags = require('../../../ext/tags')
@@ -8,8 +10,8 @@ const formats = require('../../../ext/formats')
 const HTTP_HEADERS = formats.HTTP_HEADERS
 const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
 const log = require('../../dd-trace/src/log')
-const { CLIENT_PORT_KEY, COMPONENT, ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { URL } = require('url')
+const { CLIENT_PORT_KEY, COMPONENT } = require('../../dd-trace/src/constants')
+const { addErrorTagsToSpan } = require('../../dd-trace/src/util')
 
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
@@ -116,11 +118,7 @@ class HttpClientPlugin extends ClientPlugin {
   error ({ span, error, args, customRequestTimeout }) {
     if (!span) return
     if (error) {
-      span.addTags({
-        [ERROR_TYPE]: error.name,
-        [ERROR_MESSAGE]: error.message || error.code,
-        [ERROR_STACK]: error.stack
-      })
+      addErrorTagsToSpan(span, error)
     } else {
       // conditions for no error:
       // 1. not using a custom agent instance with custom timeout specified

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -1,8 +1,10 @@
 'use strict'
 
-const fs = require('fs')
+const fs = require('node:fs')
 const assert = require('node:assert/strict')
-const path = require('path')
+const path = require('node:path')
+
+const { satisfies } = require('semver')
 
 const tags = require('../../../ext/tags')
 const { storage } = require('../../datadog-core')
@@ -12,7 +14,6 @@ const key = fs.readFileSync(path.join(__dirname, './ssl/test.key'))
 const cert = fs.readFileSync(path.join(__dirname, './ssl/test.crt'))
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const { rawExpectedSchema } = require('./naming')
-const { satisfies } = require('semver')
 
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -26,6 +26,7 @@ module.exports = {
   ERROR_TYPE: 'error.type',
   ERROR_MESSAGE: 'error.message',
   ERROR_STACK: 'error.stack',
+  ERROR_FULL_SERIALIZED: 'error.full_serialized',
   IGNORE_OTEL_ERROR: Symbol('ignore.otel.error'),
   COMPONENT: 'component',
   CLIENT_PORT_KEY: 'network.destination.port',
@@ -53,5 +54,5 @@ module.exports = {
   SPAN_POINTER_DIRECTION: Object.freeze({
     UPSTREAM: 'u',
     DOWNSTREAM: 'd'
-  })
+  }),
 }

--- a/packages/dd-trace/src/lambda/runtime/errors.js
+++ b/packages/dd-trace/src/lambda/runtime/errors.js
@@ -7,7 +7,10 @@
 
 class ExtendedError extends Error {
   constructor (reason) {
+    const { stackTraceLimit } = Error
+    Error.stackTraceLimit = 0
     super(reason)
+    Error.stackTraceLimit = stackTraceLimit
     Object.setPrototypeOf(this, new.target.prototype)
   }
 }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -9,9 +9,11 @@ const { timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/co
 
 const tracer = require('../../')
 const DatadogSpan = require('../opentracing/span')
-const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK, IGNORE_OTEL_ERROR } = require('../constants')
+const { ERROR_MESSAGE, IGNORE_OTEL_ERROR } = require('../constants')
 const { SERVICE_NAME, RESOURCE_NAME, SPAN_KIND } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
+
+const { addErrorTagsToSpan } = require('../util')
 
 const SpanContext = require('./span_context')
 const id = require('../id')
@@ -291,12 +293,8 @@ class Span {
   }
 
   recordException (exception, timeInput) {
-    this._ddSpan.addTags({
-      [ERROR_TYPE]: exception.name,
-      [ERROR_MESSAGE]: exception.message,
-      [ERROR_STACK]: exception.stack,
-      [IGNORE_OTEL_ERROR]: this._ddSpan.context()._tags[IGNORE_OTEL_ERROR] ?? true
-    })
+    addErrorTagsToSpan(this._ddSpan, exception)
+    this._ddSpan.setTag(IGNORE_OTEL_ERROR, this._ddSpan.context()._tags[IGNORE_OTEL_ERROR] ?? true)
     const attributes = {}
     if (exception.message) attributes['exception.message'] = exception.message
     if (exception.type) attributes['exception.type'] = exception.type

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -8,10 +8,11 @@ const tags = require('../../../../../ext/tags')
 const types = require('../../../../../ext/types')
 const kinds = require('../../../../../ext/kinds')
 const urlFilter = require('./urlfilter')
-const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../constants')
+const { ERROR_MESSAGE } = require('../../constants')
 const { createInferredProxySpan, finishInferredProxySpan } = require('./inferred_proxy')
 const TracingPlugin = require('../tracing')
 const { extractURL, obfuscateQs, calculateHttpEndpoint } = require('./url')
+const { addErrorTagsToSpan } = require('../../util')
 
 let extractIp
 
@@ -215,11 +216,7 @@ const web = {
 
     if (span) {
       if (error) {
-        span.addTags({
-          [ERROR_TYPE]: error.name,
-          [ERROR_MESSAGE]: error.message,
-          [ERROR_STACK]: error.stack
-        })
+        addErrorTagsToSpan(span, error)
       }
 
       span.finish()


### PR DESCRIPTION
This increases debug information for errors by inspecting the whole error and sending it as stack. That provides a) better output for errors by using util.inspect for the stack instead of the native one. That provides for example better error names. b) This improves the performance for one error in serverless by preventing to create stack frames that are not needed. c) it shows all additional properties that might exist on an error as stack output. That should be helpful for debugging issues.

To limit the output of extra properties to a minimum, only one level is inspected.

Fixes: https://github.com/DataDog/dd-trace-js/issues/6366
