### PR TITLE
Implement http test for MaxRequest

### DIFF
--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -3,12 +3,11 @@
 const assert = require('node:assert/strict')
 const http = require('node:http')
 const zlib = require('node:zlib')
-
+const { setTimeout: delay } = require('node:timers/promises')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
-const { setTimeout: delay } = require('node:timers/promises')
 
 require('../../setup/core')
 const FormData = require('../../../src/exporters/common/form-data')

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -8,6 +8,7 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
+const { setTimeout: delay } = require('node:timers/promises')
 
 require('../../setup/core')
 const FormData = require('../../../src/exporters/common/form-data')
@@ -32,6 +33,56 @@ const initHTTPServer = () => {
         server.close()
       }
       shutdown.port = (/** @type {import('net').AddressInfo} */ (server.address())).port
+      resolve(shutdown)
+    })
+  })
+}
+
+const initSlowAgentHTTPServer = () => {
+  return new Promise(resolve => {
+    const sockets = []
+    let requestCount = 0
+    /** @type {import('node:http').ServerResponse | null} */
+    let firstRes = null
+    let releaseRequested = false
+
+    const maybeReleaseFirst = () => {
+      if (!releaseRequested || !firstRes) return
+      firstRes.writeHead(200, { Connection: 'close' })
+      firstRes.end('OK')
+      firstRes = null
+    }
+
+    const requestListener = function (req, res) {
+      requestCount++
+
+      // Keep the first request open to simulate a slow/unresponsive agent.
+      if (!firstRes) {
+        firstRes = res
+        maybeReleaseFirst()
+        return
+      }
+
+      res.writeHead(200, { Connection: 'close' })
+      res.end('OK')
+    }
+
+    const server = http.createServer(requestListener)
+    server.on('connection', socket => sockets.push(socket))
+
+    server.listen(0, () => {
+      const shutdown = () => {
+        sockets.forEach(socket => socket.end())
+        server.close()
+      }
+
+      shutdown.port = (/** @type {import('net').AddressInfo} */ (server.address())).port
+      shutdown.releaseFirst = () => {
+        releaseRequested = true
+        maybeReleaseFirst()
+      }
+      shutdown.requestCount = () => requestCount
+
       resolve(shutdown)
     })
   })
@@ -207,6 +258,48 @@ describe('request', function () {
       assert.strictEqual(err, error)
       done()
     })
+  })
+
+  it('should discard payloads when agent is slow and maxActiveRequests is reached', async () => {
+    const shutdown = await initSlowAgentHTTPServer()
+
+    const makeCall = () => {
+      return new Promise(resolve => {
+        request(Buffer.from(''), {
+          path: '/',
+          method: 'PUT',
+          hostname: 'localhost',
+          protocol: 'http:',
+          port: shutdown.port,
+          timeout: 1000
+        }, (err, res) => resolve({ err, res }))
+      })
+    }
+
+    const promises = Array.from({ length: 9 }, () => makeCall())
+
+    // The 9th request should be dropped immediately because maxActiveRequests is 8.
+    const dropped = await Promise.race([
+      promises[8],
+      delay(200).then(() => {
+        throw new Error('Expected dropped request callback to be called quickly.')
+      })
+    ])
+
+    assert.strictEqual(dropped.err, null)
+    assert.strictEqual(dropped.res, undefined)
+
+    // Let the blocked request go through so the queued ones can drain.
+    shutdown.releaseFirst()
+
+    const results = await Promise.all(promises.slice(0, 8))
+    for (const { err, res } of results) {
+      assert.ifError(err)
+      assert.strictEqual(res, 'OK')
+    }
+
+    assert.strictEqual(shutdown.requestCount(), 8)
+    shutdown()
   })
 
   it('should be able to send form data', (done) => {


### PR DESCRIPTION
### What does this PR do?
Adds a test to the http integration on our handling to many concurrent http requests.

### Motivation
From working with @BridgeAR on issue **APMS-16671** where the customer was hitting the max requests limit of the tracer
### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


