### PR TITLE
Fix MongoDB flaky DBM test

### DIFF
--- a/packages/datadog-plugin-mongodb-core/test/core.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/core.spec.js
@@ -631,6 +631,7 @@ describe('Plugin', () => {
 
       describe('with dbmPropagationMode full', () => {
         before(() => {
+          tracer._tracer.configure({ sampler: { sampleRate: 1 } })
           return agent.load('mongodb-core', { dbmPropagationMode: 'full' })
         })
 
@@ -664,7 +665,6 @@ describe('Plugin', () => {
             .assertFirstTraceSpan(span => {
               const traceId = span.meta['_dd.p.tid'] + span.trace_id.toString(16).padStart(16, '0')
               const spanId = span.span_id.toString(16).padStart(16, '0')
-              const samplingPriotrity = span.metrics._sampling_priority_v1 > 0 ? '01' : '00'
 
               assert.strictEqual(startSpy.called, true)
               const { comment } = startSpy.getCall(0).args[0].ops
@@ -676,7 +676,7 @@ describe('Plugin', () => {
                 `ddps='${encodeURIComponent(span.meta.service)}',` +
                 `ddpv='${ddpv}',` +
                 `ddprs='${encodeURIComponent(span.meta['peer.service'])}',` +
-                `traceparent='00-${traceId}-${spanId}-${samplingPriotrity}'`
+                `traceparent='00-${traceId}-${spanId}-01'`
               )
             })
             .then(done)

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -565,6 +565,7 @@ describe('Plugin', () => {
 
       describe('with dbmPropagationMode full', () => {
         before(() => {
+          tracer._tracer.configure({ sampler: { sampleRate: 1 } })
           return agent.load('mongodb-core', { dbmPropagationMode: 'full' })
         })
 
@@ -591,7 +592,6 @@ describe('Plugin', () => {
             .assertFirstTraceSpan(span => {
               const traceId = span.meta['_dd.p.tid'] + span.trace_id.toString(16).padStart(16, '0')
               const spanId = span.span_id.toString(16).padStart(16, '0')
-              const samplingPriotrity = span.metrics._sampling_priority_v1 > 0 ? '01' : '00'
 
               assert.strictEqual(startSpy.called, true)
               assert.strictEqual(injectCommentSpy.called, true)
@@ -605,7 +605,7 @@ describe('Plugin', () => {
                 `ddps='${encodeURIComponent(span.meta.service)}',` +
                 `ddpv='${ddpv}',` +
                 `ddprs='${encodeURIComponent(span.meta['peer.service'])}',` +
-                `traceparent='00-${traceId}-${spanId}-${samplingPriotrity}'`
+                `traceparent='00-${traceId}-${spanId}-01'`
               )
             })
             .then(done)


### PR DESCRIPTION
### What does this PR do?
Fixes the mongoDB flaky test when DBM propagation is set to full. Example error.
```
 AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    + actual - expected
    
    + "dddb='admin.%24cmd',dddbs='test-mongodb',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='11.7.5',ddprs='admin',traceparent='00-693cf4dc00000000162f8b1eda59e22b-162f8b1eda59e22b-00'"
    - "dddb='test.4cd4a2caadc196e5',dddbs='test-mongodb',dde='tester',ddh='127.0.0.1',ddps='test',ddpv='11.7.5',ddprs='test',traceparent='00-693cf4dc0000000036365d6198aac05c-36365d6198aac05c-01'"
```
The value discrepancy was caused by MongoDB emitting `isMaster` commands, which were being traced but did not match the values included in the SQL comment. This PR updates the tests to assert against the values produced by `injectDbmComment`.

### Motivation
Flakiness test report. 

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes


