### PR TITLE
test(debugger): raise snapshot spec capture timeout

### DIFF
--- a/integration-tests/debugger/snapshot.spec.js
+++ b/integration-tests/debugger/snapshot.spec.js
@@ -4,7 +4,12 @@ const assert = require('node:assert/strict')
 const { setup } = require('./utils')
 
 describe('Dynamic Instrumentation', function () {
-  const t = setup({ dependencies: ['fastify'] })
+  const t = setup({
+    dependencies: ['fastify'],
+    env: {
+      DD_DYNAMIC_INSTRUMENTATION_CAPTURE_TIMEOUT_MS: '100',
+    },
+  })
 
   describe('input messages', function () {
     describe('with snapshot', function () {


### PR DESCRIPTION
### What does this PR do?

This PR makes `integration-tests/debugger/snapshot.spec.js` more deterministic by setting `DD_DYNAMIC_INSTRUMENTATION_CAPTURE_TIMEOUT_MS` to `100` in the shared `setup()` environment, so all snapshot tests in that file run with a higher capture deadline.

### Motivation

`Debugger` CI had a flaky failure where the snapshot payload was partially truncated with `notCapturedReason: 'timeout'` under the default capture budget, causing strict deep-equality assertions in `snapshot.spec.js` to fail intermittently even though behavior was otherwise correct. Increasing the timeout in this test file reduces timing sensitivity and stabilizes the suite.

