### PR TITLE
update pr template to not show warning in pr

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
-<ins>**Please make sure your changes are properly tested**!</ins>
+<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
+<!-- Please make sure your changes are properly tested -->
+<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 
 ### What does this PR do?
 <!-- A brief description of the change being made with this pull request. -->


### PR DESCRIPTION
<ins>**Please make sure your changes are properly tested**!</ins>

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update PR template to not show warning in PR.

### Motivation
<!-- What inspired you to submit this pull request? -->

Right now the warning is shown in the PR description visible publicly. It should only warn the author of the PR, it doesn't make sense to have it in the description.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


