### PR TITLE
chore(vscode): set JSON default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   // Use the workspace version of TypeScript instead of VSCode's bundled version
   "typescript.tsdk": "node_modules/typescript/lib",
+  "files.insertFinalNewline": true,
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml"
   },
@@ -32,5 +33,8 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": "explicit"
     }
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
   }
 }


### PR DESCRIPTION
### What does this PR do?

Configures the VS Code workspace to use the built-in JSON formatter for `[json]` and enables `files.insertFinalNewline` so formatted JSON files keep a trailing newline and match the project rule that files end with a single newline.

### Motivation

Ensures JSON files (e.g. `package.json`, config files) are formatted the same way for everyone using the repo’s VS Code/Cursor settings.
