### PR TITLE
fix(otel): correct sampling priority and origin propagation from trac…

### DIFF
--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -81,10 +81,10 @@ class Tracer {
   }
 
   _convertOtelContextToDatadog (traceId, spanId, traceFlag, ts, meta = {}) {
-    const origin = null
+    let origin = null
     let samplingPriority = traceFlag
 
-    ts = ts?.traceparent || null
+    ts = ts?.traceparent
 
     if (ts) {
       // Use TraceState.fromString to parse the tracestate header
@@ -101,19 +101,17 @@ class Tracer {
         // Assuming ddTraceStateData is now a Map or similar structure containing Datadog trace state data
         // Extract values as needed, similar to the original logic
         const samplingPriorityTs = ddTraceStateData.get('s')
-        const origin = ddTraceStateData.get('o')
+        origin = ddTraceStateData.get('o') ?? null
         // Convert Map to object for meta
         const otherPropagatedTags = Object.fromEntries(ddTraceStateData.entries())
 
         // Update meta and samplingPriority based on extracted values
         Object.assign(meta, otherPropagatedTags)
-        samplingPriority = TextMapPropagator._getSamplingPriority(
-          traceFlag,
-          Number.parseInt(samplingPriorityTs, 10),
-          origin
-        )
+        // Guard against an undefined/empty `s:` field that would result in NaN.
+        const tracestateSamplingPriority = samplingPriorityTs ? Math.trunc(samplingPriorityTs) : undefined
+        samplingPriority = TextMapPropagator._getSamplingPriority(traceFlag, tracestateSamplingPriority, origin)
       } else {
-        log.debug('no dd list member in tracestate from incoming request:', ts)
+        log.debug('No dd list member in tracestate from incoming request:', ts)
       }
     }
 
@@ -121,8 +119,8 @@ class Tracer {
       traceId: id(traceId, 16), spanId: id(), tags: meta, parentId: id(spanId, 16),
     })
 
-    spanContext._sampling = { priority: samplingPriority }
-    spanContext._trace = { origin }
+    spanContext._ddContext._sampling = { priority: samplingPriority }
+    spanContext._ddContext._trace = { ...spanContext._ddContext._trace, origin }
     return spanContext
   }
 

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -802,18 +802,25 @@ class TextMapPropagator {
     return spanContext._traceId.toString(16)
   }
 
