### PR TITLE
chore(skills): add integration-internals AI agent skill

### DIFF
--- a/.agents/skills/integration-internals/SKILL.md
+++ b/.agents/skills/integration-internals/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: integration-internals
+description: |
+  Supplementary deep-dive for dd-trace-js integration work. Use alongside the
+  repo's apm-integrations skill when you need details on: ESM detection and
+  dual-package handling, diagnostic channel internals (runStores vs publish,
+  three channel types, tracingChannel API), shimmer function-type patterns
+  (sync/async/callback/factory), addHook API, double-patching prevention,
+  dd-debug debugging tool, test failure diagnosis (80/20 rule), manual test
+  patterns (withVersions + agent.load), hot-path performance rules, or
+  environment variables for debugging.
+  Triggers: "ESM", "esmFirst", "dual module", "runStores", "publish",
+  "diagnostic channel", "tracingChannel", "three channel types",
+  "shimmer pattern", "callback wrapping", "addHook", "double patch",
+  "dd-debug", "test failing", "timeout", "wrong tags", "channel mismatch",
+  "performance", "hot path", "hasSubscribers", "failure mode",
+  "createIntegrationTestSuite", "withVersions", "agent.load",
+  "DD_TRACE_DEBUG", "environment variable".
+---
+
+# Integration Internals
+
+Supplementary reference for dd-trace-js integration development. This skill fills gaps not covered by the repo's `apm-integrations` skill — read that skill first.
+
+## ESM Detection & Dual-Package Handling
+
+See [references/esm.md](references/esm.md) for:
+- Detecting whether a package is CJS, ESM, or dual
+- The `esmFirst` flag and when to set it
+- Handling different export styles across module systems
+- Ensuring both CJS and ESM builds are instrumented
+
+## Diagnostic Channels Deep Dive
+
+See [references/channels.md](references/channels.md) for:
+- Three channel types: plain `dc.channel`, `tracingChannel`, orchestrion
+- `tracingChannel` API and auto-suffixed events
+- `runStores()` vs `publish()` with detailed examples
+- Channel event lifecycle diagram
+- Callback wrapping for context propagation
+
+## Shimmer Function-Type Patterns
+
+See [references/shimmer-patterns.md](references/shimmer-patterns.md) for:
+- Synchronous, async/promise, callback, handler/event, and factory wrapping patterns
+- `addHook` API (name, versions, file parameters)
+- Preventing double-patching (Symbol guard)
+- Common mistakes and fixes
+
+These patterns are needed when orchestrion cannot be used.
+
+## Debugging with dd-debug
+
+See [references/debugging.md](references/debugging.md) for:
+- dd-debug usage and commands (superior to `DD_TRACE_DEBUG`)
+- Output symbols reference (SUBSCRIBE, PUBLISH, LISTENER, SPAN)
+- Quick diagnosis flowchart
+- Failure modes and fixes (the 80/20 rule: 80% tags, 20% channels)
+
+## Test Helpers & Environment
+
+See [references/test-environment.md](references/test-environment.md) for:
+- `createIntegrationTestSuite` helper
+- Manual test pattern (`withVersions` + `agent.load/close`)
+- Docker services table
+- `externals.json` and `versions/package.json`
+- Environment variables (`DD_TRACE_DEBUG`, `DD_TRACE_LOG_LEVEL`, plugin enable/disable)
+- ARM64 incompatible packages
+- Test commands reference
+
+## Plugin Writing Patterns
+
+See [references/plugin-patterns.md](references/plugin-patterns.md) for:
+- Base class hierarchy and selection guide
+- Base class features (DatabasePlugin DBM, ClientPlugin peer service, etc.)
+- Key files reference table
+- Plugin registration
+- Code style rules and reference implementations
+- Debugging the ctx object
+
+## ESM Integration Testing
+
+See [references/esm-testing.md](references/esm-testing.md) for:
+- Subprocess-based ESM test file structure
+- server.mjs and client.spec.js templates
+- Key helpers: useSandbox, spawnPluginIntegrationTestProcAndExpectExit, FakeAgent, varySandbox
+- `--import` vs `--loader` distinction for LLM packages
+
+## Performance & Code Quality
+
+See [references/performance.md](references/performance.md) for:
+- Hot-path rules (allocations, loops, closures)
+- `hasSubscribers` optimization
+- GC pressure reduction
+- Logging best practices (printf-style, callback form)
+- Error handling patterns
+- Code quality checklist

