### PR TITLE
fix(ts): childOf not being able to be set to null

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -435,6 +435,7 @@ span = tracer.startSpan('test', {
   }
 });
 span = tracer.startSpan('test', { childOf: null })
+span = tracer.startSpan('test', { integrationName: 'testIntegration' })
 
 tracer.trace('test', () => {})
 tracer.trace('test', { tags: { foo: 'bar' } }, () => {})

--- a/index.d.ts
+++ b/index.d.ts
@@ -301,7 +301,11 @@ declare namespace tracer {
    * exists in the current async context. If 'undefined' the parent will be inferred from the
    * existing async context.
    */
-    childOf?: opentracing.Span | opentracing.SpanContext | null
+    childOf?: opentracing.Span | opentracing.SpanContext | null;
+    /**
+     * Optional name of the integration that crated this span.
+     */
+    integrationName?: string;
   };
   export { Tracer };
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds the proper TS declaration to allow TypeScript users to set childOf to null.

### Motivation
<!-- What inspired you to submit this pull request? -->
Allow users to set childOf to null, without this users can't create a root span that doesn't inferr its parent from the active async context.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
fixes #6077 

