### PR TITLE
fix(debugger): skip malformed ddtags

### DIFF
--- a/packages/dd-trace/src/debugger/config.js
+++ b/packages/dd-trace/src/debugger/config.js
@@ -5,6 +5,7 @@ module.exports = function getDebuggerConfig (config, inputPath) {
     commitSHA: config.commitSHA,
     debug: config.debug,
     dynamicInstrumentation: config.dynamicInstrumentation,
+    env: config.env,
     hostname: config.hostname,
     logLevel: config.logLevel,
     port: config.port,
@@ -13,6 +14,7 @@ module.exports = function getDebuggerConfig (config, inputPath) {
     runtimeId: config.tags['runtime-id'],
     service: config.service,
     url: config.url?.toString(),
+    version: config.version,
     inputPath,
   }
 }

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -23,14 +23,14 @@ const ddsource = 'dd_debugger'
 const hostname = getHostname()
 const service = config.service
 
-const ddtags = [
+const ddtags = buildTags([
   ['env', getValueFromEnvSources('DD_ENV')],
   ['version', getValueFromEnvSources('DD_VERSION')],
   ['debugger_version', version],
   ['host_name', hostname],
   [GIT_COMMIT_SHA, config.commitSHA],
   [GIT_REPOSITORY_URL, config.repositoryUrl],
-].filter(([, value]) => value !== undefined).map((pair) => pair.join(':')).join(',')
+])
 
 let path
 setInputPath(config.inputPath)
