### PR TITLE
fix(iast): Improve OCE integration test

### DIFF
--- a/packages/dd-trace/test/appsec/iast/overhead-controller.integration.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.integration.spec.js
@@ -36,7 +36,7 @@ describe('IAST - overhead-controller - integration', () => {
           DD_TRACE_AGENT_PORT: agent.port,
           DD_IAST_ENABLED: 'true',
           DD_IAST_REQUEST_SAMPLING: '100',
-          DD_TELEMETRY_HEARTBEAT_INTERVAL: '1',
+          DD_INSTRUMENTATION_TELEMETRY_ENABLED: 'false',
           NODE_OPTIONS: '--require ./resources/init.js'
         }
       })


### PR DESCRIPTION
### What does this PR do?
The IAST OCE integration test has been flaky recently. The root cause was the Fake Agent being overloaded during test startup, causing the tracer to discard payloads and preventing the test from validating traces. Since most of the requests it received at startup were telemetry data—and this test does not rely on telemetry—telemetry has been disabled for this test to prevent overload and stabilize execution.

### Motivation
To eliminate flakiness in the IAST OCE integration test caused by Fake Agent overload during startup.

### Additional Notes
[APPSEC-60589](https://datadoghq.atlassian.net/browse/APPSEC-60589)




[APPSEC-60589]: https://datadoghq.atlassian.net/browse/APPSEC-60589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