### PR TITLE
Gracefully handle kafkajs cluster id failures

### DIFF
--- a/packages/datadog-instrumentations/test/kafkajs.spec.js
+++ b/packages/datadog-instrumentations/test/kafkajs.spec.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const log = require('../../dd-trace/src/log')
+const { getKafkaClusterId } = require('../src/kafkajs')
+
+describe('kafkajs instrumentation helpers', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  function createAdmin (overrides = {}) {
+    return {
+      connect: sinon.stub().resolves(),
+      describeCluster: sinon.stub().resolves({ clusterId: 'cluster-a' }),
+      disconnect: sinon.stub().resolves(),
+      ...overrides
+    }
+  }
+
+  it('returns cached cluster id when already resolved', () => {
+    const kafka = { _ddKafkaClusterId: 'cached-id' }
+
+    expect(getKafkaClusterId(kafka)).to.equal('cached-id')
+  })
+
+  it('returns null when admin interface is missing', () => {
+    const kafka = {}
+
+    expect(getKafkaClusterId(kafka)).to.equal(null)
+  })
+
+  it('returns null when describeCluster is unavailable', () => {
+    const kafka = {
+      admin: () => ({})
+    }
+
+    expect(getKafkaClusterId(kafka)).to.equal(null)
+  })
+
+  it('fetches and caches the cluster id when available', async () => {
+    const admin = createAdmin()
+    const kafka = {
+      admin: () => admin
+    }
+
+    const clusterId = await getKafkaClusterId(kafka)
+
+    expect(clusterId).to.equal('cluster-a')
+    expect(kafka._ddKafkaClusterId).to.equal('cluster-a')
+    sinon.assert.calledOnce(admin.connect)
+    sinon.assert.calledOnce(admin.describeCluster)
+    sinon.assert.calledOnce(admin.disconnect)
+  })
+
+  it('logs a warning and resolves null when cluster lookup fails', async () => {
+    const error = new Error('no describe permission')
+    const admin = createAdmin({
+      describeCluster: sinon.stub().rejects(error)
+    })
+    const warnStub = sinon.stub(log, 'warn')
+    const kafka = {
+      admin: () => admin
+    }
+
+    const clusterId = await getKafkaClusterId(kafka)
+
+    expect(clusterId).to.equal(null)
+    sinon.assert.calledOnce(warnStub)
+    sinon.assert.calledWithMatch(warnStub, 'Failed to retrieve Kafka cluster id')
+    sinon.assert.calledOnce(admin.disconnect)
+  })
+
+  it('resolves null when connect throws synchronously', async () => {
+    const admin = createAdmin({
+      connect: sinon.stub().throws(new Error('boom'))
+    })
+    const warnStub = sinon.stub(log, 'warn')
+    const kafka = {
+      admin: () => admin
+    }
+
+    const clusterId = await getKafkaClusterId(kafka)
+
+    expect(clusterId).to.equal(null)
+    sinon.assert.calledOnce(warnStub)
+    sinon.assert.calledOnce(admin.disconnect)
+  })
+})


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3e43a50f-e383-4f2c-b201-296fd39ccdb8","source":"chat","resourceId":"cf47d1ed-2962-4a54-a9bb-cb5023aa3d6f","workflowId":"ceab4516-9fca-4edd-8b39-9edb6e84301a","codeChangeId":"ceab4516-9fca-4edd-8b39-9edb6e84301a","sourceType":"chat"} -->
[![Open Bits Dev Session](https://img.shields.io/badge/Open%20Bits%20Dev%20Session-%20?logo=datadog&logoColor=%23632CA6&labelColor=white&color=%23632CA6)](https://dd.datad0g.com/code/cf47d1ed-2962-4a54-a9bb-cb5023aa3d6f)

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do?
Adds defensive handling around KafkaJS cluster ID discovery so the Kafka consumer/producer instrumentation no longer blocks when describeCluster fails, and adds direct unit tests for the helper.

### Motivation
`case-event-handler-incident-escalation` was falling behind because the KafkaJS instrumentation rejected `consumer.run` whenever the Datastreams cluster ID lookup failed (for example due to missing ACLs), so the consumer never started processing the `domain-events` topic.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
Could not run `yarn mocha -r packages/dd-trace/test/setup/mocha.js packages/datadog-instrumentations/test/kafkajs.spec.js` because `yarn install --immutable` cannot access the public registry in this sandboxed environment.