### PR TITLE
test(appsec): skip mquery analyzer flaky test

### DIFF
--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js
@@ -12,7 +12,9 @@ const agent = require('../../../plugins/agent')
 const { withVersions } = require('../../../setup/mocha')
 const { prepareTestServerForIastInExpress } = require('../utils')
 
-describe('nosql injection detection with mquery', () => {
+// TODO(APPSEC-62431): re-enable once duplicate NOSQL_MONGODB_INJECTION
+// detection (N+1 !== N) is fixed
+describe.skip('nosql injection detection with mquery', () => {
   // https://github.com/fiznool/express-mongo-sanitize/issues/200
   withVersions('mquery', 'express', '>4.18.0 <5.0.0', expressVersion => {
     withVersions('mquery', 'mongodb', mongodbVersion => {


### PR DESCRIPTION
### What does this PR do?
Skips the `nosql injection detection with mquery` test suite in `packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.mquery.plugin.spec.js` to unblock CI while we keep investigating the underlying flake.

### Motivation
The suite intermittently fails with `AssertionError [ERR_ASSERTION]: N+1 !== N` (e.g. `2 !== 1`), caused by duplicate `NOSQL_MONGODB_INJECTION` vulnerability detections on the same request. The flake has been observed in the `mongodb-core` job and is currently blocking the all-green policy on unrelated PRs.

### Additional Notes
The skip is intentionally a `describe.skip` (suite-level) rather than an `it.skip`, since the duplicate-detection flake affects the deduplication logic shared by every test in this suite.


