### PR TITLE
chore(test): Fixing iast overhead controller flaky tests

### DIFF
--- a/packages/dd-trace/test/appsec/iast/overhead-controller.integration.spec.js
+++ b/packages/dd-trace/test/appsec/iast/overhead-controller.integration.spec.js
@@ -66,9 +66,10 @@ describe('IAST - overhead-controller - integration', () => {
         })
       }, 1000, 1, true)
 
-      await axios.request(path, { method })
-
-      await assertPromise
+      await Promise.all([
+        axios.request(path, { method }),
+        assertPromise,
+      ])
     }
 
     async function checkNoVulnerabilitiesInEndpoint (path, method = 'GET') {
@@ -78,8 +79,10 @@ describe('IAST - overhead-controller - integration', () => {
         assert.ok(!('_dd.iast.json' in payload[0][0].meta))
       }, 1000, 1, true)
 
-      await axios.request(path, { method })
-      await assertPromise
+      await Promise.all([
+        axios.request(path, { method }),
+        assertPromise,
+      ])
     }
 
     it('should report vulnerability only in the first request', async () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Tries to fix flaky test in overhead controller. 
Changes the test check to do subscription to the agent before the execution of the request, seems that there is a race condition when the traces are received before the subscription. Now should be fixed.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

CI with +200 success executions: https://github.com/DataDog/dd-trace-js/actions/runs/22357293612?pr=7607 (two iteration of +100)
