### PR TITLE
add github workflow to mirror images from flaky registries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -214,6 +214,7 @@
 /.github/actions/dd-sts-app-key/action.yml @Datadog/lang-platform-js
 /.github/actions/dd-sts-api-key/action.yml @Datadog/lang-platform-js
 /.github/chainguard @DataDog/sdlc-security
+/.github/workflows/mirror-image.yml @Datadog/lang-platform-js
 /.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
 /.github/workflows/apm-integrations.yml @DataDog/apm-idm-js
 /.github/workflows/aiguard.yml @DataDog/asm-js

--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -27,16 +27,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve GHCR target
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          IMAGE_NAME="${{ inputs.image }}"
-          GHCR_TARGET="$(echo "ghcr.io/${{ github.repository }}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
+          GHCR_TARGET="$(echo "ghcr.io/${REPOSITORY}/${IMAGE}" | tr '[:upper:]' '[:lower:]')"
           echo "GHCR_TARGET=${GHCR_TARGET}" >> $GITHUB_ENV
 
-      - name: Pull source image
-        run: docker pull ${{ inputs.image }}:${{ inputs.tag }}
-
-      - name: Tag for GHCR
-        run: docker tag ${{ inputs.image }}:${{ inputs.tag }} ${{ env.GHCR_TARGET }}:${{ inputs.tag }}
-
-      - name: Push to GHCR
-        run: docker push ${{ env.GHCR_TARGET }}:${{ inputs.tag }}
+      - name: Mirror manifest to GHCR
+        env:
+          SOURCE: ${{ inputs.image }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          docker buildx imagetools create \
+            --tag "${GHCR_TARGET}:${TAG}" \
+            "${SOURCE}:${TAG}"

--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Resolve GHCR target
         run: |
           IMAGE_NAME="${{ inputs.image }}"
-          GHCR_TARGET="$(echo "ghcr.io/${{ github.repository }}/${IMAGE_NAME##*/}" | tr '[:upper:]' '[:lower:]')"
+          GHCR_TARGET="$(echo "ghcr.io/${{ github.repository }}/${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')"
           echo "GHCR_TARGET=${GHCR_TARGET}" >> $GITHUB_ENV
 
       - name: Pull source image

--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -1,0 +1,42 @@
+name: Mirror image to GHCR
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Source image to mirror (e.g. mcr.microsoft.com/azure-storage/azurite)"
+        required: true
+        type: string
+      tag:
+        description: "Image tag to mirror (e.g. latest, 3.33.0)"
+        required: true
+        type: string
+
+permissions:
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull source image
+        run: docker pull ${{ inputs.image }}:${{ inputs.tag }}
+
+      - name: Tag for GHCR
+        run: |
+          IMAGE_NAME="${{ inputs.image }}"
+          docker tag \
+            ${IMAGE_NAME}:${{ inputs.tag }} \
+            ghcr.io/${{ github.repository }}/${IMAGE_NAME##*/}:${{ inputs.tag }}
+
+      - name: Push to GHCR
+        run: |
+          IMAGE_NAME="${{ inputs.image }}"
+          docker push ghcr.io/${{ github.repository }}/${IMAGE_NAME##*/}:${{ inputs.tag }}

--- a/.github/workflows/mirror-image.yml
+++ b/.github/workflows/mirror-image.yml
@@ -26,17 +26,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve GHCR target
+        run: |
+          IMAGE_NAME="${{ inputs.image }}"
+          GHCR_TARGET="$(echo "ghcr.io/${{ github.repository }}/${IMAGE_NAME##*/}" | tr '[:upper:]' '[:lower:]')"
+          echo "GHCR_TARGET=${GHCR_TARGET}" >> $GITHUB_ENV
+
       - name: Pull source image
         run: docker pull ${{ inputs.image }}:${{ inputs.tag }}
 
       - name: Tag for GHCR
-        run: |
-          IMAGE_NAME="${{ inputs.image }}"
-          docker tag \
-            ${IMAGE_NAME}:${{ inputs.tag }} \
-            ghcr.io/${{ github.repository }}/${IMAGE_NAME##*/}:${{ inputs.tag }}
+        run: docker tag ${{ inputs.image }}:${{ inputs.tag }} ${{ env.GHCR_TARGET }}:${{ inputs.tag }}
 
       - name: Push to GHCR
-        run: |
-          IMAGE_NAME="${{ inputs.image }}"
-          docker push ghcr.io/${{ github.repository }}/${IMAGE_NAME##*/}:${{ inputs.tag }}
+        run: docker push ${{ env.GHCR_TARGET }}:${{ inputs.tag }}


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add GitHub workflow to mirror images from flaky registries.

### Motivation
<!-- What inspired you to submit this pull request? -->

Microsoft registry is one of our leading causes of flakiness. GHCR should hopefully be better. I made the workflow generic so that we can mirror any image when needed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

GitHub has been unreliable to the extreme in the last year or so, but the hope is that GHCR is not affected by all their issues.