### PR TITLE
test: do not hide mocha errors for nested suites

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -259,6 +259,7 @@
 /packages/dd-trace/test/iitm.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/log.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/msgpack/ @DataDog/lang-platform-js
+/packages/dd-trace/test/mocha-hooks.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/noop.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/pkg.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/plugin_manager.spec.js @DataDog/lang-platform-js

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -1,0 +1,165 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { execFile } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const util = require('node:util')
+
+const execFileAsync = util.promisify(execFile)
+const mochaBin = path.join(__dirname, '../../../node_modules/mocha/bin/mocha.js')
+const coreSetupPath = path.join(__dirname, 'setup/core.js')
+
+describe('mocha hooks setup', () => {
+  it('suppresses after all errors when a test in the same suite already failed', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        after(() => {
+          throw new Error('cleanup failed')
+        })
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('suppresses after each errors when the current test already failed', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        afterEach(() => {
+          throw new Error('cleanup failed')
+        })
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('suppresses after each errors when a before each in the same suite already failed', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        beforeEach(() => {
+          throw new Error('setup failed')
+        })
+
+        afterEach(() => {
+          throw new Error('cleanup failed')
+        })
+
+        it('does something', () => {})
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['setup failed'])
+  })
+
+  it('suppresses outer after all errors when a nested test already failed', async () => {
+    const result = await runFixture(`
+      describe('outer suite', () => {
+        after(() => {
+          throw new Error('outer cleanup failed')
+        })
+
+        describe('inner suite', () => {
+          it('fails for the real reason', () => {
+            throw new Error('inner test failed')
+          })
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['inner test failed'])
+  })
+
+  it('suppresses outer after each errors when a nested before each already failed', async () => {
+    const result = await runFixture(`
+      describe('outer suite', () => {
+        afterEach(() => {
+          throw new Error('outer cleanup failed')
+        })
+
+        describe('inner suite', () => {
+          beforeEach(() => {
+            throw new Error('inner setup failed')
+          })
+
+          it('does something', () => {})
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['inner setup failed'])
+  })
+
+  it('suppresses outer after each errors when a nested after each already failed', async () => {
+    const result = await runFixture(`
+      describe('outer suite', () => {
+        afterEach(() => {
+          throw new Error('outer cleanup failed')
+        })
+
+        describe('inner suite', () => {
+          afterEach(() => {
+            throw new Error('inner cleanup failed')
+          })
+
+          it('passes before cleanup', () => {})
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['inner cleanup failed'])
+  })
+})
+
+/**
+ * @param {string} body
+ * @returns {Promise<MochaJsonResult>}
+ */
+async function runFixture (body) {
+  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-trace-mocha-hooks-'))
+  const fixture = path.join(tmpdir, 'fixture.spec.js')
+  fs.writeFileSync(fixture, `'use strict'
+
+require(${JSON.stringify(coreSetupPath)})
+
+${body}
+`)
+
+  try {
+    const { stdout } = await execFileMocha(fixture)
+    return JSON.parse(stdout)
+  } finally {
+    fs.rmSync(tmpdir, { force: true, recursive: true })
+  }
+}
+
+/**
+ * @param {string} fixture
+ * @returns {Promise<{ stdout: string }>}
+ */
+async function execFileMocha (fixture) {
+  try {
+    return await execFileAsync(process.execPath, [mochaBin, '--no-config', '--reporter', 'json', fixture])
+  } catch (err) {
+    if (!err || typeof err !== 'object' || !('stdout' in err) || typeof err.stdout !== 'string') throw err
+    return { stdout: err.stdout }
+  }
+}
+
+/**
+ * @param {MochaJsonResult} result
+ * @returns {string[]}
+ */
+function getFailureMessages (result) {
+  return result.failures.map(failure => failure.err.message)
+}

--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -12,6 +12,26 @@ const mochaBin = path.join(__dirname, '../../../node_modules/mocha/bin/mocha.js'
 const coreSetupPath = path.join(__dirname, 'setup/core.js')
 
 describe('mocha hooks setup', () => {
+  it('suppresses after all errors when a before all in the same suite already failed', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        let resource
+
+        before(() => {
+          throw new Error('setup failed')
+        })
+
+        after(() => {
+          resource.close()
+        })
+
+        it('does something', () => {})
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['setup failed'])
+  })
+
   it('suppresses after all errors when a test in the same suite already failed', async () => {
     const result = await runFixture(`
       describe('suite', () => {
@@ -42,6 +62,27 @@ describe('mocha hooks setup', () => {
     `)
 
     assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('continues running tests after suppressing an after each error', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        afterEach(function () {
+          if (this.currentTest.title === 'fails for the real reason') {
+            throw new Error('cleanup failed')
+          }
+        })
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+
+        it('still runs', () => {})
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+    assert.deepStrictEqual(getPassTitles(result), ['still runs'])
   })
 
   it('suppresses after each errors when a before each in the same suite already failed', async () => {
@@ -162,4 +203,8 @@ async function execFileMocha (fixture) {
  */
 function getFailureMessages (result) {
   return result.failures.map(failure => failure.err.message)
+}
+
+function getPassTitles (result) {
+  return result.passes.map(pass => pass.title)
 }

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -5,7 +5,7 @@
 
 /** @typedef {import('mocha')} Mocha */
 
-const { Runner } = require('mocha')
+const { Hook, Runner } = require('mocha')
 
 const patched = new WeakSet()
 const failedSuites = new WeakSet()
@@ -15,6 +15,7 @@ if (!patched.has(Runner.prototype)) {
   patched.add(Runner.prototype)
 
   const fail = Runner.prototype.fail
+  const runHook = Hook.prototype.run
 
   /**
    * @this {Mocha.Runner}
@@ -27,6 +28,21 @@ if (!patched.has(Runner.prototype)) {
 
     fail.call(this, runnable, err, force)
     markFailed(runnable)
+  }
+
+  /**
+   * @this {Mocha.Hook}
+   * @param {(err?: Error) => void} fn
+   */
+  Hook.prototype.run = function patchedRunHook (fn) {
+    try {
+      return runHook.call(this, (err) => {
+        return fn(err && shouldSuppress(this) ? undefined : err)
+      })
+    } catch (err) {
+      if (shouldSuppress(this)) return fn()
+      throw err
+    }
   }
 }
 

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -1,128 +1,80 @@
 'use strict'
 
-// Drop afterAll/afterEach errors when an earlier runnable in the same suite already
-// failed, so mocha reports the original cause instead of a teardown error masking it.
+// Drop afterAll/afterEach errors when an earlier runnable in the same test or suite already failed,
+// so mocha reports the original cause instead of a teardown error masking it.
 
 /** @typedef {import('mocha')} Mocha */
-/**
- * Structural view of `Mocha.Suite` exposing the private hook arrays we need to
- * inspect; the runtime object is still a real `Mocha.Suite`.
- *
- * @typedef {object} Suite
- * @property {Mocha.Hook[]} [_beforeAll]
- * @property {Mocha.Hook[]} [_beforeEach]
- * @property {Mocha.Hook[]} [_afterEach]
- * @property {Mocha.Test[]} [tests]
- */
-/** @typedef {(suite: Suite, ctx: Mocha.Context) => boolean} ShouldSuppress */
-/** @typedef {Mocha.Func | Mocha.AsyncFunc} HookFn */
 
-const { Suite: MochaSuite } = require('mocha')
+const { Runner } = require('mocha')
 
 const patched = new WeakSet()
-if (!patched.has(MochaSuite.prototype)) {
-  patched.add(MochaSuite.prototype)
-  patchAfter('afterAll', shouldSuppressAfterAll)
-  patchAfter('afterEach', shouldSuppressAfterEach)
-}
+const failedSuites = new WeakSet()
+const failedTests = new WeakSet()
 
-/** @type {ShouldSuppress} */
-function shouldSuppressAfterAll (suite) {
-  return anyFailed(suite._beforeAll) ||
-    anyFailed(suite._beforeEach) ||
-    anyFailed(suite._afterEach) ||
-    anyFailed(suite.tests)
-}
+if (!patched.has(Runner.prototype)) {
+  patched.add(Runner.prototype)
 
-/** @type {ShouldSuppress} */
-function shouldSuppressAfterEach (suite, ctx) {
-  return ctx.currentTest?.isFailed() === true || anyFailed(suite._beforeEach)
-}
-
-/** @param {Mocha.Runnable[] | undefined} runnables */
-function anyFailed (runnables) {
-  if (!Array.isArray(runnables)) return false
-  for (const r of runnables) if (r?.isFailed?.()) return true
-  return false
-}
-
-/**
- * @param {unknown} value
- * @returns {value is PromiseLike<unknown>}
- */
-function isThenable (value) {
-  return typeof value?.then === 'function'
-}
-
-/**
- * @param {'afterAll'|'afterEach'} method
- * @param {ShouldSuppress} shouldSuppress
- */
-function patchAfter (method, shouldSuppress) {
-  const proto = /** @type {Record<string, (title: string | HookFn, fn?: HookFn) => Mocha.Suite>} */ (
-    /** @type {unknown} */ (MochaSuite.prototype)
-  )
-  const original = proto[method]
-  /**
-   * @this {Mocha.Suite}
-   * @param {string | HookFn} title
-   * @param {HookFn} [fn]
-   */
-  proto[method] = function patchedAfter (title, fn) {
-    if (typeof title === 'function') {
-      fn = title
-      title = title.name
-    }
-    const suite = /** @type {Suite} */ (/** @type {unknown} */ (this))
-    if (typeof fn !== 'function') return original.call(this, title, fn)
-    return original.call(this, title, wrapAfter(fn, suite, shouldSuppress))
-  }
-}
-
-/**
- * @param {HookFn} fn
- * @param {Suite} suite
- * @param {ShouldSuppress} shouldSuppress
- * @returns {HookFn}
- */
-function wrapAfter (fn, suite, shouldSuppress) {
-  // Preserve `fn.length` so mocha picks the right execution path (`this.async = fn && fn.length`).
-  if (fn.length === 0) {
-    /** @this {Mocha.Context} */
-    return function wrappedAfter () {
-      let result
-      try {
-        result = (/** @type {Mocha.AsyncFunc} */ (fn)).call(this)
-      } catch (err) {
-        if (shouldSuppress(suite, this)) return
-        throw err
-      }
-      if (isThenable(result)) {
-        return Promise.resolve(result).then(undefined, (err) => {
-          if (shouldSuppress(suite, this)) return
-          throw err
-        })
-      }
-      return result
-    }
-  }
+  const fail = Runner.prototype.fail
 
   /**
-   * @this {Mocha.Context}
-   * @param {Mocha.Done} done
+   * @this {Mocha.Runner}
+   * @param {Mocha.Runnable} runnable
+   * @param {Error} err
+   * @param {boolean} [force]
    */
-  return function wrappedAfter (done) {
-    let result
-    try {
-      result = (/** @type {Mocha.Func} */ (fn)).call(this, (err) => {
-        if (err && shouldSuppress(suite, this)) return done()
-        return done(err)
-      })
-    } catch (err) {
-      if (shouldSuppress(suite, this)) return done()
-      throw err
-    }
-    // Returned for mocha's overspecification detection (callback + Promise return).
-    return result
+  Runner.prototype.fail = function patchedFail (runnable, err, force) {
+    if (shouldSuppress(runnable)) return
+
+    fail.call(this, runnable, err, force)
+    markFailed(runnable)
   }
+}
+
+/** @param {Mocha.Runnable} runnable */
+function markFailed (runnable) {
+  const test = currentTest(runnable)
+  if (test) failedTests.add(test)
+
+  let suite = runnable.parent
+  while (suite) {
+    failedSuites.add(suite)
+    suite = suite.parent
+  }
+}
+
+/**
+ * @param {Mocha.Runnable} runnable
+ * @returns {boolean}
+ */
+function shouldSuppress (runnable) {
+  if (isAfterEach(runnable)) {
+    const test = currentTest(runnable)
+    return test ? failedTests.has(test) : false
+  }
+
+  return isAfterAll(runnable) && failedSuites.has(runnable.parent)
+}
+
+/**
+ * @param {Mocha.Runnable} runnable
+ * @returns {Mocha.Test | undefined}
+ */
+function currentTest (runnable) {
+  return runnable.type === 'test' ? runnable : runnable.ctx?.currentTest
+}
+
+/**
+ * @param {Mocha.Runnable} runnable
+ * @returns {boolean}
+ */
+function isAfterAll (runnable) {
+  return runnable.type === 'hook' && runnable.title.startsWith('"after all" hook')
+}
+
+/**
+ * @param {Mocha.Runnable} runnable
+ * @returns {boolean}
+ */
+function isAfterEach (runnable) {
+  return runnable.type === 'hook' && runnable.title.startsWith('"after each" hook')
 }


### PR DESCRIPTION
### What does this PR do?
This is similar to what PR [8147](https://github.com/DataDog/dd-trace-js/pull/8147) addressed: a teardown failure can hide or distract from the original failure. The same issue also happens with nested suites, where an outer `after` / `afterEach` hook can be reported after a failure inside an inner `describe()`.

### Motivation
Simplified the `mocha-hook` by changing the monkey patch from wrapping `afterAll` / `afterEach` hooks to patching `Runner.prototype.fail`. This lets us cover both flat and nested suites cases with the same logic
