### PR TITLE
fix: stop tracing HTTPS traffic to the agent

### DIFF
--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -38,5 +38,5 @@ const HttpsAgent = createAgentClass(https.Agent)
 
 module.exports = {
   httpAgent: new HttpAgent(),
-  HttpsAgent: new HttpsAgent(),
+  httpsAgent: new HttpsAgent(),
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a bug introduced in #2920: the HTTPS agent export in `packages/dd-trace/src/exporters/common/agents.js` is renamed from `HttpsAgent` to `httpsAgent` so that `request.js`, which destructures `{ httpAgent, httpsAgent }` from `./agents`, receives the HTTPS agent instead of `undefined`.

### Motivation

#2920 moved agent creation into `agents.js` and had `request.js` consume `httpAgent` and `httpsAgent` from there. The new module exported `HttpsAgent` (PascalCase), so the destructuring in `request.js` left `httpsAgent` undefined. This PR corrects the export name to match the consumer.

### Impact

**When are users affected?** Only when the tracer is configured to use **HTTPS** to reach the Datadog agent (e.g. `DD_TRACE_AGENT_URL=https://agent.example.com:8126` or a remote HTTPS agent). Users using the default HTTP agent URL (e.g. `http://localhost:8126`) were not affected.

**Before (bug):** For HTTPS agent URLs, `options.agent` was never set (because `httpsAgent` was `undefined`). Requests used the default `https.globalAgent`. As a result, the tracer would incorrectly start tracing its own HTTPS connections to the agent (see below), and connection pooling did not use the dedicated agent intended by #2920.

The tracer's HTTP instrumentation would create spans for its own requests to the agent, so export traffic shows up in your traces. #2920's custom agent runs that connection work in a noop context so it isn't traced; with `httpsAgent` undefined, HTTPS requests skipped that and were traced again.

**After (fix):** HTTPS requests to the agent use the shared `httpsAgent` from `agents.js`. Those connections are no longer traced, and connection pooling matches the design from #2920.