### PR TITLE
fix(ci): avoid "Argument list too long" in yarn-dedupe-push

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -228,10 +228,12 @@ jobs:
 
           test -f "${{ runner.temp }}/yarn-lock-artifact/yarn.lock"
           sha="$(gh api -q '.sha' "repos/${OWNER}/${REPO}/contents/yarn.lock?ref=${BRANCH}")"
-          content="$(base64 -w 0 "${{ runner.temp }}/yarn-lock-artifact/yarn.lock")"
+          base64 -w 0 "${{ runner.temp }}/yarn-lock-artifact/yarn.lock" > "${{ runner.temp }}/yarn-lock-b64.txt"
 
-          gh api -X PUT "repos/${OWNER}/${REPO}/contents/yarn.lock" \
-            -f message="chore: deduplicate yarn.lock" \
-            -f content="${content}" \
-            -f sha="${sha}" \
-            -f branch="${BRANCH}"
+          jq -n \
+            --arg message "chore: deduplicate yarn.lock" \
+            --rawfile content "${{ runner.temp }}/yarn-lock-b64.txt" \
+            --arg sha "$sha" \
+            --arg branch "$BRANCH" \
+            '{message: $message, content: $content, sha: $sha, branch: $branch}' \
+          | gh api -X PUT "repos/${OWNER}/${REPO}/contents/yarn.lock" --input -


### PR DESCRIPTION
### What does this PR do?

Fixes the `yarn-dedupe-push` CI job which fails with `Argument list too long` (exit code 126) when trying to push a deduplicated `yarn.lock` via the GitHub API.

The base64-encoded `yarn.lock` content was being stored in a shell variable and passed as a command-line argument to `gh api`, which exceeds the Linux `ARG_MAX` limit. The fix writes the base64 output to a temp file and uses `jq --rawfile` to read it directly, piping the constructed JSON body into `gh api --input -` so the large payload never touches the command line.

### Motivation

The `yarn-dedupe-push` job in `.github/workflows/project.yml` started failing as `yarn.lock` grew large enough for its base64 encoding to exceed the ~2MB argument limit:

```
/home/runner/work/_temp/....sh: line 7: /usr/bin/gh: Argument list too long
```

See: https://github.com/DataDog/dd-trace-js/actions/runs/22666593033/job/65699811583?pr=7665
