### PR TITLE
chore: replace getValueFromEnvSources calls with config usage

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -197,11 +197,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
 
   isEnabled (request) {
     const serviceId = this.serviceIdentifier.toUpperCase()
-    // Keep reading this from the live env sources: tests toggle
-    // `DD_TRACE_AWS_SDK_<SERVICE>_ENABLED` at runtime *after* the tracer has booted, which the
-    // Config singleton (captured at init) cannot observe.
-    const envVarValue = getValueFromEnvSources(`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`)
-    return envVarValue ? isTrue(envVarValue) : true
+    return this._tracerConfig[`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`] ?? true
   }
 
   addResponseTags (span, response) {

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -197,8 +197,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
 
   isEnabled (request) {
     const serviceId = this.serviceIdentifier.toUpperCase()
-    const envVarValue = getValueFromEnvSources(`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`)
-    return envVarValue ? isTrue(envVarValue) : true
+    return this._tracerConfig[`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`] ?? true
   }
 
   addResponseTags (span, response) {

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -197,7 +197,11 @@ class BaseAwsSdkPlugin extends ClientPlugin {
 
   isEnabled (request) {
     const serviceId = this.serviceIdentifier.toUpperCase()
-    return this._tracerConfig[`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`] ?? true
+    // Keep reading this from the live env sources: tests toggle
+    // `DD_TRACE_AWS_SDK_<SERVICE>_ENABLED` at runtime *after* the tracer has booted, which the
+    // Config singleton (captured at init) cannot observe.
+    const envVarValue = getValueFromEnvSources(`DD_TRACE_AWS_SDK_${serviceId}_ENABLED`)
+    return envVarValue ? isTrue(envVarValue) : true
   }
 
   addResponseTags (span, response) {

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -332,7 +332,7 @@ describe('Plugin', () => {
             })
 
             total++
-          }).catch(() => {}, { timeoutMs: 100 })
+          }, { timeoutMs: 100 }).catch(() => {})
 
           agent.assertSomeTraces(traces => {
             const span = sort(traces[0])[0]
@@ -344,7 +344,7 @@ describe('Plugin', () => {
             })
 
             total++
-          }).catch((e) => {}, { timeoutMs: 100 })
+          }, { timeoutMs: 100 }).catch((e) => {})
 
           s3.listBuckets({}, () => {})
           sqs.listQueues({}, () => {})
