### PR TITLE
[SINT-INT] Fix dependabot-automation policy to work on pull_request events

### DIFF
--- a/.github/chainguard/dependabot-automation.sts.yaml
+++ b/.github/chainguard/dependabot-automation.sts.yaml
@@ -3,10 +3,10 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/dd-trace-js:pull_request
 
 claim_pattern:
-  actor: "dependabot\[bot\]"
+  actor: dependabot\[bot\]
   event_name: pull_request
   ref: refs/pull/[0-9]+/merge
-  job_workflow_ref: DataDog/dd-trace-js/.github/workflows/dependabot-automation.yml@refs/pull/[0-9]+/merge
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/dependabot-automation.yml@refs/pull/[0-9]+/merge
 
 permissions:
   contents: write


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates `.github/chainguard/dependabot-automation.sts.yaml` to work on dependabot PRs running on the `pull_request` event.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix failing `dependabot-automation` event.

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


