### PR TITLE
test(integration): use stopProc helper for process teardown

### DIFF
--- a/integration-tests/aiguard/index.spec.js
+++ b/integration-tests/aiguard/index.spec.js
@@ -5,7 +5,7 @@ const path = require('path')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 const { assertObjectContains } = require('../helpers')
 const startApiMock = require('./api-mock')
 const { executeRequest } = require('./util')
@@ -44,7 +44,7 @@ describe('AIGuard SDK integration tests', () => {
   })
 
   afterEach(async () => {
-    proc.kill()
+    await stopProc(proc)
     await agent.stop()
   })
 

--- a/integration-tests/appsec/data-collection.spec.js
+++ b/integration-tests/appsec/data-collection.spec.js
@@ -9,6 +9,7 @@ const {
   useSandbox,
   FakeAgent,
   spawnProc,
+  stopProc,
 } = require('../helpers')
 
 describe('ASM Data collection', () => {
@@ -42,7 +43,7 @@ describe('ASM Data collection', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
   }

--- a/integration-tests/appsec/endpoints-collection.spec.js
+++ b/integration-tests/appsec/endpoints-collection.spec.js
@@ -5,7 +5,7 @@ const path = require('node:path')
 
 const { before, describe, it } = require('mocha')
 
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 
 describe('Endpoints collection', () => {
   let cwd
@@ -193,7 +193,7 @@ describe('Endpoints collection', () => {
         assert.strictEqual(invalidEndpoints.length, 0, 'Invalid router paths should not be collected')
       }
     } finally {
-      proc?.kill()
+      await stopProc(proc)
       await agent?.stop()
     }
   }

--- a/integration-tests/appsec/graphql.spec.js
+++ b/integration-tests/appsec/graphql.spec.js
@@ -9,6 +9,7 @@ const {
   sandboxCwd,
   useSandbox,
   spawnProc,
+  stopProc,
 } = require('../helpers')
 
 describe('graphql', () => {
@@ -32,7 +33,7 @@ describe('graphql', () => {
   })
 
   afterEach(async () => {
-    proc.kill()
+    await stopProc(proc)
     await agent.stop()
   })
 

--- a/integration-tests/appsec/iast-esbuild.spec.js
+++ b/integration-tests/appsec/iast-esbuild.spec.js
@@ -10,7 +10,7 @@ const { promisify } = require('util')
 const Axios = require('axios')
 const msgpack = require('@msgpack/msgpack')
 
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 
 const exec = promisify(childProcess.exec)
 const retry = async fn => {
@@ -109,7 +109,7 @@ describe('esbuild support for IAST', () => {
       })
 
       afterEach(async () => {
-        contextVars.proc.kill()
+        await stopProc(contextVars.proc)
         await contextVars.agent.stop()
       })
     }

--- a/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
+++ b/integration-tests/appsec/iast-stack-traces-with-sourcemaps.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const childProcess = require('child_process')
 const path = require('path')
 const Axios = require('axios')
-const { sandboxCwd, useSandbox, spawnProc, FakeAgent } = require('../helpers')
+const { sandboxCwd, useSandbox, spawnProc, FakeAgent, stopProc } = require('../helpers')
 describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
   let axios, cwd, appDir, appFile, agent, proc
 
@@ -41,7 +41,7 @@ describe('IAST stack traces and vulnerabilities with sourcemaps', () => {
   })
 
   afterEach(async () => {
-    proc.kill()
+    await stopProc(proc)
     await agent.stop()
   })
 

--- a/integration-tests/appsec/iast.esm-security-controls.spec.js
+++ b/integration-tests/appsec/iast.esm-security-controls.spec.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 
 const path = require('path')
 const Axios = require('axios')
-const { sandboxCwd, useSandbox, spawnProc, FakeAgent } = require('../helpers')
+const { sandboxCwd, useSandbox, spawnProc, FakeAgent, stopProc } = require('../helpers')
 describe('ESM Security controls', () => {
   let axios, cwd, appFile, agent, proc
 
@@ -41,7 +41,7 @@ describe('ESM Security controls', () => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 

--- a/integration-tests/appsec/iast.esm.spec.js
+++ b/integration-tests/appsec/iast.esm.spec.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 
 const path = require('path')
 const Axios = require('axios')
-const { sandboxCwd, useSandbox, spawnProc, FakeAgent } = require('../helpers')
+const { sandboxCwd, useSandbox, spawnProc, FakeAgent, stopProc } = require('../helpers')
 describe('ESM', () => {
   let axios, cwd, appFile, agent, proc
 
@@ -40,7 +40,7 @@ describe('ESM', () => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 

--- a/integration-tests/appsec/index.spec.js
+++ b/integration-tests/appsec/index.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const path = require('path')
 const Axios = require('axios')
 const msgpack = require('@msgpack/msgpack')
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 
 describe('RASP', () => {
   let axios, cwd, appFile, agent, proc, stdioHandler
@@ -43,7 +43,7 @@ describe('RASP', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
   }

--- a/integration-tests/appsec/multer.spec.js
+++ b/integration-tests/appsec/multer.spec.js
@@ -11,6 +11,7 @@ const {
   useSandbox,
   FakeAgent,
   spawnProc,
+  stopProc,
 } = require('../helpers')
 
 describe('multer', () => {
@@ -39,7 +40,7 @@ describe('multer', () => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 

--- a/integration-tests/appsec/response-headers.spec.js
+++ b/integration-tests/appsec/response-headers.spec.js
@@ -9,6 +9,7 @@ const {
   useSandbox,
   FakeAgent,
   spawnProc,
+  stopProc,
 } = require('../helpers')
 
 describe('Headers collection - Fastify', () => {
@@ -34,7 +35,7 @@ describe('Headers collection - Fastify', () => {
   })
 
   afterEach(async () => {
-    proc.kill()
+    await stopProc(proc)
     await agent.stop()
   })
 

--- a/integration-tests/appsec/standalone-asm.spec.js
+++ b/integration-tests/appsec/standalone-asm.spec.js
@@ -8,6 +8,7 @@ const {
   useSandbox,
   FakeAgent,
   spawnProc,
+  stopProc,
   curlAndAssertMessage,
   curl,
 } = require('../helpers')
@@ -60,7 +61,7 @@ describe('Standalone ASM', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 
@@ -184,7 +185,7 @@ describe('Standalone ASM', () => {
       })
 
       afterEach(async () => {
-        proc2.kill()
+        await stopProc(proc2)
       })
 
       // proc/drop-and-call-sdk:
@@ -268,7 +269,7 @@ describe('Standalone ASM', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 
@@ -316,7 +317,7 @@ describe('Standalone ASM', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 

--- a/integration-tests/appsec/trace-tagging.spec.js
+++ b/integration-tests/appsec/trace-tagging.spec.js
@@ -9,6 +9,7 @@ const {
   useSandbox,
   FakeAgent,
   spawnProc,
+  stopProc,
 } = require('../helpers')
 
 describe('ASM Trace Tagging rules', () => {
@@ -29,7 +30,7 @@ describe('ASM Trace Tagging rules', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
   }

--- a/integration-tests/log_injection.spec.js
+++ b/integration-tests/log_injection.spec.js
@@ -7,6 +7,7 @@ const {
   sandboxCwd,
   useSandbox,
   spawnProc,
+  stopProc,
   curlAndAssertMessage,
   assertObjectContains,
 } = require('./helpers')
@@ -35,7 +36,7 @@ describe('Log Injection', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 

--- a/integration-tests/openfeature/openfeature-exposure-events.spec.js
+++ b/integration-tests/openfeature/openfeature-exposure-events.spec.js
@@ -3,7 +3,7 @@
 const assert = require('node:assert/strict')
 
 const path = require('path')
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('../helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('../helpers')
 const { UNACKNOWLEDGED, ACKNOWLEDGED } = require('../../packages/dd-trace/src/remote_config/apply_states')
 const ufcPayloads = require('./fixtures/ufc-payloads')
 const RC_PRODUCT = 'FFE_FLAGS'
@@ -64,7 +64,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 
@@ -160,7 +160,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 
@@ -240,7 +240,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 
@@ -301,7 +301,7 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 

--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const { fork } = require('child_process')
 const { join } = require('path')
 const axios = require('axios')
-const { FakeAgent, sandboxCwd, useSandbox } = require('./helpers')
+const { FakeAgent, sandboxCwd, useSandbox, stopProc } = require('./helpers')
 
 async function check (agent, proc, timeout, onMessage = () => { }, isMetrics) {
   const messageReceiver = isMetrics
@@ -74,7 +74,7 @@ describe('opentelemetry', () => {
   })
 
   after(async () => {
-    proc.kill()
+    await stopProc(proc)
     await agent.stop()
   })
 

--- a/integration-tests/pino.spec.js
+++ b/integration-tests/pino.spec.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 
 const path = require('path')
 const { once } = require('events')
-const { FakeAgent, spawnProc, sandboxCwd, useSandbox, curl, assertObjectContains } = require('./helpers')
+const { FakeAgent, spawnProc, sandboxCwd, useSandbox, stopProc, curl, assertObjectContains } = require('./helpers')
 
 describe('pino test', () => {
   let agent
@@ -25,7 +25,7 @@ describe('pino test', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -16,6 +16,7 @@ const {
   sandboxCwd,
   useSandbox,
   assertObjectContains,
+  stopProc,
 } = require('../helpers')
 
 const DEFAULT_PROFILE_TYPES = ['wall', 'space']
@@ -565,8 +566,8 @@ describe('profiler', () => {
       }
     })
 
-    afterEach(() => {
-      proc.kill()
+    afterEach(async () => {
+      await stopProc(proc)
     })
 
     it('records profile on process exit', async () => {
@@ -654,8 +655,8 @@ describe('profiler', () => {
   })
 
   context('SSI heuristics', () => {
-    afterEach(() => {
-      proc.kill()
+    afterEach(async () => {
+      await stopProc(proc)
     })
 
     describe('does not trigger for', () => {
@@ -683,7 +684,7 @@ describe('profiler', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 

--- a/integration-tests/remote_config.spec.js
+++ b/integration-tests/remote_config.spec.js
@@ -4,7 +4,7 @@ const assert = require('node:assert/strict')
 
 const path = require('path')
 const Axios = require('axios')
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc } = require('./helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc } = require('./helpers')
 describe('Remote config client id', () => {
   let axios, cwd, appFile
 
@@ -34,7 +34,7 @@ describe('Remote config client id', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 
@@ -98,7 +98,7 @@ describe('Remote config client id', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 

--- a/integration-tests/startup.spec.js
+++ b/integration-tests/startup.spec.js
@@ -10,6 +10,7 @@ const {
   FakeAgent,
   spawnProc,
   spawnProcAndExpectExit,
+  stopProc,
   sandboxCwd,
   useSandbox,
   curlAndAssertMessage,
@@ -71,7 +72,7 @@ execArgvs.forEach(({ execArgv, skip, optional = true }) => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 
@@ -154,7 +155,7 @@ execArgvs.forEach(({ execArgv, skip, optional = true }) => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 
@@ -203,7 +204,7 @@ execArgvs.forEach(({ execArgv, skip, optional = true }) => {
       })
 
       afterEach(async () => {
-        proc.kill()
+        await stopProc(proc)
         await agent.stop()
       })
 

--- a/integration-tests/telemetry.spec.js
+++ b/integration-tests/telemetry.spec.js
@@ -5,7 +5,7 @@ const path = require('node:path')
 
 const { afterEach, before, beforeEach, describe, it } = require('mocha')
 
-const { sandboxCwd, useSandbox, FakeAgent, spawnProc, assertObjectContains } = require('./helpers')
+const { sandboxCwd, useSandbox, FakeAgent, spawnProc, stopProc, assertObjectContains } = require('./helpers')
 
 describe('telemetry', () => {
   describe('dependencies', () => {
@@ -33,7 +33,7 @@ describe('telemetry', () => {
     })
 
     afterEach(async () => {
-      proc.kill()
+      await stopProc(proc)
       await agent.stop()
     })
 


### PR DESCRIPTION
### What does this PR do?

Integration tests that spawn child processes now use the shared `stopProc` helper from `integration-tests/helpers` in their `after`/`afterEach` teardown instead of calling `proc.kill()` directly.

### Motivation

Using `proc.kill()` alone can leave processes or resources in an inconsistent state before the next test runs. Awaiting `stopProc(proc)` ensures child processes are fully stopped and cleaned up before the next test, which should reduce flakiness caused by one test leaking state into another.
