### PR TITLE
[test optimization][do not merge] Set `test.has_failed_all_retries`

### DIFF
--- a/integration-tests/ci-visibility/test-early-flake-detection/always-failing-test.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/always-failing-test.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const assert = require('assert')
+
+describe('fail', () => {
+  it('always fails', () => {
+    assert.strictEqual(1, 2)
+  })
+})

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1751,6 +1751,10 @@ moduleTypes.forEach(({
               { name: 'other context fails', isRetry: true, isNew: true },
               { name: 'other context fails', isRetry: true, isNew: true },
             ])
+            const alwaysFailingEfdTests = tests.filter(test => test.meta[TEST_NAME] === 'other context fails')
+            const failedAllRetriesTests = alwaysFailingEfdTests
+              .filter(test => test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true')
+            assert.strictEqual(failedAllRetriesTests.length, 1)
 
             const testSession = events.find(event => event.type === 'test_session_end').content
             assertObjectContains(testSession.meta, {

--- a/integration-tests/playwright/playwright.spec.js
+++ b/integration-tests/playwright/playwright.spec.js
@@ -879,6 +879,9 @@ versions.forEach((version) => {
                 assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
                 assert.strictEqual(test.meta[TEST_STATUS], 'fail')
               })
+              const failedAllRetriesTests = newTests
+                .filter(test => test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true')
+              assert.strictEqual(failedAllRetriesTests.length, 1)
               // --retries works normally for old flaky tests
               const oldFlakyTests = tests.filter(
                 test => test.meta[TEST_NAME] === 'playwright should retry old flaky tests'

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -710,6 +710,13 @@ versions.forEach((version) => {
             // so the test session should be reported as failed
             const failedTests = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
             assert.strictEqual(failedTests.length, 6)
+            const failedAllRetriesTests = tests
+              .filter(test => test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true')
+            assert.strictEqual(failedAllRetriesTests.length, 1)
+            assert.strictEqual(
+              failedAllRetriesTests[0].meta[TEST_NAME],
+              'early flake detection can retry tests that always pass'
+            )
             const testSessionEvent = events.find(event => event.type === 'test_session_end').content
             assert.strictEqual(testSessionEvent.meta[TEST_STATUS], 'fail')
             assert.strictEqual(testSessionEvent.meta[TEST_EARLY_FLAKE_ENABLED], 'true')

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -351,6 +351,12 @@ function wrapRun (pl, isLatestVersion, version) {
 
         if (isNew || isModified) {
           isEfdRetry = numRetries > 0
+          const statuses = lastStatusByPickleId.get(this.pickle.id)
+          if (isEfdRetry &&
+            statuses.length >= earlyFlakeDetectionNumRetries + 1 &&
+            statuses.every(status => status === 'fail')) {
+            hasFailedAllRetries = true
+          }
         }
 
         const attemptCtx = numAttemptToCtx.get(numAttempt)

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -395,6 +395,11 @@ function testEndHandler ({
       test._ddHasPassedAttemptToFixRetries = true
     }
   }
+  if (test._ddIsEfdRetry &&
+    testStatuses.length >= earlyFlakeDetectionNumRetries + 1 &&
+    testStatuses.every(status => status === 'fail')) {
+    test._ddHasFailedAllRetries = true
+  }
 
   // this handles tests that do not go through the worker process (because they're skipped)
   if (shouldCreateTestSpan) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -1034,6 +1034,10 @@ addHook({
             if (statuses.every(status => status === 'fail')) {
               hasFailedAllRetries = true
             }
+          } else if (taskToStatuses.has(task) &&
+            !attemptToFixTasks.has(task) &&
+            (newTasks.has(task) || modifiedTasks.has(task))) {
+            hasFailedAllRetries = true
           }
 
           if (testCtx) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -955,6 +955,10 @@ class CypressPlugin {
             }
           }
         }
+        const isLastEfdAttempt = isEfdRetry && testStatuses.length >= this.earlyFlakeDetectionNumRetries + 1
+        if (isLastEfdAttempt && testStatuses.every(status => status === 'fail')) {
+          this.activeTestSpan.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
+        }
 
         // Ensure quarantined tests reported from support.js are tagged
         // (This catches cases where the test ran but failed, but Cypress saw it as passed)


### PR DESCRIPTION
Set test.has_failed_all_retries when early flake detection retries all fail, and add integration coverage for Jest, Mocha, Cucumber, Vitest, Playwright, and Cypress to prevent regressions.

<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


