### PR TITLE
[dependabot npm disable] Temporarily disable npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 1
       exclude:
@@ -50,7 +50,6 @@ updates:
       - dependency-name: "@datadog/pprof"
       - dependency-name: "@datadog/sketches-js"
       - dependency-name: "@datadog/wasm-js-rewriter"
-
       - dependency-name: "@types/node"
         # Update the types manually with new Node.js version support
         update-types: ["version-update:semver-major"]
@@ -100,7 +99,7 @@ updates:
       - "/packages/dd-trace/test/plugins/versions"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     labels:
       - dependabot
       - dependencies
@@ -115,7 +114,7 @@ updates:
       - "/integration-tests/esbuild"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 0
     labels:
       - dependabot
       - dependencies


### PR DESCRIPTION
This PR temporarily disables Dependabot **npm version updates** by setting `open-pull-requests-limit: 0` for all `package-ecosystem: npm` entries.

Use the matching `enable` script (or manually remove that field) to re-enable npm version updates later.