### PR TITLE
fix: pin import-in-the-middle to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.10",
-    "import-in-the-middle": "^2.0.0"
+    "import-in-the-middle": "2.0.0"
   },
   "optionalDependencies": {
     "@datadog/libdatadog": "0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2642,7 +2642,7 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^2.0.0:
+import-in-the-middle@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-2.0.0.tgz#295948cee94d0565314824c6bd75379d13e5b1a5"
   integrity sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A==


### PR DESCRIPTION
Version 2.0.1 was just released which causes issue with some of our CI tests:

<img width="827" height="182" alt="image" src="https://github.com/user-attachments/assets/58410d2e-7781-46d0-bd80-3e6daabf8e5e" />

Example 1: https://github.com/DataDog/dd-trace-js/actions/runs/20377836930/job/58560780383?pr=7144

It's too early to say if this is only a CI issue, but until we can investigate, it's better to pin it.
