### PR TITLE
ci: integrate parallel benchmarks from apm-sdks-benchmarks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,8 @@ stages:
   - macrobenchmarks
   - macrobenchmarks-gate
   - macrobenchmarks-notify
+  # These benchmarks ultimately will replace the legacy ones
+  # They will run alongside them at first before replacing them all together
   - node-express-realworld-parallel
   - node-express-realworld-parallel-slo
   - node-hapi-redis-parallel
@@ -30,12 +32,12 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/macrobenchmarks.yml"
-  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
-    file: '.gitlab/ci-node-express-realworld-parallel.yml'
-    ref: 'fayssal/integrate'
-  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
-    file: '.gitlab/ci-node-hapi-redis-parallel.yml'
-    ref: 'fayssal/integrate'
+  - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
+    file: ".gitlab/ci-node-express-realworld-parallel.yml"
+    ref: "fayssal/integrate"
+  - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
+    file: ".gitlab/ci-node-hapi-redis-parallel.yml"
+    ref: "fayssal/integrate"
 
 workflow:
   auto_cancel:
@@ -66,4 +68,3 @@ requirements_json_test:
   variables:
     REQUIREMENTS_BLOCK_JSON_PATH: ".gitlab/requirements_block.json"
     REQUIREMENTS_ALLOW_JSON_PATH: ".gitlab/requirements_allow.json"
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,10 @@ stages:
   - macrobenchmarks
   - macrobenchmarks-gate
   - macrobenchmarks-notify
+  - node-express-realworld-parallel
+  - node-express-realworld-parallel-slo
+  - node-hapi-redis-parallel
+  - node-hapi-redis-parallel-slo
 
 # Config Registry CI jobs
 validate_supported_configurations_v2_local_file:
@@ -26,6 +30,12 @@ include:
   - local: ".gitlab/one-pipeline.locked.yml"
   - local: ".gitlab/benchmarks.yml"
   - local: ".gitlab/macrobenchmarks.yml"
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-node-express-realworld-parallel.yml'
+    ref: 'fayssal/integrate'
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-node-hapi-redis-parallel.yml'
+    ref: 'fayssal/integrate'
 
 workflow:
   auto_cancel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,10 +34,10 @@ include:
   - local: ".gitlab/macrobenchmarks.yml"
   - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
     file: ".gitlab/ci-node-express-realworld-parallel.yml"
-    ref: "fayssal/integrate"
+    ref: "main"
   - project: "DataDog/apm-reliability/apm-sdks-benchmarks"
     file: ".gitlab/ci-node-hapi-redis-parallel.yml"
-    ref: "fayssal/integrate"
+    ref: "main"
 
 workflow:
   auto_cancel:


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Integrates the new suite of benchmarks to run alongside the old one for a brief period before switching and deprecating the old setup.

### Motivation
<!-- What inspired you to submit this pull request? -->
- Adds two benchmark suites: Express RealWorld and Hapi-Redis, both running multiple tracer configurations in parallel on the same machine with CPU pinning and interleaving for fair comparison   
### Additional Notes
<!-- Anything else we should know when reviewing? -->                                       
  - The parallel benchmarks complement the existing macrobenchmarks; no existing jobs are removed (for now)
  - After the transition period, all macrobenchmark configuration changes should be made in the `apm-sdks-benchmarks` repository only.

