### PR TITLE
chore(core): move span process publish to top line

### DIFF
--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -30,6 +30,8 @@ class SpanProcessor {
   }
 
   process (span) {
+    spanProcessCh.publish({ span })
+
     const spanContext = span.context()
     const active = []
     const formatted = []
@@ -57,8 +59,6 @@ class SpanProcessor {
           isChunkRoot = false
           this._stats?.onSpanFinished(formattedSpan)
           formatted.push(formattedSpan)
-
-          spanProcessCh.publish({ span })
         }
       }
 


### PR DESCRIPTION
### What does this PR do?
Moves the span process publish call to the top line before formatting

### Motivation
Decouple span process event publishing from span formatting logic
