### PR TITLE
ci: pass GITHUB_TOKEN to license attribution step

### DIFF
--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -51,6 +51,8 @@ jobs:
           EOF
 
       - name: Regenerate LICENSE-3rdparty.csv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           dd-license-attribution generate-sbom-csv \
             --use-mirrors=mirrors.json \


### PR DESCRIPTION
## What Does This Do?

Fixes the `update-3rdparty-licenses` workflow by explicitly passing the `GITHUB_TOKEN` to the license attribution step.

## Motivation

The workflow was failing with this error:

```
Invalid value for '--github-token' (env var: 'GITHUB_TOKEN'): No Github token available.
```

While the `GITHUB_TOKEN` is automatically available in GitHub Actions, it needs to be explicitly passed as an environment variable to individual steps that require it.
