### PR TITLE
fix(ci): use version-specific file path for Node.js resolved version cache

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -32,15 +32,15 @@ runs:
     - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       id: node-version-cache
       with:
-        path: /tmp/.node-resolved-version
+        path: /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
         key: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-${{ steps.cache-key.outputs.block }}
         restore-keys: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-
     - name: Read cached version
       id: cached
       shell: bash
       run: |
-        if [ -f /tmp/.node-resolved-version ]; then
-          echo "version=$(cat /tmp/.node-resolved-version)" >> "$GITHUB_OUTPUT"
+        if [ -f /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }} ]; then
+          echo "version=$(cat /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }})" >> "$GITHUB_OUTPUT"
         fi
 
     - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -55,7 +55,7 @@ runs:
     - name: Save resolved version
       if: steps.node-version-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: node -v | tr -d 'v' > /tmp/.node-resolved-version
+      run: node -v | tr -d 'v' > /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
     # Avoid GitHub REST API tag lookups (api.github.com/.../git/refs/tags) which can hit installation rate limits
     # in large orgs / high-parallelism workflows. Instead, use a direct release asset URL.
     #


### PR DESCRIPTION
### What does this PR do?
Updates node action to use a version-specific file path (/`tmp/.node-resolved-version-<version>`) instead of a shared one (`/tmp/.node-resolved-version`) when caching the resolved Node.js version.

### Motivation
When multiple invocations of the Node.js setup action run within the same job (e.g., `oldest-maintenance-lts`, `newest-maintenance-lts`, `latest`), they all write the resolved version to the same file. Because `actions/cache` saves during the post-action phase, the last version installed overwrites the file, polluting the cache entries for all other version aliases.


