### PR TITLE
[test optimization] Cache for codeowners

### DIFF
--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -627,20 +627,29 @@ function getCodeOwnersFileEntries (rootDir) {
   return entries.reverse()
 }
 
+const codeOwnersPerFileName = new Map()
+
 function getCodeOwnersForFilename (filename, entries) {
   if (!entries) {
     return null
+  }
+  if (codeOwnersPerFileName.has(filename)) {
+    return codeOwnersPerFileName.get(filename)
   }
   for (const entry of entries) {
     try {
       const isResponsible = ignore().add(entry.pattern).ignores(filename)
       if (isResponsible) {
-        return JSON.stringify(entry.owners)
+        const codeOwners = JSON.stringify(entry.owners)
+        codeOwnersPerFileName.set(filename, codeOwners)
+        return codeOwners
       }
     } catch {
+      codeOwnersPerFileName.set(filename, null)
       return null
     }
   }
+  codeOwnersPerFileName.set(filename, null)
   return null
 }
 


### PR DESCRIPTION
### What does this PR do?

Add a cache for `getCodeOwnersForFilename`

### Motivation

`getCodeOwnersForFilename` is called for each test in a test file, as it's used to calculate `test.codeowners`. If we can avoid going through the logic more than once, it's an easy win. 

We don't need to be sophisticated with the location of the cache either: even if the test framework is parallelizing work, most of the times that parallelization happens _per test file_, that is, the cache in a worker won't be usable in another worker. 

### Plugin Checklist

Nothing to test in particular, as it's just supposed to improve performance slightly. 