### PR TITLE
feat: tag trace and current span with feature flag metadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -802,6 +802,16 @@ declare namespace tracer {
          * Programmatic configuration takes precedence over the environment variables listed above.
          */
         initializationTimeoutMs?: number
+        /**
+         * Maximum number of feature flag tags to attach to a single trace.
+         * Limits bandwidth when many flags are evaluated in one trace. Capped at 1000.
+         * Can be configured via DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS environment variable.
+         *
+         * @default 300
+         * @env DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS
+         * Programmatic configuration takes precedence over the environment variables listed above.
+         */
+        maxFlagTags?: number
       }
     };
 

--- a/integration-tests/openfeature/openfeature-exposure-events.spec.js
+++ b/integration-tests/openfeature/openfeature-exposure-events.spec.js
@@ -326,4 +326,69 @@ describe('OpenFeature Remote Config and Exposure Events Integration', () => {
       })
     })
   })
+
+  describe('Feature flag span tagging', () => {
+    let agent, proc
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+      proc = await spawnProc(appFile, {
+        cwd,
+        env: {
+          DD_TRACE_AGENT_PORT: agent.port,
+          DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS: '0.1',
+          DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED: 'true',
+        },
+      })
+    })
+
+    afterEach(async () => {
+      await stopProc(proc)
+      await agent.stop()
+    })
+
+    it('should tag root span with feature flag metadata', (done) => {
+      const configId = 'org-42-env-test'
+
+      agent.on('remote-config-ack-update', async (id, _version, state) => {
+        if (state === UNACKNOWLEDGED) return
+        if (id !== configId) return
+
+        try {
+          assert.strictEqual(state, ACKNOWLEDGED)
+
+          const response = await fetch(`${proc.url}/evaluate-flags`)
+          assert.strictEqual(response.status, 200)
+        } catch (error) {
+          done(error)
+        }
+      })
+
+      agent.assertMessageReceived(({ payload }) => {
+        const trace = payload.flat()
+        const webSpan = trace.find(s => s.resource === 'GET /evaluate-flags')
+        if (!webSpan) throw new Error('Web span not found in this payload')
+
+        // Verify no child spans are created for feature flag evaluations
+        const ffSpans = trace.filter(s => s.name === 'dd-trace.feature_flag.evaluate')
+        assert.strictEqual(ffSpans.length, 0, 'Should not create child spans for flag evaluations')
+
+        // Verify root span has feature flag tags (flat format: flag key → variant)
+        assert.ok(
+          webSpan.meta['feature_flags.test-boolean-flag'],
+          'Root span should have boolean flag tag'
+        )
+        assert.ok(
+          webSpan.meta['feature_flags.test-string-flag'],
+          'Root span should have string flag tag'
+        )
+      }, 30000, 10, true).then(done, done)
+
+      agent.addRemoteConfig({
+        product: RC_PRODUCT,
+        id: configId,
+        config: ufcPayloads.testBooleanAndStringFlags,
+      })
+    })
+  })
 })

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -415,6 +415,7 @@ class Config {
       OTEL_TRACES_SAMPLER_ARG,
       DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED,
       DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS,
+      DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS,
       OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
       OTEL_EXPORTER_OTLP_LOGS_HEADERS,
       OTEL_EXPORTER_OTLP_LOGS_PROTOCOL,
@@ -602,6 +603,10 @@ class Config {
     if (DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS != null) {
       target['experimental.flaggingProvider.initializationTimeoutMs'] =
         maybeInt(DD_EXPERIMENTAL_FLAGGING_PROVIDER_INITIALIZATION_TIMEOUT_MS)
+    }
+    if (DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS != null) {
+      target['experimental.flaggingProvider.maxFlagTags'] =
+        Math.min(maybeInt(DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS), 1000)
     }
     setBoolean(target, 'traceEnabled', DD_TRACE_ENABLED)
     setBoolean(target, 'experimental.aiguard.enabled', DD_AI_GUARD_ENABLED)

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -742,6 +742,16 @@
         "default": "false"
       }
     ],
