### PR TITLE
fix(test): guard aerospike.releaseEventLoop() against undefined and add stress workflow

### DIFF
--- a/.github/workflows/aerospike-stress.yml
+++ b/.github/workflows/aerospike-stress.yml
@@ -1,0 +1,60 @@
+name: "[Stress] aerospike"
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      iterations-per-shard:
+        description: "Suite runs per shard (20 shards run in parallel, total = 20 × this)"
+        required: false
+        default: "5"
+        type: string
+
+jobs:
+  aerospike-stress:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
+        include:
+          - node-version: eol
+            aerospike-image: ce-5.7.0.15
+            range: ">=4.0.0 <5.2.0"
+            test-image: ubuntu-22.04
+    runs-on: ${{ matrix.test-image }}
+    permissions:
+      id-token: write
+    services:
+      aerospike:
+        image: aerospike:${{ matrix.aerospike-image }}
+        ports:
+          - "127.0.0.1:3000-3002:3000-3002"
+    env:
+      PLUGINS: aerospike
+      SERVICES: aerospike
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
+      - uses: ./.github/actions/testagent/start
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.node-version }}
+      - run: yarn config set ignore-engines true
+      - uses: ./.github/actions/install
+      - name: "Shard ${{ matrix.shard }}: run aerospike suite ${{ inputs.iterations-per-shard || 5 }} times"
+        run: |
+          PASS=0; FAIL=0; ITER=${{ inputs.iterations-per-shard || 5 }}
+          for i in $(seq 1 "$ITER"); do
+            echo "::group::Shard ${{ matrix.shard }} run $i / $ITER"
+            if yarn test:plugins:ci; then
+              PASS=$((PASS + 1))
+            else
+              FAIL=$((FAIL + 1))
+            fi
+            echo "::endgroup::"
+            echo "After run $i: passed=$PASS failed=$FAIL"
+          done
+          echo "## Shard ${{ matrix.shard }}: $PASS/$ITER passed, $FAIL failed" >> "$GITHUB_STEP_SUMMARY"
+          [ "$FAIL" -eq 0 ]

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -20,7 +20,8 @@ describe('Plugin', () => {
   let key
   let keyString
 
-  describe('aerospike', () => {
+  describe('aerospike', function () {
+    this.timeout(30000)
     withVersions('aerospike', 'aerospike', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -51,7 +51,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          aerospike.releaseEventLoop()
+          aerospike?.releaseEventLoop()
         })
 
         describe('client', () => {
@@ -306,7 +306,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          aerospike.releaseEventLoop()
+          aerospike?.releaseEventLoop()
         })
 
         it('should be configured with the correct values', done => {


### PR DESCRIPTION
## Summary

### The crash

`after()` in both `describe('without configuration')` and `describe('with configuration')` called `aerospike.releaseEventLoop()` unconditionally. `aerospike` is only assigned inside `beforeEach` — if the `before()` hook (`agent.load('aerospike')`) fails for any reason, Mocha skips all tests and jumps straight to `after()` without ever running `beforeEach`. At that point `aerospike` is `undefined`, so `aerospike.releaseEventLoop()` throws a `TypeError` that crashes the mocha process via the uncaught-exception path in `runner.js:998`:

```
TypeError: Cannot read properties of undefined (reading 'releaseEventLoop')
    at packages/datadog-plugin-aerospike/test/index.spec.js:54
```

This crash silences all subsequent test output — the real error from `before()` is never reported.

### The fix

`aerospike?.releaseEventLoop()` — optional chaining lets `after()` complete gracefully. Mocha can then surface the real `before()` error in the test report instead of crashing.

### What's still unknown

The root cause of `before()` (`agent.load('aerospike')`) failing is not yet visible because the crash swallows it. The stress workflow below will expose it: once `releaseEventLoop` no longer crashes the process, the actual error from `agent.load` will appear in the failing shard's output.

## Stress workflow

`.github/workflows/aerospike-stress.yml` — 20 parallel shards, each running the suite 5 times (100 total), targeting the EOL Node / aerospike 4.x / `ce-5.7.0.15` combination where the crash was observed. `fail-fast: false` so all shards report. Triggers on every PR and via `workflow_dispatch`.

## Test plan

- [ ] Stress workflow runs: check shard output for the real `agent.load` error once the crash is gone
- [ ] Existing aerospike CI jobs (all matrix combinations) stay green

🤖 Generated with [Claude Code](https://claude.com/claude-code)