### PR TITLE
fix(agent): improve fetchAgentInfo error handling

### DIFF
--- a/packages/dd-trace/src/agent/info.js
+++ b/packages/dd-trace/src/agent/info.js
@@ -36,15 +36,17 @@ function fetchAgentInfo (url, callback) {
     if (err) {
       return callback(err)
     }
+
     try {
-      const response = JSON.parse(res)
-      cachedUrl = urlKey
-      cachedData = response
-      cachedTimestamp = Date.now()
-      return callback(null, response)
+      cachedData = JSON.parse(res)
     } catch (e) {
       return callback(e)
     }
+
+    cachedUrl = urlKey
+    cachedTimestamp = Date.now()
+
+    callback(null, cachedData)
   })
 }
 


### PR DESCRIPTION
### What does this PR do?

Don't call the callback provided to fetchAgentInfo twice if it throws
