### PR TITLE
test(debugger): ignore transitional UNACKNOWLEDGED state

### DIFF
--- a/integration-tests/debugger/diagnostics.spec.js
+++ b/integration-tests/debugger/diagnostics.spec.js
@@ -208,6 +208,9 @@ describe('Dynamic Instrumentation', function () {
         let receivedAckUpdate = false
 
         t.agent.on('remote-config-ack-update', (id, version, state, error) => {
+          // Transitional UNACKNOWLEDGED can arrive before the worker transitions to ERROR.
+          if (state === UNACKNOWLEDGED) return
+
           assert.strictEqual(id, `logProbe_${config.id}`)
           assert.strictEqual(version, 1)
           assert.strictEqual(state, ERROR)


### PR DESCRIPTION
The `Dynamic Instrumentation` suite listens for remote-config ack updates and asserts that the observed state is `ERROR`. The probe's worker can transiently emit `UNACKNOWLEDGED` before it transitions to `ERROR`, which caused the first ack to fail the strict-equality check and flake the suite on slower runners.

Skip the transitional `UNACKNOWLEDGED` event so the assertion only runs on the terminal state we actually care about. The test still fails if the terminal state is anything other than `ERROR` — we are only loosening the timing of when it is allowed to arrive.