### PR TITLE
feat(esbuild): add DI worker bundling support

### DIFF
--- a/integration-tests/esbuild/build-and-test-debugger-worker.js
+++ b/integration-tests/esbuild/build-and-test-debugger-worker.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+'use strict'
+
+/* eslint-disable no-console */
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const { spawnSync } = require('node:child_process')
+
+const esbuild = require('esbuild')
+const ddPlugin = require('../../esbuild')
+
+const MAIN_SCRIPT = './di-worker-out.js'
+const WORKER_SCRIPT = './dd-trace-debugger-worker.cjs'
+
+// Create a minimal test app that initializes dd-trace with DI enabled
+const testAppCode = `
+'use strict';
+const tracer = require('../../').init();
+
+// Just verify the process can start with DI enabled
+console.log('DI worker test: app started successfully');
+
+// Give it a moment to initialize, then exit cleanly
+setTimeout(() => {
+  process.exit(0);
+}, 100);
+`
+
+// Write the test app to a temp file
+const testAppPath = './di-test-app.js'
+fs.writeFileSync(testAppPath, testAppCode)
+
+esbuild.build({
+  entryPoints: [testAppPath],
+  bundle: true,
+  outfile: MAIN_SCRIPT,
+  plugins: [ddPlugin],
+  platform: 'node',
+  target: ['node18'],
+  external: [
+    // dead code paths introduced by knex if required
+    'pg',
+    'mysql2',
+    'better-sqlite3',
+    'sqlite3',
+    'mysql',
+    'oracledb',
+    'pg-query-stream',
+    'tedious',
+    '@yaacovcr/transform',
+  ],
+}).then(() => {
+  // Verify the worker bundle was emitted
+  assert.ok(
+    fs.existsSync(WORKER_SCRIPT),
+    `Expected DI worker bundle to exist at ${WORKER_SCRIPT}`
+  )
+
+  // Verify the worker file is a valid CJS file with substantial content
+  const workerContent = fs.readFileSync(WORKER_SCRIPT, 'utf8')
+  assert.ok(
+    workerContent.length > 1000,
+    'DI worker bundle should have substantial content'
+  )
+  assert.ok(
+    workerContent.includes('Debugger.paused') || workerContent.includes('debugger'),
+    'DI worker bundle should contain debugger-related code'
+  )
+
+  // Verify the patched dd-trace lookup is present in the worker
+  assert.ok(
+    workerContent.includes('global._ddtrace'),
+    'DI worker bundle should have patched dd-trace lookup using global._ddtrace'
+  )
+
+  // Verify the main bundle references the worker file
+  const mainContent = fs.readFileSync(MAIN_SCRIPT, 'utf8')
+  assert.ok(
+    mainContent.includes('dd-trace-debugger-worker.cjs'),
+    'Main bundle should reference the DI worker bundle'
+  )
+
+  console.log('DI worker bundle emitted correctly')
+
+  // Run the bundled app with DI enabled to verify it starts without crashing
+  // Note: The app will exit quickly since we're just testing startup
+  const { status, stderr } = spawnSync('node', [MAIN_SCRIPT], {
+    env: {
+      ...process.env,
+      DD_TRACE_DEBUG: 'true',
+      DD_DYNAMIC_INSTRUMENTATION_ENABLED: 'true',
+    },
+    encoding: 'utf8',
+    timeout: 10000,
+  })
+
+  // Log stderr for debugging if there's an issue
+  if (stderr.length) {
+    console.error('stderr:', stderr)
+  }
+
+  // The app should exit cleanly (status 0)
+  // Note: DI may not fully initialize in this short-running test, but the process should not crash
+  if (status !== 0) {
+    throw new Error(`Generated script exited with unexpected exit code: ${status}`)
+  }
+
+  console.log('DI worker test: app ran successfully with DI enabled')
+  console.log('ok')
+}).catch((err) => {
+  console.error(err)
+  process.exit(1)
+}).finally(() => {
+  fs.rmSync(testAppPath, { force: true })
+  fs.rmSync(MAIN_SCRIPT, { force: true })
+  fs.rmSync(WORKER_SCRIPT, { force: true })
+})

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -61,6 +61,7 @@ esbuildVersions.forEach((version) => {
         process.exit(1)
       } finally {
         rmSync('./out.js', { force: true })
+        rmSync('./dd-trace-debugger-worker.cjs', { force: true })
       }
     })
 
@@ -106,11 +107,18 @@ esbuildVersions.forEach((version) => {
       })
     })
 
+    it('emits debugger worker bundle and allows LD/DI-enabled startup', () => {
+      execSync('node ./build-and-test-debugger-worker.js', {
+        timeout,
+      })
+    })
+
     describe('ESM', () => {
       afterEach(() => {
         rmSync('./out.mjs', { force: true })
         rmSync('./out.js', { force: true })
         rmSync('./basic-test.mjs', { force: true })
+        rmSync('./dd-trace-debugger-worker.cjs', { force: true })
       })
 
       it('works', () => {


### PR DESCRIPTION
### What does this PR do?

Add support for bundling the Live Debugging (LD) / Dynamic Instrumentation (DI) worker when building applications with esbuild. This enables LD/DI features to work in bundled applications.
    
The plugin now:
- Emits a separate worker bundle (`dd-trace-debugger-worker.cjs`) alongside the main application bundle
- Patches the debugger module to reference the emitted worker
- Patches the worker's dd-trace lookup to use `global._ddtrace` for bundler compatibility

### Motivation

Without this, LD/DI would not work in a bundled application, as the worker thread would emit an `error` event when started, saying it couldn't find the worker file on disk.

