### PR TITLE
Fixed final status tag report on intermediate executions

### DIFF
--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -4061,6 +4061,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
                 assert.ok(!(TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX in test.meta))
                 assert.ok(!(TEST_IS_RETRY in test.meta))
                 assert.ok(!(TEST_RETRY_REASON in test.meta))
+                const expectedFinalStatus = (isQuarantined || isDisabled) ? 'skip' : test.meta[TEST_STATUS]
+                assert.strictEqual(test.meta[TEST_FINAL_STATUS], expectedFinalStatus)
                 continue
               }
 
@@ -4092,6 +4094,14 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
                   assert.strictEqual(test.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
                   assert.strictEqual(test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
                 }
+                // Final status: quarantined/disabled always report 'skip'; pass only if all attempts passed, fail otherwise
+                const expectedFinalStatus = (isQuarantined || isDisabled)
+                  ? 'skip'
+                  : (shouldAlwaysPass ? 'pass' : 'fail')
+                assert.strictEqual(test.meta[TEST_FINAL_STATUS], expectedFinalStatus)
+              } else {
+                // Intermediate ATF executions must not carry a final status tag
+                assert.ok(!(TEST_FINAL_STATUS in test.meta))
               }
             }
           })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -4094,7 +4094,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
                   assert.strictEqual(test.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
                   assert.strictEqual(test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
                 }
-                // Final status: quarantined/disabled always report 'skip'; pass only if all attempts passed, fail otherwise
+                // Final status: quarantined/disabled always report 'skip';
+                // pass only if all attempts passed, fail otherwise
                 const expectedFinalStatus = (isQuarantined || isDisabled)
                   ? 'skip'
                   : (shouldAlwaysPass ? 'pass' : 'fail')

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -264,6 +264,14 @@ function getFinalStatus ({
 }) {
   // Note that intermediate executions DO NOT report a final status tag
 
+  // Intermediate EFD and ATF executions must not carry a final status, regardless of quarantine/disabled state
+  const isIntermediateExecution =
+    (isEfdRetry && !isLastEfdRetry) ||
+    (isAttemptToFix && !isLastAttemptToFix)
+  if (isIntermediateExecution) {
+    return
+  }
+
   // If the test is quarantined or disabled, regardless of its actual execution result or active retry features,
   // the final status of its last execution should be reported as 'skip'.
   if (isQuarantined || isDisabled) {


### PR DESCRIPTION
### What does this PR do?
1. Adds tests for the `final_status` tag when ATF functionality is active. It tests that the tag is not present on intermediate executions, and that it's reported to `skip` when tests are skipped, quarantined or disabled.

2. Removes `final_status` tag report on intermediate ATF executions (including when tests are quarantined, skipped or disabled)

