### PR TITLE
[test optimization] prevent payload loss in mocha parallel mode

### DIFF
--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -359,6 +359,7 @@ describe(`cucumber@${version} commonJS`, () => {
               metadataDicts.forEach(metadata => {
                 for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
                   assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+                  assert.ok(metadata[testLevel][TEST_COMMAND])
                 }
               })
 
@@ -379,14 +380,12 @@ describe(`cucumber@${version} commonJS`, () => {
               }
 
               assert.ok(testSessionEventContent.test_session_id)
-              assert.ok(testSessionEventContent.meta[TEST_COMMAND])
               assert.ok(testSessionEventContent.meta[TEST_TOOLCHAIN])
               assert.strictEqual(testSessionEventContent.resource.startsWith('test_session.'), true)
               assert.strictEqual(testSessionEventContent.meta[TEST_STATUS], 'fail')
 
               assert.ok(testModuleEventContent.test_session_id)
               assert.ok(testModuleEventContent.test_module_id)
-              assert.ok(testModuleEventContent.meta[TEST_COMMAND])
               assert.ok(testModuleEventContent.meta[TEST_MODULE])
               assert.strictEqual(testModuleEventContent.resource.startsWith('test_module.'), true)
               assert.strictEqual(testModuleEventContent.meta[TEST_STATUS], 'fail')
@@ -413,7 +412,6 @@ describe(`cucumber@${version} commonJS`, () => {
                   test_session_id: testSessionId,
                 },
               }) => {
-                assert.ok(meta[TEST_COMMAND])
                 assert.ok(meta[TEST_MODULE])
                 assert.ok(testSuiteId)
                 assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
@@ -449,7 +447,6 @@ describe(`cucumber@${version} commonJS`, () => {
                   test_session_id: testSessionId,
                 },
               }) => {
-                assert.ok(meta[TEST_COMMAND])
                 assert.ok(meta[TEST_MODULE])
                 assert.ok(testSuiteId)
                 assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))

