### PR TITLE
fix all green script not waiting to output summary before exiting

### DIFF
--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -93,7 +93,7 @@ async function checkAllGreen () {
     }
     latestRuns = [...latestByName.values()]
 
-    printSummary(latestRuns)
+    await printSummary(latestRuns)
   }
 
   const allGreen = !latestRuns.some(run => (


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix all green script not waiting to output summary before exiting.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `printSummary` call wasn't awaited, so the script could exit before sending the summary.