### PR TITLE
feat(otel): add support for scope metrics

### DIFF
--- a/packages/dd-trace/src/opentelemetry/metrics/meter_provider.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/meter_provider.js
@@ -39,12 +39,12 @@ class MeterProvider {
    * @param {MeterOptions} [options] - Additional options
    * @returns {Meter} Meter instance
    */
-  getMeter (name, version = '', { schemaUrl = '' } = {}) {
+  getMeter (name, version = '', { schemaUrl = '', attributes = {} } = {}) {
     const normalizedName = name.toLowerCase()
     const key = `${normalizedName}@${version}@${schemaUrl}`
     let meter = this.#meters.get(key)
     if (!meter) {
-      meter = new Meter(this, { name: normalizedName, version, schemaUrl })
+      meter = new Meter(this, { name: normalizedName, version, schemaUrl, attributes })
       this.#meters.set(key, meter)
     }
     return meter

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -633,6 +633,26 @@ describe('OpenTelemetry Meter Provider', () => {
 
       setTimeout(() => { validator(); done() }, 150)
     })
+
+    it('includes attributes in instrumentation scope', (done) => {
+      const validator = mockOtlpExport((decoded) => {
+        const scopeMetrics = decoded.resourceMetrics[0].scopeMetrics[0]
+        assert.strictEqual(scopeMetrics.metrics.length, 2)
+        const scopeAttributes = scopeMetrics.scope.attributes
+        assert.strictEqual(scopeAttributes.length, 2)
+        const usernameAttr = scopeAttributes.find(a => a.key === 'username')
+        const idAttr = scopeAttributes.find(a => a.key === 'id')
+        assert.strictEqual(usernameAttr?.value.stringValue, 'test')
+        assert.strictEqual(idAttr?.value.intValue, 23)
+      })
+
+      setupTracer()
+      const meter = metrics.getMeter('app', '', { attributes: { username: 'test', id: 23 } })
+      meter.createCounter('num.monkies').add(1)
+      meter.createCounter('num.baboons').add(2)
+
+      setTimeout(() => { validator(); done() }, 150)
+    })
   })
 
   describe('Unimplemented Features', () => {


### PR DESCRIPTION
### What does this PR do?

Adds support for setting attributes on the instrumentation scope when creating meters via `getMeter()`. Attributes set at the meter level are included in the exported OTLP scope and apply to all metrics created by that meter.

### Motivation

The OpenTelemetry specification supports setting attributes on the [meter level](https://opentelemetry.io/docs/specs/otel/metrics/api/#get-a-meter) (in addition to resource and individual metric levels). This was introduced in v1.13.0 of the opentelemetry spec. This allows users to avoid repeating attributes across multiple metric calls. While the OpenTelemetry JS API doesn't support this property ([link](https://github.com/open-telemetry/opentelemetry-js/blob/eebdb2a537b6f0d4250ac60ad9765657dff6c22f/api/src/api/metrics.ts#L68)), we're adding it to align with the spec and maintain compatibility with other SDKs. 

This gap was detected by system tests.

### Additional Notes

- The `attributes` parameter is optional: `getMeter(name, version, { schema_url, attributes: {...} })`
- Attributes are included in the exported OTLP scope metrics:

```json
{
  "resourceMetrics": [
    {
      "resource": {"attributes": [{...}],
      "scopeMetrics": [
        {
          "scope": {"name": "app", "version": "", "schemaUrl": "",
            "attributes": [{"key": "username","value": { "stringValue": "test" }},{"key": "id", "value": { "intValue": 23 }}
            ],
          },
          "metrics": [
            {
              "name": "num.monkies",
              // ... metric data
            },
            {
              "name": "num.baboons",
              // ... metric data
            }
          ]
        }
      ]
    }
  ]
}
```

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


