### PR TITLE
feat(opentelemetry): OTLP trace metrics export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1385,6 +1385,34 @@ declare namespace tracer {
     stats?: boolean
 
     /**
+     * Configuration for OTLP span metrics export.
+     * When enabled, span metrics (hits, errors, duration) are exported in OTLP format.
+     * Requires DD_TRACE_STATS_COMPUTATION_ENABLED or sets up its own span aggregation.
+     */
+    traceMetrics?: {
+      /**
+       * Whether to enable OTLP span metrics export.
+       * @default false
+       * @env DD_TRACE_OTEL_METRICS_ENABLED
+       */
+      enabled?: boolean
+
+      /**
+       * OTLP metrics endpoint URL.
+       * @default "http://localhost:4318/v1/metrics"
+       * @env DD_TRACE_OTEL_METRICS_URL, OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_ENDPOINT
+       */
+      url?: string
+
+      /**
+       * OTLP transport protocol. gRPC is not supported and will fall back to http/protobuf.
+       * @default "http/protobuf"
+       * @env DD_TRACE_OTEL_METRICS_PROTOCOL, OTEL_EXPORTER_OTLP_METRICS_PROTOCOL, OTEL_EXPORTER_OTLP_PROTOCOL
+       */
+      protocol?: 'http/protobuf' | 'http/json' | 'grpc'
+    }
+
+    /**
      * Whether to generate 128-bit trace IDs.
      * @default true
      * @env DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -374,6 +374,14 @@ class Config extends ConfigBase {
       setAndTrack(this, 'otelMetricsEnabled', false)
     }
 
+    if (this.traceMetrics?.protocol === 'grpc') {
+      log.warn('DD_TRACE_OTEL_METRICS_PROTOCOL=grpc is not supported in dd-trace-js; falling back to http/protobuf')
+      setAndTrack(this, 'traceMetrics.protocol', 'http/protobuf')
+    } else if (!trackedConfigOrigins.has('traceMetrics.protocol') && trackedConfigOrigins.has('otelMetricsProtocol')) {
+      // Fallback: OTEL_EXPORTER_OTLP_METRICS_PROTOCOL → OTEL_EXPORTER_OTLP_PROTOCOL (both via otelMetricsProtocol)
+      setAndTrack(this, 'traceMetrics.protocol', this.otelMetricsProtocol)
+    }
+
     if (this.telemetry.heartbeatInterval) {
       setAndTrack(this, 'telemetry.heartbeatInterval', Math.floor(this.telemetry.heartbeatInterval * 1000))
     }
@@ -599,6 +607,28 @@ class Config extends ConfigBase {
     }
     if (!this.otelMetricsUrl) {
       setAndTrack(this, 'otelMetricsUrl', `http://${agentHostname}:${DEFAULT_OTLP_PORT}/v1/metrics`)
+    }
+
+    // traceMetrics.url fallback chain:
+    // 1. DD_TRACE_OTEL_METRICS_URL (already set via supported-configurations.json)
+    // 2. OTEL_EXPORTER_OTLP_METRICS_ENDPOINT (full endpoint URL, via otelMetricsUrl)
+    // 3. OTEL_EXPORTER_OTLP_ENDPOINT + /v1/metrics
+    // 4. Default: http://localhost:4318/v1/metrics
+    if (!trackedConfigOrigins.has('traceMetrics.url')) {
+      if (trackedConfigOrigins.has('otelMetricsUrl')) {
+        // OTEL_EXPORTER_OTLP_METRICS_ENDPOINT (or alias) was explicitly set
+        setAndTrack(this, 'traceMetrics.url', this.otelMetricsUrl)
+      } else if (this.OTEL_EXPORTER_OTLP_ENDPOINT) {
+        // Generic endpoint: append /v1/metrics per OTel spec
+        setAndTrack(this, 'traceMetrics.url', this.OTEL_EXPORTER_OTLP_ENDPOINT.replace(/\/$/, '') + '/v1/metrics')
+      } else {
+        setAndTrack(this, 'traceMetrics.url', `http://localhost:${DEFAULT_OTLP_PORT}/v1/metrics`)
+      }
+    }
+
+    // traceMetrics.interval fallback: OTEL_METRIC_EXPORT_INTERVAL (ms) → seconds
+    if (!trackedConfigOrigins.has('traceMetrics.interval') && trackedConfigOrigins.has('otelMetricsExportInterval')) {
+      setAndTrack(this, 'traceMetrics.interval', Math.floor(this.otelMetricsExportInterval / 1000))
     }
 
     if (process.platform === 'win32') {

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -3273,6 +3273,58 @@
         "default": "false"
       }
     ],
+    "DD_TRACE_OTEL_METRICS_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "false",
+        "internalPropertyName": "traceMetrics.enabled",
+        "configurationNames": [
+          "traceMetrics.enabled"
+        ]
+      }
+    ],
+    "DD_TRACE_OTEL_METRICS_HISTOGRAM_TYPE": [
+      {
+        "implementation": "A",
+        "type": "string",
+        "default": "explicit",
+        "allowed": "exponential|explicit",
+        "internalPropertyName": "traceMetrics.histogramType"
+      }
+    ],
+    "DD_TRACE_OTEL_METRICS_INTERVAL_SECONDS": [
+      {
+        "implementation": "A",
+        "type": "int",
+        "allowed": "[1-9]\\d*",
+        "default": "10",
+        "internalPropertyName": "traceMetrics.interval"
+      }
+    ],
+    "DD_TRACE_OTEL_METRICS_PROTOCOL": [
+      {
+        "implementation": "A",
+        "type": "string",
+        "default": "http/protobuf",
+        "allowed": "http/protobuf|http/json|grpc",
+        "internalPropertyName": "traceMetrics.protocol",
+        "configurationNames": [
+          "traceMetrics.protocol"
+        ]
+      }
+    ],
+    "DD_TRACE_OTEL_METRICS_URL": [
+      {
+        "implementation": "A",
+        "type": "string",
+        "default": null,
+        "internalPropertyName": "traceMetrics.url",
+        "configurationNames": [
+          "traceMetrics.url"
+        ]
+      }
+    ],
     "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS": [
       {
         "implementation": "B",

--- a/packages/dd-trace/src/exporters/otlp-span-stats/index.js
+++ b/packages/dd-trace/src/exporters/otlp-span-stats/index.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const OtlpHttpExporterBase = require('../../opentelemetry/otlp/otlp_http_exporter_base')
+const OtlpStatsTransformer = require('./transformer')
+
+/**
+ * @typedef {import('../../../span_stats').SpanBuckets} SpanBuckets
+ * @typedef {{ timeNs: number, bucket: SpanBuckets }} DrainedBucket
+ */
+
+/**
+ * Exports span stats as OTLP metrics to a configurable HTTP endpoint.
+ *
+ * Acts as an additional flush consumer alongside the existing SpanStatsExporter,
+ * sharing the same raw bucket data drained by SpanStatsProcessor.onInterval().
+ *
+ * @class OtlpStatsExporter
+ * @augments OtlpHttpExporterBase
+ */
+class OtlpStatsExporter extends OtlpHttpExporterBase {
+  /**
+   * @param {object} config
+   * @param {string} config.url - OTLP metrics endpoint URL
+   * @param {string} [config.protocol] - OTLP protocol (http/protobuf or http/json)
+   * @param {string} [config.histogramType] - Histogram encoding (explicit or exponential)
+   * @param {import('@opentelemetry/api').Attributes} resourceAttributes - Resource-level attributes
+   */
+  constructor (config, resourceAttributes) {
+    const { url, protocol = 'http/protobuf', histogramType = 'explicit' } = config
+    super(url, undefined, 10_000, protocol, '/v1/metrics', 'span-stats')
+    this.transformer = new OtlpStatsTransformer(resourceAttributes, this.protocol, histogramType)
+  }
+
+  /**
+   * Exports drained span bucket data as OTLP metrics.
+   *
+   * @param {DrainedBucket[]} drained - Raw drained bucket entries from SpanStatsProcessor
+   * @param {number} bucketSizeNs - Bucket duration in nanoseconds
+   * @returns {void}
+   */
+  export (drained, bucketSizeNs) {
+    if (!drained.length) return
+
+    let pointCount = 0
+    for (const { bucket } of drained) {
+      pointCount += bucket.size
+    }
+
+    const additionalTags = [`points:${pointCount}`]
+    this.recordTelemetry('otel.span_stats_export_attempts', 1, additionalTags)
+
+    const payload = this.transformer.transform(drained, bucketSizeNs)
+    this.sendPayload(payload, (result) => {
+      if (result.code === 0) {
+        this.recordTelemetry('otel.span_stats_export_successes', 1, additionalTags)
+      }
+    })
+  }
+}
+
+module.exports = { OtlpStatsExporter }

--- a/packages/dd-trace/src/exporters/otlp-span-stats/transformer.js
+++ b/packages/dd-trace/src/exporters/otlp-span-stats/transformer.js
@@ -1,0 +1,253 @@
+'use strict'
+
+const { version: tracerVersion } = require('../../pkg')
+const OtlpTransformerBase = require('../../opentelemetry/otlp/otlp_transformer_base')
+const { getProtobufTypes } = require('../../opentelemetry/otlp/protobuf_loader')
+
+const NS_PER_SECOND = 1e9
+
+/**
+ * @typedef {import('../../../span_stats').SpanBuckets} SpanBuckets
+ * @typedef {import('../../../span_stats').SpanAggStats} SpanAggStats
+ * @typedef {{ timeNs: number, bucket: SpanBuckets }} DrainedBucket
+ */
+
+/**
+ * Transforms raw span bucket data to OTLP ExportMetricsServiceRequest format.
+ *
+ * Emits four metrics per flush (all delta temporality):
+ *   - dd.trace.span.hits          (Sum, monotonic)
+ *   - dd.trace.span.errors        (Sum, monotonic)
+ *   - dd.trace.span.top_level_hits (Sum, monotonic)
+ *   - dd.trace.span.duration      (Histogram, split by error=true/false)
+ *
+ * @class OtlpStatsTransformer
+ * @augments OtlpTransformerBase
+ */
+class OtlpStatsTransformer extends OtlpTransformerBase {
+  /**
+   * @param {import('@opentelemetry/api').Attributes} resourceAttributes - Resource-level attributes
+   * @param {string} protocol - OTLP protocol (http/protobuf or http/json)
+   * @param {string} histogramType - Histogram encoding: 'explicit' | 'exponential'
+   */
+  constructor (resourceAttributes, protocol, histogramType) {
+    super(resourceAttributes, protocol, 'span-stats')
+    this.histogramType = histogramType
+  }
+
+  /**
+   * Transforms drained bucket data to a serialized OTLP payload.
+   *
+   * @param {DrainedBucket[]} drained - Raw drained bucket entries
+   * @param {number} bucketSizeNs - Bucket duration in nanoseconds
+   * @returns {Buffer} Serialized OTLP payload (protobuf or JSON)
+   */
+  transform (drained, bucketSizeNs) {
+    const isJson = this.protocol === 'http/json'
+
+    const metricsData = {
+      resourceMetrics: [{
+        resource: this.transformResource(),
+        scopeMetrics: [{
+          scope: {
+            name: 'dd-trace',
+            version: tracerVersion,
+            droppedAttributesCount: 0,
+          },
+          metrics: this.#buildMetrics(drained, bucketSizeNs, isJson),
+        }],
+      }],
+    }
+
+    if (isJson) {
+      return this.serializeToJson(metricsData)
+    }
+    const { protoMetricsService } = getProtobufTypes()
+    return this.serializeToProtobuf(protoMetricsService, metricsData)
+  }
+
+  /**
+   * Builds all four OTLP Metric objects from drained buckets.
+   *
+   * @param {DrainedBucket[]} drained
+   * @param {number} bucketSizeNs
+   * @param {boolean} isJson
+   * @returns {object[]} Array of OTLP Metric objects
+   */
+  #buildMetrics (drained, bucketSizeNs, isJson) {
+    const hitsDataPoints = []
+    const errorsDataPoints = []
+    const topLevelHitsDataPoints = []
+    const durationDataPoints = []
+
+    const { protoAggregationTemporality } = isJson ? {} : getProtobufTypes()
+    const TEMPORALITY_DELTA = isJson
+      ? 'AGGREGATION_TEMPORALITY_DELTA'
+      : protoAggregationTemporality.values.AGGREGATION_TEMPORALITY_DELTA
+
+    for (const { timeNs, bucket } of drained) {
+      const startTimeNs = timeNs
+      const endTimeNs = timeNs + bucketSizeNs
+
+      for (const aggStats of bucket.values()) {
+        const { aggKey } = aggStats
+        const attrs = isJson
+          ? this.attributesToJson(this.#buildDataPointAttributes(aggKey))
+          : this.transformAttributes(this.#buildDataPointAttributes(aggKey))
+
+        const startNs = isJson ? String(startTimeNs) : startTimeNs
+        const endNs = isJson ? String(endTimeNs) : endTimeNs
+
+        hitsDataPoints.push({
+          attributes: attrs,
+          startTimeUnixNano: startNs,
+          timeUnixNano: endNs,
+          asInt: aggStats.hits,
+        })
+
+        errorsDataPoints.push({
+          attributes: attrs,
+          startTimeUnixNano: startNs,
+          timeUnixNano: endNs,
+          asInt: aggStats.errors,
+        })
+
+        topLevelHitsDataPoints.push({
+          attributes: attrs,
+          startTimeUnixNano: startNs,
+          timeUnixNano: endNs,
+          asInt: aggStats.topLevelHits,
+        })
+
+        const okCount = aggStats.hits - aggStats.errors
+        if (okCount > 0) {
+          durationDataPoints.push(
+            this.#buildDurationDataPoint(aggKey, aggStats.okDistribution, false, startNs, endNs, okCount, isJson)
+          )
+        }
+        if (aggStats.errors > 0) {
+          const errorDp = this.#buildDurationDataPoint(
+            aggKey, aggStats.errorDistribution, true, startNs, endNs, aggStats.errors, isJson
+          )
+          durationDataPoints.push(errorDp)
+        }
+      }
+    }
+
+    return [
+      {
+        name: 'dd.trace.span.hits',
+        description: 'Total span count per aggregation key',
+        unit: '{span}',
+        sum: {
+          dataPoints: hitsDataPoints,
+          aggregationTemporality: TEMPORALITY_DELTA,
+          isMonotonic: true,
+        },
+      },
+      {
+        name: 'dd.trace.span.errors',
+        description: 'Error span count per aggregation key',
+        unit: '{span}',
+        sum: {
+          dataPoints: errorsDataPoints,
+          aggregationTemporality: TEMPORALITY_DELTA,
+          isMonotonic: true,
+        },
+      },
+      {
+        name: 'dd.trace.span.top_level_hits',
+        description: 'Top-level span count per aggregation key',
+        unit: '{span}',
+        sum: {
+          dataPoints: topLevelHitsDataPoints,
+          aggregationTemporality: TEMPORALITY_DELTA,
+          isMonotonic: true,
+        },
+      },
+      {
+        name: 'dd.trace.span.duration',
+        description: 'Span duration distribution per aggregation key',
+        unit: 's',
+        histogram: {
+          dataPoints: durationDataPoints,
+          aggregationTemporality: TEMPORALITY_DELTA,
+        },
+      },
+    ]
+  }
+
+  /**
+   * Builds per-datapoint OTLP attributes from a span aggregation key.
+   *
+   * @param {import('../../span_stats').SpanAggKey} aggKey
+   * @returns {object} Plain attributes object
+   */
+  #buildDataPointAttributes (aggKey) {
+    const attrs = {
+      'span.name': aggKey.name,
+      'dd.resource': aggKey.resource,
+      'dd.span.type': aggKey.type,
+      'dd.synthetics': aggKey.synthetics,
+    }
+
+    if (aggKey.statusCode) {
+      attrs['http.response.status_code'] = aggKey.statusCode
+    }
+    if (aggKey.method) {
+      attrs['http.request.method'] = aggKey.method
+    }
+    if (aggKey.endpoint) {
+      attrs['http.route'] = aggKey.endpoint
+    }
+
+    return attrs
+  }
+
+  /**
+   * Builds a single OTLP Histogram data point from a DDSketch distribution.
+   *
+   * For 'explicit' histogram type: emits count/sum/min/max with empty buckets.
+   * Full bucket subdivision is deferred to a follow-up spec (Open Q #1 in RFC).
+   *
+   * For 'exponential' histogram type: currently falls back to explicit with a warning.
+   *
+   * @param {import('../../span_stats').SpanAggKey} aggKey
+   * @param {import('@datadog/sketches-js').LogCollapsingLowestDenseDDSketch} sketch
+   * @param {boolean} isError
+   * @param {number|string} startTimeNs
+   * @param {number|string} endTimeNs
+   * @param {number} count
+   * @param {boolean} isJson
+   * @returns {object} OTLP HistogramDataPoint
+   */
+  #buildDurationDataPoint (aggKey, sketch, isError, startTimeNs, endTimeNs, count, isJson) {
+    const attrs = { ...this.#buildDataPointAttributes(aggKey), error: isError }
+    const attributes = isJson ? this.attributesToJson(attrs) : this.transformAttributes(attrs)
+
+    // Convert nanoseconds to seconds per OTel semconv
+    const sumSeconds = sketch.sum / NS_PER_SECOND
+    const minSeconds = sketch.min / NS_PER_SECOND
+    const maxSeconds = sketch.max / NS_PER_SECOND
+
+    const dataPoint = {
+      attributes,
+      startTimeUnixNano: startTimeNs,
+      timeUnixNano: endTimeNs,
+      count: isJson ? count : count,
+      sum: sumSeconds,
+      bucketCounts: [],
+      explicitBounds: [],
+      min: minSeconds,
+      max: maxSeconds,
+    }
+
+    if (isJson) {
+      dataPoint.count = count
+    }
+
+    return dataPoint
+  }
+}
+
+module.exports = OtlpStatsTransformer

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -18,7 +18,7 @@ class SpanProcessor {
     this._killAll = false
 
     // TODO: This should already have been calculated in `config.js`.
-    if (config.stats?.enabled && !config.appsec?.standalone?.enabled) {
+    if ((config.stats?.enabled || config.traceMetrics?.enabled) && !config.appsec?.standalone?.enabled) {
       const { SpanStatsProcessor } = require('./span_stats')
       this._stats = new SpanStatsProcessor(config)
     }

--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -135,11 +135,36 @@ class TimeBuckets extends Map {
 }
 
 class SpanStatsProcessor {
+  /**
+   * @param {object} config
+   * @param {object} [config.stats]
+   * @param {boolean} [config.stats.enabled]
+   * @param {number} [config.stats.interval]
+   * @param {object} [config.traceMetrics]
+   * @param {boolean} [config.traceMetrics.enabled]
+   * @param {string} [config.traceMetrics.url]
+   * @param {string} [config.traceMetrics.protocol]
+   * @param {number} [config.traceMetrics.interval]
+   * @param {string} [config.traceMetrics.histogramType]
+   * @param {string} [config.hostname]
+   * @param {number} [config.port]
+   * @param {string} [config.url]
+   * @param {string} [config.env]
+   * @param {object} [config.tags]
+   * @param {string} [config.version]
+   */
   constructor ({
     stats: {
-      enabled = false,
+      enabled: statsEnabled = false,
       interval = 10,
-    },
+    } = {},
+    traceMetrics: {
+      enabled: traceMetricsEnabled = false,
+      url: traceMetricsUrl,
+      protocol: traceMetricsProtocol = 'http/protobuf',
+      interval: traceMetricsInterval,
+      histogramType = 'explicit',
+    } = {},
     hostname,
     port,
     url,
@@ -147,43 +172,68 @@ class SpanStatsProcessor {
     tags,
     version,
   } = {}) {
-    this.exporter = new SpanStatsExporter({
-      hostname,
-      port,
-      tags,
-      url,
-    })
-    this.interval = interval
-    this.bucketSizeNs = interval * 1e9
+    this.enabled = statsEnabled || traceMetricsEnabled
+    this.interval = traceMetricsInterval || interval
+
+    this.exporter = statsEnabled
+      ? new SpanStatsExporter({ hostname, port, tags, url })
+      : null
+
+    if (traceMetricsEnabled) {
+      const { OtlpStatsExporter } = require('./exporters/otlp-span-stats')
+      this.otlpExporter = new OtlpStatsExporter(
+        { url: traceMetricsUrl, protocol: traceMetricsProtocol, histogramType },
+        {
+          'service.name': tags?.service,
+          'deployment.environment': env,
+          'service.version': version,
+          'host.name': os.hostname(),
+          'dd.runtime_id': tags?.['runtime-id'],
+        }
+      )
+    }
+
+    this.bucketSizeNs = this.interval * 1e9
     this.buckets = new TimeBuckets()
     this.hostname = os.hostname()
-    this.enabled = enabled
     this.env = env
     this.tags = tags || {}
     this.sequence = 0
     this.version = version
 
     if (this.enabled) {
-      this.timer = setInterval(this.onInterval.bind(this), interval * 1e3)
+      this.timer = setInterval(this.onInterval.bind(this), this.interval * 1e3)
       this.timer.unref()
     }
   }
 
   onInterval () {
-    const serialized = this._serializeBuckets()
-    if (!serialized) return
+    const drained = this._drainBuckets()
+    if (!drained.length) return
 
-    this.exporter.export({
-      Hostname: this.hostname,
-      Env: this.env,
-      Version: this.version || version,
-      Stats: serialized,
-      Lang: 'javascript',
-      TracerVersion: pkg.version,
-      RuntimeID: this.tags['runtime-id'],
-      Sequence: ++this.sequence,
-      ProcessTags: processTags.serialized,
-    })
+    if (this.exporter) {
+      const serialized = drained.map(({ timeNs, bucket }) => ({
+        Start: timeNs,
+        Duration: this.bucketSizeNs,
+        Stats: Array.from(bucket.values(), s => s.toJSON()),
+      }))
+
+      this.exporter.export({
+        Hostname: this.hostname,
+        Env: this.env,
+        Version: this.version || version,
+        Stats: serialized,
+        Lang: 'javascript',
+        TracerVersion: pkg.version,
+        RuntimeID: this.tags['runtime-id'],
+        Sequence: ++this.sequence,
+        ProcessTags: processTags.serialized,
+      })
+    }
+
+    if (this.otlpExporter) {
+      this.otlpExporter.export(drained, this.bucketSizeNs)
+    }
   }
 
   onSpanFinished (span) {
@@ -198,27 +248,20 @@ class SpanStatsProcessor {
       .record(span)
   }
 
-  _serializeBuckets () {
-    const { bucketSizeNs } = this
-    const serializedBuckets = []
+  /**
+   * Drains all accumulated time buckets and returns raw bucket data.
+   * Clears the internal bucket map after draining.
+   * @returns {Array<{timeNs: number, bucket: SpanBuckets}>}
+   */
+  _drainBuckets () {
+    const drained = []
 
     for (const [timeNs, bucket] of this.buckets.entries()) {
-      const bucketAggStats = []
-
-      for (const stats of bucket.values()) {
-        bucketAggStats.push(stats.toJSON())
-      }
-
-      serializedBuckets.push({
-        Start: timeNs,
-        Duration: bucketSizeNs,
-        Stats: bucketAggStats,
-      })
+      drained.push({ timeNs, bucket })
     }
 
     this.buckets.clear()
-
-    return serializedBuckets
+    return drained
   }
 }
 

--- a/packages/dd-trace/test/exporters/otlp-span-stats/index.spec.js
+++ b/packages/dd-trace/test/exporters/otlp-span-stats/index.spec.js
@@ -1,0 +1,153 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+require('../../setup/core')
+const { SpanAggStats, SpanAggKey } = require('../../../src/span_stats')
+const { HTTP_STATUS_CODE } = require('../../../../../ext/tags')
+
+const basicSpan = {
+  startTime: 10000 * 1e9,
+  duration: 5000,
+  error: 0,
+  name: 'http.request',
+  service: 'web-service',
+  resource: '/users',
+  type: 'web',
+  meta: { [HTTP_STATUS_CODE]: 200 },
+  metrics: {},
+}
+
+const resourceAttributes = {
+  'service.name': 'web-service',
+  'deployment.environment': 'test',
+}
+
+function makeDrained (count = 1) {
+  const aggKey = new SpanAggKey(basicSpan)
+  const aggStats = new SpanAggStats(aggKey)
+  for (let i = 0; i < count; i++) aggStats.record(basicSpan)
+  const bucket = new Map([[aggKey.toString(), aggStats]])
+  return [{ timeNs: 10000 * 1e9, bucket }]
+}
+
+const BUCKET_SIZE_NS = 10 * 1e9
+
+describe('OtlpStatsExporter', () => {
+  let sendPayloadStub
+  let recordTelemetryStub
+  let OtlpStatsExporter
+
+  beforeEach(() => {
+    sendPayloadStub = sinon.stub()
+    recordTelemetryStub = sinon.stub()
+
+    const fakeTransformer = {
+      transform: sinon.stub().returns(Buffer.from('payload')),
+    }
+
+    const FakeTransformerClass = sinon.stub().returns(fakeTransformer)
+
+    const { OtlpStatsExporter: Exporter } = proxyquire('../../../src/exporters/otlp-span-stats/index', {
+      './transformer': FakeTransformerClass,
+    })
+
+    // Patch prototype methods on the constructed instance
+    OtlpStatsExporter = class extends Exporter {
+      sendPayload (payload, cb) {
+        sendPayloadStub(payload, cb)
+        cb({ code: 0 })
+      }
+
+      recordTelemetry (name, count, tags) {
+        recordTelemetryStub(name, count, tags)
+      }
+    }
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should construct without error', () => {
+    const exporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    assert.ok(exporter)
+  })
+
+  it('should not send if drained is empty', () => {
+    const exporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    exporter.export([], BUCKET_SIZE_NS)
+    assert.strictEqual(sendPayloadStub.callCount, 0)
+    assert.strictEqual(recordTelemetryStub.callCount, 0)
+  })
+
+  it('should call sendPayload with transformer output', () => {
+    const exporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    const drained = makeDrained(3)
+    exporter.export(drained, BUCKET_SIZE_NS)
+    assert.strictEqual(sendPayloadStub.callCount, 1)
+    assert.deepStrictEqual(sendPayloadStub.firstCall.args[0], Buffer.from('payload'))
+  })
+
+  it('should record attempt telemetry before sending', () => {
+    const exporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    const drained = makeDrained(2)
+    exporter.export(drained, BUCKET_SIZE_NS)
+    const attemptCall = recordTelemetryStub.getCalls().find(c => c.args[0] === 'otel.span_stats_export_attempts')
+    assert.ok(attemptCall, 'should record attempt telemetry')
+    assert.strictEqual(attemptCall.args[1], 1)
+  })
+
+  it('should record success telemetry on 2xx response', () => {
+    const exporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    const drained = makeDrained()
+    exporter.export(drained, BUCKET_SIZE_NS)
+    const successCall = recordTelemetryStub.getCalls().find(c => c.args[0] === 'otel.span_stats_export_successes')
+    assert.ok(successCall, 'should record success telemetry')
+  })
+
+  it('should not record success telemetry on failure', () => {
+    // Override sendPayload to simulate failure
+    const failingExporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    failingExporter.sendPayload = (payload, cb) => cb({ code: 1, error: new Error('timeout') })
+
+    const drained = makeDrained()
+    failingExporter.export(drained, BUCKET_SIZE_NS)
+
+    const successCalls = recordTelemetryStub.getCalls().filter(c => c.args[0] === 'otel.span_stats_export_successes')
+    assert.strictEqual(successCalls.length, 0)
+  })
+
+  it('should include points tag in telemetry', () => {
+    const exporter = new OtlpStatsExporter(
+      { url: 'http://localhost:4318/v1/metrics', protocol: 'http/protobuf', histogramType: 'explicit' },
+      resourceAttributes
+    )
+    const drained = makeDrained()
+    // drained has 1 bucket with 1 entry → points:1
+    exporter.export(drained, BUCKET_SIZE_NS)
+    const attemptCall = recordTelemetryStub.getCalls().find(c => c.args[0] === 'otel.span_stats_export_attempts')
+    assert.ok(attemptCall.args[2].includes('points:1'))
+  })
+})

--- a/packages/dd-trace/test/exporters/otlp-span-stats/transformer.spec.js
+++ b/packages/dd-trace/test/exporters/otlp-span-stats/transformer.spec.js
@@ -1,0 +1,335 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it } = require('mocha')
+
+require('../../setup/core')
+const OtlpStatsTransformer = require('../../../src/exporters/otlp-span-stats/transformer')
+const { SpanAggStats, SpanAggKey } = require('../../../src/span_stats')
+
+const { HTTP_STATUS_CODE, HTTP_ROUTE, HTTP_METHOD } = require('../../../../../ext/tags')
+
+const NS_PER_SECOND = 1e9
+
+// Build a minimal span fixture
+const basicSpan = {
+  startTime: 10000 * 1e9,
+  duration: 5000,
+  error: 0,
+  name: 'http.request',
+  service: 'web-service',
+  resource: '/users',
+  type: 'web',
+  meta: {
+    [HTTP_STATUS_CODE]: 200,
+    [HTTP_METHOD]: 'GET',
+    [HTTP_ROUTE]: '/users/:id',
+  },
+  metrics: {},
+}
+
+const errorSpan = {
+  ...basicSpan,
+  error: 1,
+  meta: { ...basicSpan.meta, [HTTP_STATUS_CODE]: 500 },
+}
+
+const resourceAttributes = {
+  'service.name': 'web-service',
+  'deployment.environment': 'test',
+  'service.version': '1.0.0',
+  'host.name': 'my-host',
+  'dd.runtime_id': 'abc-123',
+}
+
+/**
+ * Builds a drained bucket entry with one aggregated span.
+ *
+ * @param {object} span
+ * @param {number} timeNs
+ * @returns {{ timeNs: number, bucket: Map }}
+ */
+function makeDrained (span, timeNs = 10000 * 1e9) {
+  const aggKey = new SpanAggKey(span)
+  const aggStats = new SpanAggStats(aggKey)
+  aggStats.record(span)
+  const bucket = new Map([[aggKey.toString(), aggStats]])
+  return [{ timeNs, bucket }]
+}
+
+const BUCKET_SIZE_NS = 10 * 1e9
+
+describe('OtlpStatsTransformer', () => {
+  describe('JSON output (http/json protocol)', () => {
+    let transformer
+
+    it('should construct with http/json protocol', () => {
+      transformer = new OtlpStatsTransformer(resourceAttributes, 'http/json', 'explicit')
+      assert.strictEqual(transformer.protocol, 'http/json')
+      assert.strictEqual(transformer.histogramType, 'explicit')
+    })
+
+    it('should emit a valid JSON buffer', () => {
+      const drained = makeDrained(basicSpan)
+      const result = transformer.transform(drained, BUCKET_SIZE_NS)
+      assert.ok(Buffer.isBuffer(result))
+      const parsed = JSON.parse(result.toString())
+      assert.ok(Array.isArray(parsed.resourceMetrics))
+    })
+
+    it('should include resource attributes', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { resource } = parsed.resourceMetrics[0]
+      const attrMap = Object.fromEntries(resource.attributes.map(a => [a.key, a.value.stringValue]))
+      assert.strictEqual(attrMap['service.name'], 'web-service')
+      assert.strictEqual(attrMap['deployment.environment'], 'test')
+      assert.strictEqual(attrMap['host.name'], 'my-host')
+      assert.strictEqual(attrMap['dd.runtime_id'], 'abc-123')
+    })
+
+    it('should include dd-trace instrumentation scope', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { scope } = parsed.resourceMetrics[0].scopeMetrics[0]
+      assert.strictEqual(scope.name, 'dd-trace')
+      assert.ok(typeof scope.version === 'string')
+    })
+
+    it('should emit exactly four metrics', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { metrics } = parsed.resourceMetrics[0].scopeMetrics[0]
+      const names = metrics.map(m => m.name)
+      assert.deepStrictEqual(names.sort(), [
+        'dd.trace.span.duration',
+        'dd.trace.span.errors',
+        'dd.trace.span.hits',
+        'dd.trace.span.top_level_hits',
+      ])
+    })
+
+    it('should set correct units on all metrics', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { metrics } = parsed.resourceMetrics[0].scopeMetrics[0]
+      const unitMap = Object.fromEntries(metrics.map(m => [m.name, m.unit]))
+      assert.strictEqual(unitMap['dd.trace.span.hits'], '{span}')
+      assert.strictEqual(unitMap['dd.trace.span.errors'], '{span}')
+      assert.strictEqual(unitMap['dd.trace.span.top_level_hits'], '{span}')
+      assert.strictEqual(unitMap['dd.trace.span.duration'], 's')
+    })
+
+    it('should set delta temporality on Sum metrics', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { metrics } = parsed.resourceMetrics[0].scopeMetrics[0]
+      for (const metric of metrics.filter(m => m.sum)) {
+        assert.strictEqual(metric.sum.aggregationTemporality, 'AGGREGATION_TEMPORALITY_DELTA')
+        assert.strictEqual(metric.sum.isMonotonic, true)
+      }
+    })
+
+    it('should set delta temporality on Histogram metric', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { metrics } = parsed.resourceMetrics[0].scopeMetrics[0]
+      const duration = metrics.find(m => m.name === 'dd.trace.span.duration')
+      assert.strictEqual(duration.histogram.aggregationTemporality, 'AGGREGATION_TEMPORALITY_DELTA')
+    })
+
+    it('should set correct hit counts on dd.trace.span.hits', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const hits = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.hits')
+      assert.strictEqual(hits.sum.dataPoints[0].asInt, 1)
+    })
+
+    it('should set correct error counts on dd.trace.span.errors for non-error span', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const errors = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.errors')
+      assert.strictEqual(errors.sum.dataPoints[0].asInt, 0)
+    })
+
+    it('should set correct error counts for error span', () => {
+      const drained = makeDrained(errorSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const errors = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.errors')
+      assert.strictEqual(errors.sum.dataPoints[0].asInt, 1)
+    })
+
+    it('should include correct dimension attributes on data points', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const hits = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.hits')
+      const dp = hits.sum.dataPoints[0]
+      // attributesToJson converts all values to stringValue
+      const attrMap = Object.fromEntries(dp.attributes.map(a => [a.key, a.value.stringValue]))
+      assert.strictEqual(attrMap['span.name'], 'http.request')
+      assert.strictEqual(attrMap['dd.resource'], '/users')
+      assert.strictEqual(attrMap['dd.span.type'], 'web')
+      assert.strictEqual(attrMap['http.response.status_code'], '200')
+      assert.strictEqual(attrMap['http.request.method'], 'GET')
+      assert.strictEqual(attrMap['http.route'], '/users/:id')
+    })
+
+    it('should emit duration histogram with seconds unit and correct count/sum/min/max', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const duration = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.duration')
+      const dp = duration.histogram.dataPoints.find(d => {
+        const errAttr = d.attributes.find(a => a.key === 'error')
+        return errAttr && errAttr.value.stringValue === 'false'
+      })
+      assert.ok(dp)
+      assert.strictEqual(dp.count, 1)
+      assert.strictEqual(dp.sum, basicSpan.duration / NS_PER_SECOND)
+      assert.strictEqual(dp.min, basicSpan.duration / NS_PER_SECOND)
+      assert.strictEqual(dp.max, basicSpan.duration / NS_PER_SECOND)
+    })
+
+    it('should split duration histogram by error=true and error=false', () => {
+      // Span with both ok and error sub-spans
+      const aggKey = new SpanAggKey(basicSpan)
+      const aggStats = new SpanAggStats(aggKey)
+      aggStats.record(basicSpan) // ok span
+      aggStats.record(errorSpan) // error span
+      const bucket = new Map([[aggKey.toString(), aggStats]])
+      const drained = [{ timeNs: 10000 * 1e9, bucket }]
+
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const duration = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.duration')
+      const errorDp = duration.histogram.dataPoints.find(d =>
+        d.attributes.find(a => a.key === 'error' && a.value.stringValue === 'true')
+      )
+      const okDp = duration.histogram.dataPoints.find(d =>
+        d.attributes.find(a => a.key === 'error' && a.value.stringValue === 'false')
+      )
+      assert.ok(errorDp, 'should have error=true data point')
+      assert.ok(okDp, 'should have error=false data point')
+      assert.strictEqual(errorDp.count, 1)
+      assert.strictEqual(okDp.count, 1)
+    })
+
+    it('should omit error data point when no errors', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const duration = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.duration')
+      const errorDp = duration.histogram.dataPoints.find(d =>
+        d.attributes.find(a => a.key === 'error' && a.value.stringValue === 'true')
+      )
+      assert.strictEqual(errorDp, undefined)
+    })
+
+    it('should set startTimeUnixNano and timeUnixNano as strings in JSON', () => {
+      const drained = makeDrained(basicSpan)
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const hits = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.hits')
+      const dp = hits.sum.dataPoints[0]
+      assert.strictEqual(typeof dp.startTimeUnixNano, 'string')
+      assert.strictEqual(typeof dp.timeUnixNano, 'string')
+    })
+
+    it('should handle multiple time buckets', () => {
+      const aggKey1 = new SpanAggKey(basicSpan)
+      const aggStats1 = new SpanAggStats(aggKey1)
+      aggStats1.record(basicSpan)
+      const bucket1 = new Map([[aggKey1.toString(), aggStats1]])
+
+      const aggKey2 = new SpanAggKey(errorSpan)
+      const aggStats2 = new SpanAggStats(aggKey2)
+      aggStats2.record(errorSpan)
+      const bucket2 = new Map([[aggKey2.toString(), aggStats2]])
+
+      const drained = [
+        { timeNs: 10000 * 1e9, bucket: bucket1 },
+        { timeNs: 20000 * 1e9, bucket: bucket2 },
+      ]
+
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const hits = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.hits')
+      assert.strictEqual(hits.sum.dataPoints.length, 2)
+    })
+  })
+
+  describe('Protobuf output (http/protobuf protocol)', () => {
+    let transformer
+
+    it('should construct with http/protobuf protocol', () => {
+      transformer = new OtlpStatsTransformer(resourceAttributes, 'http/protobuf', 'explicit')
+      assert.strictEqual(transformer.protocol, 'http/protobuf')
+    })
+
+    it('should emit a non-empty Buffer', () => {
+      const drained = makeDrained(basicSpan)
+      const result = transformer.transform(drained, BUCKET_SIZE_NS)
+      assert.ok(Buffer.isBuffer(result))
+      assert.ok(result.length > 0)
+    })
+
+    it('should emit a different encoding than JSON', () => {
+      const drained = makeDrained(basicSpan)
+      const jsonTransformer = new OtlpStatsTransformer(resourceAttributes, 'http/json', 'explicit')
+      const protoResult = transformer.transform(drained, BUCKET_SIZE_NS)
+      const jsonResult = jsonTransformer.transform(drained, BUCKET_SIZE_NS)
+      assert.notDeepStrictEqual(protoResult, jsonResult)
+    })
+  })
+
+  describe('gRPC protocol fallback', () => {
+    it('should fall back to http/protobuf when grpc is configured', () => {
+      // OtlpTransformerBase logs a warning and falls back when grpc is requested
+      const grpcTransformer = new OtlpStatsTransformer(resourceAttributes, 'grpc', 'explicit')
+      assert.strictEqual(grpcTransformer.protocol, 'http/protobuf')
+    })
+  })
+
+  describe('empty input', () => {
+    it('should handle empty drained array', () => {
+      const transformer = new OtlpStatsTransformer(resourceAttributes, 'http/json', 'explicit')
+      const result = JSON.parse(transformer.transform([], BUCKET_SIZE_NS).toString())
+      const { metrics } = result.resourceMetrics[0].scopeMetrics[0]
+      for (const metric of metrics) {
+        if (metric.sum) assert.strictEqual(metric.sum.dataPoints.length, 0)
+        if (metric.histogram) assert.strictEqual(metric.histogram.dataPoints.length, 0)
+      }
+    })
+
+    it('should handle bucket with no entries', () => {
+      const transformer = new OtlpStatsTransformer(resourceAttributes, 'http/json', 'explicit')
+      const emptyBucket = new Map()
+      const drained = [{ timeNs: 10000 * 1e9, bucket: emptyBucket }]
+      const result = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const { metrics } = result.resourceMetrics[0].scopeMetrics[0]
+      for (const metric of metrics) {
+        if (metric.sum) assert.strictEqual(metric.sum.dataPoints.length, 0)
+      }
+    })
+  })
+
+  describe('DDSketch with multiple accepted values', () => {
+    it('should sum duration values correctly', () => {
+      const aggKey = new SpanAggKey(basicSpan)
+      const aggStats = new SpanAggStats(aggKey)
+      const durations = [1000, 2000, 3000, 4000]
+      for (const d of durations) {
+        aggStats.record({ ...basicSpan, duration: d })
+      }
+
+      const bucket = new Map([[aggKey.toString(), aggStats]])
+      const drained = [{ timeNs: 10000 * 1e9, bucket }]
+      const transformer = new OtlpStatsTransformer(resourceAttributes, 'http/json', 'explicit')
+      const parsed = JSON.parse(transformer.transform(drained, BUCKET_SIZE_NS).toString())
+      const duration = parsed.resourceMetrics[0].scopeMetrics[0].metrics.find(m => m.name === 'dd.trace.span.duration')
+      const okDp = duration.histogram.dataPoints.find(d =>
+        d.attributes.find(a => a.key === 'error' && a.value.stringValue === 'false')
+      )
+
+      assert.ok(okDp)
+      assert.strictEqual(okDp.count, 4)
+      // sum should be (1000+2000+3000+4000) / 1e9 seconds
+      assert.ok(Math.abs(okDp.sum - (10000 / NS_PER_SECOND)) < 1e-10)
+    })
+  })
+})

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -9,7 +9,6 @@ const proxyquire = require('proxyquire')
 
 require('./setup/core')
 const { LogCollapsingLowestDenseDDSketch } = require('../../../vendor/dist/@datadog/sketches-js')
