### PR TITLE
chore(debugger): add comment about thread paused time being approximate

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -168,7 +168,9 @@ session.on('Debugger.paused', async ({ params }) => {
   await session.post('Debugger.resume')
   const diff = process.hrtime.bigint() - start // TODO: Recored as telemetry (DEBUG-2858)
 
-  log.debug(() => `[debugger:devtools_client] Finished processing breakpoints - main thread paused for: ${
+  // This doesn't measure the overhead of the CDP protocol. The actual pause time is slightly larger.
+  // On my machine I'm seeing around 1.7ms of overhead.
+  log.debug(() => `[debugger:devtools_client] Finished processing breakpoints - main thread paused for: ~${
     Number(diff) / 1_000_000
   } ms`)
 


### PR DESCRIPTION
### What does this PR do?

If debug logging is enabled, we log the main-thread paused time: Add a `~` prefix to indicate that this time is approximate and add a code comment with defails about this apprximation.

### Motivation

Make it clear that the logged time is not precise.

