### PR TITLE
chore(ci): upgrade junit-upload-github-action from v2.0.0 to v2.1.0

### DIFF
--- a/.github/actions/instrumentations/test/action.yml
+++ b/.github/actions/instrumentations/test/action.yml
@@ -15,7 +15,7 @@ runs:
     - run: yarn test:instrumentations:ci
       shell: bash
     - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-    - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+    - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789  # v2.1.0
       if: always() && github.actor != 'dependabot[bot]'
       with:
         api_key: ${{ inputs.dd_api_key }}

--- a/.github/actions/plugins/test-and-upstream/action.yml
+++ b/.github/actions/plugins/test-and-upstream/action.yml
@@ -24,7 +24,7 @@ runs:
       uses: ./.github/actions/testagent/logs
       with:
         suffix: test-and-upstream-${{ github.job }}
-    - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+    - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789  # v2.1.0
       if: always() && github.actor != 'dependabot[bot]'
       with:
         api_key: ${{ inputs.dd_api_key }}

--- a/.github/actions/plugins/test/action.yml
+++ b/.github/actions/plugins/test/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: ./.github/actions/testagent/logs
       with:
         suffix: test-${{ github.job }}
-    - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+    - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789  # v2.1.0
       if: always() && github.actor != 'dependabot[bot]'
       with:
         api_key: ${{ inputs.dd_api_key }}

--- a/.github/actions/plugins/upstream/action.yml
+++ b/.github/actions/plugins/upstream/action.yml
@@ -20,7 +20,7 @@ runs:
       uses: ./.github/actions/testagent/logs
       with:
         suffix: upstream-${{ github.job }}
-    - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+    - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789  # v2.1.0
       if: always() && github.actor != 'dependabot[bot]'
       with:
         api_key: ${{ inputs.dd_api_key }}

--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -15,7 +15,6 @@ env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}
 
 jobs:
-
   macos:
     runs-on: macos-latest
     steps:
@@ -26,7 +25,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: aiguard-macos
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -56,12 +55,12 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
         with:
-          cache: 'true'
+          cache: "true"
       - run: yarn test:aiguard:ci
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: aiguard-windows
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -79,7 +78,7 @@ jobs:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
       - run: yarn test:integration:aiguard
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -9,10 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       latest-version:
-        description: 'Node version to use'
+        description: "Node version to use"
         required: false
         type: string
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
@@ -33,7 +32,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-capabilities-tracing-macos
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -55,7 +54,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-capabilities-tracing-ubuntu
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -68,12 +67,12 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
         with:
-          cache: 'true'
+          cache: "true"
       - run: yarn test:trace:core:ci
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-capabilities-tracing-windows
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -9,10 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       latest-version:
-        description: 'Node version to run'
+        description: "Node version to run"
         required: false
         type: string
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
@@ -29,27 +28,27 @@ jobs:
     strategy:
       matrix:
         node-version: [eol]
-        range: ['>=4.0.0 <5.2.0']
+        range: [">=4.0.0 <5.2.0"]
         aerospike-image: [ce-5.7.0.15]
         test-image: [ubuntu-22.04]
         include:
           - node-version: 18
-            range: '>=5.2.0 <6.3.0'
+            range: ">=5.2.0 <6.3.0"
             range_clean: gte.5.2.0
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
           - node-version: 20
-            range: '>=5.5.0'
+            range: ">=5.5.0"
             range_clean: gte.5.5.0
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
           - node-version: 22
-            range: '>=5.12.1'
+            range: ">=5.12.1"
             range_clean: gte.5.12.1
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
           - node-version: 22
-            range: '>=6.0.0'
+            range: ">=6.0.0"
             range_clean: gte.6.0.0
             aerospike-image: ce-6.4.0.3
             test-image: ubuntu-latest
@@ -58,7 +57,7 @@ jobs:
       aerospike:
         image: aerospike:${{ matrix.aerospike-image }}
         ports:
-          - '127.0.0.1:3000-3002:3000-3002'
+          - "127.0.0.1:3000-3002:3000-3002"
     env:
       PLUGINS: aerospike
       SERVICES: aerospike
