### PR TITLE
DRAFT: PoC Function to Handle Integration Test Setup

### DIFF
--- a/packages/datadog-plugin-hono/test/hono-test-setup.js
+++ b/packages/datadog-plugin-hono/test/hono-test-setup.js
@@ -1,0 +1,194 @@
+'use strict'
+
+const axios = require('axios')
+const assert = require('node:assert')
+
+class HonoTestSetup {
+    async setup (module) {
+        this.hono = module
+        this.serve = require('../../../../versions/@hono/node-server@1.15.0').get().serve
+        this.server = null
+        this.port = null
+    }
+
+    async teardown () {
+        if (this.server) {
+            this.server.close()
+            this.server = null
+            this.port = null
+        }
+    }
+
+    async testRoute (tracer) {
+        const app = new this.hono.Hono()
+
+        app.use((c, next) => {
+            c.set('middleware', 'test')
+            return next()
+        })
+
+        app.get('/user/:id', (c) => {
+            return c.json({
+                id: c.req.param('id'),
+                middleware: c.get('middleware')
+            })
+        })
+
+        const port = await this.startServerWithApp(app)
+
+        const { data } = await axios.get(`http://localhost:${port}/user/123`)
+
+        assert.deepStrictEqual(data, {
+            id: '123',
+            middleware: 'test'
+        })
+
+        return {
+            port,
+            expectedSpan: {
+                name: 'hono.request',
+                service: 'test',
+                type: 'web',
+                resource: 'GET /user/:id',
+                meta: {
+                    'span.kind': 'server',
+                    'http.url': `http://localhost:${port}/user/123`,
+                    'http.method': 'GET',
+                    'http.status_code': '200',
+                    component: 'hono'
+                }
+            }
+        }
+    }
+
+    async testNestedRoute () {
+        const app = new this.hono.Hono()
+        const books = new this.hono.Hono()
+
+        books.get('/:id', (c) => c.json({
+            id: c.req.param('id'),
+            name: 'test'
+        }))
+
+        app.route('/books', books)
+
+        const port = await this.startServerWithApp(app)
+
+        const { data } = await axios.get(`http://localhost:${port}/books/12345`)
+
+        assert.deepStrictEqual(data, {
+            id: '12345',
+            name: 'test'
+        })
+
+        return {
+            port,
+            expectedSpan: {
+                name: 'hono.request',
+                service: 'test',
+                type: 'web',
+                resource: 'GET /books/:id',
+                meta: {
+                    'span.kind': 'server',
+                    'http.url': `http://localhost:${port}/books/12345`,
+                    'http.method': 'GET',
+                    'http.status_code': '200',
+                    component: 'hono'
+                }
+            }
+        }
+    }
+
+    async testError () {
+        const app = new this.hono.Hono()
+        const error = new Error('message')
+
+        app.get('/error', () => {
+            throw error
+        })
+
+        const port = await this.startServerWithApp(app)
+
+        await assert.rejects(
+            axios.get(`http://localhost:${port}/error`),
+            {
+                message: 'Request failed with status code 500',
+                name: 'AxiosError'
+            }
+        )
+
+        return {
+            error,
+            expectedSpan: {
+                error: 1,
+                resource: 'GET /error',
+                meta: {
+                    'http.status_code': '500',
+                    component: 'hono'
+                }
+            }
+        }
+    }
+
+    async testActiveScope (tracer) {
+        const app = new this.hono.Hono()
+
+        app.get('/request', (c) => {
+            assert(tracer.scope().active())
+            return c.text('test')
+        })
+
+        const port = await this.startServerWithApp(app)
+
+        const { data } = await axios.get(`http://localhost:${port}/request`)
+
+        assert.deepStrictEqual(data, 'test')
+
+        return { port }
+    }
+
+    async testParentSpanExtraction (tracer) {
+        const app = new this.hono.Hono()
+
+        app.get('/user/:id', (c) => {
+            assert(tracer.scope().active())
+            return c.text('test')
+        })
+
+        const port = await this.startServerWithApp(app)
+
+        await axios.get(`http://localhost:${port}/user/123`, {
+            headers: {
+                'x-datadog-trace-id': '1234',
+                'x-datadog-parent-id': '5678',
+                'ot-baggage-foo': 'bar'
+            }
+        })
+
+        return {
+            expectedSpan: {
+                trace_id: 1234n,
+                parent_id: 5678n
+            }
+        }
+    }
+
+    async startServerWithApp (app) {
+        if (this.server) {
+            this.server.close()
+        }
+
+        return new Promise((resolve) => {
+            this.server = this.serve({
+                fetch: app.fetch,
+                port: 0
+            }, ({ port }) => {
+                this.port = port
+                resolve(port)
+            })
+        })
+    }
+}
+
+module.exports = HonoTestSetup
+

