### PR TITLE
[test optimization] Cypress: decouple instrumentation layer from tracer

### DIFF
--- a/integration-tests/cypress-legacy-plugin.config.js
+++ b/integration-tests/cypress-legacy-plugin.config.js
@@ -11,6 +11,14 @@ module.exports = defineConfig({
   defaultCommandTimeout: 1000,
   e2e: {
     setupNodeEvents (on, config) {
+      if (process.env.CYPRESS_ENABLE_AFTER_RUN_CUSTOM) {
+        const ddAfterRun = require('dd-trace/ci/cypress/after-run')
+        on('after:run', (...args) => ddAfterRun(...args))
+      }
+      if (process.env.CYPRESS_ENABLE_AFTER_SPEC_CUSTOM) {
+        const ddAfterSpec = require('dd-trace/ci/cypress/after-spec')
+        on('after:spec', (...args) => ddAfterSpec(...args))
+      }
       return ddTracePlugin(on, config)
     },
     specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',

--- a/integration-tests/cypress-legacy-plugin.config.mjs
+++ b/integration-tests/cypress-legacy-plugin.config.mjs
@@ -4,7 +4,15 @@ import ddTracePlugin from 'dd-trace/ci/cypress/plugin.js'
 export default defineConfig({
   defaultCommandTimeout: 1000,
   e2e: {
-    setupNodeEvents (on, config) {
+    async setupNodeEvents (on, config) {
+      if (process.env.CYPRESS_ENABLE_AFTER_RUN_CUSTOM) {
+        const { default: ddAfterRun } = await import('dd-trace/ci/cypress/after-run.js')
+        on('after:run', (...args) => ddAfterRun(...args))
+      }
+      if (process.env.CYPRESS_ENABLE_AFTER_SPEC_CUSTOM) {
+        const { default: ddAfterSpec } = await import('dd-trace/ci/cypress/after-spec.js')
+        on('after:spec', (...args) => ddAfterSpec(...args))
+      }
       return ddTracePlugin(on, config)
     },
     specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -398,6 +398,79 @@ moduleTypes.forEach(({
       ])
     })
 
+    over10It('reports tests with old manual plugin approach without NODE_OPTIONS', async () => {
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          // Verify full span hierarchy: session, module, suites, and tests
+          const sessionEvents = events.filter(event => event.type === 'test_session_end')
+          const moduleEvents = events.filter(event => event.type === 'test_module_end')
+          const suiteEvents = events.filter(event => event.type === 'test_suite_end')
+          const testEvents = events.filter(event => event.type === 'test')
+
+          assert.strictEqual(sessionEvents.length, 1)
+          assert.strictEqual(moduleEvents.length, 1)
+          assert.strictEqual(suiteEvents.length, 2, 'one suite per spec file')
+          assert.ok(testEvents.length >= 2, 'at least one pass and one fail test')
+
+          const passedTest = testEvents.find(event =>
+            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+          )
+          const failedTest = testEvents.find(event =>
+            event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail'
+          )
+
+          assertObjectContains(passedTest?.content, {
+            meta: {
+              [TEST_STATUS]: 'pass',
+              [TEST_FRAMEWORK]: 'cypress',
+              [TEST_TYPE]: 'browser',
+            },
+          })
+          assert.ok(passedTest?.content.meta[TEST_SOURCE_FILE])
+          assert.ok(passedTest?.content.meta[COMPONENT])
+
+          // Sanity-check _now() time tracking: duration should be positive and under 60s
+          assert.ok(passedTest.content.duration > 0, 'test duration should be positive')
+          assert.ok(passedTest.content.duration < 60_000_000_000, 'test duration should be under 60s')
+
+          assertObjectContains(failedTest?.content, {
+            meta: {
+              [TEST_STATUS]: 'fail',
+              [TEST_FRAMEWORK]: 'cypress',
+              [TEST_TYPE]: 'browser',
+            },
+          })
+          assert.ok(failedTest?.content.meta[ERROR_MESSAGE])
+        }, 60000)
+
+      // Use EVP proxy config but strip NODE_OPTIONS so the tracer is NOT preloaded.
+      // The legacy config file initializes dd-trace itself via require('dd-trace/ci/cypress/plugin').
+      const { NODE_OPTIONS, ...envVars } = getCiVisEvpProxyConfig(receiver.port)
+
+      const legacyConfigFile = type === 'esm'
+        ? 'cypress-legacy-plugin.config.mjs'
+        : 'cypress-legacy-plugin.config.js'
+
+      childProcess = exec(
+        `./node_modules/.bin/cypress run --config-file ${legacyConfigFile}`,
+        {
+          cwd,
+          env: {
+            ...envVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            SPEC_PATTERN: 'cypress/e2e/basic-*.js',
+          },
+        }
+      )
+
+      await Promise.all([
+        once(childProcess, 'exit'),
+        receiverPromise,
+      ])
+    })
+
     over10It('reports tests when using cypress.config.mjs with NODE_OPTIONS', async () => {
       const receiverPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -860,6 +933,115 @@ moduleTypes.forEach(({
         once(childProcess, 'exit'),
         receiverPromise,
       ])
+    })
+
+    // Exercises the _isInit=true channel path: NODE_OPTIONS activates auto-instrumentation
+    // (wrapSetupNodeEvents), the manual plugin sets _isInit=true, and the channel subscriber
+    // chains the after:spec/after:run handlers intercepted by wrappedOn.
+    // Differs from the backwards-compat test (APM protocol, single pass) by validating
+    // the full citestcycle span hierarchy through the channel's _isInit=true branch.
+    over10It('correctly chains hooks when auto-instrumentation and manual plugin are both active', async () => {
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const sessionEvents = events.filter(event => event.type === 'test_session_end')
+          const testEvents = events.filter(event => event.type === 'test')
+
+          assert.strictEqual(sessionEvents.length, 1, 'should have one test session')
+          assert.ok(testEvents.length >= 1, 'should have at least one test')
+
+          const passedTest = testEvents.find(event =>
+            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+          )
+          assertObjectContains(passedTest?.content, {
+            meta: {
+              [TEST_STATUS]: 'pass',
+              [TEST_FRAMEWORK]: 'cypress',
+            },
+          })
+        }, 60000)
+
+      const envVars = getCiVisAgentlessConfig(receiver.port)
+
+      const legacyConfigFile = type === 'esm'
+        ? 'cypress-legacy-plugin.config.mjs'
+        : 'cypress-legacy-plugin.config.js'
+
+      childProcess = exec(
+        `./node_modules/.bin/cypress run --config-file ${legacyConfigFile}`,
+        {
+          cwd,
+          env: {
+            ...envVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
+          },
+        }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        receiverPromise,
+      ])
+
+      assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
+    })
+
+    // Exercises the manual plugin path without NODE_OPTIONS when users also register
+    // custom after:spec and after:run handlers. Without auto-instrumentation, there is
+    // no wrappedOn to intercept and chain handlers — the manual plugin's on() calls
+    // replace earlier registrations. This test verifies the system does not crash and
+    // spans are still correctly reported through the manual plugin's own hooks.
+    over10It('manual plugin with custom after hooks works without NODE_OPTIONS', async () => {
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const sessionEvents = events.filter(event => event.type === 'test_session_end')
+          const testEvents = events.filter(event => event.type === 'test')
+
+          assert.strictEqual(sessionEvents.length, 1, 'should have one test session')
+          assert.ok(testEvents.length >= 1, 'should have at least one test')
+
+          const passedTest = testEvents.find(event =>
+            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+          )
+          assertObjectContains(passedTest?.content, {
+            meta: {
+              [TEST_STATUS]: 'pass',
+              [TEST_FRAMEWORK]: 'cypress',
+            },
+          })
+        }, 60000)
+
+      // Strip NODE_OPTIONS — the manual plugin initializes dd-trace itself.
+      const { NODE_OPTIONS, ...envVars } = getCiVisEvpProxyConfig(receiver.port)
+
+      const legacyConfigFile = type === 'esm'
+        ? 'cypress-legacy-plugin.config.mjs'
+        : 'cypress-legacy-plugin.config.js'
+
+      childProcess = exec(
+        `./node_modules/.bin/cypress run --config-file ${legacyConfigFile}`,
+        {
+          cwd,
+          env: {
+            ...envVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_ENABLE_AFTER_RUN_CUSTOM: '1',
+            CYPRESS_ENABLE_AFTER_SPEC_CUSTOM: '1',
+            SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
+          },
+        }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        receiverPromise,
+      ])
+
+      assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
     })
 
     over12It('reports correct source file and line for pre-compiled typescript test files', async function () {

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -4,8 +4,20 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 const { pathToFileURL } = require('url')
+const { channel } = require('./helpers/instrument')
 
 const DD_CONFIG_WRAPPED = Symbol('dd-trace.cypress.config.wrapped')
+
+const setupNodeEventsCh = channel('ci:cypress:setup-node-events')
+
+// Ensure the cypress plugin is loaded so it can subscribe to our channel.
+// Normally, plugins are loaded when their npm module is required (via addHook),
+// but plain-object configs don't require('cypress'), so the plugin would never
+// be instantiated in the Cypress Config Manager child process.
+const loadCh = channel('dd-trace:instrumentation:load')
+if (loadCh.hasSubscribers) {
+  loadCh.publish({ name: 'cypress' })
+}
 
 const noopTask = {
   'dd:testSuiteStart': () => null,
@@ -93,8 +105,9 @@ function injectSupportFile (config) {
 
 /**
  * Registers dd-trace's Cypress hooks (before:run, after:spec, after:run, tasks)
- * and injects the support file. Handles chaining with user-registered handlers
- * for after:spec/after:run so both the user's code and dd-trace's run in sequence.
+ * and injects the support file. Communicates with the plugin layer via
+ * the `ci:cypress:setup-node-events` diagnostic channel, avoiding direct
+ * tracer references in the instrumentation layer.
  *
  * @param {Function} on Cypress event registration function
  * @param {object} config Cypress resolved config object
@@ -110,8 +123,6 @@ function registerDdTraceHooks (on, config, userAfterSpecHandlers, userAfterRunHa
       try { fs.unlinkSync(wrapperFile) } catch { /* best effort */ }
     }
   }
-
-  const tracer = global._ddtrace
 
   const registerAfterRunWithCleanup = () => {
     on('after:run', (results) => {
@@ -129,49 +140,32 @@ function registerDdTraceHooks (on, config, userAfterSpecHandlers, userAfterRunHa
     on('task', noopTask)
   }
 
-  if (!tracer || !tracer._initialized) {
+  if (!setupNodeEventsCh.hasSubscribers) {
     registerNoopHandlers()
     return config
   }
 
-  const NoopTracer = require('../../../packages/dd-trace/src/noop/tracer')
+  // Publish to the plugin layer via diagnostic channel.
+  // The subscriber sets `payload.registered = true` and optionally
+  // `payload.configPromise` when it handles the event.
+  const payload = {
+    on,
+    config,
+    userAfterSpecHandlers,
+    userAfterRunHandlers,
+    cleanupWrapper,
+    registered: false,
+    configPromise: undefined,
+  }
 
-  if (tracer._tracer instanceof NoopTracer) {
+  setupNodeEventsCh.publish(payload)
+
+  if (!payload.registered) {
     registerNoopHandlers()
     return config
   }
 
-  const cypressPlugin = require('../../../packages/datadog-plugin-cypress/src/cypress-plugin')
-
-  if (cypressPlugin._isInit) {
-    for (const h of userAfterSpecHandlers) on('after:spec', h)
-    registerAfterRunWithCleanup()
-    return config
-  }
-
-  on('before:run', cypressPlugin.beforeRun.bind(cypressPlugin))
-
-  on('after:spec', (spec, results) => {
-    const chain = userAfterSpecHandlers.reduce(
-      (p, h) => p.then(() => h(spec, results)),
-      Promise.resolve()
-    )
-    return chain.then(() => cypressPlugin.afterSpec(spec, results))
-  })
-
-  on('after:run', (results) => {
-    const chain = userAfterRunHandlers.reduce(
-      (p, h) => p.then(() => h(results)),
-      Promise.resolve()
-    )
-    return chain
-      .then(() => cypressPlugin.afterRun(results))
-      .finally(cleanupWrapper)
-  })
-
-  on('task', cypressPlugin.getTasks())
-
-  return Promise.resolve(cypressPlugin.init(tracer, config)).then(() => config)
+  return payload.configPromise || config
 }
 
 /**

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -1,5 +1,9 @@
 'use strict'
 
+// Capture real timers at module load, before any test can install fake timers.
+const { performance } = require('perf_hooks')
+const dateNow = Date.now
+
 const {
   TEST_STATUS,
   TEST_IS_RUM_ACTIVE,
@@ -349,6 +353,19 @@ class CypressPlugin {
     this.rumFlushWaitMillis = undefined
     this._pendingRequestErrorTags = []
     this.libraryConfigurationPromise = undefined
+    this._timeOrigin = 0
+    this._perfOrigin = 0
+  }
+
+  /**
+   * Returns the current time in the same coordinate system used by span
+   * start/finish. Captured at session span creation so it shares the same
+   * epoch as the trace without reaching into span internals.
+   *
+   * @returns {number}
+   */
+  _now () {
+    return this._timeOrigin + performance.now() - this._perfOrigin
   }
 
   // Init function returns a promise that resolves with the Cypress configuration
@@ -664,6 +681,13 @@ class CypressPlugin {
 
       this.tracer._tracer._exporter.addMetadataTags(metadataTags)
     }
+
+    // Capture time references that match what startSpan records internally
+    // (trace.startTime = Date.now(), trace.ticks = performance.now()).
+    // This lets _now() produce values in the same coordinate system as
+    // span._startTime without accessing span internals.
+    this._timeOrigin = dateNow()
+    this._perfOrigin = performance.now()
 
     this.testSessionSpan = this.tracer.startSpan(`${TEST_FRAMEWORK_NAME}.test_session`, {
       childOf,
@@ -1103,7 +1127,7 @@ class CypressPlugin {
         const finishedTest = {
           testName,
           testStatus,
-          finishTime: this.activeTestSpan._getTime(), // we store the finish time here
+          finishTime: this._now(),
           testSpan: this.activeTestSpan,
           isEfdRetry,
           isAttemptToFix,

--- a/packages/datadog-plugin-cypress/src/index.js
+++ b/packages/datadog-plugin-cypress/src/index.js
@@ -1,11 +1,68 @@
 'use strict'
 
+const NoopTracer = require('../../dd-trace/src/noop/tracer')
 const Plugin = require('../../dd-trace/src/plugins/plugin')
 
-// Cypress plugin does not patch any library. This is just a placeholder to
-// follow the structure of the plugins
+/**
+ * Cypress plugin handles setup-node-events from the instrumentation layer
+ * via a diagnostic channel, keeping the instrumentation free of tracer references.
+ */
 class CypressPlugin extends Plugin {
   static id = 'cypress'
+
+  constructor (...args) {
+    super(...args)
+
+    this.addSub('ci:cypress:setup-node-events', (payload) => {
+      // Bail out if the tracer failed to init (e.g. invalid DD_SITE).
+      // Mirrors the guard in the manual plugin entrypoint (plugin.js).
+      if (this._tracer._tracer instanceof NoopTracer) return
+
+      const { on, config, userAfterSpecHandlers, userAfterRunHandlers, cleanupWrapper } = payload
+
+      const registerAfterRunWithCleanup = (afterRunHandler) => {
+        on('after:run', (results) => {
+          const chain = userAfterRunHandlers.reduce(
+            (p, h) => p.then(() => h(results)),
+            Promise.resolve()
+          )
+          if (afterRunHandler) {
+            return chain.then(() => afterRunHandler(results)).finally(cleanupWrapper)
+          }
+          return chain.finally(cleanupWrapper)
+        })
+      }
+
+      const cypressPlugin = require('./cypress-plugin')
+
+      if (cypressPlugin._isInit) {
+        // Already initialized by manual plugin call — just chain user handlers
+        for (const h of userAfterSpecHandlers) on('after:spec', h)
+        registerAfterRunWithCleanup()
+        payload.registered = true
+        return
+      }
+
+      on('before:run', cypressPlugin.beforeRun.bind(cypressPlugin))
+
+      on('after:spec', (spec, results) => {
+        const chain = userAfterSpecHandlers.reduce(
+          (p, h) => p.then(() => h(spec, results)),
+          Promise.resolve()
+        )
+        return chain.then(() => cypressPlugin.afterSpec(spec, results))
+      })
+
+      registerAfterRunWithCleanup((results) => cypressPlugin.afterRun(results))
+
+      on('task', cypressPlugin.getTasks())
+
+      payload.registered = true
+      // cypressPlugin.init expects the proxy tracer (with ._tracer._exporter),
+      // not the unwrapped internal tracer that this.tracer returns.
+      payload.configPromise = Promise.resolve(cypressPlugin.init(this._tracer, config)).then(() => config)
+    })
+  }
 }
 
 module.exports = CypressPlugin


### PR DESCRIPTION
### What does this PR do?

Moves all tracer interaction out of `packages/datadog-instrumentations/src/cypress-config.js` into `packages/datadog-plugin-cypress/src/index.js` via a `ci:cypress:setup-node-events` diagnostic channel, so the instrumentation layer has no direct references to `global._ddtrace`, `NoopTracer`, or `cypress-plugin`.

### Motivation

The instrumentation layer (`packages/datadog-instrumentations/`) should not depend on the tracer or plugin internals. This decoupling aligns Cypress with the architectural boundary used by other test framework instrumentations (jest, mocha, playwright) that communicate with their plugins via diagnostic channels.

### Additional Notes

**Channel architecture:**
- `cypress-config.js` publishes a payload on `ci:cypress:setup-node-events` containing the Cypress `on` function, config, and user event handlers
- `CypressPlugin` in `index.js` subscribes via `addSub` and registers lifecycle hooks (before:run, after:spec, after:run, tasks)
- If no subscriber is active (dd-trace not loaded), noop handlers are registered

**Plain-object config support:**
- `cypress-config.js` publishes on `dd-trace:instrumentation:load` to force plugin instantiation in Cypress Config Manager processes where the `cypress` npm module is never `require()`d

**Other changes:**
- `NoopTracer` bailout in the subscriber matches the guard in the manual plugin entrypoint (`plugin.js`)
- `span._getTime()` replaced with a self-managed `_now()` method using `Date.now` + `performance.now` captured at session span creation time — same coordinate system, immune to fake timers
- Integration tests added for the old manual plugin approach without `NODE_OPTIONS`, including full span hierarchy verification (session/module/suite/test), pass/fail/error reporting, duration sanity check, and custom after-hook chaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)