### PR TITLE
exclude versions folder from nyc coverage

### DIFF
--- a/nyc.config.js
+++ b/nyc.config.js
@@ -37,6 +37,7 @@ module.exports = {
     '**/resources/**',
     '**/test/**',
     '**/vendor/**',
+    '**/versions/**',
   ],
   // Avoid collisions when a single CI job runs coverage sequentially across multiple Node.js versions.
   tempDir: `.nyc_output/node-${process.version}${label}`,


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Exclude versions folder from nyc coverage.

### Motivation
<!-- What inspired you to submit this pull request? -->

nyc by default instruments all files that are touched by tests. Some tests import a lot of dependencies from the `versions` folder in their `beforeEach` which adds significant time and can cause reaching the timeout.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


