### PR TITLE
test(debugger): fix race condition in test helpers

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -301,17 +301,21 @@ function testBasicInputWithoutRC (t, probe, done) {
 function setupAssertionListeners (t, done, probe) {
   let traceId, spanId, dd
 
-  t.agent.on('message', ({ payload }) => {
+  const messageListener = ({ payload }) => {
     const span = payload.find((arr) => arr[0].name === 'fastify.request')?.[0]
     if (!span) return
 
     traceId = span.trace_id.toString()
     spanId = span.span_id.toString()
 
-    assertDD()
-  })
+    t.agent.removeListener('message', messageListener)
 
-  t.agent.on('debugger-input', ({ payload }) => {
+    assertDD()
+  }
+
+  t.agent.on('message', messageListener)
+
+  t.agent.once('debugger-input', ({ payload }) => {
     assertBasicInputPayload(t, payload, probe)
 
     payload = payload[0]


### PR DESCRIPTION
### What does this PR do?

Attempt to fix a race condition in the debugger integration test helper function `setupAssertionListeners` that was likely causing flaky test failures in CI, particularly the test `DD_TRACING_ENABLED=true, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED=false` → `should capture and send expected payload when a log line probe is triggered`.

The fix:
- The `'message'` listener now removes itself immediately after capturing the first valid span with `t.agent.removeListener('message', messageListener)`
- The `'debugger-input'` listener now uses `.once()` instead of `.on()` since we expect exactly one debugger payload per test

### Motivation

The test was failing intermittently with trace ID mismatches like:
```
Expected: '78160144430626865'
Actual:   '5009160858555370125'
```

The root cause seems to be that event listeners were using `.on()` and persisting across multiple events. When multiple HTTP requests occurred (from background activity or timing variations), the `'message'` listener would fire multiple times, updating the shared closure variables (`traceId`, `spanId`) with values from different requests. This caused assertions to compare trace IDs from mismatched requests.
