### PR TITLE
test(debugger): assert newly-exposed inputPath key

### DIFF
--- a/packages/dd-trace/test/debugger/config.spec.js
+++ b/packages/dd-trace/test/debugger/config.spec.js
@@ -27,6 +27,7 @@ describe('getDebuggerConfig', function () {
       'runtimeId',
       'service',
       'url',
+      'inputPath',
     ])
     assertObjectContains(config, {
       commitSHA: tracerConfig.commitSHA,


### PR DESCRIPTION
The debugger's `getDebuggerConfig` helper now forwards the tracer's `inputPath` alongside the existing fields. The test that pins the exact set of keys was still enumerating the old list and would start failing as soon as anyone touched the config snapshot, despite the new key being fully intentional.

Add `inputPath` to the asserted set so this test tracks reality. Pure catch-up — no behavior change.
