### PR TITLE
fix: use references for special configurations

### DIFF
--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -81,7 +81,8 @@ for (const [name, value] of Object.entries(defaults)) {
  * @param {string} optionName
  */
 function generateTelemetry (value = null, origin, optionName) {
-  const { type, canonicalName = optionName } = configurationsTable[optionName] ?? { type: typeof value }
+  const tableEntry = configurationsTable[optionName]
+  const { type, canonicalName = optionName } = tableEntry ?? { type: typeof value }
   // TODO: Should we not send defaults to telemetry to reduce size?
   // TODO: How to handle aliases/actual names in the future? Optional fields? Normalize the name at intake?
   // TODO: Validate that space separated tags are parsed by the backend. Optimizations would be possible with that.
@@ -90,9 +91,12 @@ function generateTelemetry (value = null, origin, optionName) {
     if (telemetryTransformers[type]) {
       value = telemetryTransformers[type](value)
     } else if (typeof value === 'object' && value !== null) {
-      value = value instanceof URL
-        ? String(value)
-        : JSON.stringify(value)
+      // Custom optionsTable entries (no `configurationsTable` row, e.g. `logger`)
+      // hold opaque user-supplied references that may carry cycles, so avoid
+      // traversing them via JSON.stringify.
+      value = tableEntry === undefined
+        ? util.inspect(value, { depth: -1 })
+        : value instanceof URL ? String(value) : JSON.stringify(value)
     } else if (typeof value === 'function') {
       value = value.name || 'function'
     }
@@ -246,7 +250,7 @@ for (const [canonicalName, entries] of Object.entries(supportedConfigurations)) 
       option.transformer = transformer
     }
     if (entry.configurationNames) {
-      addOption(option, type, entry.configurationNames)
+      addOption(option, entry.configurationNames)
     }
     configurationsTable[canonicalName] = option
 
@@ -283,7 +287,7 @@ for (const [fullPropertyName, alias] of fallbackConfigurations) {
   }
 }
 
-function addOption (option, type, configurationNames) {
+function addOption (option, configurationNames) {
   for (const name of configurationNames) {
     let index = -1
     let lastNestedProperties

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -131,7 +131,13 @@ function setAndTrack (config, name, value, rawValue = value, source = 'calculate
     }
     changeTracker[source].add(name)
   } else {
-    const copy = typeof value === 'object' && value !== null ? rfdc(value) : value
+    // Programmatic-only options (e.g. logger, lookup, plugins) have no row in
+    // `configurationsTable` and hold opaque user-supplied references that may
+    // carry cycles or non-plain prototypes — for example a winston Logger
+    // extends a Transform stream. Use a reference for these instead of cloning.
+    const copy = typeof value === 'object' && value !== null && name in configurationsTable
+      ? rfdc(value)
+      : value
     changeTracker.baseValuesByPath[name] = { value: copy, source }
   }
   set(config, name, value)

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -175,6 +175,34 @@ describe('Config', () => {
     })
   })
 
+  it('should accept a circular logger instance without overflowing the stack (issue #8122)', () => {
+    // Shape mirrors winston: log methods, transports with a parent back-reference,
+    // and stream-state self-references (Transform's _readableState.pipes).
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      transports: [],
+    }
+    logger.transports.push({ name: 'console', log: () => {}, parent: logger })
+    logger._readableState = { pipes: logger }
+    logger._writableState = { pipes: logger }
+
+    // Previously this threw `RangeError: Maximum call stack size exceeded`
+    // from the rfdc baseline-clone in setAndTrack.
+    const config = getConfig({ logger, logInjection: true })
+
+    assert.strictEqual(config.logger, logger)
+    assert.strictEqual(config.logInjection, true)
+  })
+
+  it('should hold a custom lookup function by reference', () => {
+    const lookup = (_h, _o, cb) => cb(null, '127.0.0.1', 4)
+    const config = getConfig({ lookup })
+    assert.strictEqual(config.lookup, lookup)
+  })
+
   it('should initialize from environment variables with DD env vars taking precedence OTEL env vars', () => {
     process.env.DD_SERVICE = 'service'
     process.env.OTEL_SERVICE_NAME = 'otel_service'


### PR DESCRIPTION
Cpoying user input works for all regular objects to prevent changing their objects. This is not intented though for values like the logger where the object would be a winston instance that contains circular structures. That causes problems so that the logger is not initialized properly anymore.

This is fixed by special handling all configurations that are programmatic only configurations.
The telemetry value is also handled in a way that the backend receives a simple name of the input object.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8122
