### PR TITLE
downgrade bun to 1.3.1

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -58,4 +58,4 @@ runs:
       run: node -v | tr -d 'v' > /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
-        bun-version: 1.3.13
+        bun-version: 1.3.1

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -56,44 +56,6 @@ runs:
       if: steps.node-version-cache.outputs.cache-hit != 'true'
       shell: bash
       run: node -v | tr -d 'v' > /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
-    # Avoid GitHub REST API tag lookups (api.github.com/.../git/refs/tags) which can hit installation rate limits
-    # in large orgs / high-parallelism workflows. Instead, use a direct release asset URL.
-    #
-    # Note: setup-bun's `bun-download-url` skips its own AVX2 detection, so we do a minimal check ourselves for
-    # Linux x64 (fallback to baseline build when AVX2 isn't present).
-    - id: bun-download-url
-      run: |
-        set -euo pipefail
-
-        BUN_VERSION="1.3.1"
-
-        case "${RUNNER_OS}:${RUNNER_ARCH}" in
-          Linux:X64)
-            ASSET="bun-linux-x64.zip"
-            if ! grep -qiE '(^|\\s)avx2(\\s|$)' /proc/cpuinfo; then
-              ASSET="bun-linux-x64-baseline.zip"
-            fi
-            ;;
-          Linux:ARM64)
-            ASSET="bun-linux-aarch64.zip"
-            ;;
-          macOS:X64)
-            ASSET="bun-darwin-x64.zip"
-            ;;
-          macOS:ARM64)
-            ASSET="bun-darwin-aarch64.zip"
-            ;;
-          Windows:X64)
-            ASSET="bun-windows-x64.zip"
-            ;;
-          *)
-            echo "Unsupported runner: ${RUNNER_OS}/${RUNNER_ARCH}" >&2
-            exit 1
-            ;;
-        esac
-
-        echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${ASSET}" >> "$GITHUB_OUTPUT"
-      shell: bash
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
-        bun-download-url: ${{ steps.bun-download-url.outputs.url }}
+        bun-version: 1.3.13

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "axios": "^1.15.0",
     "benchmark": "^2.1.4",
     "body-parser": "^2.2.2",
-    "bun": "1.3.12",
+    "bun": "^1.3.13",
     "codeowners-audit": "^2.9.0",
     "eslint": "^9.39.2",
     "eslint-plugin-cypress": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "axios": "^1.15.0",
     "benchmark": "^2.1.4",
     "body-parser": "^2.2.2",
-    "bun": "^1.3.13",
+    "bun": "1.3.1",
     "codeowners-audit": "^2.9.0",
     "eslint": "^9.39.2",
     "eslint-plugin-cypress": "^6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,65 +692,65 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@oven/bun-darwin-aarch64@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.12.tgz#713b8d27009286cd7853fd4127d586032d4874e0"
-  integrity sha512-b6CQgT28Jx7uDwMTcGo7WFqUd1+wWTdp8XyPi/4LRcL/R4deKT7cLx/Q2ZCWAiK6ZU7yexoCaIaKun6azjRLVA==
+"@oven/bun-darwin-aarch64@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.13.tgz#b84bad830ea6703b1a1cfc8644e394efcc49ed0b"
+  integrity sha512-qAS6Hg8Q14ckfBuqJ2Zh7gBQSVSUHeibSq4OFqBTv6DzyJuxYlr0sdYQzmYmnbPxbqobekqUDTa/4XEaqRi7vg==
 
-"@oven/bun-darwin-x64-baseline@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.12.tgz#c3eba66b98981693c7462a90da09b3df2697617c"
-  integrity sha512-9jKJNOc9ID3BxPBPR4r1Mp1Wqde89Twi5zo2LoEMLMKbqpvEM/WUGdJ0Vv7OX1QPEqVblFO6NMky5yY7rjDI2w==
+"@oven/bun-darwin-x64-baseline@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.13.tgz#a8352e7431e1903647b97ddbe68fbea40ce63753"
+  integrity sha512-gMEQayUpmCPYaE9zkNBj9TiQqHupnhjOYcuSzxFjzIjHJBUO4VjNnrpbKVeXNs+rKHFothORDd2QKquu5paSPQ==
 
