### PR TITLE
chore: type-cast server.address() calls

### DIFF
--- a/integration-tests/aiguard/server.js
+++ b/integration-tests/aiguard/server.js
@@ -48,6 +48,6 @@ app.get('/abort', async (req, res) => {
 })
 
 const server = app.listen(() => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/integration-tests/appsec/data-collection/index.js
+++ b/integration-tests/appsec/data-collection/index.js
@@ -22,5 +22,5 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/appsec/endpoints-collection/express.js
+++ b/integration-tests/appsec/endpoints-collection/express.js
@@ -122,6 +122,6 @@ app.use('/invalid', invalidRouter)
 invalidRouter.get('nested', (_, res) => res.send('ok'))
 
 const server = app.listen(0, '127.0.0.1', () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/integration-tests/appsec/esm-app/index.mjs
+++ b/integration-tests/appsec/esm-app/index.mjs
@@ -14,7 +14,7 @@ app.get('/cmdi-vulnerable', (req, res) => {
 app.use('/more', (await import('./more.mjs')).default)
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })
 
 Module.register('./custom-noop-hooks.mjs', {

--- a/integration-tests/appsec/esm-security-controls/index.mjs
+++ b/integration-tests/appsec/esm-security-controls/index.mjs
@@ -62,5 +62,5 @@ app.get('/cmdi-iv-secure', (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/appsec/iast-esbuild-cjs/app.js
+++ b/integration-tests/appsec/iast-esbuild-cjs/app.js
@@ -12,5 +12,5 @@ const app = express()
 app.use('/iast', iastRouter)
 
 const server = app.listen(0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/appsec/iast-esbuild-esm/app.mjs
+++ b/integration-tests/appsec/iast-esbuild-esm/app.mjs
@@ -9,5 +9,5 @@ const app = express()
 app.use('/iast', iastRouter)
 
 const server = app.listen(0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/appsec/iast-stack-traces-ts-with-sourcemaps/index.ts
+++ b/integration-tests/appsec/iast-stack-traces-ts-with-sourcemaps/index.ts
@@ -9,5 +9,5 @@ app.use('/not-rewritten', notRewrittenRoutes)
 app.use('/rewritten', rewrittenRoutes)
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/appsec/multer/index.js
+++ b/integration-tests/appsec/multer/index.js
@@ -59,6 +59,6 @@ app.get('/', (req, res) => {
 })
 
 const server = http.createServer(app).listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send?.({ port })
 })

--- a/integration-tests/debugger/target-app/custom-logger.js
+++ b/integration-tests/debugger/target-app/custom-logger.js
@@ -19,5 +19,5 @@ const server = http.createServer((req, res) => {
 })
 
 server.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/debugger/target-app/re-evaluation/index.js
+++ b/integration-tests/debugger/target-app/re-evaluation/index.js
@@ -5,5 +5,5 @@ const server = createServer((req, res) => {
 })
 
 server.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/debugger/target-app/re-evaluation/unique-filename.js
+++ b/integration-tests/debugger/target-app/re-evaluation/unique-filename.js
@@ -5,5 +5,5 @@ const server = createServer((req, res) => {
 })
 
 server.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/debugger/target-app/source-map-support/bundle.js
+++ b/integration-tests/debugger/target-app/source-map-support/bundle.js
@@ -44,6 +44,6 @@ var server = (0, import_node_http.createServer)((req, res) => {
   res.end((0, import_world.sayHello)());
 });
 server.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port });
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port });
 });
 //# sourceMappingURL=bundle.js.map

--- a/integration-tests/debugger/target-app/source-map-support/minify.js
+++ b/integration-tests/debugger/target-app/source-map-support/minify.js
@@ -9,5 +9,5 @@ const server = createServer((req, res) => {
 })
 
 server.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/debugger/target-app/unreffed.js
+++ b/integration-tests/debugger/target-app/unreffed.js
@@ -11,5 +11,5 @@ const server = http.createServer((req, res) => {
 })
 
 server.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/esbuild/esm-http-test.mjs
+++ b/integration-tests/esbuild/esm-http-test.mjs
@@ -9,6 +9,6 @@ const server = http.createServer((req, res) => {
 })
 
 server.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/integration-tests/init/instrument.js
