### PR TITLE
test: do not hide mocha errors

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -944,8 +944,7 @@ function useSandbox (...args) {
     this.timeout(30_000)
     const oldSandbox = sandbox
     sandbox = undefined
-    if (!oldSandbox) return
-    return oldSandbox.remove()
+    return oldSandbox?.remove()
   })
 }
 

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -942,7 +942,10 @@ function useSandbox (...args) {
 
   after(function () {
     this.timeout(30_000)
-    return sandbox.remove()
+    const oldSandbox = sandbox
+    sandbox = undefined
+    if (!oldSandbox) return
+    return oldSandbox.remove()
   })
 }
 

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -1,5 +1,7 @@
 'use strict'
 
+require('./mocha-hooks')
+
 process.env.DD_INSTRUMENTATION_TELEMETRY_ENABLED = 'false'
 
 // If this is a release PR, set the SSI variables.

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -1,38 +1,57 @@
 'use strict'
 
-// Make `afterAll`/`afterEach` best-effort when the matching `before*` already failed: any error
-// they throw is silently dropped so mocha can report the original cause instead of a follow-up
-// `TypeError` masking it (`let foo / before assigns / after uses` pattern).
+// Drop afterAll/afterEach errors when an earlier runnable in the same suite already
+// failed, so mocha reports the original cause instead of a teardown error masking it.
 
-/** @typedef {{ _beforeAll?: { isFailed?: () => boolean }[] } & Record<string, any>} AnySuite */
-/** @typedef {{ currentTest?: { state?: string } }} AnyCtx */
-/** @typedef {(suite: AnySuite, ctx: AnyCtx) => boolean} ShouldSuppress */
-/** @typedef {(...args: any[]) => any} AnyFn */
+/** @typedef {import('mocha')} Mocha */
+/**
+ * Structural view of `Mocha.Suite` exposing the private hook arrays we need to
+ * inspect; the runtime object is still a real `Mocha.Suite`.
+ *
+ * @typedef {object} Suite
+ * @property {Mocha.Hook[]} [_beforeAll]
+ * @property {Mocha.Hook[]} [_beforeEach]
+ * @property {Mocha.Hook[]} [_afterEach]
+ * @property {Mocha.Test[]} [tests]
+ */
+/** @typedef {(suite: Suite, ctx: Mocha.Context) => boolean} ShouldSuppress */
+/** @typedef {Mocha.Func | Mocha.AsyncFunc} HookFn */
 
-const Suite = /** @type {any} */ (require('mocha').Suite)
+const { Suite: MochaSuite } = require('mocha')
 
