### PR TITLE
chore(profiler): Update profiler to 5.13.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@datadog/native-iast-taint-tracking": "4.1.0",
     "@datadog/native-metrics": "3.1.1",
     "@datadog/openfeature-node-server": "^0.3.3",
-    "@datadog/pprof": "5.13.3",
+    "@datadog/pprof": "5.13.4",
     "@datadog/wasm-js-rewriter": "5.0.1",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/api-logs": "<1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,10 +182,10 @@
   dependencies:
     "@datadog/flagging-core" "0.3.3"
 
-"@datadog/pprof@5.13.3":
-  version "5.13.3"
-  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.13.3.tgz#7080d38b6c05736cb8a027835707ee4ee43eedf3"
-  integrity sha512-G25IicP7pc5CXmAfVz7nrIERsKK9hvPz6p7xsLTUwG4Qs+Zgd5KFedKCVsnvNasLc7l7OXQ6839ajowgQLWTyw==
+"@datadog/pprof@5.13.4":
+  version "5.13.4"
+  resolved "https://registry.yarnpkg.com/@datadog/pprof/-/pprof-5.13.4.tgz#3555252e177a1311826a9db4e4fb5bedc5561284"
+  integrity sha512-tX9ntTBh/pGFzZJ/dOkiZrtQ1pLMyX6liGyB5E7MpSQAXcCPj4Fh9yvZtqkKepwQn/0RWayCtZbwM3ikbh+c4w==
   dependencies:
     delay "^5.0.0"
     node-gyp-build "<4.0"


### PR DESCRIPTION
### What does this PR do?
Updates profiler to 5.13.4

### Motivation
With this we release some memory management improvements, see https://github.com/DataDog/pprof-nodejs/pull/286.

Fixes: https://github.com/DataDog/dd-trace-js/issues/7355
