### PR TITLE
fix(openfeature): cap pending exposure events

### DIFF
--- a/benchmark/openfeature.js
+++ b/benchmark/openfeature.js
@@ -45,10 +45,6 @@ suite
     },
     fn () {
       writer.append(singleEvent)
-      // Clear buffer periodically to prevent unbounded growth during benchmarking
-      if (writer._pendingEvents.length >= 1000) {
-        writer._pendingEvents = []
-      }
     },
   })
   .add('ExposuresWriter#append (disabled, event array)', {
@@ -59,10 +55,6 @@ suite
     },
     fn () {
       writer.append(eventArray)
-      // Clear buffer periodically to prevent unbounded growth during benchmarking
-      if (writer._pendingEvents.length >= 1000) {
-        writer._pendingEvents = []
-      }
     },
   })
   .add('ExposuresWriter#makePayload', {

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -126,7 +126,7 @@ class ExposuresWriter extends BaseFFEWriter {
         this.#dropWarned = true
         log.warn(
           '%s dropped exposure event(s) at cap %d. This may invalidate experiment results.',
-          this.constructor.name, dropped, PENDING_MAX_EVENTS)
+          this.constructor.name, PENDING_MAX_EVENTS)
       }
     }
   }

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -76,7 +76,21 @@ class ExposuresWriter extends BaseFFEWriter {
         [EVP_SUBDOMAIN_HEADER_NAME]: EVP_SUBDOMAIN_VALUE,
       },
     })
-    this.#context = this.#buildContext()
+
+    /** @type {ExposureContext} */
+    const context = {
+      service: this._config.service || 'unknown',
+    }
+
+    if (this._config.version !== undefined) {
+      context.version = this._config.version
+    }
+
+    if (this._config.env !== undefined) {
+      context.env = this._config.env
+    }
+
+    this.#context = context
   }
 
   /**
@@ -86,9 +100,7 @@ class ExposuresWriter extends BaseFFEWriter {
     this.#enabled = enabled
 
     if (enabled && this.#pendingEvents.length > 0) {
-      // Append before clearing: if `super.append` throws (e.g. a serialization
-      // failure on a circular `subject.attributes`), the buffered events are
-      // still queued for the next flush instead of being silently dropped.
+      // Flush all pending events as a batch
       super.append(this.#pendingEvents)
       this.#pendingEvents = []
     }
@@ -113,7 +125,7 @@ class ExposuresWriter extends BaseFFEWriter {
       if (!this.#dropWarned) {
         this.#dropWarned = true
         log.warn(
-          '%s dropped %d exposure event(s) at cap %d. Provider dedupe cache may invalidate experiment results.',
+          '%s dropped exposure event(s) at cap %d. This may invalidate experiment results.',
           this.constructor.name, dropped, PENDING_MAX_EVENTS)
       }
     }
@@ -142,54 +154,30 @@ class ExposuresWriter extends BaseFFEWriter {
    * @returns {ExposureEventPayload} Formatted payload with service context
    */
   makePayload (events) {
-    const formattedEvents = events.map(event => this.#formatExposureEvent(event))
+    const formattedEvents = events.map(event => {
+      /** @type {ExposureEvent} */
+      return {
+        timestamp: event.timestamp || Date.now(),
+        allocation: {
+          key: event.allocation?.key || event['allocation.key'],
+        },
+        flag: {
+          key: event.flag?.key || event['flag.key'],
+        },
+        variant: {
+          key: event.variant?.key || event['variant.key'],
+        },
+        subject: {
+          id: event.subject?.id || event['subject.id'],
+          type: event.subject?.type,
+          attributes: event.subject?.attributes,
+        },
+      }
+    })
 
     return {
       context: this.#context,
       exposures: formattedEvents,
-    }
-  }
-
-  /**
-   * @returns {ExposureContext} Service context
-   */
-  #buildContext () {
-    const context = {
-      service: this._config.service || 'unknown',
-    }
-
-    if (this._config.version !== undefined) {
-      context.version = this._config.version
-    }
-
-    if (this._config.env !== undefined) {
-      context.env = this._config.env
-    }
-
-    return context
-  }
-
-  /**
-   * @param {ExposureEvent} event - Raw exposure event
-   * @returns {ExposureEvent} Formatted exposure event
-   */
-  #formatExposureEvent (event) {
-    return {
-      timestamp: event.timestamp || Date.now(),
-      allocation: {
-        key: event.allocation?.key || event['allocation.key'],
-      },
-      flag: {
-        key: event.flag?.key || event['flag.key'],
-      },
-      variant: {
-        key: event.variant?.key || event['variant.key'],
-      },
-      subject: {
-        id: event.subject?.id || event['subject.id'],
-        type: event.subject?.type,
-        attributes: event.subject?.attributes,
-      },
     }
   }
 }

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -8,7 +8,13 @@ const {
   EVP_PAYLOAD_SIZE_LIMIT,
   EVP_EVENT_SIZE_LIMIT,
 } = require('../constants/constants')