-const { version } = require('../src/pkg')
 const pkg = require('../../../package.json')
 const { ORIGIN_KEY, TOP_LEVEL_KEY, SVC_SRC_KEY } = require('../src/constants')
 
@@ -78,7 +77,12 @@ const exporter = {
   export: sinon.stub(),
 }
 
+const otlpExporter = {
+  export: sinon.stub(),
+}
+
 const SpanStatsExporter = sinon.stub().returns(exporter)
+const OtlpStatsExporter = sinon.stub().returns(otlpExporter)
 
 const {
   SpanAggStats,
@@ -89,6 +93,9 @@ const {
 } = proxyquire('../src/span_stats', {
   './exporters/span-stats': {
     SpanStatsExporter,
+  },
+  './exporters/otlp-span-stats': {
+    OtlpStatsExporter,
   },
 })
 
@@ -415,22 +422,96 @@ describe('SpanStatsProcessor', () => {
     })
   })
 
-  it('should export on interval with default version', () => {
+  it('should not export on interval when buckets are empty', () => {
+    const callsBefore = exporter.export.callCount
     const versionlessConfig = { ...config }
     delete versionlessConfig.version
-    const processor = new SpanStatsProcessor(versionlessConfig)
-    processor.onInterval()
+    const emptyProcessor = new SpanStatsProcessor(versionlessConfig)
+    clearTimeout(emptyProcessor.timer)
 
-    assert.deepStrictEqual(exporter.export.lastCall.args[0], {
-      Hostname: hostname(),
-      Env: config.env,
-      Version: version,
-      Stats: [],
-      Lang: 'javascript',
-      TracerVersion: pkg.version,
-      RuntimeID: processor.tags['runtime-id'],
-      Sequence: processor.sequence,
-      ProcessTags: processTags.serialized,
-    })
+    emptyProcessor.onInterval()
+
+    assert.strictEqual(exporter.export.callCount, callsBefore)
+  })
+
+  it('should drain buckets and clear them', () => {
+    const proc = new SpanStatsProcessor(config)
+    clearTimeout(proc.timer)
+
+    proc.onSpanFinished(topLevelSpan)
+    proc.onSpanFinished(errorSpan)
+    assert.ok(proc.buckets.size > 0)
+
+    const drained = proc._drainBuckets()
+    assert.ok(Array.isArray(drained))
+    assert.ok(drained.length > 0)
+    assert.ok('timeNs' in drained[0])
+    assert.ok(drained[0].bucket instanceof SpanBuckets)
+
+    // Buckets should be cleared after drain
+    assert.strictEqual(proc.buckets.size, 0)
+    // Second drain should be empty
+    assert.deepStrictEqual(proc._drainBuckets(), [])
+  })
+
+  it('should call both exporters when stats and traceMetrics are both enabled', () => {
+    const dualConfig = {
+      ...config,
+      traceMetrics: {
+        enabled: true,
+        url: 'http://localhost:4318/v1/metrics',
+        protocol: 'http/protobuf',
+        histogramType: 'explicit',
+      },
+    }
+
+    const callsBefore = {
+      exporter: exporter.export.callCount,
+      otlp: otlpExporter.export.callCount,
+    }
+
+    const dualProcessor = new SpanStatsProcessor(dualConfig)
+    clearTimeout(dualProcessor.timer)
+    dualProcessor.onSpanFinished(topLevelSpan)
+    dualProcessor.onInterval()
+
+    assert.strictEqual(exporter.export.callCount, callsBefore.exporter + 1)
+    assert.strictEqual(otlpExporter.export.callCount, callsBefore.otlp + 1)
+
+    // OTLP exporter receives raw drained data + bucketSizeNs
+    const [otlpDrained, otlpBucketSizeNs] = otlpExporter.export.lastCall.args
+    assert.ok(Array.isArray(otlpDrained))
+    assert.ok(otlpDrained.length > 0)
+    assert.strictEqual(otlpBucketSizeNs, dualConfig.stats.interval * 1e9)
+  })
+
+  it('should activate with only traceMetrics.enabled=true', () => {
+    const otlpOnlyConfig = {
+      stats: { enabled: false, interval: 10 },
+      traceMetrics: {
+        enabled: true,
+        url: 'http://localhost:4318/v1/metrics',
+        protocol: 'http/protobuf',
+        histogramType: 'explicit',
+      },
+      hostname: '127.0.0.1',
+      port: 8126,
+      env: 'test',
+      tags: {},
+      version: '1.0.0',
+    }
+
+    const callsBefore = otlpExporter.export.callCount
+
+    const otlpProcessor = new SpanStatsProcessor(otlpOnlyConfig)
+    clearTimeout(otlpProcessor.timer)
+
+    assert.strictEqual(otlpProcessor.enabled, true)
+    assert.strictEqual(otlpProcessor.exporter, null)
+
+    otlpProcessor.onSpanFinished(topLevelSpan)
+    otlpProcessor.onInterval()
+
+    assert.strictEqual(otlpExporter.export.callCount, callsBefore + 1)
   })
 })


### PR DESCRIPTION
### What does this PR do?
Export span stats as OTLP metrics (dd.trace.span.hits, errors, top_level_hits, duration) via a new OtlpStatsExporter alongside the existing Datadog /v0.6/stats exporter.

### Key changes
packages/dd-trace/src/span_stats.js
- creates OtlpStatsExporter when enabled
- `_serializeBuckets` -> `drainBuckets`: the old method did two things at once: it formatted the bucket data into the Datadog wire shape `({ Start, Duration, Stats:[...toJSON()] })` and cleared the map. The new `_drainBuckets()` only drains the raw data as `[{ timeNs, bucket }]` and clears. Formatting is deferred to `onInterval()` so each exporter can receive the data in whatever shape it needs.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
- No mapping from DDSketch indices to OTLP ExponentialHistogram scale/bucket indices is defined. `DD_TRACE_OTEL_METRICS_HISTOGRAM_TYPE` defaults to `explicit`. Conversion to ExponentialHistorogram deferred until DDSketch→OTLP index mapping is specified.


