### PR TITLE
test(profiling): replace RegExp.escape with includes check

### DIFF
--- a/packages/dd-trace/test/profiling/config.spec.js
+++ b/packages/dd-trace/test/profiling/config.spec.js
@@ -611,7 +611,8 @@ describe('config', () => {
       })
 
       if (warning) {
-        assert.match(compressionWarnings.join('\n'), new RegExp(RegExp.escape(warning)))
+        const joined = compressionWarnings.join('\n')
+        assert.ok(joined.includes(warning), `Expected warning "${warning}" in:\n${joined}`)
       } else {
         assert.deepStrictEqual(compressionWarnings, [])
       }


### PR DESCRIPTION
`RegExp.escape` is a very recent TC39 addition (stage-4 in 2024) and is not available on Node.js 18, which this repo still supports. The existing `assert.match(..., new RegExp(RegExp.escape(warning)))` would crash with a `TypeError: RegExp.escape is not a function` on the oldest supported runtime.

Since the assertion only needed to confirm the joined warnings include a literal substring, swap it for `assert.ok(joined.includes(warning))` with a descriptive failure message. No pattern matching required, no polyfill added, and the test now works on every supported Node.js version.