### PR TITLE
test(langchain): update langchain tests to test correct peer dependency versions

### DIFF
--- a/packages/dd-trace/test/plugins/externals.json
+++ b/packages/dd-trace/test/plugins/externals.json
@@ -351,6 +351,11 @@
     {
       "name": "@langchain/classic",
       "versions": [">=1.0"]
+    },
+    {
+      "name": "@langchain/core",
+      "versions": [">=0.1"],
+      "dep": true
     }
   ],
   "ldapjs": [


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Updates `externals.json` to resolve langchain test issues when updating the dependency versions in dependabot updates.

### Motivation
Unblock dependabot updates

### Additional Notes
This was happening because without this qualifier, we were not installing the correct peer dependency version of `@langchain/core`

By adding in the following debug logs

```js
console.log('actual langchainCore version', realVersion)
console.log('langchainAnthropic version', require(`../../../versions/@langchain/anthropic@${version}`).version())
console.log('langchainCore version for langchainAnthropic', require(`../../../versions/@langchain/anthropic@${version}`).get('@langchain/core/package.json').version)
```

We see that, before the fixes, we get mismatched versions
```
actual langchainCore version 1.1.19
langchainAnthropic version 1.3.15
langchainCore version for langchainAnthropic 0.1.63
```

However, after the fix, we see everything is OK
```
actual langchainCore version 1.1.19
langchainAnthropic version 1.3.15
langchainCore version for langchainAnthropic 1.1.19
```

This was all verified by checkout out to the dependabot branch and making sure the changes applies actually resolved the issue



