### PR TITLE
fix(debugger): address TS errors

### DIFF
--- a/integration-tests/debugger/target-app/basic.js
+++ b/integration-tests/debugger/target-app/basic.js
@@ -1,6 +1,7 @@
 'use strict'
 
 require('dd-trace/init')
+// @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -1,6 +1,7 @@
 'use strict'
 
 require('dd-trace/init')
+// @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })

--- a/integration-tests/debugger/target-app/snapshot-pruning.js
+++ b/integration-tests/debugger/target-app/snapshot-pruning.js
@@ -3,6 +3,7 @@
 require('dd-trace/init')
 
 const { randomBytes } = require('crypto')
+// @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })

--- a/integration-tests/debugger/target-app/snapshot-time-budget.js
+++ b/integration-tests/debugger/target-app/snapshot-time-budget.js
@@ -2,6 +2,7 @@
 
 require('dd-trace/init')
 
+// @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })

--- a/integration-tests/debugger/target-app/snapshot.js
+++ b/integration-tests/debugger/target-app/snapshot.js
@@ -1,6 +1,7 @@
 'use strict'
 
 require('dd-trace/init')
+// @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })

--- a/integration-tests/debugger/target-app/template.js
+++ b/integration-tests/debugger/target-app/template.js
@@ -2,6 +2,7 @@
 
 require('dd-trace/init')
 const { inspect } = require('util')
+// @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')
 
 const fastify = Fastify({ logger: { level: 'error' } })

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -23,6 +23,12 @@ const pollInterval = 0.1
  */
 
 /**
+ * Bound version of generateProbeConfig that only requires optional overrides (breakpoint is already bound).
+ *
+ * @typedef {(overrides?: Partial<ProbeConfig>) => ProbeConfig} BoundGenerateProbeConfigFn
+ */
+
+/**
  * @typedef {Object} BreakpointInfo
  * @property {string} sourceFile
  * @property {string} deployedFile
@@ -37,7 +43,7 @@ const pollInterval = 0.1
  *   rcConfig: object|null,
  *   triggerBreakpoint: (url: string) => Promise<import('axios').AxiosResponse<unknown>>,
  *   generateRemoteConfig: (overrides?: object) => object,
- *   generateProbeConfig: GenerateProbeConfigFn
+ *   generateProbeConfig: BoundGenerateProbeConfigFn
  * }} EnrichedBreakpoint
  */
 
@@ -59,7 +65,7 @@ const pollInterval = 0.1
  * @property {() => Promise<import('axios').AxiosResponse<unknown>>} triggerBreakpoint - Triggers the primary breakpoint
  *   once installed.
  * @property {(overrides?: object) => object} generateRemoteConfig - Generates RC for the primary breakpoint.
