### PR TITLE
chore: add `.vscode/settings.json` file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "eslint.workingDirectories": [
+    "."
+  ],
+  "eslint.options": {
+    "overrideConfigFile": "${workspaceFolder}/eslint.config.mjs"
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
### What does this PR do?

This ensures that:
    
- The ESLint config file used by VSCode is always the correct one and that the working directory can always be identified. VSCode could become confused if this project is checked out inside a folder named `node_modules` and start complaining about unpublished files every place we reference a relative file in a `require` call.
- The TypeScript version used by VSCode is the same as being used by the project.

### Motivation

Better devex

