### PR TITLE
fix(llmobs): prevent config origin overwrite in enable()

### DIFF
--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -1156,9 +1156,8 @@ class Config {
     // This is reliant on environment config being set before options.
     // This is to make sure the origins of each value are tracked appropriately for telemetry.
     // We'll only set `llmobs.enabled` on the opts when it's not set on the environment, and options.llmobs is provided.
-    const llmobsEnabledEnv = this.#env['llmobs.enabled']
-    if (llmobsEnabledEnv == null && options.llmobs) {
-      this.#setBoolean(opts, 'llmobs.enabled', !!options.llmobs)
+    if (this.#env['llmobs.enabled'] == null && options.llmobs) {
+      this.#setBoolean(opts, 'llmobs.enabled', true)
     }
   }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -53,23 +53,20 @@ class LLMObs extends NoopLLMObs {
 
     logger.debug('Enabling LLMObs')
 
-    const { mlApp, agentlessEnabled } = options
-
     const DD_LLMOBS_ENABLED = getEnvironmentVariable('DD_LLMOBS_ENABLED')
 
-    const llmobsConfig = {
-      mlApp,
-      agentlessEnabled
-    }
-
-    const enabled = DD_LLMOBS_ENABLED == null || isTrue(DD_LLMOBS_ENABLED)
-    if (!enabled) {
+    if (DD_LLMOBS_ENABLED != null && !isTrue(DD_LLMOBS_ENABLED)) {
       logger.debug('LLMObs.enable() called when DD_LLMOBS_ENABLED is false. No action taken.')
       return
     }
 
-    this._config.llmobs.enabled = true
-    this._config.configure({ ...this._config, llmobs: llmobsConfig })
+    const llmobs = {
+      mlApp: options.mlApp,
+      agentlessEnabled: options.agentlessEnabled
+    }
+    // TODO: This will update config telemetry with the origin 'code', which is not ideal when `enable()` is called
+    // based on `APM_TRACING` RC product updates.
+    this._config.configure({ llmobs })
 
     // configure writers and channel subscribers
     this._llmobsModule.enable(this._config)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the LLMObs SDK's `enable()` method where configuration origins were being incorrectly tracked for telemetry:

- Pass only the `llmobs` config object to `configure()` to avoid spreading the entire config
- Remove unnecessary intermediate variables in both `config.js` and `sdk.js`
- Invert early-return logic in `sdk.js` for clearer control flow
- Add TODO comment noting that calling `configure()` from `enable()` still sets origin as `'code'` even when `enable()` is called from Remote Config updates

### Motivation

The `enable()` method in `packages/dd-trace/src/llmobs/sdk.js` was spreading the entire `_config` object when calling `configure()`:

```
this._config.configure({ ...this._config, llmobs: llmobsConfig })
```

This caused all configuration values to be re-set with origin `'code'`, overwriting their actual origins (e.g. `'env'`, `'default'`, etc.). This breaks telemetry tracking which relies on accurate origin information to understand how users are configuring the tracer.

### Additional Notes

I've done my best to ensure that it's ok to call `configure` with only a sub-set of config options and that it will still work even if `#applyOptions` was called previously with another sub-set of options. But this is important to review!

There's still a remaining issue (noted in the TODO): when `enable()` is called based on `APM_TRACING` RC product updates, the config telemetry will show origin as `'code'` rather than the actual source (whatever that should actually be?).
