### PR TITLE
feat(lambda): adopt mini agent for Lambda Lite environments

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -21,7 +21,7 @@ const {
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
 } = require('../serverless')
-const { ORIGIN_KEY } = require('../constants')
+const { ORIGIN_KEY, DATADOG_MINI_AGENT_PATH } = require('../constants')
 const { appendRules } = require('../payload-tagging/config')
 const { getGitMetadataFromGitProperties, removeUserSensitiveInfo, getRemoteOriginURL, resolveGitHeadSHA } =
   require('./git_properties')
@@ -620,7 +620,7 @@ class Config {
     unprocessedTarget['experimental.aiguard.timeout'] = DD_AI_GUARD_TIMEOUT
     setBoolean(target, 'experimental.enableGetRumData', DD_TRACE_EXPERIMENTAL_GET_RUM_DATA_ENABLED)
     setString(target, 'experimental.exporter', DD_TRACE_EXPERIMENTAL_EXPORTER)
-    if (AWS_LAMBDA_FUNCTION_NAME) {
+    if (AWS_LAMBDA_FUNCTION_NAME && !fs.existsSync(DATADOG_MINI_AGENT_PATH)) {
       target.flushInterval = 0
     } else if (DD_TRACE_FLUSH_INTERVAL) {
       target.flushInterval = maybeInt(DD_TRACE_FLUSH_INTERVAL)

--- a/packages/dd-trace/src/constants.js
+++ b/packages/dd-trace/src/constants.js
@@ -22,6 +22,7 @@ module.exports = {
   SPAN_SAMPLING_RULE_RATE: '_dd.span_sampling.rule_rate',
   SPAN_SAMPLING_MAX_PER_SECOND: '_dd.span_sampling.max_per_second',
   DATADOG_LAMBDA_EXTENSION_PATH: '/opt/extensions/datadog-agent',
+  DATADOG_MINI_AGENT_PATH: '/tmp/datadog/mini_agent_ready',
   DECISION_MAKER_KEY: '_dd.p.dm',
   SAMPLING_KNUTH_RATE: '_dd.p.ksr',
   PROCESS_ID: 'process_id',

--- a/packages/dd-trace/src/exporter.js
+++ b/packages/dd-trace/src/exporter.js
@@ -25,8 +25,11 @@ module.exports = function getExporter (name) {
       return require('./ci-visibility/exporters/test-worker')
     default: {
       const inAWSLambda = getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME') !== undefined
-      const usingLambdaExtension = inAWSLambda && fs.existsSync(constants.DATADOG_LAMBDA_EXTENSION_PATH)
-      return require(inAWSLambda && !usingLambdaExtension ? './exporters/log' : './exporters/agent')
+      const usingAgent = inAWSLambda && (
+        fs.existsSync(constants.DATADOG_LAMBDA_EXTENSION_PATH) ||
+        fs.existsSync(constants.DATADOG_MINI_AGENT_PATH)
+      )
+      return require(inAWSLambda && !usingAgent ? './exporters/log' : './exporters/agent')
     }
   }
 }

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -2330,6 +2330,29 @@ describe('Config', () => {
     assert.strictEqual(config.remoteConfig.enabled, false)
   })
 
+  describe('flushInterval in Lambda', () => {
+    afterEach(() => {
+      existsSyncReturn = undefined
+    })
+
+    it('should set flushInterval to 0 in standard Lambda environment', () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-great-lambda-function'
+
+      const config = getConfig()
+
+      assert.strictEqual(config.flushInterval, 0)
+    })
+
+    it('should not set flushInterval to 0 in Lambda environment with mini agent', () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-great-lambda-function'
+      existsSyncReturn = true
+
+      const config = getConfig()
+
+      assert.strictEqual(config.flushInterval, 2000)
+    })
+  })
+
   it('should not set DD_REMOTE_CONFIGURATION_ENABLED if FUNCTION_NAME and GCP_PROJECT are present', () => {
     process.env.FUNCTION_NAME = 'function_name'
     process.env.GCP_PROJECT = 'project_name'

--- a/packages/dd-trace/test/exporter.spec.js
+++ b/packages/dd-trace/test/exporter.spec.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 require('./setup/core')
 const AgentExporter = require('../src/exporters/agent')
 const LogExporter = require('../src/exporters/log')
+const { DATADOG_MINI_AGENT_PATH } = require('../src/constants')
 
 describe('exporter', () => {
   let env
@@ -40,6 +41,17 @@ describe('exporter', () => {
     process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-func'
     const stub = sinon.stub(fs, 'existsSync')
     stub.withArgs('/opt/extensions/datadog-agent').returns(true)
+
+    const Exporter = require('../src/exporter')()
+
+    assert.strictEqual(Exporter, AgentExporter)
+    stub.restore()
+  })
+
+  it('should create an AgentExporter when in Lambda environment with mini agent', () => {
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-func'
+    const stub = sinon.stub(fs, 'existsSync')
+    stub.withArgs(DATADOG_MINI_AGENT_PATH).returns(true)
 
     const Exporter = require('../src/exporter')()
 


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/SVLS-8571

### What does this PR do?                                                                                                                                                                         
                                                                                                                                                                                              
Introduces DATADOG_MINI_AGENT_PATH (/tmp/datadog/mini_agent_ready) as a sentinel constant to detect Lambda Lite + mini agent environments, and adjusts two behaviours when that path is present:                                                                                                                                                                                      
                                                                                                                                                                                              
1. Exporter selection (exporter.js): treats the mini agent the same as the Datadog Lambda Extension — selects AgentExporter instead of LogExporter.
2. flushInterval override (config/index.js): standard Lambda forces flushInterval = 0 so every span is sent before the invocation window closes. With the mini agent the process is a long-running web server, so batching is safe and flushInterval = 0 would saturate the 8-request exporter concurrency limit. The override is skipped, leaving the default (2000 ms).

This change depends on [this serverless-components PR](https://github.com/DataDog/serverless-components/pull/81)

### Motivation

Lambda Lite runs the tracer in a persistent server process alongside a mini agent, rather than the ephemeral invocation model of standard Lambda. The existing Lambda fast-path assumptions (flushInterval = 0, log exporter fallback) are counter-productive in this model and need to be gated on the absence of the mini agent ready file.

### Additional Notes

- DATADOG_MINI_AGENT_PATH mirrors the existing DATADOG_LAMBDA_EXTENSION_PATH pattern — both are file-existence checks, no new env vars.
- Unit tests added for both the exporter selection and the flushInterval branching covering all four combinations (standard Lambda, Lambda + extension, Lambda + mini agent, non-Lambda).