--- a/.agents/skills/integration-internals/references/channels.md
+++ b/.agents/skills/integration-internals/references/channels.md
@@ -1,0 +1,136 @@
+# Diagnostic Channels Deep Dive
+
+dd-trace uses Node.js diagnostic channels (via dc-polyfill) for communication between instrumentations and plugins.
+
+## runStores vs publish
+
+### runStores(ctx, callback)
+Runs callback within AsyncLocalStorage context:
+```javascript
+return startCh.runStores(ctx, () => {
+  const result = original.apply(this, args)
+  return result
+})
+```
+
+**Use for**:
+- Start events (ALWAYS)
+- Any event where child code needs span access
+
+### publish(ctx)
+Simple event emission, no context binding:
+```javascript
+errorCh.publish({ error, operation })
+```
+
+**Use for**:
+- Error notifications
+- Finish events (no callback needs context)
+
+### Summary Table
+
+| Event | Method | Why |
+|-------|--------|-----|
+| **Start** | `runStores()` | ALWAYS — establishes async context |
+| **Finish** | `publish()` | Just notification, context already established |
+| **Error** | `publish()` | Just notification |
+| **AsyncStart** | `runStores()` | For continued async context |
+| **AsyncEnd** | `publish()` | Just notification |
+
+## Channel Event Lifecycle
+
+```
+┌─────────────────────────────────────┐
+│ startCh.runStores(ctx, () => {      │ ← start event
+│   try {                             │
+│     const result = original()       │
+│     if (result.then) {              │
+│       return result                 │
+│         .then(val => {              │
+│           ctx.result = val          │
+│           finishCh.publish(ctx)     │ ← asyncEnd event
+│         })                          │
+│         .catch(err => {             │
+│           ctx.error = err           │
+│           errorCh.publish(ctx)      │ ← error event
+│         })                          │
+│     }                               │
+│     finishCh.publish(ctx)           │ ← end event (sync)
+│   } catch (err) {                   │
+│     errorCh.publish(ctx)            │ ← error event
+│   }                                 │
+│ })                                  │
+└─────────────────────────────────────┘
+```
+
+## Callback Wrapping for Context
+
+For callback-based APIs, wrap the callback to maintain context:
+```javascript
+startCh.runStores(ctx, () => {
+  return originalWithCallback(arg, (err, result) => {
+    if (err) {
+      ctx.error = err
+      errorCh.publish(ctx)
+    } else {
+      ctx.result = result
+      finishCh.publish(ctx)
+    }
+    return originalCallback.apply(this, arguments)
+  })
+})
+```
+
+## Three Channel Types
+
+### 1. Plain Diagnostic Channels (dc.channel)
+Exact name, no transformation:
+```javascript
+const ch = channel('apm:express:request:handle')
+ch.publish({ req, res })
+```
+
+### 2. Tracing Channels (dc.tracingChannel)
+Auto-creates suffixed event channels:
+```javascript
+const ch = tracingChannel('apm:mylib:query')
+// Creates:
+//   tracing:apm:mylib:query:start
+//   tracing:apm:mylib:query:end
+//   tracing:apm:mylib:query:asyncStart
+//   tracing:apm:mylib:query:asyncEnd
+//   tracing:apm:mylib:query:error
+```
+**Prefer tracingChannel over plain channels** — consistent with orchestrion's internal behavior.
+
+### 3. Orchestrion Channels
+Auto-generated from JSON config:
+```
+tracing:orchestrion:{module.name}:{channelName}:{event}
+```
+See orchestrion reference in the repo's `apm-integrations` skill for full details.
+
+## Channel Naming Conventions
+
+| Pattern | Example | Use Case |
+|---------|---------|----------|
+| `apm:{lib}:{op}:start` | `apm:pg:query:start` | Operation start |
+| `apm:{lib}:{op}:finish` | `apm:pg:query:finish` | Operation end |
+| `apm:{lib}:{op}:error` | `apm:pg:query:error` | Error occurred |
+| `tracing:apm:{lib}:{op}` | `tracing:apm:undici:fetch` | tracingChannel (auto-suffixed) |
+| `tracing:orchestrion:{module}:{name}` | `tracing:orchestrion:@langchain/core:invoke` | Orchestrion (auto-suffixed) |
+
+## hasSubscribers Optimization
+
+Check before creating expensive context:
+```javascript
+if (!startCh.hasSubscribers) {
+  return original.apply(this, arguments)
+}
+
+// Only runs if plugin is listening
+const ctx = {
+  expensiveData: computeSomething()
+}
+startCh.runStores(ctx, ...)
+```

