### PR TITLE
Fix[CI]: deny benchmark runs on temporary graphite branches

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -9,7 +9,10 @@ variables:
 .benchmarks:
   stage: benchmarks
   needs: [ ]
-  when: on_success
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
+      when: never
+    - when: on_success
   tags: ["runner:apm-k8s-m7i-metal"]
   image: $MICROBENCHMARKS_CI_IMAGE
   rules:
@@ -38,7 +41,10 @@ variables:
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment
   needs: [ benchmark, benchmark-serverless ]
-  when: on_success
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
+      when: never
+    - when: on_success
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE
   script:
@@ -49,7 +55,10 @@ benchmarks-pr-comment:
 check-big-regressions:
   stage: benchmarks-pr-comment
   needs: [ benchmark, benchmark-serverless ]
-  when: on_success
+  rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
+      when: never
+    - when: on_success
   tags: ["arch:amd64"]
   image: $MICROBENCHMARKS_CI_IMAGE
   script:

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -8,6 +8,8 @@ include:
   stage: macrobenchmarks
   when: always
   rules:
+    - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
+      when: never
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
     - interruptible: true


### PR DESCRIPTION
### What does this PR do?
This PR excludes creating pipelines based on graphite branches. This comes as it duplicates benchmark runs and induces errors in branch referencing.
<img width="641" height="232" alt="image" src="https://github.com/user-attachments/assets/29333c9d-90aa-4374-8bb8-20ff113081db" />
Example of pipeline: 
[Graphite based pipeline](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/pipelines/83319201)
[Commit reference](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/commit/bed66ba665b688295d853cff91a59be5fc362452)
[Actual reference pipeline with correct commit](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/pipelines/83345068)

### Motivation
We have had a shortage of metal instances to run benchmarks on and are culling out these duplicate pipelines.

### Tests
[Branch with graphite like name created based on current Gitlab config on main](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/pipelines?page=1&scope=all&ref=graphite-base%2Ftest-exclusion-before): pipeline exists
[Branch with graphite like name created based on current Gitlab config on this branch](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/pipelines?page=1&scope=all&ref=graphite-base%2Ftest-exclusion) : pipeline does not exist.

For [the commit sha shared yesterday](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/commit/bed66ba665b688295d853cff91a59be5fc362452), there were 2 pipelines
[graphite one](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/pipelines/83319201):  10:58 am - failed
[expected branch](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/pipelines/83319201): 1:40 pm -  successful
(both triggered from codesync) meaning the benchmarks will be triggered normally on push to the right branch.
The PR checks being based on the latest pipeline referring to the head, no pipepline from graphite and the right pipeline from the right branch should fix it!

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


