### PR TITLE
chore(ci): Use runner:apm-k8s-m7i-metal for microbenchmarking

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -10,7 +10,7 @@ variables:
   stage: benchmarks
   needs: [ ]
   when: on_success
-  tags: ["runner:apm-k8s-c8g-metal"]
+  tags: ["runner:apm-k8s-m7i-metal"]
   image: $MICROBENCHMARKS_CI_IMAGE
   interruptible: true
   timeout: 15m # TODO: Fix worker queueing and reduce this.
@@ -23,9 +23,6 @@ variables:
     paths:
       - platform/artifacts/
     expire_in: 3 months
-  variables:
-    KUBERNETES_CPU_REQUEST: "48"
-    KUBERNETES_CPU_LIMIT: "48"
 
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment


### PR DESCRIPTION
### What does this PR do?

Changes the runner type for microbenchmarks in order to mitigate capacity errors.

### Motivation

Improve execution speed for benchmarks by leveraging newer CPU. Mitigate capacity issues.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


