### PR TITLE
chore(ci): run TypeScript check as part of CI

### DIFF
--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/node/active-lts
 
       - name: Install dependencies
-        uses: ./.github/actions/install
+        run: yarn install --frozen-lockfile
 
       - name: Run TypeScript type check
         run: yarn type:check

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "./packages/dd-trace/src/debugger/**/*.mjs"
   ],
   "exclude": [
-    "./integration-tests/debugger/target-app/source-map-support/typescript.js"
+    "./integration-tests/debugger/target-app/**/*"
   ]
 }


### PR DESCRIPTION
### What does this PR do?

As the title says... Only paths in `tsconfig.json` will be checked, which currently is only the Debugger code.

### Motivation

Ensure we're always green going forward. As other parts of the code base gets green, we can add their paths to `tsconfig.json`.

