### PR TITLE
chore(types): add parameters to NoopProxy baggage methods

### DIFF
--- a/packages/dd-trace/src/noop/proxy.js
+++ b/packages/dd-trace/src/noop/proxy.js
@@ -23,10 +23,10 @@ class NoopProxy {
     this.llmobs = noopLLMObs
     this.openfeature = noopOpenFeatureProvider
     this.aiguard = noopAIGuard
-    this.setBaggageItem = () => {}
-    this.getBaggageItem = () => {}
+    this.setBaggageItem = (key, value) => {}
+    this.getBaggageItem = (key) => {}
     this.getAllBaggageItems = () => {}
-    this.removeBaggageItem = () => {}
+    this.removeBaggageItem = (keyToRemove) => {}
     this.removeAllBaggageItems = () => {}
   }
 


### PR DESCRIPTION
### What does this PR do?

Fixes last remaining TypeScript linter error in `proxy.js` where the `Tracer` class couldn't properly extend `NoopProxy` due to incompatible method signatures for baggage methods.

### Motivation

The `NoopProxy` class defined baggage methods (`setBaggageItem`, `getBaggageItem`, `removeBaggageItem`) as no-op functions with no parameters:

```js
this.setBaggageItem = () => {}
```

However, the `Tracer` class assigns the real implementations from `baggage.js` which have parameters:

```js
this.setBaggageItem = setBaggageItem // (key, value) => {...}
```

This caused TypeScript to report:

```
Class 'Tracer' incorrectly extends base class 'NoopProxy'.
Types of property 'setBaggageItem' are incompatible.
```

