### PR TITLE
fix: log plugin name in case the handler throws

### DIFF
--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -118,18 +118,13 @@ module.exports = class Plugin {
    * @returns {void}
    */
   addSub (channelName, handler) {
-    const plugin = this
-    /**
-     * @this {unknown}
-     * @returns {unknown}
-     */
-    const wrappedHandler = function () {
+    const wrappedHandler = (...args) => {
       try {
-        return handler.apply(this, arguments)
-      } catch (e) {
-        logger.error('Error in plugin handler:', e)
-        logger.info('Disabling plugin: %s', plugin.id)
-        plugin.configure(false)
+        return handler.apply(this, args)
+      } catch (error) {
+        logger.error('Error in plugin handler:', error)
+        logger.info('Disabling plugin: %s', this.constructor.name)
+        this.configure(false)
       }
     }
     this._subscriptions.push(new Subscription(channelName, wrappedHandler))


### PR DESCRIPTION
In case a plugin handler fails, it will deactivate the plugin. While doing so, the plugin that failed is logged. The id is placed on the constructor though, not on the instance. Due to that, it would log undefined so far.
Fixing it by using the constructor is also not ideal though, due to having more than a single plugin with the same id. That id represents the instrumentation, not the plugin itself. An instrumentation can actually have multiple plugins and the failure will only deactivate a specific plugin. Therefore, the information about what plugin will be deactivated should log the name of the plugin instead of the id.
