### PR TITLE
ci(benchmarks): fix cpuset overflow by increasing splits to 5

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -77,6 +77,8 @@ benchmark:
         GROUP: 3
       - MAJOR_VERSION: 18
         GROUP: 4
+      - MAJOR_VERSION: 18
+        GROUP: 5
       - MAJOR_VERSION: 20
         GROUP: 1
       - MAJOR_VERSION: 20
@@ -85,6 +87,8 @@ benchmark:
         GROUP: 3
       - MAJOR_VERSION: 20
         GROUP: 4
+      - MAJOR_VERSION: 20
+        GROUP: 5
       - MAJOR_VERSION: 22
         GROUP: 1
       - MAJOR_VERSION: 22
@@ -93,6 +97,8 @@ benchmark:
         GROUP: 3
       - MAJOR_VERSION: 22
         GROUP: 4
+      - MAJOR_VERSION: 22
+        GROUP: 5
       - MAJOR_VERSION: 24
         GROUP: 1
       - MAJOR_VERSION: 24
@@ -101,8 +107,10 @@ benchmark:
         GROUP: 3
       - MAJOR_VERSION: 24
         GROUP: 4
+      - MAJOR_VERSION: 24
+        GROUP: 5
   variables:
-    SPLITS: 4
+    SPLITS: 5
 
 benchmark-serverless:
   stage: benchmarks

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -36,8 +36,14 @@ fi
 # once all of the tests have complete move on to the next version
 
 TOTAL_CPU_CORES=$(nproc 2>/dev/null || echo "24")
-AVAILABLE_CORES=$((TOTAL_CPU_CORES - ${CPU_START_ID:-0}))
 export CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # Benchmarking Platform convention
+
+echo "CPU diagnostics:"
+echo "  nproc: ${TOTAL_CPU_CORES}"
+echo "  CPU_START_ID: ${CPU_START_ID:-<unset>}"
+echo "  CPU_AFFINITY start: ${CPU_AFFINITY}"
+echo "  cpuset: $(cat /proc/self/status 2>/dev/null | grep Cpus_allowed_list || echo 'N/A')"
+echo "  taskset: $(taskset -p $$ 2>/dev/null || echo 'N/A')"
 
 nvm install $MAJOR_VERSION # provided by each benchmark stage
 export VERSION=`nvm current`
@@ -61,8 +67,8 @@ BENCH_INDEX=0
 BENCH_END=$(($GROUP_SIZE*$GROUP))
 BENCH_START=$(($BENCH_END-$GROUP_SIZE))
 
-if [[ ${GROUP_SIZE} -gt ${AVAILABLE_CORES} ]]; then
-  echo "Group size ${GROUP_SIZE} exceeds available CPU cores (${AVAILABLE_CORES}, cpuset starts at ${CPU_START_ID:-0} of ${TOTAL_CPU_CORES} total)"
+if [[ ${GROUP_SIZE} -gt ${TOTAL_CPU_CORES} ]]; then
+  echo "Group size ${GROUP_SIZE} exceeds available CPU cores (${TOTAL_CPU_CORES} from nproc)"
   exit 1
 fi
 
@@ -78,7 +84,7 @@ for D in "${DIRS[@]}"; do
 
       export SIRUN_VARIANT=$V
 
-      (time node ../run-one-variant.js >> ../results.ndjson && echo "${D}/${V} finished.") &
+      (time node ../run-one-variant.js >> ../results.ndjson && echo "${D}/${V} finished." || echo "${D}/${V} FAILED on core ${CPU_AFFINITY}" >&2) &
       ((CPU_AFFINITY=CPU_AFFINITY+1))
     fi
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -36,20 +36,26 @@ fi
 # once all of the tests have complete move on to the next version
 
 TOTAL_CPU_CORES=$(nproc 2>/dev/null || echo "24")
-export CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # Benchmarking Platform convention
+# Derive cpuset start from the kernel when CPU_START_ID is not provided
+if [[ -z "${CPU_START_ID}" ]]; then
+  CPUSET_START=$(grep -oP 'Cpus_allowed_list:\s*\K\d+' /proc/self/status 2>/dev/null || echo "0")
+else
+  CPUSET_START="${CPU_START_ID}"
+fi
+export CPU_AFFINITY="${CPUSET_START}"
 
 echo "CPU diagnostics:"
 echo "  nproc: ${TOTAL_CPU_CORES}"
 echo "  CPU_START_ID: ${CPU_START_ID:-<unset>}"