--- a/.agents/skills/integration-internals/references/debugging.md
+++ b/.agents/skills/integration-internals/references/debugging.md
@@ -1,0 +1,127 @@
+# Debugging with dd-debug
+
+dd-debug is the preferred debugging tool for test failures. It provides real-time visibility into diagnostic channels and span lifecycle.
+
+## Why dd-debug Over DD_TRACE_DEBUG
+
+| Feature | DD_TRACE_DEBUG=true | dd-debug |
+|---------|---------------------|----------|
+| Channel subscribe/publish | No | Full visibility |
+| Listener invocation | No | See when plugins respond |
+| Span lifecycle | Limited | start/finish/tags |
+| Plugin filtering | No | Filter by plugin name |
+| Real-time formatted output | No | Colored, timestamped |
+| Method wrapping (shimmer) | No | See what gets wrapped |
+
+## Usage
+
+```bash
+dd-debug <plugin-name>                    # Basic
+dd-debug mylib --verbose                  # Span tags, shimmer wraps
+dd-debug mylib --show-data                # Data in channels (verbose)
+dd-debug mylib --output-dir ./logs        # Save to file
+dd-debug mylib --show-spans=false         # Channels only
+dd-debug mylib --test "should create span"  # Specific test
+```
+
+## Output Symbols
+
+| Symbol | Meaning |
+|--------|---------|
+| `SUBSCRIBE` | Plugin subscribed to channel |
+| `PUBLISH` | Event published to channel |
+| `LISTENER` | Plugin listener triggered |
+| `SPAN START` | Span created (spanId, operation, service) |
+| `SPAN FINISH` | Span completed |
+| `SPAN TAG` | Tag added to span |
+| `WRAP` | Method wrapped via shimmer |
+
+## Quick Diagnosis Flowchart
+
+```
+Test times out?
+    ↓
+Run: dd-debug <plugin> --verbose
+    ↓
+┌─────────────────────────────────────┐
+│ No PUBLISH events?                  │
+│ → Instrumentation not firing        │
+│ → Check hooks.js, addHook config    │
+│ → Check orchestrion filePath        │
+└─────────────────────────────────────┘
+    ↓
+┌─────────────────────────────────────┐
+│ PUBLISH but no LISTENER?            │
+│ → Plugin not subscribed correctly   │
+│ → Check channel name matches        │
+│ → Check static prefix in plugin     │
+└─────────────────────────────────────┘
+    ↓
+┌─────────────────────────────────────┐
+│ LISTENER but no SPAN START?         │
+│ → Plugin code error                 │
+│ → Check bindStart(), startSpan()    │
+└─────────────────────────────────────┘
+    ↓
+┌─────────────────────────────────────┐
+│ SPAN but test still fails?          │
+│ → Wrong tags (80% of issues!)       │
+│ → Compare TAG output to assertions  │
+└─────────────────────────────────────┘
+```
+
+## Test Failure Modes
+
+### The 80/20 Rule
+
+- **80% of failures** = Wrong/missing tags → Fix tag extraction
+- **20% of failures** = Channel issues → Fix subscriptions
+
+### Wrong Tags (Most Common)
+
+**Symptoms**: SPAN START events appear, tests timeout (not crash)
+
+**Common fixes**:
+- Missing `component` tag → add to `meta: { component: '<name>' }`
+- Wrong resource → fix extraction (`ctx.sql`, `ctx.arguments?.[0]`)
+- Missing db/messaging tags → add type-specific tags
+
+### Channel Mismatch
+
+**Symptoms**: PUBLISH events appear, no LISTENER events follow
+
+**Common fixes**:
+- Wrong prefix in plugin (orchestrion vs shimmer vs manual)
+- Typo in channel name — copy exact name from dd-debug output
+
+### No Events At All
+
+**Symptoms**: No PUBLISH events
+
+**Causes**:
+1. Not registered in hooks.js
+2. Wrong filePath in orchestrion config
+3. Method not called in test
+4. Version mismatch (check semver range)
+
+### Error Tests Failing
+
+Errors must occur WITHIN the instrumented function scope:
+
+```javascript
+// WRONG — error before traced function
+const client = await connect({ badHost: true })  // Error here
+await client.query('SELECT 1')  // Never reached
+
+// RIGHT — error during traced function
+const client = await connect()
+await client.query('INVALID SQL SYNTAX')  // Error here, captured
+```
+
+## Debug Checklist
+
+1. Run dd-debug — what events appear?
+2. Check PUBLISH — instrumentation working?
+3. Check LISTENER — plugin subscribed?
+4. Check SPAN START — tags correct?
+5. Compare to test — what's mismatched?