+++ b/integration-tests/init/instrument.js
@@ -11,7 +11,7 @@ dc.subscribe('apm:http:client:request:start', (event) => {
 const server = http.createServer((req, res) => {
   res.end('Hello World')
 }).listen(0, () => {
-  http.get(`http://localhost:${server.address().port}`, (res) => {
+  http.get(`http://localhost:${(/** @type {import('net').AddressInfo} */ (server.address())).port}`, (res) => {
     res.on('data', () => {})
     res.on('end', () => {
       server.close()

--- a/integration-tests/init/instrument.mjs
+++ b/integration-tests/init/instrument.mjs
@@ -9,7 +9,7 @@ dc.subscribe('apm:http:client:request:start', (event) => {
 const server = http.createServer((req, res) => {
   res.end('Hello World')
 }).listen(0, () => {
-  http.get(`http://localhost:${server.address().port}`, (res) => {
+  http.get(`http://localhost:${(/** @type {import('net').AddressInfo} */ (server.address())).port}`, (res) => {
     res.on('data', () => {})
     res.on('end', () => {
       server.close()

--- a/integration-tests/log_injection/index.js
+++ b/integration-tests/log_injection/index.js
@@ -45,6 +45,6 @@ app.get('/sampled', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/integration-tests/pino/index.js
+++ b/integration-tests/pino/index.js
@@ -27,6 +27,6 @@ const server = http
     res.end('hello, world\n')
   })
   .listen(0, () => {
-    const port = server.address().port
+    const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
     process.send({ port })
   })

--- a/integration-tests/remote_config/index.js
+++ b/integration-tests/remote_config/index.js
@@ -17,5 +17,5 @@ const server = app.listen(process.env.APP_PORT || 0, (error) => {
   if (error) {
     throw error
   }
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/integration-tests/standalone-asm/index.js
+++ b/integration-tests/standalone-asm/index.js
@@ -73,7 +73,7 @@ app.get('/propagation-with-event', async (req, res) => {
   const span = tracer.scope().active()
   span.context()._trace.tags['_dd.p.other'] = '1'
 
-  const port = req.query.port || server.address().port
+  const port = req.query.port || (/** @type {import('net').AddressInfo} */ (server.address())).port
   const url = `http://localhost:${port}/down`
 
   await makeRequest(url)
@@ -82,7 +82,7 @@ app.get('/propagation-with-event', async (req, res) => {
 })
 
 app.get('/propagation-without-event', async (req, res) => {
-  const port = req.query.port || server.address().port
+  const port = req.query.port || (/** @type {import('net').AddressInfo} */ (server.address())).port
   const url = `http://localhost:${port}/down`
 
   const span = tracer.scope().active()
@@ -111,6 +111,6 @@ app.get('/propagation-after-drop-and-call-sdk', async (req, res) => {
 })
 
 const server = http.createServer(app).listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send?.({ port })
 })

--- a/integration-tests/startup/index.js
+++ b/integration-tests/startup/index.js
@@ -31,6 +31,6 @@ const http = require('http')
 const server = http.createServer((req, res) => {
   res.end('hello, world\n')
 }).listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-instrumentations/test/body-parser.spec.js
+++ b/packages/datadog-instrumentations/test/body-parser.spec.js
@@ -29,7 +29,7 @@ withVersions('body-parser', 'body-parser', version => {
         res.end('DONE')
       })
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/cookie-parser.spec.js
+++ b/packages/datadog-instrumentations/test/cookie-parser.spec.js
@@ -29,7 +29,7 @@ withVersions('cookie-parser', 'cookie-parser', version => {
         res.end('DONE')
       })
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
+++ b/packages/datadog-instrumentations/test/express-mongo-sanitize.spec.js
@@ -31,7 +31,7 @@ describe('express-mongo-sanitize', () => {
         })
 
         server = app.listen(0, () => {
-          port = server.address().port
+          port = (/** @type {import('net').AddressInfo} */ (server.address())).port
           done()
         })
       })

--- a/packages/datadog-instrumentations/test/express-session.spec.js
+++ b/packages/datadog-instrumentations/test/express-session.spec.js
@@ -40,7 +40,7 @@ withVersions('express-session', 'express-session', version => {
       })
 
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/express.spec.js
+++ b/packages/datadog-instrumentations/test/express.spec.js
@@ -27,7 +27,7 @@ withVersions('express', 'express', version => {
         res.end('DONE')
       })
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/multer.spec.js
+++ b/packages/datadog-instrumentations/test/multer.spec.js
@@ -31,7 +31,7 @@ withVersions('multer', 'multer', version => {
         res.end('DONE')
       })
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/passport-http.spec.js
+++ b/packages/datadog-instrumentations/test/passport-http.spec.js
@@ -94,7 +94,7 @@ withVersions('passport-http', 'passport-http', version => {
       passportVerifyChannel.subscribe((data) => subscriberStub(data))
 
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/passport-local.spec.js
+++ b/packages/datadog-instrumentations/test/passport-local.spec.js
@@ -94,7 +94,7 @@ withVersions('passport-local', 'passport-local', version => {
       passportVerifyChannel.subscribe((data) => subscriberStub(data))
 
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-instrumentations/test/passport.spec.js
+++ b/packages/datadog-instrumentations/test/passport.spec.js
@@ -88,7 +88,7 @@ withVersions('passport', 'passport', version => {
       })
 
       server = app.listen(0, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/datadog-plugin-connect/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-connect/test/integration-test/server.mjs
@@ -8,6 +8,6 @@ app.use((req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-cookie-parser/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-cookie-parser/test/integration-test/server.mjs
@@ -16,6 +16,6 @@ app.use((req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-cookie/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-cookie/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-crypto/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-crypto/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-express-mongo-sanitize/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-express-mongo-sanitize/test/integration-test/server.mjs
@@ -19,6 +19,6 @@ app.all('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-express-session/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-express-session/test/integration-test/server.mjs
@@ -25,6 +25,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-express/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-express/test/integration-test/server.mjs
@@ -8,6 +8,6 @@ app.use((req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-fetch/test/index.spec.js
+++ b/packages/datadog-plugin-fetch/test/index.spec.js
@@ -25,7 +25,7 @@ describe('Plugin', function () {
   describe('fetch', () => {
     function server (app, listener) {
       const server = require('http').createServer(app)
-      server.listen(0, 'localhost', () => listener(server.address().port))
+      server.listen(0, 'localhost', () => listener((/** @type {import('net').AddressInfo} */ (server.address())).port))
       return server
     }
 

--- a/packages/datadog-plugin-generic-pool/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-generic-pool/test/integration-test/server.mjs
@@ -35,6 +35,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-server.mjs
@@ -50,7 +50,7 @@ const server = createServer(async (req, res) => {
 const port = process.env.PORT || 0
 
 server.listen(port, () => {
-  const actualPort = server.address().port
+  const actualPort = (/** @type {import('net').AddressInfo} */ (server.address())).port
   // Send port to parent process for integration tests
   if (process.send) {
     process.send({ port: actualPort })

--- a/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-yoga-server.mjs
+++ b/packages/datadog-plugin-graphql/test/esm-test/esm-graphql-yoga-server.mjs
@@ -31,7 +31,7 @@ const server = createServer(yoga)
 const port = process.env.PORT || 0
 
 server.listen(port, () => {
-  const actualPort = server.address().port
+  const actualPort = (/** @type {import('net').AddressInfo} */ (server.address())).port
   // Send port to parent process for integration tests
   if (process.send) {
     process.send({ port: actualPort })

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -268,7 +268,7 @@ describe('Plugin', () => {
 
           before(done => {
             server.listen(0, () => {
-              port = server.address().port
+              port = (/** @type {import('net').AddressInfo} */ (server.address())).port
               done()
             })
           })

--- a/packages/datadog-plugin-handlebars/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-handlebars/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -42,7 +42,7 @@ describe('Plugin', () => {
           server = require('node:http').createServer(app)
         }
         server.listen(0, 'localhost', () => {
-          listener(server.address().port)
+          listener((/** @type {import('net').AddressInfo} */ (server.address())).port)
         })
         return server
       }

--- a/packages/datadog-plugin-http/test/code_origin.spec.js
+++ b/packages/datadog-plugin-http/test/code_origin.spec.js
@@ -65,6 +65,6 @@ function server (callback) {
   })
 
   server.listen(() => {
-    callback(server.address().port)
+    callback((/** @type {import('net').AddressInfo} */ (server.address())).port)
   })
 }

--- a/packages/datadog-plugin-http/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http/test/integration-test/server.mjs
@@ -9,6 +9,6 @@ const server = http.createServer(async (req, res) => {
     res.end('integration test response handler failure')
   }
 }).listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -36,7 +36,9 @@ describe('Plugin', () => {
           server = require(loadPlugin).createServer()
         }
         server.on('stream', app)
-        server.listen(0, 'localhost', () => listener(server.address().port))
+        server.listen(0, 'localhost', () => listener(
+          (/** @type {import('net').AddressInfo} */ (server.address())).port
+        ))
         return server
       }
 

--- a/packages/datadog-plugin-http2/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-http2/test/integration-test/server.mjs
@@ -6,6 +6,6 @@ const server = http2.createServer((req, res) => {
 })
 
 server.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-knex/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-knex/test/integration-test/server.mjs
@@ -29,6 +29,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-koa/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-koa/test/integration-test/server.mjs
@@ -8,6 +8,6 @@ app.use(async (ctx) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-ldapjs/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-ldapjs/test/integration-test/server.mjs
@@ -19,6 +19,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-lodash/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-lodash/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-microgateway-core/test/index.spec.js
+++ b/packages/datadog-plugin-microgateway-core/test/index.spec.js
@@ -43,7 +43,7 @@ describe('Plugin', () => {
         })
 
         gateway.start((err, server) => {
-          gatewayPort = server.address().port
+          gatewayPort = (/** @type {import('net').AddressInfo} */ (server.address())).port
           cb(err)
         })
       })

--- a/packages/datadog-plugin-multer/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-multer/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.post('/upload', upload.single('file'), (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-next/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-next/test/integration-test/server.mjs
@@ -8,7 +8,7 @@ nextApp.prepare().then(() => {
   const server = createServer((req, res) => {
     handle(req, res)
   }).listen(0, () => {
-    const port = server.address().port
+    const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
     process.send({ port })
   })
 })

--- a/packages/datadog-plugin-node-serialize/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-node-serialize/test/integration-test/server.mjs
@@ -20,6 +20,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-passport-http/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-passport-http/test/integration-test/server.mjs
@@ -49,6 +49,6 @@ app.get('/',
 )
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-process/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-process/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-pug/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-pug/test/integration-test/server.mjs
@@ -18,6 +18,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-restify/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-restify/test/integration-test/server.mjs
@@ -4,6 +4,6 @@ import restify from 'restify'
 const server = restify.createServer()
 
 server.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-router/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-router/test/integration-test/server.mjs
@@ -20,6 +20,6 @@ const server = http.createServer((req, res) => {
 })
 
 server.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-sequelize/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-sequelize/test/integration-test/server.mjs
@@ -21,6 +21,6 @@ app.get('/', async (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -22,7 +22,9 @@ describe('Plugin', () => {
     withVersions('undici', 'undici', NODE_MAJOR < 20 ? '<7.11.0' : '*', (version) => {
       function server (app, listener) {
         const server = require('http').createServer(app)
-        server.listen(0, 'localhost', () => listener(server.address().port))
+        server.listen(0, 'localhost', () => listener(
+          (/** @type {import('net').AddressInfo} */ (server.address())).port)
+        )
         return server
       }
 

--- a/packages/datadog-plugin-url/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-url/test/integration-test/server.mjs
@@ -19,6 +19,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/datadog-plugin-vm/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-vm/test/integration-test/server.mjs
@@ -20,6 +20,6 @@ app.get('/', (req, res) => {
 })
 
 const server = app.listen(0, () => {
-  const port = server.address().port
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
   process.send({ port })
 })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.express.plugin.spec.js
@@ -30,7 +30,7 @@ withVersions('express', 'express', expressVersion => {
       })
 
       server = app.listen(port, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.fastify.plugin.spec.js
@@ -28,7 +28,7 @@ withVersions('fastify', 'fastify', fastifyVersion => {
       })
 
       app.listen({ port: 0 }, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-http.plugin.spec.js
@@ -60,7 +60,7 @@ withVersions('passport-http', 'passport-http', version => {
       })
 
       server = app.listen(port, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`,
           headers: {

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.passport-local.plugin.spec.js
@@ -60,7 +60,7 @@ withVersions('passport-local', 'passport-local', version => {
       })
 
       server = app.listen(port, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`,
           headers: {

--- a/packages/dd-trace/test/appsec/extended-data-collection.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/extended-data-collection.express.plugin.spec.js
@@ -60,7 +60,7 @@ describe('extended data collection', () => {
       })
 
       server = app.listen(port, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/dd-trace/test/appsec/iast/resources/eval.js
+++ b/packages/dd-trace/test/appsec/iast/resources/eval.js
@@ -15,5 +15,5 @@ app.get('/eval', async (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/iast/resources/overhead-controller.js
+++ b/packages/dd-trace/test/appsec/iast/resources/overhead-controller.js
@@ -61,5 +61,5 @@ app.get('/route2/:param', (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/iast/resources/vm.js
+++ b/packages/dd-trace/test/appsec/iast/resources/vm.js
@@ -19,5 +19,5 @@ app.get('/vm/SourceTextModule', async (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -358,7 +358,7 @@ function prepareTestServerForIastInExpress (
       expressApp.all('/', listener)
 
       server = expressApp.listen(0, () => {
-        config.port = server.address().port
+        config.port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })
@@ -468,7 +468,7 @@ function prepareTestServerForIastInFastify (description, fastifyVersion, tests, 
       await fastifyApp.listen({ port: 0 })
 
       server = fastifyApp.server
-      config.port = server.address().port
+      config.port = (/** @type {import('net').AddressInfo} */ (server.address())).port
     })
 
     beforeEachIastTest(iastConfig)

--- a/packages/dd-trace/test/appsec/index.body-parser.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.body-parser.plugin.spec.js
@@ -32,7 +32,7 @@ withVersions('body-parser', 'body-parser', version => {
       })
 
       server = app.listen(port, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/dd-trace/test/appsec/index.cookie-parser.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.cookie-parser.plugin.spec.js
@@ -32,7 +32,7 @@ withVersions('cookie-parser', 'cookie-parser', version => {
       })
 
       server = app.listen(port, () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
     })

--- a/packages/dd-trace/test/appsec/index.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.express.plugin.spec.js
@@ -61,7 +61,7 @@ withVersions('express', 'express', version => {
       app.param('callbackedParameter', paramCallbackSpy)
 
       server = app.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })
@@ -210,7 +210,7 @@ withVersions('express', 'express', version => {
       })
 
       server = app.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })
@@ -287,7 +287,7 @@ withVersions('express', 'express', version => {
       })
 
       server = app.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })

--- a/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
@@ -35,7 +35,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
       })
 
       app.listen({ port: 0 }, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })
@@ -100,7 +100,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
       })
 
       app.listen({ port: 0 }, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })
@@ -209,7 +209,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
       })
 
       app.listen({ port: 0 }, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })
@@ -298,7 +298,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
       })
 
       app.listen({ port: 0 }, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })
@@ -480,7 +480,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
             })
 
             app.listen({ port: 0 }, () => {
-              const port = server.address().port
+              const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
               axios = Axios.create({ baseURL: `http://localhost:${port}` })
               done()
             })
@@ -574,7 +574,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
         })
 
         app.listen({ port: 0 }, () => {
-          const port = server.address().port
+          const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
           axios = Axios.create({ baseURL: `http://localhost:${port}` })
           done()
         })
@@ -668,7 +668,7 @@ describe('Api Security - Fastify', () => {
       })
 
       app.listen({ port: 0 }, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({ baseURL: `http://localhost:${port}` })
         done()
       })

--- a/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
@@ -72,7 +72,7 @@ describe('sequelize', () => {
           })
 
           server = app.listen(0, () => {
-            port = server.address().port
+            port = (/** @type {import('net').AddressInfo} */ (server.address())).port
             done()
           })
         })

--- a/packages/dd-trace/test/appsec/rasp/command_injection.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.express.plugin.spec.js
@@ -80,7 +80,7 @@ describe('RASP - command_injection', () => {
       }))
 
       server = expressApp.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`
         })

--- a/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.express.plugin.spec.js
@@ -69,7 +69,7 @@ describe('RASP - lfi', () => {
         }))
 
         server = expressApp.listen(0, () => {
-          const port = server.address().port
+          const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
           axios = Axios.create({
             baseURL: `http://localhost:${port}`
           })
@@ -481,7 +481,7 @@ describe('RASP - lfi', () => {
       }))
 
       server.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`
         })

--- a/packages/dd-trace/test/appsec/rasp/resources/lfi-app/index.js
+++ b/packages/dd-trace/test/appsec/rasp/resources/lfi-app/index.js
@@ -23,5 +23,5 @@ app.get('/lfi/sync', (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/rasp/resources/postgress-app/index.js
+++ b/packages/dd-trace/test/appsec/rasp/resources/postgress-app/index.js
@@ -50,5 +50,5 @@ app.get('/sqli/pool/uncaught-promise', async (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/rasp/resources/shi-app/index.js
+++ b/packages/dd-trace/test/appsec/rasp/resources/shi-app/index.js
@@ -53,5 +53,5 @@ app.get('/cmdi/execFileSync/out-of-express-scope', async (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.mysql2.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.mysql2.plugin.spec.js
@@ -42,7 +42,7 @@ describe('RASP - sql_injection', () => {
           }))
 
           server = expressApp.listen(0, () => {
-            const port = server.address().port
+            const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
             axios = Axios.create({
               baseURL: `http://localhost:${port}`
             })

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.pg.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.pg.plugin.spec.js
@@ -49,7 +49,7 @@ describe('RASP - sql_injection', () => {
           }))
 
           server = expressApp.listen(0, () => {
-            const port = server.address().port
+            const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
             axios = Axios.create({
               baseURL: `http://localhost:${port}`
             })

--- a/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
@@ -39,7 +39,7 @@ describe('RASP - ssrf', () => {
       }))
 
       server = expressApp.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`
         })
@@ -247,7 +247,7 @@ describe('RASP - ssrf', () => {
       }))
 
       server.listen(0, () => {
-        const port = server.address().port
+        const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         axios = Axios.create({
           baseURL: `http://localhost:${port}`
         })

--- a/packages/dd-trace/test/appsec/resources/index.js
+++ b/packages/dd-trace/test/appsec/resources/index.js
@@ -16,5 +16,5 @@ app.post('/', async (req, res) => {
 })
 
 const server = app.listen(process.env.APP_PORT || 0, () => {
-  process.send?.({ port: server.address().port })
+  process.send?.({ port: (/** @type {import('net').AddressInfo} */ (server.address())).port })
 })

--- a/packages/dd-trace/test/appsec/response_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/response_blocking.spec.js
@@ -41,7 +41,7 @@ describe('HTTP Response Blocking', () => {
     await new Promise((resolve, reject) => {
       server.listen(0, 'localhost')
         .once('listening', (...args) => {
-          const port = server.address().port
+          const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
 
           axios = Axios.create(({
             baseURL: `http://localhost:${port}`,

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -31,7 +31,7 @@ const initHTTPServer = () => {
         sockets.forEach(socket => socket.end())
         server.close()
       }
-      shutdown.port = server.address().port
+      shutdown.port = (/** @type {import('net').AddressInfo} */ (server.address())).port
       resolve(shutdown)
     })
   })

--- a/packages/dd-trace/test/flare.spec.js
+++ b/packages/dd-trace/test/flare.spec.js
@@ -40,7 +40,7 @@ describe('Flare', () => {
     })
 
     listener = server.listen(0, '127.0.0.1', () => {
-      port = server.address().port
+      port = (/** @type {import('net').AddressInfo} */ (server.address())).port
       done()
     })
   }

--- a/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js
+++ b/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js
@@ -63,7 +63,7 @@ describe('Inferred Proxy Spans', function () {
 
     return new Promise((resolve, reject) => {
       appListener = server.listen(0, '127.0.0.1', () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         appListener._connections = connections
         resolve()
       })

--- a/packages/dd-trace/test/plugins/util/ip_extractor.spec.js
+++ b/packages/dd-trace/test/plugins/util/ip_extractor.spec.js
@@ -20,7 +20,7 @@ describe('ip extractor', () => {
     })
     appListener = server
       .listen(0, 'localhost', () => {
-        port = server.address().port
+        port = (/** @type {import('net').AddressInfo} */ (server.address())).port
         done()
       })
   })

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -216,7 +216,7 @@ describe('telemetry', () => {
       telemetry.start({
         telemetry: { enabled: false, heartbeatInterval: 60000 },
         hostname: 'localhost',
-        port: server.address().port
+        port: (/** @type {import('net').AddressInfo} */ (server.address())).port
       })
 
       setTimeout(() => {


### PR DESCRIPTION
### What does this PR do?

Change all `server.address().` calls to:

    (/** @type {import('net').AddressInfo} */ (server.address())).

- Only test files are being modified in this PR
- Don't touch instances where `server` is being chained, e.g.  `app.server`.

### Motivation

Avoid TS complaining about `address()` possibly returning `null`.

