### PR TITLE
chore(profiler): Upgrade pprof-nodejs to 5.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@datadog/native-iast-taint-tracking": "4.1.0",
     "@datadog/native-metrics": "3.1.1",
     "@datadog/openfeature-node-server": "^0.3.3",
-    "@datadog/pprof": "5.13.2",
+    "@datadog/pprof": "5.13.3",
     "@datadog/wasm-js-rewriter": "5.0.1",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/api-logs": "<1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,10 +182,10 @@
   dependencies:
     "@datadog/flagging-core" "0.3.3"
 
-"@datadog/pprof@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.13.2.tgz#9361809e712417e04c21e7f7ea239bfb3513c358"
-  integrity sha512-Th8u7pvoguTfbUx/mlZLHD9TxFCHO+wRAvlEaYFAYAmMvbPLww4YowvTy1UMvpi8LbUbwil3Fo8rKCrilvXHhQ==
+"@datadog/pprof@5.13.3":
+  version "5.13.3"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.13.3.tgz#7080d38b6c05736cb8a027835707ee4ee43eedf3"
+  integrity sha512-G25IicP7pc5CXmAfVz7nrIERsKK9hvPz6p7xsLTUwG4Qs+Zgd5KFedKCVsnvNasLc7l7OXQ6839ajowgQLWTyw==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Updates pprof-nodejs to 5.13.3

Fixes: https://github.com/DataDog/dd-trace-js/issues/7355