### PR TITLE
chore(test): Fix cmd injection telemetry flaky tests

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -23,10 +23,7 @@ env:
 
 jobs:
   macos:
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    name: ${{ github.workflow }} / macos (run ${{ matrix.run }})
+    name: ${{ github.workflow }} / macos
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,10 +40,7 @@ jobs:
           service: dd-trace-js-tests
 
   ubuntu:
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    name: ${{ github.workflow }} / ubuntu (run ${{ matrix.run }})
+    name: ${{ github.workflow }} / ubuntu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -69,10 +63,7 @@ jobs:
           service: dd-trace-js-tests
 
   windows:
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    name: ${{ github.workflow }} / windows (run ${{ matrix.run }})
+    name: ${{ github.workflow }} / windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -90,454 +81,454 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY }}
           service: dd-trace-js-tests
 
-# ldapjs:
-#   name: ${{ github.workflow }} / ldapjs
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: ldapjs
-#   services:
-#     openldap:
-#       image: bitnamilegacy/openldap:latest
-#       ports:
-#         - "1389:1389"
-#         - "1636:1636"
-#       env:
-#         LDAP_ADMIN_USERNAME: "admin"
-#         LDAP_ADMIN_PASSWORD: "adminpassword"
-#         LDAP_USERS: "user01,user02"
-#         LDAP_PASSWORDS: "password1,password2"
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-ldapjs
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  ldapjs:
+    name: ${{ github.workflow }} / ldapjs
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: ldapjs
+    services:
+      openldap:
+        image: bitnamilegacy/openldap:latest
+        ports:
+          - "1389:1389"
+          - "1636:1636"
+        env:
+          LDAP_ADMIN_USERNAME: "admin"
+          LDAP_ADMIN_PASSWORD: "adminpassword"
+          LDAP_USERS: "user01,user02"
+          LDAP_PASSWORDS: "password1,password2"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-ldapjs
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# postgres:
-#   name: ${{ github.workflow }} / postgres
-#   runs-on: ubuntu-latest
-#   services:
-#     postgres:
-#       image: postgres:9.5
-#       env:
-#         POSTGRES_PASSWORD: postgres
-#       ports:
-#         - 5432:5432
-#   env:
-#     PG_TEST_NATIVE: "true"
-#     PLUGINS: pg|knex
-#     SERVICES: postgres
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/newest-maintenance-lts
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-postgres
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  postgres:
+    name: ${{ github.workflow }} / postgres
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:9.5
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+    env:
+      PG_TEST_NATIVE: "true"
+      PLUGINS: pg|knex
+      SERVICES: postgres
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/newest-maintenance-lts
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-postgres
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# mysql:
-#   name: ${{ github.workflow }} / mysql
-#   runs-on: ubuntu-latest
-#   services:
-#     mysql:
-#       image: mariadb:10.4
-#       env:
-#         MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-#         MYSQL_DATABASE: "db"
-#       ports:
-#         - 3306:3306
-#   env:
-#     PLUGINS: mysql|mysql2|sequelize
-#     SERVICES: mysql
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/newest-maintenance-lts
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-mysql
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  mysql:
+    name: ${{ github.workflow }} / mysql
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mariadb:10.4
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: "db"
+        ports:
+          - 3306:3306
+    env:
+      PLUGINS: mysql|mysql2|sequelize
+      SERVICES: mysql
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/newest-maintenance-lts
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-mysql
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# express:
-#   name: ${{ github.workflow }} / express
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: express|body-parser|cookie-parser|multer
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-express
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  express:
+    name: ${{ github.workflow }} / express
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: express|body-parser|cookie-parser|multer
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-express
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# fastify:
-#   name: ${{ github.workflow }} / fastify
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: fastify
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-fastify
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  fastify:
+    name: ${{ github.workflow }} / fastify
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: fastify
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-fastify
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# graphql:
-#   name: ${{ github.workflow }} / graphql
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: apollo-server|apollo-server-express|apollo-server-fastify|apollo-server-core
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-graphql
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  graphql:
+    name: ${{ github.workflow }} / graphql
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: apollo-server|apollo-server-express|apollo-server-fastify|apollo-server-core
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-graphql
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# mongodb-core:
-#   name: ${{ github.workflow }} / mongodb-core
-#   runs-on: ubuntu-latest
-#   services:
-#     mongodb:
-#       image: circleci/mongo
-#       ports:
-#         - 27017:27017
-#   env:
-#     PLUGINS: express-mongo-sanitize|mquery
-#     SERVICES: mongo
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-mongodb-core
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  mongodb-core:
+    name: ${{ github.workflow }} / mongodb-core
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: circleci/mongo
+        ports:
+          - 27017:27017
+    env:
+      PLUGINS: express-mongo-sanitize|mquery
+      SERVICES: mongo
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-mongodb-core
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# mongoose:
-#   name: ${{ github.workflow }} / mongoose
-#   runs-on: ubuntu-latest
-#   services:
-#     mongodb:
-#       image: circleci/mongo
-#       ports:
-#         - 27017:27017
-#   env:
-#     PLUGINS: mongoose
-#     SERVICES: mongo
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-mongoose
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  mongoose:
+    name: ${{ github.workflow }} / mongoose
+    runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: circleci/mongo
+        ports:
+          - 27017:27017
+    env:
+      PLUGINS: mongoose
+      SERVICES: mongo
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-mongoose
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# sourcing:
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: cookie
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/newest-maintenance-lts
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/active-lts
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-sourcing
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  sourcing:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: cookie
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/newest-maintenance-lts
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/active-lts
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-sourcing
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# next:
-#   strategy:
-#     fail-fast: false
-#     matrix:
-#       version:
-#         - oldest
-#         - latest
-#       range:
-#         [
-#           ">=10.2.0 <11",
-#           ">=11.0.0 <13",
-#           "11.1.4",
-#           ">=13.0.0 <14",
-#           "13.2.0",
-#           ">=14.0.0 <=14.2.6",
-#           ">=14.2.7 <15",
-#           ">=15.0.0",
-#         ]
-#       include:
-#         - range: ">=10.2.0 <11"
-#           range_clean: gte.10.2.0.and.lt.11
-#         - range: ">=11.0.0 <13"
-#           range_clean: gte.11.0.0.and.lt.13
-#         - range: "11.1.4"
-#           range_clean: 11.1.4
-#         - range: ">=13.0.0 <14"
-#           range_clean: gte.13.0.0.and.lt.14
-#         - range: "13.2.0"
-#           range_clean: 13.2.0
-#         - range: ">=14.0.0 <=14.2.6"
-#           range_clean: gte.14.0.0.and.lte.14.2.6
-#         - range: ">=14.2.7 <15"
-#           range_clean: gte.14.2.7.and.lt.15
-#         - range: ">=15.0.0"
-#           range_clean: gte.15.0.0
-#   name: ${{ github.workflow }} / next (node-${{ matrix.version }}, ${{ matrix.range_clean }})
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: next
-#     PACKAGE_VERSION_RANGE: ${{ matrix.range }}
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/testagent/start
-#     - uses: ./.github/actions/node
-#       with:
-#         version: ${{ matrix.version }}
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - if: always()
-#       uses: ./.github/actions/testagent/logs
-#       with:
-#         suffix: appsec-${{ github.job }}-${{ matrix.version }}-${{ matrix.range_clean }}
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-next-${{ matrix.version }}-${{ matrix.range_clean }}
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  next:
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - oldest
+          - latest
+        range:
+          [
+            ">=10.2.0 <11",
+            ">=11.0.0 <13",
+            "11.1.4",
+            ">=13.0.0 <14",
+            "13.2.0",
+            ">=14.0.0 <=14.2.6",
+            ">=14.2.7 <15",
+            ">=15.0.0",
+          ]
+        include:
+          - range: ">=10.2.0 <11"
+            range_clean: gte.10.2.0.and.lt.11
+          - range: ">=11.0.0 <13"
+            range_clean: gte.11.0.0.and.lt.13
+          - range: "11.1.4"
+            range_clean: 11.1.4
+          - range: ">=13.0.0 <14"
+            range_clean: gte.13.0.0.and.lt.14
+          - range: "13.2.0"
+            range_clean: 13.2.0
+          - range: ">=14.0.0 <=14.2.6"
+            range_clean: gte.14.0.0.and.lte.14.2.6
+          - range: ">=14.2.7 <15"
+            range_clean: gte.14.2.7.and.lt.15
+          - range: ">=15.0.0"
+            range_clean: gte.15.0.0
+    name: ${{ github.workflow }} / next (node-${{ matrix.version }}, ${{ matrix.range_clean }})
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: next
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - if: always()
+        uses: ./.github/actions/testagent/logs
+        with:
+          suffix: appsec-${{ github.job }}-${{ matrix.version }}-${{ matrix.range_clean }}
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-next-${{ matrix.version }}-${{ matrix.range_clean }}
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# lodash:
-#   name: ${{ github.workflow }} / lodash
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: lodash
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-lodash
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  lodash:
+    name: ${{ github.workflow }} / lodash
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: lodash
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-lodash
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# integration:
-#   strategy:
-#     matrix:
-#       version: [oldest, maintenance, active, latest]
-#   name: ${{ github.workflow }} / integration (node-${{ matrix.version }})
-#   runs-on: ubuntu-latest
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node
-#       with:
-#         version: ${{ matrix.version }}
-#     - uses: ./.github/actions/install
-#     - run: yarn test:integration:appsec
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  integration:
+    strategy:
+      matrix:
+        version: [oldest, maintenance, active, latest]
+    name: ${{ github.workflow }} / integration (node-${{ matrix.version }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
+      - uses: ./.github/actions/install
+      - run: yarn test:integration:appsec
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# passport:
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: passport-local|passport-http
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-passport
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  passport:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: passport-local|passport-http
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-passport
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# template:
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: handlebars|pug
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-template
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  template:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: handlebars|pug
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-template
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# node-serialize:
-#   name: ${{ github.workflow }} / node-serialize
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: node-serialize
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-node-serialize
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  node-serialize:
+    name: ${{ github.workflow }} / node-serialize
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: node-serialize
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-node-serialize
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# kafka:
-#   runs-on: ubuntu-latest
-#   services:
-#     kafka:
-#       image: apache/kafka-native:3.9.1
-#       env:
-#         KAFKA_PROCESS_ROLES: broker,controller
-#         KAFKA_NODE_ID: "1"
-#         KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-#         KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
-#         KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-#         KAFKA_CLUSTER_ID: r4zt_wrqTRuT7W2NJsB_GA
-#         KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
-#         KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-#         KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-#         KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-#         KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
-#       ports:
-#         - 9092:9092
-#         - 9093:9093
-#   env:
-#     PLUGINS: kafkajs
-#     SERVICES: kafka
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/coverage
-#       with:
-#         flags: appsec-kafka
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  kafka:
+    runs-on: ubuntu-latest
+    services:
+      kafka:
+        image: apache/kafka-native:3.9.1
+        env:
+          KAFKA_PROCESS_ROLES: broker,controller
+          KAFKA_NODE_ID: "1"
+          KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_CLUSTER_ID: r4zt_wrqTRuT7W2NJsB_GA
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+          KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+          KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: "0"
+        ports:
+          - 9092:9092
+          - 9093:9093
+    env:
+      PLUGINS: kafkajs
+      SERVICES: kafka
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: appsec-kafka
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
-# stripe:
-#   runs-on: ubuntu-latest
-#   env:
-#     PLUGINS: stripe
-#   steps:
-#     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-#     - uses: ./.github/actions/node/oldest-maintenance-lts
-#     - uses: ./.github/actions/install
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: ./.github/actions/node/latest
-#     - run: yarn test:appsec:plugins:ci
-#     - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-#     - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94  # v2.1.1
-#       if: always() && github.actor != 'dependabot[bot]'
-#       with:
-#         api_key: ${{ secrets.DD_API_KEY }}
-#         service: dd-trace-js-tests
+  stripe:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: stripe
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - run: yarn test:appsec:plugins:ci
+      - uses: ./.github/actions/node/latest
+      - run: yarn test:appsec:plugins:ci
+      - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94  # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Instead of checking only the first 2 messages coming in the telemetry, this will wait until the first telemetry message that asserts everithing.
And also, the check will fail if the telemetry is not in appsec namespace.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[APPSEC-60075]


[APPSEC-60075]: https://datadoghq.atlassian.net/browse/APPSEC-60075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