### PR TITLE
fix(confluent): add kafka_cluster_id to DSM backlog and checkpoints

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/kafka.js
+++ b/packages/datadog-instrumentations/src/helpers/kafka.js
@@ -1,0 +1,47 @@
+'use strict'
+
+/**
+ * Retrieve the Kafka cluster ID from the admin API.
+ * Returns a cached value, a promise, or null if unavailable.
+ *
+ * @param {object} kafka - KafkaJS-compatible Kafka instance
+ * @returns {string|Promise<string>|null}
+ */
+function getKafkaClusterId (kafka) {
+  if (kafka._ddKafkaClusterId) {
+    return kafka._ddKafkaClusterId
+  }
+
+  if (!kafka.admin) {
+    return null
+  }
+
+  const admin = kafka.admin()
+
+  if (!admin.describeCluster) {
+    return null
+  }
+
+  return admin.connect()
+    .then(() => {
+      return admin.describeCluster()
+    })
+    .then((clusterInfo) => {
+      const clusterId = clusterInfo?.clusterId
+      kafka._ddKafkaClusterId = clusterId
+      admin.disconnect()
+      return clusterId
+    })
+    .catch((error) => {
+      throw error
+    })
+}
+
+function isPromise (obj) {
+  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function'
+}
+
+module.exports = {
+  getKafkaClusterId,
+  isPromise,
+}

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -7,6 +7,7 @@ const {
   channel,
   addHook,
 } = require('./helpers/instrument')
+const { getKafkaClusterId, isPromise } = require('./helpers/kafka')
 
 const producerStartCh = channel('apm:kafkajs:produce:start')
 const producerCommitCh = channel('apm:kafkajs:produce:commit')
@@ -229,36 +230,3 @@ const wrappedCallback = (fn, startCh, finishCh, errorCh, extractArgs, clusterId)
     : fn
 }
 
-const getKafkaClusterId = (kafka) => {
-  if (kafka._ddKafkaClusterId) {
-    return kafka._ddKafkaClusterId
-  }
-
-  if (!kafka.admin) {
-    return null
-  }
-
-  const admin = kafka.admin()
-
-  if (!admin.describeCluster) {
-    return null
-  }
-
-  return admin.connect()
-    .then(() => {
-      return admin.describeCluster()
-    })
-    .then((clusterInfo) => {
-      const clusterId = clusterInfo?.clusterId
-      kafka._ddKafkaClusterId = clusterId
-      admin.disconnect()
-      return clusterId
-    })
-    .catch((error) => {
-      throw error
-    })
-}
-
-function isPromise (obj) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function'
-}

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -24,22 +24,6 @@ const batchConsumerErrorCh = channel('apm:kafkajs:consume-batch:error')
 
 const disabledHeaderWeakSet = new WeakSet()
 
