### PR TITLE
chore: add .cursor dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,16 +89,14 @@ typings/
 .tap/*
 
 
-### VisualStudioCode ###
+### VSCode ###
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-
-### VisualStudioCode Patch ###
-# Ignore all local history of files
 .history
+.cursor
 
 # IntelliJ
 .idea


### PR DESCRIPTION
### What does this PR do?

As the title says

### Motivation

If the developer creates custom slash-commands for Cursor, those will be added to this directory. While some can conveniently be shared amongst devs, not all are relveant for others. So for now, lets ignore this dir.
