### PR TITLE
test: fix max listener warning in test optimization tests

### DIFF
--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -65,7 +65,7 @@ temporaryWarningExceptions.add = (warning) => {
 }
 
 process.on('warning', (warning) => {
-  if (warning.name === 'MaxListenersExceededWarning' && !warning.message.includes('[Runner]')) {
+  if (warning.name === 'MaxListenersExceededWarning') {
     throw warning
   }
   if (temporaryWarningExceptions.has(warning.message)) {

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -1,12 +1,14 @@
 'use strict'
 
 const assert = require('assert')
+const dc = require('node:diagnostics_channel')
+const events = require('node:events')
 const fs = require('fs')
 const { platform } = require('os')
 const path = require('path')
 const util = require('util')
 
-const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+const { after, afterEach, before, beforeEach, describe, it, Runner } = require('mocha')
 const semver = require('semver')
 const sinon = require('sinon')
 require('./core')
@@ -19,6 +21,11 @@ const { SVC_SRC_KEY } = require('../../src/constants')
 const extraServices = require('../../src/service-naming/extra-services')
 const { storage } = require('../../../datadog-core')
 const { getInstrumentation } = require('./helpers/load-inst')
+
+// dd-trace's mocha CI Visibility hook adds extra Runner listeners.
+if (dc.channel('ci:mocha:test:finish').hasSubscribers) {
+  Runner.prototype.setMaxListeners(events.defaultMaxListeners + 2)
+}
 
 const NODE_PATH_SEP = platform() === 'win32' ? ';' : ':'
 


### PR DESCRIPTION
The warning would show up, while it was ignored. Now, we increase the limit for mocha so that this is not triggered anymore and does not confuse about what is really going on.
