### PR TITLE
chore: add CODEOWNERS entry for .github/chainguard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -166,6 +166,7 @@
 /packages/dd-trace/test/openfeature/ @DataDog/feature-flagging
 
 # CI
+/.github/chainguard @DataDog/sdlc-security
 /.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
 /.github/workflows/apm-integrations.yml @DataDog/apm-idm-js
 /.github/workflows/aiguard.yml @DataDog/asm-js


### PR DESCRIPTION
### What does this PR do?

Adds a `CODEOWNERS` entry for `.github/chainguard/`, assigning @DataDog/sdlc-security as the owner.

### Motivation

The `.github/chainguard/` directory contains `octo-sts` trust policy files that grant scoped GitHub token permissions to specific CI workflows (e.g. releasing, dependabot automation, yarn deduplication). These are security-sensitive files and should be reviewed by the SDLC Security team. The pattern of using @DataDog/sdlc-security for this path is already established in other DataDog repos such as `homebrew-tap`.
