### PR TITLE
[test optimization] Fix CODEOWNERS extraction logic and playwright reported CI metadata

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -103,6 +103,10 @@ jobs:
         with:
           path: /github/home/.cache/ms-playwright
           key: playwright-browsers-oldest-dd${{ steps.dd-version.outputs.major }}
+      - name: Configure Git safe directory
+        # The Playwright job runs in a container where the checkout can be owned by a different UID.
+        # Git rejects metadata commands in that checkout unless the workspace is marked as safe.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - run: yarn test:integration:playwright
         env:
           NODE_OPTIONS: "-r ./ci/init"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -68,7 +68,6 @@
 "esquery","https://github.com/estools/esquery","['BSD-3-Clause']","['Joel Feenstra']"
 "estraverse","https://github.com/estools/estraverse","['BSD-2-Clause']","['estools']"
 "fast-fifo","https://github.com/mafintosh/fast-fifo","['MIT']","['Mathias Buus']"
-"ignore","https://github.com/kaelzhang/node-ignore","['MIT']","['kael']"
 "import-in-the-middle","https://github.com/nodejs/import-in-the-middle","['Apache-2.0']","['Bryan English']"
 "istanbul-lib-coverage","https://github.com/istanbuljs/istanbuljs","['BSD-3-Clause']","['Krishnan Anantheswaran']"
 "jest-docblock","https://github.com/jestjs/jest","['MIT']","['jestjs']"