-"@oven/bun-darwin-x64@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.12.tgz#38121f1ce9cc8b3cb4a316949918de76ea6609eb"
-  integrity sha512-//6W21c+GinAMMmxD2hFrFmJH+ZlEwJYbLzAGqp0mLFTli9y74RMtDgI2n9pCupXSpU1Kr1sSylVW9yNbAG9Xg==
+"@oven/bun-darwin-x64@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.13.tgz#61f1b7d436049a5811c13eff497ae50646d214f9"
+  integrity sha512-kGePeDD4IN4imo+H4uLjQGZLmvyYQg+nKr2P0nt4ksXXrWA4HE+mb0/TUPHfRI127DocXQpew+fvrHuHR5mpJQ==
 
-"@oven/bun-linux-aarch64-musl@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.12.tgz#9fac298699b9c0e8e2e86b31d52794e7633f924c"
-  integrity sha512-HWIwFzm5fALd9Lli0CgaKb6xOGqODYyHpUTgkn/IHHuS/f3XDCu71+GgkyvfgCYbPoBSgBOfp5TzhRehPcgxow==
+"@oven/bun-linux-aarch64-musl@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.13.tgz#45ae31cc0b7b235689cbd6fd74ecdfc014f81896"
+  integrity sha512-UV9EE18VE5aRhWtV2L6MTAGGn3slhJJ2OW/m+FJM15maHm0qf1V7TaZY0FovxhdQRvnklSiQ7Ntv0H5TUX4w0g==
 
-"@oven/bun-linux-aarch64@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.12.tgz#0862d4d5cc0b04a5dec3eeca95685171e50e87f5"
-  integrity sha512-eTru6tk3K4Ya3SSkUqq/LbdEjwPqLlfINmIhRORrCExBdB1tQbk+WYYflaymO61fkrjnMAjmLTGqk/K37RMIGA==
+"@oven/bun-linux-aarch64@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.13.tgz#3d8dbaa03ad970a0e3757e126ea9cc8f1649e141"
+  integrity sha512-NbLOJdr+RBFO1vFZ2YUFg4oVJ+2ua6zrwo4ZWRs0jKKcGJWtbY2wY5uz+i0PkwH6b9HYaYDgVTzE4ev06ncYZw==
 
-"@oven/bun-linux-x64-baseline@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.12.tgz#aeb52705a137bfbd08875cb150668cd3a27bae6e"
-  integrity sha512-0y+lUiQsPvSGsyM/10KtxhVAQ20p6/D+vj01l6vo9gHpYUpyc1L9pSgaPa7SC9TuaiGASlM3Cb62bmSKW0E/3Q==
+"@oven/bun-linux-x64-baseline@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.13.tgz#c55c0c32dd68e6ab3b6095b17c97fc7a5c208bab"
+  integrity sha512-fOi4ziKzgJG4UrrNd4AicBs6Fu9GY5xOqg+9tC76nuZNDAdSh6++kzab6TNi1Ck0Yzq6zIBIdGit6/0uSbBn8A==
 
-"@oven/bun-linux-x64-musl-baseline@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.12.tgz#7bcdae5356d1ec0c97b8596870a5893750dda865"
-  integrity sha512-jdsnuFD3H0l4AHtf1nInRHYWIMTWqok0aW8WysjzN5Isn6rBTBGK/ZWX6XjdTgDgcuVbVOYHiLUHHrvT9N6psA==
+"@oven/bun-linux-x64-musl-baseline@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.13.tgz#e67d4f08958fa7aef0a205765432824558c68798"
+  integrity sha512-fqBKuiiWLEu2dVkowZaXgKS98xfrvBqivdoxRtRP3eINcpI1dcelGbsOz+Xphn7tbGAuBiE1/0AelvvvdqS9rg==
 
