### PR TITLE
fix(debugger): abort on unknown Debugger.paused reason

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -59,9 +59,8 @@ session.on('Debugger.paused', async ({ params }) => {
   const start = process.hrtime.bigint()
 
   if (params.reason !== 'other') {
-    log.error(`[debugger:devtools_client] Unexpected Debugger.paused reason: ${params.reason}`)
-    // It's ok to use process.exit here: This will just exit the worker thread, not the main process.
-    process.exit(1) // eslint-disable-line unicorn/no-process-exit
+    // This error should not be caught, and should exit the worker thread, effectively stopping the debugging session
+    throw new Error(`Unexpected Debugger.paused reason: ${params.reason}`)
   }
 
   let maxReferenceDepth, maxCollectionSize, maxFieldCount, maxLength

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -91,12 +91,7 @@ describe('onPause', function () {
     expect(send).to.not.have.been.called
   })
 
-  it('should abort if paused for an unknown reason', async function () {
-    const error = new Error('process.exit called')
-    const exitStub = sinon.stub(process, 'exit').callsFake(() => {
-      throw error
-    })
-
+  it('should throw if paused for an unknown reason', async function () {
     const unknownReasonEvent = {
       ...event,
       params: {
@@ -105,18 +100,15 @@ describe('onPause', function () {
       }
     }
 
+    let thrown
     try {
       await onPaused(unknownReasonEvent)
     } catch (err) {
-      expect(err).to.equal(error)
-    } finally {
-      exitStub.restore()
+      thrown = err
     }
 
-    expect(log.error).to.have.been.calledOnceWith(
-      '[debugger:devtools_client] Unexpected Debugger.paused reason: OOM'
-    )
-    expect(exitStub).to.have.been.calledOnceWith(1)
+    expect(thrown).to.be.an('error')
+    expect(thrown.message).to.equal('Unexpected Debugger.paused reason: OOM')
     expect(session.post).to.not.have.been.called
     expect(ackReceived).to.not.have.been.called
     expect(send).to.not.have.been.called


### PR DESCRIPTION
### What does this PR do?

Terminate the debugger in case of unexpected `Debugger.paused` reason.

### Motivation

When the `Debugger.paused` event is emitted in the debugger implementation, it's expected to be because a breakpoint is hit. In that case the events `params.reason` will be set to `other`.
    
However, if the inspected thread experiences an OOM event, `Debugger.paused` will also be emitted with `params.reason` set to `OOM`. There might also be other situations where `params.reason` is different from `other`. In all these situations we should abort and close the debugger.
    
In the case of an OOM event in the inspected thread, exiting the debugging thread, will also stop the debugging session, and this will allow the inspected thread to properly exit with an OOM error. If we didn't do this we would essentially swallow the OOM error.