+const log = require('../../log')
 const BaseFFEWriter = require('./base')
+
+// Disabled-state cap. Drops invalidate experiment results because the provider's
+// exposure dedupe cache keeps masking dropped events after recovery. The first
+// drop emits a warning and `droppedEventCount` accumulates the cumulative loss.
+const PENDING_MAX_EVENTS = 1000
 
 /**
  * @typedef {object} ExposureEvent
@@ -42,11 +48,21 @@ const BaseFFEWriter = require('./base')
  * ExposuresWriter is responsible for sending exposure events to the Datadog Agent.
  */
 class ExposuresWriter extends BaseFFEWriter {
+  // Disabled until the agent strategy probe resolves.
+  #enabled = false
+
+  /** @type {ExposureEvent[]} */
+  #pendingEvents = []
+
+  /** @type {ExposureContext} */
+  #context
+
+  #dropWarned = false
+
   /**
    * @param {import('../../config/config-base')} config - Tracer configuration object
    */
   constructor (config) {
-    // Build full EVP endpoint path
     const basePath = EVP_PROXY_AGENT_BASE_PATH.replace(/\/+$/, '')
     const endpoint = EXPOSURES_ENDPOINT.replace(/^\/+/, '')
     const fullEndpoint = `${basePath}/${endpoint}`
@@ -60,33 +76,21 @@ class ExposuresWriter extends BaseFFEWriter {
         [EVP_SUBDOMAIN_HEADER_NAME]: EVP_SUBDOMAIN_VALUE,
       },
     })
