### PR TITLE
[test optimization] Align RUM flush wait to 500ms

### DIFF
--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -41,7 +41,7 @@ const testSuiteToTestStatuses = new Map()
 const testSuiteToErrors = new Map()
 const testsToTestStatuses = new Map()
 
-const RUM_FLUSH_WAIT_TIME = Number(getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')) || 1000
+const RUM_FLUSH_WAIT_TIME = Number(getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')) || 500
 
 let applyRepeatEachIndex = null
 


### PR DESCRIPTION
### What does this PR do?
Change `DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS` default value to 500ms in playwright following other languages and frameworks in JS.

### Motivation
Be aligned with other languages and JS