--- a/.agents/skills/integration-internals/references/esm-testing.md
+++ b/.agents/skills/integration-internals/references/esm-testing.md
@@ -1,0 +1,150 @@
+# ESM Integration Testing
+
+ESM packages require subprocess-based testing because ESM modules can't be unloaded.
+
+## File Structure
+
+```
+packages/datadog-plugin-{name}/test/
+├── index.spec.js              # CJS tests (if dual module)
+└── integration-test/
+    ├── client.spec.js         # Test runner (CJS)
+    └── server.mjs             # Test code (ESM)
+```
+
+## server.mjs Template
+
+```javascript
+// Pure ESM — runs in subprocess
+import 'dd-trace/init.js'
+import { Client } from 'mylib'
+
+const client = new Client({
+  host: 'localhost',
+  port: 5432
+})
+
+await client.connect()
+await client.query('SELECT 1')
+await client.close()
+```
+
+## client.spec.js Template
+
+```javascript
+'use strict'
+
+const assert = require('node:assert/strict')
+const {
+  FakeAgent,
+  sandboxCwd,
+  useSandbox,
+  checkSpansForServiceName,
+  spawnPluginIntegrationTestProcAndExpectExit,
+  varySandbox
+} = require('../../../../integration-tests/helpers')
+const { withVersions } = require('../../../dd-trace/test/setup/mocha')
+
+describe('esm', () => {
+  let agent
+  let proc
+  let variants
+
+  withVersions('mylib', 'mylib', version => {
+    useSandbox([`'mylib@${version}'`], false, [
+      './packages/datadog-plugin-mylib/test/integration-test/*'
+    ])
+
+    beforeEach(async () => {
+      agent = await new FakeAgent().start()
+    })
+
+    before(async function () {
+      variants = varySandbox('server.mjs', 'mylib', 'Client')
+    })
+
+    afterEach(async () => {
+      proc?.kill()
+      await agent.stop()
+    })
+
+    for (const variant of varySandbox.VARIANTS) {
+      it(`is instrumented ${variant}`, async () => {
+        const res = agent.assertMessageReceived(({ headers, payload }) => {
+          assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
+          assert.ok(Array.isArray(payload))
+          assert.strictEqual(checkSpansForServiceName(payload, 'mylib.query'), true)
+        })
+
+        proc = await spawnPluginIntegrationTestProcAndExpectExit(sandboxCwd(), variants[variant], agent.port)
+
+        await res
+      }).timeout(20000)
+    }
+  })
+})
+```
+
+## Key Helpers
+
+### useSandbox
+Creates isolated npm environment:
+```javascript
+useSandbox(
+  [`'mylib@${version}'`],         // Dependencies (quote the spec!)
+  false,                           // isGitRepo
+  ['./path/to/test/files/*']       // Files to copy
+)
+```
+
+### spawnPluginIntegrationTestProcAndExpectExit
+Spawns subprocess with dd-trace loaded:
+```javascript
+// Default: uses --loader=dd-trace/loader-hook.mjs
+proc = await spawnPluginIntegrationTestProcAndExpectExit(sandboxCwd(), 'server.mjs', agent.port)
+
+// With extra env vars
+proc = await spawnPluginIntegrationTestProcAndExpectExit(sandboxCwd(), 'server.mjs', agent.port, null, {
+  MY_API_KEY: 'test-key'
+})
+
+// LLM packages use --import instead of --loader
+proc = await spawnPluginIntegrationTestProcAndExpectExit(sandboxCwd(), 'server.mjs', agent.port, null, {
+  NODE_OPTIONS: '--import dd-trace/initialize.mjs'
+})
+```
+
+### FakeAgent
+Mock agent that captures traces:
+```javascript
+const agent = await new FakeAgent().start()
+agent.assertMessageReceived(({ headers, payload }) => {
+  // Assert on received spans
+})
+await agent.stop()
+```
+
+### checkSpansForServiceName
+```javascript
+assert.strictEqual(checkSpansForServiceName(payload, 'mylib.query'), true)
+```
+
+### varySandbox (Import Variants)
+Tests different import styles:
+```javascript
+// varySandbox(filename, bindingName, namedExport, packageName, byPassDefault)
+variants = varySandbox('server.mjs', 'mylib', 'Client')
+// varySandbox.VARIANTS = ['default', 'star', 'destructure']
+
+// Pass byPassDefault: true (5th arg) when module has no default export
+variants = varySandbox('server.mjs', 'mylib', 'Client', 'mylib', true)
+```
+
+## Reference Implementations
+
+| Package | Pattern | Notes |
+|---------|---------|-------|
+| kafkajs | Basic | Standard pattern |
+| pg | varySandbox | Tests import variants |
+| anthropic | --import override | LLM package |
+| openai | Extra deps | Additional sandbox deps |

--- a/.agents/skills/integration-internals/references/esm.md
+++ b/.agents/skills/integration-internals/references/esm.md
@@ -1,0 +1,123 @@
+# ESM Support in Instrumentations
+
+## Module Types
+
+| Type | package.json | Hook Registration |
+|------|--------------|-------------------|
+| CommonJS only | No `"type"` field | `'pkg': () => require('../pkg')` |
+| ESM only | `"type": "module"` | `'pkg': { esmFirst: true, fn: () => require('../pkg') }` |
+| Dual (both) | Has `"exports"` with import/require | `'pkg': { esmFirst: true, fn: () => require('../pkg') }` |
+
+## Detecting Package Type
+
+### Check package.json
+```json
+{
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  }
+}
+```
+
+### Check file structure
+```
+node_modules/pkg/
+├── index.js          # CJS entry
+├── index.mjs         # ESM entry
+├── dist/
+│   ├── cjs/          # CJS build
+│   └── esm/          # ESM build
+```
+
+## The esmFirst Flag
+
+When `esmFirst: true` is set:
+1. dd-trace's ESM loader hook (`loader-hook.mjs`) intercepts imports
+2. Instrumentation runs BEFORE the ESM module executes
+3. Allows proper wrapping of ESM exports
+
+```javascript
+// hooks.js
+module.exports = {
+  'openai': { esmFirst: true, fn: () => require('../openai') },
+  '@anthropic-ai/sdk': { esmFirst: true, fn: () => require('../anthropic') },
+  'hono': { esmFirst: true, fn: () => require('../hono') },
+}
+```
+
+## Handling Dual Packages
+
+Dual packages may export differently:
+
+```javascript
+// CJS: module.exports = { Client }
+// ESM: export { Client } or export default { Client }
+
+addHook({ name: 'dual-pkg' }, (moduleExports) => {
+  const Client = moduleExports.Client
+    || moduleExports.default?.Client
+    || moduleExports.default
+
+  if (Client?.prototype) {
+    shimmer.wrap(Client.prototype, 'method', ...)
+  }
+
+  return moduleExports
+})
+```
+
+## Different CJS/ESM Build Paths
+
+**Problem**: ESM and CJS builds may have different file paths but the same classes.
+
+```
+dual-pkg/
+├── dist/cjs/client.js    # CJS build
+└── dist/esm/client.js    # ESM build
+```
+
+**Solution for orchestrion**: Add separate entries for each file path:
+
+```javascript
+module.exports = [
+  {
+    module: { name: 'dual-pkg', filePath: 'dist/cjs/client.js', versionRange: '>=1.0.0' },
+    functionQuery: { methodName: 'query', className: 'Client', kind: 'Async' },
+    channelName: 'Client_query'
+  },
+  {
+    module: { name: 'dual-pkg', filePath: 'dist/esm/client.js', versionRange: '>=1.0.0' },
+    functionQuery: { methodName: 'query', className: 'Client', kind: 'Async' },
+    channelName: 'Client_query'  // Same channelName — same plugin handles both
+  }
+]
+```
+
+**Solution for shimmer**: Instrument at a common point, or handle both:
+
+```javascript
+addHook({ name: 'dual-pkg', file: 'dist/cjs/client.js' }, patchClient)
+addHook({ name: 'dual-pkg', file: 'dist/esm/client.js' }, patchClient)
+```
+
+## Common ESM Issues
+
+### Missing esmFirst
+**Symptom**: CJS tests pass, ESM tests show no spans
+**Fix**: Add `esmFirst: true` to hooks.js entry
+
+### Different Class Locations
+**Symptom**: Works in one module system, not the other
+**Fix**: Check where class is defined in both builds, add entries for each
+
+### Re-exports
+ESM often re-exports from submodules:
+```javascript
+// ESM index.mjs
+export { Client } from './client.js'
+```
+Instrument at source (`client.js`) not just entry point.

