### PR TITLE
ci: fix dependabot.yml to not have overlapping directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,9 +83,10 @@ updates:
       - dependency-name: "@opentelemetry/resources"
         # 2.0.0 onwards only supports Node.js 18.19.0 and above
         update-types: ["version-update:semver-major"]
-        # @opentelemetry/api has to be widened, not increased.
-        # Thus, we ignore it and update it manually.
+        # @opentelemetry/api and @opentelemetry/api-logs have to be widened, not increased.
+        # Thus, we ignore them and update them manually.
       - dependency-name: "@opentelemetry/api"
+      - dependency-name: "@opentelemetry/api-logs"
     groups:
       dev-minor-and-patch-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
A package.json can only be handled by a single config. Individual dependencies can not be handled separately in a different config. Thus, this simplifies our overall config by defining increase for all our dependencies besides the OTEL api one, since that must be widened. We have to manually update it for now, until a better solution is found.
