### PR TITLE
ci: fix vendoring pipeline

### DIFF
--- a/.github/workflows/bundle-validate.yml
+++ b/.github/workflows/bundle-validate.yml
@@ -1,0 +1,24 @@
+name: Validate vendored bundle
+
+on:
+  pull_request:
+    paths:
+      - 'vendor/**'
+  push:
+    branches: [master]
+    paths:
+      - 'vendor/**'
+  workflow_dispatch:
+
+jobs:
+  validate-vendored-bundle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/node/active-lts
+      # Running `yarn` also automatically runs Rspack as a postinstall script.
+      - run: yarn --frozen-lockfile
+        working-directory: vendor
+      - run: git diff --exit-code

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          echo "is_vendor_group=${{ steps.metadata.outputs.dependency-group == 'vendor-minor-and-patch-dependencies' }}" >> $GITHUB_OUTPUT
+          echo "is_vendor_group=${{ steps.metadata.outputs.directory == '/vendor' && steps.metadata.outputs.dependency-type == 'direct:production' }}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         if: steps.ctx.outputs.is_vendor_group == 'true'
         with:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -62,16 +62,6 @@ jobs:
       - run: ./node_modules/.bin/bun pm pack --gzip-level 0 --filename bun.tgz && tar -zxf bun.tgz -C bun
       - run: diff -r npm bun
 
-  bundle-validate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: ./.github/actions/node/active-lts
-      # Running `yarn` also automatically runs Rspack as a postinstall script.
-      - run: yarn --frozen-lockfile
-        working-directory: vendor
-      - run: git diff --exit-code
-
   core:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The vendoring validation would happen if dev dependencies were updated. These would not create a bundle and that caused issues.

The major updates were also not taken into account for vendoring and that is now the case. Instead of relying on the group, we verify what files are changed.