### PR TITLE
fix(ci): add missing octo-sts policy for license check

### DIFF
--- a/.github/chainguard/update-3rdparty-licenses.sts.yaml
+++ b/.github/chainguard/update-3rdparty-licenses.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-js:pull_request
+
+claim_pattern:
+  actor: (dependabot\[bot\]|dd-octo-sts\[bot\])
+  event_name: pull_request
+  ref: refs/pull/[0-9]+/merge
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/update-3rdparty-licenses\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  contents: write

--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -6,22 +6,17 @@ on:
       - "yarn.lock"
 
 jobs:
-  update-3rdparty-licenses:
+  check-licenses:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+    outputs:
+      needs_update: ${{ steps.check.outputs.needs_update }}
+      is_bot_same_repo: ${{ steps.check.outputs.is_bot_same_repo }}
+      head_oid: ${{ steps.check.outputs.head_oid }}
     env:
       REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
     steps:
-      - name: Mint GitHub App token (octo-sts) for bot PR updates
-        if: github.event.pull_request.user.type == 'Bot' && github.event_name == 'pull_request'
-        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
-        id: octo-sts
-        with:
-          scope: DataDog/dd-trace-js
-          policy: update-3rdparty-licenses
-
       - name: Check out PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -74,68 +69,112 @@ jobs:
         run: |
           cat .github/vendored-dependencies.csv >> LICENSE-3rdparty.csv
 
-      - name: Run LICENSE-3rdparty.csv update check
+      - name: Check for LICENSE-3rdparty.csv changes
+        id: check
         env:
           PR_USER_TYPE: ${{ github.event.pull_request.user.type }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          echo "head_oid=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+          if git diff --ignore-space-at-eol --exit-code LICENSE-3rdparty.csv; then
+            echo "✅ LICENSE-3rdparty.csv is already up to date"
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          else
+            echo "📝 LICENSE-3rdparty.csv was modified by license attribution command"
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$PR_USER_TYPE" == "Bot" ]] && [[ "$PR_HEAD_REPO" == "$BASE_REPO" ]]; then
+            echo "is_bot_same_repo=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_bot_same_repo=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload updated LICENSE-3rdparty.csv
+        if: steps.check.outputs.needs_update == 'true' && steps.check.outputs.is_bot_same_repo == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: license-csv
+          path: LICENSE-3rdparty.csv
+          if-no-files-found: error
+
+      - name: Fail for PRs with outdated licenses
+        if: steps.check.outputs.needs_update == 'true' && steps.check.outputs.is_bot_same_repo != 'true'
+        run: |
+          echo "❌ The LICENSE-3rdparty.csv file needs to be updated!"
+          echo ""
+          echo "The license attribution command has modified LICENSE-3rdparty.csv."
+          echo ""
+          echo "To fix this issue:"
+          echo "1. Set up dd-license-attribution locally by following the installation instructions in:"
+          echo "   https://github.com/DataDog/dd-license-attribution"
+          echo "2. Run the license CSV generation command locally:"
+          echo "   dd-license-attribution generate-sbom-csv \\"
+          echo "     --no-scancode-strategy \\"
+          echo "     --no-github-sbom-strategy \\"
+          echo "     https://github.com/datadog/dd-trace-js > LICENSE-3rdparty.csv"
+          echo "3. Append vendored dependencies:"
+          echo "   cat .github/vendored-dependencies.csv >> LICENSE-3rdparty.csv"
+          echo "4. Commit the updated LICENSE-3rdparty.csv file"
+          echo "5. Push your changes"
+          echo ""
+          echo "This helps keep the 3rd-party license information accurate."
+          exit 1
+
+  auto-commit-licenses:
+    needs: check-licenses
+    if: needs.check-licenses.outputs.needs_update == 'true' && needs.check-licenses.outputs.is_bot_same_repo == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Mint GitHub App token (octo-sts)
+        uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/dd-trace-js
+          policy: update-3rdparty-licenses
+
+      - name: Download updated LICENSE-3rdparty.csv
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: license-csv
+
+      - name: Commit LICENSE-3rdparty.csv via GitHub API
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          EXPECTED_HEAD_OID: ${{ needs.check-licenses.outputs.head_oid }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           set -e
 
-          if git diff --ignore-space-at-eol --exit-code LICENSE-3rdparty.csv; then
-            echo "✅ LICENSE-3rdparty.csv is already up to date"
-          else
-            echo "📝 LICENSE-3rdparty.csv was modified by license attribution command"
+          echo "🤖 Bot-created PR detected. Auto-committing LICENSE-3rdparty.csv changes..."
 
-            if [[ "$PR_USER_TYPE" == "Bot" ]] && [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && [[ "$PR_HEAD_REPO" == "$BASE_REPO" ]]; then
-              echo "🤖 Bot-created PR detected. Auto-committing LICENSE-3rdparty.csv changes..."
+          contents="$(base64 -w 0 LICENSE-3rdparty.csv)"
 
-              expected_head_oid="$(git rev-parse HEAD)"
-              contents="$(base64 -w 0 LICENSE-3rdparty.csv)"
+          variables="$(jq -c \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg branch "$GITHUB_HEAD_REF" \
+            --arg msg "Update LICENSE-3rdparty.csv" \
+            --arg expected "$EXPECTED_HEAD_OID" \
+            --arg path "LICENSE-3rdparty.csv" \
+            --arg contents "$contents" \
+            '{
+              input: {
+                branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                message: { headline: $msg },
+                expectedHeadOid: $expected,
+                fileChanges: { additions: [{ path: $path, contents: $contents }] }
+              }
+            }'
+          )"
 
-              variables="$(jq -c \
-                --arg repo "$GITHUB_REPOSITORY" \
-                --arg branch "$GITHUB_HEAD_REF" \
-                --arg msg "Update LICENSE-3rdparty.csv" \
-                --arg expected "$expected_head_oid" \
-                --arg path "LICENSE-3rdparty.csv" \
-                --arg contents "$contents" \
-                '{
-                  input: {
-                    branch: { repositoryNameWithOwner: $repo, branchName: $branch },
-                    message: { headline: $msg },
-                    expectedHeadOid: $expected,
-                    fileChanges: { additions: [{ path: $path, contents: $contents }] }
-                  }
-                }'
-              )"
+          query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }'
+          gh api graphql -f query="$query" -f variables="$variables" -q '.data.createCommitOnBranch.commit.url' >/dev/null
 
