### PR TITLE
ci: cache resolved Node.js version in CI

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -8,17 +8,54 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-      with:
-        node-version: ${{
+    # Resolve the version from the input alias so we can use it in cache keys.
+    - name: Resolve Node.js version
+      id: node-version
+      env:
+        NODE_VERSION: ${{
           inputs.version == 'eol' && '16' ||
           inputs.version == 'oldest' && '18' ||
           inputs.version == 'maintenance' && '20' ||
           inputs.version == 'active' && '22' ||
           inputs.version == 'latest' && (env.LATEST_VERSION || '24') ||
           inputs.version }}
-        check-latest: true
+      shell: bash
+      run: echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
+
+    # Cache a tiny file containing the exact Node.js version resolved by a previous run.
+    # Key rotates every 20 minutes (epoch / 1200) so patches are picked up regularly.
+    # On cache hit, we pass the exact version to setup-node and skip the HTTP manifest lookup.
+    - name: Compute cache key
+      id: cache-key
+      shell: bash
+      run: echo "block=$(( $(date -u +%s) / 1200 ))" >> "$GITHUB_OUTPUT"
+    - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      id: node-version-cache
+      with:
+        path: /tmp/.node-resolved-version
+        key: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-${{ steps.cache-key.outputs.block }}
+        restore-keys: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-
+    - name: Read cached version
+      id: cached
+      shell: bash
+      run: |
+        if [ -f /tmp/.node-resolved-version ]; then
+          echo "version=$(cat /tmp/.node-resolved-version)" >> "$GITHUB_OUTPUT"
+        fi
+
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+      with:
+        # Use the exact cached version when available, otherwise fall back to the requested version.
+        node-version: ${{ steps.cached.outputs.version || steps.node-version.outputs.version }}
+        # Resolve the latest patch on master when no cached version exists.
+        check-latest: ${{ steps.cached.outputs.version == '' }}
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}
+
+    # Persist the resolved version so subsequent runs within this 20-minute window can reuse it.
+    - name: Save resolved version
+      if: steps.node-version-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: node -v | tr -d 'v' > /tmp/.node-resolved-version
     # Avoid GitHub REST API tag lookups (api.github.com/.../git/refs/tags) which can hit installation rate limits
     # in large orgs / high-parallelism workflows. Instead, use a direct release asset URL.
     #


### PR DESCRIPTION
### What does this PR do?

Caches the resolved Node.js version in the shared `.github/actions/node/action.yml` composite action so that `actions/setup-node` can skip its GitHub API manifest lookups on subsequent runs.

When `check-latest: true` is set, `setup-node` makes two GitHub API requests to resolve the latest patch for a given major version. With hundreds of parallel CI jobs all doing this, the requests count towards our GitHub API rate limit. This PR introduces a lightweight `actions/cache` step that persists the resolved version to a file. On cache hit, the exact version is passed directly to `setup-node` with `check-latest: false`, eliminating both API calls entirely.

The cache key rotates every 20 minutes (based on epoch time) so new Node.js patch releases are still picked up promptly.

### Motivation

Every invocation of `setup-node` with `check-latest: true` triggers two GitHub REST API requests to resolve the latest version. Across our highly parallel CI matrix these add up and count towards our GitHub API rate limit. Caching the resolved version removes this overhead for the vast majority of runs.

### Additional Notes

- Only `.github/actions/node/action.yml` is changed; no workflow files need updating since they all delegate to this composite action.
- The cache is keyed on OS, architecture, and the requested Node.js version, so different matrix entries don't interfere with each other.
- On the first run (or after the 20-minute window rotates), `setup-node` behaves exactly as before (`check-latest: true`), then the resolved version is saved for subsequent runs.