-"@oven/bun-linux-x64-musl@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.12.tgz#d23aa2f8bb827332ebc3fc82f26ae0116e69441a"
-  integrity sha512-Zb7T3JxWlArSe44ATO5mtjLCBCt7kenWPl9CYD+zeqq9kHswMv8Cd3h/9uzdv2PA4Flrq57J5XBSuRdStTCXCw==
+"@oven/bun-linux-x64-musl@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.13.tgz#6fa3b1c9c14d1b09ff7d87874beb3641e75bbfec"
+  integrity sha512-+VHhE44kEjCXcTFHyc81zfTxL9+vzh9RqIh7gM1iWNhxpctD9kzntbUkP3UTFTwwNjoou1o8VRyxQafvc4OepA==
 
-"@oven/bun-linux-x64@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64/-/bun-linux-x64-1.3.12.tgz#3e9d32b9105fb17e715b72d8fec2f7da1b391f33"
-  integrity sha512-H75bcEn46lMDxd+P+R6Q/jlIKl/YO0ZXaalSyWhQHr7qNmFhQt3rOHurFoCxuwQeqFoToh0JpWVyMVzByZqgBQ==
+"@oven/bun-linux-x64@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64/-/bun-linux-x64-1.3.13.tgz#f75bb98a3c82fbbe850038305b8c72faf97adcb4"
+  integrity sha512-UwttIUXoe9fS+40OcjoaRHgZw+HCPFqBVWEXkXqAJ3W7wA0XPZrWsoMAD9sGh3TaLqrwdiMo5xPogwpXhOtVXA==
 
-"@oven/bun-windows-aarch64@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-aarch64/-/bun-windows-aarch64-1.3.12.tgz#126745ec0e453f85a24fea633d5d3e604b763f96"
-  integrity sha512-Oq0FIcCgL3JWf/4qRuxI5fxsOGyWJ1j904PDx/1TxxSCWWAu0Hh2o8ck4TcaPVv/3BMc1k6UxqQQKBrdP7a+qQ==
+"@oven/bun-windows-aarch64@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-aarch64/-/bun-windows-aarch64-1.3.13.tgz#3e0733d2c09e2c4409de421ac6e18fdcae5c7dca"
+  integrity sha512-+EvdRWRCRg95Xea4M2lqSJFTjzQBTJDQTMlbG8bmwFkVTN16MdmSH7xhfxVQWUOyZBLEpIwuNFIlBBxVCwSUyQ==
 
-"@oven/bun-windows-x64-baseline@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.12.tgz#1fb01cabc3668aebada45823f38ac191f43870ce"
-  integrity sha512-rV21md7QWnu3r/shev7IFMh6hX8BJHwofxESAofUT4yH866oCIbcNbzp6+fxrj4oGD8uisP6WoaTCboijv9yYg==
+"@oven/bun-windows-x64-baseline@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.13.tgz#7ebbcd2396ba34a8318eb8e204084fa4f9a54a05"
+  integrity sha512-6gy4hhQSjq/T/S9hC9m3NxY0RY+9Ww+XNlB+8koIMTsMSYEjk7Ho+hFHQz1Bn4W61Ub7Vykufg+jgDgPfa2GFA==
 
-"@oven/bun-windows-x64@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64/-/bun-windows-x64-1.3.12.tgz#00fe1323d37029c1870d89c1f515fb184264c867"
-  integrity sha512-veSntY7pDLDh4XmxZMwTqxfoEVp0BDdeqCBoWL46/TigtniPtDFSTIWBxa6l/RcGzklUA/uqLqmsK/9cBZAm8Q==
+"@oven/bun-windows-x64@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64/-/bun-windows-x64-1.3.13.tgz#50c46e195061cd559edf49cc30d91c9e856b8249"
+  integrity sha512-vqDEFX63ZZQF3YstPSpPD+RxNm5AILPdUuuKpNwsj7ld4NjhdHUYkAmLXDtKNWt9JMRL10bop//W8faY/LV+RQ==
 
 "@oxc-parser/binding-android-arm-eabi@0.126.0":
   version "0.126.0"
