### PR TITLE
[test optimization] Improve new cypress flakiness

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -905,10 +905,10 @@ moduleTypes.forEach(({
             assert.propertyVal(testModule.meta, TEST_CODE_COVERAGE_ENABLED, 'true')
             assert.propertyVal(testModule.meta, TEST_ITR_SKIPPING_ENABLED, 'true')
             assert.propertyVal(testModule.metrics, TEST_ITR_SKIPPING_COUNT, 0)
-          }, 25000)
+          }, 30000)
 
         const skippableRequestPromise = receiver
-          .payloadReceived(({ url }) => url.endsWith('/api/v2/ci/tests/skippable'))
+          .payloadReceived(({ url }) => url.endsWith('/api/v2/ci/tests/skippable'), 30000)
           .then(skippableRequest => {
             assert.propertyVal(skippableRequest.headers, 'dd-api-key', '1')
           })
@@ -930,6 +930,10 @@ moduleTypes.forEach(({
             stdio: 'pipe'
           }
         )
+
+        // TODO: remove this once we have figured out flakiness
+        childProcess.stdout.pipe(process.stdout)
+        childProcess.stderr.pipe(process.stderr)
 
         await Promise.all([
           once(childProcess, 'exit'),


### PR DESCRIPTION
### What does this PR do?

* Remove stdout piping from no longer flaky tests
* Add stdout piping to new flaky tests
* Increase timeouts for `.payloadReceived` and `.assertPayloadReceived`

Retried 10 times in https://github.com/DataDog/dd-trace-js/actions/runs/19068052955?pr=6834 and it seems to always pass

### Motivation

Cypress has been flaking a bit:
* https://github.com/DataDog/dd-trace-js/actions/runs/19020697472/job/54315332792
* https://github.com/DataDog/dd-trace-js/actions/runs/18978678700/job/54205278415
* https://github.com/DataDog/dd-trace-js/actions/runs/19020643202/job/54315193446
* https://github.com/DataDog/dd-trace-js/actions/runs/19034508319/job/54355466203


### Plugin Checklist
Check that tests pass