### PR TITLE
fix rewriter support for super with traceCallback

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -24,4 +24,10 @@ module.exports = {
 
     return esquery.traverse(ast, selector, visitor)
   },
+
+  query: (ast, query) => {
+    esquery ??= require('../../../../../vendor/dist/esquery').default
+
+    return esquery.query(ast, query)
+  },
 }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { parse } = require('./compiler')
+const { parse, query } = require('./compiler')
 
 const tracingChannelPredicate = (node) => (
   node.specifiers?.[0]?.local?.name === 'tr_ch_apm_tracingChannel' ||
@@ -106,34 +106,91 @@ function traceInstanceMethod (state, node, program) {
 }
 
 function wrap (state, node) {
-  const { channelName, operator, functionQuery: { index = -1 } } = state
+  const { channelName, operator } = state
+
+  if (operator === 'traceCallback') return wrapCallback(state, node)
+
   const async = operator === 'tracePromise' ? 'async' : ''
   const channelVariable = 'tr_ch_apm$' + channelName.replaceAll(':', '_')
-  const tracedArgs = operator === 'traceCallback'
-    ? `__apm$original_args.splice(${index}, 1, arguments[${index >= 0 ? index : `arguments.length + ${index}`}])`
-    : '__apm$original_args'
-  const traceParams = operator === 'traceCallback'
-    ? `__apm$traced, ${index}`
-    : '__apm$traced'
   const wrapper = parse(`
     function wrapper () {
-      const __apm$original_args = arguments;
-      const __apm$traced = ${async} function () {
+      const __apm$traced = ${async} () => {
         const __apm$wrapped = () => {};
-        const __apm$traced_args = ${tracedArgs};
-        return __apm$wrapped.apply(this, __apm$traced_args);
+        return __apm$wrapped.apply(this, arguments);
       };
-      if (!${channelVariable}.hasSubscribers) return __apm$traced.apply(this, arguments);
-      return ${channelVariable}.${operator}(${traceParams}, {
+      if (!${channelVariable}.hasSubscribers) return __apm$traced();
+      return ${channelVariable}.${operator}(__apm$traced, {
         arguments,
         self: this,
         moduleVersion: "1.0.0"
-      }, this, ...arguments);
+      });
     }
   `).body[0].body // Extract only block statement of function body.
 
   // Replace the right-hand side assignment of `const __apm$wrapped = () => {}`.
-  wrapper.body[1].declarations[0].init.body.body[0].declarations[0].init = node
+  query(wrapper, '[id.name=__apm$wrapped]')[0].init = node
+
+  return wrapper
+}
+
+function wrapCallback (state, node) {
+  const { channelName, functionQuery: { index = -1 } } = state
+  const channelVariable = 'tr_ch_apm$' + channelName.replaceAll(':', '_')
+  const wrapper = parse(`
+    function wrapper () {
+      const __apm$cb = Array.prototype.at.call(arguments, ${index});
+      const __apm$ctx = {
+        arguments,
+        self: this,
+        moduleVersion: "1.0.0"
+      };
+      const __apm$traced = () => {
+        const __apm$wrapped = () => {};
+        return __apm$wrapped.apply(this, arguments);
+      };
+
+      if (!${channelVariable}.start.hasSubscribers) return __apm$traced();
+
+      function __apm$wrappedCb(err, res) {
+        if (err) {
+          __apm$ctx.error = err;
+          ${channelVariable}.error.publish(__apm$ctx);
+        } else {
+          __apm$ctx.result = res;
+        }
+
+        ${channelVariable}.asyncStart.runStores(__apm$ctx, () => {
+          try {
+            if (__apm$cb) {
+              return __apm$cb.apply(this, arguments);
+            }
+          } finally {
+            ${channelVariable}.asyncEnd.publish(__apm$ctx);
+          }
+        });
+      }
+
+      if (typeof __apm$cb !== 'function') {
+        return __apm$traced();
+      }
+      Array.prototype.splice.call(arguments, ${index}, 1, __apm$wrappedCb);
+
+      return ${channelVariable}.start.runStores(__apm$ctx, () => {
+        try {
+          return __apm$traced();
+        } catch (err) {
+          __apm$ctx.error = err;
+          ${channelVariable}.error.publish(__apm$ctx);
+          throw err;
+        } finally {
+          ${channelVariable}.end.publish(__apm$ctx);
+        }
+      });
+    }
+  `).body[0].body // Extract only block statement of function body.
+
+  // Replace the right-hand side assignment of `const __apm$wrapped = () => {}`.
+  query(wrapper, '[id.name=__apm$wrapped]')[0].init = node
 
   return wrapper
 }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -44,6 +44,19 @@ describe('check-require-cache', () => {
         },
         {
           module: {
+            name: 'test-trace-sync-super',
+            versionRange: '>=0.1',
+            filePath: 'index.js'
+          },
+          functionQuery: {
+            methodName: 'test',
+            kind: 'Sync',
+            className: 'B'
+          },
+          channelName: 'test_invoke'
+        },
+        {
+          module: {
             name: 'test-trace-async',
             versionRange: '>=0.1',
             filePath: 'index.js'
@@ -56,6 +69,19 @@ describe('check-require-cache', () => {
         },
         {
           module: {
+            name: 'test-trace-async-super',
+            versionRange: '>=0.1',
+            filePath: 'index.js'
+          },
+          functionQuery: {
+            methodName: 'test',
+            kind: 'Async',
+            className: 'B'
+          },
+          channelName: 'test_invoke'
+        },
+        {
+          module: {
             name: 'test-trace-callback',
             versionRange: '>=0.1',
             filePath: 'index.js'
@@ -63,6 +89,19 @@ describe('check-require-cache', () => {
           functionQuery: {
             functionName: 'test',
             kind: 'Callback'
+          },
+          channelName: 'test_invoke'
+        },
+        {
+          module: {
+            name: 'test-trace-callback-super',
+            versionRange: '>=0.1',
+            filePath: 'index.js'
+          },
+          functionQuery: {
+            methodName: 'test',
+            kind: 'Callback',
+            className: 'B'
           },
           channelName: 'test_invoke'
         },
@@ -101,7 +140,7 @@ describe('check-require-cache', () => {
   })
 
   it('should auto instrument sync functions', done => {
-    const test = compile('test-trace-sync')
+    const { test } = compile('test-trace-sync')
 
     subs = {
       start () {
@@ -112,11 +151,26 @@ describe('check-require-cache', () => {
     ch = tracingChannel('orchestrion:test-trace-sync:test_invoke')
     ch.subscribe(subs)
 
-    test.test()
+    test()
+  })
+
+  it('should auto instrument sync functions with super', done => {
+    const { test } = compile('test-trace-sync-super')
+
+    subs = {
+      start () {
+        done()
+      }
+    }
+
+    ch = tracingChannel('orchestrion:test-trace-sync-super:test_invoke')
+    ch.subscribe(subs)
+
+    test(() => {})
   })
 
   it('should auto instrument async functions', done => {
-    const test = compile('test-trace-async')
+    const { test } = compile('test-trace-async')
 
     subs = {
       start () {
@@ -127,11 +181,26 @@ describe('check-require-cache', () => {
     ch = tracingChannel('orchestrion:test-trace-async:test_invoke')
     ch.subscribe(subs)
 
-    test.test()
+    test()
+  })
+
+  it('should auto instrument async functions using super', done => {
+    const { test } = compile('test-trace-async-super')
+
+    subs = {
+      start () {
+        done()
+      }
+    }
+
+    ch = tracingChannel('orchestrion:test-trace-async-super:test_invoke')
+    ch.subscribe(subs)
+
+    test(() => {})
   })
 
   it('should auto instrument callback functions', done => {
-    const test = compile('test-trace-callback')
+    const { test } = compile('test-trace-callback')
 
     subs = {
       start () {
@@ -142,7 +211,22 @@ describe('check-require-cache', () => {
     ch = tracingChannel('orchestrion:test-trace-callback:test_invoke')
     ch.subscribe(subs)
 
-    test.test(() => {})
+    test(() => {})
+  })
+
+  it('should auto instrument callback functions using super', done => {
+    const { test } = compile('test-trace-callback-super')
+
+    subs = {
+      start () {
+        done()
+      }
+    }
+
+    ch = tracingChannel('orchestrion:test-trace-callback-super:test_invoke')
+    ch.subscribe(subs)
+
+    test(() => {})
   })
 
   it('should auto instrument class instance methods', done => {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-async-super/index.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-async-super/index.js
@@ -1,0 +1,19 @@
+'use strict'
+
+class A {
+  test () {
+    return Promise.resolve()
+  }
+}
+
+class B extends A {
+  test () {
+    return super.test()
+  }
+}
+
+function test () {
+  return new B().test()
+}
+
+module.exports = { test }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-async-super/package.json
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-async-super/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-trace-async-super",
+  "version": "0.1"
+}

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-callback-super/index.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-callback-super/index.js
@@ -1,0 +1,19 @@
+'use strict'
+
+class A {
+  test (cb) {
+    cb()
+  }
+}
+
+class B extends A {
+  test (cb) {
+    return super.test(cb)
+  }
+}
+
+function test () {
+  return new B().test(() => {})
+}
+
+module.exports = { test }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-callback-super/package.json
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-callback-super/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-trace-callback-super",
+  "version": "0.1"
+}

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-sync-super/index.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-sync-super/index.js
@@ -1,0 +1,18 @@
+'use strict'
+
+class A {
+  test (cb) {
+  }
+}
+
+class B extends A {
+  test (cb) {
+    return super.test(cb)
+  }
+}
+
+function test () {
+  return new B().test()
+}
+
+module.exports = { test }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-sync-super/package.json
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-sync-super/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-trace-sync-super",
+  "version": "0.1"
+}


### PR DESCRIPTION
<ins>**Please make sure your changes are properly tested**!</ins>

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix super support for `traceCallback`.

### Motivation
<!-- What inspired you to submit this pull request? -->

We were previously using `function () {}` instead of an arrow function for the traced wrapper as it was needed for `traceCallback` which meant that `super` couldn't be used in the wrapped function. By switching to the expanded version with explicit `runStores` and `publish` calls, we can switch to an arrow function and solve the issue.