### PR TITLE
Update junit upload action to v3.1.0

### DIFF
--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -14,10 +14,7 @@ runs:
       # >  from a forked repository, and are also subject to these restrictions.
       #
       # Which means they do not have access to secrets.
-      uses: DataDog/junit-upload-github-action@24449d01fc01e721fa36ccd2caa3caae6922f0e8 # v3.0.0
+      uses: DataDog/junit-upload-github-action@ce82dc1f14a32888a057bfeeb47adfd0fd96e555 # v3.1.0
       with:
         api_key: ${{ inputs.dd_api_key }}
-        # TODO: remove once https://github.com/DataDog/junit-upload-github-action/pull/54 lands
-        # and junit-upload-github-action releases are tied to datadog-ci releases.
-        datadog-ci-version: 5.13.1
         service: dd-trace-js-tests

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -74,13 +74,10 @@ jobs:
       - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:integration:bun
-      - uses: DataDog/junit-upload-github-action@24449d01fc01e721fa36ccd2caa3caae6922f0e8 # v3.0.0
+      - uses: DataDog/junit-upload-github-action@ce82dc1f14a32888a057bfeeb47adfd0fd96e555 # v3.1.0
         if: always() && github.actor != 'dependabot[bot]'
         with:
           api_key: ${{ steps.dd-sts.outputs.api_key }}
-          # TODO: remove once https://github.com/DataDog/junit-upload-github-action/pull/54 lands
-          # and junit-upload-github-action releases are tied to datadog-ci releases.
-          datadog-ci-version: 5.13.1
           service: dd-trace-js-tests
 
   core:


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?

Updates `DataDog/junit-upload-github-action` from the pinned v3.0.0 SHA to the pinned v3.1.0 SHA in:

- `.github/actions/push_to_test_optimization/action.yml`
- `.github/workflows/platform.yml`

This also removes the temporary `datadog-ci-version` override added in #8078, since v3.1.0 now ships a pinned default `datadog-ci` version.

### Motivation

`DataDog/junit-upload-github-action` v3.1.0 includes the follow-up release behavior from DataDog/junit-upload-github-action#54, so dd-trace-js can rely on the action release SHA instead of carrying action-specific `datadog-ci-version` configuration.

