### PR TITLE
Support undici via diagnostics_channel events

### DIFF
--- a/packages/datadog-instrumentations/src/undici.js
+++ b/packages/datadog-instrumentations/src/undici.js
@@ -3,6 +3,7 @@
 const tracingChannel = require('dc-polyfill').tracingChannel
 
 const shimmer = require('../../datadog-shimmer')
+const satisfies = require('../../../vendor/dist/semifies')
 const {
   addHook
 } = require('./helpers/instrument')
@@ -10,9 +11,19 @@ const { createWrapFetch } = require('./helpers/fetch')
 
 const ch = tracingChannel('apm:undici:fetch')
 
+// Undici 5.0.x has a bug where fetch doesn't preserve AggregateError in the error cause chain
+// Use native DC only for versions where error handling works correctly
+const NATIVE_DC_VERSION = '>=4.7.0 <5.0.0 || >=5.1.0'
+
 addHook({
   name: 'undici',
   versions: ['^4.4.1', '5', '>=6.0.0']
-}, undici => {
+}, (undici, version) => {
+  // For versions with working native DC, let the plugin subscribe directly
+  if (satisfies(version, NATIVE_DC_VERSION)) {
+    return undici
+  }
+
+  // For older versions or those with buggy error handling, wrap fetch
   return shimmer.wrap(undici, 'fetch', createWrapFetch(undici.Request, ch))
 })

--- a/packages/datadog-plugin-undici/src/index.js
+++ b/packages/datadog-plugin-undici/src/index.js
@@ -1,10 +1,313 @@
 'use strict'
 