@@ -1258,23 +1258,23 @@ builtin-modules@^5.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-5.0.0.tgz#9be95686dedad2e9eed05592b07733db87dcff1a"
   integrity sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==
 
-bun@1.3.12:
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/bun/-/bun-1.3.12.tgz#1879388cb906cc085f95a2b6e59e05b347cba314"
-  integrity sha512-KLwDUqs5WIny/94F4xZ4QfaAE6YWyjR+s79pt/ItQhk2CG+PJQ5xL6VuOWhiyN2eP3fryZK95vog9CTLCaYV2Q==
+bun@^1.3.13:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/bun/-/bun-1.3.13.tgz#b509c0f82ba805027b6fdc31a9a25c90a314caa4"
+  integrity sha512-b9T4xZ8KqCHs4+TkHJv540LG1B8OD7noKu0Qaizusx3jFtMDHY6osNqgbaOlwW2B8RB2AKzz+sjzlGKIGxIjZw==
   optionalDependencies:
-    "@oven/bun-darwin-aarch64" "1.3.12"
-    "@oven/bun-darwin-x64" "1.3.12"
-    "@oven/bun-darwin-x64-baseline" "1.3.12"
-    "@oven/bun-linux-aarch64" "1.3.12"
-    "@oven/bun-linux-aarch64-musl" "1.3.12"
-    "@oven/bun-linux-x64" "1.3.12"
-    "@oven/bun-linux-x64-baseline" "1.3.12"
-    "@oven/bun-linux-x64-musl" "1.3.12"
-    "@oven/bun-linux-x64-musl-baseline" "1.3.12"
-    "@oven/bun-windows-aarch64" "1.3.12"
-    "@oven/bun-windows-x64" "1.3.12"
-    "@oven/bun-windows-x64-baseline" "1.3.12"
+    "@oven/bun-darwin-aarch64" "1.3.13"
+    "@oven/bun-darwin-x64" "1.3.13"
+    "@oven/bun-darwin-x64-baseline" "1.3.13"
+    "@oven/bun-linux-aarch64" "1.3.13"
+    "@oven/bun-linux-aarch64-musl" "1.3.13"
+    "@oven/bun-linux-x64" "1.3.13"
+    "@oven/bun-linux-x64-baseline" "1.3.13"
+    "@oven/bun-linux-x64-musl" "1.3.13"
+    "@oven/bun-linux-x64-musl-baseline" "1.3.13"
+    "@oven/bun-windows-aarch64" "1.3.13"
+    "@oven/bun-windows-x64" "1.3.13"
+    "@oven/bun-windows-x64-baseline" "1.3.13"
 
 busboy@^1.6.0:
   version "1.6.0"
@@ -4078,16 +4078,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4151,14 +4142,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4521,7 +4505,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -4534,15 +4518,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,65 +692,60 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@oven/bun-darwin-aarch64@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.13.tgz#b84bad830ea6703b1a1cfc8644e394efcc49ed0b"
-  integrity sha512-qAS6Hg8Q14ckfBuqJ2Zh7gBQSVSUHeibSq4OFqBTv6DzyJuxYlr0sdYQzmYmnbPxbqobekqUDTa/4XEaqRi7vg==
+"@oven/bun-darwin-aarch64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-aarch64/-/bun-darwin-aarch64-1.3.1.tgz#24f15a0bdec25bb52e726207bfeb84258b22f1ea"
+  integrity sha512-7Rap1BHNWqgnexc4wLjjdZeVRQKtk534iGuJ7qZ42i/q1B+cxJZ6zSnrFsYmo+zreH7dUyUXL3AHuXGrl2772Q==
 
