### PR TITLE
jest: wrap outer hooks too

### DIFF
--- a/integration-tests/ci-visibility/test-custom-tags/custom-tags.js
+++ b/integration-tests/ci-visibility/test-custom-tags/custom-tags.js
@@ -4,20 +4,32 @@ const tracer = require('dd-trace')
 const assert = require('assert')
 
 const sum = require('../test/sum')
-describe('test optimization custom tags', () => {
+describe('test optimization', () => {
   beforeEach(() => {
     const testSpan = tracer.scope().active()
-    testSpan.setTag('custom_tag.beforeEach', 'true')
+    testSpan.setTag('outer_scope.beforeEach', 'true')
   })
 
-  it('can report tests', () => {
-    const testSpan = tracer.scope().active()
-    testSpan.setTag('custom_tag.it', 'true')
-    assert.strictEqual(sum(1, 2), 3)
+  describe('custom tags', () => {
+    beforeEach(() => {
+      const testSpan = tracer.scope().active()
+      testSpan.setTag('custom_tag.beforeEach', 'true')
+    })
+
+    it('can report tests', () => {
+      const testSpan = tracer.scope().active()
+      testSpan.setTag('custom_tag.it', 'true')
+      assert.strictEqual(sum(1, 2), 3)
+    })
+
+    afterEach(() => {
+      const testSpan = tracer.scope().active()
+      testSpan.setTag('custom_tag.afterEach', 'true')
+    })
   })
 
   afterEach(() => {
     const testSpan = tracer.scope().active()
-    testSpan.setTag('custom_tag.afterEach', 'true')
+    testSpan.setTag('outer_scope.afterEach', 'true')
   })
 })

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -5971,9 +5971,11 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
           assertObjectContains(test, {
             meta: {
+              'outer_scope.beforeEach': 'true',
               'custom_tag.beforeEach': 'true',
               'custom_tag.it': 'true',
               'custom_tag.afterEach': 'true',
+              'outer_scope.afterEach': 'true',
             },
           })
         })

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -466,7 +466,13 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         testContexts.set(event.test, ctx)
 
         testStartCh.runStores(ctx, () => {
-          for (const hook of event.test.parent.hooks) {
+          let p = event.test.parent
+          const hooks = []
+          while (p != null) {
+            hooks.push(...p.hooks)
+            p = p.parent
+          }
+          for (const hook of hooks) {
             let hookFn = hook.fn
             if (originalHookFns.has(hook)) {
               hookFn = originalHookFns.get(hook)


### PR DESCRIPTION
the current implementation wraps hooks that are right next to the test. unfortunately, that means it's incredibly difficult to get access to spans in `beforeEach` hooks that are defined elsewhere.

this allows my org to apply certain tags to tests from a single logic point instead of having to put a beforeEach next to every test (or, apply the tag manually inside the test itself

Original contribution from @deecewan in #7572