### PR TITLE
test: skip next.js tests on unsupported Node.js versions

### DIFF
--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -16,6 +16,9 @@ describe('test suite', () => {
     }
 
     const realVersion = require(`../../../../versions/next@${version}`).version()
+    if (satisfies(realVersion, '>=16') && NODE_MAJOR < 20) {
+      return
+    }
 
     const tests = [
       {


### PR DESCRIPTION
This should allow to merge https://github.com/DataDog/dd-trace-js/pull/6845