### PR TITLE
ci(all-green): make workflow event-driven from check_suite

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,18 +1,13 @@
 name: All Green
 on:
-  pull_request:
-  push:
-    branches:
-      - master
-  schedule:
-    - cron: 0 4 * * *
+  check_suite:
+    types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  group: all-green-${{ github.event.check_suite.head_sha }}
   cancel-in-progress: true
 
 jobs:
-
   all-green:
     runs-on: ubuntu-latest
     permissions:
@@ -21,22 +16,22 @@ jobs:
     steps:
       - uses: wechuli/allcheckspassed@1d00cf0c34c4b0805db8866d8913f22e7125301e # v2.3.0
         with:
-          delay: ${{ github.run_attempt == 1 && '7' || '0' }} # 7 minutes on first attempt, no delay on reruns
-          retries: 15
-          polling_interval: 2 # Once every 2 minutes
+          delay: ${{ github.run_attempt == 1 && '1' || '0' }} # 1 minutes on first attempt, no delay on reruns
+          poll: false
+          commit_sha: ${{ github.event.check_suite.head_sha }}
           checks_exclude: devflow.*
-          fail_fast: false
           verbose: true # What checks are still waited for?
       - name: Require vendor validation when vendor/ changes
-        if: github.event_name == 'pull_request'
+        if: toJSON(github.event.check_suite.pull_requests) != '[]'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PULL_REQUESTS_JSON: ${{ toJSON(github.event.check_suite.pull_requests) }}
+          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
         run: |
           set -euo pipefail
 
+          BASE_SHA="$(echo "${PULL_REQUESTS_JSON}" | jq -r '.[0].base.sha')"
           vendor_changed="$(gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" --jq 'any(.files[].filename; startswith("vendor/"))')"
           if [ "$vendor_changed" != "true" ]; then
             exit 0
@@ -45,7 +40,7 @@ jobs:
           # If vendor/ was touched, require *some* vendor validation check to be present:
           # - For most PRs: `Validate vendored bundle / validate-vendored-bundle`
           # - For Dependabot vendor PRs: `Dependabot Automation / vendor-validate`
-          check_names="$(gh api "repos/${REPO}/commits/${{ github.event.pull_request.head.sha }}/check-runs" \
+          check_names="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
             -H "Accept: application/vnd.github+json" \
             --paginate \
             --jq '.check_runs[].name')"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,10 +1,11 @@
 name: All Green
 on:
+  pull_request:
   check_suite:
     types: [completed]
 
 concurrency:
-  group: all-green-${{ github.event.check_suite.head_sha }}
+  group: all-green-${{ github.event.check_suite.head_sha || github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:
@@ -18,20 +19,23 @@ jobs:
         with:
           delay: ${{ github.run_attempt == 1 && '1' || '0' }} # 1 minutes on first attempt, no delay on reruns
           poll: false
-          commit_sha: ${{ github.event.check_suite.head_sha }}
+          commit_sha: ${{ github.event.check_suite.head_sha || github.event.pull_request.head.sha }}
           checks_exclude: devflow.*
           verbose: true # What checks are still waited for?
       - name: Require vendor validation when vendor/ changes
-        if: toJSON(github.event.check_suite.pull_requests) != '[]'
+        if: github.event_name == 'pull_request' || toJSON(github.event.check_suite.pull_requests) != '[]'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PULL_REQUESTS_JSON: ${{ toJSON(github.event.check_suite.pull_requests) }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          HEAD_SHA: ${{ github.event.check_suite.head_sha || github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 
-          BASE_SHA="$(echo "${PULL_REQUESTS_JSON}" | jq -r '.[0].base.sha')"
+          if [ -z "${BASE_SHA}" ]; then
+            BASE_SHA="$(echo "${PULL_REQUESTS_JSON}" | jq -r '.[0].base.sha')"
+          fi
           vendor_changed="$(gh api "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" --jq 'any(.files[].filename; startswith("vendor/"))')"
           if [ "$vendor_changed" != "true" ]; then
             exit 0


### PR DESCRIPTION
### What does this PR do?

Makes the All Green workflow event-driven: it now triggers on `check_suite` completed instead of `pull_request`, `push`, and cron. Concurrency is keyed by head SHA with `cancel-in-progress: true` so only the latest run per commit proceeds. The workflow uses `wechuli/allcheckspassed` with `commit_sha` from the event and a 1-minute `delay` for debounce.

### Motivation

Reduce total GitHub API usage and the risk of hitting rate limits. Previously the workflow ran on a schedule and polled every 2 minutes; now it runs only when a check suite completes, and concurrency plus the action’s delay ensure we don’t run redundant polls. Fewer workflow runs and fewer API calls per commit.
