### PR TITLE
fix(opentelemetry): implement setUrl on OTLP HTTP exporter base

### DIFF
--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -31,6 +31,7 @@ class OtlpHttpExporterBase {
 
     this.protocol = protocol
     this.signalType = signalType
+    this._defaultPath = defaultPath
 
     // If no path is provided, use default path
     const path = parsedUrl.pathname === '/' ? defaultPath : parsedUrl.pathname
@@ -171,6 +172,19 @@ class OtlpHttpExporterBase {
     }
 
     return headers
+  }
+
+  /**
+   * Updates the target URL used by this exporter. Called by the tracer when
+   * the agent URL changes at runtime (e.g. via `tracer.setUrl(...)`).
+   * @param {string} url - New OTLP endpoint URL
+   */
+  setUrl (url) {
+    const parsedUrl = new URL(url)
+    const path = parsedUrl.pathname === '/' ? this._defaultPath : parsedUrl.pathname
+    this.options.hostname = parsedUrl.hostname
+    this.options.port = parsedUrl.port
+    this.options.path = path + parsedUrl.search
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -16,6 +16,8 @@ const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
  * @class OtlpHttpExporterBase
  */
 class OtlpHttpExporterBase {
+  #defaultPath
+
   /**
    * Creates a new OtlpHttpExporterBase instance.
    *
@@ -27,20 +29,14 @@ class OtlpHttpExporterBase {
    * @param {string} signalType - Signal type for error messages (e.g., 'logs', 'metrics')
    */
   constructor (url, headers, timeout, protocol, defaultPath, signalType) {
-    const parsedUrl = new URL(url)
-
     this.protocol = protocol
     this.signalType = signalType
-    this._defaultPath = defaultPath
+    this.#defaultPath = defaultPath
 
-    // If no path is provided, use default path
-    const path = parsedUrl.pathname === '/' ? defaultPath : parsedUrl.pathname
     const isJson = protocol === 'http/json'
 
+    // Initialize fields setUrl doesn't touch; it fills in hostname/port/path below.
     this.options = {
-      hostname: parsedUrl.hostname,
-      port: parsedUrl.port,
-      path: path + parsedUrl.search,
       method: 'POST',
       timeout,
       headers: {
@@ -48,6 +44,9 @@ class OtlpHttpExporterBase {
         ...this.#parseAdditionalHeaders(headers),
       },
     }
+
+    this.setUrl(url)
+
     this.telemetryTags = [
       'protocol:http',
       `encoding:${isJson ? 'json' : 'protobuf'}`,
@@ -181,7 +180,7 @@ class OtlpHttpExporterBase {
    */
   setUrl (url) {
     const parsedUrl = new URL(url)
-    const path = parsedUrl.pathname === '/' ? this._defaultPath : parsedUrl.pathname
+    const path = parsedUrl.pathname === '/' ? this.#defaultPath : parsedUrl.pathname
     this.options.hostname = parsedUrl.hostname
     this.options.port = parsedUrl.port
     this.options.path = path + parsedUrl.search

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -714,4 +714,34 @@ describe('OpenTelemetry Traces', () => {
       assert(telemetryMetrics.manager.namespace().count().inc.calledWith(1))
     })
   })
+
+  describe('setUrl', () => {
+    const OtlpHttpTraceExporter = require('../../src/opentelemetry/trace/otlp_http_trace_exporter')
+
+    it('retargets hostname, port, and path when given a full URL', () => {
+      const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', '', 1000, {})
+
+      exporter.setUrl('http://otel-collector:9999/custom/path')
+
+      assert.strictEqual(exporter.options.hostname, 'otel-collector')
+      assert.strictEqual(exporter.options.port, '9999')
+      assert.strictEqual(exporter.options.path, '/custom/path')
+    })
+
+    it('falls back to the default path when the URL has no path', () => {
+      const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', '', 1000, {})
+
+      exporter.setUrl('http://otel-collector:9999')
+
+      assert.strictEqual(exporter.options.path, '/v1/traces')
+    })
+
+    it('preserves the URL query string', () => {
+      const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', '', 1000, {})
+
+      exporter.setUrl('http://otel-collector:9999/v1/traces?token=abc')
+
+      assert.strictEqual(exporter.options.path, '/v1/traces?token=abc')
+    })
+  })
 })


### PR DESCRIPTION
### What does this PR do?

Adds a `setUrl(url)` method to `OtlpHttpExporterBase` so that `tracer.setUrl(...)` no longer throws when OTLP traces export is enabled.

### TL;DR — Impact

**Bug:** `tracer.setUrl(url)` crashes with `TypeError: this._exporter.setUrl is not a function` whenever OTLP traces export is enabled (`OTEL_TRACES_EXPORTER=otlp` or equivalent).

**Origin:** #7531 ("feat: support for OTLP trace export (http/json)") wired an OTLP exporter into `DatadogTracer` but didn't implement the `setUrl` method that the tracer base contract expects.

**Who's affected:** any customer using the new OTLP traces feature who also calls the documented public API `tracer.setUrl(...)` (`index.d.ts:61`) — common in serverless setups with dynamic agent URLs, custom init wrappers, and test harnesses. Also affects every dd-trace-js contributor whose shell exports `OTEL_TRACES_EXPORTER=otlp` (e.g. Claude Code), since the plugin test harness at `packages/dd-trace/test/plugins/agent.js:530` calls `tracer.setUrl` during setup and currently blows up before a single test runs.

**Severity:** synchronous throw out of a documented public API. Propagates up the customer's call stack or becomes an unhandled rejection if `setUrl` is invoked inside an async flow — i.e. it can crash user apps, which violates the tracer's "never crash user apps" rule.

**Scope:** opt-in (OTLP traces flag) + `setUrl` call site — narrow, but 100% reproducible for anyone who hits both.

### Motivation

`tracer.setUrl` is a documented public API (`index.d.ts:61`) and is invoked by `DatadogTracer.setUrl` at `packages/dd-trace/src/tracer.js:127-130`:

```js
setUrl (url) {
  this._exporter.setUrl(url)          // ← throws when OTLP exporter is selected
  this._dataStreamsProcessor.setUrl(url)
}
```

With this fix, customer calls to `tracer.setUrl(...)` re-target OTLP traffic instead of crashing.

### Changes

- `packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js`
  - Persist `defaultPath` on the instance as `this._defaultPath`
  - Add `setUrl(url)` that re-parses the URL and updates `options.hostname`, `options.port`, and `options.path` in place (falling back to `_defaultPath` when the URL has no path)
- `packages/dd-trace/test/opentelemetry/traces.spec.js`
  - Three new unit tests covering full URL, default-path fallback, and query-string preservation

### Additional Notes

Both OTLP subclasses (`OtlpHttpTraceExporter`, and any future OTLP logs/metrics exporter) inherit the new method automatically — no per-subclass change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)