### PR TITLE
feat(profiling): add process tags

### DIFF
--- a/packages/dd-trace/src/profiling/exporters/event_serializer.js
+++ b/packages/dd-trace/src/profiling/exporters/event_serializer.js
@@ -6,6 +6,7 @@ const os = require('os')
 const perf = require('perf_hooks').performance
 const version = require('../../../../../package.json').version
 const { availableParallelism, libuvThreadPoolSize } = require('../libuv-size')
+const processTags = require('../../process-tags')
 
 class EventSerializer {
   constructor ({ env, host, service, version, libraryInjected, activation } = {}) {
@@ -22,7 +23,7 @@ class EventSerializer {
   }
 
   getEventJSON ({ profiles, infos, start, end, tags = {}, endpointCounts }) {
-    return JSON.stringify({
+    const event = {
       attachments: Object.keys(profiles).map(t => this.typeToFile(t)),
       start: start.toISOString(),
       end: end.toISOString(),
@@ -77,7 +78,13 @@ class EventSerializer {
           version: process.version.slice(1)
         }
       }
-    })
+    }
+
+    if (processTags.serialized) {
+      event[processTags.PROFILING_FIELD_NAME] = processTags.serialized
+    }
+
+    return JSON.stringify(event)
   }
 }
 

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -18,6 +18,7 @@ const WallProfiler = require('../../../src/profiling/profilers/wall')
 const SpaceProfiler = require('../../../src/profiling/profilers/space')
 const logger = require('../../../src/log')
 const version = require('../../../../../package.json').version
+const processTags = require('../../../src/process-tags')
 
 const RUNTIME_ID = 'a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6'
 const ENV = 'test-env'
@@ -116,6 +117,8 @@ describe('exporters/agent', function () {
     assert.ok(Object.hasOwn(event.info.runtime, 'available_processors'))
     assert.strictEqual(event.info.runtime.engine, 'nodejs')
     assert.strictEqual(event.info.runtime.version, process.version.substring(1))
+    assert.ok(Object.hasOwn(event, 'process_tags'))
+    assert.strictEqual(event.process_tags, processTags.serialized)
 
     assert.strictEqual(req.files[1].fieldname, 'wall.pprof')
     assert.strictEqual(req.files[1].originalname, 'wall.pprof')


### PR DESCRIPTION
### What does this PR do?
- adds process tags to outbound messages sent from profiling

### Motivation
- assist with service naming
- RFC: https://docs.google.com/document/d/1AFdLUuVk70i0bJd5335-RxqsvwAV9ovAqcO2z5mEMbA
