### PR TITLE
switch back to hoisted linker for bun

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -19,7 +19,7 @@ runs:
       if: inputs.cache == 'true' && steps.yarn-cache.outputs.cache-hit == 'true'
       # Retry in case of server error from registry.
       # Wait 60 seconds to give the registry server time to heal.
-    - run: bun install --trust || sleep 60 && bun install --trust
+    - run: bun install --linker=hoisted --trust || sleep 60 && bun install --linker=hoisted --trust
       shell: bash
       env:
         _DD_IGNORE_ENGINES: 'true'

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,7 +38,7 @@ jobs:
           - name: yarn-berry
             install: (command -v corepack >/dev/null 2>&1 || npm install -g corepack) && yarn set version stable && yarn config set nodeLinker node-modules && yarn add
           - name: bun
-            install: bun add
+            install: bun add --linker=hoisted
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -176,8 +176,8 @@ jobs:
         id: dd-sts
       - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
-      - run: bun add --ignore-scripts mocha@10 # Use older mocha to support old Node.js versions
-      - run: bun add --ignore-scripts express@4 # Use older express to support old Node.js versions
+      - run: bun add --linker=hoisted --ignore-scripts mocha@10 # Use older mocha to support old Node.js versions
+      - run: bun add --linker=hoisted --ignore-scripts express@4 # Use older express to support old Node.js versions
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -547,7 +547,7 @@ async function createSandbox (
       NODE_OPTIONS: '--dns-result-order=ipv4first',
     },
   }
-  const addFlags = ['--trust', '--verbose']
+  const addFlags = ['--linker=hoisted', '--trust']
 
   // Tarball packing and integration-tests copy touch independent paths (sandbox root vs. the
   // sandbox folder) and neither writes anything `bun add` will read, so run them concurrently.

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -355,11 +355,11 @@ function spawnProcImpl (filename, options, stdioHandler, stderrHandler) {
 }
 
 function log (...args) {
-  console.log(...args) // eslint-disable-line no-console
+  DEBUG === 'true' && console.log(...args) // eslint-disable-line no-console
 }
 
 function error (...args) {
-  console.error(...args) // eslint-disable-line no-console
+  DEBUG === 'true' && console.error(...args) // eslint-disable-line no-console
 }
 
 function execHelper (command, options) {
@@ -540,13 +540,7 @@ async function createSandbox (
   const deps = cappedDependencies.concat(`file:${out}`)
 
   await fs.mkdir(folder, { recursive: true })
-  const addOptions = {
-    cwd: folder,
-    env: {
-      ...restOfEnv,
-      NODE_OPTIONS: '--dns-result-order=ipv4first',
-    },
-  }
+  const addOptions = { cwd: folder, env: restOfEnv }
   const addFlags = ['--linker=hoisted', '--trust']
 
   // Tarball packing and integration-tests copy touch independent paths (sandbox root vs. the

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -537,10 +537,9 @@ async function createSandbox (
   const out = tarballEnv && tarballEnv !== '0' && tarballEnv !== 'false'
     ? tarballEnv
     : path.join(sandboxRoot, 'dd-trace.tgz')
-  const deps = cappedDependencies.concat(`file:${out}`)
 
   await fs.mkdir(folder, { recursive: true })
-  const addOptions = { cwd: folder, env: restOfEnv }
+  const addOptions = { cwd: folder, env: restOfEnv, timeout: 90_000 }
   const addFlags = ['--linker=hoisted', '--trust']
 
   // Tarball packing and integration-tests copy touch independent paths (sandbox root vs. the
@@ -562,10 +561,9 @@ async function createSandbox (
     addFlags.push('--silent')
   }
 
-  execHelper(`${BUN} add ${deps.join(' ')} ${addFlags.join(' ')}`, {
-    ...addOptions,
-    timeout: 90_000,
-  })
+  execHelper(`${BUN} add ${cappedDependencies.join(' ')} ${addFlags.join(' ')}`, addOptions)
+  execHelper(`${BUN} add file:${out} ${[...addFlags, '--ignore-scripts'].join(' ')}`, addOptions)
+
   if (process.platform === 'win32') {
     // On Windows, we can only sync entire filesystem volume caches.
     execHelper(`Write-VolumeCache ${folder[0]}`, { shell: 'powershell.exe' })

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -539,7 +539,7 @@ async function createSandbox (
     : path.join(sandboxRoot, 'dd-trace.tgz')
 
   await fs.mkdir(folder, { recursive: true })
-  const addOptions = { cwd: folder, env: restOfEnv, timeout: 90_000 }
+  const addOptions = { cwd: folder, env: restOfEnv, timeout: 60_000 }
   const addFlags = ['--linker=hoisted', '--trust']
 
   // Tarball packing and integration-tests copy touch independent paths (sandbox root vs. the

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -540,8 +540,14 @@ async function createSandbox (
   const deps = cappedDependencies.concat(`file:${out}`)
 
   await fs.mkdir(folder, { recursive: true })
-  const addOptions = { cwd: folder, env: restOfEnv }
-  const addFlags = ['--trust']
+  const addOptions = {
+    cwd: folder,
+    env: {
+      ...restOfEnv,
+      NODE_OPTIONS: '--dns-result-order=ipv4first',
+    },
+  }
+  const addFlags = ['--trust', '--verbose']
 
   // Tarball packing and integration-tests copy touch independent paths (sandbox root vs. the
   // sandbox folder) and neither writes anything `bun add` will read, so run them concurrently.

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -561,7 +561,10 @@ async function createSandbox (
     addFlags.push('--silent')
   }
 
-  execHelper(`${BUN} add ${cappedDependencies.join(' ')} ${addFlags.join(' ')}`, addOptions)
+  if (cappedDependencies.length > 0) {
+    execHelper(`${BUN} add ${cappedDependencies.join(' ')} ${addFlags.join(' ')}`, addOptions)
+  }
+
   execHelper(`${BUN} add file:${out} ${[...addFlags, '--ignore-scripts'].join(' ')}`, addOptions)
 
   if (process.platform === 'win32') {

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -355,11 +355,11 @@ function spawnProcImpl (filename, options, stdioHandler, stderrHandler) {
 }
 
 function log (...args) {
-  DEBUG === 'true' && console.log(...args) // eslint-disable-line no-console
+  console.log(...args) // eslint-disable-line no-console
 }
 
 function error (...args) {
-  DEBUG === 'true' && console.error(...args) // eslint-disable-line no-console
+  console.error(...args) // eslint-disable-line no-console
 }
 
 function execHelper (command, options) {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch back to hoisted linker for bun.

### Motivation
<!-- What inspired you to submit this pull request? -->

Bun 1.3 switched the default linker to isolated. However, it still has many unresolved issues even with the latest version, so it's safer to use the more robust hoisted linker until those issues are resolved to avoid flakiness.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


