### PR TITLE
ci: esbuild: fix test breakage from @apollo/server@v5.1.0

### DIFF
--- a/integration-tests/esbuild/build.esm.common-config.js
+++ b/integration-tests/esbuild/build.esm.common-config.js
@@ -19,6 +19,7 @@ module.exports = {
     'mysql',
     'oracledb',
     'pg-query-stream',
-    'tedious'
+    'tedious',
+    '@yaacovcr/transform' // an unlisted peerDependency of @apollo/server@v5.1.0
   ]
 }

--- a/integration-tests/esbuild/build.js
+++ b/integration-tests/esbuild/build.js
@@ -20,7 +20,8 @@ esbuild.build({
     'mysql',
     'oracledb',
     'pg-query-stream',
-    'tedious'
+    'tedious',
+    '@yaacovcr/transform' // an unlisted peerDependency of @apollo/server@v5.1.0
   ]
 }).catch((err) => {
   console.error(err) // eslint-disable-line no-console


### PR DESCRIPTION
### What does this PR do?
- `@apollo/server` v5.1.0 now contains a `require('@yaacovcr/transform')` statement
- this is not a dependency or peerDependency or devDependency of @apollo/server

### Motivation
- fix CI

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


