### PR TITLE
chore(appsec): add retry to integration test setup

### DIFF
--- a/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
+++ b/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
@@ -16,7 +16,7 @@ describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
 
     appDir = path.join(cwd, 'appsec', 'iast-stack-traces-ts-with-sourcemaps')
 
-    childProcess.execSync('yarn', { cwd })
+    childProcess.execSync('yarn || yarn', { cwd })
     childProcess.execSync('npx tsc', {
       cwd: appDir,
     })


### PR DESCRIPTION
### What does this PR do?
Add one immediate retry to the `yarn` command used in one of the IAST integ test.

### Motivation
It was a bit flaky
