### PR TITLE
fix: support lazy startup log messages

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -97,7 +97,10 @@ module.exports.checkForPotentialConflicts = function () {
 }
 
 module.exports.flushStartupLogs = function (log) {
+  // Some callers pass `./log/writer` (simple pass-through) while others pass the main `./log`
+  // module (which supports lazy delegate functions). Invoke closures here so both work.
   while (warnings.length) {
-    log.warn(warnings.shift())
+    const entry = warnings.shift()
+    log.warn(typeof entry === 'function' ? entry() : entry)
   }
 }


### PR DESCRIPTION
`flushStartupLogs` is called both with the main `./log` module (which natively supports deferred/lazy message formatting via function arguments) and with the simpler `./log/writer` pass-through (which does not). Callers that push a closure onto the warnings queue — as recommended by the log module's docs for expensive formatting — ended up being stringified to `[object Function]` when the writer was used.

Invoke the closure at the call site so both log surfaces behave consistently. This is a minimal, self-contained fix with no change to the public API: callers that pass a string still work exactly as before.