--- a/packages/datadog-plugin-hono/test/index-integration.spec.js
+++ b/packages/datadog-plugin-hono/test/index-integration.spec.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { createIntegrationTestSuite } = require('../../dd-trace/test/setup/helpers/integration-tests-setup')
+const HonoTestSetup = require('./hono-test-setup')
+const {
+    ERROR_TYPE,
+    ERROR_MESSAGE,
+    ERROR_STACK
+} = require('../../dd-trace/src/constants')
+
+createIntegrationTestSuite('hono', 'hono', HonoTestSetup, {
+    additionalPlugins: ['http'],
+    pluginConfig: {},
+    additionalPluginConfigs: [{ client: false }]
+}, ({ testSetup, agent, tracer, it }) => {
+    it('should do automatic instrumentation on routes', async () => {
+        const result = await testSetup.testRoute(tracer)
+
+        await agent.assertFirstTraceSpan(result.expectedSpan)
+    })
+
+    it('should do automatic instrumentation on nested routes', async () => {
+        const result = await testSetup.testNestedRoute()
+
+        await agent.assertFirstTraceSpan(result.expectedSpan)
+    })
+
+    it('should handle errors', async () => {
+        const result = await testSetup.testError()
+
+        await agent.assertFirstTraceSpan({
+            ...result.expectedSpan,
+            meta: {
+                ...result.expectedSpan.meta,
+                [ERROR_TYPE]: result.error.name,
+                [ERROR_MESSAGE]: result.error.message,
+                [ERROR_STACK]: result.error.stack
+            }
+        })
+    })
+
+    it('should have active scope within request', async () => {
+        await testSetup.testActiveScope(tracer)
+    })
+
+    it('should extract its parent span from the headers', async () => {
+        const result = await testSetup.testParentSpanExtraction(tracer)
+
+        await agent.assertFirstTraceSpan(result.expectedSpan)
+    })
+})
+

--- a/packages/dd-trace/test/setup/helpers/integration-tests-setup.js
+++ b/packages/dd-trace/test/setup/helpers/integration-tests-setup.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
+const { expect } = require('chai')
+const agent = require('../../../plugins/agent')
+const { withVersions } = require('../../mocha')
+
+function createIntegrationTestSuite (pluginName, packageName, TestSetupClass, options, testCallback) {
+    describe('Plugin', () => {
+        describe(pluginName, () => {
+            withVersions(pluginName, packageName, version => {
+                createVersionedTests(pluginName, packageName, TestSetupClass, options, version, testCallback)
+            })
+        })
+    })
+}
+
+function createVersionedTests (pluginName, packageName, TestSetupClass, options = {}, version, testCallback) {
+    const testSetup = new TestSetupClass()
+    let tracer = null
+    let mod = null
+
+    describe('without configuration', () => {
+        before(async () => {
+            const plugins = [pluginName, ...(options.additionalPlugins || [])]
+            const additionalPluginConfigs = options.additionalPluginConfigs || []
+            const pluginConfigs = [
+                options.pluginConfig || {},
+                ...(options.additionalPlugins || []).map((_, index) => additionalPluginConfigs[index] || {})
+            ]
+            await agent.load(plugins, pluginConfigs)
+        })
+
+        after(async () => {
+            await agent.close({ ritmReset: false })
+        })
+
+        before(async () => {
+            tracer = require('../../../../../dd-trace').init()
+            mod = require(`../../../../../../versions/${packageName}@${version}`)
+            mod = options.subModule ? mod.get(options.subModule) : mod.get()
+            await testSetup.setup(mod)
+        })
+
+        after(async () => {
+            if (testSetup?.teardown) {
+                await testSetup.teardown()
+            }
+        })
+
+        const testCase = {
+            pluginName,
+            packageName,
+            category: options.category,
+            role: options.role,
+            testSetup,
+            agent,
+            tracer,
+            mod
+        }
+
+        if (testCallback) {
+            testCallback({
+                testCase,
+                testSetup,
+                agent,
+                tracer,
+                expect,
+                describe,
+                it,
+                beforeEach,
+                afterEach,
+                mod
+            })
+        }
+    })
+}
+
+module.exports = { createIntegrationTestSuite }


### PR DESCRIPTION
### What does this PR do?
Use a test helper to setup integration tests to reduce code boilerplate for tests. use sample app for test actions (which can be used by TSE's, TEE's for debugging tickets, and for semantic testing within system tests). For semantic testing, we are looking to pull in these sample apps, and run them in different deployment environments, against different configurations, etc, to test the data being produced and ensure feature functionality and semantic consistency.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


