### PR TITLE
[test optimization] Fix playwright tests in v5 release line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.0.0",
+  "version": "6.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION
### What does this PR do?
Do not stop reporting test spans in `dispatcherHook`. 

### Motivation
Older playwright versions were broken in https://github.com/DataDog/dd-trace-js/pull/6770. 

### Plugin Checklist
Just check that tests pass.

They do for 1.18.0, the minimum supported version: https://github.com/DataDog/dd-trace-js/actions/runs/18946821227/job/54100353048?pr=6798