### PR TITLE
Improve graphql instrumentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,6 +407,8 @@ You can also run the tests for multiple plugins at once by separating them with 
 PLUGINS="amqplib|bluebird" yarn test:plugins
 ```
 
+The necessary shell commands for the setup can also be executed at once by the `yarn env` script.
+
 ### Other Unit Tests
 
 There are several types of unit tests, for various types of components. The

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -177,8 +177,8 @@ function wrapExecute (execute) {
 
       return startExecuteCh.runStores(ctx, () => {
         if (schema) {
-          wrapFields(schema._queryType)
-          wrapFields(schema._mutationType)
+          wrapFields(schema.getQueryType())
+          wrapFields(schema.getMutationType())
         }
 
         contexts.set(contextValue, ctx)
@@ -295,9 +295,7 @@ function wrapFields (type) {
 
   patchedTypes.add(type)
 
-  for (const key of Object.keys(type._fields)) {
-    const field = type._fields[key]
-
+  for (const field of Object.values(type.getFields())) {
     wrapFieldResolve(field)
     wrapFieldType(field)
   }
@@ -313,6 +311,7 @@ function wrapFieldType (field) {
 
   let unwrappedType = field.type
 
+  // see graphql.getNamedType()
   while (unwrappedType.ofType) {
     unwrappedType = unwrappedType.ofType
   }
@@ -321,8 +320,7 @@ function wrapFieldType (field) {
 }
 
 function finishResolvers ({ fields }) {
-  for (const key of Object.keys(fields).reverse()) {
-    const field = fields[key]
+  for (const field of Object.values(fields).reverse()) {
     field.ctx.finishTime = field.finishTime
     field.ctx.field = field
     if (field.error) {

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -43,7 +43,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
     const span = this.startSpan('graphql.resolve', {
       service: this.config.service,
-      resource: `${info.fieldName}:${info.returnType}`,
+      resource: `${info.parentType}.${info.fieldName}`, // https://spec.graphql.org/draft/#sec-Schema-Coordinates
       childOf,
       type: 'graphql',
       meta: {

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -49,7 +49,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
       meta: {
         'graphql.field.name': info.fieldName,
         'graphql.field.path': computedPathString,
-        'graphql.field.type': info.returnType.name,
+        'graphql.field.type': info.returnType.toString(),
         'graphql.source': source,
       },
     }, fieldCtx)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -604,6 +604,7 @@ describe('Plugin', () => {
               assert.strictEqual(friends.name, 'graphql.resolve')
               assert.strictEqual(friends.resource, 'friends:[Human]')
               assert.strictEqual(friends.meta['graphql.field.path'], 'friends')
+              assert.strictEqual(friends.meta['graphql.field.type'], '[Human]')
               assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
 
               assert.strictEqual(friendsName.name, 'graphql.resolve')
@@ -614,6 +615,7 @@ describe('Plugin', () => {
               assert.strictEqual(pets.name, 'graphql.resolve')
               assert.strictEqual(pets.resource, 'pets:[Pet!]')
               assert.strictEqual(pets.meta['graphql.field.path'], 'friends.*.pets')
+              assert.strictEqual(pets.meta['graphql.field.type'], '[Pet!]')
               assert.strictEqual(pets.parent_id.toString(), friends.span_id.toString())
 
               assert.strictEqual(petsName.name, 'graphql.resolve')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -430,7 +430,7 @@ describe('Plugin', () => {
               assert.strictEqual(spans.length, 2)
               assert.strictEqual(spans[1].service, 'test')
               assert.strictEqual(spans[1].name, 'graphql.resolve')
-              assert.strictEqual(spans[1].resource, 'hello:String')
+              assert.strictEqual(spans[1].resource, 'RootQueryType.hello')
               assert.strictEqual(spans[1].type, 'graphql')
               assert.strictEqual(spans[1].error, 0)
               assert.ok(Number(spans[1].duration) > 0)
@@ -473,13 +473,13 @@ describe('Plugin', () => {
                     continue
                   }
 
-                  if (span.resource === 'fastAsyncField:String') {
+                  if (span.resource === 'Human.fastAsyncField') {
                     assert.ok(fastAsyncTime < slowAsyncTime)
                     foundFastFieldSpan = true
-                  } else if (span.resource === 'slowAsyncField:String') {
+                  } else if (span.resource === 'Human.slowAsyncField') {
                     assert.ok(slowAsyncTime < syncTime)
                     foundSlowFieldSpan = true
-                  } else if (span.resource === 'syncField:String') {
+                  } else if (span.resource === 'Human.syncField') {
                     assert.ok(syncTime > slowAsyncTime)
                     foundSyncFieldSpan = true
                   }
@@ -542,31 +542,31 @@ describe('Plugin', () => {
               assert.strictEqual(execute.error, 0)
 
               assert.strictEqual(human.name, 'graphql.resolve')
-              assert.strictEqual(human.resource, 'human:Human')
+              assert.strictEqual(human.resource, 'RootQueryType.human')
               assert.strictEqual(human.error, 0)
               assert.strictEqual(human.meta['graphql.field.path'], 'human')
               assert.strictEqual(human.parent_id.toString(), execute.span_id.toString())
 
               assert.strictEqual(humanName.name, 'graphql.resolve')
-              assert.strictEqual(humanName.resource, 'name:String')
+              assert.strictEqual(humanName.resource, 'Human.name')
               assert.strictEqual(humanName.error, 0)
               assert.strictEqual(humanName.meta['graphql.field.path'], 'human.name')
               assert.strictEqual(humanName.parent_id.toString(), human.span_id.toString())
 
               assert.strictEqual(address.name, 'graphql.resolve')
-              assert.strictEqual(address.resource, 'address:Address')
+              assert.strictEqual(address.resource, 'Human.address')
               assert.strictEqual(address.error, 0)
               assert.strictEqual(address.meta['graphql.field.path'], 'human.address')
               assert.strictEqual(address.parent_id.toString(), human.span_id.toString())
 
               assert.strictEqual(addressCivicNumber.name, 'graphql.resolve')
-              assert.strictEqual(addressCivicNumber.resource, 'civicNumber:String')
+              assert.strictEqual(addressCivicNumber.resource, 'Address.civicNumber')
               assert.strictEqual(addressCivicNumber.error, 0)
               assert.strictEqual(addressCivicNumber.meta['graphql.field.path'], 'human.address.civicNumber')
               assert.strictEqual(addressCivicNumber.parent_id.toString(), address.span_id.toString())
 
               assert.strictEqual(addressStreet.name, 'graphql.resolve')
-              assert.strictEqual(addressStreet.resource, 'street:String')
+              assert.strictEqual(addressStreet.resource, 'Address.street')
               assert.strictEqual(addressStreet.error, 0)
               assert.strictEqual(addressStreet.meta['graphql.field.path'], 'human.address.street')
               assert.strictEqual(addressStreet.parent_id.toString(), address.span_id.toString())
@@ -602,24 +602,24 @@ describe('Plugin', () => {
               assert.strictEqual(execute.name, expectedSchema.server.opName)
 
               assert.strictEqual(friends.name, 'graphql.resolve')
-              assert.strictEqual(friends.resource, 'friends:[Human]')
+              assert.strictEqual(friends.resource, 'RootQueryType.friends')
               assert.strictEqual(friends.meta['graphql.field.path'], 'friends')
               assert.strictEqual(friends.meta['graphql.field.type'], '[Human]')
               assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
 
               assert.strictEqual(friendsName.name, 'graphql.resolve')
-              assert.strictEqual(friendsName.resource, 'name:String')
+              assert.strictEqual(friendsName.resource, 'Human.name')
               assert.strictEqual(friendsName.meta['graphql.field.path'], 'friends.*.name')
               assert.strictEqual(friendsName.parent_id.toString(), friends.span_id.toString())
 
               assert.strictEqual(pets.name, 'graphql.resolve')
-              assert.strictEqual(pets.resource, 'pets:[Pet!]')
+              assert.strictEqual(pets.resource, 'Human.pets')
               assert.strictEqual(pets.meta['graphql.field.path'], 'friends.*.pets')
               assert.strictEqual(pets.meta['graphql.field.type'], '[Pet!]')
               assert.strictEqual(pets.parent_id.toString(), friends.span_id.toString())
 
               assert.strictEqual(petsName.name, 'graphql.resolve')
-              assert.strictEqual(petsName.resource, 'name:String')
+              assert.strictEqual(petsName.resource, 'Pet.name')
               assert.strictEqual(petsName.meta['graphql.field.path'], 'friends.*.pets.*.name')
               assert.strictEqual(petsName.parent_id.toString(), pets.span_id.toString())
             })
@@ -767,7 +767,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(spans[4].service, 'test')
               assert.strictEqual(spans[4].name, 'graphql.resolve')
-              assert.strictEqual(spans[4].resource, 'hello:String')
+              assert.strictEqual(spans[4].resource, 'RootQueryType.hello')
             })
             .then(done)
             .catch(done)
@@ -1608,17 +1608,17 @@ describe('Plugin', () => {
               assert.strictEqual(execute.name, expectedSchema.server.opName)
 
               assert.strictEqual(friends.name, 'graphql.resolve')
-              assert.strictEqual(friends.resource, 'friends:[Human]')
+              assert.strictEqual(friends.resource, 'RootQueryType.friends')
               assert.strictEqual(friends.meta['graphql.field.path'], 'friends')
               assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
 
               assert.strictEqual(friend0Name.name, 'graphql.resolve')
-              assert.strictEqual(friend0Name.resource, 'name:String')
+              assert.strictEqual(friend0Name.resource, 'Human.name')
               assert.strictEqual(friend0Name.meta['graphql.field.path'], 'friends.0.name')
               assert.strictEqual(friend0Name.parent_id.toString(), friends.span_id.toString())
 
               assert.strictEqual(friend1Name.name, 'graphql.resolve')
-              assert.strictEqual(friend1Name.resource, 'name:String')
+              assert.strictEqual(friend1Name.resource, 'Human.name')
               assert.strictEqual(friend1Name.meta['graphql.field.path'], 'friends.1.name')
               assert.strictEqual(friend1Name.parent_id.toString(), friends.span_id.toString())
             })
@@ -1852,7 +1852,7 @@ describe('Plugin', () => {
                 assert.ok(!('graphql.source' in spans[0].meta))
 
                 assert.strictEqual(spans[1].name, 'graphql.resolve')
-                assert.strictEqual(spans[1].resource, 'hello:String')
+                assert.strictEqual(spans[1].resource, 'RootQueryType.hello')
 
                 assert.strictEqual(spans[2].name, 'graphql.validate')
                 assert.ok(!('graphql.source' in spans[2].meta))

--- a/plugin-env
+++ b/plugin-env
@@ -13,7 +13,7 @@ if [ -z "$plugin_name" ]; then
   node - << EOF
     const fs=require('fs');
     const yaml = require('yaml');
-    const pluginsData = fs.readFileSync('.github/workflows/plugins.yml', 'utf8');
+    const pluginsData = fs.readFileSync('.github/workflows/apm-integrations.yml', 'utf8');
     const env=Object.keys(yaml.parse(pluginsData).jobs);
     console.log(...env);
 EOF
@@ -36,7 +36,7 @@ fi
 read -r PLUGINS SERVICES <<<$(node - << EOF
 const fs=require('fs');
 const yaml = require('yaml');
-const pluginsData = fs.readFileSync('.github/workflows/plugins.yml', 'utf8');
+const pluginsData = fs.readFileSync('.github/workflows/apm-integrations.yml', 'utf8');
 const { PLUGINS, SERVICES } = yaml.parse(pluginsData).jobs['$plugin_name'].env;
 console.log(PLUGINS || '', SERVICES || '')
 EOF


### PR DESCRIPTION
### What does this PR do?

* Change `resource_name` of `graphql.resolve` spans to consist of parent type and field name, making it a [schema coordinate](https://spec.graphql.org/draft/#sec-Schema-Coordinates). This uniquely identifies the field in the schema - where previously `name:String` was rather useless, it now properly distinguishes a `Human.name` from a `Pet.name`
  This imo resolves #2398, even though it does not add an extra `@graphql.field.parentType` tag as originally suggested there.
* Make `@graphql.field.type` work with non-nullable and list types

### Motivation

I was about to [patch](https://www.npmjs.com/package/patch-package) the integration for our deployment to make the traces more useful when I noticed that other people share the same issue.

### Additional Notes

I'm not sure if this is considered a breaking change ("*changing the contents or value of any existing data being reported*") and requires \<semver-major\>?
Please let me know when I should rebase or split up the PR.