### PR TITLE
docs(pr): add blank line after section headers in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,12 +3,13 @@
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 
 ### What does this PR do?
+
 <!-- A brief description of the change being made with this pull request. -->
 
 ### Motivation
+
 <!-- What inspired you to submit this pull request? -->
 
 ### Additional Notes
+
 <!-- Anything else we should know when reviewing? -->
-
-


### PR DESCRIPTION
### What does this PR do?

Adds a blank line after each section header in `.github/pull_request_template.md` so that the intended spacing is preserved when AI agents replace the comment placeholders.

### Motivation

Just a small personal nit that annoyed my eyes when using a CLI to create PRs. Comments were placed directly under the `###` headers with no blank line in between. When agents replaced those comments, they often kept that structure and omitted the blank line after the header. Adding an explicit blank line after each header in the template makes the desired spacing part of the template so agents preserve it when filling in the sections.
