### PR TITLE
chore(types): fix TypeScript errors in the esbuild package

### DIFF
--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -66,6 +66,11 @@ function isESMBuild (build) {
 }
 
 function getGitMetadata () {
+  /**
+   * @type {object}
+   * @property {string | null} repositoryURL
+   * @property {string | null} commitSHA
+   */
   const gitMetadata = {
     repositoryURL: null,
     commitSHA: null,
@@ -253,7 +258,7 @@ ${build.initialOptions.banner.js}`
       }
 
       try {
-        const packageJson = JSON.parse(fs.readFileSync(pathToPackageJson).toString())
+        const packageJson = JSON.parse(fs.readFileSync(/** @type {string} */ (pathToPackageJson)).toString())
 
         const isESM = isESMFile(fullPathToModule, pathToPackageJson, packageJson)
         if (isESM && !interceptedESMModules.has(fullPathToModule)) {
@@ -403,5 +408,9 @@ function dotFriendlyResolve (path, directory, usesImportStatement) {
   if (path.startsWith('file://')) {
     path = fileURLToPath(path)
   }
-  return require.resolve(path, { paths: [directory], conditions })
+  return require.resolve(path, {
+    paths: [directory],
+    // @ts-expect-error - Node.js 22+ unofficially supports a conditions option
+    conditions,
+  })
 }

--- a/packages/datadog-esbuild/src/utils.js
+++ b/packages/datadog-esbuild/src/utils.js
@@ -59,7 +59,11 @@ function resolve (specifier, context) {
     specifier = fileURLToPath(specifier)
   }
 
-  const resolved = require.resolve(specifier, { conditions, paths: [fileURLToPath(context.parentURL)] })
+  const resolved = require.resolve(specifier, {
+    paths: [fileURLToPath(context.parentURL)],
+    // @ts-expect-error - Node.js 22+ unofficially supports a conditions option
+    conditions,
+  })
 
   return {
     url: pathToFileURL(resolved),
@@ -79,12 +83,12 @@ function getSource (url, { format }) {
  *
  * @param {object} moduleData
  * @param {string} moduleData.path
- * @param {boolean} moduleData.internal
+ * @param {boolean} [moduleData.internal = false]
  * @param {object} moduleData.context
- * @param {boolean} moduleData.excludeDefault
+ * @param {boolean} [moduleData.excludeDefault = false]
  * @returns {Promise<Map>}
  */
-async function processModule ({ path, internal, context, excludeDefault }) {
+async function processModule ({ path, internal = false, context, excludeDefault = false }) {
   let exportNames, srcUrl
   if (internal) {
     // we can not read and parse of internal modules


### PR DESCRIPTION
### What does this PR do?

As the title says...

### Motivation

Type-safe code is better
