### PR TITLE
refactor(logging): use printf-style formatting

### DIFF
--- a/eslint-rules/eslint-log-printf-style.mjs
+++ b/eslint-rules/eslint-log-printf-style.mjs
@@ -1,0 +1,92 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Enforce printf-style formatting in log calls instead of string concatenation, template literals, or ' +
+        'callbacks. Callback-style logging (e.g., log.debug(() => ...)) is ONLY allowed for expensive formatting ' +
+        'operations where you need to avoid the overhead when the log level is disabled. In those rare cases, ' +
+        'disable this rule with: // eslint-disable-next-line eslint-rules/eslint-log-printf-style',
+    },
+    messages: {
+      useFormat: 'Use printf-style formatting (e.g., log.{{method}}("message %s", value)) instead of {{badPattern}}. ' +
+        'Only use callback-style for expensive operations and disable this rule with a comment.',
+    },
+    schema: [],
+  },
+  create (context) {
+    const LOG_METHODS = ['trace', 'debug', 'info', 'warn', 'error', 'errorWithoutTelemetry']
+
+    const isLogCall = (node) => {
+      return node.type === 'CallExpression' &&
+             node.callee.type === 'MemberExpression' &&
+             node.callee.object.name === 'log' &&
+             LOG_METHODS.includes(node.callee.property.name)
+    }
+
+    const hasBinaryStringConcat = (node) => {
+      if (node.type !== 'BinaryExpression' || node.operator !== '+') {
+        return false
+      }
+
+      // Check if either side is a string literal or another concatenation
+      const leftIsString = node.left.type === 'Literal' && typeof node.left.value === 'string'
+      const rightIsString = node.right.type === 'Literal' && typeof node.right.value === 'string'
+      const leftIsConcat = hasBinaryStringConcat(node.left)
+      const rightIsConcat = hasBinaryStringConcat(node.right)
+
+      return leftIsString || rightIsString || leftIsConcat || rightIsConcat
+    }
+
+    return {
+      CallExpression (node) {
+        if (!isLogCall(node)) return
+        if (node.arguments.length === 0) return
+
+        const firstArg = node.arguments[0]
+        const methodName = node.callee.property.name
+
+        // Check for callback-style logging (arrow functions or function expressions)
+        // NOTE: Callback-style is only acceptable for expensive formatting operations
+        // where you need to avoid overhead when the log level is disabled.
+        // Use: // eslint-disable-next-line eslint-rules/eslint-log-printf-style
+        if (firstArg.type === 'ArrowFunctionExpression' || firstArg.type === 'FunctionExpression') {
+          context.report({
+            node: firstArg,
+            messageId: 'useFormat',
+            data: {
+              method: methodName,
+              badPattern: 'callback-style logging',
+            },
+          })
+          return
+        }
+
+        // Check for template literals with expressions
+        if (firstArg.type === 'TemplateLiteral' && firstArg.expressions.length > 0) {
+          context.report({
+            node: firstArg,
+            messageId: 'useFormat',
+            data: {
+              method: methodName,
+              badPattern: 'template literals',
+            },
+          })
+          return
+        }
+
+        // Check for string concatenation with +
+        if (hasBinaryStringConcat(firstArg)) {
+          context.report({
+            node: firstArg,
+            messageId: 'useFormat',
+            data: {
+              method: methodName,
+              badPattern: 'string concatenation',
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/eslint-rules/eslint-log-printf-style.test.mjs
+++ b/eslint-rules/eslint-log-printf-style.test.mjs
@@ -1,0 +1,95 @@
+import { RuleTester } from 'eslint'
+import rule from './eslint-log-printf-style.mjs'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('eslint-log-printf-style', rule, {
+  valid: [
+    // Printf-style formatting
+    { code: 'log.debug("message %s", value)' },
+    { code: 'log.info("count: %d", count)' },
+    { code: 'log.warn("Error: %s with code %d", message, code)' },
+    { code: 'log.error("Failed with error %s", err)' },
+
+    // Simple string literals (no interpolation)
+    { code: 'log.debug("simple message")' },
+    { code: 'log.info("no variables here")' },
+
+    // Template literals without expressions
+    { code: 'log.debug(`simple template`)' },
+
+    // Not a log call
+    { code: 'console.log(`template ${value}`)' }, // eslint-disable-line no-template-curly-in-string
+    { code: 'foo.bar("test" + value)' },
+  ],
+
+  invalid: [
+    // Callback-style logging
+    {
+      code: 'log.debug(() => "foo")',
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'debug', badPattern: 'callback-style logging' },
+      }],
+    },
+    {
+      code: 'log.info(() => `message ${value}`)', // eslint-disable-line no-template-curly-in-string
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'info', badPattern: 'callback-style logging' },
+      }],
+    },
+    {
+      code: 'log.warn(function() { return "message" })',
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'warn', badPattern: 'callback-style logging' },
+      }],
+    },
+
+    // Template literals with expressions
+    {
+      code: 'log.debug(`message ${value}`)', // eslint-disable-line no-template-curly-in-string
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'debug', badPattern: 'template literals' },
+      }],
+    },
+    {
+      // eslint-disable-next-line no-template-curly-in-string
+      code: 'log.warn(`Error: ${err.message} with code ${err.code}`)',
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'warn', badPattern: 'template literals' },
+      }],
+    },
+
+    // String concatenation
+    {
+      code: 'log.error("Error: " + message)',
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'error', badPattern: 'string concatenation' },
+      }],
+    },
+    {
+      code: 'log.info("Count is " + count + " items")',
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'info', badPattern: 'string concatenation' },
+      }],
+    },
+    {
+      code: 'log.warn("Metric queue exceeded limit (max: " + max + "). Dropping " + dropped + " measurements.")',
+      errors: [{
+        messageId: 'useFormat',
+        data: { method: 'warn', badPattern: 'string concatenation' },
+      }],
+    },
+  ],
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,7 @@ import globals from 'globals'
 import eslintProcessEnv from './eslint-rules/eslint-process-env.mjs'
 import eslintEnvAliases from './eslint-rules/eslint-env-aliases.mjs'
 import eslintSafeTypeOfObject from './eslint-rules/eslint-safe-typeof-object.mjs'
