### PR TITLE
chore(ci): update heaviest-objects-in-the-universe

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       - name: Compute module size tree and report
-        uses: qard/heaviest-objects-in-the-universe@e2af4ff3a88e5fe507bd2de1943b015ba2ddda66 # v1.0.0
+        uses: qard/heaviest-objects-in-the-universe@1e02edbdda803a45537a808ede97866db47756d3 # Unreleased
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### What does this PR do?

Update `heaviest-objects-in-the-universe` GitHub Action to the newest commit in the GitHub repo.

### Motivation

Get unreleased bug-fixes so the rendering of the dependency table in PRs isn't broken.

The latest released version on npm is 3 years old, but the repo contains commits that are only 11 months old.

