### PR TITLE
test(debugger): refactor triggerBreakpoint helper function

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -54,16 +54,19 @@ function setup ({ env, testApp, testAppSource, dependencies, silent, stdioHandle
 
   // Trigger the breakpoint once probe is successfully installed
   async function triggerBreakpoint (url) {
-    let triggered = false
     return new Promise((resolve, reject) => {
-      t.agent.on('debugger-diagnostics', ({ payload }) => {
-        payload.forEach((event) => {
-          if (!triggered && event.debugger.diagnostics.status === 'INSTALLED') {
-            triggered = true
+      t.agent.on('debugger-diagnostics', diagnosticsReceived)
+
+      function diagnosticsReceived ({ payload }) {
+        payload.some((event) => {
+          if (event.debugger.diagnostics.status === 'INSTALLED') {
+            t.agent.removeListener('debugger-diagnostics', diagnosticsReceived)
             t.axios.get(url).then(resolve).catch(reject)
+            return true
           }
+          return false
         })
-      })
+      }
     })
   }
 


### PR DESCRIPTION
### What does this PR do?

Stop listening for `debugger-diagnostics` events on the fake agent once the event we're looking is found.

### Motivation

The new function is cleaner and with a theoretical lower overhead, though in reality this shouldn't make a difference during testing.

