### PR TITLE
chore: add appsec packages to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,8 +43,12 @@ updates:
       - semver-patch
     ignore:
       # Internal dependencies that we update manually
+      - dependency-name: "@datadog/libdatadog"
       - dependency-name: "@datadog/native-appsec"
       - dependency-name: "@datadog/native-iast-taint-tracking"
+      - dependency-name: "@datadog/native-metrics"
+      - dependency-name: "@datadog/pprof"
+      - dependency-name: "@datadog/sketches-js"
       - dependency-name: "@datadog/wasm-js-rewriter"
 
       - dependency-name: "@types/node"
@@ -91,12 +95,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          # Add entries that we should update manually.
-          - "@datadog/libdatadog"
-          - "@datadog/native-metrics"
-          - "@datadog/pprof"
-          - "@datadog/sketches-js"
   - package-ecosystem: "npm"
     directories:
       - "/packages/dd-trace/test/plugins/versions"


### PR DESCRIPTION
### What does this PR do?
Add AppSec native addons to the dependabot ignore list

### Motivation
We always release these package manually, so we don't need any reminder. If they get a new release it's because we're already working on it
