### PR TITLE
set graphql.resolve span as the active span in scope when executing the resolve function

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -213,11 +213,14 @@ function wrapResolve (resolve) {
 
     const field = assertField(ctx, info, args)
 
-    return callInAsyncScope(resolve, this, arguments, ctx.abortController, (err) => {
-      field.ctx.error = err
-      field.ctx.info = info
-      field.ctx.field = field
-      updateFieldCh.publish(field.ctx)
+    const resolveSpan = field.ctx.currentStore.span
+    return resolveSpan.tracer().scope().activate(resolveSpan, () => {
+      return callInAsyncScope(resolve, this, arguments, ctx.abortController, (err) => {
+        field.ctx.error = err
+        field.ctx.info = info
+        field.ctx.field = field
+        updateFieldCh.publish(field.ctx)
+      })
     })
   }
 


### PR DESCRIPTION
### What does this PR do?
Makes a change in the GraphQL instrumentation so that the active scope when executing a `resolve` function is the `graphql.resolve` span instead of the `graphql.execute` span.

### Motivation
Currently, spans created in a GraphQL `resolve` function are children of `graphql.execute` and siblings of the `graphql.resolve` that belongs to the field being resolved. Therefore, the hierarchy doesn't appear to be correct in Datadog APM.

### Additional Notes
There's likely a better way to do this, but I'm not familiar enough with the internals.