+import eslintLogPrintfStyle from './eslint-rules/eslint-log-printf-style.mjs'
 
 const { dependencies } = JSON.parse(readFileSync('./vendor/package.json', 'utf8'))
 
@@ -410,6 +411,7 @@ export default [
           'eslint-process-env': eslintProcessEnv,
           'eslint-env-aliases': eslintEnvAliases,
           'eslint-safe-typeof-object': eslintSafeTypeOfObject,
+          'eslint-log-printf-style': eslintLogPrintfStyle,
         },
       },
       n: eslintPluginN,
@@ -419,6 +421,7 @@ export default [
       'eslint-rules/eslint-process-env': 'error',
       'eslint-rules/eslint-env-aliases': 'error',
       'eslint-rules/eslint-safe-typeof-object': 'error',
+      'eslint-rules/eslint-log-printf-style': 'error',
       'n/no-restricted-require': ['error', [
         {
           name: 'diagnostics_channel',

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -234,9 +234,10 @@ function instrumentKafkaJS (kafkaJS) {
                             // This approach is implemented by other tracers as well.
                             if (err.name === 'KafkaJSError' && err.type === 'ERR_UNKNOWN') {
                               disabledHeaderWeakSet.add(producer)
-                              log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). ' +
-                                'Please look at broker logs for more information. ' +
-                                'Tracer message header injection for Kafka is disabled.')
+                              log.error(
+                                // eslint-disable-next-line @stylistic/max-len
+                                'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
+                              )
                             }
                             ctx.error = err
                             channels.producerError.publish(ctx)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -677,9 +677,7 @@ function getTestEnvironment (pkg, jestVersion) {
 function applySuiteSkipping (originalTests, rootDir, frameworkVersion) {
   const jestSuitesToRun = getJestSuitesToRun(skippableSuites, originalTests, rootDir || process.cwd())
   hasFilteredSkippableSuites = true
-  log.debug(
-    () => `${jestSuitesToRun.suitesToRun.length} out of ${originalTests.length} suites are going to run.`
-  )
+  log.debug('%d out of %d suites are going to run.', jestSuitesToRun.suitesToRun.length, originalTests.length)
   hasUnskippableSuites = jestSuitesToRun.hasUnskippableSuites
   hasForcedToRunSuites = jestSuitesToRun.hasForcedToRunSuites
 

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -93,9 +93,10 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
                   // This approach is implemented by other tracers as well.
                   if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
                     disabledHeaderWeakSet.add(producer)
-                    log.error('Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). ' +
-                      'Please look at broker logs for more information. ' +
-                      'Tracer message header injection for Kafka is disabled.')
+                    log.error(
+                      // eslint-disable-next-line @stylistic/max-len
+                      'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
+                    )
                   }
                   producerErrorCh.publish(err)
                 }

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -220,9 +220,7 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
 
     isSuitesSkipped = suitesToRun.length !== runner.suite.suites.length
 
-    log.debug(
-      () => `${suitesToRun.length} out of ${runner.suite.suites.length} suites are going to run.`
-    )
+    log.debug('%d out of %d suites are going to run.', suitesToRun.length, runner.suite.suites.length)
 
     runner.suite.suites = suitesToRun
 

--- a/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/pubsub-push-subscription.js
@@ -53,8 +53,8 @@ class GoogleCloudPubsubPushSubscriptionPlugin extends TracingPlugin {
     }
 
     log.warn(
-      '[PubSub] No x-goog-pubsub-* headers detected. pubsub.push.receive spans will not be created. ' +
-      'Add --push-no-wrapper-write-metadata to your subscription.'
+      // eslint-disable-next-line @stylistic/max-len
+      '[PubSub] No x-goog-pubsub-* headers detected. pubsub.push.receive spans will not be created. Add --push-no-wrapper-write-metadata to your subscription.'
     )
     return false
   }

--- a/packages/datadog-plugin-http/src/index.js
+++ b/packages/datadog-plugin-http/src/index.js
@@ -23,7 +23,7 @@ class HttpPlugin extends CompositePlugin {
         plugins['pubsub-push-subscription'] = PushSubscriptionPlugin
         log.debug('Loaded GCP Pub/Sub Push Subscription plugin for HTTP requests')
       } catch (e) {
-        log.debug(`Failed to load GCP Pub/Sub Push Subscription plugin: ${e.message}`)
+        log.debug('Failed to load GCP Pub/Sub Push Subscription plugin:', e)
       }
     }
 

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -42,6 +42,7 @@ class Writer extends BaseWriter {
       options.headers['X-Datadog-EVP-Subdomain'] = 'citestcov-intake'
     }
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Request to the intake: ${safeJSONStringify(options)}`)
 
     const startRequestTime = Date.now()

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
@@ -37,6 +37,7 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
       options.path = '/debugger/v1/input'
     }
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Request to the logs intake: ${safeJSONStringify(options)}`)
 
     request(data, options, (err, res) => {

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -43,6 +43,7 @@ class Writer extends BaseWriter {
       options.headers['X-Datadog-EVP-Subdomain'] = 'citestcycle-intake'
     }
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Request to the intake: ${safeJSONStringify(options)}`)
 
     const startRequestTime = Date.now()

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -716,9 +716,8 @@ class Config {
       } else if (DD_MAJOR < 6) {
         // Warn about v6 behavior change for Nx projects
         log.warn(
-          'NX_TASK_TARGET_PROJECT is set but no service name was configured. ' +
-          'In v6, NX_TASK_TARGET_PROJECT will be used as the default service name. ' +
-          'Set DD_ENABLE_NX_SERVICE_NAME=true to opt-in to this behavior now, or set a service name explicitly.'
+          // eslint-disable-next-line @stylistic/max-len
+          'NX_TASK_TARGET_PROJECT is set but no service name was configured. In v6, NX_TASK_TARGET_PROJECT will be used as the default service name. Set DD_ENABLE_NX_SERVICE_NAME=true to opt-in to this behavior now, or set a service name explicitly.'
         )
       }
     }
@@ -1614,7 +1613,7 @@ function nonNegInt (value, envVarName, allowZero = true) {
   if (value === undefined) return
   const parsed = Number.parseInt(value)
   if (Number.isNaN(parsed) || parsed < 0 || (parsed === 0 && !allowZero)) {
-    log.warn(`Invalid value ${parsed} for ${envVarName}. Using default value.`)
+    log.warn('Invalid value %d for %s. Using default value.', parsed, envVarName)
     return
   }
   return parsed

--- a/packages/dd-trace/src/datastreams/pathway.js
+++ b/packages/dd-trace/src/datastreams/pathway.js
@@ -123,6 +123,7 @@ const DsmPathwayCodec = {
     }
     carrier[CONTEXT_PROPAGATION_KEY_BASE64] = encodePathwayContextBase64(dataStreamsContext)
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Injected into DSM carrier: ${JSON.stringify(pick(carrier, logKeys))}.`)
   },
 
