### PR TITLE
(Draft) Reduce number of benchmarking jobs by using bigger instance type

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -9,16 +9,15 @@ variables:
 .benchmarks:
   stage: benchmarks
   needs: [ ]
-  rules:
-    - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
-      when: never
-    - when: on_success
   tags: [ "runner:apm-k8s-m8g-metal" ]
   image: $MICROBENCHMARKS_CI_IMAGE
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
     - interruptible: true
+    - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
+      when: never
+    - when: on_success
   timeout: 30m  # TODO: Reduce this once GitLab CI runner availability improves
   script:
     - git clone --branch dd-trace-js https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -13,7 +13,7 @@ variables:
     - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
       when: never
     - when: on_success
-  tags: ["runner:apm-k8s-m7i-metal"]
+  tags: [ "runner:apm-k8s-m8g-metal" ]
   image: $MICROBENCHMARKS_CI_IMAGE
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
@@ -37,6 +37,9 @@ variables:
       - runner_system_failure
       - scheduler_failure
       - api_failure
+  variables:
+    KUBERNETES_CPU_REQUEST: "48"
+    KUBERNETES_CPU_LIMIT: "48"
 
 benchmarks-pr-comment:
   stage: benchmarks-pr-comment
@@ -73,36 +76,20 @@ benchmark:
         GROUP: 1
       - MAJOR_VERSION: 18
         GROUP: 2
-      - MAJOR_VERSION: 18
-        GROUP: 3
-      - MAJOR_VERSION: 18
-        GROUP: 4
       - MAJOR_VERSION: 20
         GROUP: 1
       - MAJOR_VERSION: 20
         GROUP: 2
-      - MAJOR_VERSION: 20
-        GROUP: 3
-      - MAJOR_VERSION: 20
-        GROUP: 4
       - MAJOR_VERSION: 22
         GROUP: 1
       - MAJOR_VERSION: 22
         GROUP: 2
-      - MAJOR_VERSION: 22
-        GROUP: 3
-      - MAJOR_VERSION: 22
-        GROUP: 4
       - MAJOR_VERSION: 24
         GROUP: 1
       - MAJOR_VERSION: 24
         GROUP: 2
-      - MAJOR_VERSION: 24
-        GROUP: 3
-      - MAJOR_VERSION: 24
-        GROUP: 4
   variables:
-    SPLITS: 4
+    SPLITS: 2
 
 benchmark-serverless:
   stage: benchmarks

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -35,7 +35,7 @@ fi
 # run each test in parallel for a given version of Node.js
 # once all of the tests have complete move on to the next version
 
-TOTAL_CPU_CORES=$(nproc 2>/dev/null || echo "24")
+TOTAL_CPU_CORES=$(nproc 2>/dev/null || echo "48")
 export CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # Benchmarking Platform convention
 
 nvm install $MAJOR_VERSION # provided by each benchmark stage
@@ -60,7 +60,7 @@ BENCH_INDEX=0
 BENCH_END=$(($GROUP_SIZE*$GROUP))
 BENCH_START=$(($BENCH_END-$GROUP_SIZE))
 
-if [[ ${GROUP_SIZE} -gt 24 ]]; then
+if [[ ${GROUP_SIZE} -gt 48 ]]; then
   echo "Group size ${GROUP_SIZE} is larger than available number of CPU cores on Benchmarking Platform machines (${TOTAL_CPU_CORES} cores)"
   exit 1
 fi


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


