### PR TITLE
chore(debugger): change CODEOWNERS for Debugger team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,11 +8,11 @@
 /packages/dd-trace/src/aiguard/ @DataDog/asm-js
 /packages/dd-trace/test/aiguard/ @DataDog/asm-js
 
-/integration-tests/debugger/ @DataDog/dd-trace-js @DataDog/debugger
-/packages/datadog-code-origin/ @DataDog/dd-trace-js @DataDog/debugger
-/packages/datadog-plugin-*/**/code_origin.* @DataDog/dd-trace-js @DataDog/debugger
-/packages/dd-trace/src/debugger/ @DataDog/dd-trace-js @DataDog/debugger
-/packages/dd-trace/test/debugger/ @DataDog/dd-trace-js @DataDog/debugger
+/integration-tests/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/datadog-code-origin/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/datadog-plugin-*/**/code_origin.* @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/dd-trace/src/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
+/packages/dd-trace/test/debugger/ @DataDog/dd-trace-js @DataDog/debugger-nodejs
 
 /packages/dd-trace/src/lambda/ @DataDog/serverless-aws
 /packages/dd-trace/test/lambda/ @DataDog/serverless-aws
@@ -104,7 +104,7 @@
 /.github/workflows/aiguard.yml @DataDog/asm-js
 /.github/workflows/appsec.yml @DataDog/asm-js
 /.github/workflows/codeql-analysis.yml @DataDog/dd-trace-js
-/.github/workflows/debugger.yml @DataDog/debugger
+/.github/workflows/debugger.yml @DataDog/debugger-nodejs
 /.github/workflows/serverless.yml @DataDog/serverless-aws @DataDog/apm-serverless
 /.github/workflows/llmobs.yml @DataDog/ml-observability
 /.github/workflows/platform.yml @DataDog/dd-trace-js


### PR DESCRIPTION
### What does this PR do?

Change every occurrence of @DataDog/debugger to @DataDog/debugger-nodejs in the `CODEOWNERS` file.

### Motivation

Instead of notifying the entire Debugger team when a file belonging to the debugger is touched by a PR, only notify a subset of the team.

