### PR TITLE
chore: add Cursor command templates

### DIFF
--- a/.cursor/commands/commit-message.md
+++ b/.cursor/commands/commit-message.md
@@ -1,0 +1,18 @@
+Write a commit message for the staged changes.
+
+Focus on the overall picture, a brief "what has changed", potentially followed by a "why" it was changed. Do not just blindly list every change. Only include specific changes if its relevant to understand the commit.
+
+The subject line should be a maximum of 50 chars.
+Each line of the body should be a maximum of 72 chars. Long URLs are allowed to exceed this.
+
+Format it as a semantic commit message
+- Format: `<type>(<scope>): <subject>` (`<scope>` is optional).
+
+Semantic commit message types:
+- feat: (new feature for the user, not a new feature for build script)
+- fix: (bug fix for the user, not a fix to a build script)
+- docs: (changes to the documentation)
+- style: (formatting, missing semi colons, etc; no production code change)
+- refactor: (refactoring production code, eg. renaming a variable)
+- test: (adding missing tests, refactoring tests; no production code change)
+- chore: (updating grunt tasks etc; no production code change)

--- a/.cursor/commands/pr-body.md
+++ b/.cursor/commands/pr-body.md
@@ -1,0 +1,15 @@
+Write a PR body for the changes in the current branch.
+
+Focus on the overall picture.
+Do not just blindly list every change.
+Only include specific changes if its relevant to understand the PR changes.
+
+Use the PR template in `.github/pull_request_template.md` as the schema:
+- Remove the first line starting with `<ins>`
+- Add content to the relevant sections (remove any section that isn't relevant)
+- Use commit messages in the branch as a staring point
+- Use markdown
+- Use backticks for all file/path and inline code refeferences
+- Don't break lines unnecessarily
+
+**IMPORTANT:** Output the final PR body in a code block formatted using 4 backticks, so it's easy to copy/paste even if the content itself contains 3 backticks in a row.

--- a/.cursor/commands/test-branch.md
+++ b/.cursor/commands/test-branch.md
@@ -1,0 +1,5 @@
+Run all tests relevant for the changes in the current branch.
+Integration tests needs to run outside the sandbox.
+Prefer running multiple unit tests at the same time using a glob, even if a few is unrelated to the changes in the current brach.
+Integration tests takes a long time to run, so be careful about using a glob unless you actually want to run every integration test included in the glob.
+If any of the tests fail, do not try to fix them, but ask me what I want to do.

--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,7 @@ typings/
 !.vscode/launch.json
 !.vscode/extensions.json
 .history
-.cursor
+.cursor/skills
 
 # IntelliJ
 .idea


### PR DESCRIPTION
### What does this PR do?

Adds three Cursor command templates to standardize common workflows and updates `.gitignore` to track the `.cursor/commands/` directory while keeping `.cursor/skills/` ignored.

The three commands added are:
- `/commit-message` - Generates semantic commit messages following the 50/72 character formatting rules based on the currently staged changes
- `/pr-body` - Creates PR descriptions using the repository's PR template with proper formatting based on the changes in the current branch
- `/test-branch` - Runs all relevant tests for changes in the current branch, handling both unit and integration tests appropriately

### Motivation

These command templates help ensure consistent formatting and quality when creating commit messages and PR descriptions, and provide a standardized and quick approach to running tests for branch changes (so it's easier to test before pushing).
