### PR TITLE
test(openfeature): match printf-style log.debug args

### DIFF
--- a/packages/dd-trace/test/openfeature/flagging_provider.spec.js
+++ b/packages/dd-trace/test/openfeature/flagging_provider.spec.js
@@ -72,7 +72,7 @@ describe('FlaggingProvider', () => {
       const provider = new FlaggingProvider(mockTracer, mockConfig)
 
       assert.ok(provider)
-      sinon.assert.calledWith(log.debug, 'FlaggingProvider created with timeout: 30000ms')
+      sinon.assert.calledWith(log.debug, '%s created with timeout: %dms', 'FlaggingProvider', 30000)
     })
   })
 
@@ -85,7 +85,7 @@ describe('FlaggingProvider', () => {
       provider._setConfiguration(ufc)
 
       sinon.assert.calledOnceWithExactly(setConfigSpy, ufc)
-      sinon.assert.calledWith(log.debug, 'FlaggingProvider provider configuration updated')
+      sinon.assert.calledWith(log.debug, '%s provider configuration updated', 'FlaggingProvider')
     })
 
     it('should handle null/undefined configuration gracefully', () => {


### PR DESCRIPTION
The `FlaggingProvider` implementation was migrated to printf-style `log.debug('%s created with timeout: %dms', ...)` calls (cheaper in hot paths because the format string is only expanded when the log level is active). Two spec assertions still expected the pre-formatted interpolated strings and would fail once the production change lands.

Update the two `sinon.assert.calledWith` calls to match the new format-string + positional-args shape. Pure test catch-up.
