### PR TITLE
feat: enable websocket tracing by default

### DIFF
--- a/packages/datadog-plugin-ws/test/index.spec.js
+++ b/packages/datadog-plugin-ws/test/index.spec.js
@@ -280,7 +280,7 @@ describe('Plugin', () => {
         beforeEach(async () => {
           await agent.load(['ws'], [{
             service: 'custom-ws-service',
-            traceWebsocketMessagesEnabled: true
+            traceWebsocketMessagesEnabled: false
           }])
           WebSocket = require(`../../../versions/ws@${version}`).get()
 

--- a/packages/dd-trace/src/config_defaults.js
+++ b/packages/dd-trace/src/config_defaults.js
@@ -206,7 +206,7 @@ module.exports = {
   'tracePropagationStyle.inject': ['datadog', 'tracecontext', 'baggage'],
   'tracePropagationStyle.extract': ['datadog', 'tracecontext', 'baggage'],
   'tracePropagationStyle.otelPropagators': false,
-  traceWebsocketMessagesEnabled: false,
+  traceWebsocketMessagesEnabled: true,
   traceWebsocketMessagesInheritSampling: true,
   traceWebsocketMessagesSeparateTraces: true,
   tracing: true,


### PR DESCRIPTION
### What does this PR do?
- enables websocket tracing by default

### Motivation
- PHP and Java already do this

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


