### PR TITLE
fix(debugger): allow snapshotsPerSecond to be a float

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -64,7 +64,7 @@ async function addBreakpoint (probe) {
   const snapshotsPerSecond = probe.sampling?.snapshotsPerSecond ?? (probe.captureSnapshot
     ? MAX_SNAPSHOTS_PER_SECOND_PER_PROBE
     : MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE)
-  probe.nsBetweenSampling = BigInt(1 / snapshotsPerSecond * 1e9)
+  probe.nsBetweenSampling = BigInt(Math.trunc(1 / snapshotsPerSecond * 1e9))
   probe.lastCaptureNs = 0n
 
   // Warning: The code below relies on undocumented behavior of the inspector!


### PR DESCRIPTION
### What does this PR do?

Just a drive by PR: In case `snapshotsPerSecond` is ever a float, make sure that it can safely be converted to a BigInt.
    
### Motivation

This is mostly useful in testing, but it's good to safe-guard against in practise so BigInt doesn't throw an exception.