-  static _getSamplingPriority (traceparentSampled, tracestateSamplingPriority, origin = null) {
+  /**
+   * @param {number} traceparentSampled
+   * @param {number|undefined} tracestateSamplingPriority
+   * @param {string|null} origin
+   * @returns {import('../../priority_sampler').SamplingPriority}
+   */
+  static _getSamplingPriority (traceparentSampled, tracestateSamplingPriority, origin) {
     const fromRumWithoutPriority = !tracestateSamplingPriority && origin === 'rum'
 
-    let samplingPriority
-    if (!fromRumWithoutPriority && traceparentSampled === 0 &&
-    (!tracestateSamplingPriority || tracestateSamplingPriority >= 0)) {
-      samplingPriority = 0
-    } else if (!fromRumWithoutPriority && traceparentSampled === 1 &&
-    (!tracestateSamplingPriority || tracestateSamplingPriority < 0)) {
-      samplingPriority = 1
-    } else {
-      samplingPriority = tracestateSamplingPriority
+    let samplingPriority =
+      /** @type {import('../../priority_sampler').SamplingPriority} */ (tracestateSamplingPriority ?? AUTO_KEEP)
+    if (!fromRumWithoutPriority) {
+      if (traceparentSampled === 0 &&
+          (!tracestateSamplingPriority || tracestateSamplingPriority >= 0)) {
+        samplingPriority = AUTO_REJECT
+      } else if (traceparentSampled === 1 &&
+                 (!tracestateSamplingPriority || tracestateSamplingPriority < 0)) {
+        samplingPriority = AUTO_KEEP
+      }
     }
 
     return samplingPriority

--- a/packages/dd-trace/test/opentelemetry/tracer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon')
 const api = require('@opentelemetry/api')
 
 const { hrTime, timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/core')
+const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../ext/priority')
 const { storage } = require('../../../datadog-core')
 require('../setup/core')
 require('../../').init()
@@ -211,6 +212,54 @@ describe('OTel Tracer', () => {
         })
       })
       orphan1.end()
+    })
+  })
+
+  describe('_convertOtelContextToDatadog (traceparent/tracestate extraction)', () => {
+    const TRACE_ID = '0123456789abcdef0123456789abcdef'
+    const SPAN_ID = '0123456789abcdef'
+
+    /**
+     * @param {number} traceFlag
+     * @param {string|null} tracestate
+     */
+    function convert (traceFlag, tracestate) {
+      const otelTracer = new Tracer({}, {}, new TracerProvider())
+      return otelTracer._convertOtelContextToDatadog(
+        TRACE_ID,
+        SPAN_ID,
+        traceFlag,
+        tracestate ? { traceparent: tracestate } : null
+      )
+    }
+
+    it('writes sampling priority onto the wrapped Datadog context', () => {
+      const spanContext = convert(1, 'other=bleh,dd=s:2;o:synthetics;t.dm:-4')
+      assert.strictEqual(spanContext._ddContext._sampling.priority, USER_KEEP)
+      assert.strictEqual(spanContext._ddContext._trace.origin, 'synthetics')
+      assert.strictEqual(spanContext.traceFlags, 1)
+    })
+
+    it('preserves the existing _trace.started/finished/tags when writing origin', () => {
+      const spanContext = convert(1, 'other=bleh,dd=s:1;o:foo')
+      assert.deepStrictEqual(spanContext._ddContext._trace.started, [])
+      assert.deepStrictEqual(spanContext._ddContext._trace.finished, [])
+      assert.deepStrictEqual(spanContext._ddContext._trace.tags, {})
+      assert.strictEqual(spanContext._ddContext._trace.origin, 'foo')
+    })
+
+    it('falls back to AUTO_REJECT/AUTO_KEEP when tracestate has no s: field', () => {
+      const rejected = convert(0, 'other=bleh,dd=o:foo;t.dm:-4')
+      assert.strictEqual(rejected._ddContext._sampling.priority, AUTO_REJECT)
+
+      const kept = convert(1, 'other=bleh,dd=o:foo;t.dm:-4')
+      assert.strictEqual(kept._ddContext._sampling.priority, AUTO_KEEP)
+    })
+
+    it('falls back to AUTO_KEEP for RUM traces without a priority', () => {
+      const spanContext = convert(1, 'other=bleh,dd=o:rum')
+      assert.strictEqual(spanContext._ddContext._sampling.priority, AUTO_KEEP)
+      assert.strictEqual(spanContext._ddContext._trace.origin, 'rum')
     })
   })
 


### PR DESCRIPTION
…estate

Three related bugs in the OTel-to-Datadog context bridge are fixed:

1. `SpanContext` is a composition wrapper that exposes `traceFlags` via `this._ddContext._sampling.priority`. The extractor was writing `_sampling` and `_trace` directly on the wrapper, so the values never reached `_ddContext` and `traceFlags` always returned 0 regardless of the `s:` field in the incoming tracestate.

2. `Number.parseInt(samplingPriorityTs, 10)` produced `NaN` when the `dd` tracestate member had no `s:` field. The `NaN` was then passed to `_getSamplingPriority`, where it slipped through both conditional branches and was returned as-is. `_getSamplingPriority` now uses the existing `AUTO_REJECT`/`AUTO_KEEP` constants and defaults to `AUTO_KEEP` when the tracestate priority is missing or not a number. The caller in `_convertOtelContextToDatadog` guards `parseInt` to avoid producing `NaN` in the first place.

3. The `origin` pulled from the `dd` tracestate (`o:` field) was being assigned to an inner block-scoped `const origin`, which shadowed the outer `origin` variable used when writing `_trace`. As a result the origin was silently dropped from every extracted OTel context.