@@ -131,6 +132,7 @@ const DsmPathwayCodec = {
    * @returns {ReturnType<typeof decodePathwayContext>|undefined}
    */
   decode (carrier) {
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Attempting extract from DSM carrier: ${JSON.stringify(pick(carrier, logKeys))}.`)
 
     if (carrier == null) return

--- a/packages/dd-trace/src/datastreams/processor.js
+++ b/packages/dd-trace/src/datastreams/processor.js
@@ -229,7 +229,9 @@ class DataStreamsProcessor {
         closestOppositeDirectionEdgeStart = edgeStartNs
       }
       log.debug(
-        () => `Setting DSM Checkpoint from extracted parent context with hash: ${parentHash} and edge tags: ${edgeTags}`
+        'Setting DSM Checkpoint from extracted parent context with hash: %s and edge tags: %s',
+        parentHash,
+        edgeTags
       )
     }
     const hash = computePathwayHash(this.service, this.env, edgeTags, parentHash)

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -190,6 +190,7 @@ session.on('Debugger.paused', async ({ params }) => {
 
   // This doesn't measure the overhead of the CDP protocol. The actual pause time is slightly larger.
   // On my machine I'm seeing around 1.7ms of overhead.
+  // eslint-disable-next-line eslint-rules/eslint-log-printf-style
   log.debug(() => `[debugger:devtools_client] Finished processing breakpoints - main thread paused for: ~${
     Number(diff) / 1_000_000
   } ms`)

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -50,6 +50,7 @@ class AgentEncoder {
     const end = bytes.length
 
     if (this._debugEncoding) {
+      // eslint-disable-next-line eslint-rules/eslint-log-printf-style
       log.debug(() => {
         const hex = bytes.buffer.subarray(start, end).toString('hex').match(/../g).join(' ')
 

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -26,10 +26,12 @@ class Writer {
 
   append (payload) {
     if (!request.writable) {
+      // eslint-disable-next-line eslint-rules/eslint-log-printf-style
       log.debug(() => `Maximum number of active requests reached. Payload discarded: ${safeJSONStringify(payload)}`)
       return
     }
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Encoding payload: ${safeJSONStringify(payload)}`)
 
     this._encode(payload)

--- a/packages/dd-trace/src/llmobs/index.js
+++ b/packages/dd-trace/src/llmobs/index.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const util = require('node:util')
-
 const { channel } = require('dc-polyfill')
 
 const log = require('../log')
@@ -78,7 +76,7 @@ function enable (config) {
     spanWriter?.setAgentless(useAgentless)
 
     telemetry.recordLLMObsEnabled(startTime, config)
-    log.debug(`[LLMObs] Enabled LLM Observability with configuration: ${util.inspect(config.llmobs)}`)
+    log.debug('[LLMObs] Enabled LLM Observability with configuration: %o', config.llmobs)
   })
 }
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -557,7 +557,7 @@ class LLMObsTagger {
         if (role === 'tool') {
           condition = this.#tagConditionalString(toolId, 'Tool ID', messageObj, 'tool_id') && condition
         } else {
-          log.warn(`Tool ID for tool message not associated with a "tool" role, instead got "${role}"`)
+          log.warn('Tool ID for tool message not associated with a "tool" role, instead got "%s"', role)
         }
       }
 

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -24,8 +24,8 @@ class FlaggingProvider extends DatadogNodeServerProvider {
     this._tracer = tracer
     this._config = config
 
-    log.debug(this.constructor.name + ' created with timeout: ' +
-      config.experimental.flaggingProvider.initializationTimeoutMs + 'ms')
+    log.debug('%s created with timeout: %dms', this.constructor.name,
+      config.experimental.flaggingProvider.initializationTimeoutMs)
   }
 
   /**
@@ -40,7 +40,7 @@ class FlaggingProvider extends DatadogNodeServerProvider {
     if (typeof this.setConfiguration === 'function') {
       this.setConfiguration(ufc)
     }
-    log.debug(this.constructor.name + ' provider configuration updated')
+    log.debug('%s provider configuration updated', this.constructor.name)
   }
 }
 

--- a/packages/dd-trace/src/openfeature/index.js
+++ b/packages/dd-trace/src/openfeature/index.js
@@ -36,7 +36,7 @@ function _handleFlush () {
  */
 function enable (config) {
   if (exposuresWriter) {
-    log.warn(exposuresWriter.constructor.name + ' already enabled')
+    log.warn('%s already enabled', exposuresWriter.constructor.name)
     return
   }
 

--- a/packages/dd-trace/src/openfeature/writers/base.js
+++ b/packages/dd-trace/src/openfeature/writers/base.js
@@ -73,7 +73,7 @@ class BaseFFEWriter {
 
     for (const event of eventArray) {
       if (this._buffer.length >= this._bufferLimit) {
-        log.warn(`${this.constructor.name} event buffer full (limit is ${this._bufferLimit}), dropping event`)
+        log.warn('%s event buffer full (limit is %d), dropping event', this.constructor.name, this._bufferLimit)
         this._droppedEvents++
         continue
       }
@@ -82,16 +82,15 @@ class BaseFFEWriter {
 
       // Check individual event size limit if configured
       if (this._eventSizeLimit && eventSizeBytes > this._eventSizeLimit) {
-        log.warn(`${this.constructor.name} event size
-          ${eventSizeBytes} bytes exceeds limit ${this._eventSizeLimit}, dropping event`)
+        log.warn('%s event size %d bytes exceeds limit %d, dropping event',
+          this.constructor.name, eventSizeBytes, this._eventSizeLimit)
         this._droppedEvents++
         continue
       }
 
       // Check if adding this event would exceed payload size limit if configured
       if (this._payloadSizeLimit && this._bufferSize + eventSizeBytes > this._payloadSizeLimit) {
-        log.debug(() => `${this.constructor.name}
-        buffer size would exceed ${this._payloadSizeLimit} bytes, flushing first`)
+        log.debug('%s buffer size would exceed %d bytes, flushing first', this.constructor.name, this._payloadSizeLimit)
         this.flush()
       }
 
@@ -113,15 +112,16 @@ class BaseFFEWriter {
 
     const payload = this._encode(this.makePayload(events))
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `${this.constructor.name} flushing payload: ${safeJSONStringify(payload)}`)
 
     request(payload, this._requestOptions, (err, resp, code) => {
       if (err) {
-        log.error(`Failed to send events to ${this._baseUrl.href}${this._endpoint}: ${err.message}`)
+        log.error('Failed to send events to %s%s', this._baseUrl.href, this._endpoint, err)
       } else if (code >= 200 && code < 300) {
-        log.debug(() => `Successfully sent ${events.length} events`)
+        log.debug('Successfully sent %d events', events.length)
       } else {
-        log.warn(`Events request returned status ${code}`)
+        log.warn('Events request returned status %d', code)
       }
     })
   }
@@ -141,14 +141,14 @@ class BaseFFEWriter {
    */
   destroy () {
     if (this.#destroyer) {
-      log.debug(() => `Stopping ${this.constructor.name}`)
+      log.debug('Stopping %s', this.constructor.name)
       clearInterval(this._periodic)
       this.flush()
       globalThis[Symbol.for('dd-trace')].beforeExitHandlers.delete(this.#destroyer)
       this.#destroyer = undefined
 
       if (this._droppedEvents > 0) {
-        log.warn(`${this.constructor.name} dropped ${this._droppedEvents} events due to buffer overflow`)
+        log.warn('%s dropped %d events due to buffer overflow', this.constructor.name, this._droppedEvents)
       }
     }
   }

--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -138,7 +138,7 @@ class PeriodicMetricReader {
    */
   forceFlush () {
     if (this.#isShutdown) {
-      log.warn(`PeriodicMetricReader is shutdown. ${this.#droppedCount} measurement(s) were dropped`)
+      log.warn('PeriodicMetricReader is shutdown. %d measurement(s) were dropped', this.#droppedCount)
       return
     }
     this.#collectAndExport()
@@ -210,10 +210,8 @@ class PeriodicMetricReader {
     }
 
     if (this.#droppedCount > 0) {
-      log.warn(
-        `Metric queue exceeded limit (max: ${DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE}). ` +
-        `Dropping ${this.#droppedCount} measurements. `
-      )
+      log.warn('Metric queue exceeded limit (max: %d). Dropping %d measurements.',
+        DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE, this.#droppedCount)
       this.#droppedCount = 0
     }
 
@@ -308,9 +306,11 @@ class MetricAggregator {
       if (!metric) {
         if (metricsMap.size >= this.#maxBatchedQueueSize) {
           log.warn(
-            `Metric queue exceeded limit (max: ${this.#maxBatchedQueueSize}). ` +
-            `Dropping metric: ${metricKey}, value: ${value}. ` +
-            'Consider increasing OTEL_BSP_MAX_QUEUE_SIZE or decreasing OTEL_METRIC_EXPORT_INTERVAL.'
+            // eslint-disable-next-line @stylistic/max-len
+            'Metric queue exceeded limit (max: %d). Dropping metric: %s, value: %s. Consider increasing OTEL_BSP_MAX_QUEUE_SIZE or decreasing OTEL_METRIC_EXPORT_INTERVAL.',
+            this.#maxBatchedQueueSize,
+            metricKey,
+            value
           )
           continue
         }

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -101,7 +101,7 @@ class OtlpHttpExporterBase {
     })
 
     req.on('error', (error) => {
-      log.error(`Error sending OTLP ${this.signalType}:`, error)
+      log.error('Error sending OTLP %s:', this.signalType, error)
       resultCallback({ code: 1, error })
     })
 

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_transformer_base.js
@@ -28,8 +28,11 @@ class OtlpTransformerBase {
   constructor (resourceAttributes, protocol, signalType) {
     this.#resourceAttributes = this.transformAttributes(resourceAttributes)
     if (protocol === 'grpc') {
-      log.warn(`OTLP gRPC protocol is not supported for ${signalType}. ` +
-        'Defaulting to http/protobuf. gRPC protobuf support may be added in a future release.')
+      log.warn(
+        // eslint-disable-next-line @stylistic/max-len
+        'OTLP gRPC protocol is not supported for %s. Defaulting to http/protobuf. gRPC protobuf support may be added in a future release.',
+        signalType
+      )
       protocol = 'http/protobuf'
     }
     this.protocol = protocol

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -83,6 +83,7 @@ class TextMapPropagator {
       injectCh.publish({ spanContext, carrier })
     }
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Inject into carrier: ${JSON.stringify(pick(carrier, logKeys))}.`)
   }
 
@@ -95,6 +96,7 @@ class TextMapPropagator {
       extractCh.publish({ spanContext, carrier })
     }
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => {
       const keys = JSON.stringify(pick(carrier, logKeys))
       const styles = this._config.tracePropagationStyle.extract.join(', ')

--- a/packages/dd-trace/src/opentracing/propagation/text_map_dsm.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map_dsm.js
@@ -18,6 +18,7 @@ class DSMTextMapPropagator {
 
     this._injectDatadogDSMContext(ctx, carrier)
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Inject into carrier (DSM): ${JSON.stringify(pick(carrier, logKeys))}.`)
   }
 
@@ -28,6 +29,7 @@ class DSMTextMapPropagator {
 
     if (!dsmContext) return dsmContext
 
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
     log.debug(() => `Extract from carrier (DSM): ${JSON.stringify(pick(carrier, logKeys))}.`)
     return dsmContext
   }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -330,7 +330,7 @@ module.exports = class CiPlugin extends Plugin {
             const testSuite = span.meta[TEST_SUITE]
             const testSuiteSpan = this._testSuiteSpansByTestSuite.get(testSuite)
             if (!testSuiteSpan) {
-              log.warn(`Test suite span not found for test span with test suite ${testSuite}`)
+              log.warn('Test suite span not found for test span with test suite %s', testSuite)
               continue
             }
 

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -160,7 +160,8 @@ function unshallowRepository (parentOnly = false) {
     cachedExec('git', flags)
   } catch (err) {
     // If the local HEAD is a commit that has not been pushed to the remote, the above command will fail.
-    log.warn(`Git unshallow failed: ${flags.join(' ')}`)
+    // eslint-disable-next-line eslint-rules/eslint-log-printf-style
+    log.warn(() => `Git unshallow failed: ${flags.join(' ')}`)
     incrementCountMetric(
       TELEMETRY_GIT_COMMAND_ERRORS,
       { command: 'unshallow', errorType: err.code, exitCode: err.status || err.errno }
@@ -177,7 +178,8 @@ function unshallowRepository (parentOnly = false) {
       cachedExec('git', flags)
     } catch (err) {
       // If the CI is working on a detached HEAD or branch tracking hasn't been set up, the above command will fail.
-      log.warn(`Git unshallow failed again: ${flags.join(' ')}`)
+      // eslint-disable-next-line eslint-rules/eslint-log-printf-style
+      log.warn(() => `Git unshallow failed again: ${flags.join(' ')}`)
       incrementCountMetric(
         TELEMETRY_GIT_COMMAND_ERRORS,
         { command: 'unshallow', errorType: err.code, exitCode: err.status || err.errno }

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { format } = require('node:util')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
@@ -375,7 +376,7 @@ describe('OpenFeature Exposures Writer', () => {
 
       writer.destroy()
 
-      sinon.assert.calledWith(log.warn, sinon.match(/dropped 5 events/))
+      assert(log.warn.getCalls().some(call => /dropped 5 events/.test(format(...call.args))))
     })
 
     it('should prevent multiple destruction', () => {

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -4,6 +4,7 @@ process.setMaxListeners(50)
 
 const assert = require('assert')
 const http = require('http')
+const { format } = require('util')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
@@ -709,7 +710,7 @@ describe('OpenTelemetry Meter Provider', () => {
       assert.strictEqual(meterProvider.reader.exporter.transformer.protocol, 'http/protobuf')
       const expectedMsg = 'OTLP gRPC protocol is not supported for metrics. ' +
         'Defaulting to http/protobuf. gRPC protobuf support may be added in a future release.'
-      assert(warnSpy.calledWith(expectedMsg))
+      assert(warnSpy.getCalls().some(call => format(...call.args) === expectedMsg))
       warnSpy.restore()
     })
   })
@@ -807,13 +808,13 @@ describe('OpenTelemetry Meter Provider', () => {
         OTEL_METRIC_EXPORT_TIMEOUT: '0',
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE: '0',
       }, false)
-      assert(warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_BSP_SCHEDULE_DELAY/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_METRIC_EXPORT_INTERVAL/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_BSP_MAX_EXPORT_BATCH_SIZE/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_BSP_MAX_QUEUE_SIZE/)))
-      assert(!warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_EXPORTER_OTLP_TIMEOUT/)))
-      assert(!warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_METRIC_EXPORT_TIMEOUT/)))
-      assert(!warnSpy.calledWith(sinon.match(/Invalid value 0 for OTEL_EXPORTER_OTLP_METRICS_TIMEOUT/)))
+      assert(warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_BSP_SCHEDULE_DELAY/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_METRIC_EXPORT_INTERVAL/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_BSP_MAX_EXPORT_BATCH_SIZE/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_BSP_MAX_QUEUE_SIZE/.test(format(...call.args))))
+      assert(!warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_EXPORTER_OTLP_TIMEOUT/.test(format(...call.args))))
+      assert(!warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_METRIC_EXPORT_TIMEOUT/.test(format(...call.args))))
+      assert(!warnSpy.getCalls().some(call => /Invalid value 0 for OTEL_EXPORTER_OTLP_METRICS_TIMEOUT/.test(format(...call.args))))
     })
 
     it('rejects negative values for all configs', () => {
@@ -827,14 +828,14 @@ describe('OpenTelemetry Meter Provider', () => {
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE: '-1',
         OTEL_BSP_MAX_QUEUE_SIZE: '-1',
       }, false)
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_EXPORTER_OTLP_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_EXPORTER_OTLP_LOGS_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_EXPORTER_OTLP_METRICS_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_METRIC_EXPORT_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_METRIC_EXPORT_INTERVAL/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_BSP_SCHEDULE_DELAY/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_BSP_MAX_EXPORT_BATCH_SIZE/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value -1 for OTEL_BSP_MAX_QUEUE_SIZE/)))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_EXPORTER_OTLP_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_EXPORTER_OTLP_LOGS_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_EXPORTER_OTLP_METRICS_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_METRIC_EXPORT_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_METRIC_EXPORT_INTERVAL/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_BSP_SCHEDULE_DELAY/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_BSP_MAX_EXPORT_BATCH_SIZE/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value -1 for OTEL_BSP_MAX_QUEUE_SIZE/.test(format(...call.args))))
     })
 
     it('rejects values that are not numbers for all configs', () => {
@@ -848,14 +849,14 @@ describe('OpenTelemetry Meter Provider', () => {
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE: 'abc',
         OTEL_BSP_MAX_QUEUE_SIZE: 'xyz',
       }, false)
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_EXPORTER_OTLP_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_EXPORTER_OTLP_LOGS_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_EXPORTER_OTLP_METRICS_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_METRIC_EXPORT_TIMEOUT/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_METRIC_EXPORT_INTERVAL/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_BSP_SCHEDULE_DELAY/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_BSP_MAX_EXPORT_BATCH_SIZE/)))
-      assert(warnSpy.calledWith(sinon.match(/Invalid value NaN for OTEL_BSP_MAX_QUEUE_SIZE/)))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_EXPORTER_OTLP_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_EXPORTER_OTLP_LOGS_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_EXPORTER_OTLP_METRICS_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_METRIC_EXPORT_TIMEOUT/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_METRIC_EXPORT_INTERVAL/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_BSP_SCHEDULE_DELAY/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_BSP_MAX_EXPORT_BATCH_SIZE/.test(format(...call.args))))
+      assert(warnSpy.getCalls().some(call => /Invalid value NaN for OTEL_BSP_MAX_QUEUE_SIZE/.test(format(...call.args))))
     })
   })
 