+    "DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS": [
+      {
+        "implementation": "A",
+        "type": "int",
+        "configurationNames": [
+          "experimental.flaggingProvider.maxFlagTags"
+        ],
+        "default": "300"
+      }
+    ],
     "DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED": [
       {
         "implementation": "A",

--- a/packages/dd-trace/src/openfeature/constants/constants.js
+++ b/packages/dd-trace/src/openfeature/constants/constants.js
@@ -48,4 +48,10 @@ module.exports = {
    * @type {string} Reason code for noop provider evaluations
    */
   NOOP_REASON: 'STATIC',
+
+  /**
+   * @constant
+   * @type {string} Tag prefix for feature flag metadata on spans
+   */
+  FF_TAG_PREFIX: 'feature_flags',
 }

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -4,6 +4,7 @@ const { DatadogNodeServerProvider } = require('@datadog/openfeature-node-server'
 const { channel } = require('dc-polyfill')
 const log = require('../log')
 const { EXPOSURE_CHANNEL } = require('./constants/constants')
+const { tagSpansForEvaluation } = require('./span_tagger')
 
 /**
  * OpenFeature provider that integrates with Datadog's feature flagging system.
@@ -26,6 +27,76 @@ class FlaggingProvider extends DatadogNodeServerProvider {
 
     log.debug('%s created with timeout: %dms', this.constructor.name,
       config.experimental.flaggingProvider.initializationTimeoutMs)
+  }
+
+  /**
+   * Tags the active and root spans with feature flag evaluation metadata.
+   *
+   * @param {string} flagKey - The feature flag key
+   * @param {import('@openfeature/core').EvaluationContext} context - The evaluation context
+   * @param {import('@openfeature/core').ResolutionDetails<
+   *   boolean | string | number | import('@openfeature/core').JsonValue
+   * >} result - The evaluation result
+   * @returns {import('@openfeature/core').ResolutionDetails<
+   *   boolean | string | number | import('@openfeature/core').JsonValue
+   * >} The evaluation result (passthrough)
+   */
+  _tagSpans (flagKey, context, result) {
+    tagSpansForEvaluation(this._tracer, {
+      flagKey,
+      variantKey: result.variant ?? String(result.value),
+      maxFlagTags: this._config.experimental.flaggingProvider.maxFlagTags,
+    })
+
+    return result
+  }
+
+  /**
+   * @param {string} flagKey
+   * @param {boolean} defaultValue
+   * @param {import('@openfeature/core').EvaluationContext} context
+   * @param {import('@openfeature/core').Logger} logger
+   * @returns {Promise<import('@openfeature/core').ResolutionDetails<boolean>>}
+   */
+  resolveBooleanEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveBooleanEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this._tagSpans(flagKey, context, result))
+  }
+
+  /**
+   * @param {string} flagKey
+   * @param {string} defaultValue
+   * @param {import('@openfeature/core').EvaluationContext} context
+   * @param {import('@openfeature/core').Logger} logger
+   * @returns {Promise<import('@openfeature/core').ResolutionDetails<string>>}
+   */
+  resolveStringEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveStringEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this._tagSpans(flagKey, context, result))
+  }
+
+  /**
+   * @param {string} flagKey
+   * @param {number} defaultValue
+   * @param {import('@openfeature/core').EvaluationContext} context
+   * @param {import('@openfeature/core').Logger} logger
+   * @returns {Promise<import('@openfeature/core').ResolutionDetails<number>>}
+   */
+  resolveNumberEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveNumberEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this._tagSpans(flagKey, context, result))
+  }
+
+  /**
+   * @param {string} flagKey
+   * @param {import('@openfeature/core').JsonValue} defaultValue
+   * @param {import('@openfeature/core').EvaluationContext} context
+   * @param {import('@openfeature/core').Logger} logger
+   * @returns {Promise<import('@openfeature/core').ResolutionDetails<import('@openfeature/core').JsonValue>>}
+   */
+  resolveObjectEvaluation (flagKey, defaultValue, context, logger) {
+    return super.resolveObjectEvaluation(flagKey, defaultValue, context, logger)
+      .then(result => this._tagSpans(flagKey, context, result))
   }
 
   /**

--- a/packages/dd-trace/src/openfeature/span_tagger.js
+++ b/packages/dd-trace/src/openfeature/span_tagger.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const { FF_TAG_PREFIX } = require('./constants/constants')
+
+/**
+ * Builds a feature flag tag mapping flag key to variant.
+ *
+ * @param {string} flagKey - The feature flag key
+ * @param {string} [variantKey] - The variant key from the evaluation result
+ * @returns {{[key: string]: string}} Tag key-value pair
+ */
+function buildFeatureFlagTags (flagKey, variantKey) {
+  if (variantKey === undefined) return {}
+  return { [`${FF_TAG_PREFIX}.${flagKey}`]: variantKey }
+}
+
+/**
+ * Counts the number of feature flag tags in the trace-level tags.
+ *
+ * @param {import('../opentracing/span')} span
+ * @returns {number}
+ */
+function countFlagTags (span) {
+  const traceTags = span.context()._trace.tags
+  const prefix = `${FF_TAG_PREFIX}.`
+  let count = 0
+
+  for (const key in traceTags) {
+    if (key.startsWith(prefix)) {
+      count++
+    }
+  }
+
+  return count
+}
+
+/**
+ * Tags the active span and trace with feature flag evaluation metadata.
+ * Span-level tags go on the active span via addTags(). Trace-level tags go on
+ * _trace.tags, which the formatter automatically applies to the root/chunk span.
+ * Skips tagging if the number of flags already on the trace reaches maxFlagTags.
+ *
+ * @param {import('../tracer')} tracer - Datadog tracer instance
+ * @param {object} params
+ * @param {string} params.flagKey - The feature flag key
+ * @param {string} [params.variantKey] - The variant key from the evaluation result
+ * @param {number} [params.maxFlagTags] - Maximum number of flag tags per trace
+ */
+function tagSpansForEvaluation (tracer, { flagKey, variantKey, maxFlagTags }) {
+  const activeSpan = tracer.scope().active()
+  if (!activeSpan) return
+
+  if (maxFlagTags !== undefined && countFlagTags(activeSpan) >= maxFlagTags) return
+
+  const tags = buildFeatureFlagTags(flagKey, variantKey)
+
+  activeSpan.addTags(tags)
+  Object.assign(activeSpan.context()._trace.tags, tags)
+}
+
+module.exports = {
+  countFlagTags,
+  buildFeatureFlagTags,
+  tagSpansForEvaluation,
+}

