### PR TITLE
ci(codeql): exclude vendor/dist from analysis

### DIFF
--- a/.github/codeql_config.yml
+++ b/.github/codeql_config.yml
@@ -6,3 +6,4 @@ paths-ignore:
   - 'node-upstream-tests'
   - 'packages/**/test'
   - 'scripts'
+  - 'vendor/dist'


### PR DESCRIPTION
### What does this PR do?

Excludes the `vendor/dist` directory from CodeQL analysis by adding it to the paths-ignore list in `.github/codeql_config.yml`.

### Motivation

The `vendor/dist` directory contains bundled third-party dependencies that are already analyzed upstream. Including them in CodeQL scans adds noise and increases analysis time without providing meaningful security insights for our project's code.
