### PR TITLE
fix(benchmark): handle non-JSON workflow polling responses

### DIFF
--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -17,18 +17,18 @@ const getResponsePreview = (body) => {
 
 const parseGitHubJsonResponse = ({ body, endpoint, res }) => {
   const statusCode = res.statusCode || 0
-  const contentType = String(res.headers['content-type'] || '')
-  const responsePreview = getResponsePreview(body)
-
   if (statusCode < 200 || statusCode >= 300) {
     throw new Error(
-      `GitHub API ${endpoint} returned status ${statusCode}. Body preview: ${responsePreview}`
+      `GitHub API ${endpoint} returned status ${statusCode}. Body preview: ${getResponsePreview(body)}`
     )
   }
 
+  const contentType = String(res.headers['content-type'] || '')
   if (!contentType.includes('application/json')) {
     throw new Error(
-      `GitHub API ${endpoint} returned unexpected content-type "${contentType}". Body preview: ${responsePreview}`
+      `GitHub API ${endpoint} returned unexpected content-type "${contentType}". Body preview: ${
+        getResponsePreview(body)
+      }`
     )
   }
 
@@ -36,7 +36,7 @@ const parseGitHubJsonResponse = ({ body, endpoint, res }) => {
     return JSON.parse(body)
   } catch (e) {
     throw new Error(
-      `GitHub API ${endpoint} returned invalid JSON. Body preview: ${responsePreview}`
+      `GitHub API ${endpoint} returned invalid JSON. Body preview: ${getResponsePreview(body)}`
     )
   }
 }


### PR DESCRIPTION
### What does this PR do?
Hardens benchmark workflow polling by validating API responses before JSON parsing and retrying on transient non-JSON/non-2xx responses.

### Motivation

Fix flakiness in performance and correctness tests: ([01](https://github.com/DataDog/dd-trace-js/actions/runs/22474076158/job/65097229481), [02](https://github.com/DataDog/dd-trace-js/actions/runs/22486762351/job/65138207579), [03](https://github.com/DataDog/dd-trace-js/actions/runs/22354709782/job/64691203885)) 

CI sometimes receives HTML/error responses from GitHub Actions APIs while polling, which caused `JSON.parse` crashes.


### Additional Notes
Scope is limited to `benchmark/e2e-test-optimization/benchmark-run.js`.
