### PR TITLE
fix(node) appsec and capabilities tests

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js
@@ -37,7 +37,9 @@ describe('ssrf analyzer', () => {
               }
             })
 
-            clientRequest.destroy()
+            setImmediate(() => {
+              clientRequest.destroy()
+            })
           })
         }
 
@@ -65,7 +67,9 @@ describe('ssrf analyzer', () => {
               }
             })
 
-            clientRequest.destroy()
+            setImmediate(() => {
+              clientRequest.destroy()
+            })
           })
         }
 

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -329,6 +329,7 @@ describe('request', function () {
         host: 'test',
         port: 123,
         method: 'POST',
+        path: '/',
         headers: { 'Content-Type': 'text/plain; charset=utf-8' },
       },
       (err, res) => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes tests failing after node 24.15.0 were released.

Capabilities tests are failing as consequence of ( https://github.com/nodejs/node/pull/62030 ) which changed the way path defaults to '/' when not specified.

AppSec tests started failing as consequence of ( https://github.com/node/pull/61770 ) this change moved the registration of socket error listeners to an earlier step in the lifecycle. Combined with the test pattern of creating and rapidly destroying request, those listeners piled up on the same reused agent socket, excedding our low defaultMaxListeners threshold of 6.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


