### PR TITLE
feat(iast): Improve weak hash detection accuracy for `node-preload`

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/weak-hash-analyzer.js
@@ -23,7 +23,8 @@ const EXCLUDED_LOCATIONS = getNodeModulesPaths(
   'ws/lib/websocket-server.js',
   'google-gax/build/src/grpc.js',
   'cookie-signature/index.js',
-  'express-session/index.js'
+  'express-session/index.js',
+  'node-preload/preload-list-env.js'
 )
 
 const EXCLUDED_PATHS_FROM_STACK = [


### PR DESCRIPTION
### What does this PR do?

Ignore weak hash vulnerabilities detected in `node-preload` as it is safe, and it's generating noise with false positives

### Motivation
Improve weak hash IAST detection accuracy

### Additional notes

Safe usage of **sha1** in `node-preload`: https://github.com/cfware/node-preload/blob/master/preload-list-env.js#L5


