### PR TITLE
chore(codeowners): add debugger ownership entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@
 # Dynamic Instrumentation
 /benchmark/sirun/debugger @DataDog/debugger-nodejs
 
+/integration-tests/code-origin/ @DataDog/debugger-nodejs
 /integration-tests/code-origin-remote-config.spec.js @DataDog/debugger-nodejs
 /integration-tests/code-origin.spec.js @DataDog/debugger-nodejs
 /integration-tests/debugger/ @DataDog/debugger-nodejs


### PR DESCRIPTION
### What does this PR do?

Updates `CODEOWNERS` with explicit debugger ownership for `benchmark/sirun/debugger` and `integration-tests/code-origin/`, both assigned to `@DataDog/debugger-nodejs`.