### PR TITLE
[test optimization] Improve cucumber flakiness

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -1841,10 +1841,18 @@ versions.forEach(version => {
                 './node_modules/.bin/cucumber-js ci-visibility/features-di/test-hit-breakpoint.feature --retry 1',
                 {
                   cwd,
-                  env: envVars,
+                  env: {
+                    ...envVars,
+                    DD_TRACE_DEBUG: '1',
+                    DD_TRACE_LOG_LEVEL: 'warn',
+                  },
                   stdio: 'pipe'
                 }
               )
+
+              // TODO: remove once we figure out flakiness
+              childProcess.stdout.pipe(process.stdout)
+              childProcess.stderr.pipe(process.stderr)
 
               childProcess.on('exit', () => {
                 Promise.all([eventsPromise, logsPromise]).then(() => {

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -51,7 +51,8 @@ const {
 } = require('../../dd-trace/src/ci-visibility/telemetry')
 
 const BREAKPOINT_HIT_GRACE_PERIOD_MS = 200
-const BREAKPOINT_SET_GRACE_PERIOD_MS = 200
+const BREAKPOINT_SET_GRACE_PERIOD_MS = 400
+
 const isCucumberWorker = !!getEnvironmentVariable('CUCUMBER_WORKER_ID')
 
 class CucumberPlugin extends CiPlugin {


### PR DESCRIPTION
### What does this PR do?
Increase active wait from 200 to 400ms. This seems to improve flakiness locally. 

Also, add logs to the test. 

Retried 10 times and it's passing every time: https://github.com/DataDog/dd-trace-js/actions/runs/19065302216?pr=6833

### Motivation

This test has been flaking:

* https://github.com/DataDog/dd-trace-js/actions/runs/19038076289/job/54367557862 
* https://github.com/DataDog/dd-trace-js/actions/runs/18991807821/job/54245985519
* https://github.com/DataDog/dd-trace-js/actions/runs/18985169763/job/54227719919
* https://github.com/DataDog/dd-trace-js/actions/runs/18985169763/job/54227090057

### Plugin Checklist
No more tests needed, just check that the ones we have pass.