### PR TITLE
fix(ci-visibility): fix race condition in agent-proxy exporter

### DIFF
--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -47,7 +47,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       this._isInitialized = true
       let latestEvpProxyVersion = getLatestEvpProxyVersion(err, agentInfo)
       const isEvpCompatible = latestEvpProxyVersion >= 2
-      const isGzipCompatible = latestEvpProxyVersion >= 4
+      this._isGzipCompatible = latestEvpProxyVersion >= 4
 
       // v3 does not work well citestcycle, so we downgrade to v2
       if (latestEvpProxyVersion === 3) {
@@ -93,7 +93,6 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
       this._resolveCanUseCiVisProtocol(isEvpCompatible)
       this.exportUncodedTraces()
       this.exportUncodedCoverages()
-      this._isGzipCompatible = isGzipCompatible
     })
   }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -19,6 +19,7 @@ const { clearCache } = require('../../../../src/agent/info')
 describe('AgentProxyCiVisibilityExporter', () => {
   beforeEach(() => {
     clearCache()
+    nock.cleanAll()
   })
 
   const flushInterval = 50


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in `AgentProxyCiVisibilityExporter` where `_isGzipCompatible` and `evpProxyPrefix` could be read before being set, causing intermittent test failures in CI. Also adds proper test cleanup to prevent nock mock state leakage.

### Motivation

Four tests in the agent-proxy test suite were failing intermittently in CI:
- `_isGzipCompatible` - should set to true if newest version is v4 or newer
- `_isGzipCompatible` - should set to false if newest version is v3 or older  
- `evpProxyPrefix` - should set to v2 if newest version is v3
- `evpProxyPrefix` - should set to v4 if newest version is v4

**Root Cause:** A race condition in the production code, amplified by commit 6eed53f44 which added caching to `fetchAgentInfo`. When the cache is hit, the callback runs via `process.nextTick` (extremely fast), making the timing window between promise resolution and property assignment visible.

**The Race Condition:**
```javascript
// OLD CODE (buggy):
const isGzipCompatible = latestEvpProxyVersion >= 4
// ... create writers ...
this._resolveCanUseCiVisProtocol(isEvpCompatible)  // Promise resolves - tests wake up here!
this.exportUncodedTraces()
this.exportUncodedCoverages()
this._isGzipCompatible = isGzipCompatible  // Set AFTER promise resolves - too late!

// NEW CODE (fixed):
this._isGzipCompatible = latestEvpProxyVersion >= 4  // Set immediately, early in callback
// ... create writers ...
this._resolveCanUseCiVisProtocol(isEvpCompatible)  // Promise resolves - property already set!
```

**Fixes Applied:**

1. **Production code fix** (`packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js`):
   - Set `this._isGzipCompatible` directly and early in the `fetchAgentInfo` callback (line 50)
   - Ensures the property is set before `this._resolveCanUseCiVisProtocol()` resolves the promise
   - Tests and production code can now safely read the property after awaiting `_canUseCiVisProtocolPromise`
   - Matches the pattern in `AgentlessCiVisibilityExporter` which sets `_isGzipCompatible` synchronously in the constructor

2. **Test cleanup fix** (`packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js`):
   - Add `nock.cleanAll()` to `beforeEach` hook to prevent HTTP mock state leakage between tests
   - Without cleanup, nock interceptors from previous tests could interfere with subsequent tests
   - Follows the pattern used in `exporter.spec.js` and other test files

The flakiness only manifested in CI due to parallel test execution, process reuse, and timing variations that don't occur in local development.

