### PR TITLE
chore(ci): use official actionlint Docker image

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,34 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/node/latest
-      # NOTE: Ok this next bit seems unnecessary, right? The problem is that
-      # this repo is currently incompatible with npm, at least with the
-      # devDependencies. While this is intended to be corrected, it hasn't yet,
-      # so the easiest thing to do here is just use a fresh package.json. This
-      # is needed because actionlint runs an `npm install` at the beginning.
-      - name: Clear package.json
-        run: |
-          rm package.json
-          npm init -y
-      - name: actionlint
-        id: actionlint
-        uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
+      - name: Enable problem matcher
+        run: echo "::add-matcher::.github/actionlint-matcher.json"
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint@sha256:ef8299f97635c4c30e2298f48f30763ab782a4ad2c95b744649439a039421e36 # v1.7.10
         with:
-          matcher: true
-          fail-on-error: true
-          shellcheck: false # TODO should we enable this?
-      - name: actionlint Summary
-        if: ${{ steps.actionlint.outputs.exit-code != 0 }}
-        run: |
-          echo "Used actionlint version ${{ steps.actionlint.outputs.version-semver }}"
-          echo "Used actionlint release ${{ steps.actionlint.outputs.version-tag }}"
-          echo "actionlint ended with ${{ steps.actionlint.outputs.exit-code }} exit code"
-          echo "actionlint ended because '${{ steps.actionlint.outputs.exit-message }}'"
-          echo "actionlint found ${{ steps.actionlint.outputs.total-errors }} errors"
-          echo "actionlint checked ${{ steps.actionlint.outputs.total-files }} files"
-          echo "actionlint cache used: ${{ steps.actionlint.outputs.cache-hit }}"
-          exit ${{ steps.actionlint.outputs.exit-code }}
+          args: -color -shellcheck=
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

Replace the third-party `raven-actions/actionlint` wrapper with the official `rhysd/actionlint` Docker image in the `actionlint` CI job.

The Docker image is pinned by sha256 digest for supply chain security, and the `# v1.7.10` tag comment follows the same convention used for other pinned actions in this repo. PR annotations are preserved via the official problem matcher file (`.github/actionlint-matcher.json`).

### Motivation

`raven-actions/actionlint` is a small third-party wrapper around the official `rhysd/actionlint` tool. Using it required a workaround that wiped `package.json` and ran `npm init -y` because the wrapper internally runs `npm install`, which is incompatible with this repo's devDependencies.

Switching to the official Docker image:
- Removes the `package.json` workaround hack
- Removes the Node.js setup step (no longer needed)
- Eliminates a third-party supply chain dependency
