### PR TITLE
remove junit upload action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -213,6 +213,7 @@
 # CI
 /.github/actions/dd-sts-app-key/action.yml @Datadog/lang-platform-js
 /.github/actions/dd-sts-api-key/action.yml @Datadog/lang-platform-js
+/.github/actions/push_to_test_optimization/ @DataDog/ci-app-libraries
 /.github/chainguard @DataDog/sdlc-security
 /.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
 /.github/workflows/apm-integrations.yml @DataDog/apm-idm-js

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -34,6 +34,6 @@ runs:
       run: yarn global add @datadog/datadog-ci@${{ env.DATADOG_CI_VERSION }}
     - if: github.actor != 'dependabot[bot]'
       shell: bash
-      run: datadog-ci junit upload --service dd-trace-js-tests "*.xml"
+      run: datadog-ci junit upload --service dd-trace-js-tests .
       env:
         DD_API_KEY: ${{ inputs.dd_api_key }}

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -25,6 +25,10 @@ runs:
         path: ${{ steps.yarn-global-dir.outputs.dir }}
         key: datadog-ci-${{ env.DATADOG_CI_VERSION }}
     - if: github.actor != 'dependabot[bot]'
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: '20'
+    - if: github.actor != 'dependabot[bot]'
       shell: bash
       run: yarn global add @datadog/datadog-ci@${{ env.DATADOG_CI_VERSION }}
     - if: github.actor != 'dependabot[bot]'

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -14,26 +14,20 @@ runs:
       # >  from a forked repository, and are also subject to these restrictions.
       #
       # Which means they do not have access to secrets.
-      id: yarn-global-dir
-      shell: bash
-      run: |
-        echo "dir=$(yarn global dir)" >> $GITHUB_OUTPUT
-        echo "DATADOG_CI_VERSION=5.15.0" >> $GITHUB_ENV
-        echo "$(yarn global bin)" >> $GITHUB_PATH
-    - if: github.actor != 'dependabot[bot]'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        path: ${{ steps.yarn-global-dir.outputs.dir }}
-        key: datadog-ci-${{ env.DATADOG_CI_VERSION }}
+        path: ${{ github.action_path }}/node_modules
+        key: datadog-ci-${{ hashFiles('.github/actions/push_to_test_optimization/package.json') }}
     - if: github.actor != 'dependabot[bot]'
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '20'
     - if: github.actor != 'dependabot[bot]'
       shell: bash
-      run: yarn global add @datadog/datadog-ci@${{ env.DATADOG_CI_VERSION }}
+      run: yarn install --no-lockfile
+      working-directory: ${{ github.action_path }}
     - if: github.actor != 'dependabot[bot]'
       shell: bash
-      run: datadog-ci junit upload --service dd-trace-js-tests .
+      run: ${{ github.action_path }}/node_modules/.bin/datadog-ci junit upload --service dd-trace-js-tests .
       env:
         DD_API_KEY: ${{ inputs.dd_api_key }}

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -14,17 +14,22 @@ runs:
       # >  from a forked repository, and are also subject to these restrictions.
       #
       # Which means they do not have access to secrets.
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.action_path }}/node_modules
+        key: push-to-test-optimization-${{ hashFiles('.github/actions/push_to_test_optimization/package.json') }}
+    - if: github.actor != 'dependabot[bot]'
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '20'
-        cache: 'yarn'
-        cache-dependency-path: .github/actions/push_to_test_optimization/package.json
     - if: github.actor != 'dependabot[bot]'
       shell: bash
-      run: yarn install --no-lockfile
+      run: |
+        yarn install --no-lockfile
+        echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
       working-directory: ${{ github.action_path }}
     - if: github.actor != 'dependabot[bot]'
       shell: bash
-      run: ${{ github.action_path }}/node_modules/.bin/datadog-ci junit upload --service dd-trace-js-tests .
+      run: datadog-ci junit upload --service dd-trace-js-tests .
       env:
         DD_API_KEY: ${{ inputs.dd_api_key }}

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -19,6 +19,7 @@ runs:
       run: |
         echo "dir=$(yarn global dir)" >> $GITHUB_OUTPUT
         echo "DATADOG_CI_VERSION=5.15.0" >> $GITHUB_ENV
+        echo "$(yarn global bin)" >> $GITHUB_PATH
     - if: github.actor != 'dependabot[bot]'
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -14,7 +14,21 @@ runs:
       # >  from a forked repository, and are also subject to these restrictions.
       #
       # Which means they do not have access to secrets.
-      uses: DataDog/junit-upload-github-action@ce82dc1f14a32888a057bfeeb47adfd0fd96e555 # v3.1.0
+      id: yarn-global-dir
+      shell: bash
+      run: |
+        echo "dir=$(yarn global dir)" >> $GITHUB_OUTPUT
+        echo "DATADOG_CI_VERSION=5.15.0" >> $GITHUB_ENV
+    - if: github.actor != 'dependabot[bot]'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
-        api_key: ${{ inputs.dd_api_key }}
-        service: dd-trace-js-tests
+        path: ${{ steps.yarn-global-dir.outputs.dir }}
+        key: datadog-ci-${{ env.DATADOG_CI_VERSION }}
+    - if: github.actor != 'dependabot[bot]'
+      shell: bash
+      run: yarn global add @datadog/datadog-ci@${{ env.DATADOG_CI_VERSION }}
+    - if: github.actor != 'dependabot[bot]'
+      shell: bash
+      run: datadog-ci junit upload --service dd-trace-js-tests "*.xml"
+      env:
+        DD_API_KEY: ${{ inputs.dd_api_key }}

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -14,14 +14,11 @@ runs:
       # >  from a forked repository, and are also subject to these restrictions.
       #
       # Which means they do not have access to secrets.
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ${{ github.action_path }}/node_modules
-        key: datadog-ci-${{ hashFiles('.github/actions/push_to_test_optimization/package.json') }}
-    - if: github.actor != 'dependabot[bot]'
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '20'
+        cache: 'yarn'
+        cache-dependency-path: .github/actions/push_to_test_optimization/package.json
     - if: github.actor != 'dependabot[bot]'
       shell: bash
       run: yarn install --no-lockfile

--- a/.github/actions/push_to_test_optimization/package.json
+++ b/.github/actions/push_to_test_optimization/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "push-to-test-optimization",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@datadog/datadog-ci": "5.15.0"
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
     directories:
       - "/"
       - "/docs"
+      - "/.github/actions/push_to_test_optimization"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -74,11 +74,10 @@ jobs:
       - uses: ./.github/actions/node/active-lts
       - uses: ./.github/actions/install
       - run: yarn test:integration:bun
-      - uses: DataDog/junit-upload-github-action@ce82dc1f14a32888a057bfeeb47adfd0fd96e555 # v3.1.0
-        if: always() && github.actor != 'dependabot[bot]'
+      - uses: ./.github/actions/push_to_test_optimization
+        if: always()
         with:
-          api_key: ${{ steps.dd-sts.outputs.api_key }}
-          service: dd-trace-js-tests
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
   core:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove JUnit upload action.

### Motivation
<!-- What inspired you to submit this pull request? -->

We are having a lot of issues with installs from GitHub Release right now, which the JUnit upload action uses. For now it's simpler to just switch back to the npm approach, which is actually simple enough that we can just have it in dd-trace, no need for a separate action. If we make further improvements or feel the need in the future to upstream our changes we can do that, but for now it's simpler to work on the immediate issue if this code is local and not in 2 transitive actions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


