### PR TITLE
chore(ci): Add automatic retry on benchmarking infrastructure failure

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -30,7 +30,7 @@ variables:
       - data_integrity_failure
       - runner_system_failure
       - scheduler_failure
-      - api_failures
+      - api_failure
 
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment


### PR DESCRIPTION
### What does this PR do?

Adds automatic retry on benchmarking infrastructure failures.

### Motivation

Stop asking users to retrigger manually on infrastructure failures.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


