### PR TITLE
chore: fix error in `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,4 @@
 {
-  "eslint.workingDirectories": [
-    "."
-  ],
-  "eslint.options": {
-    "overrideConfigFile": "${workspaceFolder}/eslint.config.mjs"
-  },
+  "eslint.workingDirectories": ["."],
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes the `overrideConfigFile` setting since it wasn't really needed as VSCode would default to look for `eslint.config.mjs` (amongst other variants) in the root directory eventually (traversing the directory structure up). The important fix in the commit where this config option was added was `workingDirectories`, which we keep.

### Motivation

The `overrideConfigFile` setting doesn't support template strings, so VSCode was trying to look for a directory litterally named `${workspaceFolder}` and failed.

