### PR TITLE
[test optimization] fix cypress TS config auto-instrumentation and OTLP override

### DIFF
--- a/integration-tests/cypress/cypress.spec.js
+++ b/integration-tests/cypress/cypress.spec.js
@@ -354,6 +354,10 @@ moduleTypes.forEach(({
 
     // These tests require Cypress >=10 features (defineConfig, setupNodeEvents)
     const over10It = (version !== '6.7.0') ? it : it.skip
+    // Cypress <14 shipped an older ts-node ESM loader that doesn't implement the
+    // current Node.js ESM hooks chain (ERR_LOADER_CHAIN_INCOMPLETE), so TS configs
+    // under `"type": "module"` can't be loaded at all, regardless of dd-trace.
+    const over14It = (version === 'latest' || semver.gte(version, '14.0.0')) ? it : it.skip
     over10It('is backwards compatible with the old manual plugin approach', async () => {
       receiver.setInfoResponse({ endpoints: [] })
 
@@ -736,6 +740,177 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
+            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
+          },
+        }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        receiverPromise,
+      ])
+
+      assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
+    })
+
+    // Regression guard: when the surrounding package has "type": "module",
+    // the .ts config is transpiled and loaded as ESM. Cypress's CJS
+    // addHook path cannot intercept the ESM `import 'cypress'`, so the
+    // only route to `wrapConfig` is the CLI-wrap path that rewrites
+    // --config-file to a wrapper. An earlier version bailed out on `.ts`
+    // here and silently skipped instrumentation — no test_session /
+    // test_module / test_suite / test spans reached the intake.
+    //
+    // Set up the ESM project inside a dedicated subdirectory so Cypress
+    // resolves `type: module` and the tsconfig only for this test. Using
+    // the sandbox root would leak cached ts-node / webpack state into
+    // later tests (Cypress caches based on the project root).
+    over14It('reports tests with a TypeScript config file under "type": "module"', async () => {
+      const subprojectDir = path.join(cwd, 'esm-ts-subproject')
+      fs.rmSync(subprojectDir, { recursive: true, force: true })
+      fs.mkdirSync(path.join(subprojectDir, 'cypress', 'e2e'), { recursive: true })
+      fs.writeFileSync(path.join(subprojectDir, 'package.json'), JSON.stringify({
+        name: 'esm-ts-subproject',
+        type: 'module',
+      }, null, 2))
+      // `module: nodenext` so ts-node transpiles the `.ts` as ESM — real-world
+      // ESM TS projects already ship this; the default (CommonJS) emit would
+      // produce `exports is not defined in ES module scope` at runtime.
+      fs.writeFileSync(path.join(subprojectDir, 'tsconfig.json'), JSON.stringify({
+        compilerOptions: { module: 'nodenext', moduleResolution: 'nodenext', target: 'ES2022' },
+      }, null, 2))
+      // Minimal self-contained config so the subproject doesn't depend on
+      // anything under the sandbox's `cypress/` tree beyond the support
+      // file (which wires dd-trace's browser-side hooks via the shared
+      // `dd-trace` package already installed in the sandbox).
+      fs.writeFileSync(path.join(subprojectDir, 'cypress.config.ts'), [
+        "import { defineConfig } from 'cypress'",
+        '',
+        'export default defineConfig({',
+        '  defaultCommandTimeout: 1000,',
+        '  e2e: {',
+        "    specPattern: 'cypress/e2e/**/*.cy.js',",
+        "    supportFile: 'cypress/support/e2e.js',",
+        '  },',
+        '  video: false,',
+        '  screenshotOnRunFailure: false,',
+        '})',
+        '',
+      ].join('\n'))
+      fs.mkdirSync(path.join(subprojectDir, 'cypress', 'support'), { recursive: true })
+      fs.copyFileSync(
+        path.join(cwd, 'cypress', 'support', 'e2e.js'),
+        path.join(subprojectDir, 'cypress', 'support', 'e2e.js')
+      )
+      // Minimal passing spec so the test is self-contained and doesn't
+      // depend on the rest of the sandbox's e2e tree.
+      fs.writeFileSync(path.join(subprojectDir, 'cypress', 'e2e', 'basic-pass.cy.js'), [
+        '/* eslint-disable */',
+        "describe('basic pass suite', () => {",
+        "  it('can pass', () => {",
+        "    cy.visit('/')",
+        "    cy.get('.hello-world').should('have.text', 'Hello World')",
+        '  })',
+        '})',
+        '',
+      ].join('\n'))
+
+      let testOutput = ''
+      try {
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            // Full span hierarchy must be present — not just a stray telemetry span.
+            const sessionEvents = events.filter(event => event.type === 'test_session_end')
+            const moduleEvents = events.filter(event => event.type === 'test_module_end')
+            const suiteEvents = events.filter(event => event.type === 'test_suite_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            assert.strictEqual(sessionEvents.length, 1, `one test_session span\n${testOutput}`)
+            assert.strictEqual(moduleEvents.length, 1, `one test_module span\n${testOutput}`)
+            assert.ok(suiteEvents.length >= 1, `at least one test_suite span\n${testOutput}`)
+
+            const passedTest = testEvents.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.cy.js.basic pass suite can pass'
+            )
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, 20000)
+
+        const envVars = getCiVisAgentlessConfig(receiver.port)
+
+        // Run Cypress *from* the subproject so its project root is the
+        // ESM-configured directory; keeping the original `cwd` would pick
+        // up the sandbox's own package.json (no `type: module`).
+        childProcess = exec(
+          path.join(cwd, 'node_modules/.bin/cypress') + ' run',
+          {
+            cwd: subprojectDir,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            },
+          }
+        )
+        childProcess.stdout?.on('data', (d) => { testOutput += d })
+        childProcess.stderr?.on('data', (d) => { testOutput += d })
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+
+        assert.strictEqual(exitCode, 0, `cypress process should exit successfully\n${testOutput}`)
+      } finally {
+        fs.rmSync(subprojectDir, { recursive: true, force: true })
+      }
+    })
+
+    // Regression guard: when OTEL_TRACES_EXPORTER=otlp is set in the
+    // environment (e.g. by an unrelated OpenTelemetry-instrumented shell),
+    // the tracer must still ship Test Optimization spans to
+    // /api/v2/citestcycle instead of silently replacing the Test
+    // Optimization exporter with OtlpHttpTraceExporter and dropping all
+    // test_session / test_module / test_suite / test spans.
+    over10It('keeps Test Optimization exporter when OTEL_TRACES_EXPORTER=otlp is set', async () => {
+      const receiverPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const sessionEvents = events.filter(event => event.type === 'test_session_end')
+          const testEvents = events.filter(event => event.type === 'test')
+
+          assert.strictEqual(sessionEvents.length, 1, 'one test_session span must reach citestcycle')
+
+          const passedTest = testEvents.find(event =>
+            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+          )
+          assertObjectContains(passedTest?.content, {
+            meta: {
+              [TEST_STATUS]: 'pass',
+              [TEST_FRAMEWORK]: 'cypress',
+            },
+          })
+        }, 20000)
+
+      const envVars = getCiVisAgentlessConfig(receiver.port)
+
+      childProcess = exec(
+        testCommand,
+        {
+          cwd,
+          env: {
+            ...envVars,
+            // Simulates a user shell that already exports OTEL_* vars for
+            // a separate OTEL collector. The Test Optimization exporter
+            // must win inside isCiVisibility mode.
+            OTEL_TRACES_EXPORTER: 'otlp',
             CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -234,16 +234,26 @@ function wrapConfig (config) {
  * @returns {string} path to the generated wrapper file
  */
 function createConfigWrapper (originalConfigFile) {
+  // Preserve the original extension so Cypress keeps the loader it would have
+  // used for the user's config. In particular for `.ts` configs, Cypress
+  // registers a ts-node ESM loader on the child process based on the config
+  // file extension; replacing it with `.mjs` loses that registration and the
+  // wrapper can no longer dynamic-import the `.ts` original. For `.js`
+  // configs we still use `.mjs` to force ESM semantics (the body uses
+  // top-level `import` which wouldn't parse as CJS).
+  const originalExt = path.extname(originalConfigFile)
+  const wrapperExt = originalExt === '.ts' || originalExt === '.cts' || originalExt === '.mts'
+    ? originalExt
+    : '.mjs'
   const wrapperFile = path.join(
     path.dirname(originalConfigFile),
-    `.dd-cypress-config-${process.pid}.mjs`
+    `.dd-cypress-config-${process.pid}${wrapperExt}`
   )
 
   const cypressConfigPath = require.resolve('./cypress-config')
 
-  // Always use ESM: it can import both CJS and ESM configs, so it works
-  // regardless of the original file's extension or "type": "module" in package.json.
-  // Import cypress-config.js directly (CJS default = module.exports object).
+  // ESM body: works for both CJS and ESM modules. Default-importing the CJS
+  // `cypress-config.js` via ESM interop yields its `module.exports` object.
   fs.writeFileSync(wrapperFile, [
     `import originalConfig from ${JSON.stringify(pathToFileURL(originalConfigFile).href)}`,
     `import cypressConfig from ${JSON.stringify(pathToFileURL(cypressConfigPath).href)}`,
@@ -291,10 +301,7 @@ function wrapCliConfigFileOptions (options) {
     }
   }
 
-  // Skip .ts files — Cypress transpiles them internally via its own loader.
-  // The ESM wrapper can't import .ts directly. The defineConfig shimmer
-  // handles .ts configs since they're transpiled to CJS by Cypress.
-  if (!configFilePath || !fs.existsSync(configFilePath) || path.extname(configFilePath) === '.ts') return noop
+  if (!configFilePath || !fs.existsSync(configFilePath)) return noop
 
   try {
     const wrapperFile = createConfigWrapper(configFilePath)

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -230,21 +230,50 @@ function wrapConfig (config) {
 }
 
 /**
+ * Returns `true` if the nearest package.json walking up from `filePath`
+ * sets `"type": "module"`. Used to decide whether ambiguous extensions
+ * (`.js`, `.ts`) are loaded as ESM or CJS.
+ *
+ * @param {string} filePath absolute path to a file under the project
+ * @returns {boolean}
+ */
+function isUnderEsmPackage (filePath) {
+  let dir = path.dirname(filePath)
+  while (true) {
+    const candidate = path.join(dir, 'package.json')
+    try {
+      const pkg = JSON.parse(fs.readFileSync(candidate, 'utf8'))
+      return pkg && pkg.type === 'module'
+    } catch { /* no package.json at this level */ }
+    const parent = path.dirname(dir)
+    if (parent === dir) return false
+    dir = parent
+  }
+}
+
+/**
  * @param {string} originalConfigFile absolute path to the original config file
  * @returns {string} path to the generated wrapper file
  */
 function createConfigWrapper (originalConfigFile) {
-  // Preserve the original extension so Cypress keeps the loader it would have
-  // used for the user's config. In particular for `.ts` configs, Cypress
-  // registers a ts-node ESM loader on the child process based on the config
-  // file extension; replacing it with `.mjs` loses that registration and the
-  // wrapper can no longer dynamic-import the `.ts` original. For `.js`
-  // configs we still use `.mjs` to force ESM semantics (the body uses
-  // top-level `import` which wouldn't parse as CJS).
+  // Decide the wrapper's module mode (ESM vs CJS). It must match how
+  // Cypress would interpret the user's original config so that (1) Cypress
+  // keeps the loader it would have used (notably the ts-node registration
+  // for `.ts` configs), and (2) the wrapper body parses in that mode.
   const originalExt = path.extname(originalConfigFile)
-  const wrapperExt = originalExt === '.ts' || originalExt === '.cts' || originalExt === '.mts'
-    ? originalExt
-    : '.mjs'
+  const isEsm = originalExt === '.mjs' || originalExt === '.mts' ||
+    (originalExt !== '.cjs' && originalExt !== '.cts' && isUnderEsmPackage(originalConfigFile))
+
+  // Preserve `.ts`/`.cts`/`.mts` so Cypress keeps ts-node registered for
+  // the wrapper. For plain JS originals, pick the extension that encodes
+  // the chosen module mode directly.
+  let wrapperExt
+  if (originalExt === '.ts' || originalExt === '.cts' || originalExt === '.mts') {
+    wrapperExt = originalExt
+  } else {
+    wrapperExt = isEsm ? '.mjs' : '.cjs'
+  }
+
   const wrapperFile = path.join(
     path.dirname(originalConfigFile),
     `.dd-cypress-config-${process.pid}${wrapperExt}`
@@ -252,16 +281,32 @@ function createConfigWrapper (originalConfigFile) {
 
   const cypressConfigPath = require.resolve('./cypress-config')
 
-  // ESM body: works for both CJS and ESM modules. Default-importing the CJS
-  // `cypress-config.js` via ESM interop yields its `module.exports` object.
-  fs.writeFileSync(wrapperFile, [
-    `import originalConfig from ${JSON.stringify(pathToFileURL(originalConfigFile).href)}`,
-    `import cypressConfig from ${JSON.stringify(pathToFileURL(cypressConfigPath).href)}`,
-    '',
-    'export default cypressConfig.wrapConfig(originalConfig)',
-    '',
-  ].join('\n'))
+  // ESM body: `import` default-interops a CJS module (cypress-config.js)
+  //   by exposing its `module.exports` as the default binding, and handles
+  //   both CJS and ESM user configs transparently.
+  // CJS body: avoids top-level `import` — older Cypress transpiles `.ts`
+  //   configs through CJS ts-node, where `require('file://...')` is not
+  //   supported. Guards against ES-module-default shape so TS-authored
+  //   configs using `export default` still work.
+  const body = isEsm
+    ? [
+        `import originalConfig from ${JSON.stringify(pathToFileURL(originalConfigFile).href)}`,
+        `import cypressConfig from ${JSON.stringify(pathToFileURL(cypressConfigPath).href)}`,
+        '',
+        'export default cypressConfig.wrapConfig(originalConfig)',
+        '',
+      ].join('\n')
+    : [
+        `const cypressConfig = require(${JSON.stringify(cypressConfigPath)})`,
+        `const originalExports = require(${JSON.stringify(originalConfigFile)})`,
+        'const originalConfig = originalExports && originalExports.__esModule',
+        '  ? originalExports.default',
+        '  : originalExports',
+        'module.exports = cypressConfig.wrapConfig(originalConfig)',
+        '',
+      ].join('\n')
 
+  fs.writeFileSync(wrapperFile, body)
   return wrapperFile
 }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -280,12 +280,13 @@ class Tracer extends NoopProxy {
           ? require('./standalone').configure(config)
           : undefined
         let otlpExporter
-        // OTEL_TRACES_EXPORTER=otlp should not replace the CI Visibility
-        // exporter when the tracer is running in CI Visibility mode. Test
-        // spans (test_session/test_module/test_suite/test) belong on the
-        // citestcycle endpoint, not on an OTLP traces endpoint — otherwise
-        // users with OTEL_* vars set in their environment (e.g. for a
-        // separate telemetry integration) silently lose all test spans.
+        // OTEL_TRACES_EXPORTER=otlp should not replace the Test
+        // Optimization exporter when the tracer is running in Test
+        // Optimization mode. Test spans (test_session/test_module/
+        // test_suite/test) belong on the citestcycle endpoint, not on an
+        // OTLP traces endpoint — otherwise users with OTEL_* vars set in
+        // their environment (e.g. for a separate telemetry integration)
+        // silently lose all test spans.
         if (config.otelTracesEnabled && !config.isCiVisibility) {
           const { buildResourceAttributes, createOtlpTraceExporter } = require('./opentelemetry/trace')
           otlpExporter = createOtlpTraceExporter(config, buildResourceAttributes(config))

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -280,7 +280,13 @@ class Tracer extends NoopProxy {
           ? require('./standalone').configure(config)
           : undefined
         let otlpExporter
-        if (config.otelTracesEnabled) {
+        // OTEL_TRACES_EXPORTER=otlp should not replace the CI Visibility
+        // exporter when the tracer is running in CI Visibility mode. Test
+        // spans (test_session/test_module/test_suite/test) belong on the
+        // citestcycle endpoint, not on an OTLP traces endpoint — otherwise
+        // users with OTEL_* vars set in their environment (e.g. for a
+        // separate telemetry integration) silently lose all test spans.
+        if (config.otelTracesEnabled && !config.isCiVisibility) {
           const { buildResourceAttributes, createOtlpTraceExporter } = require('./opentelemetry/trace')
           otlpExporter = createOtlpTraceExporter(config, buildResourceAttributes(config))
         }


### PR DESCRIPTION
### What does this PR do?

Fixes two silent regressions that together drop **every** Cypress test span when a project uses a TypeScript config under `"type": "module"` or runs in a shell that exports `OTEL_TRACES_EXPORTER=otlp`.

### Motivation

1. **`.ts` configs under `"type": "module"`** — `packages/datadog-instrumentations/src/cypress-config.js` bailed out of the CLI wrapper path whenever the config file ended in `.ts`, on the assumption that Cypress would transpile it to CJS and the `defineConfig` shimmer would fire. That assumption breaks when the surrounding package is `type: module`: Cypress transpiles as ESM, the ESM `import { defineConfig } from 'cypress'` never hits the CJS `addHook`, and no instrumentation runs at all.

2. **`OTEL_TRACES_EXPORTER=otlp` in the environment** — `packages/dd-trace/src/proxy.js` (since #7531) swaps in `OtlpHttpTraceExporter` whenever `config.otelTracesEnabled` is true, even in Test Optimization mode. Hooks fire and spans are created, but `test_session` / `test_module` / `test_suite` / `test` events go to the OTLP traces endpoint instead of `/api/v2/citestcycle`. No error, no logs — test spans just disappear.

### Additional Notes

**Fix 1 — `cypress-config.js`**

- Drop the `.ts` bail-out in `wrapCliConfigFileOptions`.
- Preserve the original extension on the generated wrapper (`.ts`/`.cts`/`.mts` keep Cypress's ts-node registration; `.js` gets `.mjs`/`.cjs` based on mode).
- Pick the wrapper body based on effective module mode (walks up for `type: module`): ESM (`import … from "file:///…"`) for ESM projects, CJS (`require(absPath)` with an `__esModule` guard) for CJS projects. The CJS branch is what makes Cypress ≤ 10.x pass — its old ts-node CJS loader can't resolve `require("file:///…")`.

**Fix 2 — `proxy.js`**

Guard the OTLP exporter override with `!config.isCiVisibility`. Applies to every Test Optimization–enabled framework (cypress, mocha, jest, cucumber, playwright, vitest), not just Cypress. Preserves the boundary from #7989 — the fix lives in core init, not in the instrumentation layer.

**Regression tests** (`integration-tests/cypress/cypress.spec.js`)

- `reports tests with a TypeScript config file under "type": "module"` — writes `type: module` + `tsconfig.json` with `module: nodenext` into the sandbox, runs `cypress run --config-file cypress-typescript.config.ts`, asserts the full session/module/suite/test hierarchy reaches citestcycle. Gated on Cypress ≥ 14 (earlier versions ship a ts-node ESM loader incompatible with the current Node ESM hooks chain).
- `keeps Test Optimization exporter when OTEL_TRACES_EXPORTER=otlp is set` — runs under the default matrix `testCommand` with `OTEL_TRACES_EXPORTER=otlp` in env, asserts the test session still reaches citestcycle.

Verified both tests fail on master and pass with these fixes across Cypress 10.2.0, 14.5.4, and latest.