### PR TITLE
[test-optimization] Add custom tags in more hooks for Jest

### DIFF
--- a/integration-tests/ci-visibility/test-custom-tags/custom-tags.js
+++ b/integration-tests/ci-visibility/test-custom-tags/custom-tags.js
@@ -4,20 +4,32 @@ const tracer = require('dd-trace')
 const assert = require('assert')
 
 const sum = require('../test/sum')
-describe('test optimization custom tags', () => {
+describe('test optimization', () => {
   beforeEach(() => {
     const testSpan = tracer.scope().active()
-    testSpan.setTag('custom_tag.beforeEach', 'true')
+    testSpan.setTag('outer_scope.beforeEach', 'true')
   })
 
-  it('can report tests', () => {
-    const testSpan = tracer.scope().active()
-    testSpan.setTag('custom_tag.it', 'true')
-    assert.strictEqual(sum(1, 2), 3)
+  describe('custom tags', () => {
+    beforeEach(() => {
+      const testSpan = tracer.scope().active()
+      testSpan.setTag('custom_tag.beforeEach', 'true')
+    })
+
+    it('can report tests', () => {
+      const testSpan = tracer.scope().active()
+      testSpan.setTag('custom_tag.it', 'true')
+      assert.strictEqual(sum(1, 2), 3)
+    })
+
+    afterEach(() => {
+      const testSpan = tracer.scope().active()
+      testSpan.setTag('custom_tag.afterEach', 'true')
+    })
   })
 
   afterEach(() => {
     const testSpan = tracer.scope().active()
-    testSpan.setTag('custom_tag.afterEach', 'true')
+    testSpan.setTag('outer_scope.afterEach', 'true')
   })
 })

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -5971,9 +5971,11 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
           assertObjectContains(test, {
             meta: {
+              'outer_scope.beforeEach': 'true',
               'custom_tag.beforeEach': 'true',
               'custom_tag.it': 'true',
               'custom_tag.afterEach': 'true',
+              'outer_scope.afterEach': 'true',
             },
           })
         })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -466,7 +466,13 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         testContexts.set(event.test, ctx)
 
         testStartCh.runStores(ctx, () => {
-          for (const hook of event.test.parent.hooks) {
+          let p = event.test.parent
+          const hooks = []
+          while (p != null) {
+            hooks.push(...p.hooks)
+            p = p.parent
+          }
+          for (const hook of hooks) {
             let hookFn = hook.fn
             if (originalHookFns.has(hook)) {
               hookFn = originalHookFns.get(hook)


### PR DESCRIPTION
### What does this PR do?
Based on the work in https://github.com/DataDog/dd-trace-js/pull/5608, but extended to allow for all hooks applicable to a test to be wrapped. The existing code allows for only the nearest hooks to be wrapped, which makes it difficult/impossible to add tags to a test from anywhere else.

### Motivation
My team has a concept similar to `CODEOWNERS` but slightly different. And using that file we apply tags to the tests. The current system would require that we put a `beforeEach` throughout the entire application, or apply the tag inside each test. Both of these add unnecessary clutter, and are prone to people forgetting.

By expanding which hooks are wrapped, we can have 1 central location that defines a `beforeEach` to run before every test.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


