### PR TITLE
fix(ci): deduplicate check runs in all-green to handle re-runs

### DIFF
--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -69,12 +69,12 @@ async function checkCompleted () {
 }
 
 async function checkAllGreen () {
-  let checkRuns
+  let latestRuns
 
   try {
     await checkCompleted()
   } finally {
-    checkRuns = await octokit.paginate(
+    const checkRuns = await octokit.paginate(
       'GET /repos/:owner/:repo/commits/:ref/check-runs',
       {
         ...params,
@@ -82,10 +82,21 @@ async function checkAllGreen () {
       }
     )
 
-    printSummary(checkRuns)
+    // When a check is re-run, older runs remain with their original conclusions.
+    // Deduplicate by name and evaluate only the latest run for each check.
+    const latestByName = new Map()
+    for (const run of checkRuns) {
+      const existing = latestByName.get(run.name)
+      if (!existing || new Date(run.started_at) >= new Date(existing.started_at)) {
+        latestByName.set(run.name, run)
+      }
+    }
+    latestRuns = [...latestByName.values()]
+
+    printSummary(latestRuns)
   }
 
-  const allGreen = !checkRuns.some(run => (
+  const allGreen = !latestRuns.some(run => (
     run.conclusion === 'failure' || run.conclusion === 'timed_out'
   ))
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Deduplicate check runs by name in `all-green.mjs`, evaluating only the latest run for each check when determining pass/fail.

### Motivation
When a CI check is re-run (e.g. after a missing semver label is added later), GitHub retains the old failed check run alongside the new successful one. The `all-green.mjs` script was iterating over all historical check runs and failing when it found the stale failure conclusion, even though a later run succeeded. This put PRs in an unrecoverable state where all-green could never pass without pushing a new commit. The fix makes the summary table and the pass/fail decision consistent by considering only the most recently started run per check name.

### Additional Notes
This also fixes the summary table output to show only the latest run per check, avoiding confusion where the table listed old failed runs that were not actually evaluated.