--- a/.agents/skills/integration-internals/references/performance.md
+++ b/.agents/skills/integration-internals/references/performance.md
@@ -1,0 +1,148 @@
+# Performance & Code Quality
+
+dd-trace runs in application hot paths. Every operation counts.
+
+## Hot-Path Rules
+
+### Avoid Allocations
+```javascript
+// BAD — new object every call
+function getConfig() {
+  return { timeout: 5000, retries: 3 }
+}
+
+// GOOD — reuse static object
+const CONFIG = { timeout: 5000, retries: 3 }
+function getConfig() {
+  return CONFIG
+}
+```
+
+### Avoid Closures
+```javascript
+// BAD — closure created every call
+items.forEach(item => process(item))
+
+// GOOD — no closure
+for (const item of items) {
+  process(item)
+}
+```
+
+### Avoid Intermediate Arrays
+```javascript
+// BAD — creates two intermediate arrays
+const result = items.filter(x => x.valid).map(x => x.value)
+
+// GOOD — single pass
+const result = []
+for (const item of items) {
+  if (item.valid) result.push(item.value)
+}
+```
+
+### Loop Selection
+
+| Pattern | Use When |
+|---------|----------|
+| `for-of` | Simple iteration, readability |
+| `for` with index | Need index, hot path performance |
+| `while` | Custom iteration logic |
+| `.forEach()` | Test files only |
+| `.map()/.filter()` | Test files only, one-time init |
+
+## hasSubscribers Optimization
+
+Always check before creating context objects:
+
+```javascript
+// GOOD — skip work when not needed
+if (!startCh.hasSubscribers) {
+  return original.apply(this, arguments)
+}
+
+const ctx = {
+  query: buildQueryString(),  // Only computed when needed
+  metadata: extractMetadata()
+}
+startCh.runStores(ctx, ...)
+```
+
+## GC Pressure
+
+### Avoid Spread in Hot Paths
+```javascript
+// AVOID — creates new object
+const newCtx = { ...ctx, result }
+
+// PREFER — mutate existing
+ctx.result = result
+```
+
+### Cache Repeated Access
+```javascript
+// BAD — multiple property lookups
+if (ctx.self.config.database) {
+  span.setTag('db.name', ctx.self.config.database)
+  span.setTag('db.instance', ctx.self.config.database)
+}
+
+// GOOD — cache the value
+const database = ctx.self?.config?.database
+if (database) {
+  span.setTag('db.name', database)
+  span.setTag('db.instance', database)
+}
+```
+
+## Logging
+
+Use printf-style formatting (deferred evaluation):
+
+```javascript
+// BAD — string built even if log level disabled
+log.debug(`Processing ${name} with ${JSON.stringify(data)}`)
+
+// GOOD — printf-style
+log.debug('Processing %s with %j', name, data)
+
+// GOOD — callback for expensive ops
+log.debug(() => `Complex: ${expensiveOperation()}`)
+```
+
+## Error Handling
+
+### Never Crash Customer Apps
+```javascript
+// In instrumentations — fallback to original
+try {
+  // Instrumentation logic
+} catch (error) {
+  log.error('Instrumentation error: %s', error.message)
+  return original.apply(this, arguments)
+}
+```
+
+### Never Use try/catch in Hot Paths
+```javascript
+// AVOID — try/catch has performance cost
+function hotPath(data) {
+  try { return data.value } catch (e) { return null }
+}
+
+// PREFER — validate early
+function hotPath(data) {
+  if (!data?.value) return null
+  return data.value
+}
+```
+
+## Code Quality Checklist
+
+- [ ] No `.forEach()`, `.map()`, `.filter()` in hot paths
+- [ ] No unnecessary object/array allocations
+- [ ] `hasSubscribers` check before expensive operations
+- [ ] Defensive property access (`?.`)
+- [ ] No try/catch in hot paths
+- [ ] Matches existing integration patterns
+- [ ] Simple and readable — no duplication or unnecessary special cases

