### PR TITLE
Make sure space profiler (almost) always goes first

### DIFF
--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -52,9 +52,9 @@ describe('config', () => {
 
     expect(config.logger).to.be.an.instanceof(ConsoleLogger)
     expect(config.exporters[0]).to.be.an.instanceof(AgentExporter)
-    expect(config.profilers[0]).to.be.an.instanceof(WallProfiler)
-    expect(config.profilers[0].codeHotspotsEnabled()).to.equal(samplingContextsAvailable)
-    expect(config.profilers[1]).to.be.an.instanceof(SpaceProfiler)
+    expect(config.profilers[0]).to.be.an.instanceof(SpaceProfiler)
+    expect(config.profilers[1]).to.be.an.instanceof(WallProfiler)
+    expect(config.profilers[1].codeHotspotsEnabled()).to.equal(samplingContextsAvailable)
     expect(config.v8ProfilerBugWorkaroundEnabled).true
     expect(config.cpuProfilingEnabled).to.equal(samplingContextsAvailable)
     expect(config.uploadCompression.method).to.equal('gzip')
@@ -175,6 +175,40 @@ describe('config', () => {
     expect(config.profilers).to.be.an('array')
     expect(config.profilers.length).to.equal(1)
     expect(config.profilers[0]).to.be.an.instanceOf(SpaceProfiler)
+  })
+
+  it('should ensure space profiler is ordered first with DD_PROFILING_HEAP_ENABLED', () => {
+    process.env = {
+      DD_PROFILING_PROFILERS: 'wall',
+      DD_PROFILING_HEAP_ENABLED: '1'
+    }
+    const options = {
+      logger: nullLogger
+    }
+
+    const config = new Config(options)
+
+    expect(config.profilers).to.be.an('array')
+    expect(config.profilers.length).to.equal(2 + (samplingContextsAvailable ? 1 : 0))
+    expect(config.profilers[0]).to.be.an.instanceOf(SpaceProfiler)
+    expect(config.profilers[1]).to.be.an.instanceOf(WallProfiler)
+  })
+
+  it('should ensure space profiler order is preserved when explicitly set with DD_PROFILING_PROFILERS', () => {
+    process.env = {
+      DD_PROFILING_PROFILERS: 'wall,space',
+      DD_PROFILING_HEAP_ENABLED: '1'
+    }
+    const options = {
+      logger: nullLogger
+    }
+
+    const config = new Config(options)
+
+    expect(config.profilers).to.be.an('array')
+    expect(config.profilers.length).to.equal(2 + (samplingContextsAvailable ? 1 : 0))
+    expect(config.profilers[0]).to.be.an.instanceOf(WallProfiler)
+    expect(config.profilers[1]).to.be.an.instanceOf(SpaceProfiler)
   })
 
   it('should be able to read some env vars', () => {


### PR DESCRIPTION
### What does this PR do?
Unless the user explicitly specifies a different ordering with `DD_PROFILING_PROFILERS`, make sure that the Heap Live Size profiler is always the first.

### Motivation
So that CPU profile temporary memory usage is no longer reported in Heap Live Size. See https://github.com/DataDog/dd-trace-js/issues/6791#issuecomment-3472448904.

Jira: [PROF-12923]

[PROF-12923]: https://datadoghq.atlassian.net/browse/PROF-12923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