### PR TITLE
fix(serverless): prevent serverless benchmarks on merges to release branches

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -142,6 +142,10 @@ benchmark-serverless-trigger:
   rules:
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
+
+    # dont run on merges to release branches (vN.x where N is any integer)
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^v\d+\.x$/'
+      when: never
     - interruptible: true
   trigger:
     project: DataDog/serverless-tools


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
prevents running serverless ci on merges to release branches.

### Motivation
<!-- What inspired you to submit this pull request? -->
serverless ci really only checks against main. Its not very compatible with release branches, especially older releases.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


