### PR TITLE
fix: Propagate otel span kind to span.kind tag 

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -10,7 +10,7 @@ const { timeInputToHrTime } = require('@opentelemetry/core')
 const tracer = require('../../')
 const DatadogSpan = require('../opentracing/span')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK, IGNORE_OTEL_ERROR } = require('../constants')
-const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
+const { SERVICE_NAME, RESOURCE_NAME, SPAN_KIND } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
 
 const SpanContext = require('./span_context')
@@ -146,7 +146,8 @@ class Span {
       integrationName: parentTracer?._isOtelLibrary ? 'otel.library' : 'otel',
       tags: {
         [SERVICE_NAME]: _tracer._service,
-        [RESOURCE_NAME]: spanName
+        [RESOURCE_NAME]: spanName,
+        [SPAN_KIND]: spanKindNames[kind]
       },
       links
     }, _tracer._debug)

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -17,7 +17,7 @@ const SpanContext = require('../../src/opentelemetry/span_context')
 const { NoopSpanProcessor } = require('../../src/opentelemetry/span_processor')
 
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE, IGNORE_OTEL_ERROR } = require('../../src/constants')
-const { SERVICE_NAME, RESOURCE_NAME } = require('../../../../ext/tags')
+const { SERVICE_NAME, RESOURCE_NAME, SPAN_KIND } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
 const format = require('../../src/format')
 
@@ -233,6 +233,13 @@ describe('OTel Span', () => {
 
     const context = span._ddSpan.context()
     expect(context._tags[RESOURCE_NAME]).to.equal('name')
+  })
+
+  it('should copy span kind to span.kind', () => {
+    const span = makeSpan('name', { kind: api.SpanKind.CONSUMER })
+
+    const context = span._ddSpan.context()
+    expect(context._tags[SPAN_KIND]).to.equal(kinds.CONSUMER)
   })
 
   it('should expose span context', () => {


### PR DESCRIPTION
### What does this PR do?
Propagates opentelemetry's span kind into datadog's `span.kind` tag.

### Motivation
Since opentelemetry tags always have span kinds defined (and if the host project doesn't specify it then it defaults to INTERNAL) then let's propagate that span kind to DD's `span.kind` tag so that it is properly visible in the UI. Otherwise we are forcing clients to add a redundant addAttribute if they want to retain the span kind after the trace is sent to datadog.

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