- * @property {GenerateProbeConfigFn} generateProbeConfig - Generates probe config for the primary breakpoint.
+ * @property {BoundGenerateProbeConfigFn} generateProbeConfig - Generates probe config for the primary breakpoint.
  */
 
 module.exports = {

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -80,8 +80,17 @@ async function addBreakpoint (probe) {
     log.debug(
       '[debugger:devtools_client] Translating location using source map for %s:%d:%d (probe: %s, version: %d)',
       file, lineNumber, columnNumber, probe.id, probe.version
-    );
-    ({ line: lineNumber, column: columnNumber } = await getGeneratedPosition(url, source, lineNumber, sourceMapURL))
+    )
+    const position = await getGeneratedPosition(url, source, lineNumber, sourceMapURL)
+    if (position.line !== null && position.column !== null) {
+      lineNumber = position.line
+      columnNumber = position.column
+    } else {
+      throw new Error(
+        // eslint-disable-next-line @stylistic/max-len
+        `Could not find generated position for ${url}:${lineNumber}:${columnNumber} (probe: ${probe.id}, version: ${probe.version})`
+      )
+    }
   }
 
   try {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -46,6 +46,7 @@ let snapshotProbeIndexBuffer, snapshotProbeIndex
 
 if (SUPPORT_ARRAY_BUFFER_RESIZE) {
   // TODO: Is a limit of 256 snapshots ever going to be a problem?
+  // @ts-ignore - ArrayBuffer constructor with maxByteLength is available in Node.js 20+ but not in @types/node@18
   // eslint-disable-next-line n/no-unsupported-features/es-syntax
   snapshotProbeIndexBuffer = new ArrayBuffer(1, { maxByteLength: 256 })
   // TODO: Is a limit of 256 probes ever going to be a problem?

--- a/packages/dd-trace/src/debugger/devtools_client/inspector_promises_polyfill.js
+++ b/packages/dd-trace/src/debugger/devtools_client/inspector_promises_polyfill.js
@@ -5,6 +5,7 @@
 const { builtinModules } = require('node:module')
 
 if (builtinModules.includes('inspector/promises')) {
+  // @ts-ignore - inspector/promises is available in Node.js 20+ but not in @types/node@18
   module.exports = require('node:inspector/promises')
 } else {
   const inspector = require('node:inspector')
@@ -12,6 +13,7 @@ if (builtinModules.includes('inspector/promises')) {
 
   // The rest of the code in this file is lifted from:
   // https://github.com/nodejs/node/blob/1d4d76ff3fb08f9a0c55a1d5530b46c4d5d550c7/lib/inspector/promises.js
+  // @ts-expect-error - We intentionally override 'post' with a promisified version, changing its signature
   class Session extends inspector.Session {
     constructor () { super() } // eslint-disable-line no-useless-constructor
   }

--- a/packages/dd-trace/src/debugger/devtools_client/json-buffer.js
+++ b/packages/dd-trace/src/debugger/devtools_client/json-buffer.js
@@ -1,34 +1,40 @@
 'use strict'
 
 class JSONBuffer {
+  #maxSize
+  #timeout
+  #onFlush
+  #timer
+  #partialJson
+
   constructor ({ size, timeout, onFlush }) {
-    this._maxSize = size
-    this._timeout = timeout
-    this._onFlush = onFlush
-    this._reset()
+    this.#maxSize = size
+    this.#timeout = timeout
+    this.#onFlush = onFlush
+    this.#reset()
   }
 
-  _reset () {
-    clearTimeout(this._timer)
-    this._timer = null
-    this._partialJson = null
+  #reset () {
+    clearTimeout(this.#timer)
+    this.#timer = undefined
+    this.#partialJson = undefined
   }
 
-  _flush () {
-    const json = `${this._partialJson}]`
-    this._reset()
-    this._onFlush(json)
+  #flush () {
+    const json = `${this.#partialJson}]`
+    this.#reset()
+    this.#onFlush(json)
   }
 
   write (str, size = Buffer.byteLength(str)) {
-    if (this._timer === null) {
-      this._partialJson = `[${str}`
-      this._timer = setTimeout(() => this._flush(), this._timeout)
-    } else if (Buffer.byteLength(this._partialJson) + size + 2 > this._maxSize) {
-      this._flush()
+    if (this.#timer === undefined) {
+      this.#partialJson = `[${str}`
+      this.#timer = setTimeout(() => this.#flush(), this.#timeout)
+    } else if (Buffer.byteLength(/** @type {string} */ (this.#partialJson)) + size + 2 > this.#maxSize) {
+      this.#flush()
       this.write(str, size)
     } else {
-      this._partialJson += `,${str}`
+      this.#partialJson += `,${str}`
     }
   }
 }

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -81,9 +81,14 @@ module.exports = {
       }
 
       // If we found a valid match and it's better than our previous best
+      // Note: bestMatch.url cannot be null when comparing lengths because:
+      // - The first time we enter this block, lastBoundaryPos > maxMatchLength is always true
+      // - We set bestMatch.url before we could evaluate the second condition
+      // - Subsequent evaluations have bestMatch.url already set
       if (atBoundary && (
         lastBoundaryPos > maxMatchLength ||
-        (lastBoundaryPos === maxMatchLength && url.length < bestMatch.url.length) // Prefer shorter paths
+        (lastBoundaryPos === maxMatchLength &&
+          url.length < /** @type {string} */ (/** @type {unknown} */ (bestMatch.url)).length) // Prefer shorter paths
       )) {
         maxMatchLength = lastBoundaryPos
         bestMatch.url = sourceUrl || url

--- a/packages/dd-trace/test/debugger/devtools_client/log.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/log.spec.js
@@ -1,9 +1,10 @@
 'use strict'
 
+const assert = require('node:assert')
+const { MessageChannel } = require('node:worker_threads')
+
 const { describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
-
-const assert = require('node:assert')
 
 require('../../setup/mocha')
 
@@ -23,7 +24,6 @@ describe('worker thread logger', function () {
       { level: 'debug', args: ['test4'] }
     ]
 
-    // @ts-expect-error - MessagePort has 'on' method at runtime but @types/node doesn't include it
     logChannel.port2.on('message', (message) => {
       assert.deepStrictEqual(message, expected.shift())
       if (expected.length === 0) done()
@@ -43,7 +43,6 @@ describe('worker thread logger', function () {
       }
     })
 
-    // @ts-expect-error - MessagePort has 'on' method at runtime but @types/node doesn't include it
     logChannel.port2.on('message', () => {
       throw new Error('should not have logged')
     })
@@ -64,7 +63,6 @@ describe('worker thread logger', function () {
       }
     })
 
-    // @ts-expect-error - MessagePort has 'on' method at runtime but @types/node doesn't include it
     logChannel.port2.on('message', (message) => {
       assert.deepStrictEqual(message, { level: 'debug', args: ['logged'] })
       done()
@@ -96,7 +94,6 @@ function checkLogLevel (level, expectedLevels) {
 
     const expected = expectedLevels.map((level) => ({ level, args: ['logged'] }))
 
-    // @ts-expect-error - MessagePort has 'on' method at runtime but @types/node doesn't include it
     logChannel.port2.on('message', (message) => {
       assert.deepStrictEqual(message, expected.shift())
       if (expected.length === 0) done()

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/complex-types.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/complex-types.js
@@ -60,6 +60,7 @@ function get () {
     yield 1
     yield 2
   }
+  /** @type {Generator<1 | 2, void, unknown> & { foo?: number }} */
   const gen = makeIterator()
   gen.foo = 42
 
@@ -91,7 +92,7 @@ function get () {
     date: new Date('2024-09-20T07:22:59.998Z'),
     map: new Map([[1, 2], [3, 4]]),
     set: new Set([[1, 2], 3, 4]),
-    wmap: new WeakMap([[ref.wmo1, 2], [ref.wmo2, 4]]),
+    wmap: new WeakMap(/** @type {Array<[object, number]>} */ ([[ref.wmo1, 2], [ref.wmo2, 4]])),
     wset: new WeakSet([ref.wso1, ref.wso2, ref.wso3]),
     gen,
     err,

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/redaction.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/target-code/redaction.js
@@ -12,13 +12,13 @@ function run () {
     [nonNormalizedSecretToken]: 'shh!',
     nested: { secret: 'shh!' },
     arr: [{ secret: 'shh!' }],
-    map: new Map([
+    map: new Map(/** @type {Array<[string | symbol, string]>} */ ([
       ['foo', 'bar'],
       ['secret', 'shh!'],
       [nonNormalizedSecretToken, 'shh!'],
       [Symbol('secret'), 'shh!'],
       [Symbol(nonNormalizedSecretToken), 'shh!']
-    ]),
+    ])),
     weakmap: new WeakMap([[weakMapKey, 42]]),
     [Symbol('secret')]: 'shh!',
     [Symbol(nonNormalizedSecretToken)]: 'shh!'

--- a/tsconfig.debugger.json
+++ b/tsconfig.debugger.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.dev.json",
+  "include": [
+    "./benchmark/sirun/debugger/**/*.js",
+    "./benchmark/sirun/debugger/**/*.mjs",
+    "./integration-tests/debugger/**/*.js",
+    "./integration-tests/debugger/**/*.mjs",
+    "./packages/dd-trace/test/debugger/**/*.js",
+    "./packages/dd-trace/test/debugger/**/*.mjs",
+    "./packages/dd-trace/src/debugger/**/*.js",
+    "./packages/dd-trace/src/debugger/**/*.mjs"
+  ],
+  "exclude": [
+    "./integration-tests/debugger/target-app/source-map-support/typescript.js"
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Address a large majority of the TS type errors in the debugger code. The only actual change to the runtime logic is the following:
    
When adding a new breakpoint to a file that has a source map, we now validate that the generated position can be identified. If not, we abort and don't add the breakpoint (which most likely would have failed anyway). An error will be sent to the debugger diagnostics endpoint if that happens.
    
Another minor, but hopefully invisible change, is that all private fields in the `JSONBuffer` class are now properly private instead of just being prefixed with an underscore.
    
The only debugger TS errors not addressed in this PR are the following:
- The ones already addressed in https://github.com/DataDog/dd-trace-js/pull/6965
- The ones which will disappear once https://github.com/DataDog/dd-trace-js/pull/6951 lands
    
This PR also adds a `tsconfig.debugger.json` file, which can be used to check the types of the debugger code:
    
```
./node_modules/.bin/tsc --noEmit -p tsconfig.debugger.json
```

### Motivation

Once this PR and the two other mentioned above lands, we can run a TS check as part of CI for all the debugger code.