-"@oven/bun-darwin-x64-baseline@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.13.tgz#a8352e7431e1903647b97ddbe68fbea40ce63753"
-  integrity sha512-gMEQayUpmCPYaE9zkNBj9TiQqHupnhjOYcuSzxFjzIjHJBUO4VjNnrpbKVeXNs+rKHFothORDd2QKquu5paSPQ==
+"@oven/bun-darwin-x64-baseline@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64-baseline/-/bun-darwin-x64-baseline-1.3.1.tgz#fc2f3cd9caba96be20862e011ca2d11d0cd1d216"
+  integrity sha512-mJo715WvwEHmJ6khNymWyxi0QrFzU94wolsUmxolViNHrk+2ugzIkVIJhTnxf7pHnarxxHwyJ/kgatuV//QILQ==
 
-"@oven/bun-darwin-x64@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.13.tgz#61f1b7d436049a5811c13eff497ae50646d214f9"
-  integrity sha512-kGePeDD4IN4imo+H4uLjQGZLmvyYQg+nKr2P0nt4ksXXrWA4HE+mb0/TUPHfRI127DocXQpew+fvrHuHR5mpJQ==
+"@oven/bun-darwin-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-darwin-x64/-/bun-darwin-x64-1.3.1.tgz#c54e0eec263eda889169b4d83ee6b5ec3290f958"
+  integrity sha512-wpqmgT/8w+tEr5YMGt1u1sEAMRHhyA2SKZddC6GCPasHxSqkCWOPQvYIHIApnTsoSsxhxP0x6Cpe93+4c7hq/w==
 
-"@oven/bun-linux-aarch64-musl@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.13.tgz#45ae31cc0b7b235689cbd6fd74ecdfc014f81896"
-  integrity sha512-UV9EE18VE5aRhWtV2L6MTAGGn3slhJJ2OW/m+FJM15maHm0qf1V7TaZY0FovxhdQRvnklSiQ7Ntv0H5TUX4w0g==
+"@oven/bun-linux-aarch64-musl@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64-musl/-/bun-linux-aarch64-musl-1.3.1.tgz#851b4cefeea2c8219666bec5324bd560304a29d2"
+  integrity sha512-gKU3Wv3BTG5VMjqMMnRwqU6tipCveE9oyYNt62efy6cQK3Vo1DOBwY2SmjbFw+yzj+Um20YoFOLGxghfQET4Ng==
 
-"@oven/bun-linux-aarch64@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.13.tgz#3d8dbaa03ad970a0e3757e126ea9cc8f1649e141"
-  integrity sha512-NbLOJdr+RBFO1vFZ2YUFg4oVJ+2ua6zrwo4ZWRs0jKKcGJWtbY2wY5uz+i0PkwH6b9HYaYDgVTzE4ev06ncYZw==
+"@oven/bun-linux-aarch64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-aarch64/-/bun-linux-aarch64-1.3.1.tgz#3ee52397da074f40235d2f55016093cb6c98019d"
+  integrity sha512-ACn038SZL8del+sFnqCjf+haGB02//j2Ez491IMmPTvbv4a/D0iiNz9xiIB3ICbQd3EwQzi+Ut/om3Ba/KoHbQ==
 
-"@oven/bun-linux-x64-baseline@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.13.tgz#c55c0c32dd68e6ab3b6095b17c97fc7a5c208bab"
-  integrity sha512-fOi4ziKzgJG4UrrNd4AicBs6Fu9GY5xOqg+9tC76nuZNDAdSh6++kzab6TNi1Ck0Yzq6zIBIdGit6/0uSbBn8A==
+"@oven/bun-linux-x64-baseline@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-baseline/-/bun-linux-x64-baseline-1.3.1.tgz#63e3075607640d6df731cc120e43369256e19d4c"
+  integrity sha512-7+2aCrL81mtltZQbKdiPB58UL+Gr3DAIuPyUAKm0Ib/KG/Z8t7nD/eSMRY/q6b+NsAjYnVPiPwqSjC3edpMmmQ==
 
