### PR TITLE
test: make assertions order-insensitive to prevent failing tests based on Playwright version

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -2868,7 +2868,7 @@ describe(`cucumber@${version} commonJS`, () => {
             assert.ok(!('TEST_EARLY_FLAKE_ENABLED' in testSession.meta))
           }
 
-          const resourceNames = tests.map(span => span.resource)
+          const resourceNames = tests.map(span => span.resource).sort()
 
           // TODO: This is a duplication of the code below. We should refactor this.
           assertObjectContains(resourceNames,

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -189,18 +189,18 @@ versions.forEach((version) => {
               assert.exists(testSuiteEvent.content.metrics[DD_HOST_CPU_COUNT])
             })
 
-            assert.deepStrictEqual(testEvents.map(test => test.content.resource), [
+            assert.deepStrictEqual(testEvents.map(test => test.content.resource).sort(), [
+              'landing-page-test.js.highest-level-describe' +
+              '  leading and trailing spaces    should work with annotated tests',
+              'landing-page-test.js.highest-level-describe' +
+              '  leading and trailing spaces    should work with fixme',
               'landing-page-test.js.highest-level-describe' +
               '  leading and trailing spaces    should work with passing tests',
               'landing-page-test.js.highest-level-describe' +
               '  leading and trailing spaces    should work with skipped tests',
-              'landing-page-test.js.highest-level-describe' +
-              '  leading and trailing spaces    should work with fixme',
-              'landing-page-test.js.highest-level-describe' +
-              '  leading and trailing spaces    should work with annotated tests',
-              'todo-list-page-test.js.should work with fixme root',
-              'todo-list-page-test.js.playwright should work with failing tests',
               'skipped-suite-test.js.should work with fixme root',
+              'todo-list-page-test.js.playwright should work with failing tests',
+              'todo-list-page-test.js.should work with fixme root',
             ])
 
             assertObjectContains(testEvents.map(test => test.content.meta[TEST_STATUS]), [
@@ -285,9 +285,9 @@ versions.forEach((version) => {
       receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
         const events = payloads.flatMap(({ payload }) => payload.events)
         const testEvents = events.filter(event => event.type === 'test')
-        assertObjectContains(testEvents.map(test => test.content.resource), [
-          'playwright-tests-ts/one-test.js.playwright should work with skipped tests',
+        assertObjectContains(testEvents.map(test => test.content.resource).sort(), [
           'playwright-tests-ts/one-test.js.playwright should work with passing tests',
+          'playwright-tests-ts/one-test.js.playwright should work with skipped tests',
         ])
         assert.match(testOutput, /1 passed/)
         assert.match(testOutput, /1 skipped/)


### PR DESCRIPTION
### What does this PR do?
- Playwright tests are failing in the [5.81.0 release proposal PR](https://github.com/DataDog/dd-trace-js/actions/runs/20292344149/job/58279613132?pr=6964)
- During [the migration to node.js asserts](https://github.com/DataDog/dd-trace-js/pull/6999/files#diff-68b5e7860766c25caad41f6fbfce1920923567d3c88cbf7cf24894ce1bd8e305), the Playwright test assertions were changed from order-insensitive array comparison to order-sensitive comparison. The tests run against the oldest supported Playwright version, which depends on the dd-trace major version: on master this is v6 with Playwright 1.38.0, while on the v5.x branch it is v5 with Playwright 1.18.0. It looks like Playwright orders test execution differently in 1.18.0 than in 1.38.0, which is why the tests pass on master but fail on the v5.81.0-proposal branch
- Sorting the array before comparison allows to use the node.js asserts while restoring the old order-insensitive assertions
