### PR TITLE
fix: allow log injection property to be overriden

### DIFF
--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -13,6 +13,9 @@ function messageProxy (message, holder) {
 
       return target[key]
     },
+    set (target, key, value) {
+      return Reflect.set(target, key, value)
+    },
     ownKeys (target) {
       const ownKeys = Reflect.ownKeys(target)
       if (!Object.hasOwn(target, 'dd') && Reflect.isExtensible(target)) {

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -65,4 +65,43 @@ describe('LogPlugin', () => {
       assert.strictEqual(message.dd.span_id, span.context().toSpanId())
     })
   })
+
+  it('should allow overriding injected dd fields', () => {
+    const data = { message: {} }
+    testLogChannel.publish(data)
+
+    const override = {
+      trace_id: 'custom-trace-id',
+      span_id: 'custom-span-id',
+      service: 'custom-service',
+    }
+
+    data.message.dd = override
+
+    assert.strictEqual(data.message.dd, override)
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(data.message)), {
+      dd: override,
+    })
+    assert.ok(Object.hasOwn(data.message, 'dd'))
+  })
+
+  it('should allow defining dd after injection', () => {
+    const data = { message: {} }
+    testLogChannel.publish(data)
+
+    const override = {
+      trace_id: 'custom-trace-id',
+      span_id: 'custom-span-id',
+    }
+
+    Object.defineProperty(data.message, 'dd', {
+      value: override,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    })
+
+    assert.strictEqual(data.message.dd, override)
+    assert.ok(Object.hasOwn(data.message, 'dd'))
+  })
 })


### PR DESCRIPTION
This allows the customer to define the property as they deem necessary.

Fixes: https://github.com/DataDog/dd-trace-js/issues/7995