### PR TITLE
test: Improve profiling tests

### DIFF
--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -662,11 +662,14 @@ describe('profiler', () => {
       // so expect telemetry callback to time out. expectedMessageCount: Infinity keeps the listener
       // from ever resolving, so the only outcome is the timeout that expectTimeout requires.
       const checkTelemetry = agent.assertTelemetryReceived({
+        fn: ({ payload }) => {
+          assert.notStrictEqual(payload.payload.namespace, 'profilers')
+        },
         requestType: 'generate-metrics',
         timeout: 1000,
         expectedMessageCount: Infinity,
       })
-      await Promise.all([checkProfiles(agent, proc, timeout), expectTimeout(checkTelemetry)])
+      await Promise.all([checkProfiles(agent, proc, timeout), expectTimeout(checkTelemetry, true)])
     })
 
     describe('on non-Windows platform', () => {

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -662,14 +662,11 @@ describe('profiler', () => {
       // so expect telemetry callback to time out. expectedMessageCount: Infinity keeps the listener
       // from ever resolving, so the only outcome is the timeout that expectTimeout requires.
       const checkTelemetry = agent.assertTelemetryReceived({
-        fn: ({ payload }) => {
-          assert.notStrictEqual(payload.payload.namespace, 'profilers')
-        },
         requestType: 'generate-metrics',
         timeout: 1000,
         expectedMessageCount: Infinity,
       })
-      await Promise.all([checkProfiles(agent, proc, timeout), expectTimeout(checkTelemetry, true)])
+      await Promise.all([checkProfiles(agent, proc, timeout), expectTimeout(checkTelemetry)])
     })
 
     describe('on non-Windows platform', () => {

--- a/packages/dd-trace/test/profiling/exporters/agent.spec.js
+++ b/packages/dd-trace/test/profiling/exporters/agent.spec.js
@@ -5,7 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 const { request } = require('node:http')
 
-const { describe, it, beforeEach, afterEach } = require('mocha')
+const { describe, it, before, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const express = require('express')
@@ -53,6 +53,13 @@ async function createProfile (periodType) {
   return profiler.encode(profile)
 }
 
+async function createProfiles () {
+  return {
+    wall: await createProfile(['wall', 'microseconds']),
+    space: await createProfile(['space', 'bytes']),
+  }
+}
+
 describe('exporters/agent', function () {
   let AgentExporter
   let sockets
@@ -63,6 +70,17 @@ describe('exporters/agent', function () {
   let http
   let computeRetries
   let startSpan
+
+  before(function () {
+    try {
+      require('@datadog/pprof')
+    } catch (err) {
+      if (err.message?.includes('No native build was found')) {
+        this.skip()
+      }
+      throw err
+    }
+  })
 
   function verifyRequest (req, profiles, start, end) {
     assert.strictEqual(req.headers.test, 'injected')
@@ -204,15 +222,7 @@ describe('exporters/agent', function () {
         'runtime-id': RUNTIME_ID,
       }
 
-      const [wall, space] = await Promise.all([
-        createProfile(['wall', 'microseconds']),
-        createProfile(['space', 'bytes']),
-      ])
-
-      const profiles = {
-        wall,
-        space,
-      }
+      const profiles = await createProfiles()
 
       await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
         app.post('/profiling/v1/input', upload.any(), (req, res) => {
@@ -247,15 +257,7 @@ describe('exporters/agent', function () {
         'runtime-id': RUNTIME_ID,
       }
 
-      const [wall, space] = await Promise.all([
-        createProfile(['wall', 'microseconds']),
-        createProfile(['space', 'bytes']),
-      ])
-
-      const profiles = {
-        wall,
-        space,
-      }
+      const profiles = await createProfiles()
 
       let attempt = 0
       app.post('/profiling/v1/input', upload.any(), (req, res) => {
@@ -328,15 +330,7 @@ describe('exporters/agent', function () {
       const end = new Date()
       const tags = { foo: 'bar' }
 
-      const [wall, space] = await Promise.all([
-        createProfile(['wall', 'microseconds']),
-        createProfile(['space', 'bytes']),
-      ])
-
-      const profiles = {
-        wall,
-        space,
-      }
+      const profiles = await createProfiles()
 
       let tries = 0
       const json = JSON.stringify({ error: 'some error' })
@@ -365,15 +359,7 @@ describe('exporters/agent', function () {
       const end = new Date()
       const tags = { foo: 'bar' }
 
-      const [wall, space] = await Promise.all([
-        createProfile(['wall', 'microseconds']),
-        createProfile(['space', 'bytes']),
-      ])
-
-      const profiles = {
-        wall,
-        space,
-      }
+      const profiles = await createProfiles()
 
       let tries = 0
       const json = JSON.stringify({ error: 'some error' })
@@ -422,15 +408,7 @@ describe('exporters/agent', function () {
         'runtime-id': RUNTIME_ID,
       }
 
-      const [wall, space] = await Promise.all([
-        createProfile(['wall', 'microseconds']),
-        createProfile(['space', 'bytes']),
-      ])
-
-      const profiles = {
-        wall,
-        space,
-      }
+      const profiles = await createProfiles()
 
       await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
         app.post('/profiling/v1/input', upload.any(), (req, res) => {
@@ -472,15 +450,7 @@ describe('exporters/agent', function () {
         'runtime-id': RUNTIME_ID,
       }
 
-      const [wall, space] = await Promise.all([
-        createProfile(['wall', 'microseconds']),
-        createProfile(['space', 'bytes']),
-      ])
-
-      const profiles = {
-        wall,
-        space,
-      }
+      const profiles = await createProfiles()
 
       await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
         app.post('/profiling/v1/input', upload.any(), (req, res) => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Address some profiling flaky tests:

- According to https://github.com/DataDog/dd-trace-js/actions/runs/25068797764/job/73473014147#step:6:2295, we were not able to load `@datadog/pprof` so add a quick check to skip the spec when the native library is unavailable.
- Avoid creating wall and heap profiles concurrently. Start and encode the wall profile first, then do the same for the heap profile, so sampling and encoding do not overlap. [Claude proposal]


### Motivation

Address some profiling flaky tests


