### PR TITLE
chore(lint): run linting on the root of package folders

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,8 @@ const SRC_FILES = [
   'ci/**/*.mjs',
   'scripts/**/*.js',
   'scripts/**/*.mjs',
+  'packages/*/*.js',
+  'packages/*/*.mjs',
   'packages/*/src/**/*.js',
   'packages/*/src/**/*.mjs',
 ]

--- a/packages/datadog-code-origin/index.js
+++ b/packages/datadog-code-origin/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
+const { getEnvironmentVariable } = require('../dd-trace/src/config/helper')
 const { parseUserLandFrames } = require('../dd-trace/src/plugins/util/stacktrace')
 
 const ENTRY_SPAN_STACK_FRAMES_LIMIT = 1
-const EXIT_SPAN_STACK_FRAMES_LIMIT = Number(process.env._DD_CODE_ORIGIN_FOR_SPANS_EXIT_SPAN_MAX_USER_FRAMES) || 8
+const EXIT_SPAN_STACK_FRAMES_LIMIT =
+  Number(getEnvironmentVariable('_DD_CODE_ORIGIN_FOR_SPANS_EXIT_SPAN_MAX_USER_FRAMES')) || 8
 
 module.exports = {
   entryTags,


### PR DESCRIPTION
### What does this PR do?

- Include source code at the root of packages (`packages/*/*.{js|mjs}`) in the `dd-trace/src/all` ESLint group.
- Fix lint errors in those files that were not previously covered.

### Motivation

Most of the time the source code of a package is under a `src` directory (`packages/*/src`), but not always. If the source code was placed in the root of the package dir, it would previously have been excluded from our linting targeted the production code (code shipped as part of the dd-trace npm module).
