### PR TITLE
fix(hono): set resource name for single-handler routes

### DIFF
--- a/packages/datadog-instrumentations/src/hono.js
+++ b/packages/datadog-instrumentations/src/hono.js
@@ -14,6 +14,11 @@ const enterChannel = channel('apm:hono:middleware:enter')
 const exitChannel = channel('apm:hono:middleware:exit')
 const finishChannel = channel('apm:hono:middleware:finish')
 
+// Tracks handlers registered via `app.use()` so route-publishing wrappers
+// installed by `wrapRouterAdd` can skip middleware-only matches (a request
+// matching only middleware should keep the bare HTTP-method resource name).
+const middlewareHandlers = new WeakSet()
+
 // `app.request()` and non-node adapters call `app.fetch` without an `incoming`
 // IncomingMessage; the APM `web` helpers depend on one, so the wrappers below
 // skip publishing whenever it is missing.
@@ -25,6 +30,38 @@ function wrapFetch (fetch) {
     }
     return fetch.apply(this, arguments)
   }
+}
+
+function wrapUse (originalUse) {
+  return function (arg1, ...handlers) {
+    if (typeof arg1 === 'function') middlewareHandlers.add(arg1)
+    for (const h of handlers) middlewareHandlers.add(h)
+    return originalUse.call(this, arg1, ...handlers)
+  }
+}
+
+function wrapRouterAdd (originalAdd) {
+  return function (method, path, handlerData) {
+    const handler = handlerData[0]
+    if (!middlewareHandlers.has(handler)) {
+      const meta = handlerData[1]
+      const wrappedHandler = function (context, next) {
+        const req = context.env?.incoming
+        if (req && routeChannel.hasSubscribers) {
+          routeChannel.publish({ req, route: meta?.path })
+        }
+        return handler.apply(this, arguments)
+      }
+      handlerData = [wrappedHandler, meta]
+    }
+    return originalAdd.call(this, method, path, handlerData)
+  }
+}
+
+function instrumentHonoInstance (instance) {
+  shimmer.wrap(instance, 'fetch', wrapFetch)
+  shimmer.wrap(instance, 'use', wrapUse)
+  shimmer.wrap(instance.router, 'add', wrapRouterAdd)
 }
 
 function onErrorFn (error, _context_) {
@@ -74,7 +111,6 @@ function wrapMiddleware (middleware, route) {
         if (!req) {
           return middleware.apply(this, arguments)
         }
-        routeChannel.publish({ req, route })
         enterChannel.publish({ req, name, route })
         if (typeof next === 'function') {
           arguments[1] = wrapNext(req, route, next)
@@ -113,7 +149,7 @@ addHook({
   class Hono extends hono.Hono {
     constructor (...args) {
       super(...args)
-      shimmer.wrap(this, 'fetch', wrapFetch)
+      instrumentHonoInstance(this)
     }
   }
 
@@ -130,7 +166,7 @@ addHook({
   class Hono extends hono.Hono {
     constructor (...args) {
       super(...args)
-      shimmer.wrap(this, 'fetch', wrapFetch)
+      instrumentHonoInstance(this)
     }
   }
 

--- a/packages/datadog-instrumentations/src/hono.js
+++ b/packages/datadog-instrumentations/src/hono.js
@@ -40,10 +40,24 @@ function wrapUse (originalUse) {
   }
 }
 
+// `app.basePath()` returns a clone Hono instance built via the library's
+// internal class binding, so it never hits our instrumented constructor. The
+// clone shares the parent router (so `router.add` stays wrapped), but its
+// `use` is a fresh per-instance method that must be wrapped too, otherwise
+// middleware registered on the sub-app never lands in `middlewareHandlers`.
+function wrapBasePath (originalBasePath) {
+  return function (path) {
+    const clone = originalBasePath.apply(this, arguments)
+    shimmer.wrap(clone, 'use', wrapUse)
+    shimmer.wrap(clone, 'basePath', wrapBasePath)
+    return clone
+  }
+}
+
 function wrapRouterAdd (originalAdd) {
   return function (method, path, handlerData) {
-    const handler = handlerData[0]
-    if (!middlewareHandlers.has(handler)) {
+    const handler = handlerData?.[0]
+    if (typeof handler === 'function' && !middlewareHandlers.has(handler)) {
       const meta = handlerData[1]
       const wrappedHandler = function (context, next) {
         const req = context.env?.incoming
@@ -61,6 +75,7 @@ function wrapRouterAdd (originalAdd) {
 function instrumentHonoInstance (instance) {
   shimmer.wrap(instance, 'fetch', wrapFetch)
   shimmer.wrap(instance, 'use', wrapUse)
+  shimmer.wrap(instance, 'basePath', wrapBasePath)
   shimmer.wrap(instance.router, 'add', wrapRouterAdd)
 }
 

--- a/packages/datadog-plugin-hono/test/index.spec.js
+++ b/packages/datadog-plugin-hono/test/index.spec.js
@@ -151,6 +151,87 @@ describe('Plugin', () => {
         })
       })
 
+      it('should instrument routes registered on a basePath sub-app', async function () {
+        let resolver
+        const promise = new Promise((resolve) => {
+          resolver = resolve
+        })
+
+        const bareApp = new hono.Hono()
+        const api = bareApp.basePath('/api')
+
+        api.use((c, next) => {
+          c.set('middleware', 'test')
+          return next()
+        })
+
+        api.get('/users/:id', (c) => c.json({
+          id: c.req.param('id'),
+          middleware: c.get('middleware'),
+        }))
+
+        server = serve({
+          fetch: bareApp.fetch,
+          port: 0,
+        }, ({ port }) => resolver(port))
+
+        const port = await promise
+
+        const { data } = await axios.get(`http://localhost:${port}/api/users/42`)
+
+        assert.deepStrictEqual(data, {
+          id: '42',
+          middleware: 'test',
+        })
+
+        await agent.assertFirstTraceSpan({
+          name: 'hono.request',
+          service: 'test',
+          type: 'web',
+          resource: 'GET /api/users/:id',
+          meta: {
+            'span.kind': 'server',
+            'http.method': 'GET',
+            'http.status_code': '200',
+            component: 'hono',
+          },
+        })
+      })
+
+      it('should keep the bare resource name for middleware-only basePath matches', async function () {
+        let resolver
+        const promise = new Promise((resolve) => {
+          resolver = resolve
+        })
+
+        const bareApp = new hono.Hono()
+        const api = bareApp.basePath('/api')
+
+        api.use((c) => c.json({ ok: true }))
+
+        server = serve({
+          fetch: bareApp.fetch,
+          port: 0,
+        }, ({ port }) => resolver(port))
+
+        const port = await promise
+
+        await axios.get(`http://localhost:${port}/api/anything`)
+
+        await agent.assertFirstTraceSpan({
+          name: 'hono.request',
+          service: 'test',
+          type: 'web',
+          resource: 'GET',
+          meta: {
+            'span.kind': 'server',
+            'http.method': 'GET',
+            'http.status_code': '200',
+            component: 'hono',
+          },
+        })
+      })
+
       it('should do automatic instrumentation on nested routes', async function () {
         let resolver
         const promise = new Promise((resolve) => {

--- a/packages/datadog-plugin-hono/test/index.spec.js
+++ b/packages/datadog-plugin-hono/test/index.spec.js
@@ -87,6 +87,70 @@ describe('Plugin', () => {
         })
       })
 
+      it('should set the correct resource name without middleware (single-handler fast path)', async function () {
+        let resolver
+        const promise = new Promise((resolve) => {
+          resolver = resolve
+        })
+
+        const bareApp = new hono.Hono()
+        bareApp.get('/product', (c) => c.json({ ok: true }))
+
+        server = serve({
+          fetch: bareApp.fetch,
+          port: 0,
+        }, ({ port }) => resolver(port))
+
+        const port = await promise
+
+        await axios.get(`http://localhost:${port}/product`)
+
+        await agent.assertFirstTraceSpan({
+          name: 'hono.request',
+          service: 'test',
+          type: 'web',
+          resource: 'GET /product',
+          meta: {
+            'span.kind': 'server',
+            'http.method': 'GET',
+            'http.status_code': '200',
+            component: 'hono',
+          },
+        })
+      })
+
+      it('should set the correct resource name for app.all() routes', async function () {
+        let resolver
+        const promise = new Promise((resolve) => {
+          resolver = resolve
+        })
+
+        const bareApp = new hono.Hono()
+        bareApp.all('/api', (c) => c.json({ method: c.req.method }))
+
+        server = serve({
+          fetch: bareApp.fetch,
+          port: 0,
+        }, ({ port }) => resolver(port))
+
+        const port = await promise
+
+        await axios.post(`http://localhost:${port}/api`)
+
+        await agent.assertFirstTraceSpan({
+          name: 'hono.request',
+          service: 'test',
+          type: 'web',
+          resource: 'POST /api',
+          meta: {
+            'span.kind': 'server',
+            'http.method': 'POST',
+            'http.status_code': '200',
+            component: 'hono',
+          },
+        })
+      })
+
       it('should do automatic instrumentation on nested routes', async function () {
         let resolver
         const promise = new Promise((resolve) => {


### PR DESCRIPTION
### What does this PR do?
Fixes resource name being set to just the HTTP method (e.g. `"GET"`) instead of `"GET /product"` for Hono routes with no middleware.

### Motivation
Hono's `#dispatch()` has a fast path that calls a matched handler directly when only one handler matches, bypassing `compose()`. Our `wrapCompose` hook never fires in that case, so the route is never published and the span resource name is just the HTTP method. This affects any Hono app where routes have no `app.use()` middleware.

Fix by pre-checking the router match in `wrapFetch` and publishing the route for single-match requests.

### Additional Notes
The existing test suite missed this because every test sets up a global `app.use()` middleware in `beforeEach`, which forces Hono through `compose()` and masked the bug. Added a dedicated test with a bare app (no middleware) to cover this path.