--- a/packages/dd-trace/test/openfeature/flagging_provider.spec.js
+++ b/packages/dd-trace/test/openfeature/flagging_provider.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 
-const { describe, it, beforeEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -15,10 +15,12 @@ describe('FlaggingProvider', () => {
   let mockChannel
   let log
   let channelStub
+  let tagSpansForEvaluation
 
   beforeEach(() => {
     mockTracer = {
       _config: { service: 'test-service' },
+      scope: () => ({ active: () => ({}) }),
     }
 
     mockConfig = {
@@ -29,6 +31,7 @@ describe('FlaggingProvider', () => {
         flaggingProvider: {
           enabled: true,
           initializationTimeoutMs: 30_000,
+          maxFlagTags: 300,
         },
       },
     }
@@ -45,12 +48,19 @@ describe('FlaggingProvider', () => {
       warn: sinon.spy(),
     }
 
+    tagSpansForEvaluation = sinon.spy()
+
     FlaggingProvider = proxyquire('../../src/openfeature/flagging_provider', {
       'dc-polyfill': {
         channel: channelStub,
       },
       '../log': log,
+      './span_tagger': { tagSpansForEvaluation },
     })
+  })
+
+  afterEach(() => {
+    sinon.restore()
   })
 
   describe('constructor', () => {
@@ -72,7 +82,7 @@ describe('FlaggingProvider', () => {
       const provider = new FlaggingProvider(mockTracer, mockConfig)
 
       assert.ok(provider)
-      sinon.assert.calledWith(log.debug, 'FlaggingProvider created with timeout: 30000ms')
+      sinon.assert.calledWith(log.debug, '%s created with timeout: %dms', 'FlaggingProvider', 30000)
     })
   })
 
@@ -85,7 +95,7 @@ describe('FlaggingProvider', () => {
       provider._setConfiguration(ufc)
 
       sinon.assert.calledOnceWithExactly(setConfigSpy, ufc)
-      sinon.assert.calledWith(log.debug, 'FlaggingProvider provider configuration updated')
+      sinon.assert.calledWith(log.debug, '%s provider configuration updated', 'FlaggingProvider')
     })
 
     it('should handle null/undefined configuration gracefully', () => {
@@ -102,6 +112,77 @@ describe('FlaggingProvider', () => {
       const provider = new FlaggingProvider(mockTracer, mockConfig)
 
       assert.ok(provider instanceof DatadogNodeServerProvider)
+    })
+  })
+
+  describe('span tagging on resolve methods', () => {
+    const resolveMethodConfigs = [
+      { method: 'resolveBooleanEvaluation', defaultValue: false },
+      { method: 'resolveStringEvaluation', defaultValue: 'default' },
+      { method: 'resolveNumberEvaluation', defaultValue: 0 },
+      { method: 'resolveObjectEvaluation', defaultValue: {} },
+    ]
+
+    for (const { method, defaultValue } of resolveMethodConfigs) {
+      describe(method, () => {
+        it('should call tagSpansForEvaluation with correct params', async () => {
+          const provider = new FlaggingProvider(mockTracer, mockConfig)
+          const context = { targetingKey: 'user-1' }
+
+          await provider[method]('test-flag', defaultValue, context)
+
+          sinon.assert.calledOnce(tagSpansForEvaluation)
+          const [tracer, params] = tagSpansForEvaluation.firstCall.args
+          assert.strictEqual(tracer, mockTracer)
+          assert.strictEqual(params.flagKey, 'test-flag')
+          assert.strictEqual(params.maxFlagTags, 300)
+        })
+
+        it('should still return the evaluation result', async () => {
+          const provider = new FlaggingProvider(mockTracer, mockConfig)
+
+          const result = await provider[method]('test-flag', defaultValue, { targetingKey: 'user-1' })
+
+          assert.ok(Object.hasOwn(result, 'value'))
+        })
+      })
+    }
+
+    it('should pass variant from result when present', async () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(provider))
+      const stub = sinon.stub(parentProto, 'resolveBooleanEvaluation').resolves({
+        value: true,
+        variant: 'treatment',
+        reason: 'TARGETING_MATCH',
+      })
+
+      try {
+        await provider.resolveBooleanEvaluation('test-flag', false, { targetingKey: 'user-1' })
+
+        const [, params] = tagSpansForEvaluation.firstCall.args
+        assert.strictEqual(params.variantKey, 'treatment')
+      } finally {
+        stub.restore()
+      }
+    })
+
+    it('should fall back to stringified value when variant is absent', async () => {
+      const provider = new FlaggingProvider(mockTracer, mockConfig)
+      const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(provider))
+      const stub = sinon.stub(parentProto, 'resolveBooleanEvaluation').resolves({
+        value: false,
+        reason: 'DEFAULT',
+      })
+
+      try {
+        await provider.resolveBooleanEvaluation('test-flag', false, { targetingKey: 'user-1' })
+
+        const [, params] = tagSpansForEvaluation.firstCall.args
+        assert.strictEqual(params.variantKey, 'false')
+      } finally {
+        stub.restore()
+      }
     })
   })
 })

