### PR TITLE
chore: add types to the debugger session object

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/session.js
+++ b/packages/dd-trace/src/debugger/devtools_client/session.js
@@ -2,6 +2,16 @@
 
 const inspector = require('./inspector_promises_polyfill')
 
-const session = module.exports = new inspector.Session()
+/**
+ * @typedef {import('node:events').EventEmitter & {
+ *   connect: () => void,
+ *   connectToMainThread: () => void
+ *   disconnect: () => void,
+ *   post: (method: string, params?: object) => Promise<any>,
+ * }} CDPSession
+ */
+const session = /** @type {CDPSession} */ (new inspector.Session())
 
 session.connectToMainThread()
+
+module.exports = session


### PR DESCRIPTION
### What does this PR do?

Add TypeScript types via JSDoc to the debugger session object.

### Motivation

Remove a lot of type errors throughout the debugger code.

