### PR TITLE
[test optimization] feat: support multiple docblocks

### DIFF
--- a/integration-tests/ci-visibility/unskippable-test/test-unskippable.js
+++ b/integration-tests/ci-visibility/unskippable-test/test-unskippable.js
@@ -1,6 +1,8 @@
+/** Some comment */
 /**
  * @datadog {"unskippable": true}
  */
+/* Some other comment */
 'use strict'
 
 const { expect } = require('chai')

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { readFileSync } = require('fs')
-const { parse, extract } = require('jest-docblock')
+const { parse } = require('jest-docblock')
 
 const { getTestSuitePath } = require('../../dd-trace/src/plugins/util/test')
 const log = require('../../dd-trace/src/log')
@@ -61,29 +61,59 @@ function getJestTestName (test, shouldStripSeed = false) {
   return testName
 }
 
+const globalDocblockRegExp = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/
+
 function isMarkedAsUnskippable (test) {
-  let docblocks
+  let testSource
 
   try {
-    const testSource = readFileSync(test.path, 'utf8')
-    docblocks = parse(extract(testSource))
+    testSource = readFileSync(test.path, 'utf8')
   } catch {
-    // If we have issues parsing the file, we'll assume no unskippable was passed
     return false
   }
 
-  // docblocks were correctly parsed but it does not include a @datadog block
-  if (!docblocks?.datadog) {
-    return false
+  const re = globalDocblockRegExp
+  re.lastIndex = 0
+  let commentsChecked = 0
+
+  while (testSource.length) {
+    const match = re.exec(testSource)
+    if (!match) break
+    const comment = match[1]
+
+    let docblocks
+    try {
+      docblocks = parse(comment)
+    } catch {
+      // Skip unparsable comment and continue scanning
+      if (commentsChecked++ >= 10) {
+        return false
+      }
+      continue
+    }
+
+    if (docblocks?.datadog) {
+      try {
+        // @ts-expect-error The datadog type is defined by us and may only be a string.
+        return JSON.parse(docblocks.datadog).unskippable
+      } catch {
+        // If the @datadog block comment is present but malformed, we'll run the suite
+        log.warn('@datadog block comment is malformed.')
+        return true
+      }
+    }
+
+    if (commentsChecked++ >= 10) {
+      return false
+    }
+
+    // To stop as soon as no doc blocks are found, slice the source. That way the
+    // regexp works by using the `^` anchor. Without it, it would continue
+    // scanning the rest of the file.
+    testSource = testSource.slice(match[0].length)
   }
 
-  try {
-    return JSON.parse(docblocks.datadog).unskippable
-  } catch {
-    // If the @datadog block comment is present but malformed, we'll run the suite
-    log.warn('@datadog block comment is malformed.')
-    return true
-  }
+  return false
 }
 
 function getJestSuitesToRun (skippableSuites, originalTests, rootDir) {


### PR DESCRIPTION
This allows other comments to be above the actual datadog docblock. This is also a requested feature in jest-docblock.

Refs: https://github.com/jestjs/jest/issues/12573

I limited the number of docblocks to read to up to 10, just in case of a weird file.