### PR TITLE
fix(openfeature): clear flags config when RC tells us to

### DIFF
--- a/packages/dd-trace/src/openfeature/remote_config.js
+++ b/packages/dd-trace/src/openfeature/remote_config.js
@@ -19,9 +19,14 @@ function enable (rc, config, getOpenfeatureProxy) {
 
   // Set product handler for FFE_FLAGS
   rc.setProductHandler('FFE_FLAGS', (action, conf) => {
-    // Feed UFC config directly to OpenFeature provider
     if (action === 'apply' || action === 'modify') {
+      // Feed UFC config directly to OpenFeature provider
       getOpenfeatureProxy()._setConfiguration(conf)
+    } else if (action === 'unapply') {
+      // Clear the configuration so evaluations return PROVIDER_NOT_READY,
+      // consistent with Go and Python which also set config to null on RC deletion.
+      // The evaluator returns PROVIDER_NOT_READY when config is null/undefined.
+      getOpenfeatureProxy()._setConfiguration(null)
     }
   })
 }

--- a/packages/dd-trace/test/openfeature/remote_config.spec.js
+++ b/packages/dd-trace/test/openfeature/remote_config.spec.js
@@ -79,7 +79,7 @@ describe('OpenFeature Remote Config', () => {
       sinon.assert.calledOnceWithExactly(openfeatureProxy._setConfiguration, flagConfig)
     })
 
-    it('should not call _setConfiguration on unapply action', () => {
+    it('should call _setConfiguration(null) on unapply action to clear config', () => {
       enable(rc, config, getOpenfeatureProxy)
 
       const flagConfig = { flags: { 'test-flag': {} } }
@@ -87,7 +87,7 @@ describe('OpenFeature Remote Config', () => {
 
       handler('unapply', flagConfig)
 
-      sinon.assert.notCalled(openfeatureProxy._setConfiguration)
+      sinon.assert.calledOnceWithExactly(openfeatureProxy._setConfiguration, null)
     })
 
     it('should not call _setConfiguration on unknown action', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Clear flags configuration when Remote Config tells us to unapply the config.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is required to make behavior consistent with other tracers and pass new eval metrics system tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


