### PR TITLE
chore(ci): enable workflows for merge queue

### DIFF
--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -3,7 +3,7 @@ name: AI Guard
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
 

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -3,7 +3,7 @@ name: APM Capabilities
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -3,7 +3,7 @@ name: APM Integrations
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -3,7 +3,7 @@ name: AppSec
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/bundle-validate.yml
+++ b/.github/workflows/bundle-validate.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "vendor/**"
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
     paths:
       - "vendor/**"
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -3,7 +3,7 @@ name: Debugger
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
 

--- a/.github/workflows/eslint-rules.yml
+++ b/.github/workflows/eslint-rules.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "eslint-rules/**"
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
     paths:
       - "eslint-rules/**"
 

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -3,7 +3,7 @@ name: LLMObs
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -3,7 +3,7 @@ name: OpenFeature
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
 

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -3,7 +3,7 @@ name: Platform
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -3,7 +3,7 @@ name: Profiling
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -3,7 +3,7 @@ name: Project
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - dependabot/**
       - master
+      - mq-working-branch-master-*
       - v[0-9]+.[0-9]+.[0-9]+-proposal
       - v[0-9]+.x
     types:

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -3,7 +3,7 @@ name: Serverless
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
   workflow_dispatch:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -3,7 +3,7 @@ name: System Tests
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [master, mq-working-branch-master-*]
   workflow_dispatch:
   schedule:
     - cron: 0 4 * * *

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -3,8 +3,7 @@ name: Test Optimization
 on:
   pull_request:
   push:
-    branches:
-      - master
+    branches: [master, mq-working-branch-master-*]
   schedule:
     - cron: 0 4 * * *
 


### PR DESCRIPTION
### What does this PR do?

Updates CI workflow triggers so GitHub Actions also run for Datadog merge queue branches by adding `mq-working-branch-master-*` to push/ref branch filters in the relevant workflow files under `.github/workflows/`.

### Motivation

Without these branch filters, merge queue working branches do not execute the same CI workflows as `master`.

### Additional notes

I specifically chose not to include `all-green` in this, as it doesn't serve any purpose. All other relevant workflows should be included.
