### PR TITLE
chore(ci): increase benchmarking job timeout to 30 minutes

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -16,7 +16,7 @@ variables:
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
     - interruptible: true
-  timeout: 15m # TODO: Fix worker queueing and reduce this.
+  timeout: 30m  # TODO: Reduce this once GitLab CI runner availability improves
   script:
     - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
     - bp-runner bp-runner.yml --debug

--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -13,7 +13,7 @@ include:
     - interruptible: true
   tags: ["runner:apm-k8s-same-cpu"]
   needs: []
-  timeout: 15m # TODO: Fix worker queueing and reduce this.
+  timeout: 15m  # TODO: Reduce this once GitLab CI runner availability improves
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:js-hapi
   script:
     - git clone --branch js/hapi https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Bumps benchmarking job timeouts to 30 minutes.

### Motivation
<!-- What inspired you to submit this pull request? -->

[#incident-45572](https://dd.enterprise.slack.com/archives/C09S0H9M3B9) is affecting the availability of benchmarking runners.

We can increase the timeout of the benchmarking jobs to improve odds of benchmarking jobs completing and to reduce development friction.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


