### PR TITLE
ci: fix benchmarks rules

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -9,13 +9,12 @@ variables:
 .benchmarks:
   stage: benchmarks
   needs: [ ]
+  tags: ["runner:apm-k8s-m7i-metal"]
+  image: $MICROBENCHMARKS_CI_IMAGE
   rules:
     - if: '$CI_COMMIT_REF_NAME =~ /^graphite-base\/.*$/'
       when: never
     - when: on_success
-  tags: ["runner:apm-k8s-m7i-metal"]
-  image: $MICROBENCHMARKS_CI_IMAGE
-  rules:
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
     - interruptible: true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Fixes `.benchmarks` rules, which contained two `rules` maps. This is valid YAML, but only the last rules would be applied, which means the graphite rules would be ignored.

### Motivation
<!-- What inspired you to submit this pull request? -->

Benchmarks on temporary Graphite branches would be run, which is not the desired behavior.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


