### PR TITLE
Extend Next.js test coverage to v16

### DIFF
--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -131,7 +131,11 @@ describe('Plugin', function () {
         if (NODE_MAJOR < 24) {
           buildEnv.NODE_OPTIONS = '--openssl-legacy-provider'
         }
-        execSync('yarn exec next build', {
+        // Next.js 16+ uses Turbopack by default, force webpack to avoid worker_threads bug
+        const buildCmd = satisfies(realVersion, '>=16.0.0')
+          ? 'yarn exec next build --webpack'
+          : 'yarn exec next build'
+        execSync(buildCmd, {
           cwd,
           env: buildEnv,
           stdio: ['pipe', 'ignore', 'pipe'],

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict')
 
 const { execSync } = require('child_process')
+const { satisfies } = require('semver')
 const {
   FakeAgent,
   curlAndAssertMessage,
@@ -39,7 +40,11 @@ describe('esm', () => {
       if (NODE_MAJOR < 24) {
         buildEnv.NODE_OPTIONS = '--openssl-legacy-provider'
       }
-      execSync('yarn exec next build', {
+      // Next.js 16+ uses Turbopack by default, force webpack to avoid worker_threads bug
+      const buildCmd = satisfies(version, '>=16.0.0')
+        ? 'yarn exec next build --webpack'
+        : 'yarn exec next build'
+      execSync(buildCmd, {
         cwd: sandboxCwd(),
         env: buildEnv,
       })

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -55,9 +55,4 @@ if (satisfies(VERSION, '>=13.3.0 <13.4.0')) {
   config.experimental.appDir = true
 }
 
-// Next.js 16 Turbopack has worker_threads bug - force webpack
-if (satisfies(VERSION, '>=16.0.0')) {
-  config.experimental.turbo = false
-}
-
 module.exports = config


### PR DESCRIPTION
### What does this PR do?
Extends Next.js plugin test coverage from `<15.4.1` to `<17`, adding support for Next.js 16.x versions to assert quantization of resource names works for nextjs 16

### Motivation
Customer escalation ([APMS-18410](https://datadoghq.atlassian.net/browse/APMS-18410)) reported high-cardinality resource names with Next.js 16.1.5. Our test coverage only went up to 15.4.1, leaving Next.js 16 untested

[APMS-18410]: https://datadoghq.atlassian.net/browse/APMS-18410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Notes
This pr fixes quantization when using OTEL mode: https://github.com/DataDog/dd-trace-js/pull/7000