### PR TITLE
fix: handle esm and cjs in rewriter

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -5,6 +5,10 @@ const log = require('../../../../dd-trace/src/log')
 // eslint-disable-next-line camelcase, no-undef
 const runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require
 
+function isModuleSourceType (sourceType) {
+  return sourceType === 'module' || sourceType === 'esm'
+}
+
 const compiler = {
   parse: (sourceText, options) => {
     try {
@@ -31,7 +35,7 @@ const compiler = {
         return meriyah.parse(sourceText.toString(), {
           loc: range,
           ranges: range,
-          module: sourceType === 'module',
+          module: isModuleSourceType(sourceType),
         })
       }
     }
@@ -59,6 +63,7 @@ const compiler = {
 }
 
 module.exports = {
+  isModuleSourceType,
   parse: (...args) => compiler.parse(...args),
   traverse: (...args) => compiler.traverse(...args),
   query: (...args) => compiler.query(...args),

--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -63,7 +63,6 @@ const compiler = {
 }
 
 module.exports = {
-  isModuleSourceType,
   parse: (...args) => compiler.parse(...args),
   traverse: (...args) => compiler.traverse(...args),
   query: (...args) => compiler.query(...args),

--- a/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/compiler.js
@@ -5,10 +5,6 @@ const log = require('../../../../dd-trace/src/log')
 // eslint-disable-next-line camelcase, no-undef
 const runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require
 
-function isModuleSourceType (sourceType) {
-  return sourceType === 'module' || sourceType === 'esm'
-}
-
 const compiler = {
   parse: (sourceText, options) => {
     try {
@@ -31,11 +27,11 @@ const compiler = {
       // Fallback for when OXC is not available.
       const meriyah = require('../../../../../vendor/dist/meriyah')
 
-      compiler.parse = (sourceText, { range, sourceType } = {}) => {
+      compiler.parse = (sourceText, { range, isModule } = {}) => {
         return meriyah.parse(sourceText.toString(), {
           loc: range,
           ranges: range,
-          module: isModuleSourceType(sourceType),
+          module: isModule,
         })
       }
     }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -19,7 +19,7 @@ const transforms = module.exports = {
       : `const {tracingChannel: tr_ch_apm_tracingChannel} = require("${dcModule}")`
 
     node.body.splice(index + 1, 0, parse(code, {
-      sourceType: isModuleSourceType(sourceType) ? 'module' : 'script',
+      isModule: isModuleSourceType(sourceType),
     }).body[0])
   },
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -2,7 +2,7 @@
 
 // TODO: Move traceIterator to Orchestrion.
 
-const { isModuleSourceType, parse, query, traverse } = require('./compiler')
+const { parse, query, traverse } = require('./compiler')
 
 const tracingChannelPredicate = (node) => (
   node.specifiers?.[0]?.local?.name === 'tr_ch_apm_tracingChannel' ||
@@ -51,6 +51,13 @@ function traceAny (state, node, _parent, ancestry) {
   } else {
     traceFunction(state, node, program)
   }
+}
+
+/**
+ * @param {string} sourceType
+ */
+function isModuleSourceType (sourceType) {
+  return sourceType === 'module' || sourceType === 'esm'
 }
 
 function traceFunction (state, node, program) {

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -19,7 +19,7 @@ const transforms = module.exports = {
       : `const {tracingChannel: tr_ch_apm_tracingChannel} = require("${dcModule}")`
 
     node.body.splice(index + 1, 0, parse(code, {
-      sourceType: isModuleSourceType(sourceType) ? 'module' : 'script'
+      sourceType: isModuleSourceType(sourceType) ? 'module' : 'script',
     }).body[0])
   },
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/transforms.js
@@ -2,7 +2,7 @@
 
 // TODO: Move traceIterator to Orchestrion.
 
-const { parse, query, traverse } = require('./compiler')
+const { isModuleSourceType, parse, query, traverse } = require('./compiler')
 
 const tracingChannelPredicate = (node) => (
   node.specifiers?.[0]?.local?.name === 'tr_ch_apm_tracingChannel' ||
@@ -14,11 +14,13 @@ const transforms = module.exports = {
     if (node.body.some(tracingChannelPredicate)) return
 
     const index = node.body.findIndex(child => child.directive === 'use strict')
-    const code = sourceType === 'module'
+    const code = isModuleSourceType(sourceType)
       ? `import { tracingChannel as tr_ch_apm_tracingChannel } from "${dcModule}"`
       : `const {tracingChannel: tr_ch_apm_tracingChannel} = require("${dcModule}")`
 
-    node.body.splice(index + 1, 0, parse(code, { sourceType }).body[0])
+    node.body.splice(index + 1, 0, parse(code, {
+      sourceType: isModuleSourceType(sourceType) ? 'module' : 'script'
+    }).body[0])
   },
 
   tracingChannelDeclaration (state, node) {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/index.spec.js
@@ -515,4 +515,15 @@ describe('check-require-cache', () => {
 
     assert.ok(subs.start.called)
   })
+
+  it('should use import when rewriting esm modules', () => {
+    const filename = resolve(__dirname, 'node_modules', 'test', 'trace-generator-async.js')
+
+    content = readFileSync(filename, 'utf8')
+    content = rewriter.rewrite(content, filename, 'module')
+
+    assert.match(content, /\bimport\s+.+\s+from\s+"/)
+    assert.match(content, /tr_ch_apm_tracingChannel/)
+    assert.doesNotMatch(content, /require\("/)
+  })
 })


### PR DESCRIPTION
When handling ESM files, we may not introduce CJS in those. Instead use import instead.

Fixes: https://github.com/DataDog/dd-trace-js/issues/7991

We could also normalize somewhere else, but this should be a simple fix to accept both.