### PR TITLE
fix(profiling): keep real proxy when only profiling is enabled

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -254,6 +254,7 @@
 /packages/dd-trace/test/histogram.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/id.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/iitm.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/index.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/log.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/msgpack/ @DataDog/lang-platform-js
 /packages/dd-trace/test/noop.spec.js @DataDog/lang-platform-js

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -9,9 +9,11 @@ const inJestWorker = typeof jest !== 'undefined'
 const ddTraceDisabled = getValueFromEnvSources('DD_TRACE_ENABLED')
   ? isFalse(getValueFromEnvSources('DD_TRACE_ENABLED'))
   : String(getValueFromEnvSources('OTEL_TRACES_EXPORTER')).toLowerCase() === 'none'
+const profilingEnabled = String(getValueFromEnvSources('DD_PROFILING_ENABLED') ?? '').toLowerCase()
 const shouldUseProxyWhenTracingDisabled =
   isTrue(getValueFromEnvSources('DD_DYNAMIC_INSTRUMENTATION_ENABLED')) ||
-  isTrue(getValueFromEnvSources('DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED'))
+  isTrue(getValueFromEnvSources('DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED')) ||
+  isTrue(profilingEnabled) || profilingEnabled === 'auto'
 
 module.exports = (ddTraceDisabled && !shouldUseProxyWhenTracingDisabled) || inJestWorker
   ? require('./noop/proxy')

--- a/packages/dd-trace/test/index.spec.js
+++ b/packages/dd-trace/test/index.spec.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFileSync } = require('node:child_process')
+const path = require('node:path')
+
+const { describe, it } = require('mocha')
+
+require('./setup/core')
+
+const INDEX_PATH = path.resolve(__dirname, '..', 'src', 'index.js')
+
+function resolveProxyClass (env) {
+  const out = execFileSync(
+    process.execPath,
+    ['-e', `process.stdout.write(require(${JSON.stringify(INDEX_PATH)}).name)`],
+    { env: { PATH: process.env.PATH, ...env }, encoding: 'utf8' }
+  )
+  return out
+}
+
+describe('packages/dd-trace/src/index proxy selection', () => {
+  it('returns the real Tracer by default', () => {
+    assert.equal(resolveProxyClass({}), 'Tracer')
+  })
+
+  it('returns NoopProxy when DD_TRACE_ENABLED=false', () => {
+    assert.equal(resolveProxyClass({ DD_TRACE_ENABLED: 'false' }), 'NoopProxy')
+  })
+
+  it('returns NoopProxy when DD_TRACING_ENABLED=0 (alias)', () => {
+    assert.equal(resolveProxyClass({ DD_TRACING_ENABLED: '0' }), 'NoopProxy')
+  })
+
+  it('returns NoopProxy when OTEL_TRACES_EXPORTER=none', () => {
+    assert.equal(resolveProxyClass({ OTEL_TRACES_EXPORTER: 'none' }), 'NoopProxy')
+  })
+
+  describe('escape hatches that keep the real proxy when tracing is disabled', () => {
+    for (const flag of [
+      'DD_DYNAMIC_INSTRUMENTATION_ENABLED',
+      'DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED',
+    ]) {
+      it(`keeps the real Tracer when ${flag}=true`, () => {
+        assert.equal(resolveProxyClass({ DD_TRACE_ENABLED: 'false', [flag]: 'true' }), 'Tracer')
+      })
+    }
+
+    for (const value of ['true', '1', 'auto']) {
+      it(`keeps the real Tracer when DD_PROFILING_ENABLED=${value}`, () => {
+        assert.equal(
+          resolveProxyClass({ DD_TRACE_ENABLED: 'false', DD_PROFILING_ENABLED: value }),
+          'Tracer'
+        )
+      })
+    }
+
+    it('still returns NoopProxy when DD_PROFILING_ENABLED=false', () => {
+      assert.equal(
+        resolveProxyClass({ DD_TRACE_ENABLED: 'false', DD_PROFILING_ENABLED: 'false' }),
+        'NoopProxy'
+      )
+    })
+
+    it('keeps the real Tracer when DD_TRACING_ENABLED=0 alias is paired with DD_PROFILING_ENABLED=1', () => {
+      assert.equal(
+        resolveProxyClass({ DD_TRACING_ENABLED: '0', DD_PROFILING_ENABLED: '1' }),
+        'Tracer'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

When `DD_TRACE_ENABLED=false` (or its alias `DD_TRACING_ENABLED=0`), `packages/dd-trace/src/index.js` exports `NoopProxy`. `NoopProxy.init()` is a no-op, so the profiler never starts even though the user explicitly opted into profiling. This breaks the "profiling-only, no tracing" configuration.

There is already an allowlist (`shouldUseProxyWhenTracingDisabled`) for `DD_DYNAMIC_INSTRUMENTATION_ENABLED` and `DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED` that keeps the real proxy alive when tracing is off. This PR adds `DD_PROFILING_ENABLED` to that allowlist.

`DD_PROFILING_ENABLED` is declared with `"allowed": "false|true|auto|1|0"`, so the check recognizes `true`/`1`/`auto` as values that should keep the proxy alive (matching how `proxy.js` already handles those values to start the profiler or arm the SSI heuristic).

## Background

This was discovered while investigating a CI regression in [DataDog/prof-correctness](https://github.com/DataDog/prof-correctness/pull/115), where node profiling scenarios stopped producing pprof files after #6982 began resolving aliases in `getValueFromEnvSources`. The companion prof-correctness PR currently works around this by setting `DD_DYNAMIC_INSTRUMENTATION_ENABLED=true`; once this PR ships, that workaround can be removed.

## Test plan

- [x] Smoke test all combinations locally:
  - `DD_TRACE_ENABLED=false` alone → `NoopProxy`
  - `DD_TRACE_ENABLED=false` + `DD_PROFILING_ENABLED=true|1|auto` → real `Tracer`
  - `DD_TRACE_ENABLED=false` + `DD_PROFILING_ENABLED=false` → `NoopProxy`
  - `DD_TRACING_ENABLED=0` alone → `NoopProxy` (alias)
  - `DD_TRACING_ENABLED=0` + `DD_PROFILING_ENABLED=1` → real `Tracer`
- [x] `eslint packages/dd-trace/src/index.js` passes
- [ ] CI green