### PR TITLE
chore(profiling): use default service name instead re-defining it

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -55,7 +55,7 @@ class Config {
     } = getEnvironmentVariables()
 
     const env = options.env ?? DD_ENV
-    const service = options.service || DD_SERVICE || 'node'
+    const service = options.service || DD_SERVICE || defaults.service
     const host = os.hostname()
     const version = options.version ?? DD_VERSION
     // Must be longer than one minute so pad with five seconds

--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -44,13 +44,16 @@ describe('config', () => {
   it('should have the correct defaults', () => {
     const config = new Config()
 
+    // When running tests with mocha, defaults.service resolves to 'mocha' because
+    // pkg.name looks up the package.json from require.main (mocha's entry point).
+    // In a real application, it would be the app's package.json name, or 'node' as final fallback.
     assertObjectContains(config, {
-      service: 'node',
+      service: 'mocha',
       flushInterval: 65 * 1000
     })
 
     assert.deepStrictEqual(config.tags, {
-      service: 'node',
+      service: 'mocha',
       host: os.hostname()
     })
 
@@ -435,7 +438,7 @@ describe('config', () => {
           process.execPath,
           path.normalize(path.join(__dirname, '../../src/profiling', 'exporter_cli.js')),
           'http://127.0.0.1:8126/',
-          `host:${config.host},service:node,snapshot:on_oom`,
+          `host:${config.host},service:mocha,snapshot:on_oom`,
           'space'
         ]
       })
@@ -503,7 +506,7 @@ describe('config', () => {
           process.execPath,
           path.normalize(path.join(__dirname, '../../src/profiling', 'exporter_cli.js')),
           'http://127.0.0.1:8126/',
-          `host:${config.host},service:node,snapshot:on_oom`,
+          `host:${config.host},service:mocha,snapshot:on_oom`,
           'space'
         ]
       })


### PR DESCRIPTION
### What does this PR do?

Instead of hardcoding the word `node` as the default fallback for the service name in profiling, use the already defined default value from `config_defaults.js` (which is also the string `node`).

### Motivation

DRY

