### PR TITLE
test(ci-vis): fix flaky agent-proxy test race

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agent-proxy/agent-proxy.spec.js
@@ -18,8 +18,9 @@ const { clearCache } = require('../../../../src/agent/info')
 
 describe('AgentProxyCiVisibilityExporter', () => {
   beforeEach(() => {
-    clearCache()
+    nock.abortPendingRequests()
     nock.cleanAll()
+    clearCache()
   })
 
   const flushInterval = 50
@@ -300,7 +301,7 @@ describe('AgentProxyCiVisibilityExporter', () => {
   })
 
   describe('setUrl', () => {
-    it('should set the URL on self and writers', () => {
+    it('should set the URL on self and writers', async () => {
       const mockWriter = {
         setUrl: sinon.spy(),
       }
@@ -313,6 +314,7 @@ describe('AgentProxyCiVisibilityExporter', () => {
           endpoints: ['/evp_proxy/v2/'],
         }))
       const agentProxyCiVisibilityExporter = new AgentProxyCiVisibilityExporter({ port, tags })
+      await agentProxyCiVisibilityExporter._canUseCiVisProtocolPromise
       agentProxyCiVisibilityExporter._writer = mockWriter
       agentProxyCiVisibilityExporter._coverageWriter = mockCoverageWriter
 


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in the `AgentProxyCiVisibilityExporter` test suite that caused the `_isGzipCompatible` test to flake in CI.

The `setUrl` test was the only test that didn't `await _canUseCiVisProtocolPromise` after creating an exporter. This left an in-flight `fetchAgentInfo` callback that could fire after the next test's `beforeEach` had already called `clearCache()`, repopulating the module-level `/info` cache with stale data (v2-only endpoints). When the `_isGzipCompatible` test then created its own exporter, `fetchAgentInfo` would return the cached v2 response instead of hitting the test's nock mock with v4+ endpoints, causing `_isGzipCompatible` to be `false`.

Two fixes applied:
- **Await the promise in the `setUrl` test** so its `fetchAgentInfo` callback completes within the test boundary.
- **Add `nock.abortPendingRequests()` to `beforeEach`** as a general safeguard against leaked in-flight nock responses, and reorder so cache is cleared after nock cleanup.

### Motivation

The `_isGzipCompatible` test was intermittently failing in CI with `_isGzipCompatible` being `false` instead of `true`.

### Additional Notes

The `clearCache()` call was moved after `nock.abortPendingRequests()` / `nock.cleanAll()` to ensure any pending nock callbacks are aborted before the cache is cleared, preventing a late-firing callback from writing stale data back into the cache.

