### PR TITLE
Prepare support for vendored dependencies

### DIFF
--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -71,6 +71,7 @@ jobs:
             --use-mirrors=mirrors.json \
             --no-scancode-strategy \
             --no-github-sbom-strategy \
+            --yarn-subdir vendor \
             "${REPOSITORY_URL}" > LICENSE-3rdparty.csv
 
       - name: Append vendored dependencies


### PR DESCRIPTION
### What does this PR do?

Upgrade `dd-license-attribution` to gain support for a new `--yarn-subdir` flag so that we can use multiple `yarn.lock` files as the basis for the `LICENSE-3rdparty.csv` file.

### Motivation

Prepare to support the changes introduced in the upcoming PR #6958

### Additional Notes

This PR uses a temprary branch of `dd-license-attribution` to unblock #6958 (so we don't have to wait for the changes to land).

The changes in this PR can't be tested until it lands in `master`, as CI is always using the version of `.github/workflows/update-3rdparty-licenses.yml` that exists in `master` and not in this PR.

