### PR TITLE
fix(ci): remove stray quote from concurrency groups 2

### DIFF
--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -15,7 +15,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -14,7 +14,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -15,7 +15,7 @@ on:
 
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}"
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
### What does this PR do?

Removes a stray trailing double quote from the `concurrency.group` value in all GitHub Action Workflow files.

### Motivation

The extra `"` had no matching opening quote and could cause YAML parsing issues or incorrect concurrency grouping in the APM Integrations workflow (though no evidence for such).

### Additional Notes

This is a follow up PR to #7493, in which only a single instance of this bug was corrected. This PR takes care of all remaining.

