### PR TITLE
fix: encode baggage values, if necessary

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -39,6 +39,9 @@ const tagValueExpr = /^[\x20-\x2B\x2D-\x7E]*$/ // ASCII minus commas
 // RFC7230 token (used by HTTP header field-name) and compatible with Node's header name validation.
 // See https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6
 const httpHeaderNameExpr = /^[0-9A-Za-z!#$%&'*+\-.^_`|~]+$/
+// Compatible with Node's internal header value validation (allows HTAB, SP-~, and \x80-\xFF only)
+// https://github.com/nodejs/node/blob/main/lib/_http_common.js
+const invalidHeaderValueCharExpr = /[^\t\x20-\x7E\x80-\xFF]/
 const traceparentExpr = /^([a-f0-9]{2})-([a-f0-9]{32})-([a-f0-9]{16})-([a-f0-9]{2})(-.*)?$/i
 const traceparentKey = 'traceparent'
 const tracestateKey = 'tracestate'
@@ -145,7 +148,12 @@ class TextMapPropagator {
             continue
           }
 
-          carrier[headerName] = String(baggageItems[key])
+          let headerValue = String(baggageItems[key])
+          // Avoid Node throwing ERR_INVALID_CHAR when setting header values (e.g. newline from decoded OTEL baggage).
+          if (invalidHeaderValueCharExpr.test(headerValue)) {
+            headerValue = encodeURIComponent(headerValue)
+          }
+          carrier[headerName] = headerValue
         }
       }
     }

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -145,6 +145,21 @@ describe('TextMapPropagator', () => {
       sinon.assert.called(tracerMetrics.count().inc)
     })
 
+    it('should encode legacy baggage values that are not valid HTTP header content', () => {
+      const carrier = {}
+      const value = 'foo@2025.0122.110223\n'
+      const spanContext = createContext({
+        baggageItems: {
+          'sentry-release': value
+        }
+      })
+
+      propagator.inject(spanContext, carrier)
+
+      assert.strictEqual(carrier['ot-baggage-sentry-release'], encodeURIComponent(value))
+      assert.ok(!carrier['ot-baggage-sentry-release'].includes('\n'))
+    })
+
     it('should handle special characters in baggage', () => {
       const carrier = {}
       setBaggageItem('",;\\()/:<=>?@[]{}🐶é我', '",;\\🐶é我')


### PR DESCRIPTION
This is a best effort fix, by keeping things backwards compatibel for our users who currently expect values not to be encoded while fixing entries that need encoding. This is not critical in the future, due to using a different baggage implementation anyway.

Fixes: https://github.com/DataDog/dd-trace-js/issues/5159
