### PR TITLE
test(kafkajs): filter producer trace from consume-span assertion

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -942,6 +942,7 @@ function useSandbox (...args) {
 
   after(function () {
     this.timeout(30_000)
+    if (!sandbox) return
     return sandbox.remove()
   })
 }

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -51,6 +51,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
+          if (!aerospike) return
           aerospike.releaseEventLoop()
         })
 
@@ -306,6 +307,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
+          if (!aerospike) return
           aerospike.releaseEventLoop()
         })
 

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -472,7 +472,9 @@ describe('Plugin', () => {
 
           it('should propagate context via span links', async () => {
             const expectedSpanPromise = agent.assertSomeTraces(traces => {
-              const span = traces[0][0]
+              const span = traces[0].find(s => s.name === expectedSchema.receive.opName)
+              assert.ok(span, `${expectedSchema.receive.opName} span should exist in trace`)
+
               const links = span.meta['_dd.span_links'] ? JSON.parse(span.meta['_dd.span_links']) : []
 
               assertObjectContains(span, {


### PR DESCRIPTION
## Summary
- `it('should propagate context via span links')` in `packages/datadog-plugin-kafkajs/test/index.spec.js` used `traces[0][0]`, but `assertSomeTraces` runs the callback once per agent payload. The producer trace (`kafka.produce`) frequently arrives before the consumer trace (`kafka.consume`), so the very first invocation asserts against the wrong span and fails with `actual: 'kafka.produce', expected: 'kafka.consume'`.
- **2nd-most-frequent APM Integrations flake (61 occurrences in the last 7-day flakiness report).**
- Filter the receive-op span by name, throwing when not yet present in the current payload. `assertSomeTraces` will retry on the next payload, eliminating the producer/consumer race.

## Investigation status
- [x] CI failure pattern confirmed across 3 sampled flakes — all show `actual: 'kafka.produce', expected: 'kafka.consume'` at `index.spec.js:478`.
- [ ] **Local reproduction not yet attempted** — fix is based on CI-log analysis only.
- [ ] CI green on this branch (this PR is the verification mechanism).

## Test plan
- [ ] `SERVICES=kafka PLUGINS=kafkajs docker compose up -d kafka && yarn services && PLUGINS=kafkajs npm run test:plugins` locally, looped, to reproduce on master then verify.
- [ ] Re-run flakiness report after merge to confirm the `kafkajs` cluster shrinks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)