### PR TITLE
docs: add integration test permissions note to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ dd-trace is the Datadog client library for Node.js.
 
 **IMPORTANT**: The root `npm test` is intentionally disabled. Always run a specific `*.spec.js` file, or a targeted `npm run test:<area>` script.
 
+**Integration Tests**: Tests in `integration-tests/` require `required_permissions: ["all"]` when run in Cursor's AI environment.
+
 ### Running Individual Tests
 
 **Unit tests:**


### PR DESCRIPTION
### What does this PR do?

Updates `AGENTS.md` to document that integration tests in `integration-tests/` require `required_permissions: ["all"]` when run in Cursor's AI environment.

### Motivation

Integration tests often need access to Docker, network, and other system resources that are blocked by Cursor's default sandboxing. Without this documentation, AI agents attempting to run integration tests will encounter permission errors and may not understand how to resolve them.
