### PR TITLE
refactor(playwright): extract browser-side evaluate callbacks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -463,6 +463,17 @@ export default [
       'eslint-rules/eslint-env-aliases': 'error',
       'eslint-rules/eslint-log-printf-style': 'error',
 
+      // Inline `.evaluate(<fn>)` callbacks (Playwright/Puppeteer) are serialized with
+      // `toString()` and run in chromium — coverage counters inside would ReferenceError.
+      'no-restricted-syntax': ['error', {
+        selector:
+          "CallExpression[callee.property.name='evaluate']" +
+          ":matches([arguments.0.type='ArrowFunctionExpression'], [arguments.0.type='FunctionExpression'])",
+        message:
+          'Move the inline `.evaluate(...)` callback into a `*-browser-scripts.js` file ' +
+          '(NYC-excluded in nyc.config.js) and import it here.',
+      }],
+
       'n/no-restricted-require': ['error', [
         ...GLOBAL_RESTRICTED_REQUIRES,
         {

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -30,6 +30,7 @@ module.exports = {
   ],
   exclude: [
     '**/.bun/**',
+    '**/*-browser-scripts.js', // Serialized into browsers; coverage counters would ReferenceError.
     '**/*.spec.*',
     '**/fixtures/**',
     '**/integration-tests/**',

--- a/packages/datadog-instrumentations/src/playwright-browser-scripts.js
+++ b/packages/datadog-instrumentations/src/playwright-browser-scripts.js
@@ -1,0 +1,27 @@
+'use strict'
+
+// Serialized into chromium via Playwright's `page.evaluate`. Excluded from coverage by filename.
+// Rename only if you update that glob too.
+
+/** @returns {{ isRumInstrumented: boolean, isRumActive: boolean, rumSamplingRate: number | null }} */
+function detectRum () {
+  const isRumInstrumented = !!window.DD_RUM
+  const isRumActive = window.DD_RUM && window.DD_RUM.getInternalContext
+    ? !!window.DD_RUM.getInternalContext()
+    : false
+  const rumSamplingRate = window.DD_RUM && window.DD_RUM.getInitConfiguration
+    ? window.DD_RUM.getInitConfiguration().sessionSampleRate
+    : null
+  return { isRumInstrumented, isRumActive, rumSamplingRate }
+}
+
+/** @returns {boolean} */
+function stopRumSession () {
+  if (window.DD_RUM && window.DD_RUM.stopSession) {
+    window.DD_RUM.stopSession()
+    return true
+  }
+  return false
+}
+
+module.exports = { detectRum, stopRumSession }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -52,6 +52,9 @@ let applyRepeatEachIndex = null
 
 let startedSuites = []
 
+// Browser-side callbacks live in a coverage-excluded file so coverage counters can't reach chromium.
+const { detectRum, stopRumSession } = require('./playwright-browser-scripts')
+
 const STATUS_TO_TEST_STATUS = {
   passed: 'pass',
   failed: 'fail',
@@ -1117,16 +1120,7 @@ addHook({
 
     try {
       if (page) {
-        const { isRumInstrumented, isRumActive, rumSamplingRate } = await page.evaluate(() => {
-          const isRumInstrumented = !!window.DD_RUM
-          const isRumActive = window.DD_RUM && window.DD_RUM.getInternalContext
-            ? !!window.DD_RUM.getInternalContext()
-            : false
-          const rumSamplingRate = window.DD_RUM && window.DD_RUM.getInitConfiguration
-            ? window.DD_RUM.getInitConfiguration().sessionSampleRate
-            : null
-          return { isRumInstrumented, isRumActive, rumSamplingRate }
-        })
+        const { isRumInstrumented, isRumActive, rumSamplingRate } = await page.evaluate(detectRum)
         if (isRumInstrumented && rumSamplingRate < 100 && !isRumActive) {
           log.debug("RUM was detected on the page, but it isn't active because the sampling rate is below 100%")
         }
@@ -1209,13 +1203,7 @@ addHook({
           fn: async function ({ page }) {
             try {
               if (page) {
-                const isRumActive = await page.evaluate(() => {
-                  if (window.DD_RUM && window.DD_RUM.stopSession) {
-                    window.DD_RUM.stopSession()
-                    return true
-                  }
-                  return false
-                })
+                const isRumActive = await page.evaluate(stopRumSession)
 
                 if (isRumActive) {
                   // Give some time RUM to flush data, similar to what we do in selenium


### PR DESCRIPTION
Playwright's `page.evaluate(fn)` stringifies the callback with `fn.toString()` and ships the source into the chromium worker, where it runs with no access to the Node.js module graph. That is normally fine, but it breaks the moment the calling file is instrumented by NYC: the serialized body references NYC's counter globals (`cov_xxxx.f[0]++`, etc.) which do not exist in the browser, so the evaluate fails at runtime with `ReferenceError: cov_xxxx is not defined`. The symptom is silent because Playwright surfaces the browser error asynchronously — tests just start flapping.

Three coordinated pieces close the foot-gun for the whole codebase:

1. `packages/datadog-instrumentations/src/playwright-browser-scripts.js` is a new file that holds the two inline callbacks (`detectRum` and `stopRumSession`) that used to live in `playwright.js`. The file is required by the instrumentation and the two function values are passed through to `page.evaluate(...)` instead of anonymous arrows.

2. `nyc.config.js` adds `**/*-browser-scripts.js` to the exclusion list, so NYC never instruments these files. Renaming the file pattern requires updating both this glob and the eslint rule below — the in-source comment calls that out.

3. `eslint.config.mjs` adds a targeted `no-restricted-syntax` rule that errors when any `.evaluate(<inline function>)` call appears anywhere in the repo, pointing the author at the `*-browser-scripts.js` convention. Without the lint rule this class of bug would creep right back in the next time someone inlines a callback for convenience.

Behavioral parity with the old code is intentional — both helpers return the exact same shapes they did when they were inline. Only the call sites change.
