### PR TITLE
fix(ws): transparent instrumentation + reduced memory retention

### DIFF
--- a/packages/datadog-instrumentations/src/ws.js
+++ b/packages/datadog-instrumentations/src/ws.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const tracingChannel = require('dc-polyfill').tracingChannel
+const { tracingChannel } = /** @type {import('node:diagnostics_channel')} */ (require('dc-polyfill'))
 
 const shimmer = require('../../datadog-shimmer')
 const {
@@ -15,7 +15,50 @@ const closeCh = tracingChannel('ws:close')
 const emitCh = channel('tracing:ws:server:connect:emit')
 // TODO: Add a error channel / handle error events properly.
 
-const eventHandlerMap = new WeakMap()
+/**
+ * @typedef {object} WebSocketServerPrototype
+ * @property {(...args: unknown[]) => unknown} handleUpgrade
+ * @property {(...args: unknown[]) => unknown} emit
+ */
+
+/**
+ * @typedef {{ prototype: WebSocketServerPrototype }} WebSocketServerClass
+ */
+
+/**
+ * @typedef {object} WebSocketPrototype
+ * @property {(...args: unknown[]) => unknown} send
+ * @property {(...args: unknown[]) => unknown} close
+ * @property {(...args: unknown[]) => unknown} setSocket
+ */
+
+/**
+ * @typedef {{ prototype: WebSocketPrototype }} WebSocketClass
+ */
+
+/**
+ * @typedef {object} ReceiverPrototype
+ * @property {(eventName: string, listener: (...args: unknown[]) => unknown) => unknown} on
+ * @property {(eventName: string, listener: (...args: unknown[]) => unknown) => unknown} addListener
+ */
+
+/**
+ * @typedef {{ prototype: ReceiverPrototype }} ReceiverClass
+ */
+
+/**
+ * @typedef {string | Buffer | ArrayBuffer | ArrayBufferView | Blob | Buffer[]} WebSocketMessageData
+ */
+
+/**
+ * @typedef {object} WebSocketInstance
+ * @property {(...args: unknown[]) => unknown} emit
+ * @property {(eventName: string) => number} [listenerCount]
+ * @property {{ _socket?: unknown } | undefined} [_sender]
+ * @property {unknown} [_receiver]
+ */
+
+let kWebSocketSymbol
 
 function wrapHandleUpgrade (handleUpgrade) {
   return function () {
@@ -41,7 +84,9 @@ function wrapHandleUpgrade (handleUpgrade) {
 
 function wrapSend (send) {
   return function wrappedSend (...args) {
-    if (!producerCh.start.hasSubscribers) return send.apply(this, arguments)
+    if (!producerCh.start.hasSubscribers) {
+      return send.apply(this, arguments)
+    }
 
     const [data, options, cb] = arguments
 
@@ -55,7 +100,9 @@ function wrapSend (send) {
 
 function createWrapEmit (emit) {
   return function (title, headers, req) {
-    if (!serverCh.start.hasSubscribers || title !== 'headers') return emit.apply(this, arguments)
+    if (!serverCh.start.hasSubscribers || title !== 'headers') {
+      return emit.apply(this, arguments)
+    }
 
     const ctx = { req }
     ctx.req.resStatus = headers[0].split(' ')[1]
@@ -70,35 +117,42 @@ function createWrapEmit (emit) {
   }
 }
 
-function createWrappedHandler (handler) {
-  return shimmer.wrapFunction(handler, originalHandler => function (data, binary) {
-    const byteLength = dataLength(data)
-
-    const ctx = { data, binary, socket: this._sender?._socket, byteLength }
-
-    return receiverCh.traceSync(originalHandler, ctx, this, data, binary)
-  })
-}
-
-function wrapListener (originalOn) {
-  return function (eventName, handler) {
-    if (eventName === 'message') {
-      // Prevent multiple wrapping of the same handler in case the user adds the listener multiple times
-      const wrappedHandler = eventHandlerMap.get(handler) ?? createWrappedHandler(handler)
-      eventHandlerMap.set(handler, wrappedHandler)
-      return originalOn.call(this, eventName, wrappedHandler)
+/**
+ * @param {Function} setSocket
+ * @returns {(...args: unknown[]) => unknown}
+ */
+/**
+ * @param {Function} on
+ * @returns {(...args: unknown[]) => unknown}
+ */
+function wrapReceiverOn (on) {
+  return function wrappedOn (eventName, handler) {
+    if (eventName !== 'message' || typeof handler !== 'function') {
+      return on.apply(this, arguments)
     }
-    return originalOn.apply(this, arguments)
-  }
-}
 
-function removeListener (originalOff) {
-  return function (eventName, handler) {
-    if (eventName === 'message') {
-      const wrappedHandler = eventHandlerMap.get(handler) || handler
-      return originalOff.call(this, eventName, wrappedHandler)
+    const wrappedHandler = function (data, isBinary) {
+      if (!receiverCh.start.hasSubscribers || !kWebSocketSymbol) {
+        return handler.call(this, data, isBinary)
+      }
+
+      const websocket = /** @type {WebSocketInstance | undefined} */ (this[kWebSocketSymbol])
+      // Avoid receive spans when no one listens to messages.
+      if (websocket && typeof websocket.listenerCount === 'function' && websocket.listenerCount('message') === 0) {
+        return handler.call(this, data, isBinary)
+      }
+      const socket = websocket?._sender?._socket
+      if (!socket) {
+        return handler.call(this, data, isBinary)
+      }
+
+      const byteLength = dataLength(/** @type {WebSocketMessageData} */ (data))
+      const ctx = { data, binary: isBinary, socket, byteLength }
+
+      return receiverCh.traceSync(handler, ctx, this, data, isBinary)
     }
-    return originalOff.apply(this, arguments)
+
+    return on.call(this, eventName, wrappedHandler)
   }
 }
 
@@ -120,7 +174,8 @@ addHook({
   name: 'ws',
   file: 'lib/websocket-server.js',
   versions: ['>=8.0.0'],
-}, ws => {
+}, moduleExports => {
+  const ws = /** @type {WebSocketServerClass} */ (moduleExports)
   shimmer.wrap(ws.prototype, 'handleUpgrade', wrapHandleUpgrade)
   shimmer.wrap(ws.prototype, 'emit', createWrapEmit)
   return ws
@@ -130,20 +185,39 @@ addHook({
   name: 'ws',
   file: 'lib/websocket.js',
   versions: ['>=8.0.0'],
-}, ws => {
+}, moduleExports => {
+  const ws = /** @type {WebSocketClass} */ (moduleExports)
   shimmer.wrap(ws.prototype, 'send', wrapSend)
   shimmer.wrap(ws.prototype, 'close', wrapClose)
-
-  // TODO: Do not wrap these methods. Instead, add a listener to the websocket instance when one is created.
-  // That way it avoids producing too many spans for the same websocket instance and less user code is impacted.
-  shimmer.wrap(ws.prototype, 'on', wrapListener)
-  shimmer.wrap(ws.prototype, 'addListener', wrapListener)
-  shimmer.wrap(ws.prototype, 'off', removeListener)
-  shimmer.wrap(ws.prototype, 'removeListener', removeListener)
 
   return ws
 })
 
+addHook({
+  name: 'ws',
+  file: 'lib/constants.js',
+  versions: ['>=8.0.0'],
+}, moduleExports => {
+  const constants = /** @type {{ kWebSocket?: symbol }} */ (moduleExports)
+  kWebSocketSymbol = constants.kWebSocket
+  return constants
+})
+
+addHook({
+  name: 'ws',
+  file: 'lib/receiver.js',
+  versions: ['>=8.0.0'],
+}, moduleExports => {
+  const Receiver = /** @type {ReceiverClass} */ (moduleExports)
+  shimmer.wrap(Receiver.prototype, 'on', wrapReceiverOn)
+  shimmer.wrap(Receiver.prototype, 'addListener', wrapReceiverOn)
+  return Receiver
+})
+
+/**
+ * @param {WebSocketMessageData} data
+ * @returns {number}
+ */
 function dataLength (data) {
   if (typeof data === 'string') {
     return Buffer.byteLength(data)
@@ -151,5 +225,18 @@ function dataLength (data) {
   if (data instanceof Blob) {
     return data.size
   }
-  return data?.length ?? 0
+  if (ArrayBuffer.isView(data)) {
+    return data.byteLength
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength
+  }
+  let total = 0
+  if (Array.isArray(data)) {
+    const chunks = /** @type {Buffer[]} */ (data)
+    for (const chunk of chunks) {
+      total += chunk.length
+    }
+  }
+  return total
 }

--- a/packages/datadog-plugin-ws/src/close.js
+++ b/packages/datadog-plugin-ws/src/close.js
@@ -28,7 +28,7 @@ class WSClosePlugin extends TracingPlugin {
     if (!socket?.spanContext) return
 
     const spanKind = isPeerClose ? 'consumer' : 'producer'
-    const spanTags = socket.spanContext.spanTags
+    const spanTags = socket.spanTags
     const path = spanTags['resource.name'].split(' ')[1]
     const service = this.serviceName({ pluginConfig: this.config })
     const span = this.startSpan(this.operationName(), {
@@ -76,14 +76,13 @@ class WSClosePlugin extends TracingPlugin {
       linkAttributes['dd.kind'] = isIncoming ? 'executed_by' : 'resuming'
 
       // Add span pointer for context propagation
-      if (this.config.traceWebsocketMessagesEnabled && ctx.socket.handshakeSpan) {
-        const handshakeSpan = ctx.socket.handshakeSpan
+      if (this.config.traceWebsocketMessagesEnabled && ctx.socket.spanContext) {
+        const handshakeContext = ctx.socket.spanContext
 
         // Only add span pointers if distributed tracing is enabled and handshake has distributed context
-        if (hasDistributedTracingContext(handshakeSpan, ctx.socket)) {
+        if (hasDistributedTracingContext(handshakeContext, ctx.socket)) {
           const counterType = isIncoming ? 'receiveCounter' : 'sendCounter'
           const counter = incrementWebSocketCounter(ctx.socket, counterType)
-          const handshakeContext = handshakeSpan.context()
 
           const ptrHash = buildWebSocketSpanPointerHash(
             handshakeContext._traceId,

--- a/packages/datadog-plugin-ws/src/producer.js
+++ b/packages/datadog-plugin-ws/src/producer.js
@@ -22,7 +22,7 @@ class WSProducerPlugin extends TracingPlugin {
     const { byteLength, socket, binary } = ctx
     if (!socket.spanContext) return
 
-    const spanTags = socket.spanContext.spanTags
+    const spanTags = socket.spanTags
     const path = spanTags['resource.name'].split(' ')[1]
     const opCode = binary ? 'binary' : 'text'
     const service = this.serviceName({ pluginConfig: this.config })
@@ -61,13 +61,12 @@ class WSProducerPlugin extends TracingPlugin {
       const linkAttributes = { 'dd.kind': 'resuming' }
 
       // Add span pointer for context propagation
-      if (this.config.traceWebsocketMessagesEnabled && ctx.socket.handshakeSpan) {
-        const handshakeSpan = ctx.socket.handshakeSpan
+      if (this.config.traceWebsocketMessagesEnabled && ctx.socket.spanContext) {
+        const handshakeContext = ctx.socket.spanContext
 
         // Only add span pointers if distributed tracing is enabled and handshake has distributed context
-        if (hasDistributedTracingContext(handshakeSpan, ctx.socket)) {
+        if (hasDistributedTracingContext(handshakeContext, ctx.socket)) {
           const counter = incrementWebSocketCounter(ctx.socket, 'sendCounter')
-          const handshakeContext = handshakeSpan.context()
 
           const ptrHash = buildWebSocketSpanPointerHash(
             handshakeContext._traceId,

--- a/packages/datadog-plugin-ws/src/receiver.js
+++ b/packages/datadog-plugin-ws/src/receiver.js
@@ -27,7 +27,7 @@ class WSReceiverPlugin extends TracingPlugin {
     const { byteLength, socket, binary } = ctx
     if (!socket.spanContext) return
 
-    const spanTags = socket.spanContext.spanTags
+    const spanTags = socket.spanTags
     const path = spanTags['resource.name'].split(' ')[1]
     const opCode = binary ? 'binary' : 'text'
 
@@ -72,13 +72,12 @@ class WSReceiverPlugin extends TracingPlugin {
       const linkAttributes = { 'dd.kind': 'executed_by' }
 
       // Add span pointer for context propagation
-      if (this.config.traceWebsocketMessagesEnabled && ctx.socket.handshakeSpan) {
-        const handshakeSpan = ctx.socket.handshakeSpan
+      if (this.config.traceWebsocketMessagesEnabled && ctx.socket.spanContext) {
+        const handshakeContext = ctx.socket.spanContext
 
         // Only add span pointers if distributed tracing is enabled and handshake has distributed context
-        if (hasDistributedTracingContext(handshakeSpan, ctx.socket)) {
+        if (hasDistributedTracingContext(handshakeContext, ctx.socket)) {
           const counter = incrementWebSocketCounter(ctx.socket, 'receiveCounter')
-          const handshakeContext = handshakeSpan.context()
 
           const ptrHash = buildWebSocketSpanPointerHash(
             handshakeContext._traceId,

--- a/packages/datadog-plugin-ws/src/server.js
+++ b/packages/datadog-plugin-ws/src/server.js
@@ -2,8 +2,12 @@
 
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing.js')
 const tags = require('../../../ext/tags.js')
-const { FORMAT_HTTP_HEADERS } = require('../../../ext/formats')
-const { initWebSocketMessageCounters } = require('./util')
+const { HTTP_HEADERS } = require('../../../ext/formats')
+const {
+  createWebSocketSpanContext,
+  hasTraceHeaders,
+  initWebSocketMessageCounters,
+} = require('./util')
 
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 
@@ -27,11 +31,12 @@ class WSServerPlugin extends TracingPlugin {
     const indexOfParam = url.indexOf('?')
     const route = indexOfParam === -1 ? url : url.slice(0, indexOfParam)
     const uri = `${protocol}//${host}${route}`
+    const resourceName = `${options.method} ${route}`
 
     ctx.args = { options }
 
     // Extract distributed tracing context from request headers
-    const childOf = this.tracer.extract(FORMAT_HTTP_HEADERS, req.headers)
+    const childOf = this.tracer.extract(HTTP_HEADERS, req.headers)
 
     const service = this.serviceName({ pluginConfig: this.config })
     const span = this.startSpan(this.operationName(), {
@@ -42,19 +47,19 @@ class WSServerPlugin extends TracingPlugin {
         'http.upgraded': 'websocket',
         'http.method': options.method,
         'http.url': uri,
-        'resource.name': `${options.method} ${route}`,
+        'resource.name': resourceName,
         'span.kind': 'server',
       },
 
     }, ctx)
     ctx.span = span
 
-    ctx.socket.spanContext = ctx.span._spanContext
-    ctx.socket.spanContext.spanTags = ctx.span._spanContext._tags
-    // Store the handshake span for use in message span pointers
-    ctx.socket.handshakeSpan = ctx.span
-    // Store the request headers for distributed tracing check
-    ctx.socket.requestHeaders = req.headers
+    ctx.socket.spanTags = {
+      'resource.name': resourceName,
+      'service.name': service,
+    }
+    ctx.socket.spanContext = createWebSocketSpanContext(ctx.span._spanContext)
+    ctx.socket.hasTraceHeaders = hasTraceHeaders(req.headers)
 
     // Initialize message counters for span pointers
     initWebSocketMessageCounters(ctx.socket)

--- a/packages/datadog-plugin-ws/src/util.js
+++ b/packages/datadog-plugin-ws/src/util.js
@@ -1,7 +1,45 @@
 'use strict'
 
+const DatadogSpanContext = require('../../dd-trace/src/opentracing/span_context')
+
+const TRACE_ID_UPPER_TAG = '_dd.p.tid'
+
 // WeakMap to store message counters per socket without mutating the socket object
 const socketCounters = new WeakMap()
+
+/**
+ * Creates a minimal span context for span links without retaining the full trace.
+ * @param {DatadogSpanContext} spanContext
+ * @returns {DatadogSpanContext | undefined}
+ */
+function createWebSocketSpanContext (spanContext) {
+  if (!spanContext) return
+
+  const traceIdUpper = spanContext._trace?.tags?.[TRACE_ID_UPPER_TAG]
+  const trace = traceIdUpper
+    ? { started: [], finished: [], tags: { [TRACE_ID_UPPER_TAG]: traceIdUpper } }
+    : undefined
+
+  return new DatadogSpanContext({
+    traceId: spanContext._traceId,
+    spanId: spanContext._spanId,
+    parentId: spanContext._parentId,
+    sampling: spanContext._sampling,
+    traceparent: spanContext._traceparent,
+    tracestate: spanContext._tracestate,
+    isRemote: spanContext._isRemote,
+    trace,
+  })
+}
+
+/**
+ * Returns whether distributed trace headers are present.
+ * @param {Record<string, string | string[] | undefined>} headers
+ * @returns {boolean}
+ */
+function hasTraceHeaders (headers) {
+  return !!(headers && (headers['x-datadog-trace-id'] || headers.traceparent))
+}
 
 /**
  * Initializes WebSocket message counters for a socket.
@@ -69,14 +107,12 @@ function buildWebSocketSpanPointerHash (handshakeTraceId, handshakeSpanId, count
  * A span has distributed tracing context if it has a parent context that was
  * extracted from headers (remote parent).
  *
- * @param {object} span - The handshake span
- * @param {object} socket - The WebSocket socket object
+ * @param {DatadogSpanContext} spanContext - The handshake span context
+ * @param {{ hasTraceHeaders?: boolean } | undefined} socket - The WebSocket socket object
  * @returns {boolean} True if the span has distributed tracing context
  */
-function hasDistributedTracingContext (span, socket) {
-  if (!span) return false
-  const context = span.context()
-  if (!context) return false
+function hasDistributedTracingContext (spanContext, socket) {
+  if (!spanContext) return false
 
   // Check if this span has a parent. If the parent was extracted from remote headers,
   // then this span is part of a distributed trace.
@@ -86,20 +122,16 @@ function hasDistributedTracingContext (span, socket) {
   //
   // For testing purposes, we also check if Datadog trace headers are present in the socket's
   // upgrade request, which indicates distributed tracing context was sent by the client.
-  if (context._parentId !== null) {
+  if (spanContext._parentId !== null) {
     return true
   }
 
-  // Fallback check: look for distributed tracing headers in the stored request headers
-  if (socket && socket.requestHeaders) {
-    const headers = socket.requestHeaders
-    return !!(headers['x-datadog-trace-id'] || headers.traceparent)
-  }
-
-  return false
+  return !!socket?.hasTraceHeaders
 }
 
 module.exports = {
+  createWebSocketSpanContext,
+  hasTraceHeaders,
   initWebSocketMessageCounters,
   incrementWebSocketCounter,
   buildWebSocketSpanPointerHash,

--- a/packages/datadog-plugin-ws/test/index.spec.js
+++ b/packages/datadog-plugin-ws/test/index.spec.js
@@ -8,6 +8,7 @@ const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+
 describe('Plugin', () => {
   let WebSocket
   let wsServer
@@ -82,16 +83,30 @@ describe('Plugin', () => {
 
           client.off('message', brokenHandler)
 
-          return agent.assertFirstTraceSpan({
-            name: 'websocket.send',
-            type: 'websocket',
-            resource: `websocket /${route}`,
-            service: 'some',
-            parent_id: 0n,
-            error: 0,
-            meta: {
-              'span.kind': 'producer',
-            },
+          return agent.assertSomeTraces(traces => {
+            let sendSpan
+            for (const trace of traces) {
+              for (const span of trace) {
+                if (span.name === 'websocket.send') {
+                  sendSpan = span
+                  break
+                }
+              }
+              if (sendSpan) break
+            }
+
+            assert.ok(sendSpan)
+            assertObjectContains(sendSpan, {
+              name: 'websocket.send',
+              type: 'websocket',
+              resource: `websocket /${route}`,
+              service: 'some',
+              parent_id: 0n,
+              error: 0,
+              meta: {
+                'span.kind': 'producer',
+              },
+            })
           })
         })
 
@@ -138,7 +153,7 @@ describe('Plugin', () => {
           client.on('error', done)
         })
 
-        it('should instrument message sending and not double wrap the same handler', done => {
+        it('should instrument message sending once per message', () => {
           wsServer.on('connection', ws => {
             connectionReceived = true
             ws.on('message', msg => {
@@ -147,33 +162,74 @@ describe('Plugin', () => {
             })
           })
 
+          /** @type {Promise<void>} */
+          const messageHandled = new Promise((resolve, reject) => {
+            let count = 0
+            const handler = (data) => {
+              assert.strictEqual(data.toString(), 'test message')
+              count++
+              if (count === 2) resolve()
+            }
+
+            client.on('message', handler)
+            client.on('message', handler)
+            client.on('error', reject)
+          })
+
           client.on('open', () => {
             client.send('test message')
           })
 
-          const brokenHandler = () => {
-            throw new Error('broken handler')
-          }
+          return messageHandled.then(() => agent.assertSomeTraces(traces => {
+            let receiveCount = 0
+            for (const trace of traces) {
+              for (const span of trace) {
+                if (span.name === 'websocket.receive') {
+                  receiveCount++
+                }
+              }
+            }
 
-          client.on('message', brokenHandler)
+            assert.strictEqual(receiveCount, 1)
+          }))
+        })
 
-          const handler = (data) => {
-            assert.strictEqual(data.toString(), 'test message')
-            done()
-          }
+        it('should handle addEventListener/removeEventListener', () => {
+          wsServer.on('connection', ws => {
+            ws.send('test message')
+          })
 
-          client.addListener('message', handler)
-          client.on('message', handler)
+          let onMessage
+          let onError
+          /** @type {Promise<void>} */
+          const messageHandled = new Promise((resolve, reject) => {
+            onMessage = event => {
+              assert.strictEqual(event.data, 'test message')
+              resolve()
+            }
+            onError = event => {
+              reject(event?.error ?? event)
+            }
+            client.addEventListener('message', onMessage)
+            client.addEventListener('error', onError)
+          })
 
-          const handlers = client.listeners('message')
+          return messageHandled.then(() => {
+            client.removeEventListener('message', onMessage)
+            client.removeEventListener('error', onError)
 
-          assert.strictEqual(handlers[0].name, brokenHandler.name)
-          assert.strictEqual(handlers[1], handlers[2])
-
-          client.removeListener('message', brokenHandler)
-          client.removeListener('message', handler)
-
-          client.on('error', done)
+            return agent.assertSomeTraces(traces => {
+              let sendCount = 0
+              for (const trace of traces) {
+                for (const span of trace) {
+                  if (span.name === 'websocket.send') {
+                    sendCount++
+                  }
+                }
+              }
+              assert.ok(sendCount > 0)
+            })
+          })
         })
 
         it('should instrument message receiving', () => {
@@ -187,13 +243,133 @@ describe('Plugin', () => {
             client.send('test message from client')
           })
 
+          const errorPromise = once(client, 'error')
+            .then(([error]) => {
+              throw error
+            })
+
           return Promise.race([
-            once(client, 'error'),
-            agent.assertFirstTraceSpan({
-              name: 'websocket.receive',
-              resource: `websocket /${route}`,
+            errorPromise,
+            agent.assertSomeTraces(traces => {
+              let receiveSpan
+              for (const trace of traces) {
+                for (const span of trace) {
+                  if (span.name === 'websocket.receive') {
+                    receiveSpan = span
+                    break
+                  }
+                }
+                if (receiveSpan) break
+              }
+
+              assert.ok(receiveSpan)
+              assertObjectContains(receiveSpan, {
+                name: 'websocket.receive',
+                resource: `websocket /${route}`,
+              })
             }),
           ])
+        })
+
+        it('should trace a receive span for each message', () => {
+          let totalReceiveCount = 0
+          /** @type {Promise<void>} */
+          const messageHandled = new Promise((resolve, reject) => {
+            wsServer.on('connection', (ws) => {
+              let count = 0
+              ws.on('message', (data) => {
+                assert.strictEqual(data.toString(), 'test message')
+                count++
+                if (count === 2) resolve()
+              })
+              ws.on('error', reject)
+            })
+            client.on('error', reject)
+          })
+
+          client.on('open', () => {
+            client.send('test message')
+            client.send('test message')
+          })
+
+          return messageHandled.then(() => agent.assertSomeTraces(traces => {
+            for (const trace of traces) {
+              for (const span of trace) {
+                if (span.name === 'websocket.receive') {
+                  totalReceiveCount++
+                }
+              }
+            }
+            assert.strictEqual(totalReceiveCount, 2)
+          }))
+        })
+
+        it('should trace binary message length and type', () => {
+          const payload = Buffer.from('binary payload')
+          /** @type {Promise<void>} */
+          const messageHandled = new Promise((resolve, reject) => {
+            wsServer.on('connection', (ws) => {
+              ws.on('message', (data) => {
+                assert.ok(Buffer.isBuffer(data))
+                assert.strictEqual(data.toString(), payload.toString())
+                resolve()
+              })
+              ws.on('error', reject)
+            })
+            client.on('error', reject)
+          })
+
+          client.on('open', () => {
+            client.send(payload)
+          })
+
+          return messageHandled.then(() => agent.assertSomeTraces(traces => {
+            let receiveSpan
+            for (const trace of traces) {
+              for (const span of trace) {
+                if (span.name === 'websocket.receive') {
+                  receiveSpan = span
+                  break
+                }
+              }
+              if (receiveSpan) break
+            }
+
+            assert.ok(receiveSpan)
+            assert.strictEqual(receiveSpan.meta['websocket.message.type'], 'binary')
+            assert.strictEqual(receiveSpan.metrics['websocket.message.length'], payload.length)
+          }))
+        })
+
+        it('should not trace received messages without listeners', () => {
+          /** @type {Promise<void>} */
+          const sendComplete = new Promise((resolve, reject) => {
+            wsServer.on('connection', ws => {
+              ws.send('test message', err => {
+                if (err) return reject(err)
+                resolve()
+              })
+            })
+            client.on('error', reject)
+          })
+
+          return sendComplete.then(() => agent.assertSomeTraces(traces => {
+            let receiveCount = 0
+            let sendCount = 0
+            for (const trace of traces) {
+              for (const span of trace) {
+                if (span.name === 'websocket.receive') {
+                  receiveCount++
+                }
+                if (span.name === 'websocket.send') {
+                  sendCount++
+                }
+              }
+            }
+
+            assert.strictEqual(receiveCount, 0)
+            assert.ok(sendCount > 0)
+          }))
         })
 
         it('should instrument connection close', () => {


### PR DESCRIPTION
The instrumentation was noticable by a user so far and hooked into the public event listener addition / removal. The event handlers being added could not be detected as not being the ones by the user.

That is improved here by using an internal only instrumentation that should also reduce overhead and needs less coordination between the additions and removals.

The plugin is refactored to have less memory retantion. So far, the whole span was attached and in case long living ws connections existed with a high load, the spans could add up without ever being freed. Now that tracking overhead is much lower and the span is created when needed.
