### PR TITLE
test: use more lenient time window for runtime metric time window

### DIFF
--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -527,8 +527,8 @@ function createGarbage (count = 50) {
               }
               if (metric === 'runtime.node.cpu.total') {
                 assert(
-                  // Subtracting 0.02 since lower numbers can happen due to rounding issues.
-                  number >= expected - 0.02 && number <= expected + 1,
+                  // Subtracting 0.1 for time-window/baseline alignment numbers and due to rounding issues.
+                  number >= expected - 0.1 && number <= expected + 1,
                   `${metric} sanity check failed (increase CPU load above with more ticks): ${number} ${expected}`
                 )
                 totalPercent = number


### PR DESCRIPTION
Not only rounding issues can happen, the overall measured time window might sometimes slightly deviate. The more lenient range should account for that.