### PR TITLE
ci: make vendoring in CI more robust

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -26,3 +26,33 @@ jobs:
           checks_exclude: devflow.*
           fail_fast: false
           verbose: true # What checks are still waited for?
+      - name: Require vendor validation when vendor/ changes
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          vendor_changed="$(gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" --jq 'any(.files[].filename; startswith("vendor/"))')"
+          if [ "$vendor_changed" != "true" ]; then
+            exit 0
+          fi
+
+          # If vendor/ was touched, require *some* vendor validation check to be present:
+          # - For most PRs: `Validate vendored bundle / validate-vendored-bundle`
+          # - For Dependabot vendor PRs: `Dependabot Automation / vendor-validate`
+          check_names="$(gh api "repos/${REPO}/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
+            -H "Accept: application/vnd.github+json" \
+            --paginate \
+            --jq '.check_runs[].name')"
+
+          if echo "$check_names" | grep -Eq '^(validate-vendored-bundle|vendor-validate)$'; then
+            exit 0
+          fi
+
+          echo "vendor/ changed but no vendor validation check was found."
+          echo "Expected a check run named 'validate-vendored-bundle' or 'vendor-validate'."
+          exit 1

--- a/.github/workflows/bundle-validate.yml
+++ b/.github/workflows/bundle-validate.yml
@@ -13,6 +13,13 @@ on:
 jobs:
   validate-vendored-bundle:
     runs-on: ubuntu-latest
+    # Dependabot vendor PRs are post-processed by `.github/workflows/dependabot-automation.yml`
+    # which pushes the generated `vendor/dist/*` contents. Running this workflow before that
+    # push is expected to fail (it will regenerate `vendor/dist/*` and see a diff).
+    #
+    # Instead, Dependabot vendor PRs are validated after `vendor-push` via the `vendor-validate`
+    # job in `dependabot-automation.yml`, ensuring correct ordering and avoiding flakiness.
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
     steps:
@@ -21,4 +28,14 @@ jobs:
       # Running `yarn` also automatically runs Rspack as a postinstall script.
       - run: yarn --frozen-lockfile
         working-directory: vendor
-      - run: git diff --exit-code
+      - name: Ensure no untracked outputs
+        run: |
+          set -euo pipefail
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Working tree is dirty after vendoring:"
+            git status --porcelain
+            exit 1
+          fi
+      - name: Diff only expected paths
+        run: git diff --exit-code -- vendor/dist vendor/package.json vendor/yarn.lock

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -205,3 +205,46 @@ jobs:
           branch: ${{ github.event.pull_request.head.ref }}
           command: push
           commits: "${{ steps.create-commit.outputs.commits }}"
+
+  vendor-validate:
+    # Run validation after the generated vendor patch has been pushed, to ensure the PR contains
+    # the committed `vendor/dist/*` outputs. This runs inside the same workflow as the push, so it
+    # doesn't rely on additional workflows being triggered by that push.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && needs.vendor-build.outputs.is_vendor_group == 'true' && needs.vendor-build.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    needs:
+      - vendor-build
+      - vendor-push
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Restore trusted Node setup actions
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          git checkout "${{ github.event.pull_request.base.sha }}" -- .github/actions/node
+      - name: Restore trusted vendoring scripts
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          git checkout "${{ github.event.pull_request.base.sha }}" -- vendor/rspack.js vendor/rspack.config.js
+      - uses: ./.github/actions/node/active-lts
+      # Running `yarn` also automatically runs Rspack as a postinstall script.
+      - run: yarn --frozen-lockfile
+        working-directory: vendor
+      - name: Ensure no untracked outputs
+        run: |
+          set -euo pipefail
+
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Working tree is dirty after vendoring:"
+            git status --porcelain
+            exit 1
+          fi
+      - name: Diff only expected paths
+        run: git diff --exit-code -- vendor/dist vendor/package.json vendor/yarn.lock


### PR DESCRIPTION
Dependabot would still create the new commit while the validation was already running, creating a race condition. This is fixed by waiting for that job.
Also other PRs will still be validated.