-function commitsFromEvent (event) {
-  const { payload: { groupId, topics } } = event
-  const commitList = []
-  for (const { topic, partitions } of topics) {
-    for (const { partition, offset } of partitions) {
-      commitList.push({
-        groupId,
-        partition,
-        offset,
-        topic,
-      })
-    }
-  }
-  consumerCommitCh.publish(commitList)
-}
-
 addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKafka) => {
   class Kafka extends BaseKafka {
     constructor (options) {
@@ -132,6 +116,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     }
 
     const kafkaClusterIdPromise = getKafkaClusterId(this)
+    let resolvedClusterId = null
 
     const eachMessageExtractor = (args, clusterId) => {
       const { topic, partition, message } = args[0]
@@ -146,13 +131,29 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
 
     const consumer = createConsumer.apply(this, arguments)
 
-    consumer.on(consumer.events.COMMIT_OFFSETS, commitsFromEvent)
+    consumer.on(consumer.events.COMMIT_OFFSETS, (event) => {
+      const { payload: { groupId: commitGroupId, topics } } = event
+      const commitList = []
+      for (const { topic, partitions } of topics) {
+        for (const { partition, offset } of partitions) {
+          commitList.push({
+            groupId: commitGroupId,
+            partition,
+            offset,
+            topic,
+            clusterId: resolvedClusterId,
+          })
+        }
+      }
+      consumerCommitCh.publish(commitList)
+    })
 
     const run = consumer.run
     const groupId = arguments[0].groupId
 
     consumer.run = function ({ eachMessage, eachBatch, ...runArgs }) {
       const wrapConsume = (clusterId) => {
+        resolvedClusterId = clusterId
         return run({
           eachMessage: wrappedCallback(
             eachMessage,

--- a/packages/datadog-plugin-kafkajs/src/consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/consumer.js
@@ -40,14 +40,18 @@ class KafkajsConsumerPlugin extends ConsumerPlugin {
    * @returns {ConsumerBacklog}
    */
   transformCommit (commit) {
-    const { groupId, partition, offset, topic } = commit
-    return {
+    const { groupId, partition, offset, topic, clusterId } = commit
+    const backlog = {
       partition,
       topic,
       type: 'kafka_commit',
       offset: Number(offset),
       consumer_group: groupId,
     }
+    if (clusterId) {
+      backlog.kafka_cluster_id = clusterId
+    }
+    return backlog
   }
 
   commit (commitList) {

--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -219,18 +219,25 @@ describe('Plugin', () => {
               assert.strictEqual(runArg?.offset, commitMeta.offset)
               assert.strictEqual(runArg?.partition, commitMeta.partition)
               assert.strictEqual(runArg?.topic, commitMeta.topic)
-              assertObjectContains(runArg, {
+              const expectedBacklog = {
                 type: 'kafka_commit',
                 consumer_group: 'test-group',
-              })
+              }
+              if (clusterIdAvailable) {
+                expectedBacklog.kafka_cluster_id = testKafkaClusterId
+              }
+              assertObjectContains(runArg, expectedBacklog)
             })
           }
 
           it('Should add backlog on producer response', async () => {
             await sendMessages(kafka, testTopic, messages)
             sinon.assert.calledOnce(setOffsetSpy)
-            const { topic } = setOffsetSpy.lastCall.args[0]
-            assert.strictEqual(topic, testTopic)
+            const runArg = setOffsetSpy.lastCall.args[0]
+            assert.strictEqual(runArg.topic, testTopic)
+            if (clusterIdAvailable) {
+              assert.strictEqual(runArg.kafka_cluster_id, testKafkaClusterId)
+            }
           })
         })
       })


### PR DESCRIPTION
## Summary

Builds on #7569 (kafkajs backlog cluster_id fix).

The `@confluentinc/kafka-javascript` instrumentation never called `getKafkaClusterId`, so `kafka_cluster_id` was missing from **both** DSM checkpoints (edge tags) **and** backlog offset tracking — a worse version of the kafkajs bug.

- **Extract** `getKafkaClusterId` and `isPromise` to shared `helpers/kafka.js` (used by both kafkajs and confluent instrumentations)
- **Update kafkajs** instrumentation to import from the shared helper (no behavior change)
- **Add cluster ID retrieval** to confluent KafkaJS producer and consumer paths
- **Thread `clusterId`** through producer `ctx`, consumer `extractedArgs`, and offset tracking (`updateLatestOffset` key now includes `clusterId` to prevent cross-cluster mixing)

### Not addressed

The **native module path** (`Producer`/`KafkaProducer`/`Consumer`/`KafkaConsumer` classes) does not yet support cluster ID retrieval since it lacks a KafkaJS-style admin API. This could be added in a follow-up using librdkafka's `getMetadata()`.

## Test plan

- [ ] Existing confluent DSM tests pass
- [ ] Verify with multi-cluster setup that lag metrics and checkpoints include `kafka_cluster_id`

**Depends on:** #7569

🤖 Generated with [Claude Code](https://claude.com/claude-code)