### PR TITLE
chore: ensure VSCode uses the workspace TS version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-  "eslint.workingDirectories": ["."],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  // Use the workspace version of TypeScript instead of VSCode's bundled version
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
 }


### PR DESCRIPTION
### What does this PR do?

By default VSCode will use its own bundled version of TypeScript. Force it to use the version used by the `dd-trace-js` project.

### Motivation

Ensure TS errors shown in the IDE matches the ones that the `tsc` command sees when linting.

