### PR TITLE
dont run serverless ci on release branch pushes too

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -143,10 +143,10 @@ benchmark-serverless-trigger:
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
 
-    # dont run on merges to release branches ("vN.x" where N is any integer)
+    # don't run on merges to release branches ("vN.x" where N is any integer)
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^v\d+\.x$/'
       when: never
-    # dont run on pushes to release branches
+    # don't run on pushes to release branches
     - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^v\d+\.x$/'
       when: never
     - interruptible: true

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -143,8 +143,11 @@ benchmark-serverless-trigger:
     - if: $CI_COMMIT_BRANCH == 'master'
       interruptible: false
 
-    # dont run on merges to release branches (vN.x where N is any integer)
+    # dont run on merges to release branches ("vN.x" where N is any integer)
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^v\d+\.x$/'
+      when: never
+    # dont run on pushes to release branches
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH =~ /^v\d+\.x$/'
       when: never
     - interruptible: true
   trigger:


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
[APMSVLS-489](https://datadoghq.atlassian.net/browse/APMSVLS-489)

extension of #8024. This also prevents runs on push pipelines that happen after the merge
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->




[APMSVLS-489]: https://datadoghq.atlassian.net/browse/APMSVLS-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