### PR TITLE
fix(appsec): bound detectedSpecificEndpoints cache

### DIFF
--- a/packages/dd-trace/src/appsec/blocking.js
+++ b/packages/dd-trace/src/appsec/blocking.js
@@ -1,10 +1,16 @@
 'use strict'
 
+const { LRUCache } = require('../../../../vendor/dist/lru-cache')
 const log = require('../log')
+const web = require('../plugins/util/web')
 const blockedTemplates = require('./blocked_templates')
 const { updateBlockFailureMetric } = require('./telemetry')
 
-const detectedSpecificEndpoints = {}
+// Bounded by the LRU as defense-in-depth: getSpecificKey already keys on the
+// resolved route (or the path with the query string stripped) so cardinality
+// follows the routing table, not the URL space.
+const SPECIFIC_ENDPOINT_CACHE_MAX = 16_384
+const detectedSpecificEndpoints = new LRUCache({ max: SPECIFIC_ENDPOINT_CACHE_MAX })
 
 const templateKeyword = '[security_response_id]'
 
@@ -38,12 +44,18 @@ const specificBlockingTypes = {
   GRAPHQL: 'graphqlJson',
 }
 
-function getSpecificKey (method, url) {
-  return `${method}+${url}`
+function getSpecificKey (req) {
+  const route = web.getContext(req)?.paths?.join('')
+  if (route) return `${req.method}+${route}`
+
+  // Strip the query string so unique parameters do not balloon the cache.
+  const url = req.originalUrl || req.url || ''
+  const queryStart = url.indexOf('?')
+  return `${req.method}+${queryStart === -1 ? url : url.slice(0, queryStart)}`
 }
 
-function addSpecificEndpoint (method, url, type) {
-  detectedSpecificEndpoints[getSpecificKey(method, url)] = type
+function addSpecificEndpoint (req, type) {
+  detectedSpecificEndpoints.set(getSpecificKey(req), type)
 }
 
 function getBlockWithRedirectData (actionParameters) {
@@ -65,7 +77,7 @@ function getBlockWithContentData (req, specificType, actionParameters) {
   let type
   let body
 
-  const specificBlockingType = specificType || detectedSpecificEndpoints[getSpecificKey(req.method, req.url)]
+  const specificBlockingType = specificType || detectedSpecificEndpoints.get(getSpecificKey(req))
   if (specificBlockingType) {
     const specificBlockingContent = getTemplate(specificBlockingType, actionParameters)
     type = specificBlockingContent?.type

--- a/packages/dd-trace/src/appsec/graphql.js
+++ b/packages/dd-trace/src/appsec/graphql.js
@@ -78,7 +78,7 @@ function enterInApolloRequest () {
     // Set isInGraphqlRequest=true since this function only runs for GraphQL requests
     // This works for both Apollo v4 (middleware) and v5 (HTTP server) contexts
     requestData.isInGraphqlRequest = true
-    addSpecificEndpoint(req.method, req.originalUrl || req.url, specificBlockingTypes.GRAPHQL)
+    addSpecificEndpoint(req, specificBlockingTypes.GRAPHQL)
   }
 }
 

--- a/packages/dd-trace/test/appsec/blocking.spec.js
+++ b/packages/dd-trace/test/appsec/blocking.spec.js
@@ -399,6 +399,102 @@ describe('blocking', () => {
     })
   })
 
+  describe('detectedSpecificEndpoints cache', () => {
+    let addSpecificEndpoint, getBlockingData, specificBlockingTypes
+    let webStub
+
+    // Request without a resolved route — blocking falls back to URL keying.
+    function noRouteReq (method, url) {
+      return { method, url, headers: {} }
+    }
+
+    // Request that the framework would have tagged via web.setRoute.
+    function routedReq (method, url, paths) {
+      return { method, url, headers: {}, _paths: paths }
+    }
+
+    beforeEach(() => {
+      webStub = {
+        getContext (req) {
+          return req._paths ? { paths: req._paths } : undefined
+        },
+      }
+
+      const blocking = proxyquire('../../src/appsec/blocking', {
+        '../log': log,
+        '../plugins/util/web': webStub,
+        './blocked_templates': { ...defaultBlockedTemplate, graphqlJson: 'graphqlBody' },
+        './telemetry': telemetry,
+      })
+
+      addSpecificEndpoint = blocking.addSpecificEndpoint
+      getBlockingData = blocking.getBlockingData
+      specificBlockingTypes = blocking.specificBlockingTypes
+
+      blocking.setTemplates({
+        appsec: {
+          blockedTemplateHtml: undefined,
+          blockedTemplateJson: undefined,
+          blockedTemplateGraphql: undefined,
+        },
+      })
+    })
+
+    it('returns the registered specific blocking type for a known endpoint', () => {
+      const req = routedReq('POST', '/graphql?op=foo', ['/graphql'])
+      addSpecificEndpoint(req, specificBlockingTypes.GRAPHQL)
+
+      const data = getBlockingData(req, null)
+
+      assert.strictEqual(data.body, 'graphqlBody')
+      assert.strictEqual(data.headers['Content-Type'], 'application/json')
+    })
+
+    it('shares a cache entry across requests with the same route but different query strings', () => {
+      const writer = routedReq('POST', '/graphql?op=foo', ['/graphql'])
+      addSpecificEndpoint(writer, specificBlockingTypes.GRAPHQL)
+
+      const reader = routedReq('POST', '/graphql?op=bar&cb=12345', ['/graphql'])
+      const data = getBlockingData(reader, null)
+
+      assert.strictEqual(data.body, 'graphqlBody')
+    })
+
+    it('keeps cache entries separate for different routes', () => {
+      addSpecificEndpoint(routedReq('POST', '/graphql', ['/graphql']), specificBlockingTypes.GRAPHQL)
+
+      const data = getBlockingData(routedReq('POST', '/api/users', ['/api/users']), null)
+
+      assert.strictEqual(data.body, defaultBlockedTemplate.json)
+    })
+
+    it('falls back to the URL with the query string stripped when no route is set', () => {
+      addSpecificEndpoint(noRouteReq('POST', '/graphql?op=foo'), specificBlockingTypes.GRAPHQL)
+
+      const data = getBlockingData(noRouteReq('POST', '/graphql?op=bar'), null)
+
+      assert.strictEqual(data.body, 'graphqlBody')
+    })
+
+    it('does not return a specific type for an unknown endpoint', () => {
+      const data = getBlockingData(noRouteReq('POST', '/never-seen'), null)
+
+      assert.strictEqual(data.body, defaultBlockedTemplate.json)
+    })
+
+    it('evicts the oldest entry once the cap is reached', () => {
+      // SPECIFIC_ENDPOINT_CACHE_MAX is 16 384; +100 is plenty to overflow.
+      addSpecificEndpoint(routedReq('POST', '/first', ['/first']), specificBlockingTypes.GRAPHQL)
+      for (let i = 0; i < 16_384 + 100; i++) {
+        addSpecificEndpoint(routedReq('POST', `/bulk-${i}`, [`/bulk-${i}`]), specificBlockingTypes.GRAPHQL)
+      }
+
+      const data = getBlockingData(routedReq('POST', '/first', ['/first']), null)
+
+      assert.strictEqual(data.body, defaultBlockedTemplate.json)
+    })
+  })
+
   describe('security response ID', () => {
     it('should block with security response id in custom redirect url', () => {
       const actionParameters = {


### PR DESCRIPTION
`detectedSpecificEndpoints` used `req.originalUrl || req.url` as the lookup key, which is user-controlled. Any Apollo deployment that saw URL variance (query strings, persisted-query hashes, cache busters) accumulated one entry per distinct URL for the lifetime of the process.

Two coordinated pieces close it:

1. `getSpecificKey` now keys on the resolved route from `web.getContext(req).paths`, falling back to the URL with the query string stripped. `addSpecificEndpoint` takes the request directly so writer and reader agree on the key derivation.
2. The cache is backed by `LRUCache(max: 16_384)` as defense-in-depth, so a framework with no `paths` setup never grows the cache without bound.

The URL is only used as a cache key. AppSec passes the URL into the WAF through `HTTP_INCOMING_URL` on a separate path, so this change is purely a cache-key normalization with no observable behavior change.
