### PR TITLE
docs: remove trace-examples pointer

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,1 +1,0 @@
-Examples are available in the [trace-examples](https://github.com/DataDog/trace-examples/tree/master/javascript/node) repository.


### PR DESCRIPTION
### What does this PR do?

Removes `examples/README.md`, which only pointed to the external `trace-examples` repository.

### Motivation

Keep examples documentation centralized in one place and avoid stale duplicate guidance in this repository.

This folder hasn't been edited in 7 years.

