### PR TITLE
chore: refactor profiler start

### DIFF
--- a/benchmark/sirun/profiler/index.js
+++ b/benchmark/sirun/profiler/index.js
@@ -2,8 +2,6 @@
 
 const {
   profiler,
-  WallProfiler,
-  SpaceProfiler,
 } = require('../../../packages/dd-trace/src/profiling')
 
 const { PROFILER } = process.env
@@ -11,33 +9,16 @@ const { PROFILER } = process.env
 const profilers = []
 
 if (PROFILER === 'wall' || PROFILER === 'all') {
-  profilers.push(new WallProfiler())
+  profilers.push('wall')
 }
 if (PROFILER === 'space' || PROFILER === 'all') {
-  profilers.push(new SpaceProfiler())
+  profilers.push('space')
 }
 
-if (profilers.length === 0) {
-  // Add a no-op "profiler"
-  profilers.push({
-    start: () => {},
-    stop: () => {},
-    profile: () => { return true },
-    encode: () => { Promise.resolve(true) },
-  })
-}
+const exporters = ['none']
 
-const exporters = [{
-  export () {
-    profiler.stop()
-    return Promise.resolve()
-  },
-}]
-
-profiler._start({
-  profilers,
-  exporters,
-  interval: 0,
-}).then(() => {
-  profiler._timer.ref()
-})
+profiler.start(/** @type {import('../../../packages/dd-trace/src/config/config-base')} */ ({
+  DD_PROFILING_PROFILERS: profilers,
+  DD_PROFILING_EXPORTERS: exporters,
+  DD_PROFILING_HEAP_SAMPLING_INTERVAL: 0,
+}))

