### PR TITLE
ci: use sparse checkout for lightweight CI jobs

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,16 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
       - uses: ./.github/actions/node/latest
-      # NOTE: Ok this next bit seems unnecessary, right? The problem is that
-      # this repo is currently incompatible with npm, at least with the
-      # devDependencies. While this is intended to be corrected, it hasn't yet,
-      # so the easiest thing to do here is just use a fresh package.json. This
-      # is needed because actionlint runs an `npm install` at the beginning.
-      - name: Clear package.json
-        run: |
-          rm package.json
-          npm init -y
       - name: actionlint
         id: actionlint
         uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
@@ -64,9 +57,13 @@ jobs:
     name: Workflow job names (unique)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github
+            scripts/verify-workflow-job-names.js
       - uses: ./.github/actions/node/latest
-      - uses: ./.github/actions/install
-      - run: npm run verify:workflow-job-names
+      - run: npm install yaml
+      - run: node scripts/verify-workflow-job-names.js
 
   # The package size is especially useful in constrained environments, so the
   # computation is done only on the package that would be installed there.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,5 +162,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: scripts/release/status.js
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-      - run: node scripts/release/status
+      - run: node scripts/release/status.js


### PR DESCRIPTION
### What does this PR do?

Switches three lightweight CI jobs to use sparse checkout instead of cloning the full repository tree:

- **`actionlint`** (`project.yml`): Only needs `.github/` to lint workflow files. The sparse checkout also makes the `Clear package.json` workaround unnecessary — with no `package.json` in the checkout, actionlint's internal `npm install` is a harmless no-op.
- **`workflow-job-names`** (`project.yml`): Only reads `.github/workflows/*.yml` files and depends on a single npm package (`yaml`). Replaces the full `bun install` of all dependencies with `npm install yaml`.
- **`status`** (`release.yml`): The `scripts/release/status.js` script is fully self-contained (only uses Node.js built-ins and the GitHub API via env vars). Sparse-checks out just that one file.

### Motivation

These jobs were doing full repo checkouts and, in some cases, full dependency installs despite only needing a tiny subset of the repo. Sparse checkout reduces clone time and, for `workflow-job-names`, avoids installing hundreds of unnecessary packages.