@@ -891,9 +892,10 @@ describe('OpenTelemetry Meter Provider', () => {
       obsGauge.addCallback(() => {})
       obsGauge.addCallback('not a function')
       provider.reader.forceFlush()
-      assert(warnSpy.calledWith('PeriodicMetricReader is shutdown. 4 measurement(s) were dropped'))
+      assert(warnSpy.getCalls().some(call =>
+        format(...call.args) === 'PeriodicMetricReader is shutdown. 4 measurement(s) were dropped'))
       provider.reader.shutdown()
-      assert(warnSpy.calledWith('PeriodicMetricReader is already shutdown'))
+      assert(warnSpy.getCalls().some(call => format(...call.args) === 'PeriodicMetricReader is already shutdown'))
       warnSpy.restore()
     })
   })
@@ -908,7 +910,7 @@ describe('OpenTelemetry Meter Provider', () => {
       const validator = mockOtlpExport((metrics) => {
         assert.strictEqual(countMetrics(metrics), 3)
         assert(warnSpy.getCalls().some(call =>
-          call.args[0].includes('Metric queue exceeded limit (max: 3)')
+          format(...call.args).includes('Metric queue exceeded limit (max: 3)')
         ))
       })
 
@@ -932,7 +934,7 @@ describe('OpenTelemetry Meter Provider', () => {
       const validator = mockOtlpExport((metrics) => {
         if (++callCount === 1) {
           assert.strictEqual(countMetrics(metrics), 3)
-          assert(warnSpy.getCalls().some(call => call.args[0].includes('Metric queue exceeded limit')))
+          assert(warnSpy.getCalls().some(call => format(...call.args).includes('Metric queue exceeded limit')))
         }
       })
 
@@ -957,7 +959,7 @@ describe('OpenTelemetry Meter Provider', () => {
         if (!firstExport) return
         firstExport = false
         assert.strictEqual(countMetrics(metrics), 3)
-        assert(warnSpy.getCalls().some(call => call.args[0].includes('Metric queue exceeded limit')))
+        assert(warnSpy.getCalls().some(call => format(...call.args).includes('Metric queue exceeded limit')))
       })
 
       setupTracer(
@@ -990,11 +992,12 @@ describe('OpenTelemetry Meter Provider', () => {
         const counter1Metric = exportedMetrics.find(m => m.name === 'counter.sync')
         assert(counter1Metric, 'counter.sync should be exported')
         assert.strictEqual(counter1Metric.sum.dataPoints.length, DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE)
-        assert(warnSpy.getCalls().some(call =>
-          call.args[0].includes('Metric queue exceeded limit') &&
-          call.args[0].includes(`max: ${DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE}`) &&
-          call.args[0].includes('Dropping 2 measurements')
-        ))
+        assert(warnSpy.getCalls().some(call => {
+          const formatted = format(...call.args)
+          return formatted.includes('Metric queue exceeded limit') &&
+            formatted.includes(`max: ${DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE}`) &&
+            formatted.includes('Dropping 2 measurements')
+        }))
       })
 
       setupTracer({ DD_METRICS_OTEL_ENABLED: 'true', OTEL_METRIC_EXPORT_INTERVAL: '30000' }, false)


### PR DESCRIPTION
### What does this PR do?

Refactors logging statements across the codebase, where appropriate, to use printf-style formatting (`%d`, `%s` placeholders) instead of string concatenation and callback-style logging.

The changes also merge multi-line concatenated strings into single strings, eliminating runtime string concatenation overhead.

### Motivation

Improve performance by avoiding unnecessary string operations and provides more consistent logging patterns throughout the tracer.

### Additional notes

The new ESLint rule is written by AI, and I have only reviewed it briefly. But I think that's ok since it's just an ESLint rule.