### PR TITLE
fix sirun scope benchmark waiting without using cpu

### DIFF
--- a/benchmark/sirun/scope/index.js
+++ b/benchmark/sirun/scope/index.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const {
-  DD_TRACE_SCOPE,
+  SCOPE_ENABLED,
   COUNT,
 } = process.env
 
-if (DD_TRACE_SCOPE) {
+if (SCOPE_ENABLED === 'true') {
   const Scope = require('../../../packages/dd-trace/src/scope')
   const scope = new Scope()
   if (scope.enable) {

--- a/benchmark/sirun/scope/index.js
+++ b/benchmark/sirun/scope/index.js
@@ -37,19 +37,9 @@ function immediates (n, cb) {
   setImmediate(immediates, n - 1, cb)
 }
 
-function timeouts (n, cb) {
-  if (n === 0) {
-    cb()
-    return
-  }
-  setTimeout(timeouts, 0, n - 1, cb)
-}
-
 promises(COUNT, () => {
   awaits(COUNT, () => {
     immediates(COUNT, () => {
-      timeouts(COUNT, () => {
-      })
     })
   })
 })

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -8,28 +8,13 @@
   "variants": {
     "base": {
       "env": {
-        "DD_TRACE_SCOPE": "noop",
         "COUNT": "250000"
       }
     },
-    "async_hooks": {
+    "scope_enabled": {
       "baseline": "base",
       "env": {
-        "DD_TRACE_SCOPE": "async_hooks",
-        "COUNT": "250000"
-      }
-    },
-    "async_local_storage": {
-      "baseline": "base",
-      "env": {
-        "DD_TRACE_SCOPE": "async_local_storage",
-        "COUNT": "250000"
-      }
-    },
-    "async_resource": {
-      "baseline": "base",
-      "env": {
-        "DD_TRACE_SCOPE": "async_resource",
+        "SCOPE_ENABLED": "true",
         "COUNT": "250000"
       }
     }

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -3,34 +3,34 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 20,
+  "iterations": 10,
   "instructions": true,
   "variants": {
     "base": {
       "env": {
         "DD_TRACE_SCOPE": "noop",
-        "COUNT": "1250"
+        "COUNT": "250000"
       }
     },
     "async_hooks": {
       "baseline": "base",
       "env": {
         "DD_TRACE_SCOPE": "async_hooks",
-        "COUNT": "1250"
+        "COUNT": "250000"
       }
     },
     "async_local_storage": {
       "baseline": "base",
       "env": {
         "DD_TRACE_SCOPE": "async_local_storage",
-        "COUNT": "1250"
+        "COUNT": "250000"
       }
     },
     "async_resource": {
       "baseline": "base",
       "env": {
         "DD_TRACE_SCOPE": "async_resource",
-        "COUNT": "1250"
+        "COUNT": "250000"
       }
     }
   }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix sirun scope benchmark waiting without using cpu.

### Motivation
<!-- What inspired you to submit this pull request? -->

`setTimeout` has a minimum wait time of 1ms so the benchmark was waiting for way longer than expected, which ended up significantly skewing the results based on startup CPU usage since the process was almost doing nothing for a long period of time.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I also updated the sirun config to remove the old concept of a scope option since this no longer exists.