-"@oven/bun-linux-x64-musl-baseline@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.13.tgz#e67d4f08958fa7aef0a205765432824558c68798"
-  integrity sha512-fqBKuiiWLEu2dVkowZaXgKS98xfrvBqivdoxRtRP3eINcpI1dcelGbsOz+Xphn7tbGAuBiE1/0AelvvvdqS9rg==
+"@oven/bun-linux-x64-musl-baseline@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl-baseline/-/bun-linux-x64-musl-baseline-1.3.1.tgz#26608cd5f87fdf998dd494da8f3399528b23e406"
+  integrity sha512-tP0WWcAqrMayvkggOHBGBoyyoK+QHAqgRUyj1F6x5/udiqc9vCXmIt1tlydxYV/NvyvUAmJ7MWT0af44Xm2kJw==
 
-"@oven/bun-linux-x64-musl@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.13.tgz#6fa3b1c9c14d1b09ff7d87874beb3641e75bbfec"
-  integrity sha512-+VHhE44kEjCXcTFHyc81zfTxL9+vzh9RqIh7gM1iWNhxpctD9kzntbUkP3UTFTwwNjoou1o8VRyxQafvc4OepA==
+"@oven/bun-linux-x64-musl@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64-musl/-/bun-linux-x64-musl-1.3.1.tgz#fd4b6365943db3c6bfe0193ff8dbcf0998b736a0"
+  integrity sha512-8AgEAHyuJ5Jm9MUo1L53K1SRYu0bNGqV0E0L5rB5DjkteO4GXrnWGBT8qsuwuy7WMuCMY3bj64/pFjlRkZuiXw==
 
-"@oven/bun-linux-x64@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64/-/bun-linux-x64-1.3.13.tgz#f75bb98a3c82fbbe850038305b8c72faf97adcb4"
-  integrity sha512-UwttIUXoe9fS+40OcjoaRHgZw+HCPFqBVWEXkXqAJ3W7wA0XPZrWsoMAD9sGh3TaLqrwdiMo5xPogwpXhOtVXA==
+"@oven/bun-linux-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-linux-x64/-/bun-linux-x64-1.3.1.tgz#19e1417abf33ab0c3fde795ae70b2285300794e0"
+  integrity sha512-cAUeM3I5CIYlu5Ur52eCOGg9yfqibQd4lzt9G1/rA0ajqcnCBaTuekhUDZETJJf5H9QV+Gm46CqQg2DpdJzJsw==
 
-"@oven/bun-windows-aarch64@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-aarch64/-/bun-windows-aarch64-1.3.13.tgz#3e0733d2c09e2c4409de421ac6e18fdcae5c7dca"
-  integrity sha512-+EvdRWRCRg95Xea4M2lqSJFTjzQBTJDQTMlbG8bmwFkVTN16MdmSH7xhfxVQWUOyZBLEpIwuNFIlBBxVCwSUyQ==
+"@oven/bun-windows-x64-baseline@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.1.tgz#c95a119f997f4b6332c43355e1a254bd4b31487e"
+  integrity sha512-dcA+Kj7hGFrY3G8NWyYf3Lj3/GMViknpttWUf5pI6p6RphltZaoDu0lY5Lr71PkMdRZTwL2NnZopa/x/NWCdKA==
 
-"@oven/bun-windows-x64-baseline@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64-baseline/-/bun-windows-x64-baseline-1.3.13.tgz#7ebbcd2396ba34a8318eb8e204084fa4f9a54a05"
-  integrity sha512-6gy4hhQSjq/T/S9hC9m3NxY0RY+9Ww+XNlB+8koIMTsMSYEjk7Ho+hFHQz1Bn4W61Ub7Vykufg+jgDgPfa2GFA==
-
-"@oven/bun-windows-x64@1.3.13":
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64/-/bun-windows-x64-1.3.13.tgz#50c46e195061cd559edf49cc30d91c9e856b8249"
-  integrity sha512-vqDEFX63ZZQF3YstPSpPD+RxNm5AILPdUuuKpNwsj7ld4NjhdHUYkAmLXDtKNWt9JMRL10bop//W8faY/LV+RQ==
+"@oven/bun-windows-x64@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@oven/bun-windows-x64/-/bun-windows-x64-1.3.1.tgz#a64137c3b67f818b5a8a50f2680cd60d3e6ebe7e"
+  integrity sha512-xdUjOZRq6PwPbbz4/F2QEMLBZwintGp7AS50cWxgkHnyp7Omz5eJfV6/vWtN4qwZIyR3V3DT/2oXsY1+7p3rtg==
 
 "@oxc-parser/binding-android-arm-eabi@0.126.0":
   version "0.126.0"
