### PR TITLE
fix(test): Node 24 deprecation warnings and url.parse refactors

### DIFF
--- a/packages/datadog-instrumentations/test/url.spec.js
+++ b/packages/datadog-instrumentations/test/url.spec.js
@@ -5,7 +5,6 @@ const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const { temporaryWarningExceptions, URL_PARSE_DEPRECATION } = require('../../dd-trace/test/setup/core')
 const { channel } = require('../src/helpers/instrument')
 const names = ['url', 'node:url']
 
@@ -38,7 +37,6 @@ names.forEach(name => {
 
     describe('url.parse', () => {
       it('should publish', () => {
-        temporaryWarningExceptions.add(URL_PARSE_DEPRECATION)
         const result = url.parse('https://www.datadoghq.com')
 
         sinon.assert.calledOnceWithExactly(parseFinishedChannelCb, {

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.express.plugin.spec.js
@@ -4,7 +4,6 @@ const { URL } = require('url')
 const axios = require('axios')
 const { prepareTestServerForIastInExpress } = require('../utils')
 const { withVersions } = require('../../../setup/mocha')
-const { temporaryWarningExceptions, URL_PARSE_DEPRECATION } = require('../../../setup/core')
 
 function noop () {}
 
@@ -61,7 +60,6 @@ describe('Taint tracking plugin sources express tests', () => {
           testThatRequestHasVulnerability(
             {
               fn: (req) => {
-                temporaryWarningExceptions.add(URL_PARSE_DEPRECATION)
                 // eslint-disable-next-line n/no-deprecated-api
                 const { parse } = require('url')
                 const url = parse(req.body.url)

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/plugin.fastify.plugin.spec.js
@@ -4,7 +4,6 @@ const { URL } = require('url')
 const axios = require('axios')
 const { prepareTestServerForIastInFastify } = require('../utils')
 const { withVersions } = require('../../../setup/mocha')
-const { temporaryWarningExceptions, URL_PARSE_DEPRECATION } = require('../../../setup/core')
 
 function noop () {}
 
@@ -61,7 +60,6 @@ describe('Taint tracking plugin sources fastify tests', () => {
           testThatRequestHasVulnerability(
             {
               fn: (req) => {
-                temporaryWarningExceptions.add(URL_PARSE_DEPRECATION)
                 // eslint-disable-next-line n/no-deprecated-api
                 const { parse } = require('url')
                 const url = parse(req.body.url)

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -41,6 +41,9 @@ const warningExceptions = new Set([
   // Node.js core warnings. Ignore them.
   'OutgoingMessage.prototype._headers is deprecated',
   "Access to process.binding('http_parser') is deprecated.",
+  '`url.parse()` behavior is not standardized and prone to errors that have security implications. Use the WHATWG ' +
+    'URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.',
+  'The `punycode` module is deprecated. Please use a userland alternative instead.',
   // TODO: We should not be throwing warnings in the first place. Fix the following warnings instead.
   "Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html",
   'collection.count is deprecated, and will be removed in a future version. ' +
@@ -83,7 +86,4 @@ process.on('warning', (warning) => {
 // for side effects only.
 module.exports = {
   temporaryWarningExceptions,
-  // Node.js 24.13.1+ deprecation message for url.parse(); use with temporaryWarningExceptions in tests that exercise it
-  URL_PARSE_DEPRECATION: '`url.parse()` behavior is not standardized and prone to errors that have security ' +
-    'implications. Use the WHATWG URL API instead. CVEs are not issued for `url.parse()` vulnerabilities.',
 }


### PR DESCRIPTION
### What does this PR do?

- **Test setup:** Add `url.parse()` (DEP0169) and `punycode` (DEP0040) to the global deprecation warning exceptions in `packages/dd-trace/test/setup/core.js` so tests do not fail on Node.js 24.13.1+.
- **express-session spec:** Add a middleware that registers the url.parse deprecation as a temporary warning exception before the express-session middleware runs, so the warning emitted when express-session@1.5.0 calls `url.parse()` during request handling does not fail the test.
- **Refactors:** Replace deprecated `url.parse()` with the WHATWG `URL` API in test/helper code:
  - `packages/datadog-plugin-microgateway-core/test/proxy.js` — use `new URL()` and `node:` core requires.
  - `packages/datadog-plugin-next/test/server.js` and `packages/dd-trace/test/appsec/next/pages-dir/server.js` — parse request URLs with `new URL()` and pass a URL-like object to the Next request handler.

### Motivation

Node.js 24.13.1+ triggers these deprecation warnings in more code paths (e.g. url instrumentation, express-session, dependencies using punycode). The test framework treats unhandled deprecation warnings as failures. Adding the warnings to the global exceptions list keeps tests green; the refactors remove `url.parse()` from test/helper code where it is under our control.