### PR TITLE
test(sampling): verify formatKnuthRate is locale-independent

### DIFF
--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -393,3 +393,4 @@ class PrioritySampler {
 }
 
 module.exports = PrioritySampler
+module.exports.formatKnuthRate = formatKnuthRate

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -614,6 +614,29 @@ describe('PrioritySampler', () => {
     })
   })
 
+  describe('formatKnuthRate', () => {
+    // JS Number.prototype.toFixed() is locale-independent per ECMAScript spec
+    // (ECMA-262, sec 21.1.3.3) — it always uses '.' as the decimal separator.
+    // This test documents that contract.
+    const { formatKnuthRate } = require('../src/priority_sampler')
+
+    it('should format 0.3 as "0.3"', () => {
+      assert.strictEqual(formatKnuthRate(0.3), '0.3')
+    })
+
+    it('should format 1.0 as "1"', () => {
+      assert.strictEqual(formatKnuthRate(1.0), '1')
+    })
+
+    it('should format 0.000001 as "0.000001"', () => {
+      assert.strictEqual(formatKnuthRate(0.000001), '0.000001')
+    })
+
+    it('should round 0.0000001 to "0"', () => {
+      assert.strictEqual(formatKnuthRate(0.0000001), '0')
+    })
+  })
+
   describe('keepTrace', () => {
     it('should not fail if no _prioritySampler', () => {
       PrioritySampler.keepTrace(span, SAMPLING_MECHANISM_APPSEC)


### PR DESCRIPTION
### What does this PR do?

Exports `formatKnuthRate` from `priority_sampler.js` and adds direct unit tests that verify the function produces correct decimal-dot output for various sampling rates.

### Motivation

`formatKnuthRate` uses `Number.prototype.toFixed()`, which is locale-independent per ECMAScript spec (ECMA-262, sec 21.1.3.3) -- it always uses `.` as the decimal separator. This PR documents that contract with explicit tests covering normal decimals (0.3), integer rates (1.0), minimum precision (0.000001), and below-precision rounding (0.0000001).

### Additional Notes

- The named export (`module.exports.formatKnuthRate`) is additive and does not affect the default `PrioritySampler` export.
- All 57 tests in `priority_sampler.spec.js` pass, including the 4 new ones.