### PR TITLE
ci: bluebird stress test (pre-#6910)

### DIFF
--- a/.github/workflows/stress-test-bluebird.yml
+++ b/.github/workflows/stress-test-bluebird.yml
@@ -1,0 +1,48 @@
+name: Stress Test - Bluebird Instrumentation
+
+on:
+  push:
+    branches:
+      - 'stress-test/**'
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Number of test iterations'
+        default: '30'
+        type: string
+
+jobs:
+  stress-test:
+    runs-on: ubuntu-latest
+    env:
+      PLUGINS: bluebird
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/install
+      - name: Install versioned bluebird packages
+        run: PLUGINS=bluebird node scripts/install_plugin_modules.js
+      - name: Stress test
+        run: |
+          ITERATIONS="${{ inputs.iterations || '30' }}"
+          PASS=0
+          FAIL=0
+          for i in $(seq 1 $ITERATIONS); do
+            START=$(date +%s%3N)
+            set +e
+            node --expose-gc ./node_modules/mocha/bin/mocha.js \
+              --require ./scripts/time-agent-load.js \
+              "packages/datadog-instrumentations/test/bluebird.spec.js"
+            EXIT=$?
+            set -e
+            ELAPSED=$(( $(date +%s%3N) - START ))
+            if [ $EXIT -eq 0 ]; then
+              PASS=$((PASS + 1))
+              echo "Run $i: PASS (${ELAPSED}ms total)"
+            else
+              FAIL=$((FAIL + 1))
+              echo "Run $i: FAIL (${ELAPSED}ms total)"
+            fi
+          done
+          echo ""
+          echo "=== Results: $PASS passed, $FAIL failed out of $ITERATIONS ==="

--- a/scripts/time-agent-load.js
+++ b/scripts/time-agent-load.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { performance } = require('node:perf_hooks')
+const agent = require('../packages/dd-trace/test/plugins/agent')
+
+const originalLoad = agent.load.bind(agent)
+agent.load = async function (pluginNames, ...rest) {
+  const name = Array.isArray(pluginNames) ? pluginNames.join(', ') : pluginNames
+  const start = performance.now()
+  const result = await originalLoad(pluginNames, ...rest)
+  const elapsed = performance.now() - start
+  process.stdout.write(`[timing] agent.load(${name}) = ${elapsed.toFixed(1)}ms\n`)
+  return result
+}


### PR DESCRIPTION
Stress test for investigating bluebird `before all` hook flakiness. Same workflow as #8085 but based on the commit just before #6910 landed.

Compare with: `stress-test/master-bluebird` (#8085)