### PR TITLE
chore: ignore .omc/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,5 +146,8 @@ __queuestorage__/AzuriteConfig
 .claude/*
 !.claude/skills/
 
+# ignore oh-my-claudecode local state
+.omc/
+
 # Husky generates a helper dir under .husky/_ (including husky.sh). Don't commit it.
 .husky/_/


### PR DESCRIPTION
### What does this PR do?

Adds `.omc/` to `.gitignore` so the local oh-my-claudecode state directory is never committed.

### Motivation

Contributors using oh-my-claudecode have `.omc/` generated in their working tree (agent scratch state, session artifacts). It has nothing to do with the project and currently shows up in every `git status`, so it's prone to being accidentally added.

### Additional Notes

Sits alongside the existing `.claude/*` ignore rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)