### PR TITLE
Fix/rewriter this property name

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/orchestrion/transformer.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/orchestrion/transformer.js
@@ -86,7 +86,7 @@ class Transformer {
   }
 
   #fromFunctionQuery (functionQuery) {
-    const { functionName, expressionName, className } = functionQuery
+    const { functionName, expressionName, className, thisPropertyName } = functionQuery
     const method = functionQuery.methodName || functionQuery.privateMethodName
     const type = functionQuery.privateMethodName ? 'PrivateIdentifier' : 'Identifier'
     const queries = []
@@ -111,6 +111,12 @@ class Transformer {
       queries.push(
         `FunctionExpression[id.name="${expressionName}"][async]`,
         `ArrowFunctionExpression[id.name="${expressionName}"][async]`
+      )
+    }
+
+    if (thisPropertyName) {
+      queries.push(
+        `AssignmentExpression[left.object.type=ThisExpression][left.property.name="${thisPropertyName}"] > [async]`
       )
     }
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/orchestrion/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/orchestrion/transforms.js
@@ -55,6 +55,15 @@ function traceAny (state, node, _parent, ancestry) {
 function traceFunction (state, node, program) {
   transforms.tracingChannelDeclaration(state, program)
 
+  // Arrow functions have no own `arguments` or `this` binding. Converting to
+  // a regular FunctionExpression gives the wrapper its own `arguments` (the
+  // actual call arguments) and a dynamic `this` (the receiver at call time).
+  // For method-style calls (e.g. `conn.query(sql)`) `this` is identical to
+  // what an arrow function would have captured from the constructor scope.
+  if (node.type === 'ArrowFunctionExpression') {
+    node.type = 'FunctionExpression'
+  }
+
   node.body = wrap(state, {
     type: 'FunctionExpression',
     params: node.params,

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -261,6 +261,18 @@ describe('check-require-cache', () => {
           },
           channelName: 'trace_class_private_method',
         },
+        {
+          module: {
+            name: 'test-trace-this-property',
+            versionRange: '>=0.1',
+            filePath: 'index.js',
+          },
+          functionQuery: {
+            thisPropertyName: 'test',
+            kind: 'Sync',
+          },
+          channelName: 'test_invoke',
+        },
       ],
     })
   })
@@ -514,5 +526,18 @@ describe('check-require-cache', () => {
     test.test()
 
     assert.ok(subs.start.called)
+  })
+
+  it('should auto instrument arrow function instance properties (thisPropertyName)', done => {
+    const { test } = compile('test-trace-this-property')
+
+    subs = {
+      start: () => setImmediate(done),
+    }
+
+    ch = tracingChannel('orchestrion:test-trace-this-property:test_invoke')
+    ch.subscribe(subs)
+
+    test()
   })
 })

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-this-property/index.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-this-property/index.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// Simulates old-style function constructor where a query method is
+// assigned as an arrow-function instance property (as in mariadb v2).
+function Foo (opts) {
+  this.opts = opts
+
+  this.test = () => {}
+}
+
+function test () {
+  const foo = new Foo({ host: 'localhost' })
+  foo.test('SELECT 1')
+}
+
+module.exports = { test }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-this-property/package.json
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/node_modules/test-trace-this-property/package.json
@@ -1,0 +1,1 @@
+{ "name": "test-trace-this-property", "version": "1.0.0" }


### PR DESCRIPTION


### What does this PR do?
1. Add thisPropertyName query type to the transformer

    The existing transformer only supported functionName, methodName, and expressionName for targeting functions. This
     adds thisPropertyName, which matches arrow functions assigned to instance properties inside constructors:

    // Matches: this._queryPromise = (sql, values) => { ... }
    functionQuery: { thisPropertyName: '_queryPromise', kind: 'Async' }

    The AST query used is:
    AssignmentExpression[left.object.type=ThisExpression][left.property.name="${thisPropertyName}"] > [async]

    2. Fix traceFunction to convert ArrowFunctionExpression to FunctionExpression

    Arrow functions have no own arguments or this binding — they capture both from their lexically enclosing scope.
    When the rewriter wraps an arrow function, the generated wrapper references arguments to forward call-site
    arguments to the inner function. If the outer function remains an ArrowFunctionExpression, arguments resolves to
    the enclosing constructor's arguments (e.g., the connection options object) rather than the actual call-site
    arguments (e.g., [sql, values]).

    Converting to FunctionExpression gives the wrapper its own arguments and a dynamic this binding, making span
    resource and argument forwarding work correctly.


### Additional Notes
  Test plan

    - New test case in packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js: should auto instrument
    arrow function instance properties (thisPropertyName)
    - Verify mariadb v2 query spans have correct resource (SQL string, not connection options)



