### PR TITLE
test: add regression test for Azure App Services RC not disabled

### DIFF
--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -2461,6 +2461,16 @@ describe('Config', () => {
     assert.strictEqual(config.remoteConfig.enabled, false)
   })
 
+  it('should not disable remoteConfig for Azure App Services (WEBSITE_SITE_NAME without FUNCTIONS env vars)', () => {
+    // App Services sets WEBSITE_SITE_NAME but not FUNCTIONS_WORKER_RUNTIME or FUNCTIONS_EXTENSION_VERSION.
+    // IS_SERVERLESS must remain false so RC and DI work normally via the agent sidecar.
+    process.env.WEBSITE_SITE_NAME = 'my-app-service'
+
+    const config = getConfig()
+
+    assert.strictEqual(config.remoteConfig.enabled, true)
+  })
+
   it('should send empty array when remote config is called on empty options', () => {
     const config = getConfig()
 


### PR DESCRIPTION
## Summary

Adds a regression test confirming that Remote Configuration (RC) is **not** disabled for Azure App Services. No source code changes were needed — `serverless.js` already correctly distinguishes App Services from Azure Functions by checking `FUNCTIONS_EXTENSION_VERSION` and `FUNCTIONS_WORKER_RUNTIME`, which App Services does not set.

The test guards against a future regression where someone might inadvertently add `WEBSITE_SITE_NAME` (the only App Services env var) to the serverless detection path, which would silently break RC for App Services customers.

## Changes

- `packages/dd-trace/test/config/index.spec.js`: Add `"should not disable remoteConfig for Azure App Services (WEBSITE_SITE_NAME without FUNCTIONS env vars)"` — sets `WEBSITE_SITE_NAME` only (no `FUNCTIONS_*` vars), asserts `remoteConfig.enabled=true`

## Testing

- `node_modules/.bin/mocha --timeout 30000 packages/dd-trace/test/config/index.spec.js` → 212 passing, 0 failing
- New regression test passes; existing Azure Functions disable test has no regression

## Context

Part of Live Debugger on Azure (Phase 1, App Services). Source confirmed correct for App Services, test-only change needed.