### PR TITLE
chore(scope) remove tracer.scope from tests and source files

### DIFF
--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -9,6 +9,7 @@ const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+const { storage } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
@@ -172,7 +173,7 @@ describe('Plugin', () => {
           let span
 
           app.use((req, res, next) => {
-            span = tracer.scope().active()
+            span = storage('legacy').getStore()?.span
 
             sinon.spy(span, 'finish')
 

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -10,6 +10,7 @@ const sinon = require('sinon')
 
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { NODE_MAJOR } = require('../../../version')
+const { storage } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
@@ -628,7 +629,7 @@ describe('Plugin', () => {
           let span
 
           app.use((req, res, next) => {
-            span = tracer.scope().active()
+            span = storage('legacy').getStore()?.span
 
             sinon.spy(span, 'finish')
 

--- a/packages/datadog-plugin-koa/test/index.spec.js
+++ b/packages/datadog-plugin-koa/test/index.spec.js
@@ -10,6 +10,7 @@ const semver = require('semver')
 const sinon = require('sinon')
 
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+const { storage } = require('../../datadog-core')
 const { ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
@@ -192,7 +193,7 @@ describe('Plugin', () => {
           let childSpan
 
           app.use((ctx, next) => {
-            parentSpan = tracer.scope().active()
+            parentSpan = storage('legacy').getStore()?.span
 
             sinon.spy(parentSpan, 'finish')
 
@@ -213,7 +214,7 @@ describe('Plugin', () => {
           })
 
           app.use((ctx, next) => {
-            childSpan = tracer.scope().active()
+            childSpan = storage('legacy').getStore()?.span
 
             sinon.spy(childSpan, 'finish')
 

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 
+const { storage } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_TYPE } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
@@ -136,10 +137,10 @@ describe('Plugin', () => {
         )
 
         it('should restore the parent context in the callback', async () => {
-          const span = {}
-          tracer.scope().activate(span, () => {
+          const span = tracer._tracer.startSpan('test')
+          storage('legacy').run({ span }, () => {
             client.get('foo', () => {
-              assert.strictEqual(span.context().active(), span)
+              assert.strictEqual(storage('legacy').getStore()?.span, span)
             })
           })
         })

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -243,7 +243,7 @@ describe('Plugin', () => {
             it('should extract the span context', done => {
               container.once('message', msg => {
                 const span = tracer.scope().active()
-                assert.notStrictEqual(span._spanContext._parentId, null)
+                assert.notStrictEqual(span.context()._parentId, null)
                 done()
               })
               context.sender.send({ body: 'Hello World!' })

--- a/packages/dd-trace/src/appsec/sdk/set_user.js
+++ b/packages/dd-trace/src/appsec/sdk/set_user.js
@@ -19,7 +19,7 @@ function setUser (tracer, user) {
     return
   }
 
-  const rootSpan = getRootSpan(tracer)
+  const rootSpan = getRootSpan()
   if (!rootSpan) {
     log.warn('[ASM] Root span not available in setUser')
     return

--- a/packages/dd-trace/src/appsec/sdk/track_event.js
+++ b/packages/dd-trace/src/appsec/sdk/track_event.js
@@ -21,7 +21,7 @@ function trackUserLoginSuccessEvent (tracer, user, metadata) {
 
   incrementSdkEventMetric('login_success', 'v1')
 
-  const rootSpan = getRootSpan(tracer)
+  const rootSpan = getRootSpan()
   if (!rootSpan) {
     log.warn('[ASM] Root span not available in trackUserLoginSuccessEvent')
     return
@@ -54,7 +54,7 @@ function trackUserLoginFailureEvent (tracer, userId, exists, metadata) {
     ...metadata,
   }
 
-  trackEvent('users.login.failure', fields, 'trackUserLoginFailureEvent', getRootSpan(tracer))
+  trackEvent('users.login.failure', fields, 'trackUserLoginFailureEvent', getRootSpan())
 
   runWaf('users.login.failure', { login: userId })
 
@@ -67,7 +67,7 @@ function trackCustomEvent (tracer, eventName, metadata) {
     return
   }
 
-  trackEvent(eventName, metadata, 'trackCustomEvent', getRootSpan(tracer))
+  trackEvent(eventName, metadata, 'trackCustomEvent', getRootSpan())
 
   incrementSdkEventMetric('custom', 'v1')
 
@@ -84,7 +84,7 @@ function trackUserLoginSuccessV2 (tracer, login, user, metadata) {
 
   incrementSdkEventMetric('login_success', 'v2')
 
-  const rootSpan = getRootSpan(tracer)
+  const rootSpan = getRootSpan()
   if (!rootSpan) {
     log.warn('[ASM] Root span not available in eventTrackingV2.trackUserLoginSuccess')
     return
@@ -122,7 +122,7 @@ function trackUserLoginFailureV2 (tracer, login, exists, metadata) {
 
   incrementSdkEventMetric('login_failure', 'v2')
 
-  const rootSpan = getRootSpan(tracer)
+  const rootSpan = getRootSpan()
   if (!rootSpan) {
     log.warn('[ASM] Root span not available in eventTrackingV2.trackUserLoginFailure')
     return

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -19,7 +19,7 @@ function checkUserAndSetUser (tracer, user) {
     return false
   }
 
-  const rootSpan = getRootSpan(tracer)
+  const rootSpan = getRootSpan()
   if (rootSpan) {
     if (!rootSpan.context()._tags['usr.id']) {
       setUserTags(user, rootSpan)
@@ -45,7 +45,7 @@ function blockRequest (tracer, req, res) {
     return false
   }
 
-  const rootSpan = getRootSpan(tracer)
+  const rootSpan = getRootSpan()
   if (!rootSpan) {
     log.warn('[ASM] Root span not available in blockRequest')
     return false

--- a/packages/dd-trace/src/appsec/sdk/utils.js
+++ b/packages/dd-trace/src/appsec/sdk/utils.js
@@ -1,7 +1,9 @@
 'use strict'
 
-function getRootSpan (tracer) {
-  let span = tracer.scope().active()
+const { storage } = require('../../../../datadog-core')
+
+function getRootSpan () {
+  let span = storage('legacy').getStore()?.span
   if (!span) return
 
   const context = span.context()

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -59,7 +59,6 @@ class ContextManager {
   // converts otel to dd
   with (context, fn, thisArg, ...args) {
     const span = trace.getSpan(context)
-    const ddScope = tracer.scope()
     const run = () => {
       const cb = thisArg == null ? fn : fn.bind(thisArg)
       return this._store.run(context, cb, ...args)

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -4,7 +4,6 @@ const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const { storage } = require('../../../datadog-core')
 const { getAllBaggageItems, setBaggageItem, removeAllBaggageItems } = require('../baggage')
 
-const tracer = require('../../')
 const SpanContext = require('./span_context')
 
 class ContextManager {
@@ -16,7 +15,7 @@ class ContextManager {
   active () {
     const store = this._store.getStore()
     const baseContext = store || ROOT_CONTEXT
-    const activeSpan = tracer.scope().active()
+    const activeSpan = storage('legacy').getStore()?.span
 
     const storedSpan = store ? trace.getSpan(store) : null
 
@@ -74,7 +73,11 @@ class ContextManager {
     for (const baggage of baggageItems) {
       setBaggageItem(baggage[0], baggage[1].value)
     }
-    if (span && span._ddSpan) return ddScope.activate(span._ddSpan, run)
+    if (span && span._ddSpan) {
+      const ddSpan = span._ddSpan
+      const parentStore = storage('legacy').getStore(ddSpan._store) ?? storage('legacy').getStore()
+      return storage('legacy').run({ ...parentStore, span: ddSpan }, run)
+    }
     return run()
   }
 

--- a/packages/dd-trace/test/appsec/sdk/set_user.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/set_user.spec.js
@@ -63,7 +63,7 @@ describe('set_user', () => {
         getRootSpan.returns(undefined)
 
         setUser(tracer, { id: 'user' })
-        sinon.assert.calledOnceWithExactly(getRootSpan, tracer)
+        sinon.assert.calledOnce(getRootSpan)
         sinon.assert.calledOnceWithExactly(log.warn, '[ASM] Root span not available in setUser')
         sinon.assert.notCalled(rootSpan.setTag)
         sinon.assert.notCalled(waf.run)

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -74,7 +74,7 @@ describe('user_blocking - Internal API', () => {
     it('should set user when not already set', () => {
       const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
       assert.strictEqual(ret, true)
-      sinon.assert.calledOnceWithExactly(getRootSpan, tracer)
+      sinon.assert.calledOnce(getRootSpan)
       sinon.assert.calledWithExactly(rootSpan.setTag, 'usr.id', 'user')
       sinon.assert.calledWithExactly(rootSpan.setTag, '_dd.appsec.user.collection_mode', 'sdk')
     })
@@ -86,7 +86,7 @@ describe('user_blocking - Internal API', () => {
 
       const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
       assert.strictEqual(ret, true)
-      sinon.assert.calledOnceWithExactly(getRootSpan, tracer)
+      sinon.assert.calledOnce(getRootSpan)
       sinon.assert.notCalled(rootSpan.setTag)
     })
 
@@ -95,7 +95,7 @@ describe('user_blocking - Internal API', () => {
 
       const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })
       assert.strictEqual(ret, true)
-      sinon.assert.calledOnceWithExactly(getRootSpan, tracer)
+      sinon.assert.calledOnce(getRootSpan)
       sinon.assert.calledOnceWithExactly(log.warn, '[ASM] Root span not available in isUserBlocked')
       sinon.assert.notCalled(rootSpan.setTag)
     })

--- a/packages/dd-trace/test/appsec/sdk/utils.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/utils.spec.js
@@ -18,7 +18,7 @@ describe('Appsec SDK utils', () => {
   describe('getRootSpan', () => {
     it('should return root span if there are no childs', () => {
       tracer.trace('parent', { }, parent => {
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, parent)
       })
@@ -28,7 +28,7 @@ describe('Appsec SDK utils', () => {
       const childOf = tracer.startSpan('parent')
 
       tracer.trace('child1', { childOf }, child1 => {
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, childOf)
       })
@@ -39,7 +39,7 @@ describe('Appsec SDK utils', () => {
       childOf.context()._parentId = id()
 
       tracer.trace('child1', { childOf }, child1 => {
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, childOf)
       })
@@ -52,7 +52,7 @@ describe('Appsec SDK utils', () => {
         tracer.trace('child1.1.2', { childOf: child11 }, child112 => {})
       })
       tracer.trace('child1.2', { childOf }, child12 => {
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, childOf)
       })
@@ -63,7 +63,7 @@ describe('Appsec SDK utils', () => {
       childOf.setTag('_inferred_span', {})
 
       tracer.trace('child1', { childOf }, child1 => {
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, child1)
       })
@@ -75,7 +75,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1', { childOf }, child1 => {
         child1.setTag('_inferred_span', {})
 
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, childOf)
       })
@@ -88,7 +88,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1', { childOf }, child1 => {
         child1.setTag('_inferred_span', {})
 
-        const root = getRootSpan(tracer)
+        const root = getRootSpan()
 
         assert.strictEqual(root, child1)
       })
@@ -101,7 +101,7 @@ describe('Appsec SDK utils', () => {
       tracer.trace('child1.1', { childOf }, child11 => {})
       tracer.trace('child1.2', { childOf }, child12 => {
         tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
-          const root = getRootSpan(tracer)
+          const root = getRootSpan()
 
           assert.strictEqual(root, child12)
         })
@@ -116,7 +116,7 @@ describe('Appsec SDK utils', () => {
         child12.setTag('_inferred_span', {})
 
         tracer.trace('child1.2.1', { childOf: child12 }, child121 => {
-          const root = getRootSpan(tracer)
+          const root = getRootSpan()
 
           assert.strictEqual(root, childOf)
         })
@@ -134,7 +134,7 @@ describe('Appsec SDK utils', () => {
           child121.setTag('_inferred_span', {})
 
           tracer.trace('child1.2.1.1', { childOf: child121 }, child1211 => {
-            const root = getRootSpan(tracer)
+            const root = getRootSpan()
 
             assert.strictEqual(root, childOf)
           })
@@ -154,7 +154,7 @@ describe('Appsec SDK utils', () => {
           child121.setTag('_inferred_span', {})
 
           tracer.trace('child1.2.1.1', { childOf: child121 }, child1211 => {
-            const root = getRootSpan(tracer)
+            const root = getRootSpan()
 
             assert.strictEqual(root, child1211)
           })

--- a/packages/dd-trace/test/opentelemetry/tracer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 const api = require('@opentelemetry/api')
 
 const { hrTime, timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/core')
+const { storage } = require('../../../datadog-core')
 require('../setup/core')
 require('../../').init()
 const TracerProvider = require('../../src/opentelemetry/tracer_provider')
@@ -125,7 +126,7 @@ describe('OTel Tracer', () => {
 
     otelTracer.startActiveSpan('name', (span) => {
       assert.ok(span instanceof Span)
-      assert.strictEqual(span._ddSpan, tracer.scope().active())
+      assert.strictEqual(span._ddSpan, storage('legacy').getStore()?.span)
     })
   })
 

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 
 const { describe, it } = require('mocha')
 const { channel } = require('dc-polyfill')
+const { storage } = require('../../../datadog-core')
 
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 require('../setup/core')
@@ -53,14 +54,14 @@ describe('LogPlugin', () => {
   it('should include trace_id and span_id when a span is active', () => {
     const span = tracer.startSpan('test')
 
-    tracer.scope().activate(span, () => {
+    storage('legacy').run({ span }, () => {
       const data = { message: {} }
       testLogChannel.publish(data)
       const { message } = data
 
       assertObjectContains(message.dd, config)
 
-      // Should have trace/span data when none is active
+      // Should have trace/span data when a span is active
       assert.strictEqual(message.dd.trace_id, span.context().toTraceId(true))
       assert.strictEqual(message.dd.span_id, span.context().toSpanId())
     })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes the usage of tracer.scope() from test and source files and replaces it with storage. This will support upcoming efforts for the span API split.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


