### PR TITLE
refactor(iast): prefer optional chaining over guard expressions

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/cookie-analyzer.js
@@ -39,7 +39,7 @@ class CookieAnalyzer extends Analyzer {
   }
 
   _checkOCE (context, value) {
-    if (value && value.location) {
+    if (value?.location) {
       return true
     }
     return super._checkOCE(context, value)

--- a/packages/dd-trace/src/appsec/iast/analyzers/ssrf-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/ssrf-analyzer.js
@@ -12,7 +12,7 @@ class SSRFAnalyzer extends InjectionAnalyzer {
     this.addSub('apm:http:client:request:start', ({ args }) => {
       if (typeof args.originalUrl === 'string') {
         this.analyze(args.originalUrl)
-      } else if (args.options && args.options.host) {
+      } else if (args.options?.host) {
         this.analyze(args.options.host)
       }
     })

--- a/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/unvalidated-redirect-analyzer.js
@@ -36,7 +36,7 @@ class UnvalidatedRedirectAnalyzer extends InjectionAnalyzer {
   }
 
   isLocationHeader (name) {
-    return name && name.trim().toLowerCase() === 'location'
+    return name?.trim().toLowerCase() === 'location'
   }
 
   _isVulnerable (value, iastContext) {

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/command-sensitive-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-analyzers/command-sensitive-analyzer.js
@@ -10,7 +10,7 @@ module.exports = function extractSensitiveRanges (evidence) {
     pattern.lastIndex = 0
 
     const regexResult = pattern.exec(evidence.value)
-    if (regexResult && regexResult.length > 1) {
+    if (regexResult?.length > 1) {
       const start = regexResult.index + (regexResult[0].length - regexResult[1].length)
       const end = start + regexResult[1].length
       return [{ start, end }]


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Replace `x && x.prop` guard patterns with optional chaining (`x?.prop`) across IAST analyzers and evidence redaction code

### Motivation
Improve consistency across the appsec codebase.



