### PR TITLE
test(debugger): enforce teardown process isolation

### DIFF
--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -9,13 +9,12 @@ const { randomUUID } = require('crypto')
 const Axios = require('axios')
 
 const { assertObjectContains, assertUUID } = require('../helpers')
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 const { generateProbeConfig } = require('../../packages/dd-trace/test/debugger/devtools_client/utils')
 const { version } = require('../../package.json')
 
 const BREAKPOINT_TOKEN = '// BREAKPOINT'
 const pollInterval = 0.1
-const procExitTimeoutMs = 2_000
 
 /**
  * @typedef {import('../../packages/dd-trace/test/debugger/devtools_client/utils').ProbeConfig} ProbeConfig
@@ -228,58 +227,6 @@ function setup ({ env, testApp, testAppSource, dependencies, silent, stdioHandle
   })
 
   return t
-}
-
-/**
- * Stop a spawned process and wait for it to fully exit before continuing.
- *
- * @param {import('../helpers').SpawnedProcess|undefined} proc - Process to stop.
- * @returns {Promise<void>}
- */
-async function stopProc (proc) {
-  if (!proc) return
-  if (proc.exitCode !== null || proc.signalCode !== null) return
-
-  proc.kill()
-
-  if (proc.exitCode !== null || proc.signalCode !== null) return
-
-  const exitedAfterSigterm = await waitForExit(proc, procExitTimeoutMs)
-  if (exitedAfterSigterm) return
-
-  proc.kill('SIGKILL')
-  const exitedAfterSigkill = await waitForExit(proc, procExitTimeoutMs)
-
-  if (!exitedAfterSigkill) {
-    throw new Error(`Process ${proc.pid} did not exit after SIGKILL`)
-  }
-}
-
-/**
- * Wait for a process to exit for up to `timeoutMs`.
- *
- * @param {import('../helpers').SpawnedProcess} proc - Process to wait for.
- * @param {number} timeoutMs - Max time to wait in milliseconds.
- * @returns {Promise<boolean>} `true` if the process exited before timeout.
- */
-function waitForExit (proc, timeoutMs) {
-  if (proc.exitCode !== null || proc.signalCode !== null) {
-    return Promise.resolve(true)
-  }
-
-  return new Promise((resolve) => {
-    const timeout = setTimeout(() => {
-      proc.removeListener('exit', onExit)
-      resolve(false)
-    }, timeoutMs)
-
-    proc.once('exit', onExit)
-
-    function onExit () {
-      clearTimeout(timeout)
-      resolve(true)
-    }
-  })
 }
 
 /**

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -28,6 +28,7 @@ let shouldKill
 const ANY_STRING = Symbol('test.ANY_STRING')
 const ANY_NUMBER = Symbol('test.ANY_NUMBER')
 const ANY_VALUE = Symbol('test.ANY_VALUE')
+const defaultStopProcTimeoutMs = 2_000
 
 /**
  * @param {string} filename
@@ -65,7 +66,7 @@ async function runAndCheckOutput (filename, cwd, expectedOut, expectedSource) {
 
   if (expectedSource) {
     assert.match(out, new RegExp(`instrumentation source: ${expectedSource}`),
-    `Expected the process to output "${expectedSource}", but logs only contain: "${out}"`)
+      `Expected the process to output "${expectedSource}", but logs only contain: "${out}"`)
   }
   return pid
 }
@@ -258,6 +259,60 @@ function spawnProcAndExpectExit (filename, options = {}, stdioHandler, stderrHan
         }
         resolve()
       })
+  })
+}
+
+/**
+ * Stop a process and wait for it to fully exit.
+ *
+ * Sends `SIGTERM` first, waits up to `timeoutMs`, and escalates to `SIGKILL` if needed.
+ *
+ * @param {childProcess.ChildProcess|undefined} proc - Process to stop.
+ * @param {object} [options] - Stop options.
+ * @param {number} [options.timeoutMs=defaultStopProcTimeoutMs] - Max wait per signal in milliseconds.
+ * @returns {Promise<void>}
+ */
+async function stopProc (proc, { timeoutMs = defaultStopProcTimeoutMs } = {}) {
+  if (!proc) return
+  if (proc.exitCode !== null || proc.signalCode !== null) return
+
+  proc.kill()
+
+  const exitedAfterSigterm = await waitForProcExit(proc, timeoutMs)
+  if (exitedAfterSigterm) return
+
+  proc.kill('SIGKILL')
+  const exitedAfterSigkill = await waitForProcExit(proc, timeoutMs)
+
+  if (!exitedAfterSigkill) {
+    throw new Error(`Process ${proc.pid} did not exit after SIGKILL`)
+  }
+}
+
+/**
+ * Wait for a process to exit for up to `timeoutMs`.
+ *
+ * @param {childProcess.ChildProcess} proc - Process to wait for.
+ * @param {number} timeoutMs - Max time to wait in milliseconds.
+ * @returns {Promise<boolean>} `true` if the process exited before timeout.
+ */
+function waitForProcExit (proc, timeoutMs) {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return Promise.resolve(true)
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      proc.removeListener('exit', onExit)
+      resolve(false)
+    }, timeoutMs)
+
+    proc.once('exit', onExit)
+
+    function onExit () {
+      clearTimeout(timeout)
+      resolve(true)
+    }
   })
 }
 
@@ -954,6 +1009,7 @@ module.exports = {
   hookFile,
   assertObjectContains,
   assertUUID,
+  stopProc,
   spawnProc,
   spawnProcAndExpectExit,
   telemetryForwarder,


### PR DESCRIPTION
### What does this PR do?

It hardens debugger integration-test teardown in `integration-tests/debugger/utils.js` by waiting for the spawned target app process to fully exit before moving to the next test. The cleanup path now uses a bounded `SIGTERM` wait, escalates to `SIGKILL` if needed, and fails explicitly if the process still does not exit.

### Motivation

A flaky debugger integration test intermittently observed mismatched trace/span IDs, which is consistent with cross-test leakage when a previous test process is still alive long enough to flush spans into the next test’s fake agent. Enforcing strict process shutdown isolation addresses that root cause instead of relaxing assertions.

### Additional Notes

The flaky failure this aims to fix: https://github.com/DataDog/dd-trace-js/actions/runs/22429024616/job/64943721888
