### PR TITLE
chore(llmobs): change google genai integration tag to match python implementation

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/genai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/genai/index.js
@@ -14,7 +14,7 @@ const {
 
 class GenAiLLMObsPlugin extends LLMObsPlugin {
   static id = 'google-genai'
-  static integration = 'genai'
+  static integration = 'google_genai'
   static prefix = 'tracing:apm:google:genai:request'
 
   constructor () {

--- a/packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js
@@ -64,7 +64,7 @@ describe('Plugin', () => {
             output_tokens: MOCK_NUMBER,
             total_tokens: MOCK_NUMBER,
           },
-          tags: { ml_app: 'test', integration: 'genai' },
+          tags: { ml_app: 'test', integration: 'google_genai' },
         })
       })
     })
@@ -110,7 +110,7 @@ describe('Plugin', () => {
             output_tokens: MOCK_NUMBER,
             total_tokens: MOCK_NUMBER,
           },
-          tags: { ml_app: 'test', integration: 'genai' },
+          tags: { ml_app: 'test', integration: 'google_genai' },
         })
       })
     })
@@ -133,7 +133,7 @@ describe('Plugin', () => {
           modelProvider: 'google',
           inputDocuments: [{ text: 'Hello, world!' }],
           outputValue: MOCK_STRING,
-          tags: { ml_app: 'test', integration: 'genai' },
+          tags: { ml_app: 'test', integration: 'google_genai' },
         })
       })
     })


### PR DESCRIPTION
### What does this PR do?
Python tags LLM Observability spans for the Google GenAI package with a `integration:google_genai` tag, while we do `integration:genai`. Shared tests were previously not asserting this, but the new tests being written in system tests will, and I caught this while migrating them.

### Motivation
Consistency between client libraries' auto-instrumentations.

### Additional Notes
`semver-patch` because the integration has not landed yet