### PR TITLE
chore: generate more narrow config types

### DIFF
--- a/packages/dd-trace/src/config/config-types.d.ts
+++ b/packages/dd-trace/src/config/config-types.d.ts
@@ -10,11 +10,8 @@ export interface ConfigProperties extends GeneratedConfig {
   }
   commitSHA: string | undefined
   debug: boolean
-  gcpPubSubPushSubscriptionEnabled: boolean
   instrumentationSource: 'manual' | 'ssi'
-  isAzureFunction: boolean
   isCiVisibility: boolean
-  isGCPFunction: boolean
   isServiceNameInferred: boolean
   isServiceUserProvided: boolean
   logger: import('../../../../index').TracerOptions['logger'] | undefined
@@ -22,7 +19,6 @@ export interface ConfigProperties extends GeneratedConfig {
   readonly parsedDdTags: Record<string, string>
   plugins: boolean
   repositoryUrl: string | undefined
-  rules: import('../../../../index').SamplingRule[]
   sampler: {
     rateLimit: number
     rules: import('../../../../index').SamplingRule[]

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -482,7 +482,7 @@ export interface GeneratedConfig {
   OTEL_EXPORTER_OTLP_HEADERS: Record<string, string> | undefined;
   OTEL_EXPORTER_OTLP_LOGS_HEADERS: Record<string, string> | undefined;
   OTEL_EXPORTER_OTLP_METRICS_HEADERS: Record<string, string> | undefined;
-  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: string | undefined;
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: string;
   OTEL_EXPORTER_OTLP_TRACES_HEADERS: Record<string, string> | undefined;
   OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: "http/json";
   OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: number;
@@ -497,7 +497,7 @@ export interface GeneratedConfig {
   otelLogsEnabled: boolean;
   otelLogsProtocol: string;
   otelLogsTimeout: number;
-  otelLogsUrl: string | undefined;
+  otelLogsUrl: string;
   otelMaxExportBatchSize: number;
   otelMaxQueueSize: number;
   otelMetricsEnabled: boolean;
@@ -506,7 +506,7 @@ export interface GeneratedConfig {
   otelMetricsProtocol: string;
   otelMetricsTemporalityPreference: "DELTA" | "CUMULATIVE" | "LOWMEMORY";
   otelMetricsTimeout: number;
-  otelMetricsUrl: string | undefined;
+  otelMetricsUrl: string;
   otelProtocol: string;
   otelTimeout: number;
   peerServiceMapping: Record<string, string>;
@@ -537,7 +537,7 @@ export interface GeneratedConfig {
   sampleRate: number | undefined;
   samplingRules: import('../../../../index').SamplingRule[];
   scope: string | undefined;
-  service: string | undefined;
+  service: string;
   serviceMapping: Record<string, string>;
   site: string;
   spanAttributeSchema: "v0" | "v1";
@@ -583,7 +583,7 @@ export interface GeneratedConfig {
   traceWebsocketMessagesSeparateTraces: boolean;
   tracing: boolean;
   url: string | URL;
-  version: string | undefined;
+  version: string;
   vertexai: {
     spanCharLimit: number;
     spanPromptCompletionSampleRate: number;

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -583,7 +583,7 @@ export interface GeneratedConfig {
   traceWebsocketMessagesSeparateTraces: boolean;
   tracing: boolean;
   url: string | URL;
-  version: string;
+  version: string | undefined;
   vertexai: {
     spanCharLimit: number;
     spanPromptCompletionSampleRate: number;

--- a/scripts/generate-config-types.js
+++ b/scripts/generate-config-types.js
@@ -15,6 +15,11 @@ const OUTPUT_PATH = path.join(
   '..',
   'packages/dd-trace/src/config/generated-config-types.d.ts'
 )
+const CONFIG_INDEX_PATH = path.join(
+  __dirname,
+  '..',
+  'packages/dd-trace/src/config/index.js'
+)
 
 const BASE_TYPES = {
   array: 'string[]',
@@ -54,8 +59,54 @@ function getPropertyName (canonicalName, entry) {
   return configurationNames?.[0] ?? canonicalName
 }
 
-function withUndefined (type, entry) {
-  return entry.default === null ? `${type} | undefined` : type
+/**
+ * Scans `packages/dd-trace/src/config/index.js` for `if (!this.X) { setAndTrack(this, 'X', ...) }`
+ * fallback patterns inside the `#applyCalculated()` method. Any matching property name is
+ * guaranteed to be non-null after calculation, so we remove `| undefined` from the generated type.
+ *
+ * Scope: only `#applyCalculated()` — other assignment sites (env resolution, user options) are not
+ * considered. This keeps the heuristic narrow and prevents false narrowing from conditional
+ * setAndTrack calls elsewhere.
+ *
+ * @returns {Set<string>}
+ */
+function findCalculatedFallbackProperties () {
+  const source = readFileSync(CONFIG_INDEX_PATH, 'utf8')
+
+  // Locate `#applyCalculated () {` and extract its body by balancing braces.
+  const methodMarker = /#applyCalculated\s*\(\s*\)\s*\{/.exec(source)
+  if (!methodMarker) {
+    throw new Error('Could not locate #applyCalculated() in config/index.js')
+  }
+  let depth = 1
+  let i = methodMarker.index + methodMarker[0].length
+  while (i < source.length && depth > 0) {
+    const ch = source[i]
+    if (ch === '{') depth++
+    else if (ch === '}') depth--
+    i++
+  }
+  const body = source.slice(methodMarker.index + methodMarker[0].length, i - 1)
+
+  // Match `if (!this.NAME) {` followed (after any amount of code) by `setAndTrack(this, 'NAME',`
+  // where the two NAMEs match. The `[\s\S]*?` is lazy so we catch the nearest setAndTrack.
+  const pattern = /if\s*\(\s*!\s*this\.([\w.]+)\s*\)\s*\{[\s\S]*?setAndTrack\s*\(\s*this\s*,\s*['"]([\w.]+)['"]/g
+  const properties = new Set()
+  let match
+  while ((match = pattern.exec(body)) !== null) {
+    if (match[1] === match[2]) {
+      properties.add(match[1])
+    }
+  }
+  return properties
+}
+
+const CALCULATED_FALLBACK_PROPERTIES = findCalculatedFallbackProperties()
+
+function withUndefined (type, entry, propertyName) {
+  if (entry.default !== null) return type
+  if (CALCULATED_FALLBACK_PROPERTIES.has(propertyName)) return type
+  return `${type} | undefined`
 }
 
 function getAllowedType (entry) {
@@ -93,7 +144,7 @@ function getTypeForEntry (propertyName, entry) {
     throw new Error(`Unsupported configuration type for ${propertyName}: ${entry.type}`)
   }
 
-  return withUndefined(override, entry)
+  return withUndefined(override, entry, propertyName)
 }
 
 function addProperty (root, propertyName, type) {

--- a/scripts/generate-config-types.js
+++ b/scripts/generate-config-types.js
@@ -59,44 +59,61 @@ function getPropertyName (canonicalName, entry) {
   return configurationNames?.[0] ?? canonicalName
 }
 
-/**
- * Scans `packages/dd-trace/src/config/index.js` for `if (!this.X) { setAndTrack(this, 'X', ...) }`
- * fallback patterns inside the `#applyCalculated()` method. Any matching property name is
- * guaranteed to be non-null after calculation, so we remove `| undefined` from the generated type.
- *
- * Scope: only `#applyCalculated()` — other assignment sites (env resolution, user options) are not
- * considered. This keeps the heuristic narrow and prevents false narrowing from conditional
- * setAndTrack calls elsewhere.
- *
- * @returns {Set<string>}
- */
-function findCalculatedFallbackProperties () {
-  const source = readFileSync(CONFIG_INDEX_PATH, 'utf8')
+const FALLBACK_PATTERN =
+  /if\s*\(\s*!\s*this\.([\w.]+)\s*\)\s*\{[\s\S]*?setAndTrack\s*\(\s*this\s*,\s*['"]([\w.]+)['"]\s*,/g
 
-  // Locate `#applyCalculated () {` and extract its body by balancing braces.
-  const methodMarker = /#applyCalculated\s*\(\s*\)\s*\{/.exec(source)
-  if (!methodMarker) {
-    throw new Error('Could not locate #applyCalculated() in config/index.js')
-  }
+// Expression whose tail (after any top-level `||`/`??`, or the whole expression) is a string or
+// template literal — i.e. the result is guaranteed defined at runtime.
+const GUARANTEED_DEFINED = /(?:^|\|\||\?\?)\s*(?:'[^']*'|"[^"]*"|`(?:\$\{[^}`]*\}|[^`])*`)\s*$/
+
+// Returns the index right after the `close` that balances the `open` preceding `start`, or -1 if
+// unbalanced. Skips over string and template literals so their contents don't affect depth.
+function balancedEnd (s, start, open, close) {
   let depth = 1
-  let i = methodMarker.index + methodMarker[0].length
-  while (i < source.length && depth > 0) {
-    const ch = source[i]
-    if (ch === '{') depth++
-    else if (ch === '}') depth--
+  let i = start
+  while (i < s.length) {
+    const ch = s[i]
+    if (ch === open) { depth++; i++ }
+    else if (ch === close) { i++; if (--depth === 0) return i }
+    else if (ch === '"' || ch === '\'' || ch === '`') i = skipQuoted(s, i, ch)
+    else i++
+  }
+  return -1
+}
+
+function skipQuoted (s, i, quote) {
+  const isTemplate = quote === '`'
+  i++
+  while (i < s.length) {
+    if (s[i] === '\\') { i += 2; continue }
+    if (s[i] === quote) return i + 1
+    if (isTemplate && s[i] === '$' && s[i + 1] === '{') {
+      i = balancedEnd(s, i + 2, '{', '}')
+      if (i === -1) return s.length
+      continue
+    }
     i++
   }
-  const body = source.slice(methodMarker.index + methodMarker[0].length, i - 1)
+  return i
+}
 
-  // Match `if (!this.NAME) {` followed (after any amount of code) by `setAndTrack(this, 'NAME',`
-  // where the two NAMEs match. The `[\s\S]*?` is lazy so we catch the nearest setAndTrack.
-  const pattern = /if\s*\(\s*!\s*this\.([\w.]+)\s*\)\s*\{[\s\S]*?setAndTrack\s*\(\s*this\s*,\s*['"]([\w.]+)['"]/g
+function findCalculatedFallbackProperties () {
+  const source = readFileSync(CONFIG_INDEX_PATH, 'utf8')
+  const marker = /#applyCalculated\s*\(\s*\)\s*\{/.exec(source)
+  if (!marker) throw new Error('Could not locate #applyCalculated() in config/index.js')
+
+  const bodyStart = marker.index + marker[0].length
+  const body = source.slice(bodyStart, balancedEnd(source, bodyStart, '{', '}') - 1)
+
   const properties = new Set()
   let match
-  while ((match = pattern.exec(body)) !== null) {
-    if (match[1] === match[2]) {
-      properties.add(match[1])
-    }
+  while ((match = FALLBACK_PATTERN.exec(body)) !== null) {
+    if (match[1] !== match[2]) continue
+    const valueStart = match.index + match[0].length
+    const valueEnd = balancedEnd(body, valueStart, '(', ')')
+    if (valueEnd === -1) continue
+    const value = body.slice(valueStart, valueEnd - 1).trim()
+    if (GUARANTEED_DEFINED.test(value)) properties.add(match[1])
   }
   return properties
 }

--- a/scripts/generate-config-types.js
+++ b/scripts/generate-config-types.js
@@ -73,10 +73,17 @@ function balancedEnd (s, start, open, close) {
   let i = start
   while (i < s.length) {
     const ch = s[i]
-    if (ch === open) { depth++; i++ }
-    else if (ch === close) { i++; if (--depth === 0) return i }
-    else if (ch === '"' || ch === '\'' || ch === '`') i = skipQuoted(s, i, ch)
-    else i++
+    if (ch === open) {
+      depth++
+      i++
+    } else if (ch === close) {
+      i++
+      if (--depth === 0) return i
+    } else if (ch === '"' || ch === '\'' || ch === '`') {
+      i = skipQuoted(s, i, ch)
+    } else {
+      i++
+    }
   }
   return -1
 }


### PR DESCRIPTION
This updates our configuration types by checking if the calculated
configs make them always assigned or not.

Next to that, update a few other manual config entries that are
outdated due to in-between fixes.