### PR TITLE
chore(esm): Added esm test for body-parser

### DIFF
--- a/packages/datadog-plugin-body-parser/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-body-parser/test/integration-test/client.spec.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const axios = require('axios')
+const {
+  sandboxCwd, useSandbox, varySandbox,
+  FakeAgent, spawnPluginIntegrationTestProc
+} = require('../../../../integration-tests/helpers')
+const { withVersions } = require('../../../dd-trace/test/setup/mocha')
+
+withVersions('body-parser', 'body-parser', version => {
+  describe('ESM', () => {
+    let variants, proc, agent
+
+    useSandbox([`'body-parser@${version}'`, 'express'], false,
+      ['./packages/datadog-plugin-body-parser/test/integration-test/*'])
+
+    before(function () {
+      variants = varySandbox('server.mjs', 'bodyParser', undefined, 'body-parser')
+    })
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    afterEach(async () => {
+      proc?.kill()
+      await agent.stop()
+    })
+
+    for (const variant of varySandbox.VARIANTS) {
+      it(`is instrumented ${variant}`, async () => {
+        proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port)
+        const response = await axios.post(`${proc.url}/`, { key: 'value' })
+        assert.equal(response.headers['x-counter'], '1')
+      })
+    }
+  })
+})

--- a/packages/datadog-plugin-body-parser/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-body-parser/test/integration-test/server.mjs
@@ -1,0 +1,22 @@
+import 'dd-trace/init.js'
+import express from 'express'
+import bodyParser from 'body-parser'
+import dc from 'dc-polyfill'
+const bodyParserReadCh = dc.channel('datadog:body-parser:read:finish')
+
+let counter = 0
+bodyParserReadCh.subscribe(() => {
+  counter += 1
+})
+const app = express()
+
+app.use(bodyParser.json())
+app.post('/', (req, res) => {
+  res.setHeader('X-Counter', counter)
+  res.end('hello, world\n')
+})
+
+const server = app.listen(0, () => {
+  const port = server.address().port
+  process.send({ port })
+})

--- a/packages/dd-trace/test/plugins/plugin-structure.spec.js
+++ b/packages/dd-trace/test/plugins/plugin-structure.spec.js
@@ -37,6 +37,7 @@ const missingPlugins = [
   'datadog-plugin-pug', // pug does not produce spans
   'datadog-plugin-vm', // vm does not produce spans
   'datadog-plugin-sequelize', // sequelize does not produce spans
+  'datadog-plugin-body-parser', // body-parser does not produce spans
 ]
 
 // instrumentations that do not have a hook, but are still instrumented


### PR DESCRIPTION
### What does this PR do?
Added ESM test for body-parser

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] Integration tests.
- [ ] Benchmarks.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CI [jobs/workflows][4].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.github/workflows/plugins.yml

### Additional Notes
<!-- Anything else we should know when reviewing? -->


