### PR TITLE
[test optimization] Improve cypress - RUM integration

### DIFF
--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -306,6 +306,9 @@ class CypressPlugin {
 
     this.isTestIsolationEnabled = getIsTestIsolationEnabled(cypressConfig)
 
+    const envFlushWait = Number(getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS'))
+    this.rumFlushWaitMillis = Number.isFinite(envFlushWait) ? envFlushWait : undefined
+
     if (!this.isTestIsolationEnabled) {
       log.warn('Test isolation is disabled, retries will not be enabled')
     }
@@ -823,6 +826,7 @@ class CypressPlugin {
           isModifiedTest: this.getIsTestModified(testSuiteAbsolutePath),
           repositoryRoot: this.repositoryRoot,
           isTestIsolationEnabled: this.isTestIsolationEnabled,
+          rumFlushWaitMillis: this.rumFlushWaitMillis,
         }
 
         if (this.testSuiteSpan) {

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME = 'datadog-ci-visibility-test-execution-id'
-const DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS = 500
+let rumFlushWaitMillis = 500
 
 let isEarlyFlakeDetectionEnabled = false
 let isKnownTestsEnabled = false
@@ -226,6 +226,9 @@ before(function () {
       isImpactedTestsEnabled = suiteConfig.isImpactedTestsEnabled
       isModifiedTest = suiteConfig.isModifiedTest
       isTestIsolationEnabled = suiteConfig.isTestIsolationEnabled
+      if (Number.isFinite(suiteConfig.rumFlushWaitMillis)) {
+        rumFlushWaitMillis = suiteConfig.rumFlushWaitMillis
+      }
     }
   })
 })
@@ -278,7 +281,7 @@ afterEach(function () {
     if (rum.stopSession) {
       rum.stopSession()
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS)
+      cy.wait(rumFlushWaitMillis)
     }
   }
   let coverage


### PR DESCRIPTION
### What does this PR do?

* Improve how we grab the original window.
* Use `datadog-ci-visibility-test-execution-id` cookie instead of cypress global variable, as this is how it works for other integrations.
* Use `DD_RUM.stopSession`.
* Add a 500ms delay to give time to RUM to flush, configurable with `DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS`, like other frameworks.
* Do a best effort approach to work with `testIsolation:false`, which normally wouldn't work because the page does not refresh between tests. 


### Motivation
Improve the likelihood of cypress + RUM integration to succeed. 

### Additional Notes
Tested manually, as this includes using real RUM

