### PR TITLE
test: reduce runtime metric flakiness

### DIFF
--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -514,7 +514,7 @@ function createGarbage (count = 50) {
                 userPercent = number
               }
               if (metric === 'runtime.node.cpu.system') {
-                assert(number >= 0 && number <= 1, `${metric} sanity check failed: ${number}`)
+                assert(number >= 0 && number <= 5, `${metric} sanity check failed: ${number}`)
                 systemPercent = number
               }
               if (metric === 'runtime.node.cpu.total') {


### PR DESCRIPTION
The test case is already testing that the increase in system usage will not increase much anyway and the expectation that the system will not be busy with other tasks is not something that will hold at all times. It might make sense to remove the upper bound (this check as a whole) in the future while this will resolve our current flakiness.