### PR TITLE
add openfeature paths to codeowners by @datadog/feature-flagging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -98,6 +98,11 @@
 /packages/dd-trace/src/span_sampler.js @DataDog/apm-sdk-capabilities-js
 /packages/dd-trace/test/span_sampler.spec.js @DataDog/apm-sdk-capabilities-js
 
+# Feature Flagging
+/integration-tests/openfeature/ @DataDog/feature-flagging
+/packages/dd-trace/src/openfeature/ @DataDog/feature-flagging
+/packages/dd-trace/test/openfeature/ @DataDog/feature-flagging
+
 # CI
 /.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
 /.github/workflows/apm-integrations.yml @Datadog/apm-idm-js


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

Now that the feature flagging product has launched and we have observed how code standards and releases are handled (including system tests), we would like our time to own the package to be able to iterate on it on a more local scale.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


