### PR TITLE
ci: add rate limit monitoring to GitHub Actions

### DIFF
--- a/.github/actions/rate-limit-status/action.yml
+++ b/.github/actions/rate-limit-status/action.yml
@@ -1,0 +1,27 @@
+name: GitHub API Rate Limit Status
+description: Output current GitHub API rate limit usage to the workflow log.
+runs:
+  using: composite
+  steps:
+    - name: Check GitHub API rate limit
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        response=$(curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/rate_limit)
+
+        limit=$(echo "$response" | jq '.rate.limit')
+        used=$(echo "$response" | jq '.rate.used')
+        remaining=$(echo "$response" | jq '.rate.remaining')
+        reset_ts=$(echo "$response" | jq '.rate.reset')
+        reset_human=$(date -u -d "@$reset_ts" '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null \
+          || date -u -r "$reset_ts" '+%Y-%m-%d %H:%M:%S UTC')
+
+        echo "::group::GitHub API Rate Limit Status"
+        echo "Limit:     $limit"
+        echo "Used:      $used"
+        echo "Remaining: $remaining"
+        echo "Reset:     $reset_human"
+        echo "::endgroup::"

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -18,6 +18,10 @@ jobs:
       checks: read
       contents: read
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rate-limit-status
+      - uses: ./.github/actions/rate-limit-status
       - uses: wechuli/allcheckspassed@1d00cf0c34c4b0805db8866d8913f22e7125301e # v2.3.0
         with:
           delay: ${{ github.run_attempt == 1 && '7' || '0' }} # 7 minutes on first attempt, no delay on reruns
@@ -26,6 +30,8 @@ jobs:
           checks_exclude: devflow.*
           fail_fast: false
           verbose: true # What checks are still waited for?
+      - uses: ./.github/actions/rate-limit-status
+        if: always()
       - name: Require vendor validation when vendor/ changes
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: ./.github/actions/rate-limit-status
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
@@ -47,8 +49,16 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
+      - uses: ./.github/actions/rate-limit-status
+        if: always()
+
       - name: Autobuild
         uses: github/codeql-action/autobuild@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
 
+      - uses: ./.github/actions/rate-limit-status
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2
+
+      - uses: ./.github/actions/rate-limit-status
+        if: always()

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -8,8 +8,14 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rate-limit-status
+      - uses: ./.github/actions/rate-limit-status
       - uses: mheap/github-action-required-labels@8afbe8ae6ab7647d0c9f0cfa7c2f939650d22509 # v5.5.1
         with:
           mode: exactly
           count: 1
           labels: "semver-patch, semver-minor, semver-major"
+      - uses: ./.github/actions/rate-limit-status
+        if: always()

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           sparse-checkout: .github
       - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/rate-limit-status
       - name: actionlint
         id: actionlint
         uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
@@ -24,6 +25,8 @@ jobs:
           matcher: true
           fail-on-error: true
           shellcheck: false # TODO should we enable this?
+      - uses: ./.github/actions/rate-limit-status
+        if: always()
       - name: actionlint Summary
         if: ${{ steps.actionlint.outputs.exit-code != 0 }}
         run: |
@@ -81,10 +84,13 @@ jobs:
       - run: tar -zxf /tmp/dd-trace.tgz -C $(pwd) --strip-components=1
       - run: yarn --prod --ignore-optional
       - run: ls -lisa
+      - uses: ./.github/actions/rate-limit-status
       - name: Compute module size tree and report
         uses: qard/heaviest-objects-in-the-universe@1e02edbdda803a45537a808ede97866db47756d3 # Unreleased
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/rate-limit-status
+        if: always()
 
   static-analysis:
     runs-on: ubuntu-latest
@@ -206,17 +212,24 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rate-limit-status
+      - uses: ./.github/actions/rate-limit-status
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
         with:
           scope: DataDog/dd-trace-js
           policy: yarn-dedupe
+      - uses: ./.github/actions/rate-limit-status
+        if: always()
 
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: yarn-lock
           path: ${{ runner.temp }}/yarn-lock-artifact
 
+      - uses: ./.github/actions/rate-limit-status
       - name: Update yarn.lock via GitHub API (server-created verified commit)
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
@@ -235,3 +248,5 @@ jobs:
             -f content="${content}" \
             -f sha="${sha}" \
             -f branch="${BRANCH}"
+      - uses: ./.github/actions/rate-limit-status
+        if: always()


### PR DESCRIPTION
### What does this PR do?

Adds a reusable composite action (`.github/actions/rate-limit-status/`) that queries the GitHub API rate limit endpoint and logs the current usage (limit, used, remaining, reset time) to the workflow log. The action is then invoked before and after steps that consume the GitHub API across CI workflows and composite actions.

### Motivation

We've been seeing intermittent CI failures that may be caused by GitHub API rate limit exhaustion. By logging rate limit status around API-consuming steps (Codecov uploads, artifact uploads, `allcheckspassed`, CodeQL, `required-labels`, `heaviest-objects-in-the-universe`, `dd-octo-sts-action`, etc.), we can correlate failures with rate limit pressure and identify which steps are the biggest consumers.

### Additional Notes

- The action uses `if: always()` on the trailing invocations so we still capture rate limit status even when a preceding step fails.
- For jobs that don't already check out the repo (e.g. `all-green`, `pr-labels`, `yarn-dedupe`), a sparse checkout of just `.github/actions/rate-limit-status` is added to make the composite action available.
- This is a diagnostic/debugging addition with no impact on existing CI behavior -- the rate limit check is a single lightweight `curl` call to `/rate_limit`.
