### PR TITLE
move bun cache to under node_modules

### DIFF
--- a/integration-tests/helpers/bun.js
+++ b/integration-tests/helpers/bun.js
@@ -3,7 +3,7 @@
 const { join, resolve } = require('path')
 
 const PROJECT_ROOT = resolve(__dirname, '..', '..')
-const BUN_INSTALL = join(PROJECT_ROOT, '.bun')
+const BUN_INSTALL = join(PROJECT_ROOT, 'node_modules', '.cache', 'bun')
 const BUN = join(PROJECT_ROOT, 'node_modules', '.bin', 'bun')
 
 /**


### PR DESCRIPTION
<ins>**Please make sure your changes are properly tested**!</ins>

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Move Bun cache to under `node_modules`.

### Motivation
<!-- What inspired you to submit this pull request? -->

Avoids an additional folder in root, and makes it so that when `node_modules` is deleted the Bun cache is also deleted, so that if there are any problems related to the cache there is no need to know about the separate folder.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


