### PR TITLE
fix(ws): add missing ctx.span guard in bindAsyncStart and asyncStart

### DIFF
--- a/packages/datadog-plugin-ws/src/close.js
+++ b/packages/datadog-plugin-ws/src/close.js
@@ -57,11 +57,13 @@ class WSClosePlugin extends TracingPlugin {
   }
 
   bindAsyncStart (ctx) {
+    if (!ctx.span) return ctx.parentStore
     if (!ctx.isPeerClose) ctx.span.finish()
     return ctx.parentStore
   }
 
   asyncStart (ctx) {
+    if (!ctx.span) return
     ctx.span.finish()
   }
 

--- a/packages/datadog-plugin-ws/src/producer.js
+++ b/packages/datadog-plugin-ws/src/producer.js
@@ -46,11 +46,13 @@ class WSProducerPlugin extends TracingPlugin {
   }
 
   bindAsyncStart (ctx) {
+    if (!ctx.span) return ctx.parentStore
     ctx.span.finish()
     return ctx.parentStore
   }
 
   asyncStart (ctx) {
+    if (!ctx.span) return
     ctx.span.finish()
   }
 

--- a/packages/datadog-plugin-ws/src/receiver.js
+++ b/packages/datadog-plugin-ws/src/receiver.js
@@ -62,6 +62,7 @@ class WSReceiverPlugin extends TracingPlugin {
   }
 
   asyncStart (ctx) {
+    if (!ctx.span) return
     ctx.span.finish()
   }
 

--- a/packages/datadog-plugin-ws/test/index.spec.js
+++ b/packages/datadog-plugin-ws/test/index.spec.js
@@ -31,6 +31,27 @@ describe('Plugin', () => {
           WebSocket = require(`../../../versions/ws@${version}`).get()
         })
 
+        it('should not crash when sending on a socket without spanContext', async () => {
+          const server = new WebSocket.Server({ port: 16015 })
+          const connectionPromise = once(server, 'connection')
+
+          const socket = new WebSocket('ws://localhost:16015')
+          const [serverSocket] = await connectionPromise
+          await once(socket, 'open')
+
+          assert.strictEqual(socket.spanContext, undefined)
+
+          const messagePromise = once(serverSocket, 'message')
+          await new Promise((resolve, reject) => {
+            socket.send('test message', {}, (err) => err ? reject(err) : resolve())
+          })
+          await messagePromise
+
+          socket.close()
+          await once(socket, 'close')
+          server.close()
+        })
+
         it('should emit original error in case close is called before connection is established', async () => {
           const socket = new WebSocket('wss://localhost:12345')
 


### PR DESCRIPTION
### What does this PR do?

Adds `ctx.span` null guards to `bindAsyncStart()` and `asyncStart()` in the ws plugin's producer, close, and receiver files. This prevents a `TypeError` crash when `bindStart()` returns early (e.g. when `socket.spanContext` is not set) and `ctx.span` is never assigned.

As noted by @bmatcuk in #6518, PR #6660's fix needed extending to other methods. This PR addresses bindAsyncStart() and asyncStart() across producer, close, and receiver.

### Motivation
In production, WebSocket connections without a parent span context (e.g. BullMQ dashboard connections via Taskforce.sh) crash the process on send/receive/close:

```
dd-trace/packages/datadog-plugin-ws/src/producer.js:49
    ctx.span.finish()
             ^
TypeError: Cannot read properties of undefined (reading 'finish')
```

Related: #6582, #6660

### Additional Notes

The regression test added in this PR reproduces this exact flow/error when the fix is removed/commented out: `PLUGINS="ws" yarn test:plugins`

```
yarn run v1.22.22
warning ../../package.json: No license field
$ node --expose-gc ./node_modules/mocha/bin/mocha.js "packages/datadog-plugin-@(${PLUGINS})/test/**/${SPEC:-*}*.spec.js"

  Plugin
    ws
      with ws >=8.0.0 (8.0.0)
        regression tests
DATADOG TRACER CONFIGURATION - {"date":"2026-04-14T22:20:16.694Z","os_name":"Darwin","os_version":"25.3.0","architecture":"arm64","version":"6.0.0-pre","lang":"nodejs","lang_version":"23.11.1","env":"tester","service":"test","agent_url":"http://127.0.0.1:62030/","debug":false,"sampling_rules":[],"tags":{"version":"11.7.5","service":"test","env":"tester","runtime-id":"32dd917e-f71e-461c-b791-cebad808a4e4","_dd.rc.client_id":"dc0c160c-a0cc-4411-b7bc-6d9bdd3fe6bc"},"dd_version":"11.7.5","log_injection_enabled":true,"runtime_metrics_enabled":true,"profiling_enabled":false,"data_streams_enabled":false}
/Users/n/code/dd-trace-js/node_modules/mocha/lib/runner.js:998
    throw err;
    ^

TypeError: Cannot read properties of undefined (reading 'finish')
    at WSProducerPlugin.bindAsyncStart (/Users/n/code/dd-trace-js/packages/datadog-plugin-ws/src/producer.js:50:14)
    at /Users/n/code/dd-trace-js/packages/dd-trace/src/plugins/tracing.js:106:59
    at StoreBinding._transform (/Users/n/code/dd-trace-js/packages/dd-trace/src/plugins/plugin.js:56:11)
    at node:diagnostics_channel:86:17
    at Channel.runStores (node:diagnostics_channel:171:12)
    at Object.wrappedCallback [as callback] (node:diagnostics_channel:400:18)
    at callback (node:internal/streams/writable:764:21)
    at afterWrite (node:internal/streams/writable:708:5)
    at afterWriteTick (node:internal/streams/writable:694:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:89:21)

Node.js v23.11.1
error Command failed with exit code 7.
```

Crash we faced in during deployment:
<img width="1190" height="303" alt="Screenshot 2026-04-14 at 6 24 07 PM" src="https://github.com/user-attachments/assets/aa95b6cf-8bed-4781-afe4-7d37552cf097" />