@@ -1258,23 +1253,22 @@ builtin-modules@^5.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-5.0.0.tgz#9be95686dedad2e9eed05592b07733db87dcff1a"
   integrity sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==
 
-bun@^1.3.13:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/bun/-/bun-1.3.13.tgz#b509c0f82ba805027b6fdc31a9a25c90a314caa4"
-  integrity sha512-b9T4xZ8KqCHs4+TkHJv540LG1B8OD7noKu0Qaizusx3jFtMDHY6osNqgbaOlwW2B8RB2AKzz+sjzlGKIGxIjZw==
+bun@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/bun/-/bun-1.3.1.tgz#bf1cb09802a8b991b6a0dbd8e44cbc6664f2b0bc"
+  integrity sha512-enqkEb0RhNOgDzHQwv7uvnIhX3uSzmKzz779dL7kdH8SauyTdQvCz4O1UT2rU0UldQp2K9OlrJNdyDHayPEIvw==
   optionalDependencies:
-    "@oven/bun-darwin-aarch64" "1.3.13"
-    "@oven/bun-darwin-x64" "1.3.13"
-    "@oven/bun-darwin-x64-baseline" "1.3.13"
-    "@oven/bun-linux-aarch64" "1.3.13"
-    "@oven/bun-linux-aarch64-musl" "1.3.13"
-    "@oven/bun-linux-x64" "1.3.13"
-    "@oven/bun-linux-x64-baseline" "1.3.13"
-    "@oven/bun-linux-x64-musl" "1.3.13"
-    "@oven/bun-linux-x64-musl-baseline" "1.3.13"
-    "@oven/bun-windows-aarch64" "1.3.13"
-    "@oven/bun-windows-x64" "1.3.13"
-    "@oven/bun-windows-x64-baseline" "1.3.13"
+    "@oven/bun-darwin-aarch64" "1.3.1"
+    "@oven/bun-darwin-x64" "1.3.1"
+    "@oven/bun-darwin-x64-baseline" "1.3.1"
+    "@oven/bun-linux-aarch64" "1.3.1"
+    "@oven/bun-linux-aarch64-musl" "1.3.1"
+    "@oven/bun-linux-x64" "1.3.1"
+    "@oven/bun-linux-x64-baseline" "1.3.1"
+    "@oven/bun-linux-x64-musl" "1.3.1"
+    "@oven/bun-linux-x64-musl-baseline" "1.3.1"
+    "@oven/bun-windows-x64" "1.3.1"
+    "@oven/bun-windows-x64-baseline" "1.3.1"
 
 busboy@^1.6.0:
   version "1.6.0"
@@ -4079,6 +4073,7 @@ streamsearch@^1.1.0:
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4143,6 +4138,7 @@ string_decoder@~1.1.1:
     safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -4506,6 +4502,7 @@ workerpool@^9.2.0:
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Downgrade Bun to 1.3.1.

### Motivation
<!-- What inspired you to submit this pull request? -->

Downgrade Bun to last version known to work properly. It was automatically updated by Dependabot and started to cause issues a few weeks ago. This has caused our tests to take a lot more time to run, and sometimes the sandbox creation would timeout at the 5 minutes mark.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I also removed our workaround for the unnecessary API calls since that has since been fixed upstream in `setup-bun`.
