### PR TITLE
test: fix flaky http2 test

### DIFF
--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -1,33 +1,31 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { EventEmitter } = require('node:events')
+const { setImmediate } = require('node:timers/promises')
 
 const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { rawExpectedSchema } = require('./naming')
-class MockAbortController {
-  constructor () {
-    this.signal = new EventEmitter()
-  }
 
-  abort () {
-    this.signal.emit('abort')
-  }
-}
-
-function request (http2, url, { signal } = {}) {
-  url = new URL(url)
+/**
+ * @param {typeof import('http2')} http2
+ * @param {string} url
+ * @param {{ signal?: import('node:events').EventEmitter }} [options]
+ */
+function request (http2, url, options = {}) {
+  const { signal } = options
+  const urlObj = new URL(url)
   return new Promise((resolve, reject) => {
     const client = http2
-      .connect(url.origin)
+      .connect(urlObj.origin)
       .on('error', reject)
 
     const req = client.request({
-      ':path': url.pathname,
+      ':path': urlObj.pathname,
       ':method': 'GET'
     })
     req.on('error', reject)
@@ -74,13 +72,49 @@ describe('Plugin', () => {
       })
 
       describe('cancelled request', () => {
+        /** @type {Promise<void>} */
+        let requestReceived
+        /** @type {() => void} */
+        let resolveRequestReceived
+
+        /** @type {Promise<void>} */
+        let allowHandler
+        /** @type {() => void} */
+        let resolveAllowHandler
+        let responseSent
+
         beforeEach(() => {
+          requestReceived = new Promise(resolve => { resolveRequestReceived = resolve })
+          allowHandler = new Promise(resolve => { resolveAllowHandler = resolve })
+          responseSent = false
+
           listener = (req, res) => {
-            setTimeout(() => {
+            resolveRequestReceived()
+
+            // Only invoke `app` after the test has explicitly allowed it.
+            // This keeps the test deterministic and removes reliance on wall-clock time.
+            let closed = false
+            req.once('close', () => { closed = true })
+            res.once('close', () => { closed = true })
+
+            // Server-side safeguard: if something tries to send a response, record it.
+            const writeHead = res.writeHead
+            res.writeHead = function () {
+              responseSent = true
+              return writeHead.apply(this, arguments)
+            }
+            const end = res.end
+            res.end = function () {
+              responseSent = true
+              return end.apply(this, arguments)
+            }
+
+            allowHandler.then(() => {
+              if (closed) return
               app && app(req, res)
               res.writeHead(200)
               res.end()
-            }, 500)
+            })
           }
         })
 
@@ -100,30 +134,76 @@ describe('Plugin', () => {
             })
         })
 
-        it('should send traces to agent', (done) => {
+        it('should send traces to agent', async () => {
           app = sinon.stub()
-          agent
-            .assertSomeTraces(traces => {
-              sinon.assert.notCalled(app) // request should be cancelled before call to app
-              assert.strictEqual(traces[0][0].name, 'web.request')
-              assert.strictEqual(traces[0][0].service, 'test')
-              assert.strictEqual(traces[0][0].type, 'web')
-              assert.strictEqual(traces[0][0].resource, 'GET')
-              assert.strictEqual(traces[0][0].meta['span.kind'], 'server')
-              assert.strictEqual(traces[0][0].meta['http.url'], `http://localhost:${port}/user`)
-              assert.strictEqual(traces[0][0].meta['http.method'], 'GET')
-              assert.strictEqual(traces[0][0].meta['http.status_code'], '200')
-              assert.strictEqual(traces[0][0].meta.component, 'http2')
-            })
-            .then(done)
-            .catch(done)
 
-          // Don't use real AbortController because it requires 15.x+
-          const ac = new MockAbortController()
-          request(http2, `http://localhost:${port}/user`, {
-            signal: ac.signal
+          const tracesPromise = agent.assertSomeTraces(traces => {
+            sinon.assert.notCalled(app) // request should be cancelled before call to app
+
+            assertObjectContains(traces[0][0], {
+              name: 'web.request',
+              service: 'test',
+              type: 'web',
+              resource: 'GET',
+              meta: {
+                'span.kind': 'server',
+                'http.url': `http://localhost:${port}/user`,
+                'http.method': 'GET',
+                'http.status_code': '200',
+                component: 'http2'
+              }
+            })
           })
-          setTimeout(() => { ac.abort() }, 100)
+
+          const noop = () => {}
+          const url = new URL(`http://localhost:${port}/user`)
+          const client = http2.connect(url.origin)
+          client.on('error', noop)
+
+          const req = client.request({
+            ':path': url.pathname,
+            ':method': 'GET'
+          })
+          req.on('error', noop)
+
+          let responseReceived = false
+          req.once('response', () => { responseReceived = true })
+          req.on('data', () => { responseReceived = true })
+          const reqClosed = new Promise(resolve => req.once('close', resolve))
+
+          req.end()
+
+          // Ensure the server has received the request before we cancel it.
+          await requestReceived
+
+          const cancelCode = http2.constants && http2.constants.NGHTTP2_CANCEL
+          if (typeof req.close === 'function' && cancelCode !== undefined) {
+            req.close(cancelCode)
+          } else {
+            req.destroy()
+          }
+
+          if (typeof client.close === 'function') {
+            client.close()
+          } else {
+            client.destroy()
+          }
+
+          // Give the event loop a chance to process the stream cancellation before allowing
+          // the server handler to proceed (no fixed sleep, just a few turns).
+          await setImmediate()
+          await setImmediate()
+          await setImmediate()
+
+          resolveAllowHandler()
+
+          await tracesPromise
+
+          // Safeguard: if the handler ran, we'd typically see a response event/data.
+          // Wait until the stream is fully closed, then assert we never observed a response.
+          await reqClosed
+          assert.strictEqual(responseReceived, false)
+          assert.strictEqual(responseSent, false)
         })
       })
 
@@ -152,16 +232,18 @@ describe('Plugin', () => {
 
         it('should do automatic instrumentation', done => {
           agent
-            .assertSomeTraces(traces => {
-              assert.strictEqual(traces[0][0].name, 'web.request')
-              assert.strictEqual(traces[0][0].service, 'test')
-              assert.strictEqual(traces[0][0].type, 'web')
-              assert.strictEqual(traces[0][0].resource, 'GET')
-              assert.strictEqual(traces[0][0].meta['span.kind'], 'server')
-              assert.strictEqual(traces[0][0].meta['http.url'], `http://localhost:${port}/user`)
-              assert.strictEqual(traces[0][0].meta['http.method'], 'GET')
-              assert.strictEqual(traces[0][0].meta['http.status_code'], '200')
-              assert.strictEqual(traces[0][0].meta.component, 'http2')
+            .assertFirstTraceSpan({
+              name: 'web.request',
+              service: 'test',
+              type: 'web',
+              resource: 'GET',
+              meta: {
+                'span.kind': 'server',
+                'http.url': `http://localhost:${port}/user`,
+                'http.method': 'GET',
+                'http.status_code': '200',
+                component: 'http2'
+              }
             })
             .then(done)
             .catch(done)


### PR DESCRIPTION
The cancel logic was not consistently triggered early enough due to the destroy call handling the call gracefully. Thus, the timeout was triggered and the test failed.

Instead of using a timeout, the code is now reliable by starting to wait for the request to be received and only afterwards waiting briefly before a check if the call was cancelled right afterwards.

