### PR TITLE
chore: verify all test:integration* scripts are exercised in CI

### DIFF
--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -928,6 +928,18 @@ function main () {
     }
   }
 
+  // All test:integration* scripts should be referenced by CI (except test:integration:plugins).
+  for (const name of Object.keys(scripts).sort((a, b) => a.localeCompare(b, 'en'))) {
+    if (!name.startsWith('test:integration')) continue
+    // Skip test:integration:plugins - it's a convenience script for running only plugin integration
+    // tests locally, but in CI these are already covered by test:plugins:ci (which runs all plugin
+    // tests including integration tests).
+    if (name === 'test:integration:plugins') continue
+    if (!invokedScripts.has(name)) {
+      pushError(`package.json: script "${name}" is not invoked by any GitHub Actions workflow`)
+    }
+  }
+
   // Validate plugin setup (domain-specific):
   // - test:plugins* expects packages/datadog-plugin-<name>
   // - test:appsec:plugins* expects matching *.plugin.spec.js files


### PR DESCRIPTION
## What does this PR do?

Adds validation to `scripts/verify-exercised-tests.js` to ensure all `test:integration*` scripts are invoked by GitHub Actions workflows.

### Changes

- Added a new validation loop that checks all `test:integration*` scripts are invoked by CI workflows
- Excluded `test:integration:plugins` from this check (it's a local convenience script - plugin integration tests are already covered by `test:plugins:ci` which runs all plugin tests including integration tests)

## Motivation

While investigating test coverage in CI, I discovered that the verification script only checked scripts ending with `:ci` suffix, but didn't validate that all integration test scripts were being exercised. This could lead to scenarios where someone adds a new `test:integration:*` script but forgets to call it in CI, resulting in untested code.