-              query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }'
-              gh api graphql -f query="$query" -f variables="$variables" -q '.data.createCommitOnBranch.commit.url' >/dev/null
-
-              echo "✅ Successfully committed and pushed LICENSE-3rdparty.csv updates"
-            else
-              echo "❌ The LICENSE-3rdparty.csv file needs to be updated!"
-              echo ""
-              echo "The license attribution command has modified LICENSE-3rdparty.csv."
-              echo ""
-              echo "To fix this issue:"
-              echo "1. Set up dd-license-attribution locally by following the installation instructions in:"
-              echo "   https://github.com/DataDog/dd-license-attribution"
-              echo "2. Run the license CSV generation command locally:"
-              echo "   dd-license-attribution generate-sbom-csv \\"
-              echo "     --no-scancode-strategy \\"
-              echo "     --no-github-sbom-strategy \\"
-              echo "     https://github.com/datadog/dd-trace-js > LICENSE-3rdparty.csv"
-              echo "3. Append vendored dependencies:"
-              echo "   cat .github/vendored-dependencies.csv >> LICENSE-3rdparty.csv"
-              echo "4. Commit the updated LICENSE-3rdparty.csv file"
-              echo "5. Push your changes"
-              echo ""
-              echo "This helps keep the 3rd-party license information accurate."
-              exit 1
-            fi
-          fi
+          echo "✅ Successfully committed and pushed LICENSE-3rdparty.csv updates"


### PR DESCRIPTION
### What does this PR do?

Fixes the `update-3rdparty-licenses` CI workflow, which has been broken on **every bot PR** since commit 4afd74ae (Feb 5) introduced an octo-sts step without the corresponding chainguard policy.

Two changes:

1. **Adds the missing `update-3rdparty-licenses` octo-sts policy** (`.github/chainguard/update-3rdparty-licenses.sts.yaml`) — restricts token minting to `dependabot[bot]` and `dd-octo-sts[bot]` actors, and pins to this specific workflow file.

2. **Splits the workflow into two jobs for privilege separation** — the `check-licenses` job processes untrusted PR code with read-only permissions (`contents: read`), while the `auto-commit-licenses` job holds `id-token: write` but only runs for bot PRs and never executes third-party code. This follows the same pattern as `dependabot-automation.yml` (`vendor-build` / `vendor-push`).

### Motivation

The `update-3rdparty-licenses` workflow was failing at the "Mint GitHub App token (octo-sts)" step with _"Fetch failed after 4 attempts"_ because the policy file was never created. Human PRs were unaffected since the octo-sts step was skipped via an `if` condition.

Beyond just fixing the missing policy, the original single-job design granted `id-token: write` to the entire job — including steps that check out and process untrusted PR code (e.g., running `dd-license-attribution` on the PR's `yarn.lock`). Splitting into two jobs ensures the OIDC token is never available in the same job that handles untrusted input.

### Additional Notes

- The `check-licenses` job behavior is unchanged for human PRs: it still fails with instructions when `LICENSE-3rdparty.csv` is out of date.
- The `head_oid` needed for the GraphQL commit mutation is passed as a job output from `check-licenses`, avoiding a checkout in the privileged job.
- The `expectedHeadOid` field in the mutation protects against race conditions between the two jobs.
