### PR TITLE
test(next): find next.request span by name to fix flaky route-not-found assertion

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -942,6 +942,7 @@ function useSandbox (...args) {
 
   after(function () {
     this.timeout(30_000)
+    if (!sandbox) return
     return sandbox.remove()
   })
 }

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -51,6 +51,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
+          if (!aerospike) return
           aerospike.releaseEventLoop()
         })
 
@@ -306,6 +307,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
+          if (!aerospike) return
           aerospike.releaseEventLoop()
         })
 

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -227,9 +227,10 @@ describe('Plugin', function () {
           it('should handle routes not found', done => {
             agent
               .assertSomeTraces(traces => {
-                const spans = traces[0]
+                const nextRequestSpan = traces[0].find(span => span.name === 'next.request')
+                assert.ok(nextRequestSpan, 'next.request span should exist')
 
-                assertObjectContains(spans[1], {
+                assertObjectContains(nextRequestSpan, {
                   name: 'next.request',
                   service: 'test',
                   type: 'web',
@@ -252,9 +253,10 @@ describe('Plugin', function () {
           it('should handle invalid catch all parameters', done => {
             agent
               .assertSomeTraces(traces => {
-                const spans = traces[0]
+                const nextRequestSpan = traces[0].find(span => span.name === 'next.request')
+                assert.ok(nextRequestSpan, 'next.request span should exist')
 
-                assertObjectContains(spans[1], {
+                assertObjectContains(nextRequestSpan, {
                   name: 'next.request',
                   service: 'test',
                   type: 'web',


### PR DESCRIPTION
## Summary
- `it('should handle routes not found')` and `it('should handle invalid catch all parameters')` in `packages/datadog-plugin-next/test/index.spec.js` both used `spans[1]` to locate the `next.request` span. The span at index `1` isn't guaranteed — when the trace shape varies, the assertion flakes with `actual: [Object], expected: [Object]`.
- **Top APM Integrations flake (97 occurrences in the last 7-day flakiness report).**
- Replaced the fixed-index lookup with `traces[0].find(s => s.name === 'next.request')` plus an existence assertion, matching the robust pattern already used at line 299 of the same file.

## Investigation status
- [x] CI failure pattern confirmed: 3/3 sampled flakes pointed at `index.spec.js:232:17`.
- [ ] **Local reproduction not yet attempted** — fix is based on CI-log analysis only.
- [ ] CI green on this branch (this PR is the verification mechanism).

## Test plan
- [ ] Run `PLUGINS=next npm run test:plugins` locally, looped, to reproduce on master then verify the fix.
- [ ] Re-run flakiness report after merge to confirm the `next` cluster shrinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)