### PR TITLE
docs(cursor): clarify pr-body command instructions

### DIFF
--- a/.cursor/commands/pr-body.md
+++ b/.cursor/commands/pr-body.md
@@ -5,11 +5,13 @@ Do not just blindly list every change.
 Only include specific changes if its relevant to understand the PR changes.
 
 Use the PR template in `.github/pull_request_template.md` as the schema:
-- Remove all comments
-- Add content to the relevant sections (remove any section that isn't relevant)
-- Use commit messages in the branch as a staring point
-- Use markdown
-- Use backticks for all file/path and inline code refeferences
-- Don't break lines unnecessarily
+- **IMPORTANT:** Remove all comments from the template.
+- Add content to the relevant sections.
+- Remove "Additional Notes" section if it doesn't add any value.
+- Use commit messages in the branch as a staring point.
+- Use markdown.
+- Use backticks for all file/path and inline code references.
+- Don't break lines unnecessarily.
+- Add an empty line after each markdown headline, before the text.
 
 **IMPORTANT:** Output the final PR body in a code block formatted using 4 backticks, so it's easy to copy/paste even if the content itself contains 3 backticks in a row.


### PR DESCRIPTION
### What does this PR do?

Updates the `.cursor/commands/pr-body.md` command so PR bodies follow the GitHub template more consistently: clearer bullet rules (including removing template comments and the optional "Additional Notes" section), a fix for the "references" typo, and a rule to add a blank line after each markdown headline.

### Motivation

Fixes issues I've encountered many times: Make PR body generation more stable across more LLMs.
