### PR TITLE
ci(langchain): skip esm test for new langchain major while fix is implemented

### DIFF
--- a/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-langchain/test/integration-test/client.spec.js
@@ -14,11 +14,11 @@ describe('esm', () => {
   let agent
   let proc
 
-  withVersions('langchain', ['@langchain/core'], '>=0.1', version => {
+  // TODO(sabrenner, MLOB-4410): follow-up on re-enabling this test in a different PR once a fix lands
+  withVersions('langchain', ['@langchain/core'], '>=0.1 <1.0.0', version => {
     useSandbox([
       `@langchain/core@${version}`,
       `@langchain/openai@${version}`,
-      'nock'
     ], false, [
       './packages/datadog-plugin-langchain/test/integration-test/*'
     ])


### PR DESCRIPTION
### What does this PR do?
Skips ESM tests for the new major version of LangChain as our orchestrion config does not work correctly with it. To update it, we need to update the orchestrion dependency through our rewriter dependency.

### Motivation
Unblock dependabot test version updates