### PR TITLE
docs: enhance JSDoc standards and document package structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,14 @@ dd-trace is the Datadog client library for Node.js.
 - `integration-tests/` - E2E integration tests
 - `benchmark/` - Performance benchmarks
 
+**Package Structure:**
+
+Each package follows a consistent structure:
+- `src/` - Source code for the package
+- `test/` - Unit tests for the package
+- Unit test files always follow the `*.spec.js` naming convention
+- Test directories may also contain helper files (e.g., `naming.js`, `helpers.js`, `suite.js`) and integration test subdirectories
+
 ## Testing Instructions
 
 ### Testing Workflow
@@ -113,7 +121,10 @@ assertObjectContains(response, { status: 200, body: { user: { name: 'Alice' } } 
 ### Linting & Naming
 - Lint: `yarn lint` / `yarn lint:fix`
 - Files: kebab-case
-- JSDoc: TypeScript-compatible syntax (`@param {string}`, `@returns {Promise<void>}`, `@typedef`)
+
+### JSDoc
+- Use TypeScript-compatible syntax (`@param {string}`, `@returns {Promise<void>}`, `@typedef`)
+- Never use `any` (be specific or use `unknown` if type is truly unknown)
 
 ### Import Ordering
 
@@ -143,7 +154,6 @@ const log = require('../log')
   const { NODE_MAJOR } = require('./version')
   if (NODE_MAJOR >= 20) { /* Use Node.js 20+ API */ }
   ```
-- **Prefix Node.js core modules with `node:`** (e.g., `require('node:assert')`)
 
 ### Performance and Memory
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,9 +240,11 @@ DD_TRACE_DEBUG=true node your-app.js
 DD_TRACE_DEBUG=true yarn test:debugger
 ```
 
-### Documentation
+### JSDoc
 
 Document all APIs with TypeScript-compatible JSDoc to ensure proper types without using TypeScript. This enables type checking and IDE autocompletion while maintaining the JavaScript codebase. Use TypeScript type syntax in JSDoc annotations (e.g., `@param {string}`, `@returns {Promise<void>}`).
+
+Never use the type `any` - be specific.
 
 ## Adding New Configuration Options
 


### PR DESCRIPTION
Enhances the developer documentation to improve clarity around JSDoc standards and document the standard package structure. Updates both `AGENTS.md` (AI agent guidelines) and `CONTRIBUTING.md` (human contributor guidelines) to maintain consistency.

**For AI agents (AGENTS.md):**
1. **Package structure wasn't documented** - Added explicit documentation of the standard `src/` and `test/` directory layout with `*.spec.js` naming conventions used consistently across all packages. This helps agents quickly understand project organization.

2. **JSDoc standards needed better visibility** - Separated JSDoc into its own subsection (was buried as a single bullet point) and added explicit guidance to never use the `any` type, which helps agents maintain type safety.

3. **Removed duplicate guidance** - The Node.js core module prefix requirement was already covered in the Import Ordering section.

**For human contributors (CONTRIBUTING.md):**
- Aligned JSDoc documentation to match `AGENTS.md`, including the explicit rule against using `any` type in JSDoc annotations.
