### PR TITLE
ci: do not try to update @opentelemetry/resources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,9 @@ updates:
       - dependency-name: "@opentelemetry/core"
         # 2.0.0 onwards only supports Node.js 18.19.0 and above
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@opentelemetry/resources"
+        # 2.0.0 onwards only supports Node.js 18.19.0 and above
+        update-types: ["version-update:semver-major"]
       - dependency-name: "tap"
         # Contain breaking changes that are incompatible with our test usage
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
It is not supporting Node.js versions we are supporting.