### PR TITLE
More test optimization fixes to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -114,7 +114,6 @@
 /integration-tests/cypress/cypress.spec.js @DataDog/ci-app-libraries
 /integration-tests/vitest/vitest.spec.js @DataDog/ci-app-libraries
 /integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
-/integration-tests/ci-visibility/test-api-manual.spec.js @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
 /integration-tests/CODEOWNERS @DataDog/ci-app-libraries
 /integration-tests/config-jest-multiproject.js @DataDog/ci-app-libraries


### PR DESCRIPTION


### What does this PR do?
Remove manual api test path as it was wrong and the actual path is covered by the `/integration-tests/ci-visibility/` entry already. 

### Motivation
I missed this one too
