### PR TITLE
chore(test): Fixing flaky ssrf

### DIFF
--- a/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.express.plugin.spec.js
@@ -88,7 +88,7 @@ describe('RASP - ssrf', () => {
             }
 
             await Promise.all([
-              checkRaspExecutedAndNotThreat(agent, true, 9_000),
+              checkRaspExecutedAndNotThreat(agent),
               axios.get('/?host=www.datadoghq.com'),
             ])
           })
@@ -148,7 +148,7 @@ describe('RASP - ssrf', () => {
 
             await Promise.all([
               axios.get('/?host=www.datadoghq.com'),
-              checkRaspExecutedAndNotThreat(agent, true, 9_000),
+              checkRaspExecutedAndNotThreat(agent),
             ])
           })
 
@@ -202,7 +202,7 @@ describe('RASP - ssrf', () => {
 
             await Promise.all([
               axios.get('/?host=www.datadoghq.com'),
-              checkRaspExecutedAndNotThreat(agent, true, 9_000),
+              checkRaspExecutedAndNotThreat(agent),
             ])
           })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Tries to fix the flaky test happening in the rasp test file `ssrf.express.plugin.spec.js`.
There is no easy way to reproduce the failure, but I figured out that the reason why the web root span is not found is because the trace is not complete and it is not sent to the agent. 
This could happen when timeout happens before the outgoing http request finishes. That is why I made some changes in the tested controller to be sure that the outgoing request span is closed as soon as possible, calling to `res.resume()` and finishing the main request when the outgoing request has finished.

### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce flaky tests

### Additional Notes
<!-- Anything else we should know when reviewing? -->
50 success executions in the CI: https://github.com/DataDog/dd-trace-js/actions/runs/22406751414/job/64868757093?pr=7617

