### PR TITLE
[ARTSEC-INT] Migrate ddapm-test-agent image to internal registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,7 +196,7 @@ services:
       - LDAP_PASSWORDS=password1,password2
 
   testagent:
-    image: ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:v1.33.1
+    image: registry.ddbuild.io/images/mirror/dd-apm-test-agent/ddapm-test-agent:v1.33.1
     ports:
       - "127.0.0.1:9126:9126"
       - "127.0.0.1:4318:4318"


### PR DESCRIPTION
Migrates the `ddapm-test-agent` Docker image reference in `docker-compose.yml` from `ghcr.io` to the internal registry at `registry.ddbuild.io`, where the image is already mirrored. This ensures CI and local development pull from the internal source.