@@ -395,9 +395,9 @@ describe('Plugin', () => {
 
       describe('with env variable _BATCH_PROPAGATION_ENABLED configuration', () => {
         before(() => {
-          process.env.DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED = true
-          process.env.DD_TRACE_AWS_SDK_KINESIS_BATCH_PROPAGATION_ENABLED = false
-          process.env.DD_TRACE_AWS_SDK_SQS_BATCH_PROPAGATION_ENABLED = true
+          process.env.DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED = 'true'
+          process.env.DD_TRACE_AWS_SDK_KINESIS_BATCH_PROPAGATION_ENABLED = 'false'
+          process.env.DD_TRACE_AWS_SDK_SQS_BATCH_PROPAGATION_ENABLED = 'true'
 
           return agent.load(['aws-sdk'])
         })

--- a/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/kinesis.spec.js
@@ -168,12 +168,21 @@ describe('Kinesis', function () {
       })
 
       describe('Disabled', () => {
+        let savedKinesisEnv
+
         before(() => {
+          savedKinesisEnv = process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED
           process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED = 'false'
+          agent.wipe()
         })
 
         after(() => {
-          delete process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED
+          if (savedKinesisEnv === undefined) {
+            delete process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED
+          } else {
+            process.env.DD_TRACE_AWS_SDK_KINESIS_ENABLED = savedKinesisEnv
+          }
+          agent.wipe()
         })
 
         it('skip injects trace context to Kinesis putRecord when disabled', done => {

--- a/packages/datadog-plugin-azure-event-hubs/src/producer.js
+++ b/packages/datadog-plugin-azure-event-hubs/src/producer.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 
 const spanContexts = new WeakMap()
@@ -11,8 +10,9 @@ class AzureEventHubsProducerPlugin extends ProducerPlugin {
   static get prefix () { return 'tracing:apm:azure-event-hubs:send' }
 
   bindStart (ctx) {
+    const batchLinksEnabled = this._tracerConfig.DD_TRACE_AZURE_EVENTHUBS_BATCH_LINKS_ENABLED
     // we do not want to make these spans when batch linking is disabled.
-    if (!batchLinksAreEnabled() && ctx.functionName === 'tryAdd') {
+    if (!batchLinksEnabled && ctx.functionName === 'tryAdd') {
       return ctx.currentStore
     }
 
@@ -37,7 +37,7 @@ class AzureEventHubsProducerPlugin extends ProducerPlugin {
         span.setTag('message.id', ctx.eventData.messageID)
       }
 
-      if (batchLinksAreEnabled()) {
+      if (batchLinksEnabled) {
         const spanContext = spanContexts.get(ctx.batch)
         if (spanContext) {
           spanContext.push(span.context())
@@ -58,13 +58,11 @@ class AzureEventHubsProducerPlugin extends ProducerPlugin {
         for (const event of eventData) {
           injectTraceContext(this.tracer, span, event)
         }
-      } else {
-        if (batchLinksAreEnabled()) {
-          const contexts = spanContexts.get(eventData)
-          if (contexts) {
-            for (const spanContext of contexts) {
-              span.addLink(spanContext)
-            }
+      } else if (batchLinksEnabled) {
+        const contexts = spanContexts.get(eventData)
+        if (contexts) {
+          for (const spanContext of contexts) {
+            span.addLink(spanContext)
           }
         }
       }
@@ -86,11 +84,6 @@ function injectTraceContext (tracer, span, event) {
     event.properties = {}
   }
   tracer.inject(span, 'text_map', event.properties)
-}
-
-function batchLinksAreEnabled () {
-  const eh = getValueFromEnvSources('DD_TRACE_AZURE_EVENTHUBS_BATCH_LINKS_ENABLED')
-  return eh !== 'false'
 }
 
 module.exports = AzureEventHubsProducerPlugin

--- a/packages/datadog-plugin-azure-service-bus/src/producer.js
+++ b/packages/datadog-plugin-azure-service-bus/src/producer.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 const spanContexts = new WeakMap()
 
@@ -10,8 +9,9 @@ class AzureServiceBusProducerPlugin extends ProducerPlugin {
   static get prefix () { return 'tracing:apm:azure-service-bus:send' }
 
   bindStart (ctx) {
+    const batchLinksEnabled = this._tracerConfig.DD_TRACE_AZURE_SERVICEBUS_BATCH_LINKS_ENABLED
     // we do not want to make these spans when batch linking is disabled.
-    if (!batchLinksAreEnabled() && ctx.functionName === 'tryAddMessage') {
+    if (!batchLinksEnabled && ctx.functionName === 'tryAddMessage') {
       return ctx.currentStore
     }
 
@@ -36,7 +36,7 @@ class AzureServiceBusProducerPlugin extends ProducerPlugin {
         span.setTag('message.id', ctx.msg)
       }
 
-      if (batchLinksAreEnabled()) {
+      if (batchLinksEnabled) {
         const spanContext = spanContexts.get(ctx.batch)
         if (spanContext) {
           spanContext.push(span.context())
@@ -52,7 +52,7 @@ class AzureServiceBusProducerPlugin extends ProducerPlugin {
       const isBatch = messages.constructor?.name === 'ServiceBusMessageBatchImpl'
       if (isBatch) {
         span.setTag('messaging.batch.message_count', messages.count)
-        if (batchLinksAreEnabled()) {
+        if (batchLinksEnabled) {
           const contexts = spanContexts.get(messages)
           if (contexts) {
             for (const spanContext of contexts) {
@@ -87,11 +87,6 @@ function injectTraceContext (tracer, span, msg) {
   }
 
   tracer.inject(span, 'text_map', msg.applicationProperties)
-}
-
-function batchLinksAreEnabled () {
-  const sb = getValueFromEnvSources('DD_TRACE_AZURE_SERVICEBUS_BATCH_LINKS_ENABLED')
-  return sb !== 'false'
 }
 
 module.exports = AzureServiceBusProducerPlugin

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -6,7 +6,7 @@ const realSetTimeout = setTimeout
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
-const { getEnvironmentVariable, getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
+const { getEnvironmentVariable } = require('../../dd-trace/src/config/helper')
 
 const {
   addIntelligentTestRunnerSpanTags,
@@ -117,7 +117,7 @@ class CucumberPlugin extends CiPlugin {
       finishAllTraceSpans(this.testSessionSpan)
       this.telemetry.count(TELEMETRY_TEST_SESSION, {
         provider: this.ciProviderName,
-        autoInjected: !!getValueFromEnvSources('DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER'),
+        autoInjected: this._tracerConfig.DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER,
       })
 
       this.libraryConfig = null

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -5,7 +5,7 @@ const realSetTimeout = setTimeout
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
-const { getEnvironmentVariable, getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
+const { getEnvironmentVariable } = require('../../dd-trace/src/config/helper')
 const { appClosing: appClosingTelemetry } = require('../../dd-trace/src/telemetry')
 
 const {
@@ -166,7 +166,7 @@ class JestPlugin extends CiPlugin {
 
       this.telemetry.count(TELEMETRY_TEST_SESSION, {
         provider: this.ciProviderName,
-        autoInjected: !!getValueFromEnvSources('DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER'),
+        autoInjected: this._tracerConfig.DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER,
       })
 
       appClosingTelemetry()

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -5,7 +5,6 @@ const realDateNow = Date.now.bind(Date)
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
-const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 
 const {
   TEST_STATUS,
@@ -406,7 +405,7 @@ class MochaPlugin extends CiPlugin {
         finishAllTraceSpans(this.testSessionSpan)
         this.telemetry.count(TELEMETRY_TEST_SESSION, {
           provider: this.ciProviderName,
-          autoInjected: !!getValueFromEnvSources('DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER'),
+          autoInjected: this._tracerConfig.DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER,
         })
       }
       this.libraryConfig = null

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const { isTrue } = require('../../dd-trace/src/util')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
+const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 
 class MongodbCorePlugin extends DatabasePlugin {
   static id = 'mongodb-core'
@@ -18,8 +20,11 @@ class MongodbCorePlugin extends DatabasePlugin {
   configure (config) {
     super.configure(config)
 
+    const heartbeatFromEnv = getValueFromEnvSources('DD_TRACE_MONGODB_HEARTBEAT_ENABLED')
+
     this.config.heartbeatEnabled = config.heartbeatEnabled ??
-      this._tracerConfig.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
+      (heartbeatFromEnv && isTrue(heartbeatFromEnv)) ??
+      true
   }
 
   bindStart (ctx) {

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const { isTrue } = require('../../dd-trace/src/util')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
-const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 
 class MongodbCorePlugin extends DatabasePlugin {
   static id = 'mongodb-core'
@@ -20,11 +18,8 @@ class MongodbCorePlugin extends DatabasePlugin {
   configure (config) {
     super.configure(config)
 
-    const heartbeatFromEnv = getValueFromEnvSources('DD_TRACE_MONGODB_HEARTBEAT_ENABLED')
-
     this.config.heartbeatEnabled = config.heartbeatEnabled ??
-      (heartbeatFromEnv && isTrue(heartbeatFromEnv)) ??
-      true
+      this._tracerConfig.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
   }
 
   bindStart (ctx) {

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -777,13 +777,22 @@ describe('Plugin', () => {
         })
 
         describe('when heartbeat tracing is disabled via env var', () => {
-          before(() => {
+          let savedHeartbeatEnv
+
+          before(async () => {
+            savedHeartbeatEnv = process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
             process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED = 'false'
-            return agent.load('mongodb-core', {})
+            agent.wipe()
+            await agent.load('mongodb-core', {})
           })
 
-          after(() => {
-            return agent.close({ ritmReset: false })
+          after(async () => {
+            if (savedHeartbeatEnv === undefined) {
+              delete process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
+            } else {
+              process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED = savedHeartbeatEnv
+            }
+            await agent.close({ ritmReset: false, wipe: true })
           })
 
           beforeEach(async () => {
@@ -817,13 +826,22 @@ describe('Plugin', () => {
         })
 
         describe('when heartbeat tracing is enabled via env var', () => {
-          before(() => {
+          let savedHeartbeatEnv
+
+          before(async () => {
+            savedHeartbeatEnv = process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
             process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED = 'true'
-            return agent.load('mongodb-core', {})
+            agent.wipe()
+            await agent.load('mongodb-core', {})
           })
 
-          after(() => {
-            return agent.close({ ritmReset: false })
+          after(async () => {
+            if (savedHeartbeatEnv === undefined) {
+              delete process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED
+            } else {
+              process.env.DD_TRACE_MONGODB_HEARTBEAT_ENABLED = savedHeartbeatEnv
+            }
+            await agent.close({ ritmReset: false, wipe: true })
           })
 
           beforeEach(async () => {

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -3,7 +3,6 @@
 const { storage } = require('../../datadog-core')
 const id = require('../../dd-trace/src/id')
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
-const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 
 const {
   finishAllTraceSpans,
@@ -108,7 +107,7 @@ class PlaywrightPlugin extends CiPlugin {
       finishAllTraceSpans(this.testSessionSpan)
       this.telemetry.count(TELEMETRY_TEST_SESSION, {
         provider: this.ciProviderName,
-        autoInjected: !!getValueFromEnvSources('DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER'),
+        autoInjected: this._tracerConfig.DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER,
       })
       appClosingTelemetry()
       this.tracer._exporter.flush(onDone)
@@ -420,7 +419,7 @@ class PlaywrightPlugin extends CiPlugin {
       span.finish()
 
       finishAllTraceSpans(span)
-      if (getValueFromEnvSources('DD_PLAYWRIGHT_WORKER')) {
+      if (this._tracerConfig.DD_PLAYWRIGHT_WORKER) {
         this.tracer._exporter.flush(onDone)
       }
     })

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -2,7 +2,6 @@
 
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
 const { storage } = require('../../datadog-core')
-const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
 
 const {
   TEST_STATUS,
@@ -285,12 +284,12 @@ class VitestPlugin extends CiPlugin {
       const { testSuiteAbsolutePath, frameworkVersion } = ctx
 
       // TODO: Handle case where the command is not set
-      this.command = getValueFromEnvSources('DD_CIVISIBILITY_TEST_COMMAND')
+      this.command = this._tracerConfig.DD_CIVISIBILITY_TEST_COMMAND
       this.frameworkVersion = frameworkVersion
       const testSessionSpanContext = this.tracer.extract('text_map', {
         // TODO: Handle case where the session ID or module ID is not set
-        'x-datadog-trace-id': getValueFromEnvSources('DD_CIVISIBILITY_TEST_SESSION_ID'),
-        'x-datadog-parent-id': getValueFromEnvSources('DD_CIVISIBILITY_TEST_MODULE_ID'),
+        'x-datadog-trace-id': this._tracerConfig.DD_CIVISIBILITY_TEST_SESSION_ID,
+        'x-datadog-parent-id': this._tracerConfig.DD_CIVISIBILITY_TEST_MODULE_ID,
       })
 
       const trimmedCommand = DD_MAJOR < 6 ? this.command : 'vitest run'
@@ -415,7 +414,7 @@ class VitestPlugin extends CiPlugin {
       finishAllTraceSpans(this.testSessionSpan)
       this.telemetry.count(TELEMETRY_TEST_SESSION, {
         provider: this.ciProviderName,
-        autoInjected: !!getValueFromEnvSources('DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER'),
+        autoInjected: this._tracerConfig.DD_CIVISIBILITY_AUTO_INSTRUMENTATION_PROVIDER,
       })
       this.tracer._exporter.flush(onFinish)
     })

--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -1,9 +1,9 @@
 'use strict'
 
+const getConfig = require('../../config')
 const request = require('../requests/request')
 const id = require('../../id')
 const log = require('../../log')
-const { getValueFromEnvSources } = require('../../config/helper')
 
 const {
   incrementCountMetric,
@@ -151,7 +151,7 @@ function fetchFromApi ({
     options.path = `${evpProxyPrefix}/api/v2/ci/libraries/tests`
     options.headers['X-Datadog-EVP-Subdomain'] = 'api'
   } else {
-    const apiKey = getValueFromEnvSources('DD_API_KEY')
+    const { apiKey } = getConfig()
     if (!apiKey) {
       return done(new Error('Known tests were not fetched because Datadog API key is not defined.'))
     }

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/coverage-writer.js
@@ -1,8 +1,8 @@
 'use strict'
+const getConfig = require('../../../config')
 const request = require('../../../exporters/common/request')
 const log = require('../../../log')
 const { safeJSONStringify } = require('../../../exporters/common/util')
-const { getValueFromEnvSources } = require('../../../config/helper')
 
 const { CoverageCIVisibilityEncoder } = require('../../../encode/coverage-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
@@ -29,7 +29,7 @@ class Writer extends BaseWriter {
       path: '/api/v2/citestcov',
       method: 'POST',
       headers: {
-        'dd-api-key': getValueFromEnvSources('DD_API_KEY'),
+        'dd-api-key': getConfig().apiKey,
         ...form.getHeaders(),
       },
       timeout: 15_000,

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/di-logs-writer.js
@@ -1,9 +1,9 @@
 'use strict'
+const getConfig = require('../../../config')
 const request = require('../../../exporters/common/request')
 const log = require('../../../log')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 const { JSONEncoder } = require('../../encode/json-encoder')
-const { getValueFromEnvSources } = require('../../../config/helper')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
 
 const BaseWriter = require('../../../exporters/common/writer')
@@ -26,7 +26,7 @@ class DynamicInstrumentationLogsWriter extends BaseWriter {
       path: '/api/v2/logs',
       method: 'POST',
       headers: {
-        'dd-api-key': getValueFromEnvSources('DD_API_KEY'),
+        'dd-api-key': getConfig().apiKey,
         'Content-Type': 'application/json',
       },
       timeout: this.timeout,

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js
@@ -1,8 +1,8 @@
 'use strict'
+const getConfig = require('../../../config')
 const request = require('../../../exporters/common/request')
 const { safeJSONStringify } = require('../../../exporters/common/util')
 const log = require('../../../log')
-const { getValueFromEnvSources } = require('../../../config/helper')
 
 const { AgentlessCiVisibilityEncoder } = require('../../../encode/agentless-ci-visibility')
 const BaseWriter = require('../../../exporters/common/writer')
@@ -30,7 +30,7 @@ class Writer extends BaseWriter {
       path: '/api/v2/citestcycle',
       method: 'POST',
       headers: {
-        'dd-api-key': getValueFromEnvSources('DD_API_KEY'),
+        'dd-api-key': getConfig().apiKey,
         'Content-Type': 'application/msgpack',
       },
       timeout: 15_000,

--- a/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/git/git_metadata.js
@@ -3,12 +3,11 @@
 const fs = require('fs')
 const path = require('path')
 
+const getConfig = require('../../../config')
 const FormData = require('../../../exporters/common/form-data')
 const request = require('../../../exporters/common/request')
-const { getValueFromEnvSources } = require('../../../config/helper')
 
 const log = require('../../../log')
-const { isFalse } = require('../../../util')
 const {
   getLatestCommits,
   getRepositoryUrl,
@@ -51,7 +50,7 @@ function getCommonRequestOptions (url) {
   return {
     method: 'POST',
     headers: {
-      'dd-api-key': getValueFromEnvSources('DD_API_KEY'),
+      'dd-api-key': getConfig().apiKey,
     },
     timeout: 15_000,
     url,
@@ -288,7 +287,7 @@ function sendGitMetadata (url, { isEvpProxy, evpProxyPrefix }, configRepositoryU
     }
     // Otherwise we unshallow and get commits to upload again
     log.debug('It is shallow clone, unshallowing...')
-    if (!isFalse(getValueFromEnvSources('DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED'))) {
+    if (getConfig().DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED) {
       unshallowRepository(false)
     }
 

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -1,8 +1,8 @@
 'use strict'
 
+const getConfig = require('../../config')
 const request = require('../requests/request')
 const log = require('../../log')
-const { getValueFromEnvSources } = require('../../config/helper')
 const {
   incrementCountMetric,
   distributionMetric,
@@ -120,7 +120,7 @@ function fetchFromApi ({
     options.path = `${evpProxyPrefix}/api/v2/ci/tests/skippable`
     options.headers['X-Datadog-EVP-Subdomain'] = 'api'
   } else {
-    const apiKey = getValueFromEnvSources('DD_API_KEY')
+    const { apiKey } = getConfig()
     if (!apiKey) {
       return done(new Error('Skippable suites were not fetched because Datadog API key is not defined.'))
     }

--- a/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/log-submission/log-submission-plugin.js
@@ -2,26 +2,25 @@
 
 const Plugin = require('../../plugins/plugin')
 const log = require('../../log')
-const { getValueFromEnvSources } = require('../../config/helper')
 
 function getWinstonLogSubmissionParameters (config) {
-  const { site, service } = config
+  const { site, service, apiKey, DD_AGENTLESS_LOG_SUBMISSION_URL } = config
 
   const defaultParameters = {
     host: `http-intake.logs.${site}`,
     path: `/api/v2/logs?ddsource=winston&service=${service}`,
     ssl: true,
     headers: {
-      'DD-API-KEY': getValueFromEnvSources('DD_API_KEY'),
+      'DD-API-KEY': apiKey,
     },
   }
 
-  if (!getValueFromEnvSources('DD_AGENTLESS_LOG_SUBMISSION_URL')) {
+  if (!DD_AGENTLESS_LOG_SUBMISSION_URL) {
     return defaultParameters
   }
 
   try {
-    const url = new URL(getValueFromEnvSources('DD_AGENTLESS_LOG_SUBMISSION_URL'))
+    const url = new URL(DD_AGENTLESS_LOG_SUBMISSION_URL)
     return {
       host: url.hostname,
       port: url.port,

--- a/packages/dd-trace/src/ci-visibility/requests/fs-cache.js
+++ b/packages/dd-trace/src/ci-visibility/requests/fs-cache.js
@@ -5,8 +5,8 @@ const path = require('node:path')
 const { createHash } = require('node:crypto')
 const { tmpdir } = require('node:os')
 
+const getConfig = require('../../config')
 const log = require('../../log')
-const { getValueFromEnvSources } = require('../../config/helper')
 
 const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes
 const CACHE_LOCK_POLL_MS = 500
@@ -14,13 +14,12 @@ const CACHE_LOCK_TIMEOUT_MS = 120_000 // 2 minutes
 const CACHE_LOCK_HEARTBEAT_MS = 30_000 // 30 seconds
 
 /**
- * Returns whether the filesystem cache is enabled via the env var.
+ * Returns whether the filesystem cache is enabled via config.
  *
  * @returns {boolean}
  */
 function isCacheEnabled () {
-  const { isTrue } = require('../../util')
-  return isTrue(getValueFromEnvSources('DD_EXPERIMENTAL_TEST_REQUESTS_FS_CACHE'))
+  return getConfig().DD_EXPERIMENTAL_TEST_REQUESTS_FS_CACHE
 }
 
 /**

--- a/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
+++ b/packages/dd-trace/src/ci-visibility/requests/get-library-configuration.js
@@ -1,8 +1,8 @@
 'use strict'
 
+const getConfig = require('../../config')
 const id = require('../../id')
 const log = require('../../log')
-const { getValueFromEnvSources } = require('../../config/helper')
 const {
   incrementCountMetric,
   distributionMetric,
@@ -36,6 +36,7 @@ function getLibraryConfiguration ({
   custom,
   tag,
 }, done) {
+  const config = getConfig()
   const options = {
     path: '/api/v2/libraries/tests/services/setting',
     method: 'POST',
@@ -50,11 +51,10 @@ function getLibraryConfiguration ({
     options.path = `${evpProxyPrefix}/api/v2/libraries/tests/services/setting`
     options.headers['X-Datadog-EVP-Subdomain'] = 'api'
   } else {
-    const apiKey = getValueFromEnvSources('DD_API_KEY')
-    if (!apiKey) {
+    if (!config.apiKey) {
       return done(new Error('Request to settings endpoint was not done because Datadog API key is not defined.'))
     }
-    options.headers['dd-api-key'] = apiKey
+    options.headers['dd-api-key'] = config.apiKey
   }
 
   const data = JSON.stringify({
@@ -132,11 +132,11 @@ function getLibraryConfiguration ({
 
         log.debug('Remote settings: %j', settings)
 
-        if (getValueFromEnvSources('DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE')) {
+        if (config.DD_CIVISIBILITY_DANGEROUSLY_FORCE_COVERAGE) {
           settings.isCodeCoverageEnabled = true
           log.debug('Dangerously set code coverage to true')
         }
-        if (getValueFromEnvSources('DD_CIVISIBILITY_DANGEROUSLY_FORCE_TEST_SKIPPING')) {
+        if (config.DD_CIVISIBILITY_DANGEROUSLY_FORCE_TEST_SKIPPING) {
           settings.isSuitesSkippingEnabled = true
           log.debug('Dangerously set test skipping to true')
         }

--- a/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
@@ -3,10 +3,10 @@
 const { readFileSync } = require('node:fs')
 const { gzipSync } = require('node:zlib')
 
+const getConfig = require('../../config')
 const FormData = require('../../exporters/common/form-data')
 const request = require('../../exporters/common/request')
 const log = require('../../log')
-const { getValueFromEnvSources } = require('../../config/helper')
 const {
   incrementCountMetric,
   distributionMetric,
@@ -34,7 +34,7 @@ function uploadCoverageReport (
   { filePath, format, testEnvironmentMetadata, url, isEvpProxy, evpProxyPrefix },
   callback
 ) {
-  const apiKey = getValueFromEnvSources('DD_API_KEY')
+  const apiKey = getConfig().apiKey
 
   if (!apiKey && !isEvpProxy) {
     return callback(new Error('DD_API_KEY is required for coverage report upload'))

--- a/packages/dd-trace/src/ci-visibility/test-management/get-test-management-tests.js
+++ b/packages/dd-trace/src/ci-visibility/test-management/get-test-management-tests.js
@@ -1,8 +1,8 @@
 'use strict'
 
+const getConfig = require('../../config')
 const request = require('../requests/request')
 const id = require('../../id')
-const { getValueFromEnvSources } = require('../../config/helper')
 const log = require('../../log')
 
 const {
@@ -121,7 +121,7 @@ function fetchFromApi ({
     options.path = `${evpProxyPrefix}/api/v2/test/libraries/test-management/tests`
     options.headers['X-Datadog-EVP-Subdomain'] = 'api'
   } else {
-    const apiKey = getValueFromEnvSources('DD_API_KEY')
+    const { apiKey } = getConfig()
     if (!apiKey) {
       return done(new Error('Test management tests were not fetched because Datadog API key is not defined.'))
     }

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -179,7 +179,8 @@
       {
         "implementation": "A",
         "type": "int",
-        "default": "100"
+        "default": "100",
+        "allowed": "\\d+"
       }
     ],
     "DD_APM_TRACING_ENABLED": [

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -1,9 +1,8 @@
 'use strict'
 
+const getConfig = require('../config')
 const { MsgpackChunk, MsgpackEncoder } = require('../msgpack')
 const log = require('../log')
-const { isTrue } = require('../util')
-const { getValueFromEnvSources } = require('../config/helper')
 const { truncateSpan, normalizeSpan } = require('./tags-processors')
 
 const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
@@ -12,7 +11,7 @@ function formatSpan (span, config) {
   span = normalizeSpan(truncateSpan(span, false))
   if (span.span_events) {
     // ensure span events are encoded as tags if agent doesn't support native top level span events
-    if (config?.trace?.nativeSpanEvents) {
+    if (config.trace.nativeSpanEvents) {
       formatSpanEvents(span)
     } else {
       span.meta.events = JSON.stringify(span.span_events)
@@ -30,8 +29,8 @@ class AgentEncoder {
     this._stringBytes = new MsgpackChunk()
     this._writer = writer
     this._reset()
-    this._debugEncoding = isTrue(getValueFromEnvSources('DD_TRACE_ENCODING_DEBUG'))
-    this._config = this._writer?._config
+    this._config = getConfig()
+    this._debugEncoding = this._config.DD_TRACE_ENCODING_DEBUG
   }
 
   count () {

--- a/packages/dd-trace/src/exporters/agent/index.js
+++ b/packages/dd-trace/src/exporters/agent/index.js
@@ -24,7 +24,6 @@ class AgentExporter {
       lookup,
       protocolVersion,
       headers,
-      config,
     })
 
     globalThis[Symbol.for('dd-trace')].beforeExitHandlers.add(this.flush.bind(this))

--- a/packages/dd-trace/src/exporters/agent/writer.js
+++ b/packages/dd-trace/src/exporters/agent/writer.js
@@ -20,14 +20,13 @@ class AgentWriter extends BaseWriter {
       ...args[0],
       beforeFirstFlush: () => firstFlushChannel.publish(),
     })
-    const { prioritySampler, lookup, protocolVersion, headers, config = {} } = args[0]
+    const { prioritySampler, lookup, protocolVersion, headers } = args[0]
     const AgentEncoder = getEncoder(protocolVersion)
 
     this._prioritySampler = prioritySampler
     this._lookup = lookup
     this._protocolVersion = protocolVersion
     this._headers = headers
-    this._config = config
     this._encoder = new AgentEncoder(this)
   }
 

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { getValueFromEnvSources } = require('../../config/helper')
+const getConfig = require('../../config')
 const log = require('../../log')
 const request = require('../common/request')
 const tracerVersion = require('../../../../../package.json').version
@@ -39,7 +39,7 @@ class AgentlessWriter extends BaseWriter {
       }
     }
 
-    if (!getValueFromEnvSources('DD_API_KEY')) {
+    if (!getConfig().apiKey) {
       this.#apiKeyMissing = true
       log.error('DD_API_KEY is required for agentless trace intake. Set DD_API_KEY. Traces will not be sent.')
     }
@@ -108,7 +108,7 @@ class AgentlessWriter extends BaseWriter {
       return
     }
 
-    const apiKey = getValueFromEnvSources('DD_API_KEY')
+    const apiKey = getConfig().apiKey
     if (!apiKey) {
       if (!this.#apiKeyMissing) {
         this.#apiKeyMissing = true

--- a/packages/dd-trace/src/exporters/common/util.js
+++ b/packages/dd-trace/src/exporters/common/util.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { getValueFromEnvSources } = require('../../config/helper')
+const getConfig = require('../../config')
 
 function safeJSONStringify (value) {
   return JSON.stringify(
     value,
     (key, value) => key === 'dd-api-key' ? undefined : value,
-    getValueFromEnvSources('DD_TRACE_BEAUTIFUL_LOGS') ? 2 : undefined
+    getConfig().DD_TRACE_BEAUTIFUL_LOGS ? 2 : undefined
   )
 }
 

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -3,7 +3,6 @@
 const log = require('../log')
 const { channel } = require('../../../datadog-instrumentations/src/helpers/instrument')
 const { ERROR_MESSAGE, ERROR_TYPE } = require('../constants')
-const { getValueFromEnvSources } = require('../config/helper')
 const { ImpendingTimeout } = require('./runtime/errors')
 const { extractContext } = require('./context')
 
@@ -27,8 +26,7 @@ let __lambdaTimeout
 function checkTimeout (context) {
   const remainingTimeInMillis = context.getRemainingTimeInMillis()
 
-  let apmFlushDeadline = Number.parseInt(getValueFromEnvSources('DD_APM_FLUSH_DEADLINE_MILLISECONDS')) || 100
-  apmFlushDeadline = apmFlushDeadline < 0 ? 100 : apmFlushDeadline
+  const apmFlushDeadline = tracer._config.DD_APM_FLUSH_DEADLINE_MILLISECONDS
 
   __lambdaTimeout = setTimeout(() => {
     timeoutChannel.publish()

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -2,7 +2,7 @@
 
 const { channel } = require('dc-polyfill')
 
-const { isTrue, isError } = require('../util')
+const { isError, isTrue } = require('../util')
 const tracerVersion = require('../../../../package.json').version
 const logger = require('../log')
 const { getValueFromEnvSources } = require('../config/helper')
@@ -427,7 +427,7 @@ class LLMObs extends NoopLLMObs {
       }
 
       // When OTel tracing is enabled, add source:otel tag to allow backend to wait for OTel span conversion
-      if (isTrue(getValueFromEnvSources('DD_TRACE_OTEL_ENABLED'))) {
+      if (this._config.DD_TRACE_OTEL_ENABLED) {
         evaluationTags.source = 'otel'
       }
 

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { getValueFromEnvSources } = require('./config/helper')
 const NoopProxy = require('./noop/proxy')
 const DatadogTracer = require('./tracer')
 const getConfig = require('./config')
@@ -213,7 +212,7 @@ class Tracer extends NoopProxy {
         this._testApiManualPlugin.configure({ ...config, enabled: true }, false)
       }
       if (config.ciVisAgentlessLogSubmissionEnabled) {
-        if (getValueFromEnvSources('DD_API_KEY')) {
+        if (config.apiKey) {
           const LogSubmissionPlugin = require('./ci-visibility/log-submission/log-submission-plugin')
           const automaticLogPlugin = new LogSubmissionPlugin(this)
           automaticLogPlugin.configure({ ...config, enabled: true })

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -5,7 +5,6 @@ const spanFormat = require('./span_format')
 const SpanSampler = require('./span_sampler')
 const GitMetadataTagger = require('./git_metadata_tagger')
 const processTags = require('./process-tags')
-const { getValueFromEnvSources } = require('./config/helper')
 
 const startedSpans = new WeakSet()
 const finishedSpans = new WeakSet()
@@ -88,7 +87,7 @@ class SpanProcessor {
   }
 
   _erase (trace, active) {
-    if (getValueFromEnvSources('DD_TRACE_EXPERIMENTAL_STATE_TRACKING') === 'true') {
+    if (this._config.DD_TRACE_EXPERIMENTAL_STATE_TRACKING) {
       const started = new Set()
       const startedIds = new Set()
       const finished = new Set()

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -2,8 +2,6 @@
 
 const request = require('../exporters/common/request')
 const log = require('../log')
-const { isTrue } = require('../util')
-const { getValueFromEnvSources } = require('../config/helper')
 
 /**
  * @typedef {Record<string, unknown>} TelemetryPayloadObject
@@ -139,16 +137,13 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
     hostname,
     port,
     isCiVisibility,
+    DD_CIVISIBILITY_AGENTLESS_ENABLED,
   } = config
 
   let url = config.url
-
-  const isCiVisibilityAgentlessMode = isCiVisibility &&
-                                      isTrue(getValueFromEnvSources('DD_CIVISIBILITY_AGENTLESS_ENABLED'))
-
-  if (isCiVisibilityAgentlessMode) {
+  if (isCiVisibility && DD_CIVISIBILITY_AGENTLESS_ENABLED) {
     try {
-      url = url || new URL(getAgentlessTelemetryEndpoint(config.site))
+      url ||= new URL(getAgentlessTelemetryEndpoint(config.site))
     } catch (err) {
       log.error('Telemetry endpoint url is invalid', err)
       // No point to do the request if the URL is invalid
@@ -161,7 +156,7 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
     hostname,
     port,
     method: 'POST',
-    path: isCiVisibilityAgentlessMode ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
+    path: DD_CIVISIBILITY_AGENTLESS_ENABLED ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
     headers: getHeaders(config, application, reqType),
   }
 
@@ -178,14 +173,14 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
   })
 
   request(data, options, (error) => {
-    if (error && getValueFromEnvSources('DD_API_KEY') && config.site) {
+    if (error && config.apiKey && config.site) {
       if (agentTelemetry) {
         log.warn('Agent telemetry failed, started agentless telemetry')
         agentTelemetry = false
       }
       // figure out which data center to send to
       const backendUrl = getAgentlessTelemetryEndpoint(config.site)
-      const backendHeader = { ...options.headers, 'DD-API-KEY': getValueFromEnvSources('DD_API_KEY') }
+      const backendHeader = { ...options.headers, 'DD-API-KEY': config.apiKey }
       const backendOptions = {
         ...options,
         url: backendUrl,

--- a/packages/dd-trace/src/telemetry/send-data.js
+++ b/packages/dd-trace/src/telemetry/send-data.js
@@ -141,7 +141,10 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
   } = config
 
   let url = config.url
-  if (isCiVisibility && DD_CIVISIBILITY_AGENTLESS_ENABLED) {
+
+  const isCiVisibilityAgentlessMode = isCiVisibility && DD_CIVISIBILITY_AGENTLESS_ENABLED
+
+  if (isCiVisibilityAgentlessMode) {
     try {
       url ||= new URL(getAgentlessTelemetryEndpoint(config.site))
     } catch (err) {
@@ -156,7 +159,7 @@ function sendData (config, application, host, reqType, payload = {}, cb = () => 
     hostname,
     port,
     method: 'POST',
-    path: DD_CIVISIBILITY_AGENTLESS_ENABLED ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
+    path: isCiVisibilityAgentlessMode ? '/api/v2/apmtelemetry' : '/telemetry/proxy/api/v2/apmtelemetry',
     headers: getHeaders(config, application, reqType),
   }
 

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/di-logs-writer.spec.js
@@ -4,21 +4,25 @@ const assert = require('node:assert/strict')
 
 const { describe, it, beforeEach, afterEach } = require('mocha')
 const context = describe
+const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const nock = require('nock')
 
 require('../../../../../dd-trace/test/setup/core')
-const DynamicInstrumentationLogsWriter = require('../../../../src/ci-visibility/exporters/agentless/di-logs-writer')
 const log = require('../../../../src/log')
+
+const DynamicInstrumentationLogsWriterWithApiKey = proxyquire(
+  '../../../../src/ci-visibility/exporters/agentless/di-logs-writer',
+  { '../../../config': () => ({ apiKey: '1' }) }
+)
+const DynamicInstrumentationLogsWriter = require('../../../../src/ci-visibility/exporters/agentless/di-logs-writer')
 
 describe('Test Visibility DI Writer', () => {
   beforeEach(() => {
     nock.cleanAll()
-    process.env.DD_API_KEY = '1'
   })
 
   afterEach(() => {
-    delete process.env.DD_API_KEY
     sinon.restore()
   })
 
@@ -31,7 +35,7 @@ describe('Test Visibility DI Writer', () => {
         })
         .reply(202)
 
-      const logsWriter = new DynamicInstrumentationLogsWriter({ url: 'http://www.example.com' })
+      const logsWriter = new DynamicInstrumentationLogsWriterWithApiKey({ url: 'http://www.example.com' })
 
       logsWriter.append({ message: 'test' })
       logsWriter.append({ message: 'test2' })
@@ -49,7 +53,7 @@ describe('Test Visibility DI Writer', () => {
         .post('/api/v2/logs')
         .reply(500)
 
-      const logsWriter = new DynamicInstrumentationLogsWriter({ url: 'http://www.example.com' })
+      const logsWriter = new DynamicInstrumentationLogsWriterWithApiKey({ url: 'http://www.example.com' })
 
       logsWriter.append({ message: 'test5' })
       logsWriter.append({ message: 'test6' })
@@ -64,8 +68,6 @@ describe('Test Visibility DI Writer', () => {
 
   context('agent based', () => {
     it('can send logs to the debugger endpoint in the agent', (done) => {
-      delete process.env.DD_API_KEY
-
       const scope = nock('http://www.example.com')
         .post('/debugger/v1/input', body => {
           assert.deepStrictEqual(body, [{ message: 'test3' }, { message: 'test4' }])
@@ -85,8 +87,6 @@ describe('Test Visibility DI Writer', () => {
     })
 
     it('logs an error if the request fails', (done) => {
-      delete process.env.DD_API_KEY
-
       const logErrorSpy = sinon.spy(log, 'error')
 
       const scope = nock('http://www.example.com')

--- a/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/agentless/exporter.spec.js
@@ -5,12 +5,29 @@ const cp = require('node:child_process')
 
 const { describe, it, beforeEach, afterEach, before, after } = require('mocha')
 const context = describe
+const proxyquire = require('proxyquire').noPreserveCache()
 const sinon = require('sinon')
 const nock = require('nock')
 
 require('../../../../../dd-trace/test/setup/core')
 const AgentlessCiVisibilityExporter = require('../../../../src/ci-visibility/exporters/agentless')
 const DynamicInstrumentationLogsWriter = require('../../../../src/ci-visibility/exporters/agentless/di-logs-writer')
+
+// Used by the negative "no API key" test to inject a stubbed getConfig singleton into
+// the request chain. The stubbed singleton still pulls every other field from the real
+// tracer Config so the rest of the exporter behaves normally.
+function loadAgentlessExporterWithFakeConfig (fakeConfig) {
+  const realConfig = require('../../../../src/config')()
+  const getLibraryConfiguration = proxyquire('../../../../src/ci-visibility/requests/get-library-configuration', {
+    '../../config': () => ({ ...realConfig, ...fakeConfig }),
+  })
+  const CiVisibilityExporter = proxyquire('../../../../src/ci-visibility/exporters/ci-visibility-exporter', {
+    '../requests/get-library-configuration': getLibraryConfiguration,
+  })
+  return proxyquire('../../../../src/ci-visibility/exporters/agentless', {
+    '../ci-visibility-exporter': CiVisibilityExporter,
+  })
+}
 
 describe('CI Visibility Agentless Exporter', () => {
   const url = new URL('http://www.example.com')
@@ -143,8 +160,8 @@ describe('CI Visibility Agentless Exporter', () => {
     })
 
     it('will not allow skippable request if ITR configuration fails', (done) => {
-      // request will fail
-      delete process.env.DD_API_KEY
+      // Stub apiKey to be missing so the request is never sent.
+      const AgentlessCiVisibilityExporter = loadAgentlessExporterWithFakeConfig({ apiKey: undefined })
 
       const scope = nock('http://www.example.com')
         .post('/api/v2/libraries/tests/services/setting')
@@ -162,10 +179,10 @@ describe('CI Visibility Agentless Exporter', () => {
         url, isGitUploadEnabled: true, isIntelligentTestRunnerEnabled: true, tags: {},
       })
       agentlessExporter.sendGitMetadata = () => {
-        return new Promise(resolve => {
+        return /** @type {Promise<void>} */ (new Promise(resolve => {
           agentlessExporter._resolveGit()
           resolve()
-        })
+        }))
       }
 
       agentlessExporter.getLibraryConfiguration({}, (err) => {
@@ -176,7 +193,6 @@ describe('CI Visibility Agentless Exporter', () => {
           )
         )
         assert.strictEqual(agentlessExporter.shouldRequestSkippableSuites(), false)
-        process.env.DD_API_KEY = '1'
         done()
       })
     })

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -32,16 +32,14 @@ describe('git_metadata', () => {
   let generatePackFilesForCommitsStub
   let isShallowRepositoryStub
   let unshallowRepositoryStub
+  let fakeConfig
 
   before(() => {
-    process.env.DD_API_KEY = 'api-key'
     fs.writeFileSync(temporaryPackFile, '')
     fs.writeFileSync(secondTemporaryPackFile, '')
   })
 
   after(() => {
-    delete process.env.DD_API_KEY
-    delete process.env.DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED
     fs.unlinkSync(temporaryPackFile)
     fs.unlinkSync(secondTemporaryPackFile)
   })
@@ -55,6 +53,8 @@ describe('git_metadata', () => {
 
     generatePackFilesForCommitsStub = sinon.stub().returns([temporaryPackFile])
 
+    fakeConfig = { apiKey: 'api-key', DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED: true }
+
     gitMetadata = proxyquire('../../../../src/ci-visibility/exporters/git/git_metadata', {
       '../../../plugins/util/git': {
         getLatestCommits: getLatestCommitsStub,
@@ -64,6 +64,7 @@ describe('git_metadata', () => {
         isShallowRepository: isShallowRepositoryStub,
         unshallowRepository: unshallowRepositoryStub,
       },
+      '../../../config': () => fakeConfig,
     })
   })
 
@@ -104,7 +105,7 @@ describe('git_metadata', () => {
   })
 
   it('should not unshallow if the parameter to enable unshallow is false', (done) => {
-    process.env.DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED = false
+    fakeConfig.DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED = false
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
       .reply(200, JSON.stringify({ data: [] }))

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -28,8 +28,10 @@ describe('encode', () => {
       logger = {
         debug: sinon.stub(),
       }
+      const getConfig = () => ({ trace: { nativeSpanEvents: false } })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
         '../log': logger,
+        '../config': getConfig,
       })
       writer = { flush: sinon.spy() }
       encoder = new AgentEncoder(writer)
@@ -487,10 +489,12 @@ describe('encode', () => {
         debug: sinon.spy(),
       }
 
+      const getConfig = () => ({ trace: { nativeSpanEvents: true } })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
         '../log': logger,
+        '../config': getConfig,
       })
-      writer = { flush: sinon.spy(), _config: { trace: { nativeSpanEvents: true } } }
+      writer = { flush: sinon.spy() }
       encoder = new AgentEncoder(writer)
     })
 

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -18,7 +18,7 @@ describe('AgentlessWriter', () => {
   let encoderArgs
   let url
   let log
-  let getValueFromEnvSources
+  let apiKey
 
   beforeEach(() => {
     request = sinon.stub().yieldsAsync(null, '{}', 200)
@@ -38,8 +38,6 @@ describe('AgentlessWriter', () => {
       error: sinon.spy(),
     }
 
-    getValueFromEnvSources = sinon.stub().returns('test-api-key')
-
     const AgentlessJSONEncoder = function (...args) {
       encoderArgs = args
       return encoder
@@ -47,12 +45,14 @@ describe('AgentlessWriter', () => {
 
     const requestModule = Object.assign(request, { '@global': true })
 
+    apiKey = 'test-api-key'
+
     Writer = proxyquire('../../../src/exporters/agentless/writer', {
       '../common/request': requestModule,
       '../../encode/agentless-json': { AgentlessJSONEncoder },
       '../../../../../package.json': { version: 'tracerVersion' },
       '../../log': log,
-      '../../config/helper': { getValueFromEnvSources },
+      '../../config': () => ({ apiKey }),
     })
   })
 
@@ -149,7 +149,7 @@ describe('AgentlessWriter', () => {
     })
 
     it('should log error at startup when API key is missing', () => {
-      getValueFromEnvSources.returns(undefined)
+      apiKey = undefined
 
       // Error should be logged at constructor time
       writer = new Writer({ url })
@@ -161,7 +161,7 @@ describe('AgentlessWriter', () => {
     })
 
     it('should skip sending when API key is missing', (done) => {
-      getValueFromEnvSources.returns(undefined)
+      apiKey = undefined
       writer = new Writer({ url })
 
       encoder.count.returns(1)

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -376,7 +376,7 @@ describe('lambda', () => {
       },
       {
         envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',
-        value: '-100', // will default to 0
+        value: '-100', // will default to 100
       },
       {
         envVar: 'DD_APM_FLUSH_DEADLINE_MILLISECONDS',

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1380,16 +1380,17 @@ describe('sdk', () => {
       let otelLLMObs
 
       before(() => {
-        // DD_TRACE_OTEL_ENABLED is a launch-time env var that Config captures at tracer init.
+        // DD_TRACE_OTEL_ENABLED is a launch-time env var captured when `Config` is built.
+        // Build a fresh config with the env set, then wire up a sibling LLMObs SDK that uses it.
+        // The outer `llmobs` is already enabled and its writers are already subscribed to the
+        // channels, so we only need this SDK to hold a config that reports `enabled` and has
+        // `DD_TRACE_OTEL_ENABLED` set - no extra enable()/disable() calls (which would trigger
+        // flush() on the spied writer and pollute unrelated tests).
         process.env.DD_TRACE_OTEL_ENABLED = 'true'
         const config = getConfigFresh({ llmobs: { mlApp: 'mlApp', agentlessEnabled: false } })
         delete process.env.DD_TRACE_OTEL_ENABLED
+        config.llmobs.enabled = true
         otelLLMObs = new LLMObsSDK(tracer._tracer, llmobsModule, config)
-        otelLLMObs.enable({ mlApp: 'mlApp' })
-      })
-
-      after(() => {
-        otelLLMObs.disable()
       })
 
       it('adds source:otel tag', () => {

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1377,16 +1377,23 @@ describe('sdk', () => {
     })
 
     describe('with DD_TRACE_OTEL_ENABLED set', () => {
+      let otelLLMObs
+
       before(() => {
+        // DD_TRACE_OTEL_ENABLED is a launch-time env var that Config captures at tracer init.
         process.env.DD_TRACE_OTEL_ENABLED = 'true'
+        const config = getConfigFresh({ llmobs: { mlApp: 'mlApp', agentlessEnabled: false } })
+        delete process.env.DD_TRACE_OTEL_ENABLED
+        otelLLMObs = new LLMObsSDK(tracer._tracer, llmobsModule, config)
+        otelLLMObs.enable({ mlApp: 'mlApp' })
       })
 
       after(() => {
-        delete process.env.DD_TRACE_OTEL_ENABLED
+        otelLLMObs.disable()
       })
 
       it('adds source:otel tag', () => {
-        llmobs.submitEvaluation(spanCtx, {
+        otelLLMObs.submitEvaluation(spanCtx, {
           mlApp: 'test',
           timestampMs: 1234,
           label: 'test',

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -422,6 +422,15 @@ module.exports = {
       config = [config]
     }
 
+    // Ensure any plugin instances from a prior `load()` are unsubscribed before building a new
+    // tracer. Otherwise their diagnostic-channel subscriptions stay active and pile up across
+    // tests, causing each event to be handled by every accumulated plugin instance (each with
+    // its own stale `_tracerConfig`). Skip the ritm reset so already-patched modules remain
+    // patched for the next tracer.
+    if (listener !== null) {
+      await this.close({ ritmReset: false })
+    }
+
     currentIntegrationName = getCurrentIntegrationName()
 
     const defaults = proxyquire.noPreserveCache()('../../src/config/defaults', {})

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -422,17 +422,6 @@ module.exports = {
       config = [config]
     }
 
-    // Before creating a new tracer, disable any prior plugin instances that are about to be
-    // re-loaded. Otherwise their old subscriptions keep firing on diagnostic channels with their
-    // stale `_tracerConfig`, which breaks tests that toggle env between loads. We only touch the
-    // plugins that this `load()` is replacing, so unrelated plugins (e.g., `http` kept subscribed
-    // across nested `agent.load()` calls) continue to work.
-    if (tracer !== null) {
-      for (const name of pluginNames) {
-        tracer.use(name, { enabled: false })
-      }
-    }
-
     currentIntegrationName = getCurrentIntegrationName()
 
     const defaults = proxyquire.noPreserveCache()('../../src/config/defaults', {})

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -422,13 +422,15 @@ module.exports = {
       config = [config]
     }
 
-    // Ensure any lifecycle state from a prior `load()` is cleaned up before building a new
-    // tracer: plugin subscriptions are disabled, the HTTP listener is closed, and the `tracer`
-    // module variable is reset. Otherwise plugin instances pile up across tests (each with its
-    // own stale `_tracerConfig`) and every diagnostic-channel event is handled by all of them.
-    // `ritmReset: false` keeps the previously-patched modules patched for the new tracer.
-    if (listener !== null) {
-      await this.close({ ritmReset: false })
+    // Before creating a new tracer, disable any prior plugin instances that are about to be
+    // re-loaded. Otherwise their old subscriptions keep firing on diagnostic channels with their
+    // stale `_tracerConfig`, which breaks tests that toggle env between loads. We only touch the
+    // plugins that this `load()` is replacing, so unrelated plugins (e.g., `http` kept subscribed
+    // across nested `agent.load()` calls) continue to work.
+    if (tracer !== null) {
+      for (const name of pluginNames) {
+        tracer.use(name, { enabled: false })
+      }
     }
 
     currentIntegrationName = getCurrentIntegrationName()

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -422,11 +422,11 @@ module.exports = {
       config = [config]
     }
 
-    // Ensure any plugin instances from a prior `load()` are unsubscribed before building a new
-    // tracer. Otherwise their diagnostic-channel subscriptions stay active and pile up across
-    // tests, causing each event to be handled by every accumulated plugin instance (each with
-    // its own stale `_tracerConfig`). Skip the ritm reset so already-patched modules remain
-    // patched for the next tracer.
+    // Ensure any lifecycle state from a prior `load()` is cleaned up before building a new
+    // tracer: plugin subscriptions are disabled, the HTTP listener is closed, and the `tracer`
+    // module variable is reset. Otherwise plugin instances pile up across tests (each with its
+    // own stale `_tracerConfig`) and every diagnostic-channel event is handled by all of them.
+    // `ritmReset: false` keeps the previously-patched modules patched for the new tracer.
     if (listener !== null) {
       await this.close({ ritmReset: false })
     }

--- a/packages/dd-trace/test/telemetry/send-data.spec.js
+++ b/packages/dd-trace/test/telemetry/send-data.spec.js
@@ -158,11 +158,10 @@ describe('sendData', () => {
   })
 
   it('uses the CI Visibility agentless intake when agentless mode is enabled', () => {
-    process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED = '1'
-
     sendDataModule.sendData(
       {
         isCiVisibility: true,
+        DD_CIVISIBILITY_AGENTLESS_ENABLED: true,
         tags: { 'runtime-id': '123' },
         site: 'datadoghq.eu',
       },
@@ -179,6 +178,5 @@ describe('sendData', () => {
     })
     const { url } = options
     assert.deepStrictEqual(url, new URL('https://instrumentation-telemetry-intake.datadoghq.eu'))
-    delete process.env.DD_CIVISIBILITY_AGENTLESS_ENABLED
   })
 })


### PR DESCRIPTION
The config should be used directly, otherwise we duplicate the work.