### PR TITLE
set network and http client ip on ai guard

### DIFF
--- a/ext/tags.js
+++ b/ext/tags.js
@@ -25,6 +25,7 @@ const tags = {
   HTTP_RESPONSE_HEADERS: 'http.response.headers',
   HTTP_USERAGENT: 'http.useragent',
   HTTP_CLIENT_IP: 'http.client_ip',
+  NETWORK_CLIENT_IP: 'network.client.ip',
 
   // Messaging
 

--- a/integration-tests/aiguard/index.spec.js
+++ b/integration-tests/aiguard/index.spec.js
@@ -40,6 +40,7 @@ describe('AIGuard SDK integration tests', () => {
         DD_SERVICE: 'ai_guard_integration_test',
         DD_ENV: 'test',
         DD_TRACE_ENABLED: 'true',
+        DD_TRACE_CLIENT_IP_ENABLED: 'false',
         DD_TRACE_AGENT_PORT: String(agent.port),
         DD_AI_GUARD_ENABLED: 'true',
         DD_AI_GUARD_BLOCK: 'true',
@@ -66,6 +67,43 @@ describe('AIGuard SDK integration tests', () => {
       assert.notStrictEqual(span, undefined)
       assert.strictEqual(span.meta['ai_guard.action'], 'DENY')
       assert.strictEqual(span.meta['ai_guard.blocked'], 'true')
+    })
+  })
+
+  it('adds client ip tags to the request root span when AI Guard runs', async () => {
+    const response = await executeRequest(`${url}/allow`, 'GET', {
+      'x-forwarded-for': '203.0.113.10, 10.0.0.1',
+    })
+
+    assert.strictEqual(response.status, 200)
+
+    await agent.assertMessageReceived(({ payload }) => {
+      const requestSpan = payload[0].find(span => span.name === 'express.request')
+      const guardSpan = payload[0].find(span => span.name === 'ai_guard')
+
+      assert.notStrictEqual(requestSpan, undefined)
+      assert.notStrictEqual(guardSpan, undefined)
+      assert.strictEqual(requestSpan.meta['http.client_ip'], '203.0.113.10')
+      assert.ok(requestSpan.meta['network.client.ip'])
+    })
+  })
+
+  it('does not add client ip tags when no AI Guard span is created', async () => {
+    const response = await executeRequest(`${url}/no-aiguard`, 'GET', {
+      'x-forwarded-for': '203.0.113.10, 10.0.0.1',
+    })
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(response.body, { ok: true })
+
+    await agent.assertMessageReceived(({ payload }) => {
+      const requestSpan = payload[0].find(span => span.name === 'express.request')
+      const guardSpan = payload[0].find(span => span.name === 'ai_guard')
+
+      assert.notStrictEqual(requestSpan, undefined)
+      assert.strictEqual(guardSpan, undefined)
+      assert.strictEqual(requestSpan.meta['http.client_ip'], undefined)
+      assert.strictEqual(requestSpan.meta['network.client.ip'], undefined)
     })
   })
 

--- a/integration-tests/aiguard/server.js
+++ b/integration-tests/aiguard/server.js
@@ -6,6 +6,10 @@ const express = require('express')
 
 const app = express()
 
+app.get('/no-aiguard', (req, res) => {
+  res.status(200).json({ ok: true })
+})
+
 app.get('/allow', async (req, res) => {
   const evaluation = await tracer.aiguard.evaluate([
     { role: 'system', content: 'You are a beautiful AI' },

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -45,9 +45,8 @@ class HttpServerPlugin extends ServerPlugin {
       context.parentStore = store
     }
 
-    // Only AppSec needs the request scope to be active for any async work that
-    // may be scheduled after the synchronous `request` event returns (e.g.
-    // Fastify).
+    // AppSec, IAST, and AI Guard need req/res on the store so downstream
+    // subscribers can access them from the async context.
     if (incomingHttpRequestStart.hasSubscribers) {
       store = { ...store, req, res }
     }

--- a/packages/dd-trace/src/aiguard/channels.js
+++ b/packages/dd-trace/src/aiguard/channels.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const dc = require('dc-polyfill')
+
+module.exports = {
+  aiguardChannel: dc.channel('dd-trace:ai:aiguard'),
+  incomingHttpRequestStart: dc.channel('dd-trace:incomingHttpRequestStart'),
+}

--- a/packages/dd-trace/src/aiguard/index.js
+++ b/packages/dd-trace/src/aiguard/index.js
@@ -8,7 +8,9 @@ let isEnabled = false
 let aiguard
 let block
 
-function onIncomingHttpRequestStart () {}
+function onIncomingHttpRequestStart () {
+  // No-op: subscribing ensures the HTTP plugin spreads req onto the store
+}
 
 function enable (tracer, config) {
   if (isEnabled) return

--- a/packages/dd-trace/src/aiguard/index.js
+++ b/packages/dd-trace/src/aiguard/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
-const { channel } = require('dc-polyfill')
 const log = require('../log')
+const { incomingHttpRequestStart, aiguardChannel } = require('./channels')
 const AIGuard = require('./sdk')
-
-const aiguardChannel = channel('dd-trace:ai:aiguard')
 
 let isEnabled = false
 let aiguard
 let block
+
+function onIncomingHttpRequestStart () {}
 
 function enable (tracer, config) {
   if (isEnabled) return
@@ -17,6 +17,7 @@ function enable (tracer, config) {
     aiguard = new AIGuard(tracer, config)
     block = config.experimental?.aiguard?.block !== false
 
+    incomingHttpRequestStart.subscribe(onIncomingHttpRequestStart)
     aiguardChannel.subscribe(onEvaluate)
 
     isEnabled = true
@@ -29,6 +30,7 @@ function enable (tracer, config) {
 function disable () {
   if (!isEnabled) return
 
+  incomingHttpRequestStart.unsubscribe(onIncomingHttpRequestStart)
   aiguardChannel.unsubscribe(onEvaluate)
 
   aiguard = undefined

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -1,7 +1,10 @@
 'use strict'
 
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
+const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
+const { storage } = require('../../../datadog-core')
 const log = require('../log')
+const { extractIp } = require('../plugins/util/ip_extractor')
 const telemetryMetrics = require('../telemetry/metrics')
 const tracerVersion = require('../../../../package.json').version
 const { keepTrace } = require('../priority_sampler')
@@ -23,6 +26,7 @@ const {
 const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
 
 const ALLOW = 'ALLOW'
+const NETWORK_CLIENT_IP = 'network.client.ip'
 
 class AIGuardAbortError extends Error {
   constructor (reason, tags, tagProbs, sds) {
@@ -57,6 +61,7 @@ class AIGuard extends NoopAIGuard {
   #maxMessagesLength
   #maxContentSize
   #meta
+  #config
 
   /**
    * @param {import('../tracer')} tracer - Tracer instance
@@ -84,6 +89,7 @@ class AIGuard extends NoopAIGuard {
     this.#maxMessagesLength = config.experimental.aiguard.maxMessagesLength
     this.#maxContentSize = config.experimental.aiguard.maxContentSize
     this.#meta = { service: config.service, env: config.env }
+    this.#config = config
     this.#initialized = true
   }
 
@@ -139,6 +145,42 @@ class AIGuard extends NoopAIGuard {
     return null
   }
 
+  #setRootSpanClientIpTags (rootSpan) {
+    if (!rootSpan) return
+
+    const currentTags = rootSpan.context()._tags
+    const needsHttpClientIp = !Object.hasOwn(currentTags, HTTP_CLIENT_IP)
+    const needsNetworkClientIp = !Object.hasOwn(currentTags, NETWORK_CLIENT_IP)
+
+    if (!needsHttpClientIp && !needsNetworkClientIp) return
+
+    const req = storage('legacy').getStore()?.req
+
+    if (!req) return
+
+    const newTags = {}
+
+    if (needsHttpClientIp) {
+      const clientIp = extractIp(this.#config, req)
+
+      if (clientIp) {
+        newTags[HTTP_CLIENT_IP] = clientIp
+      }
+    }
+
+    if (needsNetworkClientIp) {
+      const networkClientIp = req.socket?.remoteAddress
+
+      if (networkClientIp) {
+        newTags[NETWORK_CLIENT_IP] = networkClientIp
+      }
+    }
+
+    if (Object.keys(newTags).length > 0) {
+      rootSpan.addTags(newTags)
+    }
+  }
+
   evaluate (messages, opts) {
     if (!this.#initialized) {
       return super.evaluate(messages, opts)
@@ -162,6 +204,7 @@ class AIGuard extends NoopAIGuard {
       }
       const rootSpan = span.context()?._trace?.started?.[0]
       if (rootSpan) {
+        this.#setRootSpanClientIpTags(rootSpan)
         // keepTrace must be called before executeRequest so the sampling decision
         // is propagated correctly to outgoing HTTP client calls.
         keepTrace(rootSpan, AI_GUARD)

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
-const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
+const { HTTP_CLIENT_IP, NETWORK_CLIENT_IP } = require('../../../../ext/tags')
 const { storage } = require('../../../datadog-core')
 const log = require('../log')
 const { extractIp } = require('../plugins/util/ip_extractor')
@@ -26,7 +26,6 @@ const {
 const appsecMetrics = telemetryMetrics.manager.namespace('appsec')
 
 const ALLOW = 'ALLOW'
-const NETWORK_CLIENT_IP = 'network.client.ip'
 
 class AIGuardAbortError extends Error {
   constructor (reason, tags, tagProbs, sds) {

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -3,6 +3,7 @@
 const zlib = require('zlib')
 const dc = require('dc-polyfill')
 
+const { NETWORK_CLIENT_IP } = require('../../../../ext/tags')
 const { storage } = require('../../../datadog-core')
 const web = require('../plugins/util/web')
 const { ipHeaderList } = require('../plugins/util/ip_extractor')
@@ -363,7 +364,7 @@ function reportAttack ({ events: attackData, actions }, req) {
     : '{"triggers":' + attackDataStr + '}'
 
   if (req.socket) {
-    newTags['network.client.ip'] = req.socket.remoteAddress
+    newTags[NETWORK_CLIENT_IP] = req.socket.remoteAddress
   }
 
   rootSpan.addTags(newTags)


### PR DESCRIPTION
### What does this PR do?

Set `http.client_ip` and `network.client.ip` on the local root span when an AI Guard span is created (resource_name:ai_guard), even when `DD_TRACE_CLIENT_IP_ENABLED=false` and AppSec is disabled.

### Motivation

[APPSEC-62220](https://datadoghq.atlassian.net/browse/APPSEC-62220)

### Additional Notes
<!-- Anything else we should know when reviewing? -->




[APPSEC-62220]: https://datadoghq.atlassian.net/browse/APPSEC-62220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