### PR TITLE
chore(langchain): fix peer dependency interactions in tests

### DIFF
--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -343,6 +343,30 @@
       "versions": [">=1.0"]
     }
   ],
+  "@langchain/anthropic": [
+    {
+      "name": "@langchain/core",
+      "dep": true
+    }
+  ],
+  "@langchain/google-genai": [
+    {
+      "name": "@langchain/core",
+      "dep": true
+    }
+  ],
+  "@langchain/cohere": [
+    {
+      "name": "@langchain/core",
+      "dep": true
+    }
+  ],
+  "@langchain/openai": [
+    {
+      "name": "@langchain/core",
+      "dep": true
+    }
+  ],
   "ldapjs": [
     {
       "name": "ldapjs",

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -174,16 +174,20 @@ async function assertPeerDependencies (rootFolder, parent = '') {
       const pkgJsonPath = require(folder).pkgJsonPath()
       const pkgJson = require(pkgJsonPath)
 
-      for (const section of ['devDependencies', 'peerDependencies']) {
+      for (const section of ['peerDependencies', 'devDependencies']) {
         if (pkgJson[section]?.[name]) {
+          const versionSpec = pkgJson[section][name]
+          // Skip workspace protocol versions
+          if (versionSpec.startsWith('workspace:')) continue
+
           if (dep === externalName) {
             versionPkgJson.dependencies[name] = pkgJson.version
           } else {
-            versionPkgJson.dependencies[name] = pkgJson[section][name].includes('||')
+            versionPkgJson.dependencies[name] = versionSpec.includes('||')
               // Use the first version in the list (as npm does by default)
-              ? pkgJson[section][name].split('||')[0].trim()
+              ? versionSpec.split('||')[0].trim()
               // Only one version available so use that.
-              : pkgJson[section][name]
+              : versionSpec
           }
 
           await writeFile(versionPkgJsonPath, JSON.stringify(versionPkgJson, null, 2))


### PR DESCRIPTION
### What does this PR do?
Fixes peer dependency interactions for langchain tests (ie, `@langchain/anthropic` interacting with `@langchain/core`). Previously, tests were using the incorrect peer dependency versions for the main dependency (in the example above, the `anthropic` package was using the wrong `core` langchain package version, and instead using the `>=0.1` version).

### Motivation
Fix failing depandabot PRs.

### Additional Notes
This diff was generated by checking out one of the failing depandabot branches to run the updated dependency versions.