### PR TITLE
refactor(config): use getEnv instead of getEnvironmentVariables

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -326,23 +326,20 @@ class Config {
     this.#applyRemote({})
     this.#merge()
 
-    // Use typed version of `this` to appease the type checker
-    const self = /** @type {Record<string, any>} */ (this)
-
-    tagger.add(self.tags, {
-      service: self.service,
-      env: self.env,
-      version: self.version,
+    tagger.add(this.tags, {
+      service: this.service,
+      env: this.env,
+      version: this.version,
       'runtime-id': runtimeId
     })
 
-    if (self.isCiVisibility) {
-      tagger.add(self.tags, {
+    if (this.isCiVisibility) {
+      tagger.add(this.tags, {
         [ORIGIN_KEY]: 'ciapp-test'
       })
     }
 
-    if (self.gitMetadataEnabled) {
+    if (this.gitMetadataEnabled) {
       this.#loadGitMetadata()
     }
   }
@@ -1461,11 +1458,7 @@ class Config {
         }
       }
     }
-
-    // Use typed version of `this` to appease the type checker
-    const self = /** @type {Record<string, any>} */ (this)
-    self.sampler.sampleRate = self.sampleRate
-
+    this.sampler.sampleRate = this.sampleRate
     updateConfig(changes, this)
   }
 
@@ -1479,17 +1472,14 @@ class Config {
   }
 
   #loadGitMetadata () {
-    // Use typed version of `this` to appease the type checker
-    const self = /** @type {Record<string, any>} */ (this)
-
     // try to read Git metadata from the environment variables
-    self.repositoryUrl = removeUserSensitiveInfo(
-      getEnv('DD_GIT_REPOSITORY_URL') ?? self.tags[GIT_REPOSITORY_URL]
+    this.repositoryUrl = removeUserSensitiveInfo(
+      getEnv('DD_GIT_REPOSITORY_URL') ?? this.tags[GIT_REPOSITORY_URL]
     )
-    self.commitSHA = getEnv('DD_GIT_COMMIT_SHA') ?? self.tags[GIT_COMMIT_SHA]
+    this.commitSHA = getEnv('DD_GIT_COMMIT_SHA') ?? this.tags[GIT_COMMIT_SHA]
 
     // otherwise, try to read Git metadata from the git.properties file
-    if (!self.repositoryUrl || !self.commitSHA) {
+    if (!this.repositoryUrl || !this.commitSHA) {
       const DD_GIT_PROPERTIES_FILE = getEnv('DD_GIT_PROPERTIES_FILE')
       const gitPropertiesFile = DD_GIT_PROPERTIES_FILE ?? `${process.cwd()}/git.properties`
       let gitPropertiesString
@@ -1503,21 +1493,21 @@ class Config {
       }
       if (gitPropertiesString) {
         const { commitSHA, repositoryUrl } = getGitMetadataFromGitProperties(gitPropertiesString)
-        self.commitSHA = self.commitSHA || commitSHA
-        self.repositoryUrl = self.repositoryUrl || repositoryUrl
+        this.commitSHA = this.commitSHA || commitSHA
+        this.repositoryUrl = this.repositoryUrl || repositoryUrl
       }
     }
     // otherwise, try to read Git metadata from the .git/ folder
-    if (!self.repositoryUrl || !self.commitSHA) {
+    if (!this.repositoryUrl || !this.commitSHA) {
       const DD_GIT_FOLDER_PATH = getEnv('DD_GIT_FOLDER_PATH')
       const gitFolderPath = DD_GIT_FOLDER_PATH ?? path.join(process.cwd(), '.git')
-      if (!self.repositoryUrl) {
+      if (!this.repositoryUrl) {
         // try to read git config (repository URL)
         const gitConfigPath = path.join(gitFolderPath, 'config')
         try {
           const gitConfigContent = fs.readFileSync(gitConfigPath, 'utf8')
           if (gitConfigContent) {
-            self.repositoryUrl = getRemoteOriginURL(gitConfigContent)
+            this.repositoryUrl = getRemoteOriginURL(gitConfigContent)
           }
         } catch (e) {
           // Only log error if the user has set a .git/ path
@@ -1526,11 +1516,11 @@ class Config {
           }
         }
       }
-      if (!self.commitSHA) {
+      if (!this.commitSHA) {
         // try to read git HEAD (commit SHA)
         const gitHeadSha = resolveGitHeadSHA(gitFolderPath)
         if (gitHeadSha) {
-          self.commitSHA = gitHeadSha
+          this.commitSHA = gitHeadSha
         }
       }
     }


### PR DESCRIPTION
## What Does This Do?

This PR refactors the `Config` class to standardize environment variable access by replacing `getEnvironmentVariables()` with `getEnv()` for consistency throughout the codebase.

## Motivation

Using a consistent method for environment variable access improves code maintainability and readability.