### PR TITLE
fix: Address baggage properties being leaked between server requests

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -667,6 +667,7 @@ class TextMapPropagator {
   }
 
   _extractBaggageItems (carrier, spanContext) {
+    removeAllBaggageItems()
     if (!this._hasPropagationStyle('extract', 'baggage')) return
     if (!carrier?.baggage) return
     const baggages = carrier.baggage.split(',')

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -748,6 +748,37 @@ describe('TextMapPropagator', () => {
       assert.deepStrictEqual(getAllBaggageItems(), { foo: 'bar' })
     })
 
+    it('should clear pre-existing baggage items before extracting new ones', () => {
+      removeAllBaggageItems()
+      setBaggageItem('stale', 'leftover')
+      setBaggageItem('foo', 'old-value')
+      assert.deepStrictEqual(getAllBaggageItems(), { stale: 'leftover', foo: 'old-value' })
+
+      const carrier = {
+        'x-datadog-trace-id': '123',
+        'x-datadog-parent-id': '456',
+        baggage: 'foo=new-value,fresh=added',
+      }
+      propagator.extract(carrier)
+
+      assert.deepStrictEqual(getAllBaggageItems(), { foo: 'new-value', fresh: 'added' })
+      assert.strictEqual(getBaggageItem('stale'), undefined)
+    })
+
+    it('should clear pre-existing baggage items when carrier has no baggage header', () => {
+      removeAllBaggageItems()
+      setBaggageItem('stale', 'leftover')
+      assert.deepStrictEqual(getAllBaggageItems(), { stale: 'leftover' })
+
+      const carrier = {
+        'x-datadog-trace-id': '123',
+        'x-datadog-parent-id': '456',
+      }
+      propagator.extract(carrier)
+
+      assert.deepStrictEqual(getAllBaggageItems(), {})
+    })
+
     it('should convert signed IDs to unsigned', () => {
       textMap['x-datadog-trace-id'] = '-123'
       textMap['x-datadog-parent-id'] = '-456'


### PR DESCRIPTION
### What does this PR do?
There was a memory leak noticed where `baggage` properties are not being cleared prior to extracting properties from the carrier.

In unhappy paths, like malformed properties, the entire baggage store is cleared.
But no clean up happens for the happy path.

This PR ensures that the baggage store is cleared _prior_ to extracting properties from the carrier.
Additionally 2 unit tests have been added:
1. Demonstrates that baggage properties don't leak between extractions
2. Demonstrates that baggage items are cleared even when subsequent calls have nothing to extract

### Motivation
As outlined in Issue #7506  we have run into a situation where `baggage` properties are leaking across warm lambda invocations.

This eventually causes the system to fail due to oversized lambda payloads, caused by the `baggage` property accumulating data over time.

### Additional Notes



