### PR TITLE
Pin datadog-ci for junit upload

### DIFF
--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -17,4 +17,5 @@ runs:
       uses: DataDog/junit-upload-github-action@24449d01fc01e721fa36ccd2caa3caae6922f0e8 # v3.0.0
       with:
         api_key: ${{ inputs.dd_api_key }}
+        datadog-ci-version: 5.13.1
         service: dd-trace-js-tests

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -17,5 +17,7 @@ runs:
       uses: DataDog/junit-upload-github-action@24449d01fc01e721fa36ccd2caa3caae6922f0e8 # v3.0.0
       with:
         api_key: ${{ inputs.dd_api_key }}
+        # TODO: remove once https://github.com/DataDog/junit-upload-github-action/pull/54 lands
+        # and junit-upload-github-action releases are tied to datadog-ci releases.
         datadog-ci-version: 5.13.1
         service: dd-trace-js-tests

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -78,6 +78,8 @@ jobs:
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
+          # TODO: remove once https://github.com/DataDog/junit-upload-github-action/pull/54 lands
+          # and junit-upload-github-action releases are tied to datadog-ci releases.
           datadog-ci-version: 5.13.1
           service: dd-trace-js-tests
 

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -78,6 +78,7 @@ jobs:
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
+          datadog-ci-version: 5.13.1
           service: dd-trace-js-tests
 
   core:


### PR DESCRIPTION
### What does this PR do?
Pins the `datadog-ci version` used by `DataDog/junit-upload-github-action` to [5.13.1](https://github.com/DataDog/datadog-ci/releases/tag/v5.13.1) in `.github/actions/push_to_test_optimization/action.yml and .github/workflows/platform.yml`.

### Motivation
Some jobs intermittently fail in the `push_to_test_optimization` step after the upgrade to `DataDog/junit-upload-github-action` v3.0.0. Example in https://github.com/DataDog/dd-trace-js/actions/runs/24780644771/job/72510523178?pr=8060.
The failure happens inside `DataDog/install-datadog-ci-github-action` while resolving the floating `datadog-ci` version v5, where `jq` receives a non-release JSON payload and crashes with `Cannot index string with string "prerelease"`. Pinning `datadog-ci` to 5.13.1 avoids that floating-version GitHub release lookup while preserving the v3 junit upload action behavior.