-const FetchPlugin = require('../../datadog-plugin-fetch/src/index.js')
+const HttpClientPlugin = require('../../datadog-plugin-http/src/client')
+const { storage } = require('../../datadog-core')
+const tags = require('../../../ext/tags')
+const formats = require('../../../ext/formats')
+const HTTP_HEADERS = formats.HTTP_HEADERS
+const log = require('../../dd-trace/src/log')
+const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 
-class UndiciPlugin extends FetchPlugin {
+const {
+  HTTP_STATUS_CODE,
+  HTTP_REQUEST_HEADERS,
+  HTTP_RESPONSE_HEADERS,
+} = tags
+
+// WeakMap to store span context for native undici request objects
+const requestContexts = new WeakMap()
+
+class UndiciPlugin extends HttpClientPlugin {
   static id = 'undici'
   static prefix = 'tracing:apm:undici:fetch'
+
+  constructor (...args) {
+    super(...args)
+
+    // Subscribe to native undici diagnostic channels for undici >= 4.7.0
+    // These channels fire for ALL undici requests (fetch, request, stream, etc.)
+    this.addSub('undici:request:create', this.#onNativeRequestCreate.bind(this))
+    this.addSub('undici:request:headers', this.#onNativeRequestHeaders.bind(this))
+    this.addSub('undici:request:trailers', this.#onNativeRequestTrailers.bind(this))
+    this.addSub('undici:request:error', this.#onNativeRequestError.bind(this))
+  }
+
+  // ===========================================
+  // Native undici diagnostic channel handlers
+  // These fire for undici >= 4.7.0 for ALL request types (fetch, request, stream, etc.)
+  // ===========================================
+
+  #onNativeRequestCreate ({ request }) {
+    if (!request) return
+
+    const store = storage('legacy').getStore()
+    const { origin = '', path = '/' } = request
+    const method = request.method?.toUpperCase() ?? 'GET'
+
+    // Parse origin to extract protocol, hostname, port
+    let protocol = 'http:'
+    let hostname = 'localhost'
+    let port = ''
+
+    try {
+      const url = new URL(origin)
+      protocol = url.protocol
+      hostname = url.hostname
+      port = url.port
+    } catch {
+      // If origin is not a valid URL, use defaults
+    }
+
+    const host = port ? `${hostname}:${port}` : hostname
+    const pathname = path.split(/[?#]/)[0]
+    const uri = `${protocol}//${host}${pathname}`
+
+    const allowed = this.config.filter(uri)
+    const childOf = store && allowed ? store.span : null
+
+    const span = this.startSpan(this.operationName(), {
+      childOf,
+      meta: {
+        'span.kind': 'client',
+        'http.method': method,
+        'http.url': uri,
+        'out.host': hostname
+      },
+      metrics: {
+        [CLIENT_PORT_KEY]: port ? Number.parseInt(port, 10) : undefined
+      },
+      service: this.serviceName({ pluginConfig: this.config, sessionDetails: { host: hostname, port } }),
+      resource: method,
+      type: 'http'
+    }, false)
+
+    // Disable recording if not allowed
+    if (!allowed) {
+      span._spanContext._trace.record = false
+    }
+
+    // Capture request headers if configured
+    if (request.headers && this.config.headers) {
+      addConfiguredHeaders(span, request.headers, this.config.headers, HTTP_REQUEST_HEADERS)
+    }
+
+    // Inject trace headers if propagation is allowed
+    if (this.config.propagationFilter(uri)) {
+      const headers = {}
+      this.tracer.inject(span, HTTP_HEADERS, headers)
+
+      // Use addHeader if available (undici provides this on the request object)
+      if (typeof request.addHeader === 'function') {
+        for (const [name, value] of Object.entries(headers)) {
+          request.addHeader(name, value)
+        }
+      }
+    }
+
+    // Store span context for request for later retrieval
+    requestContexts.set(request, {
+      span,
+      store,
+      uri
+    })
+
+    // Enter the span context
+    storage('legacy').enterWith({ ...store, span })
+  }
+
+  #onNativeRequestHeaders ({ request, response }) {
+    const ctx = requestContexts.get(request)
+    if (!ctx) return
+
+    const { span } = ctx
+    const statusCode = response?.statusCode
+
+    if (statusCode) {
+      span.setTag(HTTP_STATUS_CODE, statusCode)
+
+      if (!this.config.validateStatus(statusCode)) {
+        span.setTag('error', 1)
+      }
+    }
+
+    // Add response headers if configured
+    if (response?.headers && this.config.headers) {
+      addConfiguredHeaders(span, response.headers, this.config.headers, HTTP_RESPONSE_HEADERS)
+    }
+  }
+
+  #onNativeRequestTrailers ({ request }) {
+    const ctx = requestContexts.get(request)
+    if (!ctx) return
+
+    const { span, store } = ctx
+
+    // Call the request hook if configured
+    this.config.hooks.request(span, null, null)
+
+    // Finish the span
+    span.finish()
+
+    // Clean up
+    requestContexts.delete(request)
+
+    // Restore parent store
+    if (store) {
+      storage('legacy').enterWith(store)
+    }
+  }
+
+  #onNativeRequestError ({ request, error }) {
+    const ctx = requestContexts.get(request)
+    if (!ctx) return
+
+    const { span, store } = ctx
+
+    // Don't record AbortError as an error - it's user-initiated cancellation
+    if (error && error.name !== 'AbortError') {
+      span.setTag('error', error)
+    }
+
+    // Call the request hook if configured
+    this.config.hooks.request(span, null, null)
+
+    // Finish the span
+    span.finish()
+
+    // Clean up
+    requestContexts.delete(request)
+
+    // Restore parent store
+    if (store) {
+      storage('legacy').enterWith(store)
+    }
+  }
+
+  // ===========================================
+  // Fetch-based tracing channel handlers
+  // These handle fetch() for undici < 4.7.0 (before native DC was added)
+  // ===========================================
+
+  bindStart (ctx) {
+    const req = ctx.req
+    const options = new URL(req.url)
+    options.headers = Object.fromEntries(req.headers.entries())
+    options.method = req.method
+
+    ctx.args = { options }
+
+    const store = super.bindStart(ctx)
+
+    // Inject trace headers back into the request
+    for (const name of Object.keys(options.headers)) {
+      if (!req.headers.has(name)) {
+        req.headers.set(name, options.headers[name])
+      }
+    }
+
+    return store
+  }
+
+  error (ctx) {
+    // Don't record AbortError as an error - it's user-initiated cancellation
+    if (!ctx.error || ctx.error.name !== 'AbortError') {
+      return super.error(ctx)
+    }
+  }
+
+  asyncEnd (ctx) {
+    ctx.res = ctx.result
+    return this.finish(ctx)
+  }
+
+  configure (config) {
+    return super.configure(normalizeConfig(config))
+  }
 }
+
+// Add configured headers to span with appropriate tags
+function addConfiguredHeaders (span, rawHeaders, configuredHeaders, headerType) {
+  const headers = normalizeHeaders(rawHeaders)
+
+  for (const [key, tag] of configuredHeaders) {
+    const value = headers[key]
+    if (value) {
+      span.setTag(tag || `${headerType}.${key}`, value)
+    }
+  }
+}
+
+// Normalize headers to an object, handling different undici formats:
+// - Array format: alternating key-value pairs (undici >= 6.0.0)
+// - String format: HTTP header lines like "key: value\r\n" (undici 5.x)
+// - Object format: already a headers object
+function normalizeHeaders (headers) {
+  if (!headers) return {}
+
+  // String format (undici 5.x): "key: value\r\nkey2: value2\r\n"
+  if (typeof headers === 'string') {
+    const result = {}
+    const lines = headers.split('\r\n')
+    for (const line of lines) {
+      if (!line) continue
+      const colonIndex = line.indexOf(':')
+      if (colonIndex > 0) {
+        const key = line.slice(0, colonIndex).toLowerCase().trim()
+        const value = line.slice(colonIndex + 1).trim()
+        result[key] = value
+      }
+    }
+    return result
+  }
+
+  // Array format (undici >= 6.0.0): alternating key-value pairs
+  if (Array.isArray(headers)) {
+    const result = {}
+    for (let i = 0; i < headers.length; i += 2) {
+      const key = headers[i]
+      if (typeof key === 'string') {
+        result[key.toLowerCase()] = headers[i + 1]
+      } else if (Buffer.isBuffer(key)) {
+        result[key.toString().toLowerCase()] = headers[i + 1]?.toString?.() || headers[i + 1]
+      }
+    }
+    return result
+  }
+
+  // Object format: use as-is
+  return headers
+}
+
+function normalizeConfig (config) {
+  const validateStatus = getStatusValidator(config)
+  const hooks = getHooks(config)
+
+  return {
+    ...config,
+    validateStatus,
+    hooks
+  }
+}
+
+function getStatusValidator (config) {
+  if (typeof config.validateStatus === 'function') {
+    return config.validateStatus
+  } else if (Object.hasOwn(config, 'validateStatus')) {
+    log.error('Expected `validateStatus` to be a function.')
+  }
+  return defaultValidateStatus
+}
+
+function defaultValidateStatus (code) {
+  return code < 400 || code >= 500
+}
+
+function getHooks (config) {
+  const request = config.hooks?.request ?? noop
+
+  return { request }
+}
+
+function noop () {}
 
 module.exports = UndiciPlugin

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -2,16 +2,37 @@
 
 const assert = require('node:assert/strict')
 
+const semver = require('semver')
+const satisfies = require('../../../vendor/dist/semifies')
 const tags = require('../../../ext/tags')
 const { NODE_MAJOR } = require('../../../version')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { rawExpectedSchema } = require('./naming')
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 
 const SERVICE_NAME = 'test'
+
+// Helper to find an error with a specific type in the caught error's cause chain
+// Different undici versions wrap errors differently, so we need to walk the chain
+// Returns the matching error object, or null if not found
+function findErrorInCauseChain (error, targetErrorType) {
+  let current = error
+  while (current) {
+    if (current.name === targetErrorType) return current
+    // Also check errors array in AggregateError
+    if (current.errors) {
+      for (const e of current.errors) {
+        if (e.name === targetErrorType) return e
+      }
+    }
+    current = current.cause
+  }
+  return null
+}
 
 describe('Plugin', () => {
   let express
@@ -19,7 +40,7 @@ describe('Plugin', () => {
   let appListener
 
   describe('undici-fetch', () => {
-    withVersions('undici', 'undici', NODE_MAJOR < 20 ? '<7.11.0' : '*', (version) => {
+    withVersions('undici', 'undici', NODE_MAJOR < 20 ? '<7.11.0' : '*', (version, moduleName, resolvedVersion) => {
       function server (app, listener) {
         const server = require('http').createServer(app)
         server.listen(0, 'localhost', () => listener(
@@ -200,20 +221,33 @@ describe('Plugin', () => {
         })
 
         it('should handle connection errors', done => {
-          let error
+          let caughtError
 
           agent
             .assertSomeTraces(traces => {
-              assert.strictEqual(traces[0][0].meta[ERROR_TYPE], error.name)
-              assert.strictEqual(traces[0][0].meta[ERROR_MESSAGE], error.message || error.code)
-              assert.strictEqual(traces[0][0].meta[ERROR_STACK], error.stack)
-              assert.strictEqual(traces[0][0].meta.component, 'undici')
+              const spanErrorType = traces[0][0].meta[ERROR_TYPE]
+
+              // The error in the span should match either the thrown error or something in its cause chain
+              // For fetch with native DC (>= 4.7.0), the DC error becomes caught.cause
+              // For fetch wrapper (< 4.7.0), it records the thrown error directly
+              const error = findErrorInCauseChain(caughtError, spanErrorType)
+              assert.ok(error, `Error type ${spanErrorType} should match thrown error or be in cause chain`)
+
+              assertObjectContains(traces, [[{
+                error: 1,
+                meta: {
+                  [ERROR_TYPE]: error.name,
+                  [ERROR_MESSAGE]: error.message || error.code,
+                  [ERROR_STACK]: error.stack,
+                  component: 'undici'
+                }
+              }]])
             })
             .then(done)
             .catch(done)
 
           fetch.fetch('http://localhost:7357/user').catch(err => {
-            error = err
+            caughtError = err
           })
         })
 
@@ -303,6 +337,153 @@ describe('Plugin', () => {
             controller.abort()
           })
         })
+
+        // Tests for undici.request() using native diagnostic channels
+        // Only run for undici >= 4.7.0 where diagnostic channels were added
+        if (semver.satisfies(resolvedVersion, '>=4.7.0')) {
+          it('should do automatic instrumentation for undici.request()', function (done) {
+            const app = express()
+            app.get('/user', (req, res) => {
+              res.status(200).send('OK')
+            })
+            appListener = server(app, port => {
+              agent
+                .assertFirstTraceSpan({
+                  service: 'test',
+                  type: 'http',
+                  resource: 'GET',
+                  meta: {
+                    'span.kind': 'client',
+                    'http.url': `http://localhost:${port}/user`,
+                    'http.method': 'GET',
+                    'http.status_code': '200',
+                    component: 'undici',
+                    'out.host': 'localhost'
+                  }
+                })
+                .then(done)
+                .catch(done)
+
+              fetch.request(`http://localhost:${port}/user`, { method: 'GET' })
+                .then(({ body }) => body.dump())
+                .catch(() => {})
+            })
+          })
+
+          it('should support POST requests with undici.request()', done => {
+            const app = express()
+            app.post('/user', (req, res) => {
+              res.status(201).send('Created')
+            })
+            appListener = server(app, port => {
+              agent
+                .assertFirstTraceSpan({
+                  resource: 'POST',
+                  meta: {
+                    'http.method': 'POST',
+                    'http.status_code': '201'
+                  }
+                })
+                .then(done)
+                .catch(done)
+
+              fetch.request(`http://localhost:${port}/user`, { method: 'POST' })
+                .then(({ body }) => body.dump())
+                .catch(() => {})
+            })
+          })
+
+          it('should inject trace headers in undici.request()', done => {
+            const app = express()
+
+            app.get('/user', (req, res) => {
+              assert.strictEqual(typeof req.get('x-datadog-trace-id'), 'string')
+              assert.strictEqual(typeof req.get('x-datadog-parent-id'), 'string')
+
+              res.status(200).send('OK')
+            })
+
+            appListener = server(app, port => {
+              agent
+                .assertFirstTraceSpan({
+                  meta: {
+                    'http.status_code': '200'
+                  }
+                })
+                .then(done)
+                .catch(done)
+
+              fetch.request(`http://localhost:${port}/user`)
+                .then(({ body }) => body.dump())
+                .catch(() => {})
+            })
+          })
+
+          it('should handle connection errors in undici.request()', done => {
+            let error
+
+            agent
+              .assertSomeTraces(traces => {
+                assertObjectContains(traces[0][0], {
+                  meta: {
+                    [ERROR_TYPE]: error.name,
+                    [ERROR_STACK]: error.stack,
+                    component: 'undici'
+                  }
+                })
+                assert.ok(traces[0][0].meta[ERROR_MESSAGE])
+              })
+              .then(done)
+              .catch(done)
+
+            fetch.request('http://localhost:7357/user')
+              .catch(err => {
+                error = err
+              })
+          })
+
+          it('should record HTTP 4XX responses as errors in undici.request()', done => {
+            const app = express()
+
+            app.get('/user', (req, res) => {
+              res.status(400).send('Bad Request')
+            })
+
+            appListener = server(app, port => {
+              agent
+                .assertFirstTraceSpan({
+                  error: 1
+                })
+                .then(done)
+                .catch(done)
+
+              fetch.request(`http://localhost:${port}/user`)
+                .then(({ body }) => body.dump())
+                .catch(() => {})
+            })
+          })
+
+          it('should not record HTTP 5XX responses as errors in undici.request()', done => {
+            const app = express()
+
+            app.get('/user', (req, res) => {
+              res.status(500).send('Server Error')
+            })
+
+            appListener = server(app, port => {
+              agent
+                .assertFirstTraceSpan({
+                  error: 0
+                })
+                .then(done)
+                .catch(done)
+
+              fetch.request(`http://localhost:${port}/user`)
+                .then(({ body }) => body.dump())
+                .catch(() => {})
+            })
+          })
+        }
       })
       describe('with service configuration', () => {
         let config
@@ -488,6 +669,65 @@ describe('Plugin', () => {
               .catch(done)
 
             fetch.fetch(`http://localhost:${port}/users`).catch(() => {})
+          })
+        })
+      })
+
+      describe('with custom dispatcher', () => {
+        beforeEach(() => {
+          return agent.load('undici', {
+            service: 'test'
+          })
+            .then(() => {
+              express = require('express')
+              fetch = require(`../../../versions/undici@${version}`, {}).get()
+            })
+        })
+
+        afterEach(() => {
+          express = null
+        })
+
+        it('should preserve custom dispatcher option and trace the request', function (done) {
+          // Skip for versions that use fetch wrapping instead of native DC
+          // Those versions have the dispatcher issue described in #6439
+          if (!satisfies(resolvedVersion, '>=4.7.0 <5.0.0 || >=5.1.0')) {
+            this.skip()
+            return
+          }
+
+          const app = express()
+          app.get('/user', (req, res) => {
+            res.status(200).send('OK')
+          })
+
+          appListener = server(app, port => {
+            // Create a custom Agent with specific settings
+            // This is the use case from issue #6439
+            const customAgent = new fetch.Agent({
+              connect: { keepAlive: false }
+            })
+
+            agent
+              .assertSomeTraces(traces => {
+                const span = traces[0][0]
+                assert.strictEqual(span.service, 'test')
+                assert.strictEqual(span.type, 'http')
+                assert.strictEqual(span.resource, 'GET')
+              })
+              .then(done)
+              .catch(done)
+
+            // Make request with custom dispatcher
+            // For native DC versions, dispatcher is preserved because we don't wrap fetch at all
+            fetch.fetch(`http://localhost:${port}/user`, {
+              dispatcher: customAgent
+            }).then(res => {
+              assert.strictEqual(res.status, 200)
+              return res.text()
+            }).then(body => {
+              assert.strictEqual(body, 'OK')
+            }).catch(done)
           })
         })
       })


### PR DESCRIPTION
### What does this PR do?

This provides now complete support for undici, not just fetch only.

### Motivation

Presently the Undici instrumentation only supports the `fetch(...)` function, not the rest of the library. This adds full support via the diagnostics_channel events.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [x] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


