### PR TITLE
chore(ci): retry flaky instrumentation-http in platform workflow

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -199,15 +199,37 @@ jobs:
         with:
           dd_api_key: ${{ secrets.DD_API_KEY }}
 
+  # TODO: Retries below work around a flaky bug in Node.js http code. Revert to using
+  # ./.github/actions/instrumentations/test once fixed upstream.
   instrumentation-http:
     runs-on: ubuntu-latest
     env:
       PLUGINS: http
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/instrumentations/test
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - name: Run instrumentation tests (oldest-maintenance, with retries)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:
-          dd_api_key: ${{ secrets.DD_API_KEY }}
+          max_attempts: 3
+          timeout_minutes: 15
+          command: yarn test:instrumentations:ci
+      - uses: ./.github/actions/node/latest
+      - name: Run instrumentation tests (latest, with retries)
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          command: yarn test:instrumentations:ci
+      - uses: ./.github/actions/coverage
+        with:
+          flags: instrumentations-${{ github.job }}
+      - uses: DataDog/junit-upload-github-action@055560f63c405095e9228ba443eee7987e22bb94 # v2.1.1
+        if: always() && github.actor != 'dependabot[bot]'
+        with:
+          api_key: ${{ secrets.DD_API_KEY }}
+          service: dd-trace-js-tests
 
   instrumentation-knex:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

Adds retries (3 attempts) to the **instrumentation-http** job in the platform workflow. The job no longer uses the shared `./.github/actions/instrumentations/test` action; its steps are inlined in `.github/workflows/platform.yml` and each `yarn test:instrumentations:ci` run is wrapped with `nick-fields/retry`.

### Motivation

The instrumentation-http test is flaky due to [a bug](https://github.com/nodejs/node/pull/61884) in Node.js http code. Retrying up to 3 times reduces CI failures from this flake until the issue is fixed upstream.

### Additional Notes

Revert this change (restore the single `uses: ./.github/actions/instrumentations/test` step for the `instrumentation-http` job) once the upstream fix is available and the test is stable.