--- a/benchmark/sirun/profiler/meta.json
+++ b/benchmark/sirun/profiler/meta.json
@@ -6,6 +6,11 @@
   "iterations": 5,
   "instructions": true,
   "variants": {
+    "control": {
+      "env": {
+        "PROFILER": ""
+      }
+    },
     "with-cpu-profiler": {
       "env": {
         "PROFILER": "wall"

--- a/benchmark/sirun/profiler/meta.json
+++ b/benchmark/sirun/profiler/meta.json
@@ -6,11 +6,6 @@
   "iterations": 5,
   "instructions": true,
   "variants": {
-    "control": {
-      "env": {
-        "PROFILER": ""
-      }
-    },
     "with-cpu-profiler": {
       "env": {
         "PROFILER": "wall"

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -12,12 +12,6 @@ const { isWebServerSpan, endpointNameFromTags, getStartedSpans } = require('./we
 const profileSubmittedChannel = dc.channel('datadog:profiling:profile-submitted')
 const spanFinishedChannel = dc.channel('dd-trace:span:finish')
 
-function logError (logger, ...args) {
-  if (logger) {
-    logger.error(...args)
-  }
-}
-
 function findWebSpan (startedSpans, spanId) {
   for (let i = startedSpans.length; --i >= 0;) {
     const ispan = startedSpans[i]
@@ -71,33 +65,6 @@ class Profiler extends EventEmitter {
     return this.#config?.flushInterval
   }
 
-  /**
-   * @param {import('../config/config-base')} config - Tracer configuration
-   */
-  start (config) {
-    // TODO: Unify with main logger and rewrite template strings to use printf formatting.
-    const logger = {
-      debug: log.debug.bind(log),
-      info: log.info.bind(log),
-      warn: log.warn.bind(log),
-      error: log.error.bind(log),
-    }
-
-    // TODO: Rewrite this to not need to copy the config.
-    const options = {
-      ...config,
-      logger,
-    }
-
-    try {
-      return this._start(options)
-    } catch (err) {
-      logError(logger, 'Error starting profiler. For troubleshooting tips, see ' +
-        '<https://dtdg.co/nodejs-profiler-troubleshooting>', err)
-      return false
-    }
-  }
-
   get enabled () {
     return this.#enabled
   }
@@ -141,10 +108,6 @@ class Profiler extends EventEmitter {
     return fn()
   }
 
-  #logError (err) {
-    logError(this.#logger, err)
-  }
-
   #getCompressionFn () {
     if (!this.#compressionFnInitialized) {
       this.#compressionFnInitialized = true
@@ -181,8 +144,8 @@ class Profiler extends EventEmitter {
             }
             break
         }
-      } catch (err) {
-        this.#logError(err)
+      } catch (error) {
+        log.error(error)
       }
     }
     return this.#compressionFn
@@ -191,41 +154,36 @@ class Profiler extends EventEmitter {
   /**
    * @param {import('../config/config-base')} options - Tracer configuration
    */
-  _start (options) {
+  start (options) {
     if (this.enabled) return true
+    this.#enabled = true
 
     const config = this.#config = new Config(options)
-
     this.#logger = config.logger
-    this.#enabled = true
-    this._setInterval()
 
+    this._setInterval()
     // Log errors if the source map finder fails, but don't prevent the rest
     // of the profiler from running without source maps.
     let mapper
-    try {
-      const { setLogger, SourceMapper } = require('@datadog/pprof')
-      setLogger(config.logger)
+    const { setLogger, SourceMapper } = require('@datadog/pprof')
+    setLogger(config.logger)
 
-      if (config.sourceMap) {
-        mapper = new SourceMapper(config.debugSourceMaps)
-        mapper.loadDirectory(process.cwd())
-          .then(() => {
-            if (config.debugSourceMaps) {
-              const count = mapper.infoMap.size
-              this.#logger.debug(() => {
-                return count === 0
-                  ? 'Found no source maps'
-                  : `Found source maps for following files: [${[...mapper.infoMap.keys()].join(', ')}]`
-              })
-            }
-          })
-          .catch((err) => {
-            this.#logError(err)
-          })
-      }
-    } catch (err) {
-      this.#logError(err)
+    if (config.sourceMap) {
+      mapper = new SourceMapper(config.debugSourceMaps)
+      mapper.loadDirectory(process.cwd())
+        .then(() => {
+          if (config.debugSourceMaps) {
+            const count = mapper.infoMap.size
+            this.#logger.debug(() => {
+              return count === 0
+                ? 'Found no source maps'
+                : `Found source maps for following files: [${[...mapper.infoMap.keys()].join(', ')}]`
+            })
+          }
+        })
+        .catch((error) => {
+          log.error(error)
+        })
     }
 
     try {
@@ -246,12 +204,13 @@ class Profiler extends EventEmitter {
       }
 
       this._capture(this._timeoutInterval, start)
-      return true
-    } catch (e) {
-      this.#logError(e)
+    } catch (error) {
+      log.error(error)
       this.#stop()
       return false
     }
+
+    return true
   }
 
   #nearOOMExport (profileType, encodedProfile, info) {
@@ -389,10 +348,10 @@ class Profiler extends EventEmitter {
             return `Collected ${profiler.type} profile: ` + profileJson
           })
           hasEncoded = true
-        } catch (err) {
+        } catch (error) {
           // If encoding one of the profile types fails, we should still try to
           // encode and submit the other profile types.
-          this.#logError(err)
+          log.error(error)
         }
       }))
 
@@ -401,8 +360,8 @@ class Profiler extends EventEmitter {
         profileSubmittedChannel.publish()
         this.#logger.debug('Submitted profiles')
       }
-    } catch (err) {
-      this.#logError(err)
+    } catch (error) {
+      log.error(error)
       this.#stop()
     }
   }
