### PR TITLE
feat(otel): forward getActiveSpan() writes onto the active Datadog span

### DIFF
--- a/packages/dd-trace/src/opentelemetry/active-span-proxy.js
+++ b/packages/dd-trace/src/opentelemetry/active-span-proxy.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const BridgeSpanBase = require('./bridge-span-base')
+const { setOtelResource } = require('./span-helpers')
+
+/**
+ * OTel `Span`-compatible proxy around an already-active Datadog span.
+ *
+ * Makes `trace.getActiveSpan()` forward attribute/link/event/status/exception writes onto
+ * the Datadog span. `end()` is intentionally a no-op: the span's lifecycle belongs to
+ * whoever created it. Mutation methods all bail out once the underlying Datadog span has
+ * finished (gated inside the helpers), matching OTel `Span` semantics.
+ */
+class ActiveSpanProxy extends BridgeSpanBase {
+  /** @type {import('./span_context')} */
+  #otelSpanContext
+
+  /**
+   * @param {import('../opentracing/span')} ddSpan
+   * @param {import('./span_context')} otelSpanContext
+   */
+  constructor (ddSpan, otelSpanContext) {
+    super(ddSpan)
+    this.#otelSpanContext = otelSpanContext
+  }
+
+  spanContext () {
+    return this.#otelSpanContext
+  }
+
+  /**
+   * @param {string} name
+   */
+  updateName (name) {
+    setOtelResource(this._ddSpan, name)
+    return this
+  }
+
+  end () {}
+}
+
+module.exports = ActiveSpanProxy

--- a/packages/dd-trace/src/opentelemetry/bridge-span-base.js
+++ b/packages/dd-trace/src/opentelemetry/bridge-span-base.js
@@ -1,0 +1,106 @@
+'use strict'
+
+const {
+  addOtelEvent,
+  addOtelLink,
+  addOtelLinks,
+  applyOtelStatus,
+  recordException,
+  setOtelAttribute,
+  setOtelAttributes,
+} = require('./span-helpers')
+
+/**
+ * Shared base for the OTel-bridge span classes (`Span` and `ActiveSpanProxy`). Subclasses
+ * pass the underlying Datadog span to `super(ddSpan)` and provide `spanContext()`, `end()`,
+ * and `updateName()`. The writable-span gate lives in the helpers in `span-helpers.js`,
+ * so neither bridge can drift from it.
+ *
+ * `_ddSpan` is left as a `_underscore` field rather than `#private` so the bridge does not
+ * expand its published API to expose the underlying DD span. External callers that need
+ * the reference (`ContextManager` proxy-cache check, OTLP serialization, tests) reach in
+ * via `_ddSpan`, matching the existing convention for "internal, may break".
+ */
+class BridgeSpanBase {
+  // OTel SpanStatusCode: 0 = UNSET, 1 = OK, 2 = ERROR. Tracked for OK-is-final precedence.
+  #statusCode = 0
+
+  /**
+   * @param {import('../opentracing/span')} ddSpan
+   */
+  constructor (ddSpan) {
+    this._ddSpan = ddSpan
+  }
+
+  get ended () {
+    return this._ddSpan._duration !== undefined
+  }
+
+  isRecording () {
+    return !this.ended
+  }
+
+  /**
+   * @param {string} key
+   * @param {import('@opentelemetry/api').AttributeValue} value
+   */
+  setAttribute (key, value) {
+    setOtelAttribute(this._ddSpan, key, value)
+    return this
+  }
+
+  /**
+   * @param {import('@opentelemetry/api').Attributes} attributes
+   */
+  setAttributes (attributes) {
+    setOtelAttributes(this._ddSpan, attributes)
+    return this
+  }
+
+  /**
+   * @param {string} name
+   * @param {import('@opentelemetry/api').Attributes | import('@opentelemetry/api').TimeInput} [attributesOrStartTime]
+   * @param {import('@opentelemetry/api').TimeInput} [startTime]
+   */
+  addEvent (name, attributesOrStartTime, startTime) {
+    addOtelEvent(this._ddSpan, name, attributesOrStartTime, startTime)
+    return this
+  }
+
+  /**
+   * Accepts the OTel `Link` shape and the deprecated `(SpanContext, Attributes)` form.
+   *
+   * @param {import('@opentelemetry/api').Link | import('@opentelemetry/api').SpanContext} link
+   * @param {import('@opentelemetry/api').Attributes} [attrs]
+   */
+  addLink (link, attrs) {
+    addOtelLink(this._ddSpan, link, attrs)
+    return this
+  }
+
+  /**
+   * @param {import('@opentelemetry/api').Link[]} links
+   */
+  addLinks (links) {
+    addOtelLinks(this._ddSpan, links)
+    return this
+  }
+
+  /**
+   * @param {import('@opentelemetry/api').Exception} exception
+   * @param {import('@opentelemetry/api').TimeInput} [timeInput]
+   */
+  recordException (exception, timeInput) {
+    recordException(this._ddSpan, exception, timeInput)
+  }
+
+  /**
+   * @param {import('@opentelemetry/api').SpanStatus} status
+   */
+  setStatus (status) {
+    this.#statusCode = applyOtelStatus(this._ddSpan, this.#statusCode, status)
+    return this
+  }
+}
+
+module.exports = BridgeSpanBase

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -4,6 +4,7 @@ const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const { storage } = require('../../../datadog-core')
 const { getAllBaggageItems, setAllBaggageItems, removeAllBaggageItems } = require('../baggage')
 