+echo "  CPUSET_START: ${CPUSET_START}"
 echo "  CPU_AFFINITY start: ${CPU_AFFINITY}"
 echo "  cpuset: $(cat /proc/self/status 2>/dev/null | grep Cpus_allowed_list || echo 'N/A')"
-echo "  taskset: $(taskset -p $$ 2>/dev/null || echo 'N/A')"
 
 nvm install $MAJOR_VERSION # provided by each benchmark stage
 export VERSION=`nvm current`
 export ENABLE_AFFINITY=true
 echo "using Node.js ${VERSION}"
-CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # reset for each node.js version
+CPU_AFFINITY="${CPUSET_START}" # reset for each node.js version
 SPLITS=${SPLITS:-1}
 GROUP=${GROUP:-1}
 

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -36,6 +36,7 @@ fi
 # once all of the tests have complete move on to the next version
 
 TOTAL_CPU_CORES=$(nproc 2>/dev/null || echo "24")
+AVAILABLE_CORES=$((TOTAL_CPU_CORES - ${CPU_START_ID:-0}))
 export CPU_AFFINITY="${CPU_START_ID:-$TOTAL_CPU_CORES}" # Benchmarking Platform convention
 
 nvm install $MAJOR_VERSION # provided by each benchmark stage
@@ -60,8 +61,8 @@ BENCH_INDEX=0
 BENCH_END=$(($GROUP_SIZE*$GROUP))
 BENCH_START=$(($BENCH_END-$GROUP_SIZE))
 
-if [[ ${GROUP_SIZE} -gt 24 ]]; then
-  echo "Group size ${GROUP_SIZE} is larger than available number of CPU cores on Benchmarking Platform machines (${TOTAL_CPU_CORES} cores)"
+if [[ ${GROUP_SIZE} -gt ${AVAILABLE_CORES} ]]; then
+  echo "Group size ${GROUP_SIZE} exceeds available CPU cores (${AVAILABLE_CORES}, cpuset starts at ${CPU_START_ID:-0} of ${TOTAL_CPU_CORES} total)"
   exit 1
 fi
 


### PR DESCRIPTION
   ### What does this PR do?                               
                                     
  Fixes benchmark CPU pinning failures by deriving the cpuset start core from the kernel instead of relying on the unset `CPU_START_ID` env var and increases `SPLITS` from 4 to 5 to reduce group size.                                      
                                                          
  - Reads the first allowed core from `/proc/self/status` (`Cpus_allowed_list`)                 
    when `CPU_START_ID` is not provided                   
  - Bumps `SPLITS` to 5 and adds `GROUP: 5` to each Node version in the CI matrix               
  - Fixes the core count guard to use `nproc` instead of hardcoded `24`                         
  - Adds CPU diagnostics output and per-variant failure logging                                 
                                                                                                
  ### Motivation                                                                                
                                                          
  Adding `plugin-claude-agent-sdk` (2 variants) in #7974 increased the total variant count, causing more variants to be pinned to higher core numbers. `CPU_START_ID` was never set in CI, so `CPU_AFFINITY` fell back to `nproc` (24) as the starting core. On runners with cpusets that don't include cores 24+ (e.g., cpuset `4-27`), `taskset` fails with `Invalid argument` for any core outside the allowed range.
                                                                                                
  This was always latent — it went unnoticed because most runners happened to get cpusets that included cores 24+. The additional benchmarks made failures more frequent.                                                                       
                                                          
  ### Additional Notes                                                                          
                                                          
  - The extra split adds 4 CI jobs (20 total, up from 16), but each job runs fewer variants and finishes faster.
  - Some benchmarks like `debugger/enabled-but-breakpoint-not-hit` has a pre-existing failure unrelated to this change. ([link](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/jobs/1589219779#L988))
   - I expected the available cpus to be different, need to investigate. 