### PR TITLE
fix(ws): handle removing untracked event  listeners

### DIFF
--- a/packages/datadog-instrumentations/src/ws.js
+++ b/packages/datadog-instrumentations/src/ws.js
@@ -95,7 +95,7 @@ function wrapListener (originalOn) {
 function removeListener (originalOff) {
   return function (eventName, handler) {
     if (eventName === 'message') {
-      const wrappedHandler = eventHandlerMap.get(handler)
+      const wrappedHandler = eventHandlerMap.get(handler) || handler
       return originalOff.call(this, eventName, wrappedHandler)
     }
     return originalOff.apply(this, arguments)

--- a/packages/datadog-plugin-ws/test/index.spec.js
+++ b/packages/datadog-plugin-ws/test/index.spec.js
@@ -95,6 +95,26 @@ describe('Plugin', () => {
           })
         })
 
+        it('should handle removing a listener that was never added', (done) => {
+          wsServer.on('connection', (ws) => {
+            connectionReceived = true
+            ws.send('test message')
+          })
+
+          const neverAddedHandler = () => {
+            throw new Error('this should never be called')
+          }
+
+          client.on('message', (msg) => {
+            assert.strictEqual(msg.toString(), 'test message')
+            done()
+          })
+
+          assert.doesNotThrow(() => {
+            client.off('message', neverAddedHandler)
+          })
+        })
+
         it('should do automatic instrumentation for server connections', done => {
           connectionReceived = false
 


### PR DESCRIPTION
When calling removeListener/off with a handler that was never added to the tracked handlers it will fall back to the original handler instead of passing undefined. This prevents errors when users remove listeners that weren't added.  