--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -1264,6 +1264,7 @@ moduleTypes.forEach(({
           ciVisMetadataDicts.forEach(metadata => {
             for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
               assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+              assert.ok(metadata[testLevel][TEST_COMMAND])
             }
           })
           const events = ciVisPayloads.flatMap(({ payload }) => payload.events)
@@ -1277,14 +1278,12 @@ moduleTypes.forEach(({
           const { content: testModuleEventContent } = testModuleEvent
 
           assert.ok(testSessionEventContent.test_session_id)
-          assert.ok(testSessionEventContent.meta[TEST_COMMAND])
           assert.ok(testSessionEventContent.meta[TEST_TOOLCHAIN])
           assert.strictEqual(testSessionEventContent.resource.startsWith('test_session.'), true)
           assert.strictEqual(testSessionEventContent.meta[TEST_STATUS], 'fail')
 
           assert.ok(testModuleEventContent.test_session_id)
           assert.ok(testModuleEventContent.test_module_id)
-          assert.ok(testModuleEventContent.meta[TEST_COMMAND])
           assert.ok(testModuleEventContent.meta[TEST_MODULE])
           assert.strictEqual(testModuleEventContent.resource.startsWith('test_module.'), true)
           assert.strictEqual(testModuleEventContent.meta[TEST_STATUS], 'fail')
@@ -1318,7 +1317,6 @@ moduleTypes.forEach(({
               test_session_id: testSessionId,
             },
           }) => {
-            assert.ok(meta[TEST_COMMAND])
             assert.ok(meta[TEST_MODULE])
             assert.ok(testSuiteId)
             assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
@@ -1343,7 +1341,6 @@ moduleTypes.forEach(({
               test_session_id: testSessionId,
             },
           }) => {
-            assert.ok(meta[TEST_COMMAND])
             assert.ok(meta[TEST_MODULE])
             assert.ok(testSuiteId)
             assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))

--- a/integration-tests/jest/jest.spec.js
+++ b/integration-tests/jest/jest.spec.js
@@ -463,6 +463,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             metadataDicts.forEach(metadata => {
               for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
                 assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+                assert.ok(metadata[testLevel][TEST_COMMAND])
               }
             })
 
@@ -585,7 +586,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             assert.ok(testSessionEvent)
             assert.strictEqual(testSessionEvent.meta[TEST_STATUS], 'pass')
             assert.ok(testSessionEvent[TEST_SESSION_ID])
-            assert.ok(testSessionEvent.meta[TEST_COMMAND])
             assert.ok(testSessionEvent[TEST_SUITE_ID] == null)
             assert.ok(testSessionEvent[TEST_MODULE_ID] == null)
 
@@ -593,13 +593,11 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             assert.strictEqual(testModuleEvent.meta[TEST_STATUS], 'pass')
             assert.ok(testModuleEvent[TEST_SESSION_ID])
             assert.ok(testModuleEvent[TEST_MODULE_ID])
-            assert.ok(testModuleEvent.meta[TEST_COMMAND])
             assert.ok(testModuleEvent[TEST_SUITE_ID] == null)
 
             assert.ok(testSuiteEvent)
             assert.strictEqual(testSuiteEvent.meta[TEST_STATUS], 'pass')
             assert.strictEqual(testSuiteEvent.meta[TEST_SUITE], 'ci-visibility/jest-plugin-tests/jest-test-suite.js')
-            assert.ok(testSuiteEvent.meta[TEST_COMMAND])
             assert.ok(testSuiteEvent.meta[TEST_MODULE])
             assert.ok(testSuiteEvent[TEST_SUITE_ID])
             assert.ok(testSuiteEvent[TEST_SESSION_ID])
@@ -609,7 +607,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
             assert.strictEqual(testEvent.meta[TEST_STATUS], 'pass')
             assert.strictEqual(testEvent.meta[TEST_NAME], 'jest-test-suite-visibility works')
             assert.strictEqual(testEvent.meta[TEST_SUITE], 'ci-visibility/jest-plugin-tests/jest-test-suite.js')
-            assert.ok(testEvent.meta[TEST_COMMAND])
             assert.ok(testEvent.meta[TEST_MODULE])
             assert.ok(testEvent[TEST_SUITE_ID])
             assert.ok(testEvent[TEST_SESSION_ID])

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1284,6 +1284,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         metadataDicts.forEach(metadata => {
           for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
             assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+            assert.ok(metadata[testLevel][TEST_COMMAND])
           }
         })
 
@@ -1304,7 +1305,6 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           test_module_id: testModuleId,
           test_session_id: testSessionId,
         }) => {
-          assert.ok(meta[TEST_COMMAND])
           assert.ok(meta[TEST_MODULE])
           assert.ok(testSuiteId)
           assert.strictEqual(testModuleId.toString(10), moduleEventContent.test_module_id.toString(10))
@@ -1318,7 +1318,6 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           test_module_id: testModuleId,
           test_session_id: testSessionId,
         }) => {
-          assert.ok(meta[TEST_COMMAND])
           assert.ok(meta[TEST_MODULE])
           assert.ok(testSuiteId)
           assert.strictEqual(testModuleId.toString(10), moduleEventContent.test_module_id.toString(10))

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -123,6 +123,7 @@ versions.forEach((version) => {
             metadataDicts.forEach(metadata => {
               for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
                 assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+                assert.ok(metadata[testLevel][TEST_COMMAND])
               }
             })
 
@@ -222,7 +223,6 @@ versions.forEach((version) => {
               if (poolConfig === 'forks') {
                 assert.strictEqual(test.content.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
               }
-              assert.strictEqual(test.content.meta[TEST_COMMAND], 'vitest run')
               assert.ok(test.content.metrics[DD_HOST_CPU_COUNT])
               assert.strictEqual(test.content.meta[DD_TEST_IS_USER_PROVIDED_SERVICE], 'false')
             })
@@ -232,7 +232,6 @@ versions.forEach((version) => {
               if (poolConfig === 'forks') {
                 assert.strictEqual(testSuite.content.meta[TEST_IS_TEST_FRAMEWORK_WORKER], 'true')
               }
-              assert.strictEqual(testSuite.content.meta[TEST_COMMAND], 'vitest run')
               assert.strictEqual(
                 testSuite.content.meta[TEST_SOURCE_FILE].startsWith('ci-visibility/vitest-tests/test-visibility'),
                 true

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -51,6 +51,13 @@ let itrCorrelationId = ''
 let isForcedToRun = false
 const config = {}
 
+// Flush coordination state for guaranteed final flush before process exit.
+// 'idle' → 'waiting_flush' (callback set, waiting for plugin flush) → 'idle'
+// 'idle' → 'flush_done' (plugin flushed before callback was set) → 'idle'
+const FLUSH_TIMEOUT_MS = 30_000
+let _flushState = 'idle'
+let _flushDoneCallback = null
+
 // We'll preserve the original coverage here
 const originalCoverageMap = createCoverageMap()
 let untestedCoverage
@@ -102,6 +109,36 @@ function getFilteredSuites (originalSuites) {
     }
     return acc
   }, { suitesToRun: [], skippedSuites: new Set() })
+}
+
+/**
+ * Wraps mocha's completion callback to wait for the exporter flush
+ * to complete before allowing mocha to proceed with exit.
+ * @param {Function} originalCb - mocha's original completion callback
+ * @returns {Function}
+ */
+function wrapMochaCallback (originalCb) {
+  if (!originalCb) return originalCb
+  return function (...args) {
+    let called = false
+    const finish = () => {
+      if (called) return
+      called = true
+      _flushState = 'idle'
+      originalCb.apply(null, args)
+    }
+
+    if (_flushState === 'flush_done') {
+      // Flush already completed before mocha called the callback
+      _flushState = 'idle'
+      originalCb.apply(null, args)
+      return
+    }
+
+    _flushDoneCallback = finish
+    _flushState = 'waiting_flush'
+    setTimeout(finish, FLUSH_TIMEOUT_MS).unref()
+  }
 }
 
 function getOnStartHandler (frameworkVersion) {
@@ -209,6 +246,16 @@ function getOnEndHandler (isParallel) {
       isEarlyFlakeDetectionFaulty: config.isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled: config.isTestManagementTestsEnabled,
       isParallel,
+      onFlushDone () {
+        if (_flushState === 'waiting_flush') {
+          const cb = _flushDoneCallback
+          _flushDoneCallback = null
+          _flushState = 'idle'
+          cb()
+        } else {
+          _flushState = 'flush_done'
+        }
+      },
     })
 
     logDynamicNamesWarning(newTestsWithDynamicNames)
@@ -449,10 +496,13 @@ addHook({
 
   shimmer.wrap(Runner.prototype, 'runTests', runTests => getRunTestsWrapper(runTests, config))
 
-  shimmer.wrap(Runner.prototype, 'run', run => function () {
+  shimmer.wrap(Runner.prototype, 'run', run => function (fn, ...restArgs) {
     if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
+
+    // Wrap mocha's completion callback to wait for the exporter flush
+    const wrappedFn = wrapMochaCallback(fn)
 
     const { suitesByTestFile, numSuitesByTestFile } = getSuitesByTestFile(this.suite)
 
@@ -539,7 +589,7 @@ addHook({
       }
     })
 
-    return run.apply(this, arguments)
+    return run.apply(this, [wrappedFn, ...restArgs])
   })
 
   return Runner
@@ -623,10 +673,15 @@ addHook({
   versions: ['>=8.0.0'],
   file: 'lib/nodejs/parallel-buffered-runner.js',
 }, (ParallelBufferedRunner, frameworkVersion) => {
-  shimmer.wrap(ParallelBufferedRunner.prototype, 'run', run => function (cb, { files }) {
+  shimmer.wrap(ParallelBufferedRunner.prototype, 'run', run => function (cb, opts) {
     if (!testFinishCh.hasSubscribers) {
       return run.apply(this, arguments)
     }
+
+    const { files } = opts
+
+    // Wrap mocha's completion callback to wait for the exporter flush
+    const wrappedCb = wrapMochaCallback(cb)
 
     this.once('start', getOnStartHandler(frameworkVersion))
     this.once('end', getOnEndHandler(true))
@@ -667,9 +722,9 @@ addHook({
         }
         isSuitesSkipped = skippedFiles.length > 0
         skippedSuites = skippedFiles
-        run.apply(this, [cb, { files: filteredFiles }])
+        run.apply(this, [wrappedCb, { ...opts, files: filteredFiles }])
       } else {
-        run.apply(this, arguments)
+        run.apply(this, [wrappedCb, opts])
       }
     })
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -654,6 +654,7 @@ class CypressPlugin {
       for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
         metadataTags[testLevel] = {
           [TEST_SESSION_NAME]: testSessionName,
+          [TEST_COMMAND]: this.command,
         }
       }
       const libraryCapabilitiesTags = getLibraryCapabilitiesTags(this.constructor.id, this.frameworkVersion)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -16,7 +16,6 @@ const {
   getTestSuiteCommonTags,
   addIntelligentTestRunnerSpanTags,
   TEST_PARAMETERS,
-  TEST_COMMAND,
   TEST_FRAMEWORK_VERSION,
   TEST_SOURCE_START,
   TEST_ITR_UNSKIPPABLE,
@@ -184,7 +183,7 @@ class JestPlugin extends CiPlugin {
       for (const config of configs) {
         config._ddTestSessionId = this.testSessionSpan.context().toTraceId()
         config._ddTestModuleId = this.testModuleSpan.context().toSpanId()
-        config._ddTestCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
+        config._ddTestCommand = this.command
         config._ddRequestErrorTags = this.getSessionRequestErrorTags()
         config._ddItrCorrelationId = this.itrCorrelationId
         config._ddIsEarlyFlakeDetectionEnabled = !!this.libraryConfig?.isEarlyFlakeDetectionEnabled

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -356,6 +356,7 @@ class MochaPlugin extends CiPlugin {
       isEarlyFlakeDetectionFaulty,
       isTestManagementEnabled,
       isParallel,
+      onFlushDone,
     }) => {
       if (this.testSessionSpan) {
         const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.libraryConfig || {}
@@ -410,7 +411,9 @@ class MochaPlugin extends CiPlugin {
         })
       }
       this.libraryConfig = null
-      this.tracer._exporter.flush()
+      this.tracer._exporter.flush(() => {
+        if (onFlushDone) onFlushDone()
+      })
     })
 
     this.addBind('ci:mocha:global:run', (ctx) => {

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -18,6 +18,7 @@ const {
   TEST_CODE_OWNERS,
   TEST_LEVEL_EVENT_TYPES,
   TEST_SESSION_NAME,
+  TEST_COMMAND,
   TEST_SOURCE_START,
   TEST_IS_NEW,
   TEST_EARLY_FLAKE_ENABLED,
@@ -300,6 +301,7 @@ class VitestPlugin extends CiPlugin {
       for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
         metadataTags[testLevel] = {
           [TEST_SESSION_NAME]: testSessionName,
+          [TEST_COMMAND]: this.command,
         }
       }
       if (this.tracer._exporter.addMetadataTags) {

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -1,11 +1,11 @@
 'use strict'
-const request = require('../../../exporters/common/request')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 const log = require('../../../log')
 const { getValueFromEnvSources } = require('../../../config/helper')
 
 const { AgentlessCiVisibilityEncoder } = require('../../../encode/agentless-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
+const PayloadRequestQueue = require('../payload-request-queue')
 const {
   incrementCountMetric,
   distributionMetric,
@@ -23,6 +23,28 @@ class Writer extends BaseWriter {
     this._url = url
     this._encoder = new AgentlessCiVisibilityEncoder(this, { runtimeId, env, service })
     this._evpProxyPrefix = evpProxyPrefix
+    this._requestQueue = new PayloadRequestQueue()
+  }
+
+  // Override to skip the request.writable check from BaseWriter.
+  // The PayloadRequestQueue handles backpressure via queuing.
+  // Waits for all in-flight and queued requests to complete before calling done,
+  // so the final session flush does not race earlier payloads.
+  flush (done = () => {}) {
+    const count = this._encoder.count()
+    if (count > 0) {
+      const payload = this._encoder.makePayload()
+      this._sendPayload(payload, count, () => {
+        this._requestQueue.drain(done)
+      })
+    } else {
+      this._requestQueue.drain(done)
+    }
+  }
+
+  // Override to skip the request.writable check from BaseWriter.
+  append (payload) {
+    this._encode(payload)
   }
 
   _sendPayload (data, _, done) {
@@ -51,7 +73,7 @@ class Writer extends BaseWriter {
     incrementCountMetric(TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS, { endpoint: 'test_cycle' })
     distributionMetric(TELEMETRY_ENDPOINT_PAYLOAD_BYTES, { endpoint: 'test_cycle' }, Buffer.byteLength(data))
 
-    request(data, options, (err, res, statusCode) => {
+    this._requestQueue.send(data, options, (err, res, statusCode) => {
       distributionMetric(
         TELEMETRY_ENDPOINT_PAYLOAD_REQUESTS_MS,
         { endpoint: 'test_cycle' },
@@ -66,7 +88,7 @@ class Writer extends BaseWriter {
           TELEMETRY_ENDPOINT_PAYLOAD_DROPPED,
           { endpoint: 'test_cycle' }
         )
-        log.error('Error sending CI agentless payload', err)
+        log.error('Error sending Test Optimization agentless payload', err)
         done()
         return
       }

--- a/packages/dd-trace/src/ci-visibility/exporters/payload-request-queue.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/payload-request-queue.js
@@ -1,0 +1,196 @@
+'use strict'
+
+const http = require('node:http')
+const https = require('node:https')
+
+const { storage } = require('../../../../datadog-core')
+const log = require('../../log')
+const { urlToHttpOptions } = require('../../exporters/common/url-to-http-options-polyfill')
+const docker = require('../../exporters/common/docker')
+const { httpAgent, httpsAgent } = require('../../exporters/common/agents')
+
+const MAX_CONCURRENCY = 12
+const MAX_QUEUE_SIZE = 200
+const MAX_RETRIES = 3
+const RETRY_BASE_MS = 1000
+const RETRY_MAX_MS = 10_000
+
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 502, 503, 504])
+const RETRYABLE_NETWORK_ERRORS = new Set(['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE'])
+
+function getBackoffDelay (attempt) {
+  const jitter = Math.random() * 500
+  return Math.min(RETRY_BASE_MS * (2 ** attempt) + jitter, RETRY_MAX_MS)
+}
+
+function parseUrl (urlObjOrString) {
+  if (urlObjOrString !== null && typeof urlObjOrString === 'object') return urlToHttpOptions(urlObjOrString)
+
+  const url = urlToHttpOptions(new URL(urlObjOrString))
+
+  if (url.protocol === 'unix:' && url.hostname === '.') {
+    const udsPath = urlObjOrString.slice(5)
+    url.path = udsPath
+    url.pathname = udsPath
+  }
+
+  return url
+}
+
+function byteLength (data) {
+  if (Array.isArray(data)) {
+    return data.length > 0 ? data.reduce((prev, next) => prev + Buffer.byteLength(next, 'utf8'), 0) : 0
+  }
+  return Buffer.byteLength(data, 'utf8')
+}
+
+/**
+ * Concurrency-limited request queue for Test Optimization payload writers.
+ * Unlike the shared common/request.js, this queues instead of silently
+ * discarding data when under load, and retries transient failures.
+ */
+class PayloadRequestQueue {
+  _inflight = 0
+  _pendingRetries = 0
+  _queue = []
+  _drainCallbacks = []
+
+  /**
+   * @param {Buffer|string|Array<Buffer|string>} data
+   * @param {object} options - HTTP options (url, path, method, headers, timeout)
+   * @param {Function} callback - (err, res, statusCode) => void
+   */
+  send (data, options, callback) {
+    if (this._inflight < MAX_CONCURRENCY) {
+      this._doSend(data, options, callback, 0)
+    } else if (this._queue.length < MAX_QUEUE_SIZE) {
+      this._queue.push({ data, options, callback, attempt: 0 })
+    } else {
+      log.warn('Test Optimization request queue full (%d), dropping payload', MAX_QUEUE_SIZE)
+      callback(new Error('Payload dropped: queue full'))
+    }
+  }
+
+  /**
+   * Calls callback when all in-flight, queued, and pending-retry requests have completed.
+   * @param {Function} callback
+   */
+  drain (callback) {
+    if (this._isIdle()) {
+      callback()
+    } else {
+      this._drainCallbacks.push(callback)
+    }
+  }
+
+  _isIdle () {
+    return this._inflight === 0 && this._queue.length === 0 && this._pendingRetries === 0
+  }
+
+  _doSend (data, options, callback, attempt) {
+    this._inflight++
+    this._makeRequest(data, options, (err, res, statusCode) => {
+      this._inflight--
+
+      if (err && attempt + 1 < MAX_RETRIES && this._isRetryable(err, statusCode)) {
+        this._pendingRetries++
+        setTimeout(() => {
+          this._pendingRetries--
+          // Route through concurrency check instead of calling _doSend directly
+          if (this._inflight < MAX_CONCURRENCY) {
+            this._doSend(data, options, callback, attempt + 1)
+          } else if (this._queue.length < MAX_QUEUE_SIZE) {
+            this._queue.unshift({ data, options, callback, attempt: attempt + 1 })
+          } else {
+            log.warn('Test Optimization request queue full during retry, dropping payload')
+            callback(new Error('Payload dropped: queue full during retry'))
+          }
+          this._processQueue()
+        }, getBackoffDelay(attempt))
+      } else {
+        callback(err, res, statusCode)
+      }
+
+      this._processQueue()
+    })
+  }
+
+  _processQueue () {
+    while (this._queue.length > 0 && this._inflight < MAX_CONCURRENCY) {
+      const { data, options, callback, attempt = 0 } = this._queue.shift()
+      this._doSend(data, options, callback, attempt)
+    }
+
+    if (this._isIdle() && this._drainCallbacks.length > 0) {
+      const callbacks = this._drainCallbacks.splice(0)
+      for (const cb of callbacks) cb()
+    }
+  }
+
+  _isRetryable (err, statusCode) {
+    if (statusCode && RETRYABLE_STATUS_CODES.has(statusCode)) return true
+    if (err.code && RETRYABLE_NETWORK_ERRORS.has(err.code)) return true
+    return false
+  }
+
+  _makeRequest (data, options, callback) {
+    if (!options.headers) {
+      options.headers = {}
+    }
+
+    if (options.url) {
+      const url = parseUrl(options.url)
+      if (url.protocol === 'unix:') {
+        options.socketPath = url.pathname
+      } else {
+        if (!options.path) options.path = url.path
+        options.protocol = url.protocol
+        options.hostname = url.hostname
+        options.port = url.port
+      }
+    }
+
+    const timeout = options.timeout || 15_000
+    const isSecure = options.protocol === 'https:'
+    const client = isSecure ? https : http
+
+    let dataArray = data
+    if (!Array.isArray(data)) {
+      dataArray = [data]
+    }
+    options.headers['Content-Length'] = byteLength(data)
+    docker.inject(options.headers)
+    options.agent = isSecure ? httpsAgent : httpAgent
+
+    storage('legacy').run({ noop: true }, () => {
+      const req = client.request(options, (res) => {
+        const chunks = []
+        res.setTimeout(timeout)
+        res.on('data', chunk => chunks.push(chunk))
+        res.once('end', () => {
+          const buffer = Buffer.concat(chunks)
+          if (res.statusCode >= 200 && res.statusCode <= 299) {
+            callback(null, buffer.toString(), res.statusCode)
+            return
+          }
+          const error = new log.NoTransmitError(
+            `Test Optimization payload error: ${res.statusCode} ${http.STATUS_CODES[res.statusCode]}`
+          )
+          error.status = res.statusCode
+          callback(error, null, res.statusCode)
+        })
+      })
+
+      req.once('error', err => callback(err, null))
+
+      req.setTimeout(timeout, () => {
+        req.destroy()
+      })
+
+      for (const buffer of dataArray) req.write(buffer)
+      req.end()
+    })
+  }
+}
+
+module.exports = PayloadRequestQueue

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -1,12 +1,13 @@
 'use strict'
 const { version: ddTraceVersion } = require('../../../../package.json')
-const { ITR_CORRELATION_ID } = require('../../src/plugins/util/test')
+const { ITR_CORRELATION_ID, TEST_COMMAND } = require('../../src/plugins/util/test')
 const id = require('../../src/id')
 const {
   distributionMetric,
   TELEMETRY_ENDPOINT_PAYLOAD_SERIALIZATION_MS,
   TELEMETRY_ENDPOINT_PAYLOAD_EVENTS_COUNT,
 } = require('../ci-visibility/telemetry')
+const log = require('../log')
 const { AgentEncoder } = require('./0.4')
 const { truncateSpan, normalizeSpan } = require('./tags-processors')
 
@@ -25,10 +26,14 @@ function formatSpan (span) {
   if (span.type === 'test' && span.meta && span.meta.test_session_id) {
     encodingVersion = 2
   }
+  const content = normalizeSpan(truncateSpan(span))
+  // Strip test.command from individual event meta — it is carried
+  // in the payload metadata section to avoid per-span duplication.
+  delete content.meta[TEST_COMMAND]
   return {
     type: ALLOWED_CONTENT_TYPES.has(span.type) ? span.type : 'span',
     version: encodingVersion,
-    content: normalizeSpan(truncateSpan(span)),
+    content,
   }
 }
 
@@ -258,19 +263,33 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     }
   }
 
-  _encode (bytes, trace) {
-    if (this._isReset) {
-      this._encodePayloadStart(bytes)
-      this._isReset = false
-    }
-    const startTime = Date.now()
+  /**
+   * Overrides parent to check soft limit per event (not per trace).
+   * Skips the parent's post-trace check since we handle it here.
+   * @param {object} trace
+   */
+  encode (trace) {
+    const bytes = this._traceBytes
+    this._traceCount++
+    this._encode(bytes, trace)
+  }
 
+  _encode (bytes, trace) {
+    const startTime = Date.now()
     const events = trace.map(formatSpan)
 
-    this._eventCount += events.length
-
     for (const event of events) {
+      if (this._isReset) {
+        this._encodePayloadStart(bytes)
+        this._isReset = false
+      }
       this._encodeEvent(bytes, event)
+      this._eventCount++
+
+      if (bytes.length > this._limit) {
+        log.debug('Buffer went over soft limit, flushing')
+        this._writer.flush()
+      }
     }
     distributionMetric(
       TELEMETRY_ENDPOINT_PAYLOAD_SERIALIZATION_MS,

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -192,6 +192,7 @@ module.exports = class CiPlugin extends Plugin {
       for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
         metadataTags[testLevel] = {
           [TEST_SESSION_NAME]: testSessionName,
+          [TEST_COMMAND]: command,
         }
       }
       // tracer might not be initialized correctly
@@ -241,7 +242,7 @@ module.exports = class CiPlugin extends Plugin {
     })
 
     this.addSub(`ci:${this.constructor.id}:itr:skipped-suites`, ({ skippedSuites, frameworkVersion }) => {
-      const testCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
+      const testCommand = this.command
       for (const testSuite of skippedSuites) {
         const testSuiteMetadata = {
           ...getTestSuiteCommonTags(testCommand, frameworkVersion, testSuite, this.constructor.id),

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/writer.spec.js
@@ -9,7 +9,7 @@ require('../../../../../dd-trace/test/setup/core')
 let Writer
 let writer
 let span
-let request
+let queueSend
 let encoder
 let coverageEncoder
 let url
@@ -19,7 +19,9 @@ describe('CI Visibility Writer', () => {
   beforeEach(() => {
     span = 'formatted'
 
-    request = sinon.stub().yieldsAsync(null, 'OK', 200)
+    queueSend = sinon.stub().callsFake((data, options, cb) => {
+      process.nextTick(() => cb(null, 'OK', 200))
+    })
 
     encoder = {
       encode: sinon.stub(),
@@ -50,8 +52,13 @@ describe('CI Visibility Writer', () => {
       return coverageEncoder
     }
 
+    const MockPayloadRequestQueue = function () {
+      this.send = queueSend
+      this.drain = sinon.stub().callsFake((cb) => cb())
+    }
+
     Writer = proxyquire('../../../../src/ci-visibility/exporters/agentless/writer', {
-      '../../../exporters/common/request': request,
+      '../payload-request-queue': MockPayloadRequestQueue,
       '../../../encode/agentless-ci-visibility': { AgentlessCiVisibilityEncoder },
       '../../../encode/coverage-ci-visibility': { CoverageCIVisibilityEncoder },
       '../../../log': log,
@@ -93,7 +100,7 @@ describe('CI Visibility Writer', () => {
       encoder.makePayload.returns(expectedData)
 
       writer.flush(() => {
-        sinon.assert.calledWithMatch(request, expectedData, {
+        sinon.assert.calledWithMatch(queueSend, expectedData, {
           url,
           path: '/api/v2/citestcycle',
           method: 'POST',
@@ -109,12 +116,14 @@ describe('CI Visibility Writer', () => {
       it('should log request errors', done => {
         const error = new Error('boom')
 
-        request.yields(error)
+        queueSend.callsFake((data, options, cb) => {
+          process.nextTick(() => cb(error))
+        })
 
         encoder.count.returns(1)
 
         writer.flush(() => {
-          sinon.assert.calledWith(log.error, 'Error sending CI agentless payload', error)
+          sinon.assert.calledWith(log.error, 'Error sending Test Optimization agentless payload', error)
           done()
         })
       })


### PR DESCRIPTION
## Summary

Fixes a customer issue where mocha `--jobs 40` with a large command line (hundreds of file paths) causes silent loss of test session, module, and suite events. The root cause is a cascading failure:

1. `test.command` tag (~15-20KB) duplicated on every span inflates payloads
2. High throughput from 40 workers triggers frequent HTTP flushes
3. Failed requests (413/408/500x) accumulate in `activeBufferSize`
4. Once the shared 64MB cap in `common/request.js` is hit, all new data is silently discarded
5. Session/module/suite events (exported last) are lost

### Changes

- **Move `test.command` to payload metadata**: encoded once per payload instead of per span. The CI visibility encoder strips it from individual event `meta` in `formatSpan`, while keeping it on spans for the non-EVP agent fallback path. All framework plugins (mocha, jest, vitest, cypress, playwright, cucumber) updated.
- **New `PayloadRequestQueue`** for the agentless test cycle writer: concurrency-limited (12), bounded queue (200), retry with jittered exponential backoff for transient errors (408/429/5xx/network). Replaces the shared `request.js` that silently discards data at 64MB.
- **Per-event soft limit check** in encoder: flush mid-trace when buffer exceeds 2MB instead of waiting for the full trace to complete.
- **Wrap mocha's completion callback** to delay process exit until the exporter flush (including all queued payloads) completes, with a 30s safety timeout.

## Test plan

- [x] Unit tests: encoder, agentless writer, coverage writer, DI logs writer (27 passing)
- [x] Integration tests: mocha (142 passing)
- [ ] Integration tests: jest, vitest, cypress, cucumber (CI)
- [ ] Verify `test.command` appears in payload metadata for all frameworks
- [ ] Verify non-EVP fallback path still carries `test.command` on individual spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)