### PR TITLE
feat(llmobs): add source:otel tag to evaluations when DD_TRACE_OTEL_ENABLED is set

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -411,7 +411,7 @@ class LLMObs extends NoopLLMObs {
       }
 
       // When OTel tracing is enabled, add source:otel tag to allow backend to wait for OTel span conversion
-      if (getEnvironmentVariable('DD_TRACE_OTEL_ENABLED')) {
+      if (isTrue(getEnvironmentVariable('DD_TRACE_OTEL_ENABLED'))) {
         evaluationTags.source = 'otel'
       }
 

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1259,36 +1259,27 @@ describe('sdk', () => {
       }), { message: 'value must be a boolean for a boolean metric' })
     })
 
-    it('adds source:otel tag when DD_TRACE_OTEL_ENABLED is set', () => {
-      process.env.DD_TRACE_OTEL_ENABLED = 'true'
-
-      llmobs.submitEvaluation(spanCtx, {
-        mlApp: 'test',
-        timestampMs: 1234,
-        label: 'test',
-        metricType: 'score',
-        value: 0.6
+    describe('with DD_TRACE_OTEL_ENABLED set', () => {
+      before(() => {
+        process.env.DD_TRACE_OTEL_ENABLED = 'true'
       })
 
-      const evalMetric = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
-      assert.ok(evalMetric.tags.includes('source:otel'), 'Expected source:otel tag to be present')
-
-      delete process.env.DD_TRACE_OTEL_ENABLED
-    })
-
-    it('does not add source:otel tag when DD_TRACE_OTEL_ENABLED is not set', () => {
-      delete process.env.DD_TRACE_OTEL_ENABLED
-
-      llmobs.submitEvaluation(spanCtx, {
-        mlApp: 'test',
-        timestampMs: 1234,
-        label: 'test',
-        metricType: 'score',
-        value: 0.6
+      after(() => {
+        delete process.env.DD_TRACE_OTEL_ENABLED
       })
 
-      const evalMetric = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
-      assert.ok(!evalMetric.tags.includes('source:otel'), 'Expected source:otel tag to NOT be present')
+      it('adds source:otel tag', () => {
+        llmobs.submitEvaluation(spanCtx, {
+          mlApp: 'test',
+          timestampMs: 1234,
+          label: 'test',
+          metricType: 'score',
+          value: 0.6
+        })
+
+        const evalMetric = LLMObsEvalMetricsWriter.prototype.append.getCall(0).args[0]
+        assert.ok(evalMetric.tags.includes('source:otel'), 'Expected source:otel tag to be present')
+      })
     })
   })
 


### PR DESCRIPTION
## Description

Auto-add `source:otel` tag to LLMObs evaluations when OTel tracing is enabled.

When `DD_TRACE_OTEL_ENABLED=true`, automatically adds `source:otel` tag to all submitted evaluations. This allows the backend to wait ~3 minutes for OTel span conversion before discarding unmatched evaluations.

**Related:** DataDog/dd-trace-py#15538

## Changes

- Add `source:otel` tag in `submitEvaluation()` when `DD_TRACE_OTEL_ENABLED` environment variable is set

## Testing

Added unit tests:
- `adds source:otel tag when DD_TRACE_OTEL_ENABLED is set`
- `does not add source:otel tag when DD_TRACE_OTEL_ENABLED is not set`


### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