+const ActiveSpanProxy = require('./active-span-proxy')
 const SpanContext = require('./span_context')
 
 class ContextManager {
@@ -48,11 +49,19 @@ class ContextManager {
       ddContext._otelSpanContext = new SpanContext(ddContext)
     }
 
-    if (store && trace.getSpanContext(store) === ddContext._otelSpanContext) {
+    // Cache the active-span proxy next to the bridge span context. This lets
+    // `trace.getActiveSpan()` forward attribute/status/link/exception writes
+    // onto the active Datadog span rather than returning a NonRecordingSpan
+    // whose mutation methods are silent no-ops.
+    if (!ddContext._otelActiveSpan) {
+      ddContext._otelActiveSpan = new ActiveSpanProxy(activeSpan, ddContext._otelSpanContext)
+    }
+
+    if (store && trace.getSpan(store) === ddContext._otelActiveSpan) {
       return otelBaggages ? propagation.setBaggage(store, otelBaggages) : store
     }
 
-    const wrappedContext = trace.setSpanContext(baseContext, ddContext._otelSpanContext)
+    const wrappedContext = trace.setSpan(baseContext, ddContext._otelActiveSpan)
     return otelBaggages ? propagation.setBaggage(wrappedContext, otelBaggages) : wrappedContext
   }
 

--- a/packages/dd-trace/src/opentelemetry/span-helpers.js
+++ b/packages/dd-trace/src/opentelemetry/span-helpers.js
@@ -268,6 +268,32 @@ function applyOtelStatus (ddSpan, currentCode, status) {
   return code
 }
 
+/**
+ * OTel `updateName` for OTel-created bridge spans: writes the DD operation name, matching
+ * the OTel SDK semantic that `updateName` updates the canonical span identifier.
+ *
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {string} name
+ */
+function setOtelOperationName (ddSpan, name) {
+  if (!isWritable(ddSpan)) return
+
+  ddSpan.setOperationName(name)
+}
+
+/**
+ * OTel `updateName` for DD-native spans the bridge did not create: writes `resource.name`
+ * so the operation name (and the backend metric aggregation it drives) stays stable.
+ *
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {string} name
+ */
+function setOtelResource (ddSpan, name) {
+  if (!isWritable(ddSpan)) return
+
+  ddSpan.setTag('resource.name', name)
+}
+
 module.exports = {
   addOtelEvent,
   addOtelLink,
@@ -277,4 +303,6 @@ module.exports = {
   recordException,
   setOtelAttribute,
   setOtelAttributes,
+  setOtelOperationName,
+  setOtelResource,
 }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -13,16 +13,9 @@ const { SERVICE_NAME, RESOURCE_NAME, SPAN_KIND } = require('../../../../ext/tags
 const kinds = require('../../../../ext/kinds')
 
 const id = require('../id')
+const BridgeSpanBase = require('./bridge-span-base')
 const SpanContext = require('./span_context')
-const {
-  addOtelEvent,
-  addOtelLink,
-  addOtelLinks,
-  applyOtelStatus,
-  recordException,
-  setOtelAttribute,
-  setOtelAttributes,
-} = require('./span-helpers')
+const { setOtelOperationName } = require('./span-helpers')
 
 const spanKindNames = {
   [api.SpanKind.INTERNAL]: kinds.INTERNAL,
@@ -124,10 +117,7 @@ function spanNameMapper (spanName, kind, attributes) {
  * OTel-bridge span backed by a `DatadogSpan`. `Tracer` constructs these on the OTel API
  * surface; the underlying DD span carries the lifecycle.
  */
-class Span {
-  // OTel SpanStatusCode: 0 = UNSET, 1 = OK, 2 = ERROR. Tracked for OK-is-final precedence.
-  #statusCode = 0
-
+class Span extends BridgeSpanBase {
   /**
    * @param {import('./tracer')} parentTracer
    * @param {import('@opentelemetry/api').Context} context
@@ -153,7 +143,7 @@ class Span {
     const hrStartTime = timeInputToHrTime(timeInput || (performance.now() + timeOrigin))
     const startTime = hrTimeToMilliseconds(hrStartTime)
 
-    this._ddSpan = new DatadogSpan(_tracer, _tracer._processor, _tracer._prioritySampler, {
+    const ddSpan = new DatadogSpan(_tracer, _tracer._processor, _tracer._prioritySampler, {
       operationName: spanNameMapper(spanName, kind, attributes),
       context: spanContext._ddContext,
       startTime,
@@ -166,6 +156,8 @@ class Span {
       },
       links,
     }, _tracer._debug)
+
+    super(ddSpan)
 
     if (attributes) {
       this.setAttributes(attributes)
@@ -208,42 +200,6 @@ class Span {
   }
 
   /**
-   * @param {string} key
-   * @param {import('@opentelemetry/api').AttributeValue} value
-   */
-  setAttribute (key, value) {
-    setOtelAttribute(this._ddSpan, key, value)
-    return this
-  }
-
-  /**
-   * @param {import('@opentelemetry/api').Attributes} attributes
-   */
-  setAttributes (attributes) {
-    setOtelAttributes(this._ddSpan, attributes)
-    return this
-  }
-
-  /**
-   * Accepts the OTel `Link` shape and the deprecated `(SpanContext, Attributes)` form.
-   *
-   * @param {import('@opentelemetry/api').Link | import('@opentelemetry/api').SpanContext} link
-   * @param {import('@opentelemetry/api').Attributes} [attrs]
-   */
-  addLink (link, attrs) {
-    addOtelLink(this._ddSpan, link, attrs)
-    return this
-  }
-
-  /**
-   * @param {import('@opentelemetry/api').Link[]} links
-   */
-  addLinks (links) {
-    addOtelLinks(this._ddSpan, links)
-    return this
-  }
-
-  /**
    * @param {string} ptrKind
    * @param {string} ptrDir
    * @param {string} ptrHash
@@ -264,20 +220,10 @@ class Span {
   }
 
   /**
-   * @param {import('@opentelemetry/api').SpanStatus} status
-   */
-  setStatus (status) {
-    this.#statusCode = applyOtelStatus(this._ddSpan, this.#statusCode, status)
-    return this
-  }
-
-  /**
    * @param {string} name
    */
   updateName (name) {
-    if (!this.ended) {
-      this._ddSpan.setOperationName(name)
-    }
+    setOtelOperationName(this._ddSpan, name)
     return this
   }
 
@@ -297,34 +243,8 @@ class Span {
     this._spanProcessor.onEnd(this)
   }
 
-  isRecording () {
-    return this.ended === false
-  }
-
-  /**
-   * @param {string} name
-   * @param {import('@opentelemetry/api').Attributes | import('@opentelemetry/api').TimeInput} [attributesOrStartTime]
-   * @param {import('@opentelemetry/api').TimeInput} [startTime]
-   */
-  addEvent (name, attributesOrStartTime, startTime) {
-    addOtelEvent(this._ddSpan, name, attributesOrStartTime, startTime)
-    return this
-  }
-
-  /**
-   * @param {import('@opentelemetry/api').Exception} exception
-   * @param {import('@opentelemetry/api').TimeInput} [timeInput]
-   */
-  recordException (exception, timeInput) {
-    recordException(this._ddSpan, exception, timeInput)
-  }
-
   get duration () {
     return this._ddSpan._duration
-  }
-
-  get ended () {
-    return this.duration !== undefined
   }
 }
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -30,6 +30,7 @@ class DatadogSpanContext {
       tags: {},
     }
     this._otelSpanContext = undefined
+    this._otelActiveSpan = undefined
   }
 
   [util.inspect.custom] () {

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach } = require('mocha')
 const { context, propagation, trace, ROOT_CONTEXT } = require('@opentelemetry/api')
 const api = require('@opentelemetry/api')
+const { assertObjectContains, ANY_STRING } = require('../../../../integration-tests/helpers')
 const { getAllBaggageItems, removeAllBaggageItems, removeBaggageItem, setBaggageItem } = require('../../src/baggage')
 
 require('../setup/core')
@@ -204,6 +205,230 @@ describe('OTel Context Manager', () => {
       const activeSpan = trace.getActiveSpan()
       assert.strictEqual(activeSpan, span)
       span.end()
+    })
+  })
+
+  describe('with an active Datadog span', () => {
+    const ddTracer = require('../../')
+
+    it('exposes the active span via trace.getActiveSpan() and forwards writes', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        assert.ok(active)
+        assert.strictEqual(active.isRecording(), true)
+
+        active.setAttribute('my.otel.attr', 'ok')
+        active.setAttributes({ 'my.otel.attrs': 'ok2' })
+
+        active.addLink({
+          context: {
+            traceId: '0123456789abcdef0123456789abcdef',
+            spanId: '0123456789abcdef',
+            traceFlags: 1,
+          },
+          attributes: { foo: 'bar' },
+        })
+
+        active.setStatus({ code: 2, message: 'status boom' })
+
+        assert.strictEqual(ddSpan._links.length, 1)
+        assert.deepStrictEqual({
+          tags: {
+            'my.otel.attr': ddSpan.context()._tags['my.otel.attr'],
+            'my.otel.attrs': ddSpan.context()._tags['my.otel.attrs'],
+            'error.message': ddSpan.context()._tags['error.message'],
+          },
+          link: {
+            traceId: ddSpan._links[0].context.toTraceId(true),
+            spanId: ddSpan._links[0].context.toSpanId(true),
+            attributes: ddSpan._links[0].attributes,
+          },
+        }, {
+          tags: {
+            'my.otel.attr': 'ok',
+            'my.otel.attrs': 'ok2',
+            'error.message': 'status boom',
+          },
+          link: {
+            traceId: '0123456789abcdef0123456789abcdef',
+            spanId: '0123456789abcdef',
+            attributes: { foo: 'bar' },
+          },
+        })
+
+        active.recordException(new Error('boom'))
+        assert.strictEqual(ddSpan.context()._tags['error.message'], 'boom')
+      })
+    })
+
+    it('addEvent normalizes OTel time/attribute inputs onto the Datadog span', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        assert.ok(active)
+
+        const hrTime = /** @type {[number, number]} */ ([1700000000, 500000000])
+        const hrTimeMs = hrTime[0] * 1e3 + hrTime[1] / 1e6
+        const date = new Date(1700000000000)
+
+        active.addEvent('with-hr-time', hrTime)
+        active.addEvent('with-date', date)
+        active.addEvent('with-attrs-and-hr-time', { code: 42 }, hrTime)
+
+        // Single equality guards: no array-indexed attribute leak on the time-only forms,
+        // numeric startTime (not hrTime array) so span_format's Math.round(startTime * 1e6)
+        // cannot produce NaN.
+        assert.deepStrictEqual(ddSpan._events, [
+          { name: 'with-hr-time', startTime: hrTimeMs },
+          { name: 'with-date', startTime: date.getTime() },
+          { name: 'with-attrs-and-hr-time', attributes: { code: 42 }, startTime: hrTimeMs },
+        ])
+      })
+    })
+
+    it('recordException forwards a user-supplied hrTime timestamp as ms', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        assert.ok(active)
+
+        const hrTime = /** @type {[number, number]} */ ([1700000500, 250000000])
+        const hrTimeMs = hrTime[0] * 1e3 + hrTime[1] / 1e6
+
+        active.recordException(new Error('boom'), hrTime)
+
+        assertObjectContains(ddSpan._events.at(-1), {
+          name: 'Error',
+          startTime: hrTimeMs,
+          attributes: {
+            'exception.message': 'boom',
+            'exception.stacktrace': ANY_STRING,
+          },
+        })
+      })
+    })
+
+    it('end() on the proxy does not finish the Datadog span', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        active.end()
+        assert.strictEqual(ddSpan._duration, undefined)
+      })
+    })
+
+    it('addLinks forwards every valid link and skips invalid contexts', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+
+        active.addLinks([
+          {
+            context: {
+              traceId: '0123456789abcdef0123456789abcdef',
+              spanId: '0123456789abcdef',
+              traceFlags: 1,
+            },
+            attributes: { tag: 'first' },
+          },
+          { context: undefined, attributes: { skipped: 'yes' } },
+          {
+            context: {
+              traceId: 'fedcba9876543210fedcba9876543210',
+              spanId: 'fedcba9876543210',
+            },
+            attributes: { tag: 'second' },
+          },
+        ])
+
+        assert.strictEqual(ddSpan._links.length, 2)
+        assert.deepStrictEqual(
+          ddSpan._links.map(({ context, attributes }) => ({
+            traceId: context.toTraceId(true),
+            spanId: context.toSpanId(true),
+            attributes,
+          })),
+          [
+            {
+              traceId: '0123456789abcdef0123456789abcdef',
+              spanId: '0123456789abcdef',
+              attributes: { tag: 'first' },
+            },
+            {
+              traceId: 'fedcba9876543210fedcba9876543210',
+              spanId: 'fedcba9876543210',
+              attributes: { tag: 'second' },
+            },
+          ]
+        )
+      })
+    })
+
+    it('addLinks ignores non-array input', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        active.addLinks(undefined)
+        active.addLinks('not an array')
+        assert.strictEqual(ddSpan._links.length, 0)
+      })
+    })
+
+    it('caches the proxy so repeated calls return the same object', () => {
+      ddTracer.trace('dd-active', () => {
+        assert.strictEqual(trace.getActiveSpan(), trace.getActiveSpan())
+      })
+    })
+
+    it('updateName updates resource.name on the DD span, not the operation name', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        active.updateName('renamed')
+
+        const ddContext = ddSpan.context()
+        assert.strictEqual(ddContext._name, 'dd-active')
+        assert.strictEqual(ddContext._tags['resource.name'], 'renamed')
+      })
+    })
+
+    describe('setStatus precedence (OTel spec)', () => {
+      it('OK locks subsequent ERROR and UNSET writes', () => {
+        ddTracer.trace('dd-active-ok', (ddSpan) => {
+          const active = trace.getActiveSpan()
+          active.setStatus({ code: 1 })
+          active.setStatus({ code: 2, message: 'late error' })
+          active.setStatus({ code: 0, message: 'late unset' })
+
+          assert.ok(!('error.message' in ddSpan.context()._tags))
+        })
+      })
+
+      it('ERROR can be replaced by a later ERROR with a fresh message', () => {
+        ddTracer.trace('dd-active-error', (ddSpan) => {
+          const active = trace.getActiveSpan()
+          active.setStatus({ code: 2, message: 'first error' })
+          active.setStatus({ code: 2, message: 'second error' })
+
+          assert.strictEqual(ddSpan.context()._tags['error.message'], 'second error')
+        })
+      })
+    })
+
+    it('mutation methods are all no-ops once the underlying DD span has finished', () => {
+      ddTracer.trace('dd-active', (ddSpan) => {
+        const active = trace.getActiveSpan()
+        ddSpan.finish()
+
+        active.setAttribute('after.end', 'no')
+        active.setAttributes({ 'after.end.batch': 'no' })
+        active.addLink({
+          context: { traceId: 'a'.repeat(32), spanId: 'b'.repeat(16), traceFlags: 1 },
+        })
+        active.addLinks([{ context: { traceId: 'c'.repeat(32), spanId: 'd'.repeat(16) } }])
+        active.addEvent('after.end.event')
+        active.recordException(new Error('after end'))
+        active.setStatus({ code: 2, message: 'after end' })
+        active.updateName('after end')
+
+        assert.deepStrictEqual(ddSpan.context()._tags, {})
+        assert.strictEqual(ddSpan._links.length, 0)
+        assert.strictEqual(ddSpan._events.length, 0)
+      })
     })
   })
 })

