### PR TITLE
fix(appsec): isolate fs state from tracing context

### DIFF
--- a/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
+++ b/packages/dd-trace/src/appsec/iast/analyzers/path-traversal-analyzer.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 
+const { APPSEC_FS_STORAGE } = require('../../rasp/fs-plugin')
 const { getIastContext } = require('../iast-context')
 const { storage } = require('../../../../../datadog-core')
 const { PATH_TRAVERSAL } = require('../vulnerabilities')
@@ -29,8 +30,8 @@ class PathTraversalAnalyzer extends InjectionAnalyzer {
 
   onConfigure () {
     this.addSub('apm:fs:operation:start', (obj) => {
-      const store = storage('legacy').getStore()
-      const outOfReqOrChild = !store?.fs?.root
+      const fs = storage(APPSEC_FS_STORAGE).getStore()
+      const outOfReqOrChild = !fs?.root
 
       // we could filter out all the nested fs.operations based on store.fs.root
       // but if we spect a store in the context to be present we are going to exclude

--- a/packages/dd-trace/src/appsec/rasp/fs-plugin.js
+++ b/packages/dd-trace/src/appsec/rasp/fs-plugin.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const dc = require('dc-polyfill')
+
 const Plugin = require('../../plugins/plugin')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 
 const RASP_MODULE = 'rasp'
 const IAST_MODULE = 'iast'
+const APPSEC_FS_STORAGE = 'appsec-fs'
 
 const enabledFor = {
   [RASP_MODULE]: false,
@@ -13,16 +16,18 @@ const enabledFor = {
 }
 
 let fsPlugin
+const appsecFsStorage = storage(APPSEC_FS_STORAGE)
+const fsOperationStart = dc.channel('apm:fs:operation:start')
+const fsOperationFinish = dc.channel('apm:fs:operation:finish')
+const responseRenderStart = dc.channel('tracing:datadog:express:response:render:start')
+const responseRenderEnd = dc.channel('tracing:datadog:express:response:render:end')
 
-function getStoreToStart (fsProps, store = storage('legacy').getStore()) {
-  if (store && !store.fs?.opExcluded) {
+function getStoreToStart (fsProps, store = appsecFsStorage.getStore()) {
+  if (!store || !store.opExcluded) {
     return {
       ...store,
-      fs: {
-        ...store.fs,
-        ...fsProps,
-        parentStore: store,
-      },
+      ...fsProps,
+      parentStore: store,
     }
   }
 
@@ -31,24 +36,29 @@ function getStoreToStart (fsProps, store = storage('legacy').getStore()) {
 
 class AppsecFsPlugin extends Plugin {
   enable () {
-    this.addBind('apm:fs:operation:start', this._onFsOperationStart)
-    this.addBind('apm:fs:operation:finish', this._onFsOperationFinishOrRenderEnd)
-    this.addBind('tracing:datadog:express:response:render:start', this._onResponseRenderStart)
-    this.addBind('tracing:datadog:express:response:render:end', this._onFsOperationFinishOrRenderEnd)
-    // We might have to add the same subscribers for fastify later
+    // The tracing fs plugin binds the legacy store on these channels. AppSec
+    // keeps its fs-only state in a dedicated storage namespace to avoid
+    // clobbering tracing state while still tracking nested operations.
+    fsOperationStart.bindStore(appsecFsStorage, this._onFsOperationStart)
+    fsOperationFinish.bindStore(appsecFsStorage, this._onFsOperationFinishOrRenderEnd)
+    responseRenderStart.bindStore(appsecFsStorage, this._onResponseRenderStart)
+    responseRenderEnd.bindStore(appsecFsStorage, this._onFsOperationFinishOrRenderEnd)
 
     super.configure(true)
   }
 
   disable () {
+    fsOperationStart.unbindStore(appsecFsStorage)
+    fsOperationFinish.unbindStore(appsecFsStorage)
+    responseRenderStart.unbindStore(appsecFsStorage)
+    responseRenderEnd.unbindStore(appsecFsStorage)
     super.configure(false)
   }
 
   _onFsOperationStart () {
-    const store = storage('legacy').getStore()
-    if (store) {
-      return getStoreToStart({ root: store.fs?.root === undefined }, store)
-    }
+    const store = appsecFsStorage.getStore()
+
+    return getStoreToStart({ root: store?.root === undefined }, store)
   }
 
   _onResponseRenderStart () {
@@ -56,11 +66,7 @@ class AppsecFsPlugin extends Plugin {
   }
 
   _onFsOperationFinishOrRenderEnd () {
-    const store = storage('legacy').getStore()
-    if (store?.fs) {
-      return store.fs.parentStore
-    }
-    return store
+    return appsecFsStorage.getStore()?.parentStore
   }
 }
 
@@ -97,6 +103,7 @@ module.exports = {
   disable,
 
   AppsecFsPlugin,
+  APPSEC_FS_STORAGE,
 
   RASP_MODULE,
   IAST_MODULE,

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -6,7 +6,12 @@ const { fsOperationStart, incomingHttpRequestStart, expressResponseRenderStart }
 const { storage } = require('../../../../datadog-core')
 const { FS_OPERATION_PATH } = require('../addresses')
 const waf = require('../waf')
-const { enable: enableFsPlugin, disable: disableFsPlugin, RASP_MODULE } = require('./fs-plugin')
+const {
+  APPSEC_FS_STORAGE,
+  enable: enableFsPlugin,
+  disable: disableFsPlugin,
+  RASP_MODULE,
+} = require('./fs-plugin')
 const { RULE_TYPES, handleResult } = require('./utils')
 
 let config
@@ -58,9 +63,10 @@ function analyzeLfiInResponseRender (ctx) {
 
 function analyzeLfi (ctx) {
   const store = storage('legacy').getStore()
+  const fs = storage(APPSEC_FS_STORAGE).getStore()
   if (!store) return
 
-  const { req, fs, res } = store
+  const { req, res } = store
   if (!req || !fs) return
 
   for (const path of getPaths(ctx, fs)) {

--- a/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
@@ -8,7 +8,7 @@ const proxyquire = require('proxyquire')
 const dc = require('dc-polyfill')
 
 const { storage } = require('../../../../datadog-core')
-const { AppsecFsPlugin } = require('../../../src/appsec/rasp/fs-plugin')
+const { APPSEC_FS_STORAGE, AppsecFsPlugin } = require('../../../src/appsec/rasp/fs-plugin')
 const agent = require('../../plugins/agent')
 const { assertObjectContains } = require('../../../../../integration-tests/helpers')
 
@@ -99,50 +99,44 @@ describe('AppsecFsPlugin', () => {
 
   describe('_onFsOperationStart', () => {
     it('should return fs root', () => {
-      const origStore = {}
-      storage('legacy').enterWith(origStore)
+      storage(APPSEC_FS_STORAGE).enterWith(undefined)
 
       let store = appsecFsPlugin._onFsOperationStart()
 
-      assert.ok(Object.hasOwn(store, 'fs'))
-      assert.strictEqual(store.fs.parentStore, origStore)
-      assert.strictEqual(store.fs.root, true)
+      assert.strictEqual(store.parentStore, undefined)
+      assert.strictEqual(store.root, true)
 
       store = appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      assert.strictEqual(store, origStore)
-      assert.ok(!('fs' in store))
+      assert.strictEqual(store, undefined)
     })
 
     it('should mark fs children', () => {
       const origStore = { orig: true }
-      storage('legacy').enterWith(origStore)
+      storage(APPSEC_FS_STORAGE).enterWith(origStore)
 
       const rootStore = appsecFsPlugin._onFsOperationStart()
 
-      assert.ok(Object.hasOwn(rootStore, 'fs'))
-      assert.strictEqual(rootStore.fs.parentStore, origStore)
-      assert.strictEqual(rootStore.fs.root, true)
+      assert.strictEqual(rootStore.parentStore, origStore)
+      assert.strictEqual(rootStore.root, true)
 
-      storage('legacy').enterWith(rootStore)
+      storage(APPSEC_FS_STORAGE).enterWith(rootStore)
 
       let store = appsecFsPlugin._onFsOperationStart()
 
       assertObjectContains(store, {
-        fs: {
-          parentStore: rootStore,
-          root: false,
-        },
+        parentStore: rootStore,
+        root: false,
         orig: true,
       })
 
-      storage('legacy').enterWith(store)
+      storage(APPSEC_FS_STORAGE).enterWith(store)
 
       store = appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
       assert.strictEqual(store, rootStore)
 
-      storage('legacy').enterWith(store)
+      storage(APPSEC_FS_STORAGE).enterWith(store)
 
       store = appsecFsPlugin._onFsOperationFinishOrRenderEnd()
       assert.strictEqual(store, origStore)
@@ -153,21 +147,18 @@ describe('AppsecFsPlugin', () => {
     it('should mark fs ops as excluded while response rendering', () => {
       appsecFsPlugin.enable()
 
-      const origStore = {}
-      storage('legacy').enterWith(origStore)
+      storage(APPSEC_FS_STORAGE).enterWith(undefined)
 
       let store = appsecFsPlugin._onResponseRenderStart()
 
-      assert.ok(Object.hasOwn(store, 'fs'))
-      assert.strictEqual(store.fs.parentStore, origStore)
-      assert.strictEqual(store.fs.opExcluded, true)
+      assert.strictEqual(store.parentStore, undefined)
+      assert.strictEqual(store.opExcluded, true)
 
-      storage('legacy').enterWith(store)
+      storage(APPSEC_FS_STORAGE).enterWith(store)
 
       store = appsecFsPlugin._onFsOperationFinishOrRenderEnd()
 
-      assert.strictEqual(store, origStore)
-      assert.ok(!('fs' in store))
+      assert.strictEqual(store, undefined)
     })
   })
 
@@ -184,16 +175,15 @@ describe('AppsecFsPlugin', () => {
       it('should mark root operations', () => {
         let count = 0
         const onStart = () => {
-          const store = storage('legacy').getStore()
-          assert.notStrictEqual(store.fs, null)
+          const store = storage(APPSEC_FS_STORAGE).getStore()
+          assert.notStrictEqual(store, null)
 
           count++
-          assert.strictEqual(count === 1, store.fs.root)
+          assert.strictEqual(count === 1, store.root)
         }
 
         try {
-          const origStore = {}
-          storage('legacy').enterWith(origStore)
+          storage(APPSEC_FS_STORAGE).enterWith(undefined)
 
           opStartCh.subscribe(onStart)
 
@@ -208,18 +198,15 @@ describe('AppsecFsPlugin', () => {
       it('should mark root even if op is excluded', () => {
         let count = 0
         const onStart = () => {
-          const store = storage('legacy').getStore()
-          assert.notStrictEqual(store.fs, null)
+          const store = storage(APPSEC_FS_STORAGE).getStore()
+          assert.notStrictEqual(store, null)
 
           count++
-          assert.strictEqual(store.fs.root, undefined)
+          assert.strictEqual(store.root, undefined)
         }
 
         try {
-          const origStore = {
-            fs: { opExcluded: true },
-          }
-          storage('legacy').enterWith(origStore)
+          storage(APPSEC_FS_STORAGE).enterWith({ opExcluded: true })
 
           opStartCh.subscribe(onStart)
 
@@ -234,16 +221,15 @@ describe('AppsecFsPlugin', () => {
       it('should clean up store when finishing op', () => {
         let count = 4
         const onFinish = () => {
-          const store = storage('legacy').getStore()
+          const store = storage(APPSEC_FS_STORAGE).getStore()
           count--
 
           if (count === 0) {
-            assert.strictEqual(store.fs, undefined)
+            assert.strictEqual(store, undefined)
           }
         }
         try {
-          const origStore = {}
-          storage('legacy').enterWith(origStore)
+          storage(APPSEC_FS_STORAGE).enterWith(undefined)
 
           opFinishCh.subscribe(onFinish)
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -7,13 +7,17 @@ const proxyquire = require('proxyquire')
 
 const { fsOperationStart, incomingHttpRequestStart } = require('../../../src/appsec/channels')
 const { FS_OPERATION_PATH } = require('../../../src/appsec/addresses')
-const { RASP_MODULE } = require('../../../src/appsec/rasp/fs-plugin')
+const { APPSEC_FS_STORAGE, RASP_MODULE } = require('../../../src/appsec/rasp/fs-plugin')
 
 describe('RASP - lfi.js', () => {
-  let waf, legacyStorage, lfi, web, blocking, appsecFsPlugin, config
+  let waf, legacyStorage, appsecFsStorage, lfi, web, blocking, appsecFsPlugin, config
 
   beforeEach(() => {
     legacyStorage = {
+      getStore: sinon.stub(),
+    }
+
+    appsecFsStorage = {
       getStore: sinon.stub(),
     }
 
@@ -35,7 +39,9 @@ describe('RASP - lfi.js', () => {
     }
 
     lfi = proxyquire('../../../src/appsec/rasp/lfi', {
-      '../../../../datadog-core': { storage: () => legacyStorage },
+      '../../../../datadog-core': {
+        storage: (name) => name === APPSEC_FS_STORAGE ? appsecFsStorage : legacyStorage,
+      },
       '../waf': waf,
       '../../plugins/util/web': web,
       '../blocking': blocking,
@@ -107,7 +113,8 @@ describe('RASP - lfi.js', () => {
 
     it('should analyze lfi for root fs operations', () => {
       const fs = { root: true }
-      legacyStorage.getStore.returns({ req, fs })
+      legacyStorage.getStore.returns({ req })
+      appsecFsStorage.getStore.returns(fs)
 
       fsOperationStart.publish(ctx)
 
@@ -117,7 +124,8 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for child fs operations', () => {
       const fs = {}
-      legacyStorage.getStore.returns({ req, fs })
+      legacyStorage.getStore.returns({ req })
+      appsecFsStorage.getStore.returns(fs)
 
       fsOperationStart.publish(ctx)
 
@@ -125,8 +133,8 @@ describe('RASP - lfi.js', () => {
     })
 
     it('should NOT analyze lfi for undefined fs (AppsecFsPlugin disabled)', () => {
-      const fs = undefined
-      legacyStorage.getStore.returns({ req, fs })
+      legacyStorage.getStore.returns({ req })
+      appsecFsStorage.getStore.returns(undefined)
 
       fsOperationStart.publish(ctx)
 
@@ -135,7 +143,8 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for excluded operations', () => {
       const fs = { opExcluded: true, root: true }
-      legacyStorage.getStore.returns({ req, fs })
+      legacyStorage.getStore.returns({ req })
+      appsecFsStorage.getStore.returns(fs)
 
       fsOperationStart.publish(ctx)
 


### PR DESCRIPTION
### What does this PR do?

Isolates AppSec `fs` nesting state from the shared tracing context by moving it into its own async storage namespace.

Today both tracing `fs` and AppSec `fs` tracking try to use the same `legacy` store on `apm:fs:operation:*` channels. This PR makes AppSec keep its `root` / `opExcluded` state in a dedicated AppSec `fs` store instead, and updates the RASP/IAST consumers and tests to read from that store.

### Motivation

This is a small stack step to remove a real production coupling between AppSec and tracing `fs` state management.

Using the same store for both concerns makes behavior depend on channel store ownership and load order. By separating AppSec `fs` state from the main tracing context, we make the current behavior more robust on its own and unblock the follow-up PR that makes `fs` a real configurable plugin target.

### Additional Notes

This PR is intentionally limited to the AppSec side of the issue and does not change `fs` plugin registry/configurability behavior by itself (that will follow in: https://github.com/DataDog/dd-trace-js/pull/7596).
