### PR TITLE
fix(debugger): don't expect probe config to contain `capture` object

### DIFF
--- a/integration-tests/debugger/target-app/snapshot.js
+++ b/integration-tests/debugger/target-app/snapshot.js
@@ -19,7 +19,7 @@ fastify.get('/:name', function handler (request) {
   const lstr = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
   const sym = Symbol('foo')
   const regex = /bar/i
-  const arr = [1, 2, 3, 4, 5]
+  const arr = Array.from({ length: 200 }, (_, i) => i + 1)
   const obj = {
     foo: {
       baz: 42,

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -117,10 +117,10 @@ session.on('Debugger.paused', async ({ params }) => {
         }
 
         snapshotProbeIndex[numberOfProbesWithSnapshots++] = probes.length
-        maxReferenceDepth = highestOrUndefined(probe.capture.maxReferenceDepth, maxReferenceDepth)
-        maxCollectionSize = highestOrUndefined(probe.capture.maxCollectionSize, maxCollectionSize)
-        maxFieldCount = highestOrUndefined(probe.capture.maxFieldCount, maxFieldCount)
-        maxLength = highestOrUndefined(probe.capture.maxLength, maxLength)
+        maxReferenceDepth = highestOrUndefined(probe.capture?.maxReferenceDepth, maxReferenceDepth)
+        maxCollectionSize = highestOrUndefined(probe.capture?.maxCollectionSize, maxCollectionSize)
+        maxFieldCount = highestOrUndefined(probe.capture?.maxFieldCount, maxFieldCount)
+        maxLength = highestOrUndefined(probe.capture?.maxLength, maxLength)
       }
 
       if (probe.condition !== undefined) {


### PR DESCRIPTION
### What does this PR do?

Don't throw if the probe config doesn't contain a `capture` object when `captureSnapshot: true`.
    
### Motivation

Currently, all probe config objects does contain a `capture` object, but in case this ever changes in the future we'll be prepared.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