-const prototypes = new WeakMap()
-
-if (!prototypes.get(Suite.prototype)) {
-  prototypes.set(Suite.prototype, true)
-
+const patched = new WeakSet()
+if (!patched.has(MochaSuite.prototype)) {
+  patched.add(MochaSuite.prototype)
   patchAfter('afterAll', shouldSuppressAfterAll)
   patchAfter('afterEach', shouldSuppressAfterEach)
 }
 
 /** @type {ShouldSuppress} */
 function shouldSuppressAfterAll (suite) {
-  const hooks = suite?._beforeAll
-  if (!Array.isArray(hooks)) return false
-  for (const hook of hooks) {
-    if (hook?.isFailed?.()) return true
-  }
-  return false
+  return anyFailed(suite._beforeAll) ||
+    anyFailed(suite._beforeEach) ||
+    anyFailed(suite._afterEach) ||
+    anyFailed(suite.tests)
 }
 
 /** @type {ShouldSuppress} */
-function shouldSuppressAfterEach (_suite, ctx) {
-  return ctx?.currentTest?.state === 'failed'
+function shouldSuppressAfterEach (suite, ctx) {
+  return ctx.currentTest?.isFailed() === true || anyFailed(suite._beforeEach)
+}
+
+/** @param {Mocha.Runnable[] | undefined} runnables */
+function anyFailed (runnables) {
+  if (!Array.isArray(runnables)) return false
+  for (const r of runnables) if (r?.isFailed?.()) return true
+  return false
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is PromiseLike<unknown>}
+ */
+function isThenable (value) {
+  return value != null && typeof value === 'object' && 'then' in value && typeof value.then === 'function'
 }
 
 /**
@@ -40,37 +59,46 @@ function shouldSuppressAfterEach (_suite, ctx) {
  * @param {ShouldSuppress} shouldSuppress
  */
 function patchAfter (method, shouldSuppress) {
-  const original = Suite.prototype[method]
-  Suite.prototype[method] =
-    /** @this {AnySuite} @param {any} title @param {AnyFn=} fn */
-    function patchedAfter (title, fn) {
-      if (typeof title === 'function') {
-        fn = title
-        title = title.name
-      }
-      if (typeof fn !== 'function') return original.call(this, title, fn)
-      return original.call(this, title, wrapAfter(fn, this, shouldSuppress))
+  const proto = /** @type {Record<string, (title: string | HookFn, fn?: HookFn) => Mocha.Suite>} */ (
+    /** @type {unknown} */ (MochaSuite.prototype)
+  )
+  const original = proto[method]
+  /**
+   * @this {Mocha.Suite}
+   * @param {string | HookFn} title
+   * @param {HookFn} [fn]
+   */
+  proto[method] = function patchedAfter (title, fn) {
+    if (typeof title === 'function') {
+      fn = title
+      title = title.name
     }
+    const suite = /** @type {Suite} */ (/** @type {unknown} */ (this))
+    if (typeof fn !== 'function') return original.call(this, title, fn)
+    return original.call(this, title, wrapAfter(fn, suite, shouldSuppress))
+  }
 }
 
 /**
- * @param {AnyFn} fn
- * @param {AnySuite} suite
+ * @param {HookFn} fn
+ * @param {Suite} suite
  * @param {ShouldSuppress} shouldSuppress
+ * @returns {HookFn}
  */
 function wrapAfter (fn, suite, shouldSuppress) {
   // Preserve `fn.length` so mocha picks the right execution path (`this.async = fn && fn.length`).
   if (fn.length === 0) {
-    return /** @this {AnyCtx} */ function wrappedAfter () {
+    /** @this {Mocha.Context} */
+    return function wrappedAfter () {
       let result
       try {
-        result = fn.call(this)
+        result = (/** @type {Mocha.AsyncFunc} */ (fn)).call(this)
       } catch (err) {
         if (shouldSuppress(suite, this)) return
         throw err
       }
-      if (result && typeof result.then === 'function') {
-        return result.then(undefined, (/** @type {unknown} */ err) => {
+      if (isThenable(result)) {
+        return Promise.resolve(result).then(undefined, (err) => {
           if (shouldSuppress(suite, this)) return
           throw err
         })
@@ -79,21 +107,22 @@ function wrapAfter (fn, suite, shouldSuppress) {
     }
   }
 
-  return (
-    /**
-     * @this {AnyCtx}
-     * @param {(err?: unknown, ...rest: unknown[]) => void} done
-     */
-    function wrappedAfter (done) {
-      try {
-        fn.call(this, (/** @type {unknown} */ err, /** @type {unknown[]} */ ...rest) => {
-          if (err && shouldSuppress(suite, this)) return done(undefined, ...rest)
-          return done(err, ...rest)
-        })
-      } catch (err) {
-        if (shouldSuppress(suite, this)) return done()
-        throw err
-      }
+  /**
+   * @this {Mocha.Context}
+   * @param {Mocha.Done} done
+   */
+  return function wrappedAfter (done) {
+    let result
+    try {
+      result = (/** @type {Mocha.Func} */ (fn)).call(this, (err) => {
+        if (err && shouldSuppress(suite, this)) return done()
+        return done(err)
+      })
+    } catch (err) {
+      if (shouldSuppress(suite, this)) return done()
+      throw err
     }
-  )
+    // Returned for mocha's overspecification detection (callback + Promise return).
+    return result
+  }
 }

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -1,0 +1,99 @@
+'use strict'
+
+// Make `afterAll`/`afterEach` best-effort when the matching `before*` already failed: any error
+// they throw is silently dropped so mocha can report the original cause instead of a follow-up
+// `TypeError` masking it (`let foo / before assigns / after uses` pattern).
+
+/** @typedef {{ _beforeAll?: { isFailed?: () => boolean }[] } & Record<string, any>} AnySuite */
+/** @typedef {{ currentTest?: { state?: string } }} AnyCtx */
+/** @typedef {(suite: AnySuite, ctx: AnyCtx) => boolean} ShouldSuppress */
+/** @typedef {(...args: any[]) => any} AnyFn */
+
+const Suite = /** @type {any} */ (require('mocha').Suite)
+
+const prototypes = new WeakMap()
+
+if (!prototypes.get(Suite.prototype)) {
+  prototypes.set(Suite.prototype, true)
+
+  patchAfter('afterAll', shouldSuppressAfterAll)
+  patchAfter('afterEach', shouldSuppressAfterEach)
+}
+
+/** @type {ShouldSuppress} */
+function shouldSuppressAfterAll (suite) {
+  const hooks = suite?._beforeAll
+  if (!Array.isArray(hooks)) return false
+  for (const hook of hooks) {
+    if (hook?.isFailed?.()) return true
+  }
+  return false
+}
+
+/** @type {ShouldSuppress} */
+function shouldSuppressAfterEach (_suite, ctx) {
+  return ctx?.currentTest?.state === 'failed'
+}
+
+/**
+ * @param {'afterAll'|'afterEach'} method
+ * @param {ShouldSuppress} shouldSuppress
+ */
+function patchAfter (method, shouldSuppress) {
+  const original = Suite.prototype[method]
+  Suite.prototype[method] =
+    /** @this {AnySuite} @param {any} title @param {AnyFn=} fn */
+    function patchedAfter (title, fn) {
+      if (typeof title === 'function') {
+        fn = title
+        title = title.name
+      }
+      if (typeof fn !== 'function') return original.call(this, title, fn)
+      return original.call(this, title, wrapAfter(fn, this, shouldSuppress))
+    }
+}
+
+/**
+ * @param {AnyFn} fn
+ * @param {AnySuite} suite
+ * @param {ShouldSuppress} shouldSuppress
+ */
+function wrapAfter (fn, suite, shouldSuppress) {
+  // Preserve `fn.length` so mocha picks the right execution path (`this.async = fn && fn.length`).
+  if (fn.length === 0) {
+    return /** @this {AnyCtx} */ function wrappedAfter () {
+      let result
+      try {
+        result = fn.call(this)
+      } catch (err) {
+        if (shouldSuppress(suite, this)) return
+        throw err
+      }
+      if (result && typeof result.then === 'function') {
+        return result.then(undefined, (/** @type {unknown} */ err) => {
+          if (shouldSuppress(suite, this)) return
+          throw err
+        })
+      }
+      return result
+    }
+  }
+
+  return (
+    /**
+     * @this {AnyCtx}
+     * @param {(err?: unknown, ...rest: unknown[]) => void} done
+     */
+    function wrappedAfter (done) {
+      try {
+        fn.call(this, (/** @type {unknown} */ err, /** @type {unknown[]} */ ...rest) => {
+          if (err && shouldSuppress(suite, this)) return done(undefined, ...rest)
+          return done(err, ...rest)
+        })
+      } catch (err) {
+        if (shouldSuppress(suite, this)) return done()
+        throw err
+      }
+    }
+  )
+}

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -51,7 +51,7 @@ function anyFailed (runnables) {
  * @returns {value is PromiseLike<unknown>}
  */
 function isThenable (value) {
-  return value != null && typeof value === 'object' && 'then' in value && typeof value.then === 'function'
+  return typeof value?.then === 'function'
 }
 
 /**


### PR DESCRIPTION
If a after* hook fails after a failure in a before* hook or the test, the after hook error is going to be read first and tears down the test runner. This causes the actual error not to be visible anymore.

This surfaces these again by hooking into mocha internals and ignoring the after* errors, if it comes after a former error. That way we know what actually fails.

Downside is not knowing about teardown issues that are in addition to former issues, while that is in almost all cases not important.

Hiding also seemed better than logging both to let us focus on the main problem area.
