### PR TITLE
fix activeRequests leak when requests timeout on Bun

### DIFF
--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -128,16 +128,14 @@ function request (data, options, callback) {
     }
 
     activeRequests++
-    const finalize = (() => {
-      // Ensures decrementing activeRequests only once across multiple event handlers
-      let called = false
-      return () => {
-        if (!called) {
-          activeRequests--
-          called = true
-        }
+    // Ensures decrementing activeRequests only once across multiple event handlers
+    let called = false
+    const finalize = () => {
+      if (!called) {
+        activeRequests--
+        called = true
       }
-    })()
+    }
 
     const store = storage('legacy').getStore()
 


### PR DESCRIPTION
### What does this PR do?

Ensures `activeRequests` is decremented when a request terminates via `'close'`, even if `'error'` is not emitted, by finalizing cleanup exactly once at the end of the request lifecycle.

### Motivation

When running dd-trace-js on Bun, requests could stop being sent after `activeRequests` was exhausted.
This happens because `request.abort` on timeout may terminate a request without emitting an `'error'` event, leaving `activeRequests` undecremented.