--- a/.agents/skills/integration-internals/references/plugin-patterns.md
+++ b/.agents/skills/integration-internals/references/plugin-patterns.md
@@ -1,0 +1,122 @@
+# Plugin Writing Patterns
+
+Plugins live in `packages/datadog-plugin-{name}/src/` and subscribe to diagnostic channel events to create spans.
+
+## Base Class Hierarchy
+
+```
+Plugin
+├── CompositePlugin
+└── TracingPlugin
+    ├── ServerPlugin
+    ├── OutboundPlugin
+    │   ├── ClientPlugin
+    │   │   └── StoragePlugin
+    │   │       └── DatabasePlugin
+    │   └── CachePlugin
+    ├── ProducerPlugin
+    ├── ConsumerPlugin
+    ├── LogPlugin
+    └── WebPlugin
+        └── RouterPlugin
+```
+
+## Base Class Selection
+
+| Library Type | Base Class | Examples |
+|--------------|------------|----------|
+| Database client | `DatabasePlugin` | pg, mysql, mongodb |
+| Cache client | `CachePlugin` | redis, memcached, ioredis |
+| HTTP client | `ClientPlugin` | axios, fetch, undici |
+| HTTP server | `ServerPlugin` | http server |
+| Web framework routing | `RouterPlugin` | express, fastify, koa |
+| Message producer | `ProducerPlugin` | kafkajs producer |
+| Message consumer | `ConsumerPlugin` | kafkajs consumer |
+| Multiple features | `CompositePlugin` | express (tracing + code origin) |
+| Logging | `LogPlugin` | winston, pino, bunyan |
+
+**Wrong base class = complex workarounds.** If you're fighting the base class, you probably chose wrong.
+
+## Base Class Features
+
+### DatabasePlugin
+- `injectDbmComment(span, queryText)` — DBM trace injection
+- Pre-configured for `db.*` tags
+- Handles connection info extraction
+
+### CachePlugin
+- Cache-specific tags and metrics
+
+### ClientPlugin
+- Peer service detection
+- Distributed tracing header injection
+
+### ProducerPlugin / ConsumerPlugin
+- DSM (Data Streams Monitoring) integration
+- Context propagation in messages
+- Messaging-specific tags
+
+### LogPlugin
+- Injects trace context (dd.trace_id, dd.span_id) into log records
+- Does NOT create spans
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `datadog-instrumentations/src/helpers/hooks.js` | Package → instrumentation mapping |
+| `datadog-instrumentations/src/helpers/instrument.js` | addHook, channel, tracingChannel APIs |
+| `dd-trace/src/plugins/plugin.js` | Base Plugin class |
+| `dd-trace/src/plugins/tracing.js` | TracingPlugin with span helpers |
+| `dd-trace/src/plugins/database.js` | DatabasePlugin with DBM features |
+| `dd-trace/src/plugins/index.js` | Plugin registration |
+
+## Registration
+
+```javascript
+// packages/dd-trace/src/plugins/index.js
+module.exports = {
+  get mylib () { return require('../../../datadog-plugin-mylib/src') },
+}
+```
+
+## Code Style: Keep It Simple
+
+**Your plugin should look like production plugins.**
+
+| Aspect | Avoid | Prefer |
+|--------|-------|--------|
+| Subscriptions | Manual `addSub`/`addBind` calls | Inherit from base class via `static prefix`/`static operation` |
+| Tag extraction | Complex fallback chains | Simple, direct access |
+| finish() | Custom logic | Inherited from base |
+| Channel routing | `if (channel.includes(...))` | One channel per operation via CompositePlugin |
+
+Process:
+1. Find a similar working plugin
+2. Copy its structure exactly
+3. Only change what's specific to your library
+
+## Reference Implementations
+
+| Type | Reference Plugin |
+|------|------------------|
+| Database | `datadog-plugin-pg` |
+| Cache | `datadog-plugin-redis` |
+| HTTP client | `datadog-plugin-fetch` |
+| Messaging | `datadog-plugin-kafkajs` |
+| Web framework | `datadog-plugin-express` |
+| Orchestrion-based | `datadog-plugin-langchain` |
+
+## Debugging ctx
+
+Add temporary logging to see what's available:
+```javascript
+bindStart(ctx) {
+  console.log('=== ctx debug ===')
+  console.log('Keys:', Object.keys(ctx))
+  console.log('arguments:', ctx.arguments)
+  console.log('self:', ctx.self?.constructor?.name)
+  console.log('self keys:', Object.keys(ctx.self || {}))
+  // Remove after debugging!
+}
+```