--- a/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
@@ -16,6 +16,8 @@ const {
   recordException,
   setOtelAttribute,
   setOtelAttributes,
+  setOtelOperationName,
+  setOtelResource,
 } = require('../../src/opentelemetry/span-helpers')
 
 /**
@@ -74,10 +76,13 @@ describe('OTel bridge helpers', () => {
       ])
       addOtelEvent(ddSpan, 'evt', { code: 42 })
       recordException(ddSpan, new Error('boom'))
+      setOtelOperationName(ddSpan, 'GET /users')
+      setOtelResource(ddSpan, 'GET /users')
 
       assert.deepStrictEqual(ddSpan.tags, {})
       assert.strictEqual(ddSpan.links.length, 0)
       assert.strictEqual(ddSpan.events.length, 0)
+      assert.strictEqual(ddSpan.operationName, undefined)
     })
   })
 
@@ -285,6 +290,24 @@ describe('OTel bridge helpers', () => {
       assert.strictEqual(stillOk, 1)
       // The first ERROR's message stays. Tag clearing on OK override is out of scope.
       assert.strictEqual(ddSpan.tags[ERROR_MESSAGE], 'first')
+    })
+  })
+
+  describe('setOtelOperationName vs setOtelResource', () => {
+    it('setOtelOperationName routes to setOperationName on the DD span', () => {
+      const ddSpan = createMockDdSpan()
+      setOtelOperationName(ddSpan, 'GET /users')
+
+      assert.strictEqual(ddSpan.operationName, 'GET /users')
+      assert.strictEqual(ddSpan.tags['resource.name'], undefined)
+    })
+
+    it('setOtelResource routes to the resource.name tag, not the operation name', () => {
+      const ddSpan = createMockDdSpan()
+      setOtelResource(ddSpan, 'GET /users')
+
+      assert.strictEqual(ddSpan.tags['resource.name'], 'GET /users')
+      assert.strictEqual(ddSpan.operationName, undefined)
     })
   })
 

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -61,6 +61,7 @@ describe('SpanContext', () => {
       _traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
       _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'),
       _otelSpanContext: undefined,
+      _otelActiveSpan: undefined,
     }
     Object.setPrototypeOf(expected, SpanContext.prototype)
     assert.deepStrictEqual(spanContext, expected)
@@ -93,6 +94,7 @@ describe('SpanContext', () => {
       _traceparent: undefined,
       _tracestate: undefined,
       _otelSpanContext: undefined,
+      _otelActiveSpan: undefined,
     }
     Object.setPrototypeOf(expected, SpanContext.prototype)
     assert.deepStrictEqual(spanContext, expected)


### PR DESCRIPTION
OTel consumers that retrieve a span via `trace.getActiveSpan()` and call
mutators on it expect those writes to land on whatever span is currently
active. When the active span was created by the Datadog tracer (i.e. all
DD-native instrumentations), the bridge previously returned a no-op span
proxy, so `getActiveSpan().setAttribute(...)` quietly went nowhere. The
pattern is documented in the OTel API and is used heavily by user code
that mixes manual OTel calls with auto-instrumentation, so this gap was
a frequent source of "my attribute didn't show up" reports.

Cache an `ActiveSpanProxy` per active context so `getActiveSpan()` hands
back the same proxy on every call, and forward all OTel mutators through
the same `span-helpers.js` surface that the bridge `Span` class uses.
Both bridge classes now extend a small `BridgeSpanBase` that owns the
shared method bodies (`setAttribute`, `setAttributes`, `addEvent`,
`addLink`, `addLinks`, `recordException`, `setStatus`, `isRecording`),
so the proxy and the OTel-created span cannot drift on the spec going
forward.

`updateName` is intentionally split between the two bridges:

- For OTel-created spans, `updateName` writes the DD operation name. The
  span exists because OTel asked for it, so the OTel name *is* the
  operation name.
- For the proxy wrapping a DD-native span, `updateName` writes
  `resource.name` instead. Touching the operation name on a span that an
  integration created would scramble metric aggregation in the backend
  (operation names drive the metric grouping); `resource.name` is the
  display field and is the correct target for "rename what I'm looking
  at" semantics.

The two paths share `span-helpers.js`'s `setOtelOperationName` and
`setOtelResource` so the gate logic still lives in one place.

Test coverage: the new proxy describe block in
`context_manager.spec.js` exercises the proxy lifecycle (caching across
calls, no-op once the underlying span has finished, the resource-name
path, attribute/event/link forwarding). `span-helpers.spec.js` gains
coverage for the two new name helpers. `span_context.js` records the
active OTel span on the DD span context (`_otelActiveSpan`) so the proxy
cache survives context propagation.