### PR TITLE
Pin system-tests for transitioning to dd-sts

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -49,9 +49,6 @@ jobs:
       - build-artifacts
       - get-credentials
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
-    secrets:
-      TEST_OPTIMIZATION_API_KEY: ${{ needs.get-credentials.outputs.api_key }}
-      DD_API_KEY: ${{ needs.get-credentials.outputs.api_key }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -55,6 +55,7 @@ jobs:
       packages: write
     with:
       library: nodejs
+      ref: 1e5d6b7096279ca43ce4826fda3cc805635b63c1
       binaries_artifact: system_tests_binaries
       desired_execution_time: 300 # 5 minutes
       scenarios_groups: tracer-release

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -48,7 +48,7 @@ jobs:
     needs:
       - build-artifacts
       - get-credentials
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@1e5d6b7096279ca43ce4826fda3cc805635b63c1
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ needs.get-credentials.outputs.api_key }}
       DD_API_KEY: ${{ needs.get-credentials.outputs.api_key }}


### PR DESCRIPTION
## Summary

  Pins the system-tests reusable workflow to \`1e5d6b7096279ca43ce4826fda3cc805635b63c1\` (current \`main\`) for a controlled rollout of [DataDog/system-tests#6726](https://github.com/DataDog/system-tests/pull/6726).

  [system-tests#6726](https://github.com/DataDog/system-tests/pull/6726) updates \`push_to_test_optim\` to handle dd-sts internally using a shared \`system-tests\` policy (see
  [dd-source#408172](https://github.com/DataDog/dd-source/pull/408172)). Pinning here ensures the workflow is not affected by that change until this repo is ready to update.

  ## How to review

  The only change is the pinned SHA and removing the secrets — no functional impact at this ref.