--- a/.agents/skills/integration-internals/references/shimmer-patterns.md
+++ b/.agents/skills/integration-internals/references/shimmer-patterns.md
@@ -1,0 +1,192 @@
+# Shimmer Function-Type Patterns
+
+When orchestrion cannot be used, shimmer wrapping must match the function type being wrapped. **Always include a comment explaining why orchestrion is not viable.**
+
+## Synchronous Functions
+```javascript
+shimmer.wrap(obj, 'syncMethod', original => function (...args) {
+  if (!startCh.hasSubscribers) return original.apply(this, args)
+
+  const ctx = { args }
+
+  return startCh.runStores(ctx, () => {
+    try {
+      const result = original.apply(this, args)
+      ctx.result = result
+      finishCh.publish(ctx)
+      return result
+    } catch (error) {
+      ctx.error = error
+      errorCh.publish(ctx)
+      throw error
+    }
+  })
+})
+```
+
+## Async/Promise Functions
+```javascript
+shimmer.wrap(obj, 'asyncMethod', original => function (...args) {
+  if (!startCh.hasSubscribers) return original.apply(this, args)
+
+  const ctx = { args }
+
+  return startCh.runStores(ctx, () => {
+    const promise = original.apply(this, args)
+
+    return promise.then(
+      result => {
+        ctx.result = result
+        finishCh.publish(ctx)
+        return result
+      },
+      error => {
+        ctx.error = error
+        errorCh.publish(ctx)
+        throw error
+      }
+    )
+  })
+})
+```
+
+## Callback Functions
+```javascript
+shimmer.wrap(obj, 'callbackMethod', original => function (...args) {
+  if (!startCh.hasSubscribers) return original.apply(this, args)
+
+  const ctx = { args }
+  const callbackIndex = args.length - 1
+  const originalCallback = args[callbackIndex]
+
+  args[callbackIndex] = function (error, result) {
+    if (error) {
+      ctx.error = error
+      errorCh.publish(ctx)
+    } else {
+      ctx.result = result
+      finishCh.publish(ctx)
+    }
+    return originalCallback.apply(this, arguments)
+  }
+
+  return startCh.runStores(ctx, () => {
+    return original.apply(this, args)
+  })
+})
+```
+
+## Handler/Event Pattern (Consumers)
+
+For message consumers and event handlers — wrap the internal method that calls the handler, not the registration method:
+
+```javascript
+shimmer.wrap(consumer, '_processMessage', original => function (message) {
+  if (!startCh.hasSubscribers) return original.apply(this, arguments)
+
+  const ctx = { message }
+
+  return startCh.runStores(ctx, () => {
+    try {
+      const result = original.apply(this, arguments)
+      if (result?.then) {
+        return result.then(
+          r => { finishCh.publish(ctx); return r },
+          e => { ctx.error = e; errorCh.publish(ctx); throw e }
+        )
+      }
+      finishCh.publish(ctx)
+      return result
+    } catch (error) {
+      ctx.error = error
+      errorCh.publish(ctx)
+      throw error
+    }
+  })
+})
+```
+
+## Factory Pattern
+
+When a library returns new instances from a factory function:
+
+```javascript
+shimmer.wrap(moduleExports, 'createClient', original => function (...args) {
+  const client = original.apply(this, args)
+
+  // Wrap methods on the returned instance
+  shimmer.wrap(client, 'query', queryWrapper)
+
+  return client
+})
+```
+
+## addHook API
+
+```javascript
+addHook({
+  name: 'package-name',           // npm package name (or array)
+  versions: ['>=1.0.0', '<3.0'],  // semver ranges
+  file: 'lib/client.js',          // optional: specific file within package
+}, (moduleExports, version, name) => {
+  // Patch moduleExports
+  return moduleExports  // Must return!
+})
+```
+
+## Preventing Double-Patching
+
+```javascript
+const PATCHED = Symbol('mylib.patched')
+
+addHook({ name: 'mylib' }, (moduleExports) => {
+  if (moduleExports[PATCHED]) return moduleExports
+  moduleExports[PATCHED] = true
+
+  // ... patching logic
+  return moduleExports
+})
+```
+
+## Common Mistakes
+
+### Using publish() for Start Events
+```javascript
+// WRONG — loses async context
+startCh.publish(ctx)
+const result = original.apply(this, args)
+
+// CORRECT — preserves context
+return startCh.runStores(ctx, () => {
+  return original.apply(this, args)
+})
+```
+
+### Wrong Pattern for Function Type
+```javascript
+// WRONG — treating promise like sync
+const result = original.apply(this, args)  // Returns promise!
+finishCh.publish(ctx)
+return result  // Span closes before promise resolves
+
+// CORRECT — handle promise
+return original.apply(this, args).then(result => {
+  finishCh.publish(ctx)
+  return result
+})
+```
+
+### Forgetting to Return moduleExports
+```javascript
+// WRONG
+addHook({ name: 'lib' }, (exports) => {
+  shimmer.wrap(exports, 'method', ...)
+  // Missing return!
+})
+
+// CORRECT
+addHook({ name: 'lib' }, (exports) => {
+  shimmer.wrap(exports, 'method', ...)
+  return exports
+})
+```

