### PR TITLE
ci: fix added commits breaking CI validation

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -15,6 +15,27 @@ jobs:
   dependabot:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    # Keep this job as a stable, always-green check on Dependabot PRs, even when the workflow is
+    # re-triggered by an automation commit (e.g., vendoring). Sensitive operations (OIDC token mint,
+    # approving, enabling auto-merge) are delegated to `dependabot-automation` below.
+    permissions:
+      contents: read
+    steps:
+      - name: Status
+        run: |
+          echo "Dependabot PR detected."
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "Automation steps will run in the 'dependabot-automation' job."
+          else
+            echo "Skipping automation: workflow actor is '${{ github.actor }}'."
+          fi
+
+  dependabot-automation:
+    # Only run automation on the initial Dependabot-triggered run. If an automation commit is pushed
+    # (e.g. vendor output), GitHub re-triggers this workflow with `github.actor == 'dd-octo-sts[bot]'`.
+    # We intentionally avoid minting tokens / approving / enabling auto-merge on that follow-up run.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
@@ -150,6 +171,11 @@ jobs:
         with:
           scope: DataDog/dd-trace-js
           policy: dependabot-automation
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # 2.5.0
+        with:
+          github-token: "${{ steps.octo-sts.outputs.token }}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.octo-sts.outputs.token }}
@@ -208,6 +234,22 @@ jobs:
           # so the resulting push triggers CI workflows normally.
           auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$DD_OCTO_STS_TOKEN" | base64 | tr -d '\n')"
           git -c "http.https://github.com/.extraheader=$auth_header" push origin "HEAD:$TARGET_BRANCH"
+
+      # If branch protection is configured to dismiss stale approvals when new commits are pushed,
+      # the vendoring commit will invalidate the earlier approval. Re-approve and (re-)enable
+      # auto-merge after pushing so Dependabot PRs can still merge automatically.
+      - name: Approve a PR (after vendoring commit)
+        if: contains(fromJSON(env.GROUPS), steps.metadata.outputs.dependency-group)
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+      - name: Enable auto-merge for Dependabot PRs (after vendoring commit)
+        if: contains(fromJSON(env.GROUPS), steps.metadata.outputs.dependency-group)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
   vendor-validate:
     # Run validation after the generated vendor patch has been pushed, to ensure the PR contains

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -198,7 +198,10 @@ jobs:
           if-no-files-found: error
 
   yarn-dedupe-push:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.yarn-dedupe.outputs.has_changes == 'true'
+    # If this job pushes a commit, GitHub will re-trigger the workflow on `pull_request:synchronize`
+    # with `github.actor == 'dd-octo-sts[bot]'`. Never attempt to mint another token / push again on
+    # that follow-up run.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.yarn-dedupe.outputs.has_changes == 'true' && github.actor != 'dd-octo-sts[bot]'
     runs-on: ubuntu-latest
     needs: yarn-dedupe
     # Security: this job has an STS-minted token, but never runs installs/builds.

--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -70,6 +70,8 @@ jobs:
           PR_USER_TYPE: ${{ github.event.pull_request.user.type }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           set -e
 
@@ -78,7 +80,7 @@ jobs:
           else
             echo "📝 LICENSE-3rdparty.csv was modified by license attribution command"
 
-            if [[ "$PR_USER_TYPE" == "Bot" ]] && [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            if [[ "$PR_USER_TYPE" == "Bot" ]] && [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && [[ "$PR_HEAD_REPO" == "$BASE_REPO" ]]; then
               echo "🤖 Bot-created PR detected. Auto-committing LICENSE-3rdparty.csv changes..."
 
               git config --local user.email "action@github.com"


### PR DESCRIPTION
The added commit does not match our permission claim, so we just skip that part in case it is not pushed by dependabot anymore.

