### PR TITLE
ci: use official version of dd-license-attribution

### DIFF
--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Check out dd-license-attribution
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          repository: watson/dd-license-attribution
-          ref: 18b3d1cb2d17c500a14108891db2486f0f103826
+          repository: DataDog/dd-license-attribution
+          ref: 58e29701db6c72889f9298ff59717987404659c8
           path: dd-license-attribution
 
       - name: Install dd-license-attribution


### PR DESCRIPTION
### What does this PR do?

Bump dd-license-attribution version.

### Motivation

Previously we needed to use a fork of dd-license-attribution to get access to a new feature that had yet to be merged to the official repo.
Now that the official repo supports the required feature, we can switch back to use that.