--- a/packages/dd-trace/test/openfeature/span_tagger.spec.js
+++ b/packages/dd-trace/test/openfeature/span_tagger.spec.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach } = require('mocha')
+
+require('../setup/core')
+
+const {
+  buildFeatureFlagTags,
+  countFlagTags,
+  tagSpansForEvaluation,
+} = require('../../src/openfeature/span_tagger')
+
+describe('span_tagger', () => {
+  describe('buildFeatureFlagTags', () => {
+    it('should build a tag mapping flag key to variant', () => {
+      const tags = buildFeatureFlagTags('my-feature-flag', 'control')
+
+      assert.deepStrictEqual(tags, {
+        'feature_flags.my-feature-flag': 'control',
+      })
+    })
+
+    it('should handle flag keys with dots', () => {
+      const tags = buildFeatureFlagTags('org.feature.enabled', 'variant-a')
+
+      assert.deepStrictEqual(tags, {
+        'feature_flags.org.feature.enabled': 'variant-a',
+      })
+    })
+
+    it('should handle flag keys with hyphens', () => {
+      const tags = buildFeatureFlagTags('my-cool-feature', 'treatment')
+
+      assert.deepStrictEqual(tags, {
+        'feature_flags.my-cool-feature': 'treatment',
+      })
+    })
+
+    it('should return empty tags when variantKey is undefined', () => {
+      const tags = buildFeatureFlagTags('flag-1', undefined)
+
+      assert.deepStrictEqual(tags, {})
+    })
+  })
+
+  describe('tagSpansForEvaluation', () => {
+    let activeSpan, traceTags, tracer
+
+    beforeEach(() => {
+      traceTags = {}
+
+      const activeContext = {
+        _spanId: 'span-2',
+        _parentId: 'span-1',
+        _trace: { tags: traceTags },
+        _tags: {},
+      }
+
+      activeSpan = {
+        addTags (tags) { Object.assign(activeContext._tags, tags) },
+        get _tags () { return activeContext._tags },
+        context: () => activeContext,
+      }
+
+      tracer = {
+        scope: () => ({
+          active: () => activeSpan,
+        }),
+      }
+    })
+
+    it('should tag the active span', () => {
+      tagSpansForEvaluation(tracer, {
+        flagKey: 'test-flag',
+        variantKey: 'control',
+      })
+
+      assert.deepStrictEqual(activeSpan._tags, {
+        'feature_flags.test-flag': 'control',
+      })
+    })
+
+    it('should add tags to _trace.tags for trace-level propagation', () => {
+      tagSpansForEvaluation(tracer, {
+        flagKey: 'test-flag',
+        variantKey: 'control',
+      })
+
+      assert.deepStrictEqual(traceTags, {
+        'feature_flags.test-flag': 'control',
+      })
+    })
+
+    it('should be a no-op when there is no active span', () => {
+      const noActiveTracer = {
+        scope: () => ({
+          active: () => undefined,
+        }),
+      }
+
+      // Should not throw
+      tagSpansForEvaluation(noActiveTracer, {
+        flagKey: 'test-flag',
+        variantKey: 'control',
+      })
+    })
+
+    it('should handle undefined variant gracefully', () => {
+      tagSpansForEvaluation(tracer, {
+        flagKey: 'test-flag',
+        variantKey: undefined,
+      })
+
+      assert.deepStrictEqual(activeSpan._tags, {})
+      assert.deepStrictEqual(traceTags, {})
+    })
+
+    it('should skip tagging when maxFlagTags is reached', () => {
+      tagSpansForEvaluation(tracer, { flagKey: 'flag-1', variantKey: 'v1', maxFlagTags: 2 })
+      tagSpansForEvaluation(tracer, { flagKey: 'flag-2', variantKey: 'v2', maxFlagTags: 2 })
+      tagSpansForEvaluation(tracer, { flagKey: 'flag-3', variantKey: 'v3', maxFlagTags: 2 })
+
+      assert.strictEqual(countFlagTags(activeSpan), 2)
+      assert.strictEqual(traceTags['feature_flags.flag-1'], 'v1')
+      assert.strictEqual(traceTags['feature_flags.flag-2'], 'v2')
+      assert.strictEqual(traceTags['feature_flags.flag-3'], undefined)
+    })
+
+    it('should not enforce limit when maxFlagTags is undefined', () => {
+      for (let i = 0; i < 5; i++) {
+        tagSpansForEvaluation(tracer, { flagKey: `flag-${i}`, variantKey: `v${i}` })
+      }
+
+      assert.strictEqual(countFlagTags(activeSpan), 5)
+    })
+  })
+})


