### PR TITLE
chore: add `yarn add` command to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 **Package manager policy:**
 
 - Use **yarn only for installing dependencies and services**:
+  - `yarn add`
   - `yarn install`
   - `yarn services`
 - Use **npm for running scripts and other commands**: `npm run <script>`


### PR DESCRIPTION
### What does this PR do?

As the title says

### Motivation

The `yarn install` command is only getting the installed dependencies up-to-date. Make the list of allowed `yarn` commands complete by included `yarn add` in the list.
