### PR TITLE
fix(test-optimization): no advanced features are enabled if ITR kill …

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -103,10 +103,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
     )
   }
 
-  shouldRequestLibraryConfiguration () {
-    return this._config.isIntelligentTestRunnerEnabled
-  }
-
   canReportSessionTraces () {
     return this._canUseCiVisProtocol
   }
@@ -163,9 +159,6 @@ class CiVisibilityExporter extends AgentInfoExporter {
   getLibraryConfiguration (testConfiguration, callback) {
     const { repositoryUrl } = testConfiguration
     this.sendGitMetadata(repositoryUrl)
-    if (!this.shouldRequestLibraryConfiguration()) {
-      return callback(null, {})
-    }
     this._canUseCiVisProtocolPromise.then((canUseCiVisProtocol) => {
       if (!canUseCiVisProtocol) {
         return callback(null, {})

--- a/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/ci-visibility-exporter.spec.js
@@ -106,21 +106,6 @@ describe('CI Visibility Exporter', () => {
         done()
       })
     })
-    context('if ITR is disabled', () => {
-      it('should resolve immediately and not request settings', (done) => {
-        const scope = nock(url)
-          .post('/api/v2/libraries/tests/services/setting')
-          .reply(200)
-
-        const ciVisibilityExporter = new CiVisibilityExporter({ port })
-        ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
-          assert.deepStrictEqual(libraryConfig, {})
-          assert.strictEqual(err, null)
-          assert.notStrictEqual(scope.isDone(), true)
-          done()
-        })
-      })
-    })
     context('if ITR is enabled', () => {
       it('should add custom configurations', (done) => {
         let customConfig
@@ -278,7 +263,6 @@ describe('CI Visibility Exporter', () => {
           port, isIntelligentTestRunnerEnabled: true
         })
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        assert.strictEqual(ciVisibilityExporter.shouldRequestLibraryConfiguration(), true)
         ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           assert.strictEqual(scope.isDone(), true)
           assert.strictEqual(err, null)
@@ -320,7 +304,6 @@ describe('CI Visibility Exporter', () => {
           port, isIntelligentTestRunnerEnabled: true
         })
         ciVisibilityExporter._resolveCanUseCiVisProtocol(true)
-        assert.strictEqual(ciVisibilityExporter.shouldRequestLibraryConfiguration(), true)
         ciVisibilityExporter.getLibraryConfiguration({}, (err, libraryConfig) => {
           assert.strictEqual(scope.isDone(), true)
           assert.strictEqual(err, null)


### PR DESCRIPTION
### What does this PR do?
This PR removes a condition that causes the Datadog backend not to be queried for advanced feature settings in case a kill-switch for ITR is provided through the environment variables.

### Motivation
In the past, ITR was the only advanced feature, so calling the endpoint to receive feature configuration wasn't necessary with the kill-switch being provided. With more advanced features being added, this causes unwanted side-effects - users might want to toggle off ITR through environment variables but use other features that are being toggled on using the backend request.
In other tracers, this logic was already removed in the past, e.g., [dd-trace-py](https://github.com/DataDog/dd-trace-py/pull/12780/files)