### PR TITLE
fix(debugger): ensure hostname is encoded correctly

### DIFF
--- a/integration-tests/debugger/ddtags.spec.js
+++ b/integration-tests/debugger/ddtags.spec.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const os = require('os')
-
 const assert = require('assert')
 const { version } = require('../../package.json')
 const { assertObjectContains } = require('../helpers')
@@ -34,7 +32,6 @@ describe('Dynamic Instrumentation', function () {
             'env',
             'git.commit.sha',
             'git.repository_url',
-            'host_name',
             'version',
           ], Object.keys(ddtags).sort())
 
@@ -42,7 +39,6 @@ describe('Dynamic Instrumentation', function () {
             env: 'test-env',
             version: 'test-version',
             debugger_version: version,
-            host_name: os.hostname(),
             'git.commit.sha': 'test-commit-sha',
             'git.repository_url': 'test-repository-url',
           })
@@ -65,7 +61,7 @@ describe('Dynamic Instrumentation', function () {
 
           const ddtags = extractDDTagsFromQuery(query)
 
-          assert.deepStrictEqual(['debugger_version', 'host_name'], Object.keys(ddtags).sort())
+          assert.deepStrictEqual(['debugger_version'], Object.keys(ddtags).sort())
 
           done()
         })

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -375,7 +375,7 @@ function assertBasicInputPayload (t, payload, probe = t.rcConfig.config) {
 
   const expected = {
     ddsource: 'dd_debugger',
-    hostname: os.hostname(),
+    host: os.hostname(),
     service: 'node',
     message: 'Hello World!',
     logger: {

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -19,14 +19,13 @@ const MAX_LOG_PAYLOAD_SIZE_MB = 1
 const MAX_LOG_PAYLOAD_SIZE_BYTES = MAX_LOG_PAYLOAD_SIZE_MB * 1024 * 1024
 
 const ddsource = 'dd_debugger'
-const hostname = getHostname()
+const host = getHostname()
 const service = config.service
 
 const ddtags = buildTags([
   ['env', config.env],
   ['version', config.version],
   ['debugger_version', version],
-  ['host_name', hostname],
   [GIT_COMMIT_SHA, config.commitSHA],
   [GIT_REPOSITORY_URL, config.repositoryUrl],
 ])
@@ -43,7 +42,7 @@ const jsonBuffer = new JSONBuffer({
 function send (message, logger, dd, snapshot) {
   const payload = {
     ddsource,
-    hostname,
+    host,
     service,
     message: message?.length > MAX_MESSAGE_LENGTH
       ? message.slice(0, MAX_MESSAGE_LENGTH) + '…'

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -20,7 +20,7 @@ const commitSHA = 'my-commit-sha'
 const repositoryUrl = 'my-repository-url'
 const url = 'my-url'
 const ddsource = 'dd_debugger'
-const hostname = getHostname()
+const host = getHostname()
 const message = { message: true }
 const logger = { logger: true }
 const dd = { dd: true }
@@ -95,7 +95,6 @@ describe('input message http requests', function () {
         `env%3A${env}%2C` +
         `version%3A${version}%2C` +
         `debugger_version%3A${debuggerVersion}%2C` +
-        `host_name%3A${hostname}%2C` +
         `git.commit.sha%3A${commitSHA}%2C` +
         `git.repository_url%3A${repositoryUrl}`)
 
@@ -132,7 +131,6 @@ describe('input message http requests', function () {
         `env%3A${env}%2C` +
         `version%3A${version}%2C` +
         `debugger_version%3A${debuggerVersion}%2C` +
-        `host_name%3A${hostname}%2C` +
         `git.commit.sha%3A${commitSHA}`)
 
     done()
@@ -354,7 +352,7 @@ describe('input message http requests', function () {
 function getPayload (_message = message, _snapshot = snapshot) {
   return {
     ddsource,
-    hostname,
+    host,
     service,
     message: _message,
     logger,

--- a/packages/dd-trace/test/debugger/devtools_client/snapshot-pruner.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/snapshot-pruner.spec.js
@@ -3,46 +3,18 @@
 const assert = require('node:assert/strict')
 
 const { describe, it } = require('mocha')
-
 const { pruneSnapshot } = require('../../../src/debugger/devtools_client/snapshot-pruner')
 
 require('../../setup/mocha')
 
 describe('snapshot-pruner', function () {
   describe('pruneSnapshot', function () {
-    let locals, snapshot
+    let locals
+    let snapshot
 
     beforeEach(() => {
       locals = {}
-      snapshot = {
-        service: 'my-service',
-        hostname: 'my-host',
-        message: 'my-message',
-        logger: {
-          name: 'test.js',
-          method: 'testMethod',
-          version: '1.0.0',
-        },
-        dd: { service: 'my-service' },
-        debugger: {
-          snapshot: {
-            id: '12345',
-            timestamp: 123456789,
-            probe: { id: 'probe-1', version: 1 },
-            stack: [
-              { function: 'test', fileName: 'test.js', lineNumber: 10 },
-            ],
-            language: 'javascript',
-            captures: {
-              lines: {
-                10: {
-                  locals,
-                },
-              },
-            },
-          },
-        },
-      }
+      snapshot = createSnapshot(locals)
     })
 
     it('should return original JSON if already under size limit', function () {
@@ -324,8 +296,7 @@ describe('snapshot-pruner', function () {
     })
 
     it('should promote parent to leaf when all children are pruned', function () {
-      // At 674, all the children are pruned, but the parent is not, at 675 one of the children is not pruned
-      assertPrunedSnapshot(674, {
+      const originalLocals = {
         smallVar: { type: 'number', value: '42' },
         parent: {
           type: 'object',
@@ -344,10 +315,23 @@ describe('snapshot-pruner', function () {
             },
           },
         },
-      }, {
+      }
+
+      const expectedLocals = {
         smallVar: { type: 'number', value: '42' },
         parent: { pruned: true },
-      })
+      }
+
+      const maxSize = findBoundaryMaxSize(
+        originalLocals,
+        parsedLocals => parsedLocals.parent?.pruned === true
+      )
+
+      const parsedLocalsAtBoundary = getPrunedLocals(maxSize, originalLocals)
+      assert.deepStrictEqual(parsedLocalsAtBoundary, expectedLocals)
+
+      const parsedLocalsAfterBoundary = getPrunedLocals(maxSize + 1, originalLocals)
+      assert.notDeepStrictEqual(parsedLocalsAfterBoundary, expectedLocals)
     })
 
     it('should handle multi-byte characters correctly', function () {
@@ -429,29 +413,98 @@ describe('snapshot-pruner', function () {
         },
       })
     })
-
-    /**
-     * Assert that the pruneSnapshot function successfully prunes the snapshot and returns the expected locals.
-     * @param {number} maxSize - Used to define the max allowed size of the snapshot. If positive, it's the absolute max
-     *   size value. If negative, it's redacted from the actual size.
-     * @param {object} originalLocals - The locals to use for the snapshot.
-     * @param {object} expectedLocals - The expected locals after pruning.
-     */
-    function assertPrunedSnapshot (maxSize, originalLocals, expectedLocals) {
-      Object.assign(locals, originalLocals)
-
-      const json = JSON.stringify(snapshot)
-      const size = Buffer.byteLength(json)
-      maxSize = maxSize < 0 ? size + maxSize : maxSize
-
-      const result = pruneSnapshot(json, size, maxSize)
-
-      assert.ok(result, 'Expected pruneSnapshot() to successfully prune')
-
-      const parsed = JSON.parse(result)
-      const parsedLocals = parsed.debugger.snapshot.captures.lines['10'].locals
-
-      assert.deepStrictEqual(parsedLocals, expectedLocals)
-    }
   })
 })
+
+/**
+ * Build the standard snapshot fixture used by these tests.
+ * @param {object} locals
+ * @returns {object}
+ */
+function createSnapshot (locals) {
+  return {
+    service: 'my-service',
+    host: 'my-host',
+    message: 'my-message',
+    logger: {
+      name: 'test.js',
+      method: 'testMethod',
+      version: '1.0.0',
+    },
+    dd: { service: 'my-service' },
+    debugger: {
+      snapshot: {
+        id: '12345',
+        timestamp: 123456789,
+        probe: { id: 'probe-1', version: 1 },
+        stack: [
+          { function: 'test', fileName: 'test.js', lineNumber: 10 },
+        ],
+        language: 'javascript',
+        captures: {
+          lines: {
+            10: {
+              locals,
+            },
+          },
+        },
+      },
+    },
+  }
+}
+
+/**
+ * Assert that the pruneSnapshot function successfully prunes the snapshot and returns the expected locals.
+ * @param {number} maxSize - Used to define the max allowed size of the snapshot. If positive, it's the absolute max
+ *   size value. If negative, it's redacted from the actual size.
+ * @param {object} originalLocals - The locals to use for the snapshot.
+ * @param {object} expectedLocals - The expected locals after pruning.
+ */
+function assertPrunedSnapshot (maxSize, originalLocals, expectedLocals) {
+  const parsedLocals = getPrunedLocals(maxSize, originalLocals)
+  assert.deepStrictEqual(parsedLocals, expectedLocals)
+}
+
+/**
+ * Find the largest maxSize that still satisfies the provided predicate.
+ * @param {object} originalLocals - The locals to use for the snapshot.
+ * @param {(parsedLocals: object) => boolean} predicate
+ *   - Returns true when the current pruning result matches.
+ * @returns {number|undefined}
+ */
+function findBoundaryMaxSize (originalLocals, predicate) {
+  const snapshot = createSnapshot(originalLocals)
+  const json = JSON.stringify(snapshot)
+  const size = Buffer.byteLength(json)
+
+  for (let maxSize = size; maxSize >= 0; maxSize--) {
+    const result = pruneSnapshot(json, size, maxSize)
+    if (!result) continue
+
+    const parsedLocals = JSON.parse(result).debugger.snapshot.captures.lines['10'].locals
+    if (predicate(parsedLocals)) {
+      return maxSize
+    }
+  }
+
+  assert.fail('Expected to find a maxSize where the parent gets promoted to a leaf')
+}
+
+/**
+ * Prune a snapshot built from the provided locals and return the parsed locals.
+ * @param {number} maxSize - Used to define the max allowed size of the snapshot. If positive, it's the absolute max
+ *   size value. If negative, it's redacted from the actual size.
+ * @param {object} originalLocals - The locals to use for the snapshot.
+ * @returns {object}
+ */
+function getPrunedLocals (maxSize, originalLocals) {
+  const snapshot = createSnapshot(originalLocals)
+  const json = JSON.stringify(snapshot)
+  const size = Buffer.byteLength(json)
+  maxSize = maxSize < 0 ? size + maxSize : maxSize
+
+  const result = pruneSnapshot(json, size, maxSize)
+  assert.ok(result, 'Expected pruneSnapshot() to successfully prune')
+
+  return JSON.parse(result).debugger.snapshot.captures.lines['10'].locals
+}


### PR DESCRIPTION
### What does this PR do?

Align debugger upload payloads with the backend contract by sending `host` instead of `hostname`, and stop redundantly adding `host_name` to `ddtags` in `packages/dd-trace/src/debugger/devtools_client/send.js`. The PR also updates the related debugger integration and unit tests so they assert the normalized payload shape consistently.

### Motivation

The backend expects hostname information on the top-level `host` field, while the agent already contributes host tagging separately. Keeping both `hostname` and `host_name` in the debugger payload was redundant and could cause the hostname to be encoded in the wrong place.
