### PR TITLE
Only add host tag to profiles when DD_TRACE_REPORT_HOSTNAME is set

### DIFF
--- a/packages/dd-trace/src/profiling/config.js
+++ b/packages/dd-trace/src/profiling/config.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const os = require('os')
 const path = require('path')
 const { pathToFileURL } = require('url')
 const satisfies = require('../../../../vendor/dist/semifies')
@@ -50,7 +49,6 @@ class Config {
       DD_TAGS,
     } = getProfilingEnvValues()
 
-    const host = os.hostname()
     // Must be longer than one minute so pad with five seconds
     const flushInterval = options.interval ?? (Number(DD_PROFILING_UPLOAD_PERIOD) * 1000 || 65 * 1000)
     const uploadTimeout = options.uploadTimeout ?? (Number(DD_PROFILING_UPLOAD_TIMEOUT) || 60 * 1000)
@@ -59,7 +57,6 @@ class Config {
     // TODO: Remove the fallback. Just use the value from the config.
     this.service = options.service || 'node'
     this.env = options.env
-    this.host = host
     this.functionname = AWS_LAMBDA_FUNCTION_NAME
 
     this.version = options.version
@@ -68,7 +65,7 @@ class Config {
       tagger.parse(options.tags),
       tagger.parse({
         env: options.env,
-        host,
+        host: options.reportHostname ? require('os').hostname() : undefined,
         service: this.service,
         version: this.version,
         functionname: AWS_LAMBDA_FUNCTION_NAME,

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -76,6 +76,7 @@ class Profiler extends EventEmitter {
       repositoryUrl,
       commitSHA,
       injectionEnabled,
+      reportHostname,
     } = config
     const { enabled, sourceMap, exporters } = config.profiling
     const { heartbeatInterval } = config.telemetry
@@ -112,6 +113,7 @@ class Profiler extends EventEmitter {
       libraryInjected,
       activation,
       heartbeatInterval,
+      reportHostname,
     }
 
     return this._start(options).catch((err) => {


### PR DESCRIPTION
### What does this PR do?
Only adds the `host:` tag to profiles when `DD_TRACE_REPORT_HOSTNAME` is set to true.

### Motivation
Node.js profiler unconditionally emits host tag with the value of `os.hostname()`. This causes issues for serverless usage, where host names are ephemeral and unnecessarily increase cardinality of various lists and metrics.

The agent also adds a host tag when necessary, so the profiler needn’t do it. There is also a `DD_TRACE_REPORT_HOSTNAME` env var that regulates whether the tracer includes host name in the traces, it defaults to false. We changed the logic so we only emit the host tag in profiles if the env var is explicitly set to true.

Jira: [PROF-13728](https://datadoghq.atlassian.net/browse/PROF-13728)