@@ -135,4 +135,39 @@ function buildRequestOpts () {
 function setInputPath (newPath) {
   config.inputPath = newPath
   path = `${newPath}?${stringify({ ddtags })}`
+}
+
+/**
+ * @param {Array<[string, string | undefined]>} tags - The tags to serialize.
+ * @returns {string} The serialized tags.
+ */
+function buildTags (tags) {
+  const serializedTags = []
+
+  for (const [key, rawValue] of tags) {
+    const tag = buildTag(key, rawValue)
+
+    if (tag !== undefined) {
+      serializedTags.push(tag)
+    }
+  }
+
+  return serializedTags.join(',')
+}
+
+/**
+ * @param {string} key - The tag key.
+ * @param {string | undefined} rawValue - The tag value.
+ * @returns {string | undefined} The serialized tag.
+ */
+function buildTag (key, rawValue) {
+  if (rawValue === undefined) {
+    return
+  }
+
+  if (!rawValue.includes(',')) {
+    return `${key}:${rawValue}`
+  }
+
+  log.warn('[debugger:devtools_client] Skipping invalid tag value for %s', key)
 }

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -6,7 +6,6 @@ const { stringify } = require('querystring')
 const { version } = require('../../../../../package.json')
 const request = require('../../exporters/common/request')
 const { GIT_COMMIT_SHA, GIT_REPOSITORY_URL } = require('../../plugins/util/tags')
-const { getValueFromEnvSources } = require('../../config/helper')
 const { DEBUGGER_DIAGNOSTICS_V1, DEBUGGER_INPUT_V2 } = require('../constants')
 const log = require('./log')
 const JSONBuffer = require('./json-buffer')
@@ -24,8 +23,8 @@ const hostname = getHostname()
 const service = config.service
 
 const ddtags = buildTags([
-  ['env', getValueFromEnvSources('DD_ENV')],
-  ['version', getValueFromEnvSources('DD_VERSION')],
+  ['env', config.env],
+  ['version', config.version],
   ['debugger_version', version],
   ['host_name', hostname],
   [GIT_COMMIT_SHA, config.commitSHA],

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -137,36 +137,22 @@ function setInputPath (newPath) {
 }
 
 /**
- * @param {Array<[string, string | undefined]>} tags - The tags to serialize.
+ * @param {Array<[string, unknown]>} tags - The tags to serialize.
  * @returns {string} The serialized tags.
  */
 function buildTags (tags) {
   const serializedTags = []
 
   for (const [key, rawValue] of tags) {
-    const tag = buildTag(key, rawValue)
+    if (rawValue === undefined) continue
 
-    if (tag !== undefined) {
-      serializedTags.push(tag)
+    if (String(rawValue).includes(',')) {
+      log.warn('[debugger:devtools_client] Skipping invalid tag value for %s', key)
+      continue
     }
+
+    serializedTags.push(`${key}:${rawValue}`)
   }
 
   return serializedTags.join(',')
-}
-
-/**
- * @param {string} key - The tag key.
- * @param {string | undefined} rawValue - The tag value.
- * @returns {string | undefined} The serialized tag.
- */
-function buildTag (key, rawValue) {
-  if (rawValue === undefined) {
-    return
-  }
-
-  if (!rawValue.includes(',')) {
-    return `${key}:${rawValue}`
-  }
-
-  log.warn('[debugger:devtools_client] Skipping invalid tag value for %s', key)
 }

--- a/packages/dd-trace/test/debugger/config.spec.js
+++ b/packages/dd-trace/test/debugger/config.spec.js
@@ -19,6 +19,7 @@ describe('getDebuggerConfig', function () {
       'commitSHA',
       'debug',
       'dynamicInstrumentation',
+      'env',
       'hostname',
       'logLevel',
       'port',
@@ -27,12 +28,14 @@ describe('getDebuggerConfig', function () {
       'runtimeId',
       'service',
       'url',
+      'version',
       'inputPath',
     ])
     assertObjectContains(config, {
       commitSHA: tracerConfig.commitSHA,
       debug: tracerConfig.debug,
       dynamicInstrumentation: tracerConfig.dynamicInstrumentation,
+      env: tracerConfig.env,
       hostname: tracerConfig.hostname,
       logLevel: tracerConfig.logLevel,
       port: tracerConfig.port,
@@ -40,6 +43,7 @@ describe('getDebuggerConfig', function () {
       runtimeId: tracerConfig.tags['runtime-id'],
       service: tracerConfig.service,
       url: tracerConfig.url.toString(),
+      version: tracerConfig.version,
     })
   })
 

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -102,6 +102,41 @@ describe('input message http requests', function () {
     done()
   })
 
+  it('should drop tag values containing commas', function (done) {
+    const logStub = {
+      debug: sinon.stub(),
+      error: sinon.stub(),
+      warn: sinon.stub(),
+      '@noCallThru': true,
+    }
+
+    const sendWithInvalidTag = proxyquire('../../../src/debugger/devtools_client/send', {
+      './config': createConfigMock({ repositoryUrl: 'my-repository-url,forged:value' }),
+      './json-buffer': JSONBuffer,
+      './log': logStub,
+      '../../exporters/common/request': request,
+      './snapshot-pruner': { pruneSnapshot: pruneSnapshotStub },
+    })
+
+    sendWithInvalidTag(message, logger, dd, snapshot)
+    clock.tick(1000)
+
+    sinon.assert.calledOnce(request)
+    sinon.assert.calledOnceWithExactly(logStub.warn,
+      '[debugger:devtools_client] Skipping invalid tag value for %s',
+      'git.repository_url')
+
+    const opts = getRequestOptions(request)
+    assert.strictEqual(opts.path,
+      '/debugger/v2/input?ddtags=' +
+        `env%3A${process.env.DD_ENV}%2C` +
+        `version%3A${process.env.DD_VERSION}%2C` +
+        `debugger_version%3A${version}%2C` +
+        `git.commit.sha%3A${commitSHA}`)
+
+    done()
+  })
+
   it('should use /debugger/v2/input when configured', function (done) {
     // Create a new send module with v2 endpoint configured
     const sendV2 = proxyquire('../../../src/debugger/devtools_client/send', {

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -138,6 +138,27 @@ describe('input message http requests', function () {
     done()
   })
 
+  it('should coerce non-string tag values to strings', function (done) {
+    const sendWithNumericTag = proxyquire('../../../src/debugger/devtools_client/send', {
+      './config': createConfigMock({ commitSHA: 123 }),
+      './json-buffer': JSONBuffer,
+      '../../exporters/common/request': request,
+      './snapshot-pruner': { pruneSnapshot: pruneSnapshotStub },
+    })
+
+    sendWithNumericTag(message, logger, dd, snapshot)
+    clock.tick(1000)
+
+    sinon.assert.calledOnce(request)
+    const opts = getRequestOptions(request)
+    assert.ok(
+      opts.path.includes('git.commit.sha%3A123'),
+      `Expected path to include git.commit.sha%3A123 but got ${opts.path}`
+    )
+
+    done()
+  })
+
   it('should use /debugger/v2/input when configured', function (done) {
     // Create a new send module with v2 endpoint configured
     const sendV2 = proxyquire('../../../src/debugger/devtools_client/send', {

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -8,13 +8,13 @@ const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 
 const JSONBuffer = require('../../../src/debugger/devtools_client/json-buffer')
-const { version } = require('../../../../../package.json')
+const { version: debuggerVersion } = require('../../../../../package.json')
 const { getRequestOptions } = require('./utils')
 
 require('../../setup/mocha')
 
-process.env.DD_ENV = 'my-env'
-process.env.DD_VERSION = 'my-version'
+const env = 'my-env'
+const version = 'my-version'
 const service = 'my-service'
 const commitSHA = 'my-commit-sha'
 const repositoryUrl = 'my-repository-url'
@@ -92,9 +92,9 @@ describe('input message http requests', function () {
     assert.strictEqual(opts.method, 'POST')
     assert.strictEqual(opts.path,
       '/debugger/v2/input?ddtags=' +
-        `env%3A${process.env.DD_ENV}%2C` +
-        `version%3A${process.env.DD_VERSION}%2C` +
-        `debugger_version%3A${version}%2C` +
+        `env%3A${env}%2C` +
+        `version%3A${version}%2C` +
+        `debugger_version%3A${debuggerVersion}%2C` +
         `host_name%3A${hostname}%2C` +
         `git.commit.sha%3A${commitSHA}%2C` +
         `git.repository_url%3A${repositoryUrl}`)
@@ -129,9 +129,10 @@ describe('input message http requests', function () {
     const opts = getRequestOptions(request)
     assert.strictEqual(opts.path,
       '/debugger/v2/input?ddtags=' +
-        `env%3A${process.env.DD_ENV}%2C` +
-        `version%3A${process.env.DD_VERSION}%2C` +
-        `debugger_version%3A${version}%2C` +
+        `env%3A${env}%2C` +
+        `version%3A${version}%2C` +
+        `debugger_version%3A${debuggerVersion}%2C` +
+        `host_name%3A${hostname}%2C` +
         `git.commit.sha%3A${commitSHA}`)
 
     done()
@@ -348,6 +349,8 @@ function getPayload (_message = message, _snapshot = snapshot) {
  */
 function createConfigMock (overrides = {}) {
   return {
+    env,
+    version,
     service,
     commitSHA,
     repositoryUrl,


### PR DESCRIPTION
### What does this PR do?

Refactors `ddtags` construction in `packages/dd-trace/src/debugger/devtools_client/send.js` so tag serialization and validation live in a small helper instead of an inline array chain.

The new logic also skips malformed tag values containing `,` and logs a warning, which prevents a single invalid value from being serialized as multiple tags in the `ddtags` query parameter.

In addition, the `env` and `version` tags are now sourced from the resolved tracer config instead of read directly from `DD_ENV`/`DD_VERSION`. This reduces overhead and ensures values supplied via init options, stable config, or any other config source are honored — matching how `service`, `host_name`, `git.commit.sha` and `git.repository_url` are already populated.

### Motivation

`ddtags` is sent as a comma-separated string, so values containing `,` can break the tag structure and effectively craft extra tags. This change makes that behavior explicit and keeps the debugger client from forwarding malformed tag data.

Reading `env`/`version` from the tracer config (rather than re-reading env vars in the worker) keeps the debugger consistent with the rest of the tracer and makes sure non-env-var configuration sources are taken into account.