### PR TITLE
Revert "fix(startup-log): emit immediately after init and send to stderr"

### DIFF
--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -3,7 +3,7 @@
 const { inspect } = require('util')
 
 const request = require('../common/request')
-const { logAgentError } = require('../../startup-log')
+const { startupLog } = require('../../startup-log')
 const runtimeMetrics = require('../../runtime_metrics')
 const log = require('../../log')
 const tracerVersion = require('../../../../../package.json').version
@@ -30,10 +30,8 @@ class AgentWriter extends BaseWriter {
 
     const { _headers, _lookup, _protocolVersion, _url } = this
     makeRequest(_protocolVersion, data, count, _url, _headers, _lookup, (err, res, status) => {
-      // Log agent connection diagnostic error (only once)
-      if (status && status !== 404 && status !== 200) {
-        logAgentError({ status, message: err?.message ?? inspect(err) })
-      }
+      // Note that logging will only happen once, regardless of how many times this is called.
+      startupLog(status !== 404 && status !== 200 ? { status, message: err?.message ?? inspect(err) } : undefined)
 
       if (status) {
         runtimeMetrics.increment(`${METRIC_PREFIX}.responses`, true)

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -6,7 +6,7 @@ const DatadogTracer = require('./tracer')
 const getConfig = require('./config')
 const runtimeMetrics = require('./runtime_metrics')
 const log = require('./log')
-const { setStartupLogPluginManager, startupLog } = require('./startup-log')
+const { setStartupLogPluginManager } = require('./startup-log')
 const DynamicInstrumentation = require('./debugger')
 const telemetry = require('./telemetry')
 const nomenclature = require('./service-naming')
@@ -288,8 +288,6 @@ class Tracer extends NoopProxy {
       this._pluginManager.configure(config)
       DynamicInstrumentation.configure(config)
       setStartupLogPluginManager(this._pluginManager)
-      // Emit startup log immediately after tracer is fully initialized
-      startupLog()
     }
   }
 

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -4,45 +4,38 @@ const os = require('os')
 const { inspect } = require('util')
 const tracerVersion = require('../../../package.json').version
 const { getAgentUrl } = require('./agent/url')
-const { warn } = require('./log/writer')
+const { info, warn } = require('./log/writer')
 
 const errors = {}
 let config
 let pluginManager
 /** @type {import('./sampling_rule')[]} */
 let samplingRules = []
-let startupLogRan = false
-let agentErrorLogged = false
+let alreadyRan = false
 
 /**
- * Logs the tracer configuration on startup
+ * @param {{ status: number, message: string } } [agentError]
  */
-function startupLog () {
-  if (startupLogRan || !config || !config.startupLogs || !pluginManager) {
+function startupLog (agentError) {
+  if (alreadyRan || !config || !config.startupLogs || !pluginManager) {
     return
   }
 
-  startupLogRan = true
+  alreadyRan = true
 
   const out = tracerInfo()
-  warn('DATADOG TRACER CONFIGURATION - ' + out)
-}
 
-/**
- * Logs a diagnostic error when the agent connection fails
- * @param {{ status: number, message: string }} agentError
- */
-function logAgentError (agentError) {
-  if (agentErrorLogged || !config || !config.startupLogs) {
-    return
+  if (agentError) {
+    out.agent_error = agentError.message
   }
 
-  agentErrorLogged = true
-
-  warn('DATADOG TRACER DIAGNOSTIC - Agent Error: ' + agentError.message)
-  errors.agentError = {
-    code: agentError.status,
-    message: `Agent Error: ${agentError.message}`,
+  info('DATADOG TRACER CONFIGURATION - ' + out)
+  if (agentError) {
+    warn('DATADOG TRACER DIAGNOSTIC - Agent Error: ' + agentError.message)
+    errors.agentError = {
+      code: agentError.status,
+      message: `Agent Error: ${agentError.message}`,
+    }
   }
 }
 
@@ -111,7 +104,6 @@ function setSamplingRules (theRules) {
 
 module.exports = {
   startupLog,
-  logAgentError,
   setStartupLogConfig,
   setStartupLogPluginManager,
   setSamplingRules,

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -17,6 +17,7 @@ describe('startup logging', () => {
   let tracerInfoMethod
 
   before(() => {
+    sinon.stub(console, 'info')
     sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
@@ -24,7 +25,6 @@ describe('startup logging', () => {
       setStartupLogPluginManager,
       setSamplingRules,
       startupLog,
-      logAgentError,
       tracerInfo,
     } = require('../src/startup-log')
     tracerInfoMethod = tracerInfo
@@ -60,11 +60,13 @@ describe('startup logging', () => {
     ])
     // Use sinon's stub instance directly to avoid type errors
     // eslint-disable-next-line no-console
+    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
+    // eslint-disable-next-line no-console
     const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
-    startupLog()
-    logAgentError({ status: 500, message: 'Error: fake error' })
-    firstStderrCall = warnStub.firstCall
-    secondStderrCall = warnStub.secondCall
+    startupLog({ message: 'Error: fake error' })
+    firstStderrCall = infoStub.firstCall
+    secondStderrCall = warnStub.firstCall
+    infoStub.restore()
     warnStub.restore()
   })
 
@@ -101,7 +103,7 @@ describe('startup logging', () => {
     })
   })
 
-  it('logAgentError should correctly output the diagnostic message separately', () => {
+  it('startupLog should correctly also output the diagnostic message', () => {
     assert.strictEqual(secondStderrCall.args[0], 'DATADOG TRACER DIAGNOSTIC - Agent Error: Error: fake error')
   })
 })
@@ -112,7 +114,7 @@ describe('data_streams_enabled', () => {
   })
 
   it('should be true when env var is true and config is unset', () => {
-    sinon.stub(console, 'warn')
+    sinon.stub(console, 'info')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
       setStartupLogConfig,
@@ -125,14 +127,14 @@ describe('data_streams_enabled', () => {
     setStartupLogPluginManager({ _pluginsByName: {} })
     startupLog()
     /* eslint-disable-next-line no-console */
-    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
-    const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    warnStub.restore()
+    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
+    const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+    infoStub.restore()
     assert.strictEqual(logObj.data_streams_enabled, true)
   })
 
   it('should be true when env var is not set and config is true', () => {
-    sinon.stub(console, 'warn')
+    sinon.stub(console, 'info')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
       setStartupLogConfig,
@@ -145,14 +147,14 @@ describe('data_streams_enabled', () => {
     setStartupLogPluginManager({ _pluginsByName: {} })
     startupLog()
     /* eslint-disable-next-line no-console */
-    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
-    const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    warnStub.restore()
+    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
+    const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+    infoStub.restore()
     assert.strictEqual(logObj.data_streams_enabled, true)
   })
 
   it('should be false when env var is true but config is false', () => {
-    sinon.stub(console, 'warn')
+    sinon.stub(console, 'info')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
       setStartupLogConfig,
@@ -165,9 +167,9 @@ describe('data_streams_enabled', () => {
     setStartupLogPluginManager({ _pluginsByName: {} })
     startupLog()
     /* eslint-disable-next-line no-console */
-    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
-    const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    warnStub.restore()
+    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
+    const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+    infoStub.restore()
     assert.strictEqual(logObj.data_streams_enabled, false)
   })
 })
@@ -181,7 +183,7 @@ describe('profiling_enabled', () => {
       ['auto', true],
       ['true', true],
     ].forEach(([envVar, expected]) => {
-      sinon.stub(console, 'warn')
+      sinon.stub(console, 'info')
       delete require.cache[require.resolve('../src/startup-log')]
       const {
         setStartupLogConfig,
@@ -194,9 +196,9 @@ describe('profiling_enabled', () => {
       setStartupLogPluginManager({ _pluginsByName: {} })
       startupLog()
       /* eslint-disable-next-line no-console */
-      const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
-      const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-      warnStub.restore()
+      const infoStub = /** @type {sinon.SinonStub} */ (console.info)
+      const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+      infoStub.restore()
       assert.strictEqual(logObj.profiling_enabled, expected)
     })
   })


### PR DESCRIPTION
Reverts DataDog/dd-trace-js#7470

This caused a regression where loaded integrations are not longer included in the startup logs, which is one of the most crucial information we get from them. As it's blocking us from releasing, I'm reverting for now.