### PR TITLE
release: pass github token from sts to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
           git tag v${{ fromJson(steps.pkg.outputs.json).version }}
           git push https://x-access-token:${{ steps.octo-sts.outputs.token }}@github.com/${{ github.repository }}.git v${{ fromJson(steps.pkg.outputs.json).version }}
       - run: node scripts/release/notes --latest
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
   docs:
     needs: "publish-latest"


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
The node release notes [step](https://github.com/DataDog/dd-trace-js/actions/runs/24243280946/job/70782946176) was failing with HTTP 403 because `contents: write` was removed from GITHUB_TOKEN permissions as part of the dd-octo-sts migration. 

### Motivation
Release notes step is failing https://github.com/DataDog/dd-trace-js/actions/runs/24243280946/job/70782946176 due to miss of GH token


