### PR TITLE
test(appsec): set 15s timeout on sequelize plugin spec

### DIFF
--- a/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js
@@ -9,7 +9,9 @@ const appsec = require('../../src/appsec')
 const { getConfigFresh } = require('../helpers/config')
 const { withVersions } = require('../setup/mocha')
 
-describe('sequelize', () => {
+describe('sequelize', function () {
+  this.timeout(15000) // Normal: <5s. If we're unlucky and get a slow GitHub Actions runner, they can take longer.
+
   withVersions('sequelize', 'sequelize', sequelizeVersion => {
     let sequelize, User
 


### PR DESCRIPTION
### What does this PR do?

Increases the Mocha timeout for the sequelize AppSec plugin spec to 15s so DB/Sequelize setup can finish on slow CI runners. The timeout is set only in `packages/dd-trace/test/appsec/index.sequelize.plugin.spec.js` via `this.timeout(15000)`, consistent with other appsec plugin specs (e.g. next, kafkajs).

### Motivation

The AppSec / mysql job was flaking with "Timeout of 5000ms exceeded" in `index.sequelize.plugin.spec.js` when runners were slow. Using a per-spec timeout keeps the default 5s for other appsec plugin tests and only relaxes it where DB setup is slow.
