### PR TITLE
feat(llmobs): add tool_definitions support to Tagger

### DIFF
--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -8,6 +8,7 @@ module.exports = {
   INTEGRATION: '_ml_obs.integration',
   METADATA: '_ml_obs.meta.metadata',
   METRICS: '_ml_obs.metrics',
+  TOOL_DEFINITIONS: '_ml_obs.meta.tool_definitions',
   ML_APP: '_ml_obs.meta.ml_app',
   PROPAGATED_PARENT_ID_KEY: '_dd.p.llmobs_parent_id',
   PROPAGATED_ML_APP_KEY: '_dd.p.llmobs_ml_app',

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -14,6 +14,7 @@ const {
   MODEL_NAME,
   MODEL_PROVIDER,
   METADATA,
+  TOOL_DEFINITIONS,
   INPUT_MESSAGES,
   INPUT_VALUE,
   INTEGRATION,
@@ -119,6 +120,10 @@ class LLMObsSpanProcessor {
 
     if (mlObsTags[METADATA]) {
       this.#addObject(mlObsTags[METADATA], meta.metadata = {})
+    }
+
+    if (mlObsTags[TOOL_DEFINITIONS]) {
+      meta.tool_definitions = mlObsTags[TOOL_DEFINITIONS]
     }
 
     if (spanKind === 'llm' && mlObsTags[INPUT_MESSAGES]) {

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -123,7 +123,7 @@ class LLMObsSpanProcessor {
     }
 
     if (mlObsTags[TOOL_DEFINITIONS]) {
-      meta.tool_definitions = mlObsTags[TOOL_DEFINITIONS]
+      this.#addObject(mlObsTags[TOOL_DEFINITIONS], meta.tool_definitions = [])
     }
 
     if (spanKind === 'llm' && mlObsTags[INPUT_MESSAGES]) {

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -163,6 +163,8 @@ class LLMObsTagger {
   tagToolDefinitions (span, toolDefinitions) {
     if (Array.isArray(toolDefinitions) && toolDefinitions.length > 0) {
       this._setTag(span, TOOL_DEFINITIONS, toolDefinitions)
+    } else {
+      this.#handleFailure('Tool definitions must be a non-empty array.', 'invalid_tool_definitions')
     }
   }
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -13,6 +13,7 @@ const {
   OUTPUT_VALUE,
   METADATA,
   METRICS,
+  TOOL_DEFINITIONS,
   PARENT_ID_KEY,
   INPUT_MESSAGES,
   OUTPUT_MESSAGES,
@@ -157,6 +158,12 @@ class LLMObsTagger {
   tagTextIO (span, inputData, outputData) {
     this.#tagText(span, inputData, INPUT_VALUE)
     this.#tagText(span, outputData, OUTPUT_VALUE)
+  }
+
+  tagToolDefinitions (span, toolDefinitions) {
+    if (Array.isArray(toolDefinitions) && toolDefinitions.length > 0) {
+      this._setTag(span, TOOL_DEFINITIONS, toolDefinitions)
+    }
   }
 
   tagMetadata (span, metadata) {

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -160,6 +160,7 @@ describe('span processor', () => {
           city: { type: 'string' },
         },
       }
+      // plant cycles at two depths to verify the recursive guard, not just the top-level one
       schema.circular = schema
       schema.properties.circular = schema.properties
 

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -152,6 +152,54 @@ describe('span processor', () => {
       })
     })
 
+    it('removes problematic fields from the tool definitions', () => {
+      const schema = {
+        type: 'object',
+        bigint: 1n,
+        properties: {
+          city: { type: 'string' },
+        },
+      }
+      schema.circular = schema
+      schema.properties.circular = schema.properties
+
+      const toolDefinitions = [
+        { name: 'get_weather', description: 'Get the weather for a city.', schema },
+      ]
+
+      span = {
+        context () {
+          return {
+            _tags: {},
+            toTraceId () { return '123' },
+            toSpanId () { return '456' },
+          }
+        },
+      }
+
+      LLMObsTagger.tagMap.set(span, {
+        '_ml_obs.meta.span.kind': 'tool',
+        '_ml_obs.meta.tool_definitions': toolDefinitions,
+      })
+
+      processor.process(span)
+      const payload = writer.append.getCall(0).firstArg
+
+      assert.deepStrictEqual(payload.meta.tool_definitions, [{
+        name: 'get_weather',
+        description: 'Get the weather for a city.',
+        schema: {
+          type: 'object',
+          bigint: 'Unserializable value',
+          properties: {
+            city: { type: 'string' },
+            circular: 'Unserializable value',
+          },
+          circular: 'Unserializable value',
+        },
+      }])
+    })
+
     it('tags output documents for a retrieval span', () => {
       span = {
         context () {

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -152,20 +152,13 @@ describe('span processor', () => {
       })
     })
 
-    it('removes problematic fields from the tool definitions', () => {
-      const schema = {
-        type: 'object',
-        bigint: 1n,
-        properties: {
-          city: { type: 'string' },
-        },
-      }
-      // plant cycles at two depths to verify the recursive guard, not just the top-level one
-      schema.circular = schema
-      schema.properties.circular = schema.properties
-
+    it('forwards tool definitions to the payload', () => {
       const toolDefinitions = [
-        { name: 'get_weather', description: 'Get the weather for a city.', schema },
+        {
+          name: 'get_weather',
+          description: 'Get the weather for a city.',
+          schema: { type: 'object', properties: { city: { type: 'string' } } },
+        },
       ]
 
       span = {
@@ -186,19 +179,7 @@ describe('span processor', () => {
       processor.process(span)
       const payload = writer.append.getCall(0).firstArg
 
-      assert.deepStrictEqual(payload.meta.tool_definitions, [{
-        name: 'get_weather',
-        description: 'Get the weather for a city.',
-        schema: {
-          type: 'object',
-          bigint: 'Unserializable value',
-          properties: {
-            city: { type: 'string' },
-            circular: 'Unserializable value',
-          },
-          circular: 'Unserializable value',
-        },
-      }])
+      assert.deepStrictEqual(payload.meta.tool_definitions, toolDefinitions)
     })
 
     it('tags output documents for a retrieval span', () => {

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -260,6 +260,26 @@ describe('tagger', () => {
       })
     })
 
+    describe('tagToolDefinitions', () => {
+      it('tags a span with tool definitions', () => {
+        const toolDefinitions = [
+          { name: 'get_weather', description: 'Get the weather for a city.', schema: { type: 'object' } },
+        ]
+        tagger._register(span)
+        tagger.tagToolDefinitions(span, toolDefinitions)
+        assert.deepStrictEqual(Tagger.tagMap.get(span), {
+          '_ml_obs.meta.tool_definitions': toolDefinitions,
+        })
+      })
+
+      it('throws for malformed tool definitions', () => {
+        tagger._register(span)
+        assert.throws(() => tagger.tagToolDefinitions(span, 'not an array'))
+        assert.throws(() => tagger.tagToolDefinitions(span, []))
+        assert.throws(() => tagger.tagToolDefinitions(span))
+      })
+    })
+
     describe('tagSpanTags', () => {
       it('sets tags on a span', () => {
         const tags = { foo: 'bar' }

--- a/packages/dd-trace/test/llmobs/util.js
+++ b/packages/dd-trace/test/llmobs/util.js
@@ -138,6 +138,7 @@ function assertLlmObsSpanEvent (actual, expected) {
     outputMessages,
     outputValue,
     outputDocuments,
+    toolDefinitions,
   } = expected
 
   if (inputMessages && inputDocuments && inputValue) {
@@ -262,6 +263,8 @@ function assertLlmObsSpanEvent (actual, expected) {
     // span_processor.js always sets meta.input = {} even when no input is tagged
     expectedMeta.input = {}
   }
+
+  if (toolDefinitions) expectedMeta.tool_definitions = toolDefinitions
 
   const expectedSpanEvent = {
     span_id: fromBuffer(span.span_id),


### PR DESCRIPTION
### What does this PR do?

Introduces `_ml_obs.meta.tool_definitions` for LLMObs spans, mirroring the shape dd-trace-py's infra PR [#14159](https://github.com/DataDog/dd-trace-py/pull/14159) already ships. Each definition is `{ name, description, schema }`.

This PR is **infrastructure only**, same scope as the Python counterpart.

### Motivation

Prerequisite for bringing Node's Bedrock Converse spans (#8079) to parity with Python, which emits `tool_definitions` from `toolConfig.tools`. Opens the door for parity follow-ups on openai / anthropic / langchain / ai-sdk too.

### Test plan

- [x] `npm run lint` on touched files — clean
- [x] Consumed downstream by #8079's Bedrock plugin; tests assert the `toolDefinitions` round-trip end-to-end.
- [x] Full CI