### PR TITLE
feat(llmobs): auto-tag spans with session/user from RUM OTel baggage

### DIFF
--- a/packages/dd-trace/src/llmobs/constants/tags.js
+++ b/packages/dd-trace/src/llmobs/constants/tags.js
@@ -53,4 +53,16 @@ module.exports = {
 
   ROUTING_API_KEY: '_dd.llmobs.routing.api_key',
   ROUTING_SITE: '_dd.llmobs.routing.site',
+
+  // OTel baggage keys propagated by the RUM browser SDK's `propagateTraceBaggage`
+  // option. When present on the active span context (typically extracted from an
+  // incoming HTTP request), these values are auto-applied to LLMObs spans so RUM
+  // sessions and users correlate to LLM traces without any manual tagging.
+  RUM_BAGGAGE_SESSION_ID_KEY: 'session.id',
+  RUM_BAGGAGE_USER_ID_KEY: 'user.id',
+  RUM_BAGGAGE_ACCOUNT_ID_KEY: 'account.id',
+
+  // LLMObs tag keys aligned with Datadog standard attributes for user identity.
+  USER_ID_TAG_KEY: 'usr.id',
+  USER_ACCOUNT_ID_TAG_KEY: 'usr.account_id',
 }

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -30,6 +30,11 @@ const {
   INPUT_PROMPT,
   ROUTING_API_KEY,
   ROUTING_SITE,
+  RUM_BAGGAGE_SESSION_ID_KEY,
+  RUM_BAGGAGE_USER_ID_KEY,
+  RUM_BAGGAGE_ACCOUNT_ID_KEY,
+  USER_ID_TAG_KEY,
+  USER_ACCOUNT_ID_TAG_KEY,
 } = require('./constants/tags')
 const { UNSERIALIZABLE_VALUE_TEXT } = require('./constants/text')
 const telemetry = require('./telemetry')
