### PR TITLE
test,ci: fix langchain being tested against Node.js 18

### DIFF
--- a/.github/actions/plugins/test-and-upstream/action.yml
+++ b/.github/actions/plugins/test-and-upstream/action.yml
@@ -1,12 +1,20 @@
 name: Plugin and Upstream Tests
 description: Run plugin tests and upstream test suite
+inputs:
+  node-floor:
+    description: 'Lower Node alias: oldest-maintenance-lts or newest-maintenance-lts.'
+    required: false
+    default: oldest-maintenance-lts
 runs:
   using: composite
   steps:
     - uses: ./.github/actions/dd-sts-api-key
       id: dd-sts
     - uses: ./.github/actions/testagent/start
-    - uses: ./.github/actions/node/oldest-maintenance-lts
+    - if: ${{ inputs.node-floor == 'oldest-maintenance-lts' }}
+      uses: ./.github/actions/node/oldest-maintenance-lts
+    - if: ${{ inputs.node-floor == 'newest-maintenance-lts' }}
+      uses: ./.github/actions/node/newest-maintenance-lts
     - uses: ./.github/actions/install
     - run: yarn test:plugins:ci
       shell: bash

--- a/.github/actions/plugins/test/action.yml
+++ b/.github/actions/plugins/test/action.yml
@@ -1,12 +1,20 @@
 name: Plugin Tests
 description: Run plugin tests
+inputs:
+  node-floor:
+    description: 'Lower Node alias: oldest-maintenance-lts or newest-maintenance-lts.'
+    required: false
+    default: oldest-maintenance-lts
 runs:
   using: composite
   steps:
     - uses: ./.github/actions/dd-sts-api-key
       id: dd-sts
     - uses: ./.github/actions/testagent/start
-    - uses: ./.github/actions/node/oldest-maintenance-lts
+    - if: ${{ inputs.node-floor == 'oldest-maintenance-lts' }}
+      uses: ./.github/actions/node/oldest-maintenance-lts
+    - if: ${{ inputs.node-floor == 'newest-maintenance-lts' }}
+      uses: ./.github/actions/node/newest-maintenance-lts
     - uses: ./.github/actions/install
     - run: yarn test:plugins:ci
       shell: bash

--- a/.github/actions/plugins/upstream/action.yml
+++ b/.github/actions/plugins/upstream/action.yml
@@ -1,12 +1,20 @@
 name: Plugin Upstream Tests
 description: Run upstream test suite
+inputs:
+  node-floor:
+    description: 'Lower Node alias: oldest-maintenance-lts or newest-maintenance-lts.'
+    required: false
+    default: oldest-maintenance-lts
 runs:
   using: composite
   steps:
     - uses: ./.github/actions/dd-sts-api-key
       id: dd-sts
     - uses: ./.github/actions/testagent/start
-    - uses: ./.github/actions/node/oldest-maintenance-lts
+    - if: ${{ inputs.node-floor == 'oldest-maintenance-lts' }}
+      uses: ./.github/actions/node/oldest-maintenance-lts
+    - if: ${{ inputs.node-floor == 'newest-maintenance-lts' }}
+      uses: ./.github/actions/node/newest-maintenance-lts
     - uses: ./.github/actions/install
     - run: yarn test:plugins:upstream
       shell: bash

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1106,27 +1106,9 @@ jobs:
       PLUGINS: pino
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/dd-sts-api-key
-        id: dd-sts
-      - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/newest-maintenance-lts
-      - uses: ./.github/actions/install
-      - run: yarn test:plugins:ci
-      - uses: ./.github/actions/node/latest
-      - run: yarn test:plugins:ci
-      # - run: yarn test:plugins:upstream
-      - if: always()
-        uses: ./.github/actions/testagent/logs
+      - uses: ./.github/actions/plugins/test
         with:
-          suffix: plugins-${{ github.job }}
-      - uses: ./.github/actions/coverage
-        with:
-          flags: apm-integrations-pino
-          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
-      - uses: ./.github/actions/push_to_test_optimization
-        if: "!cancelled()"
-        with:
-          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+          node-floor: newest-maintenance-lts
 
   passport-http:
     runs-on: ubuntu-latest

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - uses: ./.github/actions/install
       - run: yarn test:plugins:ci
       - run: yarn test:llmobs:plugins:ci
@@ -290,6 +290,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/plugins/test
+        with:
+          node-floor: newest-maintenance-lts
 
   modelcontextprotocol-sdk:
     runs-on: ubuntu-latest


### PR DESCRIPTION
They dropped support for Node.js 18 in 2025 and the versions we support automatically pull in latest peer dependencies that now start to fail.

To fix it, a new action option is added that allows to adjust the lower bound of the testing range.
