### PR TITLE
chore(lint): fix a few minor local ESLint errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,7 @@ export default [
       '**/versions', // This is effectively a node_modules tree.
       '**/acmeair-nodejs', // We don't own this.
       '**/vendor', // Generally, we didn't author this code.
+      '.bun', // Bun’s local cache and metadata directory
       'integration-tests/code-origin/typescript.js', // Generated
       'integration-tests/debugger/target-app/source-map-support/bundle.js', // Generated
       'integration-tests/debugger/target-app/source-map-support/hello/world.js', // Generated

--- a/integration-tests/appsec/iast-esbuild/app.js
+++ b/integration-tests/appsec/iast-esbuild/app.js
@@ -1,6 +1,6 @@
 'use strict'
 
-require('dd-trace').init()
+require('dd-trace').init() // eslint-disable-line n/no-extraneous-require
 
 const express = require('express')
 

--- a/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
+++ b/integration-tests/appsec/iast-esbuild/esbuild.common-config.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ddPlugin = require('dd-trace/esbuild')
+const ddPlugin = require('dd-trace/esbuild') // eslint-disable-line n/no-extraneous-require
 
 module.exports = {
   entryPoints: ['app.js'],


### PR DESCRIPTION
### What does this PR do?

- Add the root `.bun` directory to the global ESLint ignore-list. This is used by Bun as a cache and might appear locally on the developer machine if they run Bun. It's already in `.gitignore`.
- Disable two places in the integration tests where ESLint was complaining about `n/no-extraneous-require` where `dd-trace` was being required. Not sure why this wasn't blowing up in CI?!?

### Motivation

Make the local dev-experience better.

### Additional Notes

I'm very curious why the two integration test issues wasn't a problem in CI, but only locally.

