### PR TITLE
chore(otel): document otel api limitations

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -379,9 +379,17 @@ The following attributes are available to override Datadog-specific options:
 * `resource.name`: The resource name to be used for this span. The operation name will be used if this is not provided.
 * `span.type`: The span type to be used for this span. Will fallback to `custom` if not provided.
 
+### Important: Use the Same OpenTelemetry API Module
+
+dd-trace-js and your application must use the **same instance** of the `@opentelemetry/api` module. Having multiple copies in your `node_modules` will cause spans to become no-ops with all-zero trace IDs.
+
 <h3 id="opentelemetry-logs">OpenTelemetry Logs</h3>
 
-dd-trace-js includes experimental support for OpenTelemetry logs, designed as a drop-in replacement for the OpenTelemetry SDK. This support is primarily intended for logging libraries rather than direct user configuration. Enable it by setting `DD_LOGS_OTEL_ENABLED=true` and use the [OpenTelemetry Logs API](https://open-telemetry.github.io/opentelemetry-js/modules/_opentelemetry_api-logs.html) to emit structured log data:
+dd-trace-js includes experimental support for OpenTelemetry logs, designed as a drop-in replacement for the OpenTelemetry SDK. This support is primarily intended for logging libraries rather than direct user configuration.
+
+**Important:** Similar to `@opentelemetry/api`, dd-trace-js and your application must use the **same instance** of the `@opentelemetry/api-logs` module.
+
+Enable OpenTelemetry logs by setting `DD_LOGS_OTEL_ENABLED=true` and use the [OpenTelemetry Logs API](https://open-telemetry.github.io/opentelemetry-js/modules/_opentelemetry_api-logs.html) to emit structured log data:
 
 ```javascript
 require('dd-trace').init()

--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -55,7 +55,7 @@ describe('opentelemetry', () => {
   let cwd
   const timeout = 5000
   const dependencies = [
-    '@opentelemetry/api@1.8.0',
+    '@opentelemetry/api@1.9.0',
     '@opentelemetry/instrumentation',
     '@opentelemetry/instrumentation-http',
     '@opentelemetry/instrumentation-express@0.47.1',


### PR DESCRIPTION
Resolves: https://github.com/DataDog/dd-trace-js/issues/6882

### What does this PR do?

Updates OpenTelemetry documentation to clearly warn users that dd-trace-js and their application must use the same instance of `@opentelemetry/api` and `@opentelemetry/api-logs` modules.

### Motivation

Users installing different versions of `@opentelemetry/api` (e.g., v1.9.0) can end up with multiple copies in node_modules, causing module duplication. This breaks OpenTelemetry's singleton pattern, resulting in spans becoming no-ops with all-zero trace IDs and opentelemetry logs not being submitted.

This documentation update serves as an alternative to converting these packages to peer dependencies. It makes users aware of the requirement to use the same module instance as dd-trace-js.

### Additional Notes

- Added concise warnings to both OpenTelemetry API and Logs sections
- Explains the consequence: spans become no-ops with all-zero trace IDs
- No code changes, documentation only