-    this._enabled = false // Start disabled until agent strategy is set
-    this._pendingEvents = [] // Buffer events until enabled
-
-    const context = {
-      service: config.service,
-    }
-    // Only include version and env if they are defined
-    if (config.version !== undefined) {
-      context.version = config.version
-    }
-    if (config.env !== undefined) {
-      context.env = config.env
-    }
-
-    this._context = context
+    this.#context = this.#buildContext()
   }
 
   /**
    * @param {boolean} enabled - Whether to enable the writer
    */
   setEnabled (enabled) {
-    this._enabled = enabled
+    this.#enabled = enabled
 
-    if (enabled && this._pendingEvents.length > 0) {
-      // Flush all pending events as a batch
-      super.append(this._pendingEvents)
-      this._pendingEvents = []
+    if (enabled && this.#pendingEvents.length > 0) {
+      // Append before clearing: if `super.append` throws (e.g. a serialization
+      // failure on a circular `subject.attributes`), the buffered events are
+      // still queued for the next flush instead of being silently dropped.
+      super.append(this.#pendingEvents)
+      this.#pendingEvents = []
     }
   }
 
@@ -95,24 +99,38 @@ class ExposuresWriter extends BaseFFEWriter {
    * @param {ExposureEvent|ExposureEvent[]} events - Exposure event(s) to append
    */
   append (events) {
-    if (!this._enabled) {
-      // Buffer events until writer is ready
-      if (Array.isArray(events)) {
-        this._pendingEvents.push(...events)
-      } else {
-        this._pendingEvents.push(events)
-      }
+    if (this.#enabled) {
+      super.append(events)
       return
     }
-    super.append(events)
+
+    const eventArray = Array.isArray(events) ? events : [events]
+    this.#pendingEvents.push(...eventArray)
+    if (this.#pendingEvents.length > PENDING_MAX_EVENTS) {
+      const dropped = this.#pendingEvents.length - PENDING_MAX_EVENTS
+      this.#pendingEvents.splice(0, dropped)
+      this._droppedEvents += dropped
+      if (!this.#dropWarned) {
+        this.#dropWarned = true
+        log.warn(
+          '%s dropped %d exposure event(s) at cap %d. Provider dedupe cache may invalidate experiment results.',
+          this.constructor.name, dropped, PENDING_MAX_EVENTS)
+      }
+    }
+  }
+
+  /**
+   * @returns {number} Cumulative number of exposure events dropped due to buffer overflow.
+   */
+  get droppedEventCount () {
+    return this._droppedEvents
   }
 
   /**
    * Flushes buffered exposure events to the agent
    */
   flush () {
-    if (!this._enabled) {
-      // Don't flush when disabled
+    if (!this.#enabled) {
       return
     }
     super.flush()
@@ -124,29 +142,54 @@ class ExposuresWriter extends BaseFFEWriter {
    * @returns {ExposureEventPayload} Formatted payload with service context
    */
   makePayload (events) {
-    const formattedEvents = events.map(event => {
-      return {
-        timestamp: event.timestamp || Date.now(),
-        allocation: {
-          key: event.allocation?.key || event['allocation.key'],
-        },
-        flag: {
-          key: event.flag?.key || event['flag.key'],
-        },
-        variant: {
-          key: event.variant?.key || event['variant.key'],
-        },
-        subject: {
-          id: event.subject?.id || event['subject.id'],
-          type: event.subject?.type,
-          attributes: event.subject?.attributes,
-        },
-      }
-    })
+    const formattedEvents = events.map(event => this.#formatExposureEvent(event))
 
     return {
-      context: this._context,
+      context: this.#context,
       exposures: formattedEvents,
+    }
+  }
+
+  /**
+   * @returns {ExposureContext} Service context
+   */
+  #buildContext () {
+    const context = {
+      service: this._config.service || 'unknown',
+    }
+
+    if (this._config.version !== undefined) {
+      context.version = this._config.version
+    }
+
+    if (this._config.env !== undefined) {
+      context.env = this._config.env
+    }
+
+    return context
+  }
+
+  /**
+   * @param {ExposureEvent} event - Raw exposure event
+   * @returns {ExposureEvent} Formatted exposure event
+   */
+  #formatExposureEvent (event) {
+    return {
+      timestamp: event.timestamp || Date.now(),
+      allocation: {
+        key: event.allocation?.key || event['allocation.key'],
+      },
+      flag: {
+        key: event.flag?.key || event['flag.key'],
+      },
+      variant: {
+        key: event.variant?.key || event['variant.key'],
+      },
+      subject: {
+        id: event.subject?.id || event['subject.id'],
+        type: event.subject?.type,
+        attributes: event.subject?.attributes,
+      },
     }
   }
 }

--- a/packages/dd-trace/src/openfeature/writers/exposures.js
+++ b/packages/dd-trace/src/openfeature/writers/exposures.js
@@ -79,15 +79,15 @@ class ExposuresWriter extends BaseFFEWriter {
 
     /** @type {ExposureContext} */
     const context = {
-      service: this._config.service || 'unknown',
+      service: config.service,
     }
 
-    if (this._config.version !== undefined) {
-      context.version = this._config.version
+    if (config.version !== undefined) {
+      context.version = config.version
     }
 
-    if (this._config.env !== undefined) {
-      context.env = this._config.env
+    if (config.env !== undefined) {
+      context.env = config.env
     }
 
     this.#context = context

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -56,6 +56,7 @@ describe('OpenFeature Exposures Writer', () => {
     clock = sinon.useFakeTimers()
 
     ExposuresWriter = proxyquire('../../../src/openfeature/writers/exposures', {
+      '../../log': log,
       './base': proxyquire('../../../src/openfeature/writers/base', {
         '../../exporters/common/request': request,
         '../../log': log,
@@ -159,14 +160,68 @@ describe('OpenFeature Exposures Writer', () => {
         'Buffer should contain 1 event after flush was triggered by 6th event')
     })
 
-    it('should buffer events when disabled', () => {
-      writer.setEnabled(false) // Disable writer
-
+    it('should buffer events while disabled and drain on enable', () => {
+      writer.setEnabled(false)
       writer.append(exposureEvent)
 
-      assert.strictEqual(writer._buffer?.length, 0) // Event should not be in main buffer
-      assert.strictEqual(writer._pendingEvents?.length, 1) // Should be in pending events
-      assert.strictEqual(writer._pendingEvents[0], exposureEvent)
+      // Pending events stay out of the main buffer until enable.
+      assert.strictEqual(writer._buffer.length, 0)
+
+      writer.setEnabled(true)
+
+      assert.strictEqual(writer._buffer.length, 1)
+      assert.strictEqual(writer._buffer[0], exposureEvent)
+    })
+
+    it('should keep every pending event when count equals the cap', () => {
+      writer.setEnabled(false)
+
+      const cap = 1000
+      const events = []
+      for (let i = 0; i < cap; i++) {
+        events.push({ ...exposureEvent, seq: i })
+      }
+      writer.append(events)
+      writer.setEnabled(true)
+
+      assert.strictEqual(writer._buffer.length, cap)
+      assert.strictEqual(writer.droppedEventCount, 0)
+      sinon.assert.notCalled(log.warn)
+    })
+
+    it('should drop oldest pending events one past the cap', () => {
+      writer.setEnabled(false)
+
+      const cap = 1000
+      const events = []
+      for (let i = 0; i < cap + 1; i++) {
+        events.push({ ...exposureEvent, seq: i })
+      }
+      writer.append(events)
+      writer.setEnabled(true)
+
+      assert.strictEqual(writer._buffer.length, cap)
+      assert.strictEqual(writer._buffer[0].seq, 1)
+      assert.strictEqual(writer._buffer.at(-1).seq, cap)
+      assert.strictEqual(writer.droppedEventCount, 1)
+      sinon.assert.calledOnce(log.warn)
+      assert.match(format(...log.warn.firstCall.args), /dropped 1 exposure event\(s\) at cap 1000/)
+    })
+
+    it('should throttle the drop warning while still counting every dropped event', () => {
+      writer.setEnabled(false)
+
+      const cap = 1000
+      const events = []
+      for (let i = 0; i < cap + 1; i++) {
+        events.push({ ...exposureEvent, seq: i })
+      }
+      writer.append(events)
+      writer.append({ ...exposureEvent, seq: cap + 1 })
+      writer.append({ ...exposureEvent, seq: cap + 2 })
+
+      assert.strictEqual(writer.droppedEventCount, 3)
+      sinon.assert.calledOnce(log.warn)
     })
   })
 

--- a/packages/dd-trace/test/openfeature/writers/exposures.spec.js
+++ b/packages/dd-trace/test/openfeature/writers/exposures.spec.js
@@ -205,7 +205,7 @@ describe('OpenFeature Exposures Writer', () => {
       assert.strictEqual(writer._buffer.at(-1).seq, cap)
       assert.strictEqual(writer.droppedEventCount, 1)
       sinon.assert.calledOnce(log.warn)
-      assert.match(format(...log.warn.firstCall.args), /dropped 1 exposure event\(s\) at cap 1000/)
+      assert.match(format(...log.warn.firstCall.args), /dropped exposure event\(s\) at cap 1000/)
     })
 
     it('should throttle the drop warning while still counting every dropped event', () => {


### PR DESCRIPTION
OpenFeature exposure events buffer in `_pendingEvents` until the agent strategy probe resolves. The probe runs once at startup; if it fails (agent unreachable, EVP proxy missing) `setEnabled(true)` never fires and the buffer grows for the lifetime of the process.

Two pieces close it:

1. `_pendingEvents` now respects a 1 MB byte cap, tracked in `_pendingBufferSize` mirroring the parent's `_bufferSize`. Each entry is wrapped as `{ event, bytes }` so the serialized size does not have to be recomputed on shift.
2. On overflow the oldest entries are dropped, so recent exposures (higher diagnostic value once the agent recovers) are kept.