### PR DESCRIPTION
### What does this PR do?
Attaches feature flag evaluation metadata to APM spans, enabling correlation between flag evaluations and traces.

When a flag is evaluated via the OpenFeature provider, we add tags on both the active span and trace with flag metadata (`feature_flags.[flag key]: [variant key]`). 

Falls back to `String(result.value)` as the variant when the provider returns no explicit variant (e.g., flag not found, default returned). 

Also enforces a configurable per-span limit on the number of flag tags to prevent bandwidth issues in traces with many evaluations


### Motivation
<!-- What inspired you to submit this pull request? -->
Users of Datadog Feature Flagging + APM want to be able to filter APM traces by feature flag variant. These changes aim to enable that use case. 

### Additional Notes
Added config option:
  - `DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS` (default: 300) — maximum number of unique flag tags per span. Once reached, further evaluations still tag the current span, but skip tagging the trace.
    - The default maximum for feature flags added to RUM/Product Analytics events is 300, but that is across an entire user session. I chose to use 300 here to align with RUM.

### Testing
* Installed the tracer on a local NodeJS application
* Created an endpoint which evaluated N (as input) number of feature flags
* Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS=3`
* Invoked the endpoint with N=10
* Ensured span tags were added to the current span
* Ensured 3 trace tags were added

<img width="2107" height="1175" alt="image" src="https://github.com/user-attachments/assets/6f7a0ad4-cb7c-4406-887c-41df65dbf9d2" />


* Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_MAX_FLAG_TAGS=50` 
* Invoked the endpoint with N=50
* Ensured span tags were added to the current span
* Ensured 50 trace tags were added

<img width="2108" height="1509" alt="image" src="https://github.com/user-attachments/assets/40ee8fbe-b8dc-4ad2-9823-3ec8404d35b9" />



