### PR TITLE
(ci): Migrate to short-lived token in benchmark-serverless job

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -124,7 +124,6 @@ benchmark-serverless:
       BTI_RESPONSE=$(curl --silent --request GET \
         --header "$BTI_CI_API_TOKEN" \  --header "Content-Type: application/vnd.api+json" \
         "https://bti-ci-api.us1.ddbuild.io/internal/ci/gitlab/token?owner=DataDog&repository=serverless-tools")
-    - echo "here"
     - GITLAB_TOKEN=$(echo "$BTI_RESPONSE" | jq -r '.token // empty')
     - git clone https://serverless-tools:${GITLAB_TOKEN}@gitlab.ddbuild.io/DataDog/serverless-tools.git ./serverless-tools && cd ./serverless-tools
     - ./ci/check_trigger_status.sh


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Migrates benchmark-serverless job to short-lived token instead of Gitlab personal access token for cloning serverless-tools repo.


### Motivation
Recent incident in which CI broke because of expired personal access token.
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


