### PR TITLE
[test optimization] Fix cypress tests in release branch

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -775,7 +775,7 @@ moduleTypes.forEach(({
       assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
     })
 
-    it('custom after:spec and after:run handlers are chained with dd-trace instrumentation', async () => {
+    over10It('custom after:spec and after:run handlers are chained with dd-trace instrumentation', async () => {
       const receiverPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
           const events = payloads

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "5.0.0-pre",
+  "version": "6.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dd-trace",
-  "version": "6.0.0-pre",
+  "version": "5.0.0-pre",
   "description": "Datadog APM tracing client for JavaScript",
   "main": "index.js",
   "typings": "index.d.ts",


### PR DESCRIPTION

### What does this PR do?
Test is failing in https://github.com/DataDog/dd-trace-js/pull/7958 in https://github.com/DataDog/dd-trace-js/actions/runs/24238186876/job/70767514582?pr=7958 because it shouldn't run for cypress 6.7.0

I changed the version of the package to 5 so that this test would run to make sure it passes: https://github.com/DataDog/dd-trace-js/actions/runs/24239241987/job/70769472851?pr=7973. It passes 👍 

### Motivation
I missed this in https://github.com/DataDog/dd-trace-js/pull/7829. This test should only run in cypress >=10