--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -40,7 +40,6 @@ if (Number(process.env.EVERYTHING)) {
     'glob',
     'globals',
     'graphql',
-    'ignore',
     'import-in-the-middle',
     'istanbul-lib-coverage',
     'jest-docblock',

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -9,7 +9,6 @@ const { getEnvironmentVariable } = require('../../config/helper')
 const satisfies = require('../../../../../vendor/dist/semifies')
 
 const istanbul = require('../../../../../vendor/dist/istanbul-lib-coverage')
-const ignore = require('../../../../../vendor/dist/ignore')
 
 const id = require('../../id')
 const {
@@ -671,24 +670,146 @@ function getCodeOwnersFileEntries (rootDir) {
     const trimmed = content.trim()
     if (trimmed === '') continue
     const [pattern, ...owners] = trimmed.split(/\s+/)
-    entries.push({ pattern, owners })
+    entries.push(setCodeOwnersPatternRegex({ pattern, owners }))
   }
   // Reverse because rules defined last take precedence
   return entries.reverse()
 }
 
-const codeOwnersPerFileName = new Map()
+const codeOwnersPerEntries = new WeakMap()
+
+/**
+ * @param {string} character
+ * @returns {string}
+ */
+function escapeRegexCharacter (character) {
+  return character.replaceAll(/[|\\{}()[\]^$+*?.]/g, String.raw`\$&`)
+}
+
+/**
+ * @param {string} pattern
+ * @returns {boolean}
+ */
+function hasUnescapedWildcard (pattern) {
+  for (let i = 0; i < pattern.length; i++) {
+    const character = pattern[i]
+    if (character === '\\') {
+      i++
+    } else if (character === '*' || character === '?') {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * @param {string} pattern
+ * @returns {string}
+ */
+function codeOwnersPatternToRegexSource (pattern) {
+  let source = ''
+  for (let i = 0; i < pattern.length; i++) {
+    const character = pattern[i]
+
+    if (character === '\\') {
+      const escapedCharacter = pattern[i + 1]
+      source += escapedCharacter === undefined
+        ? escapeRegexCharacter(character)
+        : escapeRegexCharacter(escapedCharacter)
+      i++
+    } else if (character === '*') {
+      if (pattern[i + 1] === '*') {
+        if (pattern[i + 2] === '/') {
+          source += '(?:.*/)?'
+          i += 2
+        } else {
+          source += '.*'
+          i++
+        }
+      } else {
+        source += '[^/]*'
+      }
+    } else if (character === '?') {
+      source += '[^/]'
+    } else {
+      source += escapeRegexCharacter(character)
+    }
+  }
+  return source
+}
+
+/**
+ * @param {string} pattern
+ * @returns {RegExp|null}
+ */
+function getCodeOwnersPatternRegex (pattern) {
+  if (!pattern || pattern[0] === '!') {
+    return null
+  }
+
+  const directoryOnly = pattern.endsWith('/')
+  const normalizedPattern = pattern.replace(/^\/+/, '').replace(/\/+$/, '')
+  const anchored = pattern.startsWith('/') || normalizedPattern.includes('/')
+
+  if (!normalizedPattern) {
+    return null
+  }
+
+  const lastSlashIndex = normalizedPattern.lastIndexOf('/')
+  const lastSegment = lastSlashIndex === -1 ? normalizedPattern : normalizedPattern.slice(lastSlashIndex + 1)
+  const descendantSuffix = directoryOnly || !hasUnescapedWildcard(lastSegment) ? '(?:/.*)?' : ''
+  const patternSource = codeOwnersPatternToRegexSource(normalizedPattern)
+  const regexSource = anchored
+    ? `^${patternSource}${descendantSuffix}$`
+    : `(?:^|/)${patternSource}${descendantSuffix}$`
+
+  return new RegExp(regexSource)
+}
+
+function setCodeOwnersPatternRegex (entry) {
+  Object.defineProperty(entry, 'regex', {
+    configurable: true,
+    value: getCodeOwnersPatternRegex(entry.pattern),
+    writable: true,
+  })
+  return entry
+}
+
+/**
+ * Match a repository-relative filename against a CODEOWNERS pattern.
+ * See GitHub's CODEOWNERS pattern rules:
+ * https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+ *
+ * @param {RegExp|null} regex
+ * @param {string} filename
+ * @returns {boolean}
+ */
+function isCodeOwnersPatternMatch (regex, filename) {
+  if (!regex || !filename) {
+    return false
+  }
+
+  const normalizedFilename = filename.replaceAll('\\', '/').replace(/^\/+/, '')
+  return regex.test(normalizedFilename)
+}
 
 function getCodeOwnersForFilename (filename, entries) {
   if (!entries) {
     return null
   }
-  if (codeOwnersPerFileName.has(filename)) {
+  let codeOwnersPerFileName = codeOwnersPerEntries.get(entries)
+
+  if (!codeOwnersPerFileName) {
+    codeOwnersPerFileName = new Map()
+    codeOwnersPerEntries.set(entries, codeOwnersPerFileName)
+  } else if (codeOwnersPerFileName.has(filename)) {
     return codeOwnersPerFileName.get(filename)
   }
+
   for (const entry of entries) {
     try {
-      const isResponsible = ignore().add(entry.pattern).ignores(filename)
+      const regex = entry.regex === undefined ? setCodeOwnersPatternRegex(entry).regex : entry.regex
+      const isResponsible = isCodeOwnersPatternMatch(regex, filename)
       if (isResponsible) {
         const codeOwners = JSON.stringify(entry.owners)
         codeOwnersPerFileName.set(filename, codeOwners)

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -168,6 +168,128 @@ describe('getCodeOwnersForFilename', () => {
     assert.strictEqual(codeOwners, null)
   })
 
+  it('matches supported GitHub CODEOWNERS patterns', () => {
+    const patternTests = [
+      {
+        pattern: '*',
+        matches: ['index.js', 'packages/dd-trace/src/index.js'],
+      },
+      {
+        pattern: '*.js',
+        matches: ['index.js', 'packages/dd-trace/src/index.js'],
+        misses: ['index.jsx', 'packages/dd-trace/src/index.js.map'],
+      },
+      {
+        pattern: 'README.md',
+        matches: ['README.md', 'packages/dd-trace/README.md'],
+        misses: ['README.txt', 'packages/dd-trace/readme.md'],
+      },
+      {
+        pattern: '/package.json',
+        matches: ['package.json'],
+        misses: ['packages/dd-trace/package.json'],
+      },
+      {
+        pattern: '/docs/',
+        matches: ['docs/README.md', 'docs/api/reference.md'],
+        misses: ['src/docs/README.md'],
+      },
+      {
+        pattern: 'apps/',
+        matches: ['apps/api/index.js', 'packages/apps/api/index.js'],
+        misses: ['applications/api/index.js'],
+      },
+      {
+        pattern: 'docs/*',
+        matches: ['docs/getting-started.md'],
+        misses: ['docs/build-app/troubleshooting.md', 'src/docs/getting-started.md'],
+      },
+      {
+        pattern: '**/logs',
+        matches: ['logs/app.log', 'build/logs/app.log', 'deeply/nested/logs/app.log'],
+        misses: ['build/logs-old/app.log'],
+      },
+      {
+        pattern: 'logs/**',
+        matches: ['logs/app.log', 'logs/deeply/nested/app.log'],
+        misses: ['src/logs/app.log'],
+      },
+      {
+        pattern: '/packages/**/dsm.spec.js',
+        matches: ['packages/dsm.spec.js', 'packages/datadog-plugin-kafkajs/test/dsm.spec.js'],
+        misses: ['src/packages/datadog-plugin-kafkajs/test/dsm.spec.js'],
+      },
+      {
+        pattern: 'file?.js',
+        matches: ['file1.js', 'packages/dd-trace/fileA.js'],
+        misses: ['file10.js', 'packages/dd-trace/file/name.js'],
+      },
+    ]
+
+    for (const { pattern, matches = [], misses = [] } of patternTests) {
+      const entries = [{ pattern, owners: [`@owner-${pattern}`] }]
+      const expectedCodeOwners = JSON.stringify([`@owner-${pattern}`])
+
+      for (const filename of matches) {
+        assert.strictEqual(getCodeOwnersForFilename(filename, entries), expectedCodeOwners)
+      }
+
+      for (const filename of misses) {
+        assert.strictEqual(getCodeOwnersForFilename(filename, entries), null)
+      }
+    }
+  })
+
+  it('keeps CODEOWNERS matching case-sensitive', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/Docs/', owners: ['@datadog-docs'] },
+    ]
+
+    assert.strictEqual(
+      getCodeOwnersForFilename('Docs/reference.md', codeOwnersFileEntries),
+      JSON.stringify(['@datadog-docs'])
+    )
+    assert.strictEqual(getCodeOwnersForFilename('docs/reference.md', codeOwnersFileEntries), null)
+  })
+
+  it('uses the last matching CODEOWNERS entry', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '*.js', owners: ['@datadog-default-js'] },
+      { pattern: '/packages/dd-trace/', owners: ['@datadog-dd-trace-js'] },
+    ].reverse()
+
+    const codeOwners = getCodeOwnersForFilename(
+      'packages/dd-trace/src/index.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwners, JSON.stringify(['@datadog-dd-trace-js']))
+  })
+
+  it('preserves multiple CODEOWNERS owners and email owners', () => {
+    const codeOwnersFileEntries = [
+      {
+        pattern: '*.js',
+        owners: ['@datadog-team-a', '@datadog/team-b', 'user@example.com'],
+      },
+    ]
+
+    const codeOwners = getCodeOwnersForFilename('index.js', codeOwnersFileEntries)
+
+    assert.strictEqual(codeOwners, JSON.stringify(['@datadog-team-a', '@datadog/team-b', 'user@example.com']))
+  })
+
+  it('supports empty owner overrides', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '*', owners: ['@datadog-default'] },
+      { pattern: '/apps/github', owners: [] },
+    ].reverse()
+
+    const codeOwners = getCodeOwnersForFilename('apps/github/index.js', codeOwnersFileEntries)
+
+    assert.strictEqual(codeOwners, JSON.stringify([]))
+  })
+
   it('returns the code owners for a given file path', () => {
     const rootDir = path.join(__dirname, '__test__')
     const codeOwnersFileEntries = getCodeOwnersFileEntries(rootDir)
@@ -185,6 +307,164 @@ describe('getCodeOwnersForFilename', () => {
     )
 
     assert.strictEqual(codeOwnersForTestSpec, JSON.stringify(['@datadog-ci-app']))
+  })
+
+  it('does not let root-level fallbacks override integration test directories', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/*', owners: ['@datadog-lang-platform-js'] },
+      { pattern: '/integration-tests/mocha/', owners: ['@datadog-ci-app-libraries'] },
+      { pattern: '/integration-tests/playwright/', owners: ['@datadog-ci-app-libraries'] },
+    ]
+
+    const codeOwnersForMochaSpec = getCodeOwnersForFilename(
+      'integration-tests/mocha/codeowners-root-pattern.spec.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForPlaywrightSpec = getCodeOwnersForFilename(
+      'integration-tests/playwright/codeowners-root-pattern.spec.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForRootFile = getCodeOwnersForFilename('root-level-codeowners-test.js', codeOwnersFileEntries)
+
+    assert.strictEqual(codeOwnersForMochaSpec, JSON.stringify(['@datadog-ci-app-libraries']))
+    assert.strictEqual(codeOwnersForPlaywrightSpec, JSON.stringify(['@datadog-ci-app-libraries']))
+    assert.strictEqual(codeOwnersForRootFile, JSON.stringify(['@datadog-lang-platform-js']))
+  })
+
+  it('matches directory patterns against descendants', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/packages/dd-trace/src/ci-visibility/', owners: ['@datadog-ci-app-libraries'] },
+    ]
+
+    const codeOwnersForCiVisibilityFile = getCodeOwnersForFilename(
+      'packages/dd-trace/src/ci-visibility/exporters/agentless/writer.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForCiVisibilityFile, JSON.stringify(['@datadog-ci-app-libraries']))
+  })
+
+  it('matches wildcard directory patterns against descendants', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/*', owners: ['@datadog-lang-platform-js'] },
+      { pattern: '/packages/datadog-plugin-*/', owners: ['@datadog-apm-idm-js'] },
+    ]
+
+    const codeOwnersForPluginFile = getCodeOwnersForFilename(
+      'packages/datadog-plugin-http/test/codeowners-wildcard-directory.spec.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForPluginFile, JSON.stringify(['@datadog-apm-idm-js']))
+  })
+
+  it('does not match single-star wildcards across directories', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/packages/dd-trace/*/standalone', owners: ['@datadog-lang-platform-js'] },
+    ]
+
+    const codeOwnersForDirectMatch = getCodeOwnersForFilename(
+      'packages/dd-trace/src/standalone/codeowners-single-star.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForNestedMismatch = getCodeOwnersForFilename(
+      'packages/dd-trace/src/profiling/standalone/codeowners-single-star.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForDirectMatch, JSON.stringify(['@datadog-lang-platform-js']))
+    assert.strictEqual(codeOwnersForNestedMismatch, null)
+  })
+
+  it('matches double-star patterns across directories', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/packages/**/dsm.spec.js', owners: ['@datadog-data-streams-monitoring'] },
+      { pattern: '/packages/**/*.dsm.spec.js', owners: ['@datadog-data-streams-monitoring'] },
+    ]
+
+    const codeOwnersForDsmSpec = getCodeOwnersForFilename(
+      'packages/datadog-plugin-kafkajs/test/dsm.spec.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForTopLevelDsmSpec = getCodeOwnersForFilename(
+      'packages/dsm.spec.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForSuffixDsmSpec = getCodeOwnersForFilename(
+      'packages/datadog-plugin-kafkajs/test/codeowners.dsm.spec.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForTopLevelSuffixDsmSpec = getCodeOwnersForFilename(
+      'packages/codeowners.dsm.spec.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForDsmSpec, JSON.stringify(['@datadog-data-streams-monitoring']))
+    assert.strictEqual(codeOwnersForTopLevelDsmSpec, JSON.stringify(['@datadog-data-streams-monitoring']))
+    assert.strictEqual(codeOwnersForSuffixDsmSpec, JSON.stringify(['@datadog-data-streams-monitoring']))
+    assert.strictEqual(codeOwnersForTopLevelSuffixDsmSpec, JSON.stringify(['@datadog-data-streams-monitoring']))
+  })
+
+  it('matches slashless patterns in any directory', () => {
+    const codeOwnersFileEntries = [
+      { pattern: 'github_event_payload.json', owners: ['@datadog-ci-app-libraries'] },
+    ]
+
+    const codeOwnersForNestedFixture = getCodeOwnersForFilename(
+      'packages/dd-trace/test/plugins/util/fixtures/github_event_payload.json',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForNestedFixture, JSON.stringify(['@datadog-ci-app-libraries']))
+  })
+
+  it('matches patterns with middle slashes from the repository root', () => {
+    const codeOwnersFileEntries = [
+      { pattern: 'fixtures/codeowners-middle-slash.json', owners: ['@datadog-ci-app-libraries'] },
+    ]
+
+    const codeOwnersForRootFixture = getCodeOwnersForFilename(
+      'fixtures/codeowners-middle-slash.json',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForNestedFixture = getCodeOwnersForFilename(
+      'packages/dd-trace/test/plugins/util/fixtures/codeowners-middle-slash.json',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForRootFixture, JSON.stringify(['@datadog-ci-app-libraries']))
+    assert.strictEqual(codeOwnersForNestedFixture, null)
+  })
+
+  it('does not let a root-level wildcard match nested files', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/*', owners: ['@datadog-lang-platform-js'] },
+    ]
+
+    const codeOwnersForNestedFile = getCodeOwnersForFilename(
+      'packages/dd-trace/test/plugins/util/root-wildcard-check.spec.js',
+      codeOwnersFileEntries
+    )
+    const codeOwnersForRootFile = getCodeOwnersForFilename(
+      'root-wildcard-check.spec.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForNestedFile, null)
+    assert.strictEqual(codeOwnersForRootFile, JSON.stringify(['@datadog-lang-platform-js']))
+  })
+
+  it('matches paths with Windows separators', () => {
+    const codeOwnersFileEntries = [
+      { pattern: '/integration-tests/vitest/', owners: ['@datadog-ci-app-libraries'] },
+    ]
+
+    const codeOwnersForWindowsPath = getCodeOwnersForFilename(
+      'integration-tests\\vitest\\vitest.spec.js',
+      codeOwnersFileEntries
+    )
+
+    assert.strictEqual(codeOwnersForWindowsPath, JSON.stringify(['@datadog-ci-app-libraries']))
   })
 })
 

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -16,7 +16,6 @@
         "crypto-randomuuid": "^1.0.0",
         "escape-string-regexp": "^5.0.0",
         "esquery": "^1.7.0",
-        "ignore": "^7.0.5",
         "istanbul-lib-coverage": "^3.2.2",
         "jest-docblock": "^29.7.0",
         "jsonpath-plus": "^10.4.0",
@@ -612,15 +611,6 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -13,7 +13,6 @@
     "crypto-randomuuid": "^1.0.0",
     "escape-string-regexp": "^5.0.0",
     "esquery": "^1.7.0",
-    "ignore": "^7.0.5",
     "istanbul-lib-coverage": "^3.2.2",
     "jest-docblock": "^29.7.0",
     "jsonpath-plus": "^10.4.0",


### PR DESCRIPTION
### What does this PR do?
Fixes CODEOWNERS matching for test optimization events so CODEOWNERS root-relative directory rules such as `/integration-tests/mocha/` are honored before the later `/*` fallback. This replaces the previous `ignore` package based matching with small CODEOWNERS-specific matching logic and removes the now-unused vendored `ignore` dependency.

It also configures the Playwright job checkout as a safe Git directory so CI Visibility can read commit metadata inside the job container.

### Motivation
Test optimization integration jobs were reporting `test.codeowners` as `DataDog/lang-platform-js` instead of `DataDog/ci-app-libraries`. The previous implementation used the `ignore` package, which applies gitignore-style matching rather than CODEOWNERS semantics. In this repo that caused the later `/* @DataDog/lang-platform-js` rule to match nested test source files, instead of letting the intended `/integration-tests/.../` owner rules win.

The Playwright job also missed `git.commit.author.email` because Git rejected metadata commands in the containerized checkout with a dubious ownership error.

### Additional Notes
Validation run locally: `./node_modules/.bin/mocha packages/dd-trace/test/plugins/util/test.spec.js`.

The Playwright job runs inside a container where the checkout can be owned by a different UID. Without marking `$GITHUB_WORKSPACE` as a safe Git directory, Git rejects metadata commands and the tracer cannot populate git author metadata.