### PR TITLE
fix: stop reading deprecated req.connection.encrypted

### DIFF
--- a/packages/dd-trace/src/plugins/util/url.js
+++ b/packages/dd-trace/src/plugins/util/url.js
@@ -31,7 +31,8 @@ function extractURL (req) {
 }
 
 function getProtocol (req) {
-  return (req.socket?.encrypted || req.connection?.encrypted) ? 'https' : 'http'
+  // Do not check deprecated `req.connection` property.
+  return req.socket?.encrypted ? 'https' : 'http'
 }
 
 /**

--- a/packages/dd-trace/test/plugins/util/url.spec.js
+++ b/packages/dd-trace/test/plugins/util/url.spec.js
@@ -54,7 +54,7 @@ describe('plugins/util/url', () => {
       assert.strictEqual(result, 'https://secure.example.com/secure/path')
     })
 
-    it('should extract full URL from HTTPS request with connection.encrypted', () => {
+    it('should not read `connection.encrypted` (deprecated alias for `socket.encrypted`)', () => {
       const req = {
         headers: {
           host: 'secure.example.com',
@@ -65,7 +65,7 @@ describe('plugins/util/url', () => {
       }
 
       const result = url.extractURL(req)
-      assert.strictEqual(result, 'https://secure.example.com/secure/path')
+      assert.strictEqual(result, 'http://secure.example.com/secure/path')
     })
 
     it('should extract full URL from HTTP/2 request', () => {


### PR DESCRIPTION
`IncomingMessage.connection` is a deprecated alias for `.socket` (DEP0163 in Node.js since v13). Every access emits a deprecation warning, including from light-my-request's request mock, which makes the deprecation pipe through to downstream consumers of dd-trace.

On real `http` / `http2` request objects `req.socket` and `req.connection` point to the exact same object reference, so dropping the second check is observationally equivalent — there is no combination of real request plumbing where `socket.encrypted` is falsy while `connection.encrypted` is truthy. A unit test that was previously asserting the legacy alias is updated to document the new behavior and act as a regression guard so nobody reintroduces the deprecated read.

Refs: https://nodejs.org/docs/latest-v18.x/api/http.html#messageconnection
