### PR TITLE
fix(dogstatsd): stop re-emitting stale gauges

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -16,6 +16,8 @@ const TYPE_GAUGE = 'g'
 const TYPE_DISTRIBUTION = 'd'
 const TYPE_HISTOGRAM = 'h'
 
+const GAUGE_EVICTION_FLUSHES = 60 // roughly 10 minutes at the 10s flush cadence
+
 /**
  * @import { DogStatsD } from "../../../index.d.ts"
  * @implements {DogStatsD}
@@ -263,7 +265,7 @@ class MetricsAggregationClient {
   }
 
   _captureGauges () {
-    this._captureTree(this._gauges, (node, name, tags) => {
+    this._captureAndPrune(this._gauges, (node, name, tags) => {
       this._client.gauge(name, node.value, tags)
     })
   }
@@ -277,13 +279,8 @@ class MetricsAggregationClient {
   }
 
   _captureHistograms () {
-    this._captureTree(this._histograms, (node, name, tags) => {
-      let stats = node.value
-
-      // Stats can contain garbage data when a value was never recorded.
-      if (stats.count === 0) {
-        stats = { max: 0, min: 0, sum: 0, avg: 0, median: 0, p95: 0, count: 0 }
-      }
+    this._captureAndPrune(this._histograms, (node, name, tags) => {
+      const stats = node.value
 
       this._client.gauge(`${name}.min`, stats.min, tags)
       this._client.gauge(`${name}.max`, stats.max, tags)
@@ -294,7 +291,7 @@ class MetricsAggregationClient {
       this._client.gauge(`${name}.median`, stats.median, tags)
       this._client.gauge(`${name}.95percentile`, stats.p95, tags)
 
-      node.value.reset()
+      stats.reset()
     })
   }
 
@@ -314,6 +311,41 @@ class MetricsAggregationClient {
       this._captureNode(next, name, tags, fn)
       tags.pop()
     }
+  }
+
+  _captureAndPrune (tree, emit) {
+    for (const [name, root] of tree) {
+      if (this._captureAndPruneNode(root, name, [], emit)) {
+        tree.delete(name)
+      }
+    }
+  }
+
+  // Returns true when the node and all its descendants are fully cold and can be evicted.
+  _captureAndPruneNode (node, name, tags, emit) {
+    let canPrune
+
+    if (node.touched) {
+      emit(node, name, tags)
+      node.touched = false
+      node.coldFlushes = 0
+      canPrune = false
+    } else {
+      node.coldFlushes++
+      canPrune = node.coldFlushes >= GAUGE_EVICTION_FLUSHES
+    }
+
+    for (const [tag, next] of node.nodes) {
+      tags.push(tag)
+      if (this._captureAndPruneNode(next, name, tags, emit)) {
+        node.nodes.delete(tag)
+      } else {
+        canPrune = false
+      }
+      tags.pop()
+    }
+
+    return canPrune
   }
 
   _ensureTree (tree, name, tags = [], value) {
@@ -336,7 +368,7 @@ class MetricsAggregationClient {
     let node = container.get(key)
 
     if (!node) {
-      node = { nodes: new Map(), touched: false, value }
+      node = { nodes: new Map(), touched: false, coldFlushes: 0, value }
 
       if (typeof key === 'string') {
         container.set(key, node)
@@ -413,4 +445,5 @@ module.exports = {
   DogStatsDClient,
   CustomMetrics,
   MetricsAggregationClient,
+  GAUGE_EVICTION_FLUSHES,
 }

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -16,8 +16,6 @@ const TYPE_GAUGE = 'g'
 const TYPE_DISTRIBUTION = 'd'
 const TYPE_HISTOGRAM = 'h'
 
-const GAUGE_EVICTION_FLUSHES = 60 // roughly 10 minutes at the 10s flush cadence
-
 /**
  * @import { DogStatsD } from "../../../index.d.ts"
  * @implements {DogStatsD}
@@ -265,9 +263,11 @@ class MetricsAggregationClient {
   }
 
   _captureGauges () {
-    this._captureAndPrune(this._gauges, (node, name, tags) => {
+    this._captureTree(this._gauges, (node, name, tags) => {
       this._client.gauge(name, node.value, tags)
     })
+
+    this._gauges.clear()
   }
 
   _captureCounters () {
@@ -279,7 +279,7 @@ class MetricsAggregationClient {
   }
 
   _captureHistograms () {
-    this._captureAndPrune(this._histograms, (node, name, tags) => {
+    this._captureTree(this._histograms, (node, name, tags) => {
       const stats = node.value
 
       this._client.gauge(`${name}.min`, stats.min, tags)
@@ -290,9 +290,9 @@ class MetricsAggregationClient {
       this._client.increment(`${name}.count`, stats.count, tags)
       this._client.gauge(`${name}.median`, stats.median, tags)
       this._client.gauge(`${name}.95percentile`, stats.p95, tags)
-
-      stats.reset()
     })
+
+    this._histograms.clear()
   }
 
   _captureTree (tree, fn) {
@@ -311,41 +311,6 @@ class MetricsAggregationClient {
       this._captureNode(next, name, tags, fn)
       tags.pop()
     }
-  }
-
-  _captureAndPrune (tree, emit) {
-    for (const [name, root] of tree) {
-      if (this._captureAndPruneNode(root, name, [], emit)) {
-        tree.delete(name)
-      }
-    }
-  }
-
-  // Returns true when the node and all its descendants are fully cold and can be evicted.
-  _captureAndPruneNode (node, name, tags, emit) {
-    let canPrune
-
-    if (node.touched) {
-      emit(node, name, tags)
-      node.touched = false
-      node.coldFlushes = 0
-      canPrune = false
-    } else {
-      node.coldFlushes++
-      canPrune = node.coldFlushes >= GAUGE_EVICTION_FLUSHES
-    }
-
-    for (const [tag, next] of node.nodes) {
-      tags.push(tag)
-      if (this._captureAndPruneNode(next, name, tags, emit)) {
-        node.nodes.delete(tag)
-      } else {
-        canPrune = false
-      }
-      tags.pop()
-    }
-
-    return canPrune
   }
 
   _ensureTree (tree, name, tags = [], value) {
@@ -368,7 +333,7 @@ class MetricsAggregationClient {
     let node = container.get(key)
 
     if (!node) {
-      node = { nodes: new Map(), touched: false, coldFlushes: 0, value }
+      node = { nodes: new Map(), touched: false, value }
 
       if (typeof key === 'string') {
         container.set(key, node)
@@ -445,5 +410,4 @@ module.exports = {
   DogStatsDClient,
   CustomMetrics,
   MetricsAggregationClient,
-  GAUGE_EVICTION_FLUSHES,
 }

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -16,7 +16,6 @@ describe('dogstatsd', () => {
   let DogStatsDClient
   let CustomMetrics
   let MetricsAggregationClient
-  let GAUGE_EVICTION_FLUSHES
   let dgram
   let udp4
   let udp6
@@ -79,7 +78,6 @@ describe('dogstatsd', () => {
     DogStatsDClient = dogstatsd.DogStatsDClient
     CustomMetrics = dogstatsd.CustomMetrics
     MetricsAggregationClient = dogstatsd.MetricsAggregationClient
-    GAUGE_EVICTION_FLUSHES = dogstatsd.GAUGE_EVICTION_FLUSHES
 
     httpData = []
     statusCode = 200
@@ -723,23 +721,15 @@ describe('dogstatsd', () => {
       assert.deepStrictEqual(incrementCalls, [])
     })
 
-    it('evicts a cold gauge subtree after GAUGE_EVICTION_FLUSHES silent flushes', () => {
+    it('drains all metric trees on flush so cardinality is bounded', () => {
       aggregator.gauge('test.avg', 5, ['t:1'])
+      aggregator.histogram('test.hist', 10, ['t:1'])
+      aggregator.increment('test.count', 1, ['t:1'])
       aggregator.flush()
-
-      assert.strictEqual(aggregator._gauges.size, 1)
-
-      for (let i = 0; i < GAUGE_EVICTION_FLUSHES; i++) {
-        aggregator.flush()
-      }
 
       assert.strictEqual(aggregator._gauges.size, 0)
-
-      gaugeCalls.length = 0
-      aggregator.gauge('test.avg', 7, ['t:1'])
-      aggregator.flush()
-
-      assert.deepStrictEqual(gaugeCalls, [['test.avg', 7, ['t:1']]])
+      assert.strictEqual(aggregator._histograms.size, 0)
+      assert.strictEqual(aggregator._counters.size, 0)
     })
   })
 })

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -15,6 +15,8 @@ describe('dogstatsd', () => {
   let client
   let DogStatsDClient
   let CustomMetrics
+  let MetricsAggregationClient
+  let GAUGE_EVICTION_FLUSHES
   let dgram
   let udp4
   let udp6
@@ -76,6 +78,8 @@ describe('dogstatsd', () => {
     })
     DogStatsDClient = dogstatsd.DogStatsDClient
     CustomMetrics = dogstatsd.CustomMetrics
+    MetricsAggregationClient = dogstatsd.MetricsAggregationClient
+    GAUGE_EVICTION_FLUSHES = dogstatsd.GAUGE_EVICTION_FLUSHES
 
     httpData = []
     statusCode = 200
@@ -657,6 +661,85 @@ describe('dogstatsd', () => {
 
       sinon.assert.called(udp4.send)
       assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:10|g|#foo:bar|c:ci-1234\n')
+    })
+  })
+
+  describe('MetricsAggregationClient', () => {
+    let aggregator
+    let gaugeCalls
+    let incrementCalls
+
+    beforeEach(() => {
+      gaugeCalls = []
+      incrementCalls = []
+      const inner = {
+        gauge: (name, value, tags) => gaugeCalls.push([name, value, tags?.slice()]),
+        increment: (name, value, tags) => incrementCalls.push([name, value, tags?.slice()]),
+        distribution: () => {},
+        histogram: () => {},
+        flush: () => {},
+      }
+      aggregator = new MetricsAggregationClient(inner)
+    })
+
+    it('emits a gauge once and then stays silent until it is set again', () => {
+      aggregator.gauge('test.avg', 5)
+      aggregator.flush()
+
+      assert.deepStrictEqual(gaugeCalls, [['test.avg', 5, []]])
+
+      gaugeCalls.length = 0
+      aggregator.flush()
+      aggregator.flush()
+
+      assert.deepStrictEqual(gaugeCalls, [])
+    })
+
+    it('re-emits a gauge on every flush when it is updated each cycle', () => {
+      for (let i = 1; i <= 3; i++) {
+        aggregator.gauge('test.avg', i)
+        aggregator.flush()
+      }
+
+      assert.deepStrictEqual(gaugeCalls, [
+        ['test.avg', 1, []],
+        ['test.avg', 2, []],
+        ['test.avg', 3, []],
+      ])
+    })
+
+    it('does not re-emit a histogram once observations stop', () => {
+      aggregator.histogram('test.hist', 10)
+      aggregator.flush()
+
+      assert(gaugeCalls.length > 0 && incrementCalls.length > 0)
+
+      gaugeCalls.length = 0
+      incrementCalls.length = 0
+      aggregator.flush()
+      aggregator.flush()
+
+      assert.deepStrictEqual(gaugeCalls, [])
+      assert.deepStrictEqual(incrementCalls, [])
+    })
+
+    it('evicts a cold gauge subtree after GAUGE_EVICTION_FLUSHES silent flushes', () => {
+      aggregator.gauge('test.avg', 5, ['t:1'])
+      aggregator.flush()
+
+      assert.strictEqual(aggregator._gauges.size, 1)
+
+      for (let i = 0; i < GAUGE_EVICTION_FLUSHES; i++) {
+        aggregator.flush()
+      }
+
+      assert.strictEqual(aggregator._gauges.size, 0)
+
+      gaugeCalls.length = 0
+      aggregator.gauge('test.avg', 7, ['t:1'])
+      aggregator.flush()
+
+      assert.deepStrictEqual(gaugeCalls, [['test.avg', 7, ['t:1']]])
     })
   })
 })


### PR DESCRIPTION
This fixes Datadog "no data" alerting being silently masked for custom metrics. The aggregator's flush loop never cleared the gauge tree, so it kept rebroadcasting the last value of every gauge every 10 seconds for the lifetime of the process. Histograms had the same masking effect once observed at least once: the count===0 fallback emitted a row of zeros forever.

The fix re-purposes the existing `touched` flag to mean "set since the last flush". Gauges and histograms now emit only touched nodes and reset the flag after emission. A small per-node cold-flush counter prunes subtrees that have been silent for ~10 minutes, bounding memory under tag-value churn without a public knob. Counters already cleared their tree, so they are unchanged. Runtime metrics re-set every gauge each interval, so dashboards using them stay identical.

In addition, if being used with a high cardinality input, this would be a memory leak.

Fixes: https://github.com/DataDog/dd-trace-js/issues/7504
