### PR TITLE
fix(codeowners): correct dd-trace plugin paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,19 +41,12 @@
 /packages/datadog-esbuild @DataDog/apm-idm-js
 /packages/datadog-plugin-*/ @DataDog/apm-idm-js
 /packages/datadog-instrumentations/ @DataDog/apm-idm-js
-/packages/ddtrace/src/plugins/ @DataDog/apm-idm-js
-/packages/ddtrace/test/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/src/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/test/plugins/ @DataDog/apm-idm-js
 /packages/dd-trace/src/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/service-naming/ @DataDog/apm-idm-js
 /packages/dd-trace/test/payload_tagging.spec.js @DataDog/apm-idm-js
 /packages/dd-trace/test/payload-tagging/index.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/database-dbm-hash.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/log_plugin.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/outbound.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/plugin-structure.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/tracing.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/util/url.spec.js @DataDog/apm-idm-js
-/packages/dd-trace/test/plugins/util/web.spec.js @DataDog/apm-idm-js
 /packages/dd-trace/test/propagation-hash.spec.js @DataDog/apm-idm-js
 
 # Test Optimization


### PR DESCRIPTION
### What does this PR do?

Fixes the CODEOWNERS entries in `.github/CODEOWNERS` for the `dd-trace` plugin paths.

The previous entries used `ddtrace` instead of `dd-trace`, so those ownership rules did not match the real paths. With the directory-level entries corrected, the redundant per-test plugin entries are no longer needed and can be removed.

### Motivation

This corrects a spelling mistake introduced in [`11a099c`](https://github.com/DataDog/dd-trace-js/commit/11a099c2930f090b1b1a27a4eddcae5584cde703), which left the intended `CODEOWNERS` coverage for the plugin directories ineffective.

