### PR TITLE
feat: process tags for telemetry, crash tracking, remote config

### DIFF
--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -299,6 +299,9 @@ function buildExpressServer (agent) {
       cached_target_files: cachedTargetFiles
     } = req.body
 
+    // Emit the remote config request payload for testing
+    agent.emit('remote-config-request', req.body)
+
     if (state.has_error) {
       // Print the error sent by the client in case it's useful in debugging tests
       console.error(state.error) // eslint-disable-line no-console

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -8,6 +8,7 @@ const log = require('../log')
 const defaults = require('../config_defaults')
 const { URL } = require('url')
 const pkg = require('../../../../package.json')
+const processTags = require('../process-tags')
 
 class Crashtracker {
   #started = false
@@ -76,6 +77,13 @@ class Crashtracker {
 
   #getMetadata (config) {
     const tags = Object.keys(config.tags).map(key => `${key}:${config.tags[key]}`)
+
+    // Add process tags to the tags array
+    for (const [key, value] of processTags.tags) {
+      if (value !== undefined) {
+        tags.push(`${key}:${value}`)
+      }
+    }
 
     return {
       library_name: pkg.name,

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -216,7 +216,7 @@ session.on('Debugger.paused', async ({ params }) => {
       language: 'javascript'
     }
 
-    if (config.propagateProcessTags?.enabled) {
+    if (config.propagateProcessTags.enabled) {
       snapshot[processTags.DYNAMIC_INSTRUMENTATION_FIELD_NAME] = processTags.tagsObject
     }
 

--- a/packages/dd-trace/src/process-tags/index.js
+++ b/packages/dd-trace/src/process-tags/index.js
@@ -58,11 +58,11 @@ module.exports.TRACING_FIELD_NAME = '_dd.tags.process'
 module.exports.DSM_FIELD_NAME = 'ProcessTags'
 module.exports.PROFILING_FIELD_NAME = 'process_tags'
 module.exports.DYNAMIC_INSTRUMENTATION_FIELD_NAME = 'process_tags'
+module.exports.TELEMETRY_FIELD_NAME = 'process_tags'
+module.exports.REMOTE_CONFIG_FIELD_NAME = 'process_tags'
+module.exports.CRASH_TRACKING_FIELD_NAME = 'process_tags'
 
-// TODO: CRASH_TRACKING_FIELD_NAME /process_tags /application/process_tags
-// TODO: TELEMETRY_FIELD_NAME /application/process_tags
 // TODO: CLIENT_TRACE_STATISTICS_FIELD_NAME process_tags
-// TODO: REMOTE_CONFIG_FIELD_NAME process_tags
 
 function serialize (tags) {
   const intermediary = []

--- a/packages/dd-trace/src/remote_config/manager.js
+++ b/packages/dd-trace/src/remote_config/manager.js
@@ -12,6 +12,7 @@ const Scheduler = require('./scheduler')
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../plugins/util/tags')
 const tagger = require('../tagger')
 const defaults = require('../config_defaults')
+const processTags = require('../process-tags')
 
 const clientId = uuid()
 
@@ -87,7 +88,8 @@ class RemoteConfigManager extends EventEmitter {
           env: config.env,
           app_version: config.version,
           extra_services: [],
-          tags: Object.entries(tags).map((pair) => pair.join(':'))
+          tags: Object.entries(tags).map((pair) => pair.join(':')),
+          [processTags.REMOTE_CONFIG_FIELD_NAME]: processTags.tagsObject
         },
         capabilities: DEFAULT_CAPABILITY // updated by `updateCapabilities()`
       },

--- a/packages/dd-trace/src/telemetry/telemetry.js
+++ b/packages/dd-trace/src/telemetry/telemetry.js
@@ -9,6 +9,7 @@ const { errors } = require('../startup-log')
 const { manager: metricsManager } = require('./metrics')
 const telemetryLogger = require('./logs')
 const logger = require('../log')
+const processTags = require('../process-tags')
 
 const telemetryStartChannel = dc.channel('datadog:telemetry:start')
 const telemetryStopChannel = dc.channel('datadog:telemetry:stop')
@@ -78,7 +79,8 @@ function getIntegrations () {
     newIntegrations.push({
       name: pluginName,
       enabled: pluginManager._pluginsByName[pluginName]._enabled,
-      auto_enabled: true
+      auto_enabled: true,
+      [processTags.TELEMETRY_FIELD_NAME]: processTags.tagsObject
     })
     sentIntegrations.add(pluginName)
   }
@@ -155,7 +157,8 @@ function createAppObject (config) {
     service_version: config.version,
     tracer_version: tracerVersion,
     language_name: 'nodejs',
-    language_version: process.versions.node
+    language_version: process.versions.node,
+    process_tags: processTags.tagsObject
   }
 }
 

--- a/packages/dd-trace/test/process-tags.spec.js
+++ b/packages/dd-trace/test/process-tags.spec.js
@@ -10,6 +10,20 @@ describe('process-tags', () => {
   const processTags = require('../src/process-tags')
   const { serialize, sanitize } = require('../src/process-tags')
 
+  describe('field name constants', () => {
+    it('should define field names for different subsystems', () => {
+      assertObjectContains(processTags, {
+        TRACING_FIELD_NAME: '_dd.tags.process',
+        DSM_FIELD_NAME: 'ProcessTags',
+        PROFILING_FIELD_NAME: 'process_tags',
+        DYNAMIC_INSTRUMENTATION_FIELD_NAME: 'process_tags',
+        TELEMETRY_FIELD_NAME: 'process_tags',
+        REMOTE_CONFIG_FIELD_NAME: 'process_tags',
+        CRASH_TRACKING_FIELD_NAME: 'process_tags'
+      })
+    })
+  })
+
   describe('processTags', () => {
     it('should return an object with tags, serialized, and tagsObject properties', () => {
       assert.ok(Object.hasOwn(processTags, 'tags'))

--- a/packages/dd-trace/test/remote_config/manager.spec.js
+++ b/packages/dd-trace/test/remote_config/manager.spec.js
@@ -117,7 +117,8 @@ describe('RemoteConfigManager', () => {
           env: config.env,
           app_version: config.version,
           extra_services: [],
-          tags: ['runtime-id:runtimeId']
+          tags: ['runtime-id:runtimeId'],
+          process_tags: rc.state.client.client_tracer.process_tags
         },
         capabilities: 'AA=='
       },
@@ -125,6 +126,22 @@ describe('RemoteConfigManager', () => {
     })
 
     assert.ok(rc.appliedConfigs instanceof Map)
+  })
+
+  it('should include process_tags in client_tracer', () => {
+    const clientTracer = rc.state.client.client_tracer
+
+    assert.ok(clientTracer.process_tags, 'process_tags should exist')
+    assert.strictEqual(typeof clientTracer.process_tags, 'object')
+
+    // Verify expected process tag keys are present
+    assert.ok('entrypoint.basedir' in clientTracer.process_tags)
+    assert.ok('entrypoint.name' in clientTracer.process_tags)
+    assert.ok('entrypoint.type' in clientTracer.process_tags)
+    assert.ok('entrypoint.workdir' in clientTracer.process_tags)
+
+    // Verify entrypoint.type has expected value
+    assert.strictEqual(clientTracer.process_tags['entrypoint.type'], 'script')
   })
 
   it('should add git metadata to tags if present', () => {


### PR DESCRIPTION
### What does this PR do?
- adds [process tags](https://docs.google.com/document/d/1AFdLUuVk70i0bJd5335-RxqsvwAV9ovAqcO2z5mEMbA) to outbound data
- things like the directory the app is in, CWD, script name, boring static stuff

### Motivation
- we'll use this information for service renaming

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


