### PR TITLE
fix: fix AppSec http memory retention

### DIFF
--- a/packages/datadog-instrumentations/test/passport-http.spec.js
+++ b/packages/datadog-instrumentations/test/passport-http.spec.js
@@ -8,7 +8,7 @@ const { after, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage } = require('../../datadog-core')
+const { getActiveRequest } = require('../../dd-trace/src/appsec/store')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
 withVersions('passport-http', 'passport-http', version => {
@@ -185,7 +185,8 @@ withVersions('passport-http', 'passport-http', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage('legacy').getStore().req.res.writeHead(403).end('Blocked')
+        const req = getActiveRequest()
+        req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport-local.spec.js
+++ b/packages/datadog-instrumentations/test/passport-local.spec.js
@@ -8,7 +8,7 @@ const sinon = require('sinon')
 
 const axios = require('axios').create({ validateStatus: null })
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage } = require('../../datadog-core')
+const { getActiveRequest } = require('../../dd-trace/src/appsec/store')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
 withVersions('passport-local', 'passport-local', version => {
@@ -164,7 +164,8 @@ withVersions('passport-local', 'passport-local', version => {
 
     it('should block when subscriber aborts', async () => {
       subscriberStub = sinon.spy(({ abortController }) => {
-        storage('legacy').getStore().req.res.writeHead(403).end('Blocked')
+        const req = getActiveRequest()
+        req.res.writeHead(403).end('Blocked')
         abortController.abort()
       })
 

--- a/packages/datadog-instrumentations/test/passport.spec.js
+++ b/packages/datadog-instrumentations/test/passport.spec.js
@@ -7,7 +7,7 @@ const sinon = require('sinon')
 
 const axios = require('axios').create({ validateStatus: null })
 const agent = require('../../dd-trace/test/plugins/agent')
-const { storage } = require('../../datadog-core')
+const { getActiveRequest } = require('../../dd-trace/src/appsec/store')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
 const users = [
@@ -149,7 +149,8 @@ withVersions('passport', 'passport', version => {
       const cookie = login.headers['set-cookie'][0]
 
       subscriberStub.callsFake(({ abortController }) => {
-        const res = storage('legacy').getStore().req.res
+        const req = getActiveRequest()
+        const res = req.res
         res.writeHead(403)
         res.constructor.prototype.end.call(res, 'Blocked')
         abortController.abort()

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -2,9 +2,12 @@
 
 const ServerPlugin = require('../../dd-trace/src/plugins/server')
 const { storage } = require('../../datadog-core')
+const { withRequest } = require('../../dd-trace/src/appsec/store')
 const web = require('../../dd-trace/src/plugins/util/web')
 const { incomingHttpRequestStart, incomingHttpRequestEnd } = require('../../dd-trace/src/appsec/channels')
 const { COMPONENT, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
+
+const legacyStorage = storage('legacy')
 
 class HttpServerPlugin extends ServerPlugin {
   static id = 'http'
@@ -17,7 +20,7 @@ class HttpServerPlugin extends ServerPlugin {
   }
 
   start ({ req, res, abortController }) {
-    let store = storage('legacy').getStore()
+    let store = legacyStorage.getStore()
     const { name: schemaServiceName, source: schemaServiceSource } = this.serviceName()
     const service = this.config.service || schemaServiceName
     const serviceSource = (this.config.service && service !== this.tracer._service)
@@ -40,15 +43,13 @@ class HttpServerPlugin extends ServerPlugin {
     span._integrationName = this.constructor.id
 
     const context = web.getContext(req)
+    context.parentStore = store
 
-    if (context) {
-      context.parentStore = store
-    }
-
-    // AppSec, IAST, and AI Guard need req/res on the store so downstream
-    // subscribers can access them from the async context.
-    if (incomingHttpRequestStart.hasSubscribers) {
-      store = { ...store, req, res }
+    const appsecActive = incomingHttpRequestStart.hasSubscribers
+    if (appsecActive) {
+      // AppSec, IAST, and AI Guard need req on the store so downstream
+      // subscribers can access them from the async context.
+      store = withRequest(store, req)
     }
 
     this.enter(span, store)
@@ -58,7 +59,7 @@ class HttpServerPlugin extends ServerPlugin {
       context.instrumented = true
     }
 
-    if (incomingHttpRequestStart.hasSubscribers) {
+    if (appsecActive) {
       incomingHttpRequestStart.publish({ req, res, abortController }) // TODO: no need to make a new object here
     }
   }

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -7,6 +7,8 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
 
 const { incomingHttpRequestStart } = require('../../dd-trace/src/appsec/channels')
+const { storage } = require('../../datadog-core')
+const { getRequest } = require('../../dd-trace/src/appsec/store')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema } = require('../../dd-trace/test/setup/mocha')
 const { rawExpectedSchema } = require('./naming')
@@ -143,6 +145,28 @@ describe('Plugin', () => {
 
             const abortController = new AbortController()
             sinon.assert.calledOnceWithExactly(spy, { req, res, abortController }, incomingHttpRequestStart.name)
+
+            done()
+          }
+
+          axios.get(`http://localhost:${port}/user`).catch(done)
+        })
+
+        it('should preserve request access through child scope activation without strong fields', done => {
+          const spy = sinon.spy()
+          incomingHttpRequestStart.subscribe(spy)
+
+          app = (req, res) => {
+            const childSpan = tracer.startSpan('child')
+
+            tracer.scope().activate(childSpan, () => {
+              const store = storage('legacy').getStore()
+
+              sinon.assert.calledOnce(spy)
+              assert.strictEqual(getRequest(store), req)
+              assert.strictEqual(Object.hasOwn(store, 'req'), false)
+              assert.strictEqual(Object.hasOwn(store, 'res'), false)
+            })
 
             done()
           }

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -2,7 +2,7 @@
 
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
 const { HTTP_CLIENT_IP, NETWORK_CLIENT_IP } = require('../../../../ext/tags')
-const { storage } = require('../../../datadog-core')
+const { getActiveRequest } = require('../appsec/store')
 const log = require('../log')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const telemetryMetrics = require('../telemetry/metrics')
@@ -154,7 +154,7 @@ class AIGuard extends NoopAIGuard {
 
     if (!needsHttpClientIp && !needsNetworkClientIp) return
 
-    const req = storage('legacy').getStore()?.req
+    const req = getActiveRequest()
 
     if (!req) return
 

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { storage } = require('../../../datadog-core')
 const log = require('../log')
 const web = require('../plugins/util/web')
+const { getActiveRequest } = require('./store')
 const {
   addSpecificEndpoint,
   specificBlockingTypes,
@@ -33,7 +33,7 @@ function disable () {
 }
 
 function onGraphqlStartResolve ({ context, resolverInfo }) {
-  const req = storage('legacy').getStore()?.req
+  const req = getActiveRequest()
 
   if (!req) return
 
@@ -52,7 +52,7 @@ function onGraphqlStartResolve ({ context, resolverInfo }) {
 }
 
 function enterInApolloMiddleware (data) {
-  const req = data?.req || storage('legacy').getStore()?.req
+  const req = data?.req || getActiveRequest()
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -61,7 +61,7 @@ function enterInApolloMiddleware (data) {
 }
 
 function enterInApolloServerCoreRequest () {
-  const req = storage('legacy').getStore()?.req
+  const req = getActiveRequest()
   if (!req) return
 
   graphqlRequestData.set(req, {
@@ -71,7 +71,7 @@ function enterInApolloServerCoreRequest () {
 }
 
 function enterInApolloRequest () {
-  const req = storage('legacy').getStore()?.req
+  const req = getActiveRequest()
 
   const requestData = graphqlRequestData.get(req)
   if (requestData) {
@@ -83,7 +83,7 @@ function enterInApolloRequest () {
 }
 
 function beforeWriteApolloGraphqlResponse ({ abortController, abortData }) {
-  const req = storage('legacy').getStore()?.req
+  const req = getActiveRequest()
   if (!req) return
 
   const requestData = graphqlRequestData.get(req)

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -40,6 +40,7 @@ const Reporter = require('./reporter')
 const appsecTelemetry = require('./telemetry')
 const apiSecuritySampler = require('./api_security_sampler')
 const { isBlocked, block, callBlockDelegation, setTemplates, getBlockingAction } = require('./blocking')
+const { getActiveRequest, getRequest } = require('./store')
 const UserTracking = require('./user_tracking')
 const graphql = require('./graphql')
 const rasp = require('./rasp')
@@ -117,7 +118,7 @@ function onRequestBodyParsed ({ req, res, body, abortController }) {
 
   if (!req) {
     const store = storage('legacy').getStore()
-    req = store?.req
+    req = getRequest(store)
   }
 
   const rootSpan = web.root(req)
@@ -258,8 +259,8 @@ function incomingHttpEndTranslator ({ req, res }) {
 }
 
 function onPassportVerify ({ framework, login, user, success, abortController }) {
-  const store = storage('legacy').getStore()
-  const rootSpan = store?.req && web.root(store.req)
+  const req = getActiveRequest()
+  const rootSpan = req && web.root(req)
 
   if (!rootSpan) {
     log.warn('[ASM] No rootSpan found in onPassportVerify')
@@ -268,12 +269,12 @@ function onPassportVerify ({ framework, login, user, success, abortController })
 
   const results = UserTracking.trackLogin(framework, login, user, success, rootSpan)
 
-  handleResults(results?.actions, store.req, store.req.res, rootSpan, abortController)
+  handleResults(results?.actions, req, web.getContext(req)?.res, rootSpan, abortController)
 }
 
 function onPassportDeserializeUser ({ user, abortController }) {
-  const store = storage('legacy').getStore()
-  const rootSpan = store?.req && web.root(store.req)
+  const req = getActiveRequest()
+  const rootSpan = req && web.root(req)
 
   if (!rootSpan) {
     log.warn('[ASM] No rootSpan found in onPassportDeserializeUser')
@@ -282,7 +283,7 @@ function onPassportDeserializeUser ({ user, abortController }) {
 
   const results = UserTracking.trackUser(user, rootSpan)
 
-  handleResults(results?.actions, store.req, store.req.res, rootSpan, abortController)
+  handleResults(results?.actions, req, web.getContext(req)?.res, rootSpan, abortController)
 }
 
 function onExpressSession ({ req, res, sessionId, abortController }) {
@@ -309,7 +310,7 @@ function onRequestQueryParsed ({ req, res, query, abortController }) {
 
   if (!req) {
     const store = storage('legacy').getStore()
-    req = store?.req
+    req = getRequest(store)
   }
 
   const rootSpan = web.root(req)

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -4,7 +4,6 @@ const log = require('../log')
 const web = require('../plugins/util/web')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
-const { storage } = require('../../../datadog-core')
 const { IS_SERVERLESS } = require('../serverless')
 const RuleManager = require('./rule_manager')
 const appsecRemoteConfig = require('./remote_config')
@@ -40,7 +39,7 @@ const Reporter = require('./reporter')
 const appsecTelemetry = require('./telemetry')
 const apiSecuritySampler = require('./api_security_sampler')
 const { isBlocked, block, callBlockDelegation, setTemplates, getBlockingAction } = require('./blocking')
-const { getActiveRequest, getRequest } = require('./store')
+const { getActiveRequest } = require('./store')
 const UserTracking = require('./user_tracking')
 const graphql = require('./graphql')
 const rasp = require('./rasp')
@@ -117,8 +116,7 @@ function onRequestBodyParsed ({ req, res, body, abortController }) {
   if (body === undefined || body === null) return
 
   if (!req) {
-    const store = storage('legacy').getStore()
-    req = getRequest(store)
+    req = getActiveRequest()
   }
 
   const rootSpan = web.root(req)
@@ -309,8 +307,7 @@ function onRequestQueryParsed ({ req, res, query, abortController }) {
   if (!query || typeof query !== 'object') return
 
   if (!req) {
-    const store = storage('legacy').getStore()
-    req = getRequest(store)
+    req = getActiveRequest()
   }
 
   const rootSpan = web.root(req)

--- a/packages/dd-trace/src/appsec/rasp/command_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/command_injection.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const { childProcessExecutionTracingChannel } = require('../channels')
-const { storage } = require('../../../../datadog-core')
 const addresses = require('../addresses')
+const web = require('../../plugins/util/web')
+const { getActiveRequest } = require('../store')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
 
@@ -27,8 +28,7 @@ function disable () {
 function analyzeCommandInjection ({ file, fileArgs, shell, abortController }) {
   if (!file) return
 
-  const store = storage('legacy').getStore()
-  const req = store?.req
+  const req = getActiveRequest()
   if (!req) return
 
   const ephemeral = {}
@@ -46,8 +46,7 @@ function analyzeCommandInjection ({ file, fileArgs, shell, abortController }) {
 
   const result = waf.run({ ephemeral }, req, raspRule)
 
-  const res = store?.res
-  handleResult(result, req, res, abortController, config, raspRule)
+  handleResult(result, req, web.getContext(req)?.res, abortController, config, raspRule)
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -60,11 +60,11 @@ function analyzeLfiInResponseRender (ctx) {
 
 function analyzeLfi (ctx) {
   const store = storage('legacy').getStore()
-  if (!store) return
+  const fs = store?.fs
+  if (!fs) return
 
   const req = getRequest(store)
-  const fs = store.fs
-  if (!req || !fs) return
+  if (!req) return
 
   const res = web.getContext(req)?.res
   for (const path of getPaths(ctx, fs)) {

--- a/packages/dd-trace/src/appsec/rasp/lfi.js
+++ b/packages/dd-trace/src/appsec/rasp/lfi.js
@@ -4,7 +4,9 @@ const { isAbsolute } = require('path')
 
 const { fsOperationStart, incomingHttpRequestStart, expressResponseRenderStart } = require('../channels')
 const { storage } = require('../../../../datadog-core')
+const web = require('../../plugins/util/web')
 const { FS_OPERATION_PATH } = require('../addresses')
+const { getRequest } = require('../store')
 const waf = require('../waf')
 const { enable: enableFsPlugin, disable: disableFsPlugin, RASP_MODULE } = require('./fs-plugin')
 const { RULE_TYPES, handleResult } = require('./utils')
@@ -53,16 +55,18 @@ function analyzeLfiInResponseRender (ctx) {
   const store = storage('legacy').getStore()
   if (!store) return
 
-  analyzeLfiPath(ctx.view, ctx.req, store.res, ctx.abortController)
+  analyzeLfiPath(ctx.view, ctx.req, web.getContext(ctx.req)?.res, ctx.abortController)
 }
 
 function analyzeLfi (ctx) {
   const store = storage('legacy').getStore()
   if (!store) return
 
-  const { req, fs, res } = store
+  const req = getRequest(store)
+  const fs = store.fs
   if (!req || !fs) return
 
+  const res = web.getContext(req)?.res
   for (const path of getPaths(ctx, fs)) {
     analyzeLfiPath(path, req, res, ctx.abortController)
   }

--- a/packages/dd-trace/src/appsec/rasp/sql_injection.js
+++ b/packages/dd-trace/src/appsec/rasp/sql_injection.js
@@ -6,8 +6,9 @@ const {
   wafRunFinished,
   mysql2OuterQueryStart,
 } = require('../channels')
-const { storage } = require('../../../../datadog-core')
 const addresses = require('../addresses')
+const web = require('../../plugins/util/web')
+const { getActiveRequest } = require('../store')
 const waf = require('../waf')
 const { RULE_TYPES, handleResult } = require('./utils')
 
@@ -49,10 +50,7 @@ function analyzePgSqlInjection (ctx) {
 }
 
 function analyzeSqlInjection (query, dbSystem, abortController) {
-  const store = storage('legacy').getStore()
-  if (!store) return
-
-  const { req, res } = store
+  const req = getActiveRequest()
 
   if (!req) return
 
@@ -76,7 +74,7 @@ function analyzeSqlInjection (query, dbSystem, abortController) {
 
   const result = waf.run({ ephemeral }, req, raspRule)
 
-  handleResult(result, req, res, abortController, config, raspRule)
+  handleResult(result, req, web.getContext(req)?.res, abortController, config, raspRule)
 }
 
 function hasInputAddress (payload) {
@@ -91,10 +89,7 @@ function hasAddressesObjectInputAddress (addressesObject) {
 function clearQuerySet ({ payload }) {
   if (!payload) return
 
-  const store = storage('legacy').getStore()
-  if (!store) return
-
-  const { req } = store
+  const req = getActiveRequest()
   if (!req) return
 
   const executedQueries = reqQueryMap.get(req)

--- a/packages/dd-trace/src/appsec/rasp/ssrf.js
+++ b/packages/dd-trace/src/appsec/rasp/ssrf.js
@@ -5,8 +5,9 @@ const {
   httpClientRequestStart,
   httpClientResponseFinish,
 } = require('../channels')
-const { storage } = require('../../../../datadog-core')
 const addresses = require('../addresses')
+const web = require('../../plugins/util/web')
+const { getActiveRequest } = require('../store')
 const waf = require('../waf')
 const downstream = require('../downstream_requests')
 const { updateRaspRuleMatchMetricTags } = require('../telemetry')
@@ -30,8 +31,7 @@ function disable () {
 }
 
 function analyzeSsrf (ctx) {
-  const store = storage('legacy').getStore()
-  const req = store?.req
+  const req = getActiveRequest()
   const outgoingUrl = (ctx.args.options?.uri && format(ctx.args.options.uri)) ?? ctx.args.uri
 
   if (!req || !outgoingUrl) return
@@ -50,7 +50,7 @@ function analyzeSsrf (ctx) {
 
   const result = waf.run({ ephemeral }, req, raspRule)
 
-  handleResult(result, req, store?.res, ctx.abortController, config, raspRule)
+  handleResult(result, req, web.getContext(req)?.res, ctx.abortController, config, raspRule)
 
   downstream.incrementDownstreamAnalysisCount(req)
 }
@@ -67,8 +67,7 @@ function handleResponseFinish ({ ctx, res, body }) {
   // downstream response object
   if (!res) return
 
-  const store = storage('legacy').getStore()
-  const originatingRequest = store?.req
+  const originatingRequest = getActiveRequest()
   if (!originatingRequest) return
 
   // Skip body analysis for redirect responses

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -4,11 +4,11 @@ const zlib = require('zlib')
 const dc = require('dc-polyfill')
 
 const { NETWORK_CLIENT_IP } = require('../../../../ext/tags')
-const { storage } = require('../../../datadog-core')
 const web = require('../plugins/util/web')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
 const { keepTrace } = require('../priority_sampler')
 const { ASM } = require('../standalone/product')
+const { getActiveRequest } = require('./store')
 const {
   incrementWafInitMetric,
   incrementWafUpdatesMetric,
@@ -303,7 +303,7 @@ function reportWafConfigUpdate (product, rcConfigId, diagnostics, wafVersion) {
 
 function reportMetrics (metrics, raspRule, req) {
   if (!req) {
-    req = storage('legacy').getStore()?.req
+    req = getActiveRequest()
   }
   const rootSpan = req && web.root(req)
 
@@ -338,7 +338,7 @@ function reportTruncationMetrics (rootSpan, metrics) {
 
 function reportAttack ({ events: attackData, actions }, req) {
   if (!req) {
-    req = storage('legacy').getStore()?.req
+    req = getActiveRequest()
   }
 
   const rootSpan = web.root(req)
@@ -482,7 +482,7 @@ function reportAttributes (attributes, req) {
   if (!attributes) return
 
   if (!req) {
-    req = storage('legacy').getStore()?.req
+    req = getActiveRequest()
   }
 
   const rootSpan = web.root(req)

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -3,8 +3,9 @@
 const { USER_ID } = require('../addresses')
 const waf = require('../waf')
 const { block, getBlockingAction } = require('../blocking')
-const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
+const web = require('../../plugins/util/web')
+const { getActiveRequest } = require('../store')
 const { setUserTags } = require('./set_user')
 const { getRootSpan } = require('./utils')
 
@@ -32,13 +33,8 @@ function checkUserAndSetUser (tracer, user) {
 }
 
 function blockRequest (tracer, req, res) {
-  if (!req || !res) {
-    const store = storage('legacy').getStore()
-    if (store) {
-      req = req || store.req
-      res = res || store.res
-    }
-  }
+  req ||= getActiveRequest()
+  res ||= req && web.getContext(req)?.res
 
   if (!req || !res) {
     log.warn('[ASM] Requests or response object not available in blockRequest')

--- a/packages/dd-trace/src/appsec/store.js
+++ b/packages/dd-trace/src/appsec/store.js
@@ -2,7 +2,6 @@
 
 const { storage } = require('../../../datadog-core')
 
-// The legacy storage is a singleton, so resolve it once at module load.
 const legacyStorage = storage('legacy')
 
 const kReq = Symbol('dd-trace.appsec.req')
@@ -36,8 +35,7 @@ function getRequest (store) {
 
 /**
  * Resolve the inbound request attached to the currently active legacy store.
- * Shortcut for `getRequest(storage('legacy').getStore())`, implemented with
- * a single optional chain so it stays cheap in AppSec hot paths.
+ * Shortcut for `getRequest(storage('legacy').getStore())`.
  *
  * @returns {object|undefined}
  */

--- a/packages/dd-trace/src/appsec/store.js
+++ b/packages/dd-trace/src/appsec/store.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { storage } = require('../../../datadog-core')
+
+// The legacy storage is a singleton, so resolve it once at module load.
+const legacyStorage = storage('legacy')
+
+const kReq = Symbol('dd-trace.appsec.req')
+
+/**
+ * Return a new legacy-storage clone that weakly references `req`.
+ *
+ * The ref lives on an enumerable symbol key so it survives the
+ * `{ ...store, span }` spreads performed by plugin scope handling,
+ * while still allowing `req` (and therefore `res`) to be garbage
+ * collected once the request is done.
+ *
+ * @param {object|undefined} store
+ * @param {object} req
+ * @returns {object}
+ */
+function withRequest (store, req) {
+  return { ...store, [kReq]: new WeakRef(req) }
+}
+
+/**
+ * Resolve the inbound request attached to a specific legacy store.
+ * Prefer {@link getActiveRequest} unless you already have a store in hand.
+ *
+ * @param {object|undefined} store
+ * @returns {object|undefined}
+ */
+function getRequest (store) {
+  return store?.[kReq]?.deref()
+}
+
+/**
+ * Resolve the inbound request attached to the currently active legacy store.
+ * Shortcut for `getRequest(storage('legacy').getStore())`, implemented with
+ * a single optional chain so it stays cheap in AppSec hot paths.
+ *
+ * @returns {object|undefined}
+ */
+function getActiveRequest () {
+  return legacyStorage.getStore()?.[kReq]?.deref()
+}
+
+module.exports = {
+  withRequest,
+  getRequest,
+  getActiveRequest,
+}

--- a/packages/dd-trace/src/appsec/waf/index.js
+++ b/packages/dd-trace/src/appsec/waf/index.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 const Reporter = require('../reporter')
 const Limiter = require('../../rate_limiter')
 const { keepTrace } = require('../../priority_sampler')
 const { ASM } = require('../../standalone/product')
 const web = require('../../plugins/util/web')
+const { getActiveRequest } = require('../store')
 const { updateRateLimitedMetric } = require('../telemetry')
 
 class WafUpdateError extends Error {
@@ -112,13 +112,11 @@ function removeConfig (configPath) {
 
 function run (data, req, raspRule) {
   if (!req) {
-    const store = storage('legacy').getStore()
-    if (!store || !store.req) {
+    req = getActiveRequest()
+    if (!req) {
       log.warn('[ASM] Request object not available in waf.run')
       return
     }
-
-    req = store.req
   }
 
   const wafContext = waf.wafManager.getWAFContext(req)

--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -51,6 +51,8 @@ module.exports = {
     const trackEventLoop = config.runtimeMetrics.eventLoop !== false
     const trackGc = config.runtimeMetrics.gc !== false
 
+    client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
+
     if (trackGc) {
       startGCObserver()
     }
@@ -71,8 +73,6 @@ module.exports = {
         nativeMetrics = null
       }
     }
-
-    client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
 
     lastTime = performance.now()
 

--- a/packages/dd-trace/test/appsec/graphql.spec.js
+++ b/packages/dd-trace/test/appsec/graphql.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 
 const { storage } = require('../../../datadog-core')
 const addresses = require('../../src/appsec/addresses')
+const { withRequest } = require('../../src/appsec/store')
 const waf = require('../../src/appsec/waf')
 const web = require('../../src/plugins/util/web')
 const {
@@ -101,7 +102,7 @@ describe('GraphQL', () => {
   describe('onGraphqlStartResolve', () => {
     beforeEach(() => {
       sinon.stub(waf, 'run').returns([''])
-      sinon.stub(storage('legacy'), 'getStore').returns({ req: {} })
+      sinon.stub(storage('legacy'), 'getStore').returns(withRequest(undefined, {}))
       sinon.stub(web, 'root').returns({})
       graphql.enable()
     })
@@ -137,7 +138,7 @@ describe('GraphQL', () => {
         user: [{ id: '1234' }],
       }
 
-      storage('legacy').getStore().req = undefined
+      storage('legacy').getStore.returns({})
 
       startGraphqlResolve.publish({ context, resolverInfo })
 
@@ -176,7 +177,7 @@ describe('GraphQL', () => {
     let context, rootSpan
 
     beforeEach(() => {
-      sinon.stub(storage('legacy'), 'getStore').returns({ req, res })
+      sinon.stub(storage('legacy'), 'getStore').returns(withRequest(undefined, req))
 
       graphql.enable()
       graphqlMiddlewareChannel.start.publish({ req, res })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -34,6 +34,7 @@ const agent = require('../plugins/agent')
 const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../../src/telemetry/metrics')
 const addresses = require('../../src/appsec/addresses')
+const { withRequest } = require('../../src/appsec/store')
 const { getConfigFresh } = require('../helpers/config')
 const { blockedTemplateHtml, blockedTemplateJson, setTestBlockingTemplates } = require('./utils')
 
@@ -1107,7 +1108,8 @@ describe('AppSec Index', function () {
 
     describe('onPassportVerify', () => {
       beforeEach(() => {
-        sinon.stub(storage('legacy'), 'getStore').returns({ req })
+        web.getContext.withArgs(req).returns({ res })
+        sinon.stub(storage('legacy'), 'getStore').returns(withRequest(undefined, req))
       })
 
       it('should block when UserTracking.trackLogin() returns action', () => {
@@ -1188,7 +1190,8 @@ describe('AppSec Index', function () {
 
     describe('onPassportDeserializeUser', () => {
       beforeEach(() => {
-        sinon.stub(storage('legacy'), 'getStore').returns({ req })
+        web.getContext.withArgs(req).returns({ res })
+        sinon.stub(storage('legacy'), 'getStore').returns(withRequest(undefined, req))
       })
 
       it('should block when UserTracking.trackUser() returns action', () => {

--- a/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/command_injection.spec.js
@@ -3,19 +3,22 @@
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { storage } = require('../../../../datadog-core')
 const addresses = require('../../../src/appsec/addresses')
 const { childProcessExecutionTracingChannel } = require('../../../src/appsec/channels')
+const { withRequest } = require('../../../src/appsec/store')
+const web = require('../../../src/plugins/util/web')
 
 const { start } = childProcessExecutionTracingChannel
 
 describe('RASP - command_injection.js', () => {
-  let waf, legacyStorage, commandInjection, utils, config
+  let waf, commandInjection, utils, config
+
+  const enterStore = (store) => {
+    storage('legacy').enterWith(store)
+  }
 
   beforeEach(() => {
-    legacyStorage = {
-      getStore: sinon.stub(),
-    }
-
     waf = {
       run: sinon.stub(),
     }
@@ -25,7 +28,6 @@ describe('RASP - command_injection.js', () => {
     }
 
     commandInjection = proxyquire('../../../src/appsec/rasp/command_injection', {
-      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf,
       './utils': utils,
     })
@@ -46,6 +48,7 @@ describe('RASP - command_injection.js', () => {
   afterEach(() => {
     sinon.restore()
     commandInjection.disable()
+    enterStore({})
   })
 
   describe('analyzeCommandInjection', () => {
@@ -55,7 +58,7 @@ describe('RASP - command_injection.js', () => {
         file: 'cmd',
       }
       const req = {}
-      legacyStorage.getStore.returns({ req })
+      enterStore(withRequest(undefined, req))
 
       start.publish(ctx)
 
@@ -66,7 +69,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd',
       }
-      legacyStorage.getStore.returns(undefined)
+      enterStore(undefined)
 
       start.publish(ctx)
 
@@ -77,7 +80,7 @@ describe('RASP - command_injection.js', () => {
       const ctx = {
         file: 'cmd',
       }
-      legacyStorage.getStore.returns({})
+      enterStore({})
 
       start.publish(ctx)
 
@@ -89,7 +92,7 @@ describe('RASP - command_injection.js', () => {
         fileArgs: ['arg0'],
       }
       const req = {}
-      legacyStorage.getStore.returns({ req })
+      enterStore(withRequest(undefined, req))
 
       start.publish(ctx)
 
@@ -103,7 +106,7 @@ describe('RASP - command_injection.js', () => {
           shell: true,
         }
         const req = {}
-        legacyStorage.getStore.returns({ req })
+        enterStore(withRequest(undefined, req))
 
         start.publish(ctx)
 
@@ -120,7 +123,7 @@ describe('RASP - command_injection.js', () => {
           shell: true,
         }
         const req = {}
-        legacyStorage.getStore.returns({ req })
+        enterStore(withRequest(undefined, req))
 
         start.publish(ctx)
 
@@ -138,7 +141,8 @@ describe('RASP - command_injection.js', () => {
         const res = { res: 'res' }
         const raspRule = { type: 'command_injection', variant: 'shell' }
         waf.run.returns(wafResult)
-        legacyStorage.getStore.returns({ req, res })
+        web.patch(req).res = res
+        enterStore(withRequest(undefined, req))
 
         start.publish(ctx)
 
@@ -153,7 +157,7 @@ describe('RASP - command_injection.js', () => {
           shell: false,
         }
         const req = {}
-        legacyStorage.getStore.returns({ req })
+        enterStore(withRequest(undefined, req))
 
         start.publish(ctx)
 
@@ -170,7 +174,7 @@ describe('RASP - command_injection.js', () => {
           shell: false,
         }
         const req = {}
-        legacyStorage.getStore.returns({ req })
+        enterStore(withRequest(undefined, req))
 
         start.publish(ctx)
 
@@ -188,7 +192,8 @@ describe('RASP - command_injection.js', () => {
         const res = { res: 'res' }
         const raspRule = { type: 'command_injection', variant: 'exec' }
         waf.run.returns(wafResult)
-        legacyStorage.getStore.returns({ req, res })
+        web.patch(req).res = res
+        enterStore(withRequest(undefined, req))
 
         start.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/lfi.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/lfi.spec.js
@@ -5,18 +5,16 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
+const { storage } = require('../../../../datadog-core')
 const { fsOperationStart, incomingHttpRequestStart } = require('../../../src/appsec/channels')
 const { FS_OPERATION_PATH } = require('../../../src/appsec/addresses')
 const { RASP_MODULE } = require('../../../src/appsec/rasp/fs-plugin')
+const { withRequest } = require('../../../src/appsec/store')
 
 describe('RASP - lfi.js', () => {
-  let waf, legacyStorage, lfi, web, blocking, appsecFsPlugin, config
+  let waf, lfi, web, blocking, appsecFsPlugin, config
 
   beforeEach(() => {
-    legacyStorage = {
-      getStore: sinon.stub(),
-    }
-
     waf = {
       run: sinon.stub(),
     }
@@ -35,7 +33,6 @@ describe('RASP - lfi.js', () => {
     }
 
     lfi = proxyquire('../../../src/appsec/rasp/lfi', {
-      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf,
       '../../plugins/util/web': web,
       '../blocking': blocking,
@@ -56,6 +53,7 @@ describe('RASP - lfi.js', () => {
   afterEach(() => {
     sinon.restore()
     lfi.disable()
+    storage('legacy').enterWith({})
   })
 
   describe('enable', () => {
@@ -107,7 +105,7 @@ describe('RASP - lfi.js', () => {
 
     it('should analyze lfi for root fs operations', () => {
       const fs = { root: true }
-      legacyStorage.getStore.returns({ req, fs })
+      storage('legacy').enterWith(withRequest({ fs }, req))
 
       fsOperationStart.publish(ctx)
 
@@ -117,7 +115,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for child fs operations', () => {
       const fs = {}
-      legacyStorage.getStore.returns({ req, fs })
+      storage('legacy').enterWith(withRequest({ fs }, req))
 
       fsOperationStart.publish(ctx)
 
@@ -126,7 +124,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for undefined fs (AppsecFsPlugin disabled)', () => {
       const fs = undefined
-      legacyStorage.getStore.returns({ req, fs })
+      storage('legacy').enterWith(withRequest({ fs }, req))
 
       fsOperationStart.publish(ctx)
 
@@ -135,7 +133,7 @@ describe('RASP - lfi.js', () => {
 
     it('should NOT analyze lfi for excluded operations', () => {
       const fs = { opExcluded: true, root: true }
-      legacyStorage.getStore.returns({ req, fs })
+      storage('legacy').enterWith(withRequest({ fs }, req))
 
       fsOperationStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/sql_injection.spec.js
@@ -3,23 +3,24 @@
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
+const { storage } = require('../../../../datadog-core')
 const { pgQueryStart, mysql2OuterQueryStart } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
+const { withRequest } = require('../../../src/appsec/store')
 
 describe('RASP - sql_injection', () => {
-  let waf, legacyStorage, sqli
+  let waf, sqli
+
+  const enterStore = (store) => {
+    storage('legacy').enterWith(store)
+  }
 
   beforeEach(() => {
-    legacyStorage = {
-      getStore: sinon.stub(),
-    }
-
     waf = {
       run: sinon.stub(),
     }
 
     sqli = proxyquire('../../../src/appsec/rasp/sql_injection', {
-      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf,
     })
 
@@ -39,6 +40,7 @@ describe('RASP - sql_injection', () => {
   afterEach(() => {
     sinon.restore()
     sqli.disable()
+    enterStore({})
   })
 
   describe('analyzePgSqlInjection', () => {
@@ -49,7 +51,7 @@ describe('RASP - sql_injection', () => {
         },
       }
       const req = {}
-      legacyStorage.getStore.returns({ req })
+      enterStore(withRequest(undefined, req))
 
       pgQueryStart.publish(ctx)
 
@@ -69,7 +71,7 @@ describe('RASP - sql_injection', () => {
         },
       }
       const req = {}
-      legacyStorage.getStore.returns({ req })
+      enterStore(withRequest(undefined, req))
 
       pgQueryStart.publish(ctx)
 
@@ -82,7 +84,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1',
         },
       }
-      legacyStorage.getStore.returns(undefined)
+      enterStore(undefined)
 
       pgQueryStart.publish(ctx)
 
@@ -95,7 +97,7 @@ describe('RASP - sql_injection', () => {
           text: 'SELECT 1',
         },
       }
-      legacyStorage.getStore.returns({})
+      enterStore({})
 
       pgQueryStart.publish(ctx)
 
@@ -106,7 +108,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         query: {},
       }
-      legacyStorage.getStore.returns({})
+      enterStore({})
 
       pgQueryStart.publish(ctx)
 
@@ -120,7 +122,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1',
       }
       const req = {}
-      legacyStorage.getStore.returns({ req })
+      enterStore(withRequest(undefined, req))
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -138,7 +140,7 @@ describe('RASP - sql_injection', () => {
         sql: 'SELECT 1',
       }
       const req = {}
-      legacyStorage.getStore.returns({ req })
+      enterStore(withRequest(undefined, req))
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -149,7 +151,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1',
       }
-      legacyStorage.getStore.returns(undefined)
+      enterStore(undefined)
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -160,7 +162,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1',
       }
-      legacyStorage.getStore.returns({})
+      enterStore({})
 
       mysql2OuterQueryStart.publish(ctx)
 
@@ -171,7 +173,7 @@ describe('RASP - sql_injection', () => {
       const ctx = {
         sql: 'SELECT 1',
       }
-      legacyStorage.getStore.returns({})
+      enterStore({})
 
       mysql2OuterQueryStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/ssrf.spec.js
@@ -5,17 +5,18 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
+const { storage } = require('../../../../datadog-core')
 const {
   httpClientRequestStart,
   httpClientResponseFinish,
 } = require('../../../src/appsec/channels')
 const addresses = require('../../../src/appsec/addresses')
+const { withRequest } = require('../../../src/appsec/store')
 
 const DEFAULT_URL = 'http://example.com'
 
 describe('RASP - ssrf.js', () => {
   let waf
-  let legacyStorage
   let downstream
   let ssrf
   let telemetry
@@ -30,8 +31,12 @@ describe('RASP - ssrf.js', () => {
   })
 
   const stubStore = (req = {}, res = {}) => {
-    legacyStorage.getStore.returns({ req, res })
+    storage('legacy').enterWith(req ? withRequest(undefined, req) : {})
     return { req, res }
+  }
+
+  const clearStore = () => {
+    storage('legacy').enterWith({})
   }
 
   const publishRequestStart = ({ ctx, includeBodies = false, requestAddresses = {} }) => {
@@ -48,10 +53,6 @@ describe('RASP - ssrf.js', () => {
   }
 
   beforeEach(() => {
-    legacyStorage = {
-      getStore: sinon.stub(),
-    }
-
     waf = {
       run: sinon.stub(),
     }
@@ -72,7 +73,6 @@ describe('RASP - ssrf.js', () => {
     }
 
     ssrf = proxyquire('../../../src/appsec/rasp/ssrf', {
-      '../../../../datadog-core': { storage: () => legacyStorage },
       '../waf': waf,
       '../downstream_requests': downstream,
       '../telemetry': telemetry,
@@ -94,6 +94,7 @@ describe('RASP - ssrf.js', () => {
   afterEach(() => {
     sinon.restore()
     ssrf.disable()
+    clearStore()
   })
 
   describe('analyzeSsrf', () => {
@@ -133,7 +134,7 @@ describe('RASP - ssrf.js', () => {
 
     it('should not analyze ssrf if no store', () => {
       const ctx = makeCtx()
-      legacyStorage.getStore.returns(undefined)
+      clearStore()
 
       httpClientRequestStart.publish(ctx)
 

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -11,6 +11,7 @@ const sinon = require('sinon')
 const { USER_KEEP } = require('../../../../ext/priority')
 const { storage } = require('../../../datadog-core')
 const { ASM } = require('../../src/standalone/product')
+const { withRequest } = require('../../src/appsec/store')
 const { getConfigFresh } = require('../helpers/config')
 function getAppSecConfig (options) {
   return getConfigFresh({ appsec: options }).appsec
@@ -183,7 +184,7 @@ describe('reporter', () => {
 
     beforeEach(() => {
       req = {}
-      storage('legacy').enterWith({ req })
+      storage('legacy').enterWith(withRequest(undefined, req))
     })
 
     afterEach(() => {
@@ -221,11 +222,10 @@ describe('reporter', () => {
 
     it('should call updateWafRequestsMetricTags', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage('legacy').getStore()
 
       Reporter.reportMetrics(metrics)
 
-      sinon.assert.calledOnceWithExactly(telemetry.updateWafRequestsMetricTags, metrics, store.req)
+      sinon.assert.calledOnceWithExactly(telemetry.updateWafRequestsMetricTags, metrics, req)
       sinon.assert.notCalled(telemetry.updateRaspRequestsMetricTags)
     })
 
@@ -290,13 +290,12 @@ describe('reporter', () => {
 
     it('should call updateRaspRequestsMetricTags when raspRule is provided', () => {
       const metrics = { rulesVersion: '1.2.3' }
-      const store = storage('legacy').getStore()
 
       const raspRule = { type: 'rule_type', variant: 'rule_variant' }
 
       Reporter.reportMetrics(metrics, raspRule)
 
-      sinon.assert.calledOnceWithExactly(telemetry.updateRaspRequestsMetricTags, metrics, store.req, raspRule)
+      sinon.assert.calledOnceWithExactly(telemetry.updateRaspRequestsMetricTags, metrics, req, raspRule)
       sinon.assert.notCalled(telemetry.updateWafRequestsMetricTags)
     })
   })
@@ -380,7 +379,7 @@ describe('reporter', () => {
           'user-agent': 'arachni',
         },
       }
-      storage('legacy').enterWith({ req })
+      storage('legacy').enterWith(withRequest(undefined, req))
     })
 
     afterEach(() => {

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -6,8 +6,11 @@ const { before, beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
+const { storage } = require('../../../../datadog-core')
 const { USER_ID } = require('../../../src/appsec/addresses')
 const waf = require('../../../src/appsec/waf')
+const { withRequest } = require('../../../src/appsec/store')
+const web = require('../../../src/plugins/util/web')
 const resultActions = {
   actions: {
     block_request: {
@@ -23,7 +26,7 @@ describe('user_blocking - Internal API', () => {
   const res = { headersSent: false }
   const tracer = {}
 
-  let rootSpan, getRootSpan, block, legacyStorage, log, userBlocking
+  let rootSpan, getRootSpan, block, log, userBlocking
 
   before(() => {
     const runStub = sinon.stub(waf, 'run')
@@ -42,9 +45,8 @@ describe('user_blocking - Internal API', () => {
 
     block = sinon.stub().returns(true)
 
-    legacyStorage = {
-      getStore: sinon.stub().returns({ req, res }),
-    }
+    web.patch(req).res = res
+    storage('legacy').enterWith(withRequest(undefined, req))
 
     log = {
       warn: sinon.stub(),
@@ -53,9 +55,12 @@ describe('user_blocking - Internal API', () => {
     userBlocking = proxyquire('../../../src/appsec/sdk/user_blocking', {
       './utils': { getRootSpan },
       '../blocking': { block },
-      '../../../../datadog-core': { storage: () => legacyStorage },
       '../../log': log,
     })
+  })
+
+  afterEach(() => {
+    storage('legacy').enterWith({})
   })
 
   describe('checkUserAndSetUser', () => {
@@ -112,16 +117,14 @@ describe('user_blocking - Internal API', () => {
     it('should get req and res from local storage when they are not passed', () => {
       const ret = userBlocking.blockRequest(tracer)
       assert.strictEqual(ret, true)
-      sinon.assert.calledOnce(legacyStorage.getStore)
       sinon.assert.calledOnceWithExactly(block, req, res, rootSpan)
     })
 
     it('should log warning when req or res is not available', () => {
-      legacyStorage.getStore.returns(undefined)
+      storage('legacy').enterWith({})
 
       const ret = userBlocking.blockRequest(tracer)
       assert.strictEqual(ret, false)
-      sinon.assert.calledOnce(legacyStorage.getStore)
       sinon.assert.calledOnceWithExactly(log.warn, '[ASM] Requests or response object not available in blockRequest')
       sinon.assert.notCalled(block)
     })

--- a/packages/dd-trace/test/appsec/store.spec.js
+++ b/packages/dd-trace/test/appsec/store.spec.js
@@ -1,0 +1,117 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { setTimeout: wait } = require('node:timers/promises')
+
+const { describe, it } = require('mocha')
+
+require('../setup/core')
+const { storage } = require('../../../datadog-core')
+const DatadogTracer = require('../../src/tracer')
+const web = require('../../src/plugins/util/web')
+const { getConfigFresh } = require('../helpers/config')
+const { getActiveRequest, getRequest, withRequest } = require('../../src/appsec/store')
+
+const gc = global.gc
+
+describe('AppSec store', () => {
+  describe('withRequest', () => {
+    it('should preserve weak request access through nested span stores', () => {
+      const tracer = new DatadogTracer(getConfigFresh({
+        enabled: true,
+      }))
+      const req = {}
+      const res = { req }
+
+      web.patch(req).res = res
+      const store = withRequest(undefined, req)
+
+      storage('legacy').enterWith(store)
+
+      tracer.trace('root', {}, rootSpan => {
+        const rootStore = storage('legacy').getStore()
+        assert.strictEqual(getRequest(rootStore), req)
+
+        tracer.trace('child', {}, childSpan => {
+          const childStore = storage('legacy').getStore()
+
+          assert.notStrictEqual(childStore, rootStore)
+          assert.strictEqual(getRequest(childStore), req)
+          assert.strictEqual(childStore.span, childSpan)
+        })
+
+        assert.strictEqual(storage('legacy').getStore().span, rootSpan)
+      })
+    })
+
+    it('should not expose req or res as own enumerable properties', () => {
+      const req = {}
+      const res = { req }
+
+      web.patch(req).res = res
+      const store = withRequest(undefined, req)
+
+      assert.strictEqual(getRequest(store), req)
+      assert.strictEqual(Object.hasOwn(store, 'req'), false)
+      assert.strictEqual(Object.hasOwn(store, 'res'), false)
+    })
+  })
+
+  describe('getActiveRequest', () => {
+    it('should resolve the request from the current legacy store', () => {
+      const req = {}
+      web.patch(req)
+
+      storage('legacy').enterWith(withRequest(undefined, req))
+
+      assert.strictEqual(getActiveRequest(), req)
+    })
+
+    it('should return undefined when no request is attached', () => {
+      storage('legacy').enterWith({})
+
+      assert.strictEqual(getActiveRequest(), undefined)
+    })
+
+    it('should allow the request to be collected even if a cloned child store remains alive', async function () {
+      if (typeof gc !== 'function') this.skip()
+
+      this.timeout(10000)
+
+      const tracer = new DatadogTracer(getConfigFresh({
+        enabled: true,
+      }))
+      let childStore
+      let requestWasCollected = false
+      const finalizationRegistry = new FinalizationRegistry(() => {
+        requestWasCollected = true
+      })
+
+      ;(() => {
+        const req = {}
+        const res = { req }
+        finalizationRegistry.register(req, 'request')
+        web.patch(req).res = res
+
+        storage('legacy').enterWith(withRequest(undefined, req))
+
+        tracer.trace('root', {}, () => {
+          tracer.trace('child', {}, () => {
+            childStore = storage('legacy').getStore()
+            assert.strictEqual(getRequest(childStore), req)
+          })
+        })
+      })()
+
+      // requestWasCollected is updated from the FinalizationRegistry callback.
+      // eslint-disable-next-line no-unmodified-loop-condition
+      for (let i = 0; i < 5 && !requestWasCollected; i++) {
+        gc()
+        await wait(100)
+      }
+
+      assert.strictEqual(requestWasCollected, true)
+      assert.strictEqual(getRequest(childStore), undefined)
+    })
+  })
+})


### PR DESCRIPTION
When AppSec is active, http calls have a long memory retention due
to a strong reference behind held. That reference is freed at the
end of a span for example, but it takes additional time and shows
in many memory profiles.

Fix that by using a weak reference and a specific handling to
circumvent that retention issue.