### PR TITLE
test(debugger): merge caller snapshotConfig with defaults

### DIFF
--- a/packages/dd-trace/test/debugger/devtools_client/snapshot/utils.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot/utils.js
@@ -115,6 +115,8 @@ function assertOnBreakpoint (done, snapshotConfig, callback) {
   if (typeof snapshotConfig === 'function') {
     callback = snapshotConfig
     snapshotConfig = DEFAULT_CAPTURE_LIMITS
+  } else {
+    snapshotConfig = { ...DEFAULT_CAPTURE_LIMITS, ...snapshotConfig }
   }
 
   session.once('Debugger.paused', ({ params }) => {


### PR DESCRIPTION
`assertOnBreakpoint` accepts either a callback (in which case it applies `DEFAULT_CAPTURE_LIMITS`) or a `{ snapshotConfig, callback }` pair. The second shape was replacing the full capture-limits object with whatever the caller passed in, so tests that only wanted to override a single field (e.g. `maxReferenceDepth`) silently dropped every other default and behaved unpredictably.

Spread the defaults underneath the caller's override so partial configs refine the defaults instead of replacing them — matching the callback- only path's semantics and what every existing caller expects.