@@ -81,7 +80,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-aerospike-${{ matrix.node-version }}-${{ matrix.range_clean }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -214,7 +213,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-child-process
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -235,10 +234,10 @@ jobs:
       matrix:
         # using node versions matrix since this plugin testing fails due to install differences between node versions
         node-version: [18, 20, 22]
-        range: ['>=1.0.0']
+        range: [">=1.0.0"]
         include:
           - node-version: 24
-            range: '>=1.4.0'
+            range: ">=1.4.0"
             range_clean: gte.1.4.0
     runs-on: ubuntu-latest
     services:
@@ -246,7 +245,7 @@ jobs:
         image: apache/kafka-native:3.9.1
         env:
           KAFKA_PROCESS_ROLES: broker,controller
-          KAFKA_NODE_ID: '1'
+          KAFKA_NODE_ID: "1"
           KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
           KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
           KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
@@ -254,8 +253,8 @@ jobs:
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
           KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
           KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
         ports:
           - 9092:9092
           - 9093:9093
@@ -283,7 +282,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-confluentinc-kafka-javascript-${{ matrix.node-version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -316,11 +315,11 @@ jobs:
         range:
           # - '^2.6.12' skipping due to bug with couchbase integration that is blocking CI.
           # TODO: diagnose and fix failures. Link to bug issue: https://github.com/DataDog/dd-trace-js/issues/6400
-          - '^3.0.7'
-          - '>=4.0.0 <4.2.0'
+          - "^3.0.7"
+          - ">=4.0.0 <4.2.0"
         include:
           - node-version: 18
-            range: '>=4.2.0'
+            range: ">=4.2.0"
     runs-on: ubuntu-latest
     services:
       couchbase:
@@ -332,7 +331,7 @@ jobs:
       PLUGINS: couchbase
       SERVICES: couchbase
       PACKAGE_VERSION_RANGE: ${{ matrix.range }}
-      DD_INJECT_FORCE: 'true'
+      DD_INJECT_FORCE: "true"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/testagent/start
@@ -345,7 +344,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-couchbase-${{ matrix.node-version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -384,7 +383,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-dns
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -415,7 +414,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-elasticsearch
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -545,7 +544,7 @@ jobs:
   http:
     strategy:
       matrix:
-        node-version: [oldest, maintenance, 'latest']
+        node-version: [oldest, maintenance, "latest"]
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
@@ -564,7 +563,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-http-${{ matrix.node-version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -593,7 +592,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-http2
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -602,14 +601,14 @@ jobs:
   kafkajs:
     strategy:
       matrix:
-        node-version: ['oldest', 'latest']
+        node-version: ["oldest", "latest"]
     runs-on: ubuntu-latest
     services:
       kafka:
         image: apache/kafka-native:3.9.1
         env:
           KAFKA_PROCESS_ROLES: broker,controller
-          KAFKA_NODE_ID: '1'
+          KAFKA_NODE_ID: "1"
           KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
           KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
           KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
@@ -617,8 +616,8 @@ jobs:
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
           KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
           KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1'
-          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0'
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
         ports:
           - 9092:9092
           - 9093:9093
@@ -645,7 +644,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-kafkajs-${{ matrix.node-version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -672,7 +671,7 @@ jobs:
           dd_api_key: ${{ secrets.DD_API_KEY }}
 
   ldapjs:
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     env:
       PLUGINS: ldapjs
     steps:
@@ -687,9 +686,9 @@ jobs:
       limitd:
         image: rochdev/limitd
         env:
-          BUCKET_1_NAME: 'user'
-          BUCKET_1_SIZE: '10'
-          BUCKET_1_PER_SECOND: '5'
+          BUCKET_1_NAME: "user"
+          BUCKET_1_SIZE: "10"
+          BUCKET_1_PER_SECOND: "5"
         ports:
           - 9231:9231
     env:
@@ -702,14 +701,14 @@ jobs:
           dd_api_key: ${{ secrets.DD_API_KEY }}
 
   lodash:
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     env:
       PLUGINS: lodash
     steps:
-    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-    - uses: ./.github/actions/plugins/test
-      with:
-        dd_api_key: ${{ secrets.DD_API_KEY }}
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/plugins/test
+        with:
+          dd_api_key: ${{ secrets.DD_API_KEY }}
 
   mariadb:
     runs-on: ubuntu-latest
@@ -717,8 +716,8 @@ jobs:
       mysql:
         image: mariadb:10.4
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: 'db'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: "db"
         ports:
           - 3306:3306
     env:
@@ -832,8 +831,8 @@ jobs:
       mysql:
         image: mariadb:10.4
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: 'db'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: "db"
         ports:
           - 3306:3306
     env:
@@ -851,8 +850,8 @@ jobs:
       mysql:
         image: mariadb:10.4
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: 'db'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: "db"
         ports:
           - 3306:3306
     env:
@@ -887,7 +886,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-net
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -903,30 +902,30 @@ jobs:
           - 18
           - latest
         range:
-          - '>=10.2.0 <11'
-          - '>=11.0.0 <13'
-          - '11.1.4'
-          - '>=13.0.0 <14'
-          - '13.2.0'
-          - '>=14.0.0 <=14.2.6'
-          - '>=14.2.7 <15'
-          - '>=15.0.0 <15.4.1'
+          - ">=10.2.0 <11"
+          - ">=11.0.0 <13"
+          - "11.1.4"
+          - ">=13.0.0 <14"
+          - "13.2.0"
+          - ">=14.0.0 <=14.2.6"
+          - ">=14.2.7 <15"
+          - ">=15.0.0 <15.4.1"
         include:
-          - range: '>=10.2.0 <11'
+          - range: ">=10.2.0 <11"
             range_clean: gte.10.2.0.and.lt.11
-          - range: '>=11.0.0 <13'
+          - range: ">=11.0.0 <13"
             range_clean: gte.11.0.0.and.lt.13
-          - range: '11.1.4'
+          - range: "11.1.4"
             range_clean: 11.1.4
-          - range: '>=13.0.0 <14'
+          - range: ">=13.0.0 <14"
             range_clean: gte.13.0.0.and.lt.14
-          - range: '13.2.0'
+          - range: "13.2.0"
             range_clean: 13.2.0
-          - range: '>=14.0.0 <=14.2.6'
+          - range: ">=14.0.0 <=14.2.6"
             range_clean: gte.14.0.0.and.lte.14.2.6
-          - range: '>=14.2.7 <15'
+          - range: ">=14.2.7 <15"
             range_clean: gte.14.2.7.and.lt.15
-          - range: '>=15.0.0 <15.4.1'
+          - range: ">=15.0.0 <15.4.1"
             range_clean: gte.15.0.0
     runs-on: ubuntu-latest
     env:
@@ -945,7 +944,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-next-${{ matrix.range_clean }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -967,7 +966,7 @@ jobs:
       opensearch:
         image: opensearchproject/opensearch:2.8.0
         env:
-          plugins.security.disabled: 'true'
+          plugins.security.disabled: "true"
           discovery.type: single-node
         ports:
           - 9201:9200
@@ -1003,7 +1002,7 @@ jobs:
     env:
       PLUGINS: oracledb
       SERVICES: oracledb
-      DD_INJECT_FORCE: 'true'
+      DD_INJECT_FORCE: "true"
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/node
@@ -1025,7 +1024,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-oracledb
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -1052,7 +1051,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-pino
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -1068,7 +1067,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      PG_TEST_NATIVE: 'true'
+      PG_TEST_NATIVE: "true"
       PLUGINS: pg
       SERVICES: postgres
     steps:
@@ -1082,10 +1081,10 @@ jobs:
       matrix:
         include:
           - node-version: 18
-            range: '>=6.1.0 <7.0.0'
+            range: ">=6.1.0 <7.0.0"
             range_clean: gte.6.16.0.and.lt.7.0.0
-          - node-version: 'latest'
-            range: ''
+          - node-version: "latest"
+            range: ""
             range_clean: all
     runs-on: ubuntu-latest
     services:
@@ -1115,7 +1114,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-prisma-${{ matrix.node-version }}-${{ matrix.range_clean }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -1272,7 +1271,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-sharedb
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -1284,7 +1283,7 @@ jobs:
       mssql:
         image: mcr.microsoft.com/mssql/server:2019-latest
         env:
-          ACCEPT_EULA: 'Y'
+          ACCEPT_EULA: "Y"
           SA_PASSWORD: DD_HUNTER2
           MSSQL_PID: Express
         ports:
@@ -1306,7 +1305,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: apm-integrations-tedious
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-macos
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -54,7 +54,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-ubuntu
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -72,7 +72,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-windows
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -103,7 +103,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-ldapjs
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -132,7 +132,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-postgres
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -161,7 +161,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-mysql
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -181,7 +181,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-express
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -201,7 +201,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-fastify
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -221,7 +221,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-graphql
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -247,7 +247,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-mongodb-core
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -273,7 +273,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-mongoose
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -297,7 +297,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-sourcing
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -357,7 +357,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-next-${{ matrix.version }}-${{ matrix.range_clean }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -377,7 +377,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-lodash
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -395,7 +395,7 @@ jobs:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
       - run: yarn test:integration:appsec
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -415,7 +415,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-passport
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -435,7 +435,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-template
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -455,7 +455,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-node-serialize
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -494,7 +494,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: appsec-kafka
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: debugger-ubuntu-${{ matrix.version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       latest-version:
-        description: 'Node version to use'
+        description: "Node version to use"
         required: false
         type: string
 
@@ -42,7 +42,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: llmobs-sdk-${{ matrix.version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -71,7 +71,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -100,7 +100,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -127,7 +127,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -156,7 +156,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -185,7 +185,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -214,7 +214,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -243,7 +243,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: llmobs-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: openfeature-unit-${{ matrix.version }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -48,7 +48,7 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       - run: yarn test:integration:openfeature
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -67,7 +67,7 @@ jobs:
       - run: yarn test:integration:openfeature
       - uses: ./.github/actions/node/latest
       - run: yarn test:integration:openfeature
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -80,9 +80,9 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
         with:
-          cache: 'true'
+          cache: "true"
       - run: yarn test:integration:openfeature
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       latest-version:
-        description: 'Node version to use'
+        description: "Node version to use"
         required: false
         type: string
 
@@ -84,7 +84,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: platform-core
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -99,7 +99,6 @@ jobs:
       - uses: ./.github/actions/plugins/test
         with:
           dd_api_key: ${{ secrets.DD_API_KEY }}
-
 
   esbuild:
     runs-on: ubuntu-latest
@@ -262,8 +261,8 @@ jobs:
       mysql:
         image: mariadb:10.4
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-          MYSQL_DATABASE: 'db'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: "db"
         ports:
           - 3306:3306
     env:
@@ -315,7 +314,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      PG_TEST_NATIVE: 'true'
+      PG_TEST_NATIVE: "true"
       PLUGINS: pg
       SERVICES: postgres
     steps:
@@ -399,7 +398,7 @@ jobs:
         uses: ./.github/actions/testagent/logs
         with:
           suffix: test-${{ github.job }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -425,7 +424,7 @@ jobs:
       - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
       - run: yarn test:integration
       - run: yarn test:integration:esbuild
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -441,7 +440,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: platform-unit-guardrails
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -463,7 +462,7 @@ jobs:
       - run: bun add --ignore-scripts mocha@10 # Use older mocha to support old Node.js versions
       - run: bun add --ignore-scripts express@4 # Use older express to support old Node.js versions
       - run: node node_modules/.bin/mocha --colors --timeout 30000 integration-tests/init.spec.js
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -473,10 +472,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['0.8', '0.10', '0.12', '4', '6', '8', '10', '12']
+        version: ["0.8", "0.10", "0.12", "4", "6", "8", "10", "12"]
     runs-on: ubuntu-latest
     env:
-      DD_TRACE_DEBUG: 'true' # This exercises more of the guardrails code
+      DD_TRACE_DEBUG: "true" # This exercises more of the guardrails code
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/node
@@ -485,7 +484,7 @@ jobs:
       - run: node ./init
       - run: node ./init
         env:
-          DD_INJECTION_ENABLED: 'true'
+          DD_INJECTION_ENABLED: "true"
 
   shimmer:
     runs-on: ubuntu-latest
@@ -499,7 +498,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: platform-shimmer
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       latest-version:
-        description: 'Node version to use'
+        description: "Node version to use"
         required: false
         type: string
 
@@ -33,7 +33,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: profiling-macos
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -59,7 +59,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: profiling-ubuntu
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -72,13 +72,13 @@ jobs:
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
         with:
-          cache: 'true'
+          cache: "true"
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: profiling-windows
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -9,10 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       latest-version:
-        description: 'Node version to use'
+        description: "Node version to use"
         required: false
         type: string
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
@@ -21,7 +20,6 @@ concurrency:
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}
   LATEST_VERSION: ${{ inputs.latest-version }}
-
 
 jobs:
   lambda:
@@ -45,7 +43,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: serverless-lambda
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -79,8 +77,8 @@ jobs:
           EXTRA_CORS_ALLOWED_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           EXTRA_CORS_EXPOSE_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           AWS_DEFAULT_REGION: us-east-1
-          FORCE_NONINTERACTIVE: 'true'
-          START_WEB: '0'
+          FORCE_NONINTERACTIVE: "true"
+          START_WEB: "0"
         ports:
           - 4566:4566
         volumes:
@@ -96,9 +94,9 @@ jobs:
           EXTRA_CORS_ALLOWED_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           EXTRA_CORS_EXPOSE_HEADERS: x-amz-request-id,x-amzn-requestid,x-amz-id-2
           AWS_DEFAULT_REGION: us-east-1
-          FORCE_NONINTERACTIVE: 'true'
+          FORCE_NONINTERACTIVE: "true"
           LAMBDA_EXECUTOR: local
-          START_WEB: '0'
+          START_WEB: "0"
           GATEWAY_LISTEN: 127.0.0.1:4567
           EDGE_PORT: 4567
           EDGE_PORT_HTTP: 4567
@@ -122,7 +120,7 @@ jobs:
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           flags: serverless-aws-sdk-${{ matrix.node-version }}-${{ matrix.spec }}
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -131,64 +129,64 @@ jobs:
   azure-event-hubs:
     runs-on: ubuntu-latest
     services:
-        azurite:
-          image: mcr.microsoft.com/azure-storage/azurite:3.35.0
-          ports:
-            - "127.0.0.1:10000:10000"
-            - "127.0.0.1:10001:10001"
-            - "127.0.0.1:10002:10002"
-        azureeventhubsemulator:
-          image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0
-          ports:
-            - "127.0.0.1:5673:5672"
-            - "127.0.0.1:9092:9092"
-          env:
-            BLOB_SERVER: azurite
-            METADATA_SERVER: azurite
-            ACCEPT_EULA: "Y"
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite:3.35.0
+        ports:
+          - "127.0.0.1:10000:10000"
+          - "127.0.0.1:10001:10001"
+          - "127.0.0.1:10002:10002"
+      azureeventhubsemulator:
+        image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0
+        ports:
+          - "127.0.0.1:5673:5672"
+          - "127.0.0.1:9092:9092"
+        env:
+          BLOB_SERVER: azurite
+          METADATA_SERVER: azurite
+          ACCEPT_EULA: "Y"
     env:
       PLUGINS: azure-event-hubs
       SERVICES: azurite,azureeventhubsemulator
     steps:
-        - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        - uses: ./.github/actions/plugins/test
-          with:
-            dd_api_key: ${{ secrets.DD_API_KEY }}
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/plugins/test
+        with:
+          dd_api_key: ${{ secrets.DD_API_KEY }}
 
   azure-functions:
     runs-on: ubuntu-latest
     services:
-        azurite:
-          image: mcr.microsoft.com/azure-storage/azurite:3.34.0
-          ports:
-              - "127.0.0.1:10000:10000"
-              - "127.0.0.1:10001:10001"
-              - "127.0.0.1:10002:10002"
-        azureeventhubsemulator:
-          image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0
-          ports:
-            - "127.0.0.1:5673:5672"
-            - "127.0.0.1:9092:9092"
-          env:
-            BLOB_SERVER: azurite
-            METADATA_SERVER: azurite
-            ACCEPT_EULA: "Y"
-        azuresqledge:
-          image: mcr.microsoft.com/azure-sql-edge:1.0.7
-          ports:
-              - "127.0.0.1:1433:1433"
-          env:
-              ACCEPT_EULA: "Y"
-              MSSQL_SA_PASSWORD: "Localtestpass1!"
-        azureservicebusemulator:
-          image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
-          ports:
-              - "127.0.0.1:5672:5672"
-              - "127.0.0.1:5300:5300"
-          env:
-              ACCEPT_EULA: "Y"
-              MSSQL_SA_PASSWORD: "Localtestpass1!"
-              SQL_SERVER: azuresqledge
+      azurite:
+        image: mcr.microsoft.com/azure-storage/azurite:3.34.0
+        ports:
+          - "127.0.0.1:10000:10000"
+          - "127.0.0.1:10001:10001"
+          - "127.0.0.1:10002:10002"
+      azureeventhubsemulator:
+        image: mcr.microsoft.com/azure-messaging/eventhubs-emulator:2.1.0
+        ports:
+          - "127.0.0.1:5673:5672"
+          - "127.0.0.1:9092:9092"
+        env:
+          BLOB_SERVER: azurite
+          METADATA_SERVER: azurite
+          ACCEPT_EULA: "Y"
+      azuresqledge:
+        image: mcr.microsoft.com/azure-sql-edge:1.0.7
+        ports:
+          - "127.0.0.1:1433:1433"
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Localtestpass1!"
+      azureservicebusemulator:
+        image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
+        ports:
+          - "127.0.0.1:5672:5672"
+          - "127.0.0.1:5300:5300"
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Localtestpass1!"
+          SQL_SERVER: azuresqledge
     env:
       PLUGINS: azure-functions
       SERVICES: azuresqledge,azureservicebusemulator,azurite,azureeventhubsemulator
@@ -205,7 +203,7 @@ jobs:
           ${{ github.workspace }}/packages/datadog-plugin-azure-functions/test/fixtures/servicebus-emulator-config.json \
           ${{ job.services.azureservicebusemulator.id }}:/ServiceBus_Emulator/ConfigFiles/Config.json
       - name: Restart emulators to pick up config changes
-        run : |
+        run: |
           docker restart ${{ job.services.azureeventhubsemulator.id }}
           docker restart ${{ job.services.azureservicebusemulator.id }}
       - uses: ./.github/actions/node/newest-maintenance-lts
@@ -213,7 +211,7 @@ jobs:
       - run: npm install -g azure-functions-core-tools@4.3.0
       - run: echo "$(dirname $(which func))" >> $GITHUB_PATH
       - run: yarn test:plugins:ci
-      - uses: DataDog/junit-upload-github-action@762867566348d59ac9bcf479ebb4ec040db8940a  # v2.0.0
+      - uses: DataDog/junit-upload-github-action@a0226c9f1a3bd34f24ee659fec9639ab8cdc4789 # v2.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ secrets.DD_API_KEY }}
@@ -222,22 +220,22 @@ jobs:
   azure-service-bus:
     runs-on: ubuntu-latest
     services:
-        azureservicebusemulator:
-          image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
-          ports:
-              - "127.0.0.1:5672:5672"
-              - "127.0.0.1:5300:5300"
-          env:
-              ACCEPT_EULA: "Y"
-              MSSQL_SA_PASSWORD: "Localtestpass1!"
-              SQL_SERVER: azuresqledge
-        azuresqledge:
-          image: mcr.microsoft.com/azure-sql-edge:1.0.7
-          ports:
-              - "127.0.0.1:1433:1433"
-          env:
-              ACCEPT_EULA: "Y"
-              MSSQL_SA_PASSWORD: "Localtestpass1!"
+      azureservicebusemulator:
+        image: mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2
+        ports:
+          - "127.0.0.1:5672:5672"
+          - "127.0.0.1:5300:5300"
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Localtestpass1!"
+          SQL_SERVER: azuresqledge
+      azuresqledge:
+        image: mcr.microsoft.com/azure-sql-edge:1.0.7
+        ports:
+          - "127.0.0.1:1433:1433"
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Localtestpass1!"
     env:
       PLUGINS: azure-service-bus
       SERVICES: azureservicebusemulator,azuresqledge


### PR DESCRIPTION
### What does this PR do?

As the title says

### Motivation

This new version includes the ability to cache datadog-ci, which should mean a bit faster CI runs for the jobs using this action (hopefully).
