### PR TITLE
test source collection of trace service overrides

### DIFF
--- a/ext/tags.d.ts
+++ b/ext/tags.d.ts
@@ -10,6 +10,7 @@ declare const tags: {
   MANUAL_DROP: 'manual.drop'
   MEASURED: '_dd.measured'
   BASE_SERVICE: '_dd.base_service'
+  SRV_SRC: '_dd.srv_src'
   DD_PARENT_ID: '_dd.parent_id'
   HTTP_URL: 'http.url'
   HTTP_METHOD: 'http.method'

--- a/ext/tags.js
+++ b/ext/tags.js
@@ -13,6 +13,7 @@ const tags = {
   MANUAL_DROP: 'manual.drop',
   MEASURED: '_dd.measured',
   BASE_SERVICE: '_dd.base_service',
+  SRV_SRC: '_dd.srv_src',
   DD_PARENT_ID: '_dd.parent_id',
 
   // HTTP

--- a/packages/datadog-plugin-aerospike/src/index.js
+++ b/packages/datadog-plugin-aerospike/src/index.js
@@ -20,9 +20,13 @@ class AerospikePlugin extends DatabasePlugin {
     const childOf = store ? store.span : null
     const meta = getMeta(resourceName, commandArgs)
 
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
+
     const span = this.startSpan(this.operationName(), {
       childOf,
-      service: this.serviceName({ pluginConfig: this.config }),
+      service,
+      srvSrc: snOpts.srvSrc,
       type: 'aerospike',
       kind: 'client',
       resource: resourceName,

--- a/packages/datadog-plugin-amqplib/src/client.js
+++ b/packages/datadog-plugin-amqplib/src/client.js
@@ -17,8 +17,15 @@ class AmqplibClientPlugin extends ClientPlugin {
     if (method === 'basic.publish') return
 
     const stream = (channel.connection && channel.connection.stream) || {}
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     const span = this.startSpan(this.operationName(), {
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: getResourceName(method, fields),
       kind: this.constructor.kind,
       meta: {

--- a/packages/datadog-plugin-apollo/src/gateway/request.js
+++ b/packages/datadog-plugin-apollo/src/gateway/request.js
@@ -15,10 +15,13 @@ class ApolloGatewayRequestPlugin extends ApolloBasePlugin {
   bindStart (ctx) {
     const store = storage('legacy').getStore()
     const childOf = store ? store.span : null
+    const snOpts = { id: `${this.constructor.id}.${this.constructor.operation}`, pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
+
     const spanData = {
       childOf,
-      service: this.serviceName(
-        { id: `${this.constructor.id}.${this.constructor.operation}`, pluginConfig: this.config }),
+      service,
+      srvSrc: snOpts.srvSrc,
       type: this.constructor.type,
       kind: this.constructor.kind,
       meta: {},

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -53,9 +53,12 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         return parentStore
       }
 
+      const snOpts = {}
+      const serviceName = this.serviceName(snOpts)
+
       const meta = {
         'span.kind': 'client',
-        'service.name': this.serviceName(),
+        'service.name': serviceName,
         'aws.operation': operation,
         'aws.region': awsRegion,
         region: awsRegion,
@@ -63,6 +66,9 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         aws_service: awsService,
         'aws.service': awsService,
         component: 'aws-sdk',
+      }
+      if (snOpts.srvSrc) {
+        meta['_dd.srv_src'] = snOpts.srvSrc
       }
       if (this.requestTags) this.requestTags.set(request, meta)
 

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -60,8 +60,10 @@ class AzureFunctionsPlugin extends TracingPlugin {
       ctx.webContext = webContext
     } else {
       // For non-HTTP triggers, use standard flow
+      const snOpts = {}
       span = this.startSpan(this.operationName(), {
-        service: this.serviceName(),
+        service: this.serviceName(snOpts),
+        srvSrc: snOpts.srvSrc,
         type: 'serverless',
         meta,
       }, ctx)

--- a/packages/datadog-plugin-cassandra-driver/src/index.js
+++ b/packages/datadog-plugin-cassandra-driver/src/index.js
@@ -15,8 +15,12 @@ class CassandraDriverPlugin extends DatabasePlugin {
       query = combine(query)
     }
 
+    const snOpts = { pluginConfig: this.config, system: this.system }
+    const service = this.serviceName(snOpts)
+
     this.startSpan(this.operationName(), {
-      service: this.serviceName({ pluginConfig: this.config, system: this.system }),
+      service,
+      srvSrc: snOpts.srvSrc,
       resource: trim(query, 5000),
       type: 'cassandra',
       kind: 'client',

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -31,10 +31,14 @@ class CouchBasePlugin extends StoragePlugin {
       tags[tag] = customTags[tag]
     }
 
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
+
     return super.startSpan(
       this.operationName({ operation }),
       {
-        service: this.serviceName({ pluginConfig: this.config }),
+        service,
+        srvSrc: snOpts.srvSrc,
         meta: tags,
       },
       ctx

--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -10,8 +10,12 @@ class ElasticsearchPlugin extends DatabasePlugin {
 
     const body = getBody(params.body || params.bulkBody)
 
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
+
     this.startSpan(this.operationName(), {
-      service: this.serviceName({ pluginConfig: this.config }),
+      service,
+      srvSrc: snOpts.srvSrc,
       resource: `${params.method} ${quantizePath(params.path)}`,
       type: 'elasticsearch',
       kind: 'client',

--- a/packages/datadog-plugin-google-cloud-pubsub/src/client.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/client.js
@@ -12,8 +12,15 @@ class GoogleCloudPubsubClientPlugin extends ClientPlugin {
 
     if (api === 'publish') return
 
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     const spanOptions = {
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: [api, request.name].filter(Boolean).join(' '),
       kind: this.constructor.kind,
       meta: {

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -19,8 +19,15 @@ class GraphQLExecutePlugin extends TracingPlugin {
     const document = args.document
     const source = this.config.source && document && docSource
 
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     const span = this.startSpan(this.operationName(), {
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: getSignature(document, name, type, this.config.signature),
       kind: this.constructor.kind,
       type: this.constructor.type,

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -24,8 +24,15 @@ class GrpcClientPlugin extends ClientPlugin {
     const { metadata, path, type } = message
     const metadataFilter = this.config.metadataFilter
     const method = getMethodMetadata(path, type)
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     const span = this.startSpan(this.operationName(), {
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: path,
       kind: 'client',
       type: 'http',

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -32,9 +32,16 @@ class GrpcServerPlugin extends ServerPlugin {
     const metadataFilter = this.config.metadataFilter
     const childOf = extract(this.tracer, metadata)
     const method = getMethodMetadata(name, type)
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     const span = this.startSpan(this.operationName(), {
       childOf,
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: name,
       kind: 'server',
       type: 'web',

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -37,19 +37,28 @@ class HttpClientPlugin extends ClientPlugin {
     const method = (options.method || 'GET').toUpperCase()
     const childOf = store && allowed ? store.span : null
     // TODO delegate to super.startspan
+    const snOpts = { pluginConfig: this.config, sessionDetails: extractSessionDetails(options) }
+    const serviceName = this.serviceName(snOpts)
+
+    const meta = {
+      [COMPONENT]: this.constructor.id,
+      'span.kind': 'client',
+      'service.name': serviceName,
+      'resource.name': method,
+      'span.type': 'http',
+      'http.method': method,
+      'http.url': uri,
+      'out.host': hostname,
+    }
+
+    if (snOpts.srvSrc) {
+      meta['_dd.srv_src'] = snOpts.srvSrc
+    }
+
     const span = this.startSpan(this.operationName(), {
       childOf,
       integrationName: this.constructor.id,
-      meta: {
-        [COMPONENT]: this.constructor.id,
-        'span.kind': 'client',
-        'service.name': this.serviceName({ pluginConfig: this.config, sessionDetails: extractSessionDetails(options) }),
-        'resource.name': method,
-        'span.type': 'http',
-        'http.method': method,
-        'http.url': uri,
-        'out.host': hostname,
-      },
+      meta,
       metrics: {
         [CLIENT_PORT_KEY]: Number.parseInt(options.port),
       },

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -38,19 +38,28 @@ class Http2ClientPlugin extends ClientPlugin {
 
     const store = storage('legacy').getStore()
     const childOf = store && allowed ? store.span : null
+    const snOpts = { pluginConfig: this.config, sessionDetails }
+    const serviceName = this.serviceName(snOpts)
+
+    const meta = {
+      [COMPONENT]: this.constructor.id,
+      [SPAN_KIND]: CLIENT,
+      'service.name': serviceName,
+      'resource.name': method,
+      'span.type': 'http',
+      'http.method': method,
+      'http.url': uri,
+      'out.host': sessionDetails.host,
+    }
+
+    if (snOpts.srvSrc) {
+      meta['_dd.srv_src'] = snOpts.srvSrc
+    }
+
     const span = this.startSpan(this.operationName(), {
       childOf,
       integrationName: this.constructor.id,
-      meta: {
-        [COMPONENT]: this.constructor.id,
-        [SPAN_KIND]: CLIENT,
-        'service.name': this.serviceName({ pluginConfig: this.config, sessionDetails }),
-        'resource.name': method,
-        'span.type': 'http',
-        'http.method': method,
-        'http.url': uri,
-        'out.host': sessionDetails.host,
-      },
+      meta,
       metrics: {
         [CLIENT_PORT_KEY]: Number.parseInt(sessionDetails.port),
       },

--- a/packages/datadog-plugin-memcached/src/index.js
+++ b/packages/datadog-plugin-memcached/src/index.js
@@ -20,8 +20,12 @@ class MemcachedPlugin extends CachePlugin {
       meta['memcached.command'] = query.command
     }
 
+    const snOpts = { pluginConfig: this.config, system: this.system }
+    const service = this.serviceName(snOpts)
+
     this.startSpan({
-      service: this.serviceName({ pluginConfig: this.config, system: this.system }),
+      service,
+      srvSrc: snOpts.srvSrc,
       resource: query.type,
       type: 'memcached',
       meta,

--- a/packages/datadog-plugin-moleculer/src/client.js
+++ b/packages/datadog-plugin-moleculer/src/client.js
@@ -10,8 +10,15 @@ class MoleculerClientPlugin extends ClientPlugin {
   bindStart (ctx) {
     const { actionName, opts } = ctx
 
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     const span = this.startSpan(this.operationName(), {
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: actionName,
       kind: 'client',
     }, ctx)

--- a/packages/datadog-plugin-moleculer/src/server.js
+++ b/packages/datadog-plugin-moleculer/src/server.js
@@ -11,9 +11,16 @@ class MoleculerServerPlugin extends ServerPlugin {
     const { action, middlewareCtx, broker } = ctx
 
     const followsFrom = this.tracer.extract('text_map', middlewareCtx.meta)
+    const snOpts = {}
+    const service = this.config.service || this.serviceName(snOpts)
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : snOpts.srvSrc
+
     this.startSpan(this.operationName(), {
       childOf: followsFrom || ctx?.currentStore?.span || this.activeSpan,
-      service: this.config.service || this.serviceName(),
+      service,
+      srvSrc,
       resource: action.name,
       kind: 'server',
       type: 'web',

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -35,9 +35,11 @@ class MongodbCorePlugin extends DatabasePlugin {
     }
     const query = getQuery(ops)
     const resource = truncate(getResource(this, ns, query, name))
-    const service = this.serviceName({ pluginConfig: this.config })
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       resource,
       type: 'mongodb',
       kind: 'client',

--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -19,9 +19,11 @@ class MySQLPlugin extends DatabasePlugin {
   }
 
   bindStart (ctx) {
-    const service = this.serviceName({ pluginConfig: this.config, dbConfig: ctx.conf, system: this.system })
+    const snOpts = { pluginConfig: this.config, dbConfig: ctx.conf, system: this.system }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       resource: ctx.sql,
       type: 'sql',
       kind: 'client',

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -20,16 +20,27 @@ class NextPlugin extends ServerPlugin {
   bindStart ({ req, res }) {
     const store = storage('legacy').getStore()
     const childOf = store ? store.span : store
+    const serviceName = this.config.service || this.serviceName()
+    const srvSrc = this.config.service
+      ? (this.config.serviceFromMapping ? 'opt.mapping' : 'm')
+      : undefined
+
+    const tags = {
+      [COMPONENT]: this.constructor.id,
+      'service.name': serviceName,
+      'resource.name': req.method,
+      'span.type': 'web',
+      'span.kind': 'server',
+      'http.method': req.method,
+    }
+
+    if (srvSrc) {
+      tags['_dd.srv_src'] = srvSrc
+    }
+
     const span = this.tracer.startSpan(this.operationName(), {
       childOf,
-      tags: {
-        [COMPONENT]: this.constructor.id,
-        'service.name': this.config.service || this.serviceName(),
-        'resource.name': req.method,
-        'span.type': 'web',
-        'span.kind': 'server',
-        'http.method': req.method,
-      },
+      tags,
       integrationName: this.constructor.id,
     })
 

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -13,7 +13,8 @@ class OracledbPlugin extends DatabasePlugin {
   bindStart (ctx) {
     let { query, connAttrs, port, hostname, dbInstance } = ctx
 
-    const service = this.serviceName({ pluginConfig: this.config, params: connAttrs })
+    const snOpts = { pluginConfig: this.config, params: connAttrs }
+    const service = this.serviceName(snOpts)
 
     if (hostname === undefined) {
       // Lazy load for performance. This is not needed in v6 and up
@@ -26,6 +27,7 @@ class OracledbPlugin extends DatabasePlugin {
 
     this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       resource: query,
       type: 'sql',
       kind: 'client',

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -10,11 +10,13 @@ class PGPlugin extends DatabasePlugin {
 
   bindStart (ctx) {
     const { params = {}, query, processId, stream } = ctx
-    const service = this.serviceName({ pluginConfig: this.config, params })
+    const snOpts = { pluginConfig: this.config, params }
+    const service = this.serviceName(snOpts)
     const originalStatement = this.maybeTruncate(query.text)
 
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       resource: originalStatement,
       type: 'sql',
       kind: 'client',

--- a/packages/datadog-plugin-prisma/src/index.js
+++ b/packages/datadog-plugin-prisma/src/index.js
@@ -41,12 +41,14 @@ class PrismaPlugin extends DatabasePlugin {
 
   startEngineSpan (ctx) {
     const { engineSpan, childrenByParent, childOf, dbConfig } = ctx
-    const service = this.serviceName({ pluginConfig: this.config, system: this.system })
+    const snOpts = { pluginConfig: this.config, system: this.system }
+    const service = this.serviceName(snOpts)
     const spanName = engineSpan.name.slice(14) // remove 'prisma:engine:' prefix
     const options = {
       childOf,
       resource: spanName,
       service,
+      srvSrc: snOpts.srvSrc,
       kind: engineSpan.kind,
       meta: {
         prisma: {
@@ -85,10 +87,11 @@ class PrismaPlugin extends DatabasePlugin {
   }
 
   bindStart (ctx) {
-    const service = this.serviceName({ pluginConfig: this.config })
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
     const resource = formatResourceName(ctx.resourceName, ctx.attributes)
 
-    const options = { service, resource }
+    const options = { service, srvSrc: snOpts.srvSrc, resource }
 
     if (ctx.resourceName === 'operation') {
       options.meta = {

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -22,9 +22,13 @@ class RedisPlugin extends CachePlugin {
       return { noop: true }
     }
 
+    const snOpts = { pluginConfig: this.config, system: this.system, connectionName }
+    const service = this.serviceName(snOpts)
+
     this.startSpan({
       resource,
-      service: this.serviceName({ pluginConfig: this.config, system: this.system, connectionName }),
+      service,
+      srvSrc: snOpts.srvSrc,
       type: this._spanType,
       meta: {
         'db.type': this._spanType,

--- a/packages/datadog-plugin-tedious/src/index.js
+++ b/packages/datadog-plugin-tedious/src/index.js
@@ -9,9 +9,11 @@ class TediousPlugin extends DatabasePlugin {
   static system = 'mssql'
 
   bindStart (ctx) {
-    const service = this.serviceName({ pluginConfig: this.config, system: this.system })
+    const snOpts = { pluginConfig: this.config, system: this.system }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       resource: ctx.queryOrProcedure,
       type: 'sql',
       kind: 'client',

--- a/packages/datadog-plugin-undici/src/index.js
+++ b/packages/datadog-plugin-undici/src/index.js
@@ -65,6 +65,9 @@ class UndiciPlugin extends HttpClientPlugin {
     const allowed = this.config.filter(uri)
     const childOf = store && allowed ? store.span : null
 
+    const snOpts = { pluginConfig: this.config, sessionDetails: { host: hostname, port } }
+    const service = this.serviceName(snOpts)
+
     const span = this.startSpan(this.operationName(), {
       childOf,
       meta: {
@@ -76,7 +79,8 @@ class UndiciPlugin extends HttpClientPlugin {
       metrics: {
         [CLIENT_PORT_KEY]: port ? Number.parseInt(port, 10) : undefined,
       },
-      service: this.serviceName({ pluginConfig: this.config, sessionDetails: { host: hostname, port } }),
+      service,
+      srvSrc: snOpts.srvSrc,
       resource: method,
       type: 'http',
     }, false)

--- a/packages/datadog-plugin-ws/src/close.js
+++ b/packages/datadog-plugin-ws/src/close.js
@@ -30,9 +30,11 @@ class WSClosePlugin extends TracingPlugin {
     const spanKind = isPeerClose ? 'consumer' : 'producer'
     const spanTags = socket.spanTags
     const path = spanTags['resource.name'].split(' ')[1]
-    const service = this.serviceName({ pluginConfig: this.config })
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       meta: {
         'resource.name': `websocket ${path}`,
         'span.type': 'websocket',

--- a/packages/datadog-plugin-ws/src/producer.js
+++ b/packages/datadog-plugin-ws/src/producer.js
@@ -25,9 +25,11 @@ class WSProducerPlugin extends TracingPlugin {
     const spanTags = socket.spanTags
     const path = spanTags['resource.name'].split(' ')[1]
     const opCode = binary ? 'binary' : 'text'
-    const service = this.serviceName({ pluginConfig: this.config })
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       meta: {
         'span.type': 'websocket',
         'span.kind': 'producer',

--- a/packages/datadog-plugin-ws/src/receiver.js
+++ b/packages/datadog-plugin-ws/src/receiver.js
@@ -31,9 +31,11 @@ class WSReceiverPlugin extends TracingPlugin {
     const path = spanTags['resource.name'].split(' ')[1]
     const opCode = binary ? 'binary' : 'text'
 
-    const service = this.serviceName({ pluginConfig: this.config })
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       meta: {
         'span.type': 'websocket',
         'span.kind': 'consumer',

--- a/packages/datadog-plugin-ws/src/server.js
+++ b/packages/datadog-plugin-ws/src/server.js
@@ -46,9 +46,11 @@ class WSServerPlugin extends TracingPlugin {
     // Extract distributed tracing context from request headers
     const childOf = this.tracer.extract(HTTP_HEADERS, req.headers)
 
-    const service = this.serviceName({ pluginConfig: this.config })
+    const snOpts = { pluginConfig: this.config }
+    const service = this.serviceName(snOpts)
     const span = this.startSpan(this.operationName(), {
       service,
+      srvSrc: snOpts.srvSrc,
       childOf,
       meta: {
         'span.type': 'websocket',

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -396,6 +396,13 @@ class DatadogSpan {
   }
 
   _addTags (keyValuePairs) {
+    if (keyValuePairs) {
+      const serviceName = keyValuePairs['service.name'] || keyValuePairs.service
+      if (serviceName && serviceName !== this._parentTracer?._service && !keyValuePairs['_dd.srv_src']) {
+        keyValuePairs['_dd.srv_src'] = 'm'
+      }
+    }
+
     tagger.add(this._spanContext._tags, keyValuePairs)
 
     this._prioritySampler.sample(this, false)

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -53,13 +53,19 @@ class DatadogTracer {
       : getParent(options.references)
 
     // as per spec, allow the setting of service name through options
+    const serviceTag = options?.tags?.service || options?.tags?.['service.name']
+    const hasServiceOverride = serviceTag && String(serviceTag) !== this._service
     const tags = {
-      'service.name': options?.tags?.service ? String(options.tags.service) : this._service,
+      'service.name': serviceTag ? String(serviceTag) : this._service,
+    }
+
+    if (hasServiceOverride && !options?.tags?.['_dd.srv_src']) {
+      tags['_dd.srv_src'] = 'm'
     }
 
     // As per unified service tagging spec if a span is created with a service name different from the global
     // service name it will not inherit the global version value
-    if (options?.tags?.service && options.tags.service !== this._service) {
+    if (hasServiceOverride) {
       options.tags.version = undefined
     }
 

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -201,6 +201,7 @@ module.exports = class PluginManager {
 
     if (serviceMapping && serviceMapping[name]) {
       sharedConfig.service = serviceMapping[name]
+      sharedConfig.serviceFromMapping = true
     }
 
     if (clientIpEnabled !== undefined) {

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -12,9 +12,16 @@ class ApolloBasePlugin extends TracingPlugin {
     const store = storage('legacy').getStore()
     const childOf = store ? /** @type {import('../opentracing/span') | undefined} */ (store.span) : null
 
+    const snOpts = {
+      id: `${this.constructor.id}.${this.constructor.operation}`,
+      pluginConfig: this.config,
+    }
+    const service = this.serviceName(snOpts)
+
     const span = this.startSpan(this.getOperationName(), {
       childOf,
-      service: this.getServiceName(),
+      service,
+      srvSrc: snOpts.srvSrc,
       type: this.constructor.type,
       kind: this.constructor.kind,
       meta: {},

--- a/packages/dd-trace/src/plugins/consumer.js
+++ b/packages/dd-trace/src/plugins/consumer.js
@@ -9,7 +9,14 @@ class ConsumerPlugin extends InboundPlugin {
 
   startSpan (options, enterOrCtx) {
     if (!options.service) {
-      options.service = this.config.service || this.serviceName()
+      if (this.config.service) {
+        options.service = this.config.service
+        options.srvSrc = this.config.serviceFromMapping ? 'opt.mapping' : 'm'
+      } else {
+        const snOpts = {}
+        options.service = this.serviceName(snOpts)
+        options.srvSrc = snOpts.srvSrc
+      }
     }
     if (!options.kind) {
       options.kind = this.constructor.kind

--- a/packages/dd-trace/src/plugins/producer.js
+++ b/packages/dd-trace/src/plugins/producer.js
@@ -12,7 +12,14 @@ class ProducerPlugin extends OutboundPlugin {
       kind: this.constructor.kind,
     }
     if (!options.service) {
-      options.service = this.config.service || this.serviceName()
+      if (this.config.service) {
+        options.service = this.config.service
+        options.srvSrc = this.config.serviceFromMapping ? 'opt.mapping' : 'm'
+      } else {
+        const snOpts = {}
+        options.service = this.serviceName(snOpts)
+        options.srvSrc = snOpts.srvSrc
+      }
     }
     for (const key of Object.keys(spanDefaults)) {
       if (!options[key]) {

--- a/packages/dd-trace/src/plugins/storage.js
+++ b/packages/dd-trace/src/plugins/storage.js
@@ -14,6 +14,7 @@ class StoragePlugin extends ClientPlugin {
   startSpan (name, options, ctx) {
     if (!options.service && this.system) {
       options.service = `${this.tracer._service}-${this.system}`
+      options.srvSrc = this.component
     }
 
     return super.startSpan(name, options, ctx)

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -176,6 +176,7 @@ class TracingPlugin extends Plugin {
       meta,
       metrics,
       service,
+      srvSrc,
       startTime,
       resource,
       type,
@@ -189,18 +190,24 @@ class TracingPlugin extends Plugin {
       childOf = /** @type {import('../opentracing/span') | undefined} */ (store.span)
     }
 
+    const tags = {
+      [COMPONENT]: component,
+      'service.name': service || meta?.service || tracer._service,
+      'resource.name': resource,
+      'span.kind': kind,
+      'span.type': type,
+      ...meta,
+      ...metrics,
+    }
+
+    if (srvSrc) {
+      tags['_dd.srv_src'] = srvSrc
+    }
+
     const span = tracer.startSpan(name, {
       startTime,
       childOf,
-      tags: {
-        [COMPONENT]: component,
-        'service.name': service || meta?.service || tracer._service,
-        'resource.name': resource,
-        'span.kind': kind,
-        'span.type': type,
-        ...meta,
-        ...metrics,
-      },
+      tags,
       integrationName: integrationName || component,
       links: childOf?._links,
     })

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -105,6 +105,7 @@ const web = {
 
     if (config.service) {
       span.setTag(SERVICE_NAME, config.service)
+      span.setTag('_dd.srv_src', config.serviceFromMapping ? 'opt.mapping' : 'm')
     }
 
     analyticsSampler.sample(span, config.measured, true)

--- a/packages/dd-trace/src/service-naming/index.js
+++ b/packages/dd-trace/src/service-naming/index.js
@@ -48,7 +48,14 @@ class SchemaManager {
       ? this.schemas.v1
       : this.schema
 
-    return schema.getServiceName(type, kind, plugin, { ...opts, tracerService: this.config.service })
+    const schemaOpts = { ...opts, tracerService: this.config.service }
+    const result = schema.getServiceName(type, kind, plugin, schemaOpts)
+
+    if (schemaOpts.srvSrc !== undefined && opts) {
+      opts.srvSrc = schemaOpts.srvSrc
+    }
+
+    return result
   }
 
   /**

--- a/packages/dd-trace/src/service-naming/schemas/util.js
+++ b/packages/dd-trace/src/service-naming/schemas/util.js
@@ -8,17 +8,22 @@ function getFormattedHostString ({ host, port }) {
   return [host, port].filter(Boolean).join(':')
 }
 
-function httpPluginClientService ({ tracerService, pluginConfig, sessionDetails }) {
+function httpPluginClientService (opts) {
+  const { tracerService, pluginConfig, sessionDetails } = opts
   if (pluginConfig.splitByDomain) {
+    opts.srvSrc = 'http'
     return getFormattedHostString(sessionDetails)
   } else if (pluginConfig.service) {
+    opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
     return pluginConfig.service
   }
 
   return tracerService
 }
 
-function awsServiceV0 ({ tracerService, awsService }) {
+function awsServiceV0 (opts) {
+  const { tracerService, awsService } = opts
+  opts.srvSrc = 'aws'
   return `${tracerService}-aws-${awsService}`
 }
 

--- a/packages/dd-trace/src/service-naming/schemas/v0/messaging.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/messaging.js
@@ -2,8 +2,9 @@
 
 const { identityService, awsServiceV0 } = require('../util')
 
-function amqpServiceName ({ tracerService }) {
-  return `${tracerService}-amqp`
+function amqpServiceName (opts) {
+  opts.srvSrc = 'amqplib'
+  return `${opts.tracerService}-amqp`
 }
 
 const messaging = {
@@ -14,31 +15,52 @@ const messaging = {
     },
     amqp10: {
       opName: () => 'amqp.send',
-      serviceName: amqpServiceName,
+      serviceName: (opts) => {
+        opts.srvSrc = 'amqp10'
+        return `${opts.tracerService}-amqp`
+      },
     },
     'azure-event-hubs': {
       opName: () => 'azure.eventhubs.send',
-      serviceName: ({ tracerService }) => `${tracerService}-azure-event-hubs`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'azure-event-hubs'
+        return `${opts.tracerService}-azure-event-hubs`
+      },
     },
     'azure-service-bus': {
       opName: () => 'azure.servicebus.send',
-      serviceName: ({ tracerService }) => `${tracerService}-azure-service-bus`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'azure-service-bus'
+        return `${opts.tracerService}-azure-service-bus`
+      },
     },
     'google-cloud-pubsub': {
       opName: () => 'pubsub.request',
-      serviceName: ({ tracerService }) => `${tracerService}-pubsub`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'google-cloud-pubsub'
+        return `${opts.tracerService}-pubsub`
+      },
     },
     kafkajs: {
       opName: () => 'kafka.produce',
-      serviceName: ({ tracerService }) => `${tracerService}-kafka`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'kafkajs'
+        return `${opts.tracerService}-kafka`
+      },
     },
     'confluentinc-kafka-javascript': {
       opName: () => 'kafka.produce',
-      serviceName: ({ tracerService }) => `${tracerService}-kafka`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'confluentinc-kafka-javascript'
+        return `${opts.tracerService}-kafka`
+      },
     },
     rhea: {
       opName: () => 'amqp.send',
-      serviceName: ({ tracerService }) => `${tracerService}-amqp-producer`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'rhea'
+        return `${opts.tracerService}-amqp-producer`
+      },
     },
     sqs: {
       opName: () => 'aws.request',
@@ -50,7 +72,10 @@ const messaging = {
     },
     bullmq: {
       opName: () => 'bullmq.add',
-      serviceName: ({ tracerService }) => `${tracerService}-bullmq`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'bullmq'
+        return `${opts.tracerService}-bullmq`
+      },
     },
   },
   consumer: {
@@ -60,7 +85,10 @@ const messaging = {
     },
     amqp10: {
       opName: () => 'amqp.receive',
-      serviceName: amqpServiceName,
+      serviceName: (opts) => {
+        opts.srvSrc = 'amqp10'
+        return `${opts.tracerService}-amqp`
+      },
     },
     'google-cloud-pubsub': {
       opName: () => 'pubsub.receive',
@@ -68,11 +96,17 @@ const messaging = {
     },
     kafkajs: {
       opName: () => 'kafka.consume',
-      serviceName: ({ tracerService }) => `${tracerService}-kafka`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'kafkajs'
+        return `${opts.tracerService}-kafka`
+      },
     },
     'confluentinc-kafka-javascript': {
       opName: () => 'kafka.consume',
-      serviceName: ({ tracerService }) => `${tracerService}-kafka`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'confluentinc-kafka-javascript'
+        return `${opts.tracerService}-kafka`
+      },
     },
     rhea: {
       opName: () => 'amqp.receive',
@@ -84,7 +118,10 @@ const messaging = {
     },
     bullmq: {
       opName: () => 'bullmq.processJob',
-      serviceName: ({ tracerService }) => `${tracerService}-bullmq`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'bullmq'
+        return `${opts.tracerService}-bullmq`
+      },
     },
   },
   client: {
@@ -94,7 +131,10 @@ const messaging = {
     },
     'google-cloud-pubsub': {
       opName: () => 'pubsub.request',
-      serviceName: ({ tracerService }) => `${tracerService}-pubsub`,
+      serviceName: (opts) => {
+        opts.srvSrc = 'google-cloud-pubsub'
+        return `${opts.tracerService}-pubsub`
+      },
     },
   },
 }

--- a/packages/dd-trace/src/service-naming/schemas/v0/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/storage.js
@@ -1,46 +1,70 @@
 'use strict'
 
-function getRedisService (pluginConfig, connectionName) {
+function getRedisService (opts, pluginConfig, connectionName) {
   if (pluginConfig.splitByInstance && connectionName) {
-    return pluginConfig.service
-      ? `${pluginConfig.service}-${connectionName}`
-      : connectionName
+    if (pluginConfig.service) {
+      opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+      return `${pluginConfig.service}-${connectionName}`
+    }
+    opts.srvSrc = 'redis'
+    return connectionName
   }
 
-  return pluginConfig.service
+  if (pluginConfig.service) {
+    opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+    return pluginConfig.service
+  }
 }
 
-function fromSystem (tracerService, system) {
-  return system ? `${tracerService}-${system}` : undefined
+function fromSystem (opts, tracerService, system, integrationName) {
+  if (system) {
+    opts.srvSrc = integrationName
+    return `${tracerService}-${system}`
+  }
 }
 
-function mysqlServiceName ({ tracerService, pluginConfig, dbConfig, system }) {
+function mysqlServiceName (opts) {
+  const { tracerService, pluginConfig, dbConfig, system } = opts
   if (typeof pluginConfig.service === 'function') {
+    opts.srvSrc = 'm'
     return pluginConfig.service(dbConfig)
   }
-  return pluginConfig.service || fromSystem(tracerService, system)
+  if (pluginConfig.service) {
+    opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+    return pluginConfig.service
+  }
+  return fromSystem(opts, tracerService, system, 'mysql')
 }
 
-function withSuffixFunction (suffix) {
-  return ({ tracerService, pluginConfig, params }) => {
+function withSuffixFunction (suffix, integrationName) {
+  return (opts) => {
+    const { tracerService, pluginConfig, params } = opts
     if (typeof pluginConfig.service === 'function') {
+      opts.srvSrc = 'm'
       return pluginConfig.service(params)
     }
-    return pluginConfig.service || `${tracerService}-${suffix}`
+    if (pluginConfig.service) {
+      opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+      return pluginConfig.service
+    }
+    opts.srvSrc = integrationName
+    return `${tracerService}-${suffix}`
   }
 }
 
 const redisConfig = {
   opName: () => 'redis.command',
-  serviceName: ({ tracerService, pluginConfig, system, connectionName }) => {
-    return getRedisService(pluginConfig, connectionName) || fromSystem(tracerService, system)
+  serviceName: (opts) => {
+    const { tracerService, pluginConfig, system, connectionName } = opts
+    return getRedisService(opts, pluginConfig, connectionName) || fromSystem(opts, tracerService, system, 'redis')
   },
 }
 
 const valkeyConfig = {
   opName: () => 'valkey.command',
-  serviceName: ({ tracerService, pluginConfig, system, connectionName }) => {
-    return getRedisService(pluginConfig, connectionName) || fromSystem(tracerService, system)
+  serviceName: (opts) => {
+    const { tracerService, pluginConfig, system, connectionName } = opts
+    return getRedisService(opts, pluginConfig, connectionName) || fromSystem(opts, tracerService, system, 'valkey')
   },
 }
 
@@ -48,22 +72,50 @@ const storage = {
   client: {
     aerospike: {
       opName: () => 'aerospike.command',
-      serviceName: ({ tracerService, pluginConfig }) =>
-        pluginConfig.service || `${tracerService}-aerospike`,
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        opts.srvSrc = 'aerospike'
+        return `${tracerService}-aerospike`
+      },
     },
     'cassandra-driver': {
       opName: () => 'cassandra.query',
-      serviceName: ({ tracerService, pluginConfig, system }) =>
-        pluginConfig.service || fromSystem(tracerService, system),
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig, system } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        return fromSystem(opts, tracerService, system, 'cassandra-driver')
+      },
     },
     couchbase: {
       opName: ({ operation }) => `couchbase.${operation}`,
-      serviceName: ({ tracerService, pluginConfig }) => pluginConfig.service || `${tracerService}-couchbase`,
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        opts.srvSrc = 'couchbase'
+        return `${tracerService}-couchbase`
+      },
     },
     elasticsearch: {
       opName: () => 'elasticsearch.query',
-      serviceName: ({ tracerService, pluginConfig }) =>
-        pluginConfig.service || `${tracerService}-elasticsearch`,
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        opts.srvSrc = 'elasticsearch'
+        return `${tracerService}-elasticsearch`
+      },
     },
     ioredis: redisConfig,
     iovalkey: valkeyConfig,
@@ -73,13 +125,26 @@ const storage = {
     },
     memcached: {
       opName: () => 'memcached.command',
-      serviceName: ({ tracerService, pluginConfig, system }) =>
-        pluginConfig.service || fromSystem(tracerService, system),
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig, system } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        return fromSystem(opts, tracerService, system, 'memcached')
+      },
     },
     'mongodb-core': {
       opName: () => 'mongodb.query',
-      serviceName: ({ tracerService, pluginConfig }) =>
-        pluginConfig.service || `${tracerService}-mongodb`,
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        opts.srvSrc = 'mongodb-core'
+        return `${tracerService}-mongodb`
+      },
     },
     mysql: {
       opName: () => 'mysql.query',
@@ -91,26 +156,39 @@ const storage = {
     },
     opensearch: {
       opName: () => 'opensearch.query',
-      serviceName: ({ tracerService, pluginConfig }) =>
-        pluginConfig.service || `${tracerService}-opensearch`,
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        opts.srvSrc = 'opensearch'
+        return `${tracerService}-opensearch`
+      },
     },
     oracledb: {
       opName: () => 'oracle.query',
-      serviceName: withSuffixFunction('oracle'),
+      serviceName: withSuffixFunction('oracle', 'oracledb'),
     },
     pg: {
       opName: () => 'pg.query',
-      serviceName: withSuffixFunction('postgres'),
+      serviceName: withSuffixFunction('postgres', 'pg'),
     },
     prisma: {
       opName: ({ operation }) => `prisma.${operation}`,
-      serviceName: withSuffixFunction('prisma'),
+      serviceName: withSuffixFunction('prisma', 'prisma'),
     },
     redis: redisConfig,
     tedious: {
       opName: () => 'tedious.request',
-      serviceName: ({ tracerService, pluginConfig, system }) =>
-        pluginConfig.service || fromSystem(tracerService, system),
+      serviceName: (opts) => {
+        const { tracerService, pluginConfig, system } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        return fromSystem(opts, tracerService, system, 'tedious')
+      },
     },
   },
 }

--- a/packages/dd-trace/src/service-naming/schemas/v0/web.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/web.js
@@ -2,6 +2,15 @@
 
 const { identityService, httpPluginClientService, awsServiceV0 } = require('../util')
 
+function apolloServiceName (opts) {
+  const { pluginConfig, tracerService } = opts
+  if (pluginConfig.service) {
+    opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+    return pluginConfig.service
+  }
+  return tracerService
+}
+
 const web = {
   client: {
     grpc: {
@@ -26,7 +35,14 @@ const web = {
     },
     genai: {
       opName: () => 'google_genai.request',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: (opts) => {
+        const { pluginConfig, tracerService } = opts
+        if (pluginConfig.service) {
+          opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+          return pluginConfig.service
+        }
+        return tracerService
+      },
     },
     aws: {
       opName: () => 'aws.request',
@@ -44,27 +60,27 @@ const web = {
   server: {
     'apollo.gateway.request': {
       opName: () => 'apollo.gateway.request',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: apolloServiceName,
     },
     'apollo.gateway.plan': {
       opName: () => 'apollo.gateway.plan',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: apolloServiceName,
     },
     'apollo.gateway.validate': {
       opName: () => 'apollo.gateway.validate',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: apolloServiceName,
     },
     'apollo.gateway.execute': {
       opName: () => 'apollo.gateway.execute',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: apolloServiceName,
     },
     'apollo.gateway.fetch': {
       opName: () => 'apollo.gateway.fetch',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: apolloServiceName,
     },
     'apollo.gateway.postprocessing': {
       opName: () => 'apollo.gateway.postprocessing',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: apolloServiceName,
     },
     grpc: {
       opName: () => 'grpc.server',

--- a/packages/dd-trace/src/service-naming/schemas/v0/websocket.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/websocket.js
@@ -1,28 +1,37 @@
 'use strict'
 
+function wsServiceName (opts) {
+  const { pluginConfig, tracerService } = opts
+  if (pluginConfig.service) {
+    opts.srvSrc = pluginConfig.serviceFromMapping ? 'opt.mapping' : 'm'
+    return pluginConfig.service
+  }
+  return tracerService
+}
+
 const websocket = {
   request: {
     ws: {
       opName: () => 'web.request',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: wsServiceName,
     },
   },
   producer: {
     ws: {
       opName: () => 'websocket.send',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: wsServiceName,
     },
   },
   consumer: {
     ws: {
       opName: () => 'websocket.receive',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: wsServiceName,
     },
   },
   close: {
     ws: {
       opName: () => 'websocket.close',
-      serviceName: ({ pluginConfig, tracerService }) => pluginConfig.service || tracerService,
+      serviceName: wsServiceName,
     },
   },
 }

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -442,6 +442,55 @@ describe('Span', () => {
     })
   })
 
+  describe('_dd.srv_src on service override via setTag/addTags', () => {
+    it('should set _dd.srv_src to m when setTag changes service.name to a different service', () => {
+      tracer._service = 'my-service'
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      span.setTag('service.name', 'other-service')
+
+      sinon.assert.calledWith(tagger.add, span.context()._tags, {
+        'service.name': 'other-service',
+        '_dd.srv_src': 'm',
+      })
+    })
+
+    it('should set _dd.srv_src to m when addTags sets service to a different service', () => {
+      tracer._service = 'my-service'
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      span.addTags({ service: 'other-service' })
+
+      sinon.assert.calledWith(tagger.add, span.context()._tags, {
+        service: 'other-service',
+        '_dd.srv_src': 'm',
+      })
+    })
+
+    it('should not set _dd.srv_src when service.name matches tracer service', () => {
+      tracer._service = 'my-service'
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      span.setTag('service.name', 'my-service')
+
+      sinon.assert.calledWith(tagger.add, span.context()._tags, {
+        'service.name': 'my-service',
+      })
+    })
+
+    it('should not overwrite _dd.srv_src when explicitly provided in the same call', () => {
+      tracer._service = 'my-service'
+      span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+
+      span.addTags({ 'service.name': 'other-service', '_dd.srv_src': 'redis' })
+
+      sinon.assert.calledWith(tagger.add, span.context()._tags, {
+        'service.name': 'other-service',
+        '_dd.srv_src': 'redis',
+      })
+    })
+  })
+
   describe('finish', () => {
     it('should add itself to the context trace finished spans', () => {
       processor.process.returns(Promise.resolve())

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -279,6 +279,7 @@ describe('Tracer', () => {
         parent: null,
         tags: {
           'service.name': 'new-service',
+          '_dd.srv_src': 'm',
         },
         startTime: fields.startTime,
         hostname: undefined,
@@ -287,6 +288,37 @@ describe('Tracer', () => {
         links: undefined,
       })
       assert.strictEqual(testSpan, span)
+    })
+
+    it('should set _dd.srv_src to m when service.name tag differs from global service', () => {
+      fields.tags = {
+        'service.name': 'custom-service',
+      }
+
+      tracer = new Tracer(config)
+      tracer.startSpan('name', fields)
+
+      sinon.assert.calledWith(Span, tracer, processor, prioritySampler, sinon.match({
+        tags: {
+          'service.name': 'custom-service',
+          '_dd.srv_src': 'm',
+        },
+      }))
+    })
+
+    it('should not set _dd.srv_src when service matches global service', () => {
+      fields.tags = {
+        service: 'service',
+      }
+
+      tracer = new Tracer(config)
+      tracer.startSpan('name', fields)
+
+      sinon.assert.calledWith(Span, tracer, processor, prioritySampler, sinon.match({
+        tags: {
+          'service.name': 'service',
+        },
+      }))
     })
 
     it('should start a span with the trace ID generation configuration', () => {

--- a/packages/dd-trace/test/service-naming/srv-src.spec.js
+++ b/packages/dd-trace/test/service-naming/srv-src.spec.js
@@ -1,0 +1,579 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+describe('_dd.srv_src tracking in v0 schema', () => {
+  describe('storage schemas', () => {
+    let storage
+
+    beforeEach(() => {
+      storage = require('../../src/service-naming/schemas/v0/storage')
+    })
+
+    describe('pg (withSuffixFunction)', () => {
+      it('should set srvSrc to integration name when using default service', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', params: {} }
+        const result = storage.client.pg.serviceName(opts)
+
+        assert.equal(result, 'myapp-postgres')
+        assert.equal(opts.srvSrc, 'pg')
+      })
+
+      it('should set srvSrc to "m" when pluginConfig.service is set by user', () => {
+        const opts = { pluginConfig: { service: 'custom-pg' }, tracerService: 'myapp', params: {} }
+        const result = storage.client.pg.serviceName(opts)
+
+        assert.equal(result, 'custom-pg')
+        assert.equal(opts.srvSrc, 'm')
+      })
+
+      it('should set srvSrc to "opt.mapping" when service comes from serviceMapping', () => {
+        const opts = {
+          pluginConfig: { service: 'mapped-pg', serviceFromMapping: true },
+          tracerService: 'myapp',
+          params: {},
+        }
+        const result = storage.client.pg.serviceName(opts)
+
+        assert.equal(result, 'mapped-pg')
+        assert.equal(opts.srvSrc, 'opt.mapping')
+      })
+
+      it('should set srvSrc to "m" when pluginConfig.service is a function', () => {
+        const opts = {
+          pluginConfig: { service: () => 'fn-pg' },
+          tracerService: 'myapp',
+          params: {},
+        }
+        const result = storage.client.pg.serviceName(opts)
+
+        assert.equal(result, 'fn-pg')
+        assert.equal(opts.srvSrc, 'm')
+      })
+    })
+
+    describe('aerospike', () => {
+      it('should set srvSrc to "aerospike" when using default service', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp' }
+        const result = storage.client.aerospike.serviceName(opts)
+
+        assert.equal(result, 'myapp-aerospike')
+        assert.equal(opts.srvSrc, 'aerospike')
+      })
+
+      it('should set srvSrc to "m" when pluginConfig.service is set', () => {
+        const opts = { pluginConfig: { service: 'custom' }, tracerService: 'myapp' }
+        const result = storage.client.aerospike.serviceName(opts)
+
+        assert.equal(result, 'custom')
+        assert.equal(opts.srvSrc, 'm')
+      })
+
+      it('should set srvSrc to "opt.mapping" when service comes from mapping', () => {
+        const opts = {
+          pluginConfig: { service: 'mapped', serviceFromMapping: true },
+          tracerService: 'myapp',
+        }
+        const result = storage.client.aerospike.serviceName(opts)
+
+        assert.equal(result, 'mapped')
+        assert.equal(opts.srvSrc, 'opt.mapping')
+      })
+    })
+
+    describe('redis (redisConfig)', () => {
+      it('should set srvSrc to "redis" when using system default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', system: 'redis' }
+        const result = storage.client.redis.serviceName(opts)
+
+        assert.equal(result, 'myapp-redis')
+        assert.equal(opts.srvSrc, 'redis')
+      })
+
+      it('should set srvSrc to "m" when pluginConfig.service is set', () => {
+        const opts = { pluginConfig: { service: 'my-redis' }, tracerService: 'myapp', system: 'redis' }
+        const result = storage.client.redis.serviceName(opts)
+
+        assert.equal(result, 'my-redis')
+        assert.equal(opts.srvSrc, 'm')
+      })
+
+      it('should set srvSrc to "redis" when splitByInstance with connectionName and no service', () => {
+        const opts = {
+          pluginConfig: { splitByInstance: true },
+          tracerService: 'myapp',
+          system: 'redis',
+          connectionName: 'cache',
+        }
+        const result = storage.client.redis.serviceName(opts)
+
+        assert.equal(result, 'cache')
+        assert.equal(opts.srvSrc, 'redis')
+      })
+
+      it('should set srvSrc to "m" when splitByInstance with service', () => {
+        const opts = {
+          pluginConfig: { splitByInstance: true, service: 'custom' },
+          tracerService: 'myapp',
+          system: 'redis',
+          connectionName: 'cache',
+        }
+        const result = storage.client.redis.serviceName(opts)
+
+        assert.equal(result, 'custom-cache')
+        assert.equal(opts.srvSrc, 'm')
+      })
+    })
+
+    describe('mysql (mysqlServiceName)', () => {
+      it('should set srvSrc to "mysql" when using system default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', system: 'mysql', dbConfig: {} }
+        const result = storage.client.mysql.serviceName(opts)
+
+        assert.equal(result, 'myapp-mysql')
+        assert.equal(opts.srvSrc, 'mysql')
+      })
+
+      it('should set srvSrc to "m" when service is a function', () => {
+        const opts = {
+          pluginConfig: { service: () => 'fn-mysql' },
+          tracerService: 'myapp',
+          system: 'mysql',
+          dbConfig: {},
+        }
+        const result = storage.client.mysql.serviceName(opts)
+
+        assert.equal(result, 'fn-mysql')
+        assert.equal(opts.srvSrc, 'm')
+      })
+
+      it('should set srvSrc to "opt.mapping" when from mapping', () => {
+        const opts = {
+          pluginConfig: { service: 'mapped-mysql', serviceFromMapping: true },
+          tracerService: 'myapp',
+          system: 'mysql',
+          dbConfig: {},
+        }
+        const result = storage.client.mysql.serviceName(opts)
+
+        assert.equal(result, 'mapped-mysql')
+        assert.equal(opts.srvSrc, 'opt.mapping')
+      })
+    })
+
+    describe('cassandra-driver (fromSystem)', () => {
+      it('should set srvSrc to "cassandra-driver" when using system default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', system: 'cassandra' }
+        const result = storage.client['cassandra-driver'].serviceName(opts)
+
+        assert.equal(result, 'myapp-cassandra')
+        assert.equal(opts.srvSrc, 'cassandra-driver')
+      })
+    })
+
+    describe('elasticsearch', () => {
+      it('should set srvSrc to "elasticsearch" when using default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp' }
+        const result = storage.client.elasticsearch.serviceName(opts)
+
+        assert.equal(result, 'myapp-elasticsearch')
+        assert.equal(opts.srvSrc, 'elasticsearch')
+      })
+    })
+
+    describe('mongodb-core', () => {
+      it('should set srvSrc to "mongodb-core" when using default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp' }
+        const result = storage.client['mongodb-core'].serviceName(opts)
+
+        assert.equal(result, 'myapp-mongodb')
+        assert.equal(opts.srvSrc, 'mongodb-core')
+      })
+    })
+
+    describe('opensearch', () => {
+      it('should set srvSrc to "opensearch" when using default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp' }
+        const result = storage.client.opensearch.serviceName(opts)
+
+        assert.equal(result, 'myapp-opensearch')
+        assert.equal(opts.srvSrc, 'opensearch')
+      })
+    })
+
+    describe('couchbase', () => {
+      it('should set srvSrc to "couchbase" when using default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp' }
+        const result = storage.client.couchbase.serviceName(opts)
+
+        assert.equal(result, 'myapp-couchbase')
+        assert.equal(opts.srvSrc, 'couchbase')
+      })
+    })
+
+    describe('oracledb (withSuffixFunction)', () => {
+      it('should set srvSrc to "oracledb" when using default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', params: {} }
+        const result = storage.client.oracledb.serviceName(opts)
+
+        assert.equal(result, 'myapp-oracle')
+        assert.equal(opts.srvSrc, 'oracledb')
+      })
+    })
+
+    describe('prisma (withSuffixFunction)', () => {
+      it('should set srvSrc to "prisma" when using default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', params: {} }
+        const result = storage.client.prisma.serviceName(opts)
+
+        assert.equal(result, 'myapp-prisma')
+        assert.equal(opts.srvSrc, 'prisma')
+      })
+    })
+
+    describe('tedious (fromSystem)', () => {
+      it('should set srvSrc to "tedious" when using system default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', system: 'mssql' }
+        const result = storage.client.tedious.serviceName(opts)
+
+        assert.equal(result, 'myapp-mssql')
+        assert.equal(opts.srvSrc, 'tedious')
+      })
+    })
+
+    describe('valkey (valkeyConfig)', () => {
+      it('should set srvSrc to "valkey" when using system default', () => {
+        const opts = { pluginConfig: {}, tracerService: 'myapp', system: 'valkey' }
+        const result = storage.client.iovalkey.serviceName(opts)
+
+        assert.equal(result, 'myapp-valkey')
+        assert.equal(opts.srvSrc, 'valkey')
+      })
+    })
+  })
+
+  describe('messaging schemas', () => {
+    let messaging
+
+    beforeEach(() => {
+      messaging = require('../../src/service-naming/schemas/v0/messaging')
+    })
+
+    it('should set srvSrc to "kafkajs" for kafka producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer.kafkajs.serviceName(opts)
+
+      assert.equal(result, 'myapp-kafka')
+      assert.equal(opts.srvSrc, 'kafkajs')
+    })
+
+    it('should set srvSrc to "kafkajs" for kafka consumer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.consumer.kafkajs.serviceName(opts)
+
+      assert.equal(result, 'myapp-kafka')
+      assert.equal(opts.srvSrc, 'kafkajs')
+    })
+
+    it('should set srvSrc to "amqplib" for amqp producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer.amqplib.serviceName(opts)
+
+      assert.equal(result, 'myapp-amqp')
+      assert.equal(opts.srvSrc, 'amqplib')
+    })
+
+    it('should set srvSrc to "amqp10" for amqp10 producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer.amqp10.serviceName(opts)
+
+      assert.equal(result, 'myapp-amqp')
+      assert.equal(opts.srvSrc, 'amqp10')
+    })
+
+    it('should set srvSrc to "bullmq" for bullmq producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer.bullmq.serviceName(opts)
+
+      assert.equal(result, 'myapp-bullmq')
+      assert.equal(opts.srvSrc, 'bullmq')
+    })
+
+    it('should set srvSrc to "rhea" for rhea producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer.rhea.serviceName(opts)
+
+      assert.equal(result, 'myapp-amqp-producer')
+      assert.equal(opts.srvSrc, 'rhea')
+    })
+
+    it('should set srvSrc to "azure-event-hubs" for azure event hubs producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer['azure-event-hubs'].serviceName(opts)
+
+      assert.equal(result, 'myapp-azure-event-hubs')
+      assert.equal(opts.srvSrc, 'azure-event-hubs')
+    })
+
+    it('should set srvSrc to "google-cloud-pubsub" for pubsub producer', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer['google-cloud-pubsub'].serviceName(opts)
+
+      assert.equal(result, 'myapp-pubsub')
+      assert.equal(opts.srvSrc, 'google-cloud-pubsub')
+    })
+
+    it('should NOT set srvSrc for identityService consumers (google-cloud-pubsub)', () => {
+      const opts = { tracerService: 'myapp' }
+      messaging.consumer['google-cloud-pubsub'].serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+
+    it('should NOT set srvSrc for identityService consumers (rhea)', () => {
+      const opts = { tracerService: 'myapp' }
+      messaging.consumer.rhea.serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+
+    it('should set srvSrc to "aws" for sqs producer', () => {
+      const opts = { tracerService: 'myapp', awsService: 'sqs' }
+      messaging.producer.sqs.serviceName(opts)
+
+      assert.equal(opts.srvSrc, 'aws')
+    })
+
+    it('should set srvSrc to "confluentinc-kafka-javascript" for confluent kafka', () => {
+      const opts = { tracerService: 'myapp' }
+      const result = messaging.producer['confluentinc-kafka-javascript'].serviceName(opts)
+
+      assert.equal(result, 'myapp-kafka')
+      assert.equal(opts.srvSrc, 'confluentinc-kafka-javascript')
+    })
+  })
+
+  describe('web schemas', () => {
+    let web
+
+    beforeEach(() => {
+      web = require('../../src/service-naming/schemas/v0/web')
+    })
+
+    it('should NOT set srvSrc for identityService (grpc client)', () => {
+      const opts = { tracerService: 'myapp' }
+      web.client.grpc.serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+
+    it('should NOT set srvSrc for identityService (http server)', () => {
+      const opts = { tracerService: 'myapp' }
+      web.server.http.serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+
+    it('should set srvSrc to "http" for http client with splitByDomain', () => {
+      const opts = {
+        pluginConfig: { splitByDomain: true },
+        tracerService: 'myapp',
+        sessionDetails: { host: 'example.com', port: 443 },
+      }
+      web.client.http.serviceName(opts)
+
+      assert.equal(opts.srvSrc, 'http')
+    })
+
+    it('should set srvSrc to "m" for http client with user service', () => {
+      const opts = {
+        pluginConfig: { service: 'my-http' },
+        tracerService: 'myapp',
+        sessionDetails: {},
+      }
+      web.client.http.serviceName(opts)
+
+      assert.equal(opts.srvSrc, 'm')
+    })
+
+    it('should NOT set srvSrc for http client with default service', () => {
+      const opts = {
+        pluginConfig: {},
+        tracerService: 'myapp',
+        sessionDetails: {},
+      }
+      web.client.http.serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+
+    it('should set srvSrc to "aws" for aws client', () => {
+      const opts = { tracerService: 'myapp', awsService: 's3' }
+      web.client.aws.serviceName(opts)
+
+      assert.equal(opts.srvSrc, 'aws')
+    })
+
+    it('should set srvSrc to "m" for apollo gateway with user service', () => {
+      const opts = {
+        pluginConfig: { service: 'my-apollo' },
+        tracerService: 'myapp',
+      }
+      web.server['apollo.gateway.request'].serviceName(opts)
+
+      assert.equal(opts.srvSrc, 'm')
+    })
+
+    it('should NOT set srvSrc for apollo gateway with default service', () => {
+      const opts = {
+        pluginConfig: {},
+        tracerService: 'myapp',
+      }
+      web.server['apollo.gateway.request'].serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+  })
+
+  describe('websocket schemas', () => {
+    let websocket
+
+    beforeEach(() => {
+      websocket = require('../../src/service-naming/schemas/v0/websocket')
+    })
+
+    it('should set srvSrc to "m" for ws with user service', () => {
+      const opts = {
+        pluginConfig: { service: 'my-ws' },
+        tracerService: 'myapp',
+      }
+      websocket.request.ws.serviceName(opts)
+
+      assert.equal(opts.srvSrc, 'm')
+    })
+
+    it('should NOT set srvSrc for ws with default service', () => {
+      const opts = {
+        pluginConfig: {},
+        tracerService: 'myapp',
+      }
+      websocket.request.ws.serviceName(opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+  })
+
+  describe('util helpers', () => {
+    let util
+
+    beforeEach(() => {
+      util = require('../../src/service-naming/schemas/util')
+    })
+
+    describe('identityService', () => {
+      it('should NOT set srvSrc', () => {
+        const opts = { tracerService: 'myapp' }
+        util.identityService(opts)
+
+        assert.equal(opts.srvSrc, undefined)
+      })
+    })
+
+    describe('httpPluginClientService', () => {
+      it('should set srvSrc to "http" for splitByDomain', () => {
+        const opts = {
+          pluginConfig: { splitByDomain: true },
+          tracerService: 'myapp',
+          sessionDetails: { host: 'example.com', port: 443 },
+        }
+        util.httpPluginClientService(opts)
+
+        assert.equal(opts.srvSrc, 'http')
+      })
+
+      it('should set srvSrc to "m" for user service', () => {
+        const opts = {
+          pluginConfig: { service: 'custom' },
+          tracerService: 'myapp',
+          sessionDetails: {},
+        }
+        util.httpPluginClientService(opts)
+
+        assert.equal(opts.srvSrc, 'm')
+      })
+
+      it('should set srvSrc to "opt.mapping" for mapped service', () => {
+        const opts = {
+          pluginConfig: { service: 'mapped', serviceFromMapping: true },
+          tracerService: 'myapp',
+          sessionDetails: {},
+        }
+        util.httpPluginClientService(opts)
+
+        assert.equal(opts.srvSrc, 'opt.mapping')
+      })
+
+      it('should NOT set srvSrc when returning tracerService', () => {
+        const opts = {
+          pluginConfig: {},
+          tracerService: 'myapp',
+          sessionDetails: {},
+        }
+        util.httpPluginClientService(opts)
+
+        assert.equal(opts.srvSrc, undefined)
+      })
+    })
+
+    describe('awsServiceV0', () => {
+      it('should set srvSrc to "aws"', () => {
+        const opts = { tracerService: 'myapp', awsService: 's3' }
+        util.awsServiceV0(opts)
+
+        assert.equal(opts.srvSrc, 'aws')
+      })
+    })
+  })
+
+  describe('SchemaManager srvSrc propagation', () => {
+    let SchemaManager
+
+    beforeEach(() => {
+      delete require.cache[require.resolve('../../src/service-naming')]
+      SchemaManager = require('../../src/service-naming')
+      SchemaManager.configure({
+        spanAttributeSchema: 'v0',
+        spanRemoveIntegrationFromService: false,
+        service: 'myapp',
+      })
+    })
+
+    it('should propagate srvSrc from schema function back to caller opts', () => {
+      const opts = { pluginConfig: {}, params: {} }
+      SchemaManager.serviceName('storage', 'client', 'pg', opts)
+
+      assert.equal(opts.srvSrc, 'pg')
+    })
+
+    it('should propagate srvSrc "m" for user service', () => {
+      const opts = { pluginConfig: { service: 'custom' }, params: {} }
+      SchemaManager.serviceName('storage', 'client', 'pg', opts)
+
+      assert.equal(opts.srvSrc, 'm')
+    })
+
+    it('should propagate srvSrc "opt.mapping" for mapped service', () => {
+      const opts = { pluginConfig: { service: 'mapped', serviceFromMapping: true }, params: {} }
+      SchemaManager.serviceName('storage', 'client', 'pg', opts)
+
+      assert.equal(opts.srvSrc, 'opt.mapping')
+    })
+
+    it('should not set srvSrc for identityService', () => {
+      const opts = {}
+      SchemaManager.serviceName('web', 'server', 'http', opts)
+
+      assert.equal(opts.srvSrc, undefined)
+    })
+  })
+})


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
This PR is an attempt to collect service override source following the patterns done in dd-trace-java
(see last column for service source)

<img width="1380" height="643" alt="Screenshot 2026-03-03 at 17 29 30" src="https://github.com/user-attachments/assets/df2ba8ce-9c4b-4ca7-ae7f-3842481dba12" />



### Identified entry points for service

| Method | How | `_dd.srv_src` handled? |
| :--- | :--- | :--- |
| `tracer.startSpan(name, { tags: { service } })` | tracer.js line 59 | Yes - tracer.js line 62 |
| `tracer.startSpan(name, { tags: { 'service.name' } })` | tracer.js line 59 | Yes - tracer.js line 62 |
| `tracer.trace(name, { service })` | tracer.js line 163 → `span.addTags` | Yes - `span._addTags` |
| `tracer.wrap(name, { service })` | delegates to `tracer.trace` | Yes - same path |
| `span.setTag('service.name', x)` | `span._addTags` | Yes - span.js line 398 |
| `span.setTag('service', x)` | `span._addTags` | Yes - span.js line 398 |
| `span.addTags({ 'service.name': x })` | `span._addTags` | Yes - span.js line 398 |
| `OTel span.setAttribute('service.name', x)` | → `_ddSpan.setTag` | Yes - same path |
| `OTel span.setAttributes({ 'service.name': x })` | → `_ddSpan.addTags` | Yes - same path |
| `Plugin TracingPlugin.startSpan({ service, srvSrc })` | tracing.js line 168 | Yes - explicit srvSrc |
| `web.setConfig(req, config)` | web.js line 106-107 | Yes - explicit setTag |
| `DD_TRACE_SERVICE_MAPPING` | plugin_manager.js → plugin config | Yes - serviceFromMapping |



### Recommended review order

**Code**
 1. core
  - packages/dd-trace/src/*
Check the tag interception and start_span method changes

2. schema definitions
  - packages/dd-trace/src/service-naming/schemas/v0/storage.js  largest schema file
  - packages/dd-trace/src/service-naming/schemas/v0/web.js  same
  - packages/dd-trace/src/service-naming/schemas/v0/messaging.js same
  - packages/dd-trace/src/service-naming/schemas/v0/websocket.js same

 3. base plugin classes
  - packages/dd-trace/src/plugins/consumer.js + producer.js + apollo.js  biggest ones
  - packages/dd-trace/src/plugins/storage.js + packages/dd-trace/src/plugins/util/web.js smallest changes

 4. individual plugins
  - packages/datadog-plugin-http/src/client.js complex change due to manual span building
  - packages/datadog-plugin-http2/src/client.js same as above
  - packages/datadog-plugin-next/src/index.js  other manual case
  - the rest (redis, kafka, grpc, etc.) to spot check


**Tests**
  - packages/dd-trace/test/service-naming/srv-src.spec.js — Review last. By now you'll know exactly what the tests should assert, so you can evaluate coverage gaps.

todo: adding more