@@ -424,10 +383,8 @@ class Profiler extends EventEmitter {
       : undefined
     const exportSpec = { profiles, infos, start, end, tags, endpointCounts, customAttributes }
     const tasks = this.#config.exporters.map(exporter =>
-      exporter.export(exportSpec).catch(err => {
-        if (this.#logger) {
-          this.#logger.warn(err)
-        }
+      exporter.export(exportSpec).catch(error => {
+        log.warn(error)
       })
     )
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -255,10 +255,10 @@ class Tracer extends NoopProxy {
     // do not stop tracer initialization if the profiler fails to be imported
     try {
       return require('./profiler').start(config)
-    } catch (e) {
+    } catch (error) {
       log.error(
         'Error starting profiler. For troubleshooting tips, see <https://dtdg.co/nodejs-profiler-troubleshooting>',
-        e
+        error
       )
       return false
     }

--- a/packages/dd-trace/test/profiling/profiler.spec.js
+++ b/packages/dd-trace/test/profiling/profiler.spec.js
@@ -123,11 +123,13 @@ describe('profiler', function () {
   describe('not serverless', function () {
     function initProfiler () {
       Profiler = proxyquire('../../src/profiling/profiler', {
+        '../log': consoleLogger,
         './config': {
           Config: ConfigStub,
         },
         '@datadog/pprof': {
           SourceMapper: SourceMapperStub,
+          setLogger: sinon.stub(),
         },
       }).Profiler
 
@@ -145,22 +147,22 @@ describe('profiler', function () {
     })
 
     it('should start the internal time profilers', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       sinon.assert.calledOnce(wallProfiler.start)
       sinon.assert.calledOnce(spaceProfiler.start)
     })
 
     it('should start only once', async () => {
-      await profiler._start(makeStartOptions())
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       sinon.assert.calledOnce(wallProfiler.start)
       sinon.assert.calledOnce(spaceProfiler.start)
     })
 
     it('should stop the internal profilers', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
       profiler.stop()
 
       sinon.assert.calledOnce(wallProfiler.stop)
@@ -170,7 +172,7 @@ describe('profiler', function () {
     it('should stop when starting failed', async () => {
       wallProfiler.start.throws()
 
-      await profiler._start(makeStartOptions({ logger }))
+      await profiler.start(makeStartOptions({ logger }))
 
       sinon.assert.calledOnce(wallProfiler.stop)
       sinon.assert.calledOnce(spaceProfiler.stop)
@@ -180,7 +182,7 @@ describe('profiler', function () {
     it('should stop when capturing failed', async () => {
       wallProfiler.profile.throws(new Error('boom'))
 
-      await profiler._start(makeStartOptions({ logger }))
+      await profiler.start(makeStartOptions({ logger }))
 
       clock.tick(interval)
 
@@ -196,7 +198,7 @@ describe('profiler', function () {
       const rejected = Promise.reject(new Error('boom'))
       wallProfiler.encode.returns(rejected)
 
-      await profiler._start(makeStartOptions({ logger }))
+      await profiler.start(makeStartOptions({ logger }))
 
       clock.tick(interval)
 
@@ -213,7 +215,7 @@ describe('profiler', function () {
       const rejected = Promise.reject(new Error('boom'))
       exporter.export.returns(rejected)
 
-      await profiler._start(makeStartOptions({ logger }))
+      await profiler.start(makeStartOptions({ logger }))
 
       clock.tick(interval)
 
@@ -226,7 +228,7 @@ describe('profiler', function () {
     })
 
     it('should flush when the interval is reached', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       clock.tick(interval)
 
@@ -236,7 +238,7 @@ describe('profiler', function () {
     })
 
     it('should flush when the profiler is stopped', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       profiler.stop()
 
@@ -264,7 +266,7 @@ describe('profiler', function () {
       process.env = {
         DD_PROFILING_DEBUG_UPLOAD_COMPRESSION: compression,
       }
-      await profiler._start(makeStartOptions({ tags: { foo: 'foo' } }))
+      await profiler.start(makeStartOptions({ tags: { foo: 'foo' } }))
       process.env = env
 
       clock.tick(interval)
@@ -306,7 +308,7 @@ describe('profiler', function () {
     it('should log exporter errors', async () => {
       exporter.export.rejects(new Error('boom'))
 
-      await profiler._start(makeStartOptions({ logger }))
+      await profiler.start(makeStartOptions({ logger }))
 
       clock.tick(interval)
 
@@ -318,7 +320,7 @@ describe('profiler', function () {
     it('should log encoded profile', async () => {
       exporter.export.rejects(new Error('boom'))
 
-      await profiler._start(makeStartOptions({ logger }))
+      await profiler.start(makeStartOptions({ logger }))
 
       clock.tick(interval)
 
@@ -343,7 +345,7 @@ describe('profiler', function () {
     })
 
     it('should have a new start time for each capture', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       clock.tick(interval)
       await waitForExport()
@@ -370,14 +372,14 @@ describe('profiler', function () {
     })
 
     it('should not pass source mapper to profilers when disabled', async () => {
-      await profiler._start(makeStartOptions({ sourceMap: false }))
+      await profiler.start(makeStartOptions({ sourceMap: false }))
 
       const options = profilers[0].start.args[0][0]
       assert.strictEqual(options.mapper, undefined)
     })
 
     it('should pass source mapper to profilers when enabled', async () => {
-      profiler._start(makeStartOptions({ sourceMap: true }))
+      profiler.start(makeStartOptions({ sourceMap: true }))
 
       const options = profilers[0].start.args[0][0]
       assert.ok(Object.hasOwn(options, 'mapper'))
@@ -387,7 +389,7 @@ describe('profiler', function () {
     it('should work with a root working dir and source maps on', async () => {
       const error = new Error('fail')
       mapperInstance.loadDirectory.rejects(error)
-      profiler._start(makeStartOptions({ logger, sourceMap: true }))
+      profiler.start(makeStartOptions({ logger, sourceMap: true }))
       await Promise.resolve() // let .then() propagate the rejection
       await Promise.resolve() // let .catch() callback run
       assert.strictEqual(consoleLogger.error.args[0][0], error)
@@ -406,7 +408,7 @@ describe('profiler', function () {
         }
       })
 
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       clock.tick(interval)
 
@@ -429,7 +431,7 @@ describe('profiler', function () {
         }
       })
 
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       clock.tick(interval)
 
@@ -446,7 +448,7 @@ describe('profiler', function () {
         }
       })
 
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       clock.tick(interval)
 
@@ -461,11 +463,13 @@ describe('profiler', function () {
 
     function initServerlessProfiler () {
       Profiler = proxyquire('../../src/profiling/profiler', {
+        '../log': consoleLogger,
         './config': {
           Config: ConfigStub,
         },
         '@datadog/pprof': {
           SourceMapper: SourceMapperStub,
+          setLogger: sinon.stub(),
         },
       }).ServerlessProfiler
 
@@ -487,7 +491,7 @@ describe('profiler', function () {
     })
 
     it('should increment profiled intervals after one interval elapses', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
       assert.strictEqual(profiler.profiledIntervals, 0)
 
       clock.tick(interval)
@@ -497,7 +501,7 @@ describe('profiler', function () {
     })
 
     it('should flush when flush after intervals is reached', async () => {
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       // flushAfterIntervals + 1 because it flushes after last interval
       for (let i = 0; i < flushAfterIntervals + 1; i++) {
@@ -521,7 +525,7 @@ describe('profiler', function () {
         }
       })
 
-      await profiler._start(makeStartOptions())
+      await profiler.start(makeStartOptions())
 
       // flushAfterIntervals + 1 because it flushes after last interval
       for (let i = 0; i < flushAfterIntervals + 1; i++) {
@@ -547,7 +551,7 @@ describe('profiler', function () {
         }
       })
 
-      profiler._start(makeStartOptions())
+      profiler.start(makeStartOptions())
 
       // flushAfterIntervals + 1 because it flushes after last interval
       for (let i = 0; i < flushAfterIntervals + 1; i++) {


### PR DESCRIPTION
The profiler start code used to copy the configs and to have a separate logger behavior. That is now changed to use the generic logger the same way as other code.

This simplifies a lot of code overall.