### PR TITLE
chore(debugger): fix spelling and types

### DIFF
--- a/integration-tests/debugger/basic.spec.js
+++ b/integration-tests/debugger/basic.spec.js
@@ -194,24 +194,24 @@ describe('Dynamic Instrumentation', function () {
 
       it(
         'should send expected error diagnostics messages if probe doesn\'t conform to expected schema',
-        unsupporedOrInvalidProbesTest({ invalid: 'config' }, { status: 'ERROR' })
+        unsupportedOrInvalidProbesTest({ invalid: 'config' }, { status: 'ERROR' })
       )
 
       it(
         'should send expected error diagnostics messages if probe type isn\'t supported',
         // @ts-expect-error Expecting this probe type to be invalid
-        unsupporedOrInvalidProbesTest(t.generateProbeConfig({ type: 'INVALID_PROBE' }))
+        unsupportedOrInvalidProbesTest(t.generateProbeConfig({ type: 'INVALID_PROBE' }))
       )
 
       it(
         'should send expected error diagnostics messages if it isn\'t a line-probe',
-        unsupporedOrInvalidProbesTest(
+        unsupportedOrInvalidProbesTest(
           // @ts-expect-error Expecting this probe type to be invalid
           t.generateProbeConfig({ where: { typeName: 'index.js', methodName: 'handlerA' } })
         )
       )
 
-      function unsupporedOrInvalidProbesTest (config, customErrorDiagnosticsObj) {
+      function unsupportedOrInvalidProbesTest (config, customErrorDiagnosticsObj) {
         return function (done) {
           let receivedAckUpdate = false
 
@@ -369,7 +369,7 @@ describe('Dynamic Instrumentation', function () {
           t.agent.addRemoteConfig(rcConfig2)
         })
 
-        it('should only trigger the probes whos conditions are met (all have conditions)', function (done) {
+        it('should only trigger the probes whose conditions are met (all have conditions)', function (done) {
           let installed = 0
           const rcConfig1 = t.generateRemoteConfig({
             when: { json: { eq: [{ getmember: [{ getmember: [{ ref: 'request' }, 'params'] }, 'name'] }, 'invalid'] } }
@@ -450,7 +450,7 @@ describe('Dynamic Instrumentation', function () {
           }
         })
 
-        it('should only trigger the probes whos conditions are met (not all have conditions)', function (done) {
+        it('should only trigger the probes whose conditions are met (not all have conditions)', function (done) {
           let installed = 0
           const rcConfig1 = t.generateRemoteConfig({
             when: { json: { eq: [{ getmember: [{ getmember: [{ ref: 'request' }, 'params'] }, 'name'] }, 'invalid'] } }
@@ -539,7 +539,7 @@ describe('Dynamic Instrumentation', function () {
         t.agent.on('debugger-diagnostics', ({ payload }) => {
           payload.forEach((event) => {
             if (event.debugger.diagnostics.status === 'INSTALLED') {
-              t.agent.once('remote-confg-responded', async () => {
+              t.agent.once('remote-config-responded', async () => {
                 await t.axios.get(t.breakpoint.url)
                 // We want to wait enough time to see if the client triggers on the breakpoint so that the test can fail
                 // if it does, but not so long that the test times out.
@@ -607,15 +607,15 @@ describe('Dynamic Instrumentation', function () {
         const rcConfig2 = t.breakpoints[1].generateRemoteConfig({ sampling: { snapshotsPerSecond: 1 } })
         const state = {
           [rcConfig1.config.id]: {
-            tiggerBreakpointContinuously () {
+            triggerBreakpointContinuously () {
               t.axios.get(t.breakpoints[0].url).catch(done)
-              this.timer = setTimeout(this.tiggerBreakpointContinuously.bind(this), 10)
+              this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             }
           },
           [rcConfig2.config.id]: {
-            tiggerBreakpointContinuously () {
+            triggerBreakpointContinuously () {
               t.axios.get(t.breakpoints[1].url).catch(done)
-              this.timer = setTimeout(this.tiggerBreakpointContinuously.bind(this), 10)
+              this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             }
           }
         }
@@ -623,7 +623,7 @@ describe('Dynamic Instrumentation', function () {
         t.agent.on('debugger-diagnostics', ({ payload }) => {
           payload.forEach((event) => {
             const { probeId, status } = event.debugger.diagnostics
-            if (status === 'INSTALLED') state[probeId].tiggerBreakpointContinuously()
+            if (status === 'INSTALLED') state[probeId].triggerBreakpointContinuously()
           })
         })
 
@@ -741,7 +741,7 @@ describe('Dynamic Instrumentation', function () {
               t.axios.get(t.breakpoint.url).catch((err) => {
                 // If the request hasn't fully completed by the time the tests ends and the target app is destroyed,
                 // Axios will complain with a "socket hang up" error. Hence this sanity check before calling
-                // `done(err)`. If we later add more tests below this one, this shouuldn't be an issue.
+                // `done(err)`. If we later add more tests below this one, this shouldn't be an issue.
                 if (!finished) done(err)
               })
             }
@@ -909,7 +909,7 @@ function assertBasicInputPayload (t, payload, probe = t.rcConfig.config) {
     assert.isAbove(frame.columnNumber, 0)
   }
   const topFrame = payload.debugger.snapshot.stack[0]
-  // path seems to be prefeixed with `/private` on Mac
+  // path seems to be prefixed with `/private` on Mac
   assert.match(topFrame.fileName, new RegExp(`${t.appFile}$`))
   assert.strictEqual(topFrame.function, 'fooHandler')
   assert.strictEqual(topFrame.lineNumber, t.breakpoint.line)

--- a/integration-tests/debugger/re-evaluation.spec.js
+++ b/integration-tests/debugger/re-evaluation.spec.js
@@ -21,7 +21,7 @@ const { generateProbeConfig } = require('../../packages/dd-trace/test/debugger/d
 // breakpoint is never exercised during the test, and the tracer therefore never emits the `EMITTING` event.
 //
 // This is only really an issue if Node.js is using the ESM loader, as this is really slow. If the application is
-// purely a CommonJS application, this race condtion will probably never be triggered.
+// purely a CommonJS application, this race condition will probably never be triggered.
 //
 // This test tries to trigger the race condition. However, it doesn't always happen, so it runs multiple times.
 describe('Dynamic Instrumentation Probe Re-Evaluation', function () {

--- a/integration-tests/debugger/snapshot-global-sample-rate.spec.js
+++ b/integration-tests/debugger/snapshot-global-sample-rate.spec.js
@@ -28,15 +28,15 @@ describe('Dynamic Instrumentation', function () {
         // Two breakpoints, each triggering a request every 10ms, so we should get 200 requests per second
         const state = {
           [rcConfig1.config.id]: {
-            tiggerBreakpointContinuously () {
+            triggerBreakpointContinuously () {
               t.axios.get(t.breakpoints[0].url).catch(done)
-              this.timer = setTimeout(this.tiggerBreakpointContinuously.bind(this), 10)
+              this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             }
           },
           [rcConfig2.config.id]: {
-            tiggerBreakpointContinuously () {
+            triggerBreakpointContinuously () {
               t.axios.get(t.breakpoints[1].url).catch(done)
-              this.timer = setTimeout(this.tiggerBreakpointContinuously.bind(this), 10)
+              this.timer = setTimeout(this.triggerBreakpointContinuously.bind(this), 10)
             }
           }
         }
@@ -45,7 +45,7 @@ describe('Dynamic Instrumentation', function () {
           payload.forEach((event) => {
             const { probeId, status } = event.debugger.diagnostics
             if (status === 'INSTALLED') {
-              state[probeId].tiggerBreakpointContinuously()
+              state[probeId].triggerBreakpointContinuously()
             }
           })
         })

--- a/integration-tests/debugger/source-map-support.spec.js
+++ b/integration-tests/debugger/source-map-support.spec.js
@@ -5,7 +5,7 @@ const { setup } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
   describe('source map support', function () {
-    describe('Different file extention (TypeScript)', function () {
+    describe('Different file extension (TypeScript)', function () {
       const t = setup({
         testApp: 'target-app/source-map-support/typescript.js',
         testAppSource: 'target-app/source-map-support/typescript.ts'
@@ -38,7 +38,7 @@ describe('Dynamic Instrumentation', function () {
         t.agent.on('debugger-input', ({ payload: [{ debugger: { snapshot: { probe: { location } } } }] }) => {
           assert.deepEqual(location, {
             file: 'target-app/source-map-support/minify.js',
-            lines: ['8']
+            lines: ['9']
           })
           done()
         })

--- a/integration-tests/debugger/target-app/basic.js
+++ b/integration-tests/debugger/target-app/basic.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 // @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')

--- a/integration-tests/debugger/target-app/custom-logger.js
+++ b/integration-tests/debugger/target-app/custom-logger.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace').init({
   logger: {
     error: (...args) => console.log('[CUSTOM LOGGER][ERROR]:', ...args), // eslint-disable-line no-console

--- a/integration-tests/debugger/target-app/redact.js
+++ b/integration-tests/debugger/target-app/redact.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 // @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')

--- a/integration-tests/debugger/target-app/snapshot-pruning.js
+++ b/integration-tests/debugger/target-app/snapshot-pruning.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 
 const { randomBytes } = require('crypto')

--- a/integration-tests/debugger/target-app/snapshot-time-budget.js
+++ b/integration-tests/debugger/target-app/snapshot-time-budget.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 
 // @ts-expect-error This code is running in a sandbox where fastify is available

--- a/integration-tests/debugger/target-app/snapshot.js
+++ b/integration-tests/debugger/target-app/snapshot.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 // @ts-expect-error This code is running in a sandbox where fastify is available
 const Fastify = require('fastify')

--- a/integration-tests/debugger/target-app/source-map-support/minify.js
+++ b/integration-tests/debugger/target-app/source-map-support/minify.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 
 const { createServer } = require('node:http')

--- a/integration-tests/debugger/target-app/template.js
+++ b/integration-tests/debugger/target-app/template.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 const { inspect } = require('util')
 // @ts-expect-error This code is running in a sandbox where fastify is available

--- a/integration-tests/debugger/target-app/unreffed.js
+++ b/integration-tests/debugger/target-app/unreffed.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// @ts-expect-error This code is running in a sandbox where dd-trace is available
 require('dd-trace/init')
 const http = require('http')
 

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -318,7 +318,7 @@ function buildExpressServer (agent) {
     }
 
     res.on('close', () => {
-      agent.emit('remote-confg-responded')
+      agent.emit('remote-config-responded')
     })
 
     if (agent._rcTargetsVersion === state.targets_version) {

--- a/packages/dd-trace/src/debugger/devtools_client/condition.js
+++ b/packages/dd-trace/src/debugger/devtools_client/condition.js
@@ -33,7 +33,7 @@ const reservedWords = new Set([
   // Future reserved words in strict mode
   'implements', 'interface', 'package', 'private', 'protected', 'public',
 
-  // Litterals
+  // Literals
   'NaN'
 ])
 

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -178,7 +178,7 @@ session.on('Debugger.paused', async ({ params }) => {
   )
 
   await session.post('Debugger.resume')
-  const diff = process.hrtime.bigint() - start // TODO: Recored as telemetry (DEBUG-2858)
+  const diff = process.hrtime.bigint() - start // TODO: Recorded as telemetry (DEBUG-2858)
 
   // This doesn't measure the overhead of the CDP protocol. The actual pause time is slightly larger.
   // On my machine I'm seeing around 1.7ms of overhead.

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/collector.js
@@ -94,7 +94,7 @@ async function traverseGetPropertiesResult (props, opts, depth) {
     // Iterate over the work in chunks of 2. The closer to 1, the less we'll overshoot the deadline, but the longer it
     // takes to complete. `2` seems to be the best compromise.
     // Anecdotally, on my machine, with no deadline, a concurrency of `1` takes twice as long as a concurrency of `2`.
-    // From thereon, there's no real measureable savings with a higher concurrency.
+    // From thereon, there's no real measurable savings with a higher concurrency.
     for (let i = 0; i < work.length; i += 2) {
       if (overBudget(opts)) {
         for (let j = i; j < work.length; j++) {

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot/index.js
@@ -65,7 +65,7 @@ async function getLocalStateForCallFrame (
       if (scope.type === 'global') continue // The global scope is too noisy
       const { objectId } = scope.object
       if (objectId === undefined) continue // I haven't seen this happen, but according to the types it's possible
-      // The objectId for a scope points to a pseudo-object whos properties are the actual variables in the scope.
+      // The objectId for a scope points to a pseudo-object whose properties are the actual variables in the scope.
       // This is why we can just call `collectObjectProperties` directly and expect it to return the in-scope variables
       // as an array.
       // eslint-disable-next-line no-await-in-loop

--- a/packages/dd-trace/src/debugger/index.js
+++ b/packages/dd-trace/src/debugger/index.js
@@ -89,7 +89,7 @@ function start (config, rc) {
 
     log.error('[debugger] worker thread exited unexpectedly', error)
 
-    // Be nice, clean up now that the worker thread encounted an issue and we can't continue
+    // Be nice, clean up now that the worker thread encountered an issue and we can't continue
     rc.removeProductHandler('LIVE_DEBUGGING')
     worker.removeAllListeners()
     configChannel = null

--- a/packages/dd-trace/test/debugger/config.spec.js
+++ b/packages/dd-trace/test/debugger/config.spec.js
@@ -1,10 +1,12 @@
 'use strict'
 
-require('../setup/mocha')
-
 const assert = require('node:assert')
+const { MessageChannel } = require('node:worker_threads')
+
 const getDebuggerConfig = require('../../src/debugger/config')
 const getConfig = require('../../src/config')
+
+require('../setup/mocha')
 
 describe('getDebuggerConfig', function () {
   it('should only contain the allowed properties', function () {

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -8,8 +8,26 @@ const sinon = require('sinon')
 require('../../setup/mocha')
 
 describe('breakpoints', function () {
+  /** @type {typeof import('../../../src/debugger/devtools_client/breakpoints')} */
   let breakpoints
+  /**
+   * @type {{
+   *   post: sinon.SinonStub;
+   *   on: Function;
+   *   '@noCallThru': boolean;
+   * }}
+   */
   let sessionMock
+  /**
+   * @type {{
+   *   findScriptFromPartialPath: sinon.SinonStub;
+   *   clearState: sinon.SinonStub;
+   *   locationToBreakpoint: Map<any, any>;
+   *   breakpointToProbes: Map<any, any>;
+   *   probeToLocation: Map<any, any>;
+   *   '@noCallThru': boolean;
+   * }}
+   */
   let stateMock
 
   beforeEach(function () {
@@ -322,7 +340,7 @@ describe('breakpoints', function () {
         sinon.assert.calledTwice(sessionMock.post)
       })
 
-      it('mixed: removed probe with condtion', async function () {
+      it('mixed: removed probe with condition', async function () {
         await addProbe({
           when: {
             json: { eq: [{ ref: 'foo' }, 42] },

--- a/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition-test-cases.js
@@ -103,7 +103,7 @@ const references = [
   [{ ref: 'this' }, {}, global], // Unless bound, `this` defaults to the global object
   { ast: { ref: 'super' }, expected: 'super', execute: false },
 
-  // Litterals, but we allow them as they can be useful
+  // Literals, but we allow them as they can be useful
   [{ ref: 'undefined' }, {}, undefined],
   [{ ref: 'Infinity' }, {}, Infinity],
 

--- a/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/condition.spec.js
@@ -49,7 +49,7 @@ const testCases = [
   ...typeAndDefinitionChecks
 ]
 
-describe('Expresion language', function () {
+describe('Expression language', function () {
   beforeEach(() => {
     // Mock the presence of `util.types` as it would be available when DI is active in the tracer
     process[Symbol.for('datadog:node:util:types')] = require('util').types

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -34,7 +34,7 @@ describe('onPause', function () {
    */
   /** @type {MockSession} */
   let session
-  /** @type {Function} */
+  /** @type {sinon.SinonSpy} */
   let send
   /** @type {Function} */
   let onPaused

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -30,12 +30,12 @@ const snapshot = { snapshot: true }
 describe('input message http requests', function () {
   /** @type {sinon.SinonFakeTimers} */
   let clock
-  /** @type {Function} */
+  /** @type {typeof import('../../../src/debugger/devtools_client/send')} */
   let send
   /** @type {sinon.SinonSpy} */
   let request
-  /** @type {import('../../../src/debugger/devtools_client/json-buffer')} */
-  let jsonBuffer
+  /** @type {sinon.SinonSpy} */
+  let jsonBufferWrite
 
   beforeEach(function () {
     clock = sinon.useFakeTimers({
@@ -48,8 +48,7 @@ describe('input message http requests', function () {
     class JSONBufferSpy extends JSONBuffer {
       constructor (...args) {
         super(...args)
-        jsonBuffer = this
-        sinon.spy(this, 'write')
+        jsonBufferWrite = sinon.spy(this, 'write')
       }
     }
 
@@ -75,14 +74,9 @@ describe('input message http requests', function () {
   })
 
   it('should buffer instead of calling request directly', function () {
-    const callback = sinon.spy()
-
-    send(message, logger, dd, snapshot, callback)
+    send(message, logger, dd, snapshot)
     sinon.assert.notCalled(request)
-    sinon.assert.calledOnceWithMatch(jsonBuffer.write,
-      JSON.stringify(getPayload())
-    )
-    sinon.assert.notCalled(callback)
+    sinon.assert.calledOnceWithMatch(jsonBufferWrite, JSON.stringify(getPayload()))
   })
 
   it('should call request with the expected payload once the buffer is flushed', function (done) {

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/error-handling.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/error-handling.spec.js
@@ -8,7 +8,7 @@ const { getLocalStateForCallFrame } = require('./utils')
 
 describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', function () {
   describe('error handling', function () {
-    it('should generate a notCapturedReason if an error is thrown during inital collection', async function () {
+    it('should generate a notCapturedReason if an error is thrown during initial collection', async function () {
       const invalidCallFrameThatTriggersAnException = {}
       const processLocalState = await getLocalStateForCallFrame(invalidCallFrameThatTriggersAnException)
       const result = processLocalState()

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/max-collection-size.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/max-collection-size.spec.js
@@ -28,7 +28,7 @@ describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', fu
       const maxCollectionSize = config?.maxCollectionSize ?? DEFAULT_MAX_COLLECTION_SIZE
       const postfix = config === undefined ? 'not set' : `set to ${config.maxCollectionSize}`
 
-      describe(`shold respect the default maxCollectionSize if ${postfix}`, function () {
+      describe(`should respect the default maxCollectionSize if ${postfix}`, function () {
         let state
 
         const expectedElements = []

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count-scopes.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count-scopes.spec.js
@@ -15,7 +15,7 @@ describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', fu
 
     afterEach(teardown)
 
-    describe('shold respect maxFieldCount on each collected scope', function () {
+    describe('should respect maxFieldCount on each collected scope', function () {
       const maxFieldCount = 3
       let state
 

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/max-field-count.spec.js
@@ -16,9 +16,9 @@ describe('debugger -> devtools client -> snapshot.getLocalStateForCallFrame', fu
 
     afterEach(teardown)
 
-    describe('shold respect the default maxFieldCount if not set', generateTestCases())
+    describe('should respect the default maxFieldCount if not set', generateTestCases())
 
-    describe('shold respect maxFieldCount if set to 10', generateTestCases({ maxFieldCount: 10 }))
+    describe('should respect maxFieldCount if set to 10', generateTestCases({ maxFieldCount: 10 }))
   })
 })
 

--- a/packages/dd-trace/test/debugger/devtools_client/utils.js
+++ b/packages/dd-trace/test/debugger/devtools_client/utils.js
@@ -8,6 +8,12 @@ module.exports = {
 }
 
 /**
+ * @typedef {object} RequestOptions
+ * @property {string} method
+ * @property {string} path
+ */
+
+/**
  * @typedef {object} ProbeConfig
  * @property {string} id
  * @property {number} version
@@ -63,7 +69,7 @@ function generateProbeConfig (breakpoint, overrides = {}) {
  * Get the request options from a request spy call
  *
  * @param {sinon.SinonSpy} request - The request spy to get the options from.
- * @returns {unknown} - The 2nd argument to the `request` function (i.e. the request options).
+ * @returns {RequestOptions} - The 2nd argument to the `request` function (i.e. the request options).
  */
 function getRequestOptions (request) {
   return request.lastCall.args[1]


### PR DESCRIPTION
### What does this PR do?

Fixes spelling mistakes and adds missing JSDoc types in the Debugger code

### Motivation

Reduce error/warning noise in the IDE when browsing Debugger code.

