### PR TITLE
fix(startup-log): send startup logs to stderr

### DIFF
--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -4,7 +4,7 @@ const os = require('os')
 const { inspect } = require('util')
 const tracerVersion = require('../../../package.json').version
 const { getAgentUrl } = require('./agent/url')
-const { info, warn } = require('./log/writer')
+const { warn } = require('./log/writer')
 
 const errors = {}
 let config
@@ -29,7 +29,7 @@ function startupLog (agentError) {
     out.agent_error = agentError.message
   }
 
-  info('DATADOG TRACER CONFIGURATION - ' + out)
+  warn('DATADOG TRACER CONFIGURATION - ' + out)
   if (agentError) {
     warn('DATADOG TRACER DIAGNOSTIC - Agent Error: ' + agentError.message)
     errors.agentError = {

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -17,7 +17,6 @@ describe('startup logging', () => {
   let tracerInfoMethod
 
   before(() => {
-    sinon.stub(console, 'info')
     sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
@@ -60,13 +59,10 @@ describe('startup logging', () => {
     ])
     // Use sinon's stub instance directly to avoid type errors
     // eslint-disable-next-line no-console
-    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
-    // eslint-disable-next-line no-console
     const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
     startupLog({ message: 'Error: fake error' })
-    firstStderrCall = infoStub.firstCall
-    secondStderrCall = warnStub.firstCall
-    infoStub.restore()
+    firstStderrCall = warnStub.firstCall
+    secondStderrCall = warnStub.secondCall
     warnStub.restore()
   })
 
@@ -114,7 +110,7 @@ describe('data_streams_enabled', () => {
   })
 
   it('should be true when env var is true and config is unset', () => {
-    sinon.stub(console, 'info')
+    sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
       setStartupLogConfig,
@@ -127,14 +123,14 @@ describe('data_streams_enabled', () => {
     setStartupLogPluginManager({ _pluginsByName: {} })
     startupLog()
     /* eslint-disable-next-line no-console */
-    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
-    const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    infoStub.restore()
+    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+    const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+    warnStub.restore()
     assert.strictEqual(logObj.data_streams_enabled, true)
   })
 
   it('should be true when env var is not set and config is true', () => {
-    sinon.stub(console, 'info')
+    sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
       setStartupLogConfig,
@@ -147,14 +143,14 @@ describe('data_streams_enabled', () => {
     setStartupLogPluginManager({ _pluginsByName: {} })
     startupLog()
     /* eslint-disable-next-line no-console */
-    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
-    const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    infoStub.restore()
+    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+    const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+    warnStub.restore()
     assert.strictEqual(logObj.data_streams_enabled, true)
   })
 
   it('should be false when env var is true but config is false', () => {
-    sinon.stub(console, 'info')
+    sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const {
       setStartupLogConfig,
@@ -167,9 +163,9 @@ describe('data_streams_enabled', () => {
     setStartupLogPluginManager({ _pluginsByName: {} })
     startupLog()
     /* eslint-disable-next-line no-console */
-    const infoStub = /** @type {sinon.SinonStub} */ (console.info)
-    const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-    infoStub.restore()
+    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+    const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+    warnStub.restore()
     assert.strictEqual(logObj.data_streams_enabled, false)
   })
 })
@@ -183,7 +179,7 @@ describe('profiling_enabled', () => {
       ['auto', true],
       ['true', true],
     ].forEach(([envVar, expected]) => {
-      sinon.stub(console, 'info')
+      sinon.stub(console, 'warn')
       delete require.cache[require.resolve('../src/startup-log')]
       const {
         setStartupLogConfig,
@@ -196,9 +192,9 @@ describe('profiling_enabled', () => {
       setStartupLogPluginManager({ _pluginsByName: {} })
       startupLog()
       /* eslint-disable-next-line no-console */
-      const infoStub = /** @type {sinon.SinonStub} */ (console.info)
-      const logObj = JSON.parse(infoStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
-      infoStub.restore()
+      const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+      const logObj = JSON.parse(warnStub.firstCall.args[0].replace('DATADOG TRACER CONFIGURATION - ', ''))
+      warnStub.restore()
       assert.strictEqual(logObj.profiling_enabled, expected)
     })
   })


### PR DESCRIPTION
## What does this PR do?

Changes startup logs to output to stderr (via `console.warn`) instead of stdout (via `console.info`), following Unix conventions and aligning with other Datadog language tracers.

This PR addresses only the stderr output change from #7470, which was reverted in #7478 due to a regression introduced by the immediate emission timing change. This PR does NOT modify when the logs are emitted - they continue to be emitted on the first payload sent to the agent (same timing as before).

Changing the timing of logs will be done in a future PR

## Motivation

Diagnostic and informational logs should be sent to stderr rather than stdout, following standard Unix conventions. This aligns with how other Datadog language tracers handle startup logs.

## Additional Notes

Related PRs:
- #7470 (original PR with both stderr and immediate emission changes - merged then reverted)
- #7478 (revert of #7470 due to regression from immediate emission)

This PR includes only the safe stderr output change without the problematic timing modification.

## How to test the change?

Run the startup-log tests:
```bash
node scripts/mocha-run-file.js packages/dd-trace/test/startup-log.spec.js
```

All tests should pass and verify that startup logs use `console.warn` (stderr) instead of `console.info` (stdout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)