### PR TITLE
Apply per-endpoint limits to active requests

### DIFF
--- a/packages/dd-trace/src/datastreams/writer.js
+++ b/packages/dd-trace/src/datastreams/writer.js
@@ -41,10 +41,6 @@ class DataStreamsWriter {
   }
 
   flush (payload) {
-    if (!request.writable) {
-      log.debug('Maximum number of active requests reached. Payload discarded: %j', payload)
-      return
-    }
     const encodedPayload = msgpack.encode(payload)
 
     zlib.gzip(encodedPayload, { level: 1 }, (err, compressedData) => {
@@ -56,6 +52,8 @@ class DataStreamsWriter {
         log.debug('Response from the agent:', res)
         if (err) {
           log.error('Error sending datastream', err)
+        } else if (res == null) {
+          log.debug('Maximum number of active requests reached for endpoint. Datastream payload discarded.')
         }
       })
     })

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -27,6 +27,12 @@ class AgentWriter extends BaseWriter {
 
     const { _headers, _lookup, _protocolVersion, _url } = this
     makeRequest(_protocolVersion, data, count, _url, _headers, _lookup, true, (err, res, status) => {
+      // When the request is dropped due to backpressure, callback is invoked with no response or status.
+      if (!err && !status && res == null) {
+        done()
+        return
+      }
+
       if (status) {
         runtimeMetrics.increment(`${METRIC_PREFIX}.responses`, true)
         runtimeMetrics.increment(`${METRIC_PREFIX}.responses.by.status`, `status:${status}`, true)
@@ -85,7 +91,7 @@ function makeRequest (version, data, count, url, headers, lookup, needsStartupLo
     url
   }
 
-  log.debug('Request to the agent: %j', options)
+  console.log('Request to the agent: %j', options)
 
   request(data, options, (err, res, status) => {
     if (needsStartupLog) {

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -91,7 +91,7 @@ function makeRequest (version, data, count, url, headers, lookup, needsStartupLo
     url
   }
 
-  console.log('Request to the agent: %j', options)
+  log.debug('Request to the agent: %j', options)
 
   request(data, options, (err, res, status) => {
     if (needsStartupLog) {

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -1,6 +1,5 @@
 'use strict'
 
-// TODO: Add test with slow or unresponsive agent.
 // TODO: Add telemetry for things like dropped requests, errors, etc.
 
 const { Readable } = require('stream')
@@ -14,9 +13,137 @@ const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
 
-const maxActiveRequests = 8
+const maxActiveRequestsPerEndpoint = 8
+const activeRequestsByEndpoint = new Map()
+const activeRequestsByUrl = new Map()
 
-let activeRequests = 0
+function stripQueryAndHash (path) {
+  if (!path) return '/'
+
+  const queryIndex = path.indexOf('?')
+  const hashIndex = path.indexOf('#')
+
+  let endIndex = path.length
+  if (queryIndex !== -1) endIndex = Math.min(endIndex, queryIndex)
+  if (hashIndex !== -1) endIndex = Math.min(endIndex, hashIndex)
+
+  const stripped = path.slice(0, endIndex)
+  return stripped || '/'
+}
+
+function formatHostname (hostname) {
+  if (!hostname) return 'localhost'
+  // Wrap IPv6 literals in brackets for stable endpoint keys.
+  if (hostname.includes(':') && !hostname.startsWith('[') && !hostname.endsWith(']')) {
+    return `[${hostname}]`
+  }
+  return hostname
+}
+
+function getUrlKeyFromOptions (options) {
+  if (options.socketPath) {
+    return `unix:${options.socketPath}`
+  }
+
+  const protocol = options.protocol || 'http:'
+  const { hostname: hostFromHost, port: portFromHost } = parseHostAndPort(options.host)
+
+  const hostname = options.hostname || hostFromHost || 'localhost'
+  const port = options.port || portFromHost || (protocol === 'https:' ? 443 : 80)
+
+  return `${protocol}//${formatHostname(hostname)}:${String(port)}`
+}
+
+function getUrlKey (urlObjOrString) {
+  if (!urlObjOrString) return ''
+
+  const url = parseUrl(urlObjOrString)
+  if (url.protocol === 'unix:') {
+    return `unix:${url.pathname}`
+  }
+
+  const protocol = url.protocol || 'http:'
+  const hostname = url.hostname || 'localhost'
+  const port = url.port || (protocol === 'https:' ? 443 : 80)
+
+  return `${protocol}//${formatHostname(hostname)}:${String(port)}`
+}
+
+function parseHostAndPort (host) {
+  if (!host) return {}
+
+  // IPv6 like "[::1]:8126"
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']')
+    if (end !== -1) {
+      const hostname = host.slice(1, end)
+      const rest = host.slice(end + 1)
+      if (rest.startsWith(':')) return { hostname, port: rest.slice(1) }
+      return { hostname }
+    }
+  }
+
+  const idx = host.lastIndexOf(':')
+  if (idx !== -1 && host.indexOf(':') === idx) {
+    return { hostname: host.slice(0, idx), port: host.slice(idx + 1) }
+  }
+
+  return { hostname: host }
+}
+
+function getEndpointKey (options) {
+  const path = stripQueryAndHash(options.path)
+
+  if (options.socketPath) {
+    // Unix domain sockets and Windows named pipes are both expressed as socketPath in Node.
+    return `unix:${options.socketPath}${path}`
+  }
+
+  const protocol = options.protocol || 'http:'
+  const { hostname: hostFromHost, port: portFromHost } = parseHostAndPort(options.host)
+
+  const hostname = options.hostname || hostFromHost || 'localhost'
+  const port = options.port || portFromHost || (protocol === 'https:' ? 443 : 80)
+
+  return `${protocol}//${formatHostname(hostname)}:${String(port)}${path}`
+}
+
+function canStartRequestForEndpoint (endpointKey) {
+  const count = activeRequestsByEndpoint.get(endpointKey) || 0
+  return count < maxActiveRequestsPerEndpoint
+}
+
+function incrementEndpoint (endpointKey) {
+  const count = activeRequestsByEndpoint.get(endpointKey) || 0
+  activeRequestsByEndpoint.set(endpointKey, count + 1)
+}
+
+function decrementEndpoint (endpointKey) {
+  const count = activeRequestsByEndpoint.get(endpointKey)
+  if (!count) return
+
+  if (count <= 1) {
+    activeRequestsByEndpoint.delete(endpointKey)
+  } else {
+    activeRequestsByEndpoint.set(endpointKey, count - 1)
+  }
+}
+
+function incrementUrl (urlKey) {
+  const count = activeRequestsByUrl.get(urlKey) || 0
+  activeRequestsByUrl.set(urlKey, count + 1)
+}
+
+function decrementUrl (urlKey) {
+  const count = activeRequestsByUrl.get(urlKey)
+  if (!count) return
+
+  if (count <= 1) {
+    activeRequestsByUrl.delete(urlKey)
+  } else {
+    activeRequestsByUrl.set(urlKey, count - 1)
+  }
+}
 
 function parseUrl (urlObjOrString) {
   if (urlObjOrString !== null && typeof urlObjOrString === 'object') return urlToHttpOptions(urlObjOrString)
@@ -51,6 +178,7 @@ function request (data, options, callback) {
   }
 
   const isReadable = data instanceof Readable
+  if (!options.path) options.path = '/'
 
   // The timeout should be kept low to avoid excessive queueing.
   const timeout = options.timeout || 2000
@@ -69,76 +197,90 @@ function request (data, options, callback) {
 
   options.agent = isSecure ? httpsAgent : httpAgent
 
-  const onResponse = res => {
-    const chunks = []
-
-    res.setTimeout(timeout)
-
-    res.on('data', chunk => {
-      chunks.push(chunk)
-    })
-    res.on('end', () => {
-      activeRequests--
-      const buffer = Buffer.concat(chunks)
-
-      if (res.statusCode >= 200 && res.statusCode <= 299) {
-        const isGzip = res.headers['content-encoding'] === 'gzip'
-        if (isGzip) {
-          zlib.gunzip(buffer, (err, result) => {
-            if (err) {
-              log.error('Could not gunzip response: %s', err.message)
-              callback(null, '', res.statusCode)
-            } else {
-              callback(null, result.toString(), res.statusCode)
-            }
-          })
-        } else {
-          callback(null, buffer.toString(), res.statusCode)
-        }
-      } else {
-        let errorMessage = ''
-        try {
-          const fullUrl = new URL(
-            options.path,
-            options.url || options.hostname || `http://localhost:${options.port}`
-          ).href
-          errorMessage = `Error from ${fullUrl}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}.`
-        } catch {
-          // ignore error
-        }
-
-        const responseData = buffer.toString()
-        if (responseData) {
-          errorMessage += ` Response from the endpoint: "${responseData}"`
-        }
-        const error = new log.NoTransmitError(errorMessage)
-        error.status = res.statusCode
-
-        callback(error, null, res.statusCode)
-      }
-    })
-  }
-
   const makeRequest = onError => {
-    if (!request.writable) {
-      log.debug('Maximum number of active requests reached: payload is discarded.')
+    const endpointKey = getEndpointKey(options)
+    if (!canStartRequestForEndpoint(endpointKey)) {
+      log.debug('Maximum number of active requests reached for endpoint %s. Payload discarded.', endpointKey)
       return callback(null)
     }
 
-    activeRequests++
+    const urlKey = getUrlKeyFromOptions(options)
+    incrementEndpoint(endpointKey)
+    incrementUrl(urlKey)
+    let finished = false
+    const finishOnce = () => {
+      if (finished) return
+      finished = true
+      decrementEndpoint(endpointKey)
+      decrementUrl(urlKey)
+    }
 
     const store = storage('legacy').getStore()
 
     storage('legacy').enterWith({ noop: true })
 
+    const onResponse = res => {
+      const chunks = []
+
+      res.setTimeout(timeout)
+
+      res.on('data', chunk => {
+        chunks.push(chunk)
+      })
+      res.on('close', () => {
+        finishOnce()
+        const buffer = Buffer.concat(chunks)
+
+        if (res.statusCode >= 200 && res.statusCode <= 299) {
+          const isGzip = res.headers['content-encoding'] === 'gzip'
+          if (isGzip) {
+            zlib.gunzip(buffer, (err, result) => {
+              if (err) {
+                log.error('Could not gunzip response: %s', err.message)
+                callback(null, '', res.statusCode)
+              } else {
+                callback(null, result.toString(), res.statusCode)
+              }
+            })
+          } else {
+            callback(null, buffer.toString(), res.statusCode)
+          }
+        } else {
+          let errorMessage = ''
+          try {
+            const fullUrl = new URL(
+              options.path,
+              options.url || options.hostname || `http://localhost:${options.port}`
+            ).href
+            errorMessage = `Error from ${fullUrl}: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}.`
+          } catch {
+            // ignore error
+          }
+
+          const responseData = buffer.toString()
+          if (responseData) {
+            errorMessage += ` Response from the endpoint: "${responseData}"`
+          }
+          const error = new log.NoTransmitError(errorMessage)
+          error.status = res.statusCode
+
+          callback(error, null, res.statusCode)
+        }
+      })
+    }
+
     const req = client.request(options, onResponse)
 
     req.once('error', err => {
-      activeRequests--
+      finishOnce()
       onError(err)
     })
 
-    req.setTimeout(timeout, req.abort)
+    req.setTimeout(timeout, () => {
+      req.destroy()
+    })
+
+    req.once('close', finishOnce)
 
     if (isReadable) {
       data.pipe(req) // TODO: Validate whether this is actually retriable.
@@ -161,10 +303,12 @@ function byteLength (data) {
   return data.length > 0 ? data.reduce((prev, next) => prev + Buffer.byteLength(next, 'utf8'), 0) : 0
 }
 
-Object.defineProperty(request, 'writable', {
-  get () {
-    return activeRequests < maxActiveRequests
-  }
-})
+request.isUrlWritable = (urlObjOrString) => {
+  const urlKey = getUrlKey(urlObjOrString)
+  if (!urlKey) return true
+
+  const count = activeRequestsByUrl.get(urlKey) || 0
+  return count < maxActiveRequestsPerEndpoint
+}
 
 module.exports = request

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -12,10 +12,13 @@ class Writer {
   flush (done = () => {}) {
     const count = this._encoder.count()
 
-    if (!request.writable) {
-      this._encoder.reset()
-      done()
-    } else if (count > 0) {
+    if (count > 0) {
+      if (typeof request.isUrlWritable === 'function' && !request.isUrlWritable(this._url)) {
+        this._encoder.reset()
+        done()
+        return
+      }
+
       const payload = this._encoder.makePayload()
 
       this._sendPayload(payload, count, done)
@@ -25,7 +28,7 @@ class Writer {
   }
 
   append (payload) {
-    if (!request.writable) {
+    if (typeof request.isUrlWritable === 'function' && !request.isUrlWritable(this._url)) {
       log.debug(() => `Maximum number of active requests reached. Payload discarded: ${safeJSONStringify(payload)}`)
       return
     }

--- a/packages/dd-trace/test/exporters/agent/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agent/writer.spec.js
@@ -32,6 +32,7 @@ function describeWriter (protocolVersion) {
     })
 
     request = sinon.stub().yieldsAsync(null, response, 200)
+    request.isUrlWritable = sinon.stub().returns(true)
 
     encoder = {
       encode: sinon.stub(),

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -3,12 +3,11 @@
 const assert = require('node:assert/strict')
 const http = require('node:http')
 const zlib = require('node:zlib')
-
+const { setTimeout: delay } = require('node:timers/promises')
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
-const { setTimeout: delay } = require('node:timers/promises')
 
 require('../../setup/core')
 const FormData = require('../../../src/exporters/common/form-data')

--- a/packages/dd-trace/test/exporters/span-stats/writer.spec.js
+++ b/packages/dd-trace/test/exporters/span-stats/writer.spec.js
@@ -20,6 +20,7 @@ describe('span-stats writer', () => {
     span = 'formatted'
 
     request = sinon.stub().yieldsAsync(null, 'OK', 200)
+    request.isUrlWritable = sinon.stub().returns(true)
 
     encoder = {
       encode: sinon.stub(),


### PR DESCRIPTION
### What does this PR do?
This PR introduces per-endpoint active request limits instead of a single global limit.

This ensures that slow or high-latency endpoints cannot monopolize the active requests, preventing unrelated endpoints from having their payloads dropped under load.

### Motivation
Working with @BridgeAR on issue APMS-16671 where the customer was hitting the max requests limit of the tracer

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


