### PR TITLE
chore: configure Datadog merge queue

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,8 +1,6 @@
 name: All Green
 on:
   pull_request:
-    branches-ignore:
-      - 'mq-working-branch-**'
   push:
     branches:
       - master


### PR DESCRIPTION
### What does this PR do?

Adds `repository.datadog.yaml` configuration to configure the Datadog merge queue with speculative workflow. It is heavily inspired by [its dd-trace-py counterpart](https://github.com/DataDog/dd-trace-py/blob/1c21042e5ff003b4aa08db5c8c8dbacbf24c2c0a/repository.datadog.yml). This allows PRs to be validated against the latest base branch before merging, preventing conflicts and broken builds in high-velocity merges.

The queue is restricted to `master` to avoid running on other branches.

Configuration details:
- Speculative workflow with fallback enabled
- Up to 5 PRs validated in parallel
- GitLab checks enabled with retry support
- Fail-fast disabled to wait for full pipeline completion
- Labels skipped to avoid triggering required status checks

### Motivation

The merge queue helps prevent merge conflicts and broken builds by validating PRs against the latest base branch before merging, which is especially important in repositories with high merge velocity where multiple PRs may be merged in quick succession.

### Additional Notes

For now, the merge queue isn't enforced, but opt-in. This allows us to test drive it, and only choose to enforce it if we decide the pros outweigh the cons.
