### PR TITLE
docs: instruct Aider and Gemini CLI to use AGENTS.md

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,1 @@
+read: [AGENTS.md]

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,1 @@
+{"contextFileName":"AGENTS.md"}


### PR DESCRIPTION
### What does this PR do?

Configures Aider and Gemini CLI to automatically use `AGENTS.md` as their context file for AI-assisted development contributions.

### Motivation

Contributors using Aider or Gemini CLI will now automatically have access to the comprehensive development guidelines in `AGENTS.md`, ensuring better consistency and adherence to project conventions when using AI coding assistants. This follows the pattern recommended in the [agents.md FAQ](https://agents.md/).