--- a/.agents/skills/integration-internals/references/test-environment.md
+++ b/.agents/skills/integration-internals/references/test-environment.md
@@ -1,0 +1,165 @@
+# Test Helpers & Environment
+
+## createIntegrationTestSuite (Recommended)
+
+Simplifies test boilerplate — handles `withVersions`, `agent.load/close` automatically:
+
+```javascript
+const { createIntegrationTestSuite } = require('../../dd-trace/test/setup/helpers/integration-test-helpers')
+
+const testSetup = {
+  async setup(mod) {
+    this.client = new mod.Client({ host: 'localhost' })
+    await this.client.connect()
+  },
+  async teardown() {
+    await this.client.close()
+  }
+}
+
+createIntegrationTestSuite('mylib', 'mylib', testSetup, {}, ({ agent, it, expect }) => {
+  it('should create span on query', done => {
+    agent.assertSomeTraces(traces => {
+      const span = traces[0][0]
+      expect(span.name).to.equal('mylib.query')
+      expect(span.meta.component).to.equal('mylib')
+    }).then(done, done)
+
+    testSetup.client.query('SELECT 1').catch(done)
+  })
+})
+```
+
+## Docker Services
+
+| Integration Type | Service | Command |
+|------------------|---------|---------|
+| Redis/Memcached/Valkey | redis | `docker compose up -d redis` |
+| PostgreSQL | postgres | `docker compose up -d postgres` |
+| MySQL/MariaDB | mysql | `docker compose up -d mysql` |
+| MongoDB | mongo | `docker compose up -d mongo` |
+| Kafka | kafka | `docker compose up -d kafka` |
+| RabbitMQ/AMQP | rabbitmq | `docker compose up -d rabbitmq` |
+| Elasticsearch | elasticsearch | `docker compose up -d elasticsearch` |
+| Bull/BullMQ/Bee-queue | redis | `docker compose up -d redis` |
+
+Find required services for a plugin:
+```bash
+grep -A10 "mylib" .github/workflows/apm-integrations.yml | grep SERVICES
+```
+
+## externals.json
+
+Located at `packages/dd-trace/test/plugins/externals.json`. Tracks subpackage dependencies needed by tests.
+
+```json
+{
+  "mylib": ["mylib-subpackage", "some-peer-dep"]
+}
+```
+
+**When to add entries:**
+- Test fails with "Module not found" for a dependency
+- Library has peer dependencies needed at runtime
+- Library re-exports from subpackages
+
+## versions/package.json
+
+Tested packages are installed per-version to `versions/{package}@{version}/node_modules/`. Tests load via `withVersions`:
+
+```javascript
+const lib = require(`../../../versions/mylib@${version}`).get()
+```
+
+These are auto-installed based on `versions/package.json` when `yarn services` runs.
+
+## Manual Test Pattern (withVersions + agent.load)
+
+For when `createIntegrationTestSuite` doesn't fit:
+
+```javascript
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+
+describe('Plugin', () => {
+  describe('mylib', () => {
+    withVersions('mylib', 'mylib', version => {
+      let myLib
+
+      beforeEach(() => {
+        return agent.load('mylib')
+      })
+
+      beforeEach(() => {
+        myLib = require(`../../../versions/mylib@${version}`).get()
+      })
+
+      afterEach(() => {
+        return agent.close({ ritmReset: false })
+      })
+
+      it('should create a span', async () => {
+        const p = agent.assertSomeTraces(traces => {
+          const span = traces[0][0]
+          assert.strictEqual(span.name, 'mylib.query')
+        })
+
+        myLib.query('SELECT 1')
+
+        await p
+      })
+    })
+  })
+})
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `DD_TRACE_DEBUG=true` | Enable debug logging |
+| `DD_TRACE_LOG_LEVEL=info` | Set log level (trace, debug, info, warn, error) |
+| `DD_TRACE_<NAME>_ENABLED=false` | Disable specific plugin |
+| `DD_TRACE_DISABLED_PLUGINS=pg,redis` | Disable multiple plugins |
+
+## ARM64 Incompatible Packages
+
+These fail on ARM64 (M1/M2 Macs): `aerospike`, `couchbase`, `grpc`, `oracledb`
+
+## Never Delete Tests Policy
+
+When fixing tests, never delete test cases. Fix the underlying issue or update assertions to match new behavior.
+
+## Test Commands Reference
+
+```bash
+# CI command (preferred) — handles yarn services automatically
+PLUGINS="mylib" npm run test:plugins:ci
+
+# Unit tests only (assumes yarn services already ran)
+PLUGINS="mylib" npm run test:plugins
+
+# Multiple plugins
+PLUGINS="mylib|redis|pg" npm run test:plugins:ci
+
+# With mocha directly
+./node_modules/.bin/mocha \
+  -r "packages/dd-trace/test/setup/mocha.js" \
+  packages/datadog-plugin-mylib/test/index.spec.js
+
+# Specific test
+./node_modules/.bin/mocha \
+  -r "packages/dd-trace/test/setup/mocha.js" \
+  packages/datadog-plugin-mylib/test/index.spec.js \
+  --grep "should create span"
+
+# With Docker services
+docker compose up -d redis
+SERVICES="redis" PLUGINS="mylib" npm run test:plugins:ci
+
+# ESM integration tests
+yarn test:integration packages/datadog-plugin-mylib/test/integration-test/client.spec.js
+
+# Debug output
+DD_TRACE_DEBUG=true PLUGINS="mylib" npm run test:plugins:ci
+```


### PR DESCRIPTION
Adds a supplementary skill for dd-trace-js integration development, covering topics not in the existing apm-integrations skill:
- ESM detection and dual-package handling
- Diagnostic channel internals (runStores vs publish, three channel types)
- Shimmer function-type patterns (sync/async/callback/factory)
- Debugging with dd-debug (preferred over DD_TRACE_DEBUG)
- Test helpers and environment setup
- Plugin writing patterns and base class selection guide
- ESM integration testing with subprocess pattern
- Hot-path performance rules

Used by the APM instrumentation toolkit when running automated migration agents (e.g. shimmer → orchestrion rewriter migration).

<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


