### PR TITLE
chore(debugger): add name to worker thread

### DIFF
--- a/packages/dd-trace/src/debugger/index.js
+++ b/packages/dd-trace/src/debugger/index.js
@@ -102,6 +102,7 @@ function start (config, rcInstance) {
     worker = new Worker(
       join(__dirname, 'devtools_client', 'index.js'),
       {
+        name: 'dd-debugger',
         execArgv: [], // Avoid worker thread inheriting the `-r` command line argument
         env, // Avoid worker thread inheriting the `NODE_OPTIONS` environment variable (in case it contains `-r`)
         workerData: {


### PR DESCRIPTION
### What does this PR do?

Adds the `name` option to the debugger worker thread in `packages/dd-trace/src/debugger/index.js`, setting it to `'dd-debugger'`.

### Motivation

Improves observability and debugging experience by making the debugger worker thread identifiable in:
- Node.js inspector and debugger tools
- Process monitoring and inspection utilities
- Performance profiling tools

This makes it easier to identify and debug issues related to the Dynamic Instrumentation worker thread.

### Additional Notes

The `name` option was introduced in Node.js v18.16.0. Earlier versions (18.0.0-18.15.x) safely ignore this option without errors, maintaining backward compatibility with the project's minimum Node.js version requirement (18.0.0).
