### PR TITLE
chore(deps): bump @datadog/native-iast-taint-tracking to v4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "@datadog/libdatadog": "0.7.0",
     "@datadog/native-appsec": "10.3.0",
-    "@datadog/native-iast-taint-tracking": "4.0.0",
+    "@datadog/native-iast-taint-tracking": "4.1.0",
     "@datadog/native-metrics": "3.1.1",
     "@datadog/openfeature-node-server": "0.1.0-preview.15",
     "@datadog/pprof": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -223,10 +223,10 @@
   dependencies:
     node-gyp-build "^3.9.0"
 
-"@datadog/native-iast-taint-tracking@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.0.0.tgz#a774742e6723b93d58bf31a87728e4da1634074f"
-  integrity sha512-2uF8RnQkJO5bmLi26Zkhxg+RFJn/uEsesYTflScI/Cz/BWv+792bxI+OaCKvhgmpLkm8EElenlpidcJyZm7GYw==
+"@datadog/native-iast-taint-tracking@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/native-iast-taint-tracking/-/native-iast-taint-tracking-4.1.0.tgz#133d1b5530f60aec4875fda8d7b07a2fc1a8deb0"
+  integrity sha512-g9K9Ddx1YQfrQIC2hgtfnYUGuzAFvSvhvt2lPZOAWBPo+bkYoW5KEkMHoY5XykCigTfXBYcQicRV0xB22AMkHw==
   dependencies:
     node-gyp-build "^3.9.0"
 


### PR DESCRIPTION
### What does this PR do?
Bumps `@datadog/native-iast-taint-tracking` to v4.1.0

This new version includes:
- Support for Node.js v25
- Binary size reduction
- New transaction key handling



