### PR TITLE
[Bug-fix] dependabot jobs failing from wrong claim

### DIFF
--- a/.github/chainguard/dependabot-automation.sts.yaml
+++ b/.github/chainguard/dependabot-automation.sts.yaml
@@ -3,7 +3,7 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/dd-trace-js:pull_request
 
 claim_pattern:
-  event_name: pull_request
+  event_name: pull_request_target
   ref: refs/heads/master
   ref_protected: "true"
   job_workflow_ref: DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/heads/master


### PR DESCRIPTION
Dependabot workflows have been failing since 12-11-2025 (the last change to this file) due to 
```
Attempt 1 failed. Error: HTTP error! status: 403, {"code":7,"message":"trust policy: claim \"job_workflow_ref\" did not match \"^DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/heads/master$\"","details":[]}
```
The JWT in the error logs have claim: "job_workflow_ref": "DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/pull/{number}/merge", while the [policy](https://github.com/DataDog/dd-trace-js/edit/master/.github/chainguard/dependabot-automation.sts.yaml) only accepts "^DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/heads/master$\".

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


