### PR TITLE
ci: delay all-green check for six minutes and activate verbose mode

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@b0eaef5be76003932c9520e2b3dd03c85cc43d87 # v2.2.0
         with:
-          delay: '6' # Wait for 6 minutes before polling for the first time
+          delay: ${{ github.run_attempt == 1 && '6' || '0' }} # 6m on first attempt, no delay on reruns
           retries: 30 # once per minute, some checks take up to 15 min, retries are possible
           checks_exclude: devflow.*
           fail_fast: false


### PR DESCRIPTION
This should a) reduce github API rate limit usages and b) increase the overall successrate of the all-green job for long running processes as well as jobs that hit the API rate limit early on.

Six minutes is choosen as our CI normally needs about twice as long overall and even if we optimize slow runs away, we likely will not drop below six minutes.

The verbose mode allows to understand better why the job fails, which is currently partially difficult.
