### PR TITLE
chore(ci) : fix concurrency clause on master

### DIFF
--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -8,8 +8,8 @@ on:
     - cron: 0 4 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -8,8 +8,8 @@ on:
     - cron: 0 4 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   all-green:

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,8 +6,8 @@ on:
       - dependabot/**
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dependencies:

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -8,8 +8,8 @@ on:
     - cron: 0 4 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/eslint-rules.yml
+++ b/.github/workflows/eslint-rules.yml
@@ -10,8 +10,8 @@ on:
       - "eslint-rules/**"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   eslint-rules:

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}
@@ -280,7 +280,7 @@ jobs:
         if: "!cancelled()"
         with:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
-  
+
   langgraph:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -8,8 +8,8 @@ on:
     - cron: 0 4 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}
@@ -74,7 +74,7 @@ jobs:
       - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:integration:bun
-      - uses: DataDog/junit-upload-github-action@24449d01fc01e721fa36ccd2caa3caae6922f0e8  # v3.0.0
+      - uses: DataDog/junit-upload-github-action@24449d01fc01e721fa36ccd2caa3caae6922f0e8 # v3.0.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -6,8 +6,8 @@ on:
     branches: [master, mq-working-branch-master-*]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   actionlint:

--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -6,8 +6,8 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+-proposal
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate-proposal:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish-v3:

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -14,8 +14,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ inputs.latest-version }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}
@@ -292,8 +292,8 @@ jobs:
       SERVICES: azurite
 
     steps:
-     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-     - uses: ./.github/actions/plugins/test
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/plugins/test
 
   google-cloud-pubsub:
     runs-on: ubuntu-latest

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -10,8 +10,8 @@ on:
 
 concurrency:
   # this ensures that only one workflow runs at a time for a given branch on pull requests
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-artifacts:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -8,8 +8,8 @@ on:
     - cron: 0 4 * * *
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  cancel-in-progress: true
 
 env:
   MOCHA_OPTIONS: ${{ github.ref == 'refs/heads/master' && '--retries 1' || '' }}


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Follow up of #8016, fixing the concurrency clause on `master`, but adding  `run_id` on concurrency group when it runs on `master`

### Motivation

I misunderstood how `cancel-in-progress`. I initially understood that if `cancel-in-progress=false`, all jobs will be executed. But that's not true : https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/workflow-syntax#concurrency

The concurrency clause allows to *have only one job running at the same time*. If a job is running and a new job in the same group is spawn : 

*`cancel-in-progress=true` will cancel the running job. 
*`cancel-in-progress=false` will queue the second job.

But if  `cancel-in-progress` is set to `false`, it does not mean that all jobs will be executed, it only means only one job will be queued. Any other queued job will cancel the queued job.

So to run all job on master, we need to set a different `concurrency.group` for all of them.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