@@ -151,7 +156,9 @@ class LLMObsSpanProcessor {
     const metrics = mlObsTags[METRICS] || {}
 
     const mlApp = mlObsTags[ML_APP]
-    const sessionId = mlObsTags[SESSION_ID]
+    // Fall back to the session.id baggage key propagated by the RUM browser SDK so that
+    // RUM sessions automatically correlate to LLMObs traces without a manual annotate call.
+    const sessionId = mlObsTags[SESSION_ID] || span.getBaggageItem?.(RUM_BAGGAGE_SESSION_ID_KEY)
     const parentId = mlObsTags[PARENT_ID_KEY]
 
     const name = mlObsTags[NAME] || span._name
@@ -269,6 +276,15 @@ class LLMObsSpanProcessor {
 
     const existingTags = LLMObsTagger.tagMap.get(span)?.[TAGS] || {}
     if (existingTags) tags = { ...tags, ...existingTags }
+
+    // RUM browser SDK propagates user/account identity via OTel baggage when
+    // `propagateTraceBaggage` is enabled. Map onto Datadog standard attribute
+    // names so RUM users correlate to LLMObs traces. Explicit annotate() tags win.
+    const userId = span.getBaggageItem?.(RUM_BAGGAGE_USER_ID_KEY)
+    if (userId && tags[USER_ID_TAG_KEY] === undefined) tags[USER_ID_TAG_KEY] = userId
+
+    const accountId = span.getBaggageItem?.(RUM_BAGGAGE_ACCOUNT_ID_KEY)
+    if (accountId && tags[USER_ACCOUNT_ID_TAG_KEY] === undefined) tags[USER_ACCOUNT_ID_TAG_KEY] = accountId
 
     return tags
   }

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -335,6 +335,80 @@ describe('span processor', () => {
       assertObjectContains(payload.tags, ['session_id:1234'])
     })
 
+    describe('RUM baggage auto-tagging', () => {
+      // Simulates a request where the RUM browser SDK's `propagateTraceBaggage` has
+      // injected session/user/account identifiers into the inbound trace context.
+      function spanWithBaggage (baggage) {
+        return {
+          context () {
+            return {
+              _tags: {},
+              toTraceId () { return '123' },
+              toSpanId () { return '456' },
+            }
+          },
+          getBaggageItem (key) { return baggage[key] },
+        }
+      }
+
+      it('auto-tags session_id, usr.id and usr.account_id from RUM baggage', () => {
+        span = spanWithBaggage({
+          'session.id': 'rum-session-123',
+          'user.id': 'user-abc',
+          'account.id': 'acct-xyz',
+        })
+        LLMObsTagger.tagMap.set(span, { '_ml_obs.meta.span.kind': 'llm' })
+
+        processor.process(span)
+        const payload = writer.append.getCall(0).firstArg
+
+        assert.strictEqual(payload.session_id, 'rum-session-123')
+        assertObjectContains(payload.tags, [
+          'session_id:rum-session-123',
+          'usr.id:user-abc',
+          'usr.account_id:acct-xyz',
+        ])
+      })
+
+      it('does not overwrite an explicit session id', () => {
+        span = spanWithBaggage({ 'session.id': 'rum-session-123' })
+        LLMObsTagger.tagMap.set(span, {
+          '_ml_obs.meta.span.kind': 'llm',
+          '_ml_obs.session_id': 'explicit-session',
+        })
+
+        processor.process(span)
+        const payload = writer.append.getCall(0).firstArg
+
+        assert.strictEqual(payload.session_id, 'explicit-session')
+      })
+
+      it('does not overwrite an annotated usr.id tag', () => {
+        span = spanWithBaggage({ 'user.id': 'rum-user' })
+        LLMObsTagger.tagMap.set(span, {
+          '_ml_obs.meta.span.kind': 'llm',
+          '_ml_obs.tags': { 'usr.id': 'explicit-user' },
+        })
+
+        processor.process(span)
+        const payload = writer.append.getCall(0).firstArg
+
+        assertObjectContains(payload.tags, ['usr.id:explicit-user'])
+      })
+
+      it('only tags the baggage keys that are present', () => {
+        span = spanWithBaggage({ 'user.id': 'user-only' })
+        LLMObsTagger.tagMap.set(span, { '_ml_obs.meta.span.kind': 'llm' })
+
+        processor.process(span)
+        const payload = writer.append.getCall(0).firstArg
+
+        assert.strictEqual(payload.session_id, undefined)
+        assertObjectContains(payload.tags, ['usr.id:user-only'])
+        assert.ok(!payload.tags.some(t => t.startsWith('usr.account_id:')))
+      })
+    })
+
     it('sets span tags appropriately', () => {
       span = {
         context () {


### PR DESCRIPTION
## What does this PR do?

When the RUM browser SDK's `propagateTraceBaggage` option is enabled, it injects `session.id`, `user.id`, and `account.id` as OTel baggage on outbound requests. LLMObs spans now read these values from the active span context and auto-apply them as `session_id`, `usr.id`, and `usr.account_id` (Datadog standard attributes) on the submitted LLMObs event, enabling RUM → LLMObs correlation with zero customer changes.

Explicit values set via `llmobs.annotate(...)` continue to take precedence over baggage-derived values.

Jira: [MLOB-7334](https://datadoghq.atlassian.net/browse/MLOB-7334) (parent epic [MLOB-7330](https://datadoghq.atlassian.net/browse/MLOB-7330))

Companion PR (Python): DataDog/dd-trace-py#17701

## Motivation

Reported by the Studio team: LLMObs spans generated for a RUM-instrumented web app had no automatic correlation to the RUM session/user, requiring manual `annotate` calls per endpoint. This change mirrors how APM already consumes `@baggage.*` attributes, but lands them under Datadog-standard `usr.*` keys directly.

## Change type

- [x] New feature (non-breaking change which adds functionality)

## Test plan

- 4 new unit tests in `packages/dd-trace/test/llmobs/span_processor.spec.js`:
  - `auto-tags session_id, usr.id and usr.account_id from RUM baggage`
  - `does not overwrite an explicit session id`
  - `does not overwrite an annotated usr.id tag`
  - `only tags the baggage keys that are present`
- Full `span_processor.spec.js` suite (16 tests) passes locally.
- `eslint` clean on all modified files.

## Additional notes

RUM baggage keys verified against `browser-sdk/packages/rum-core/src/domain/tracing/tracer.ts:208-229`. RUM does not propagate `user.name` or `user.email` — only `user.id` + `account.id` — so those two are out of scope for v1 auto-tagging.

This is the JS counterpart of MLOB-7332 / dd-trace-py#17701. The backend (MLOB-7333) is a follow-up that adds `usr.id`/`usr.account_id` to `LlmObsFacets.java` so these become queryable in the LLMObs UI.

Claude session: `ff51fe11-3672-4ff3-924f-9595500003dd`
Resume: `claude --resume ff51fe11-3672-4ff3-924f-9595500003dd`

[MLOB-7334]: https://datadoghq.atlassian.net/browse/MLOB-7334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MLOB-7330]: https://datadoghq.atlassian.net/browse/MLOB-7330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