### PR TITLE
test(debugger): detect bracketed `byteLength` at runtime

### DIFF
--- a/integration-tests/debugger/template.spec.js
+++ b/integration-tests/debugger/template.spec.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const semver = require('semver')
+const { inspect } = require('node:util')
 const { NODE_MAJOR } = require('../../version')
 const { setup } = require('./utils')
 
-const NODE_24_11_1_OR_LATER = semver.gte(process.version, '24.11.1')
+// Backported across LTS lines, so detect at runtime instead of version-gating.
+const HAS_BRACKETED_BYTELENGTH = inspect(new ArrayBuffer(0)).includes('[byteLength]')
 
 describe('Dynamic Instrumentation', function () {
   describe('template evaluation', function () {
@@ -100,7 +101,7 @@ describe('Dynamic Instrumentation', function () {
           messages.shift(),
           'ArrayBuffer { ' +
             '[Uint8Contents]: <00 00 00 ... 7 more bytes>, ' +
-            (NODE_24_11_1_OR_LATER ? '[byteLength]' : 'byteLength') +
+            (HAS_BRACKETED_BYTELENGTH ? '[byteLength]' : 'byteLength') +
               ": 10, '0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9 " +
           '}'
         )


### PR DESCRIPTION
## Summary

The template integration test version-gates the bracketed `[byteLength]` form of `util.inspect(new ArrayBuffer(...))` on `>=24.11.1`. That same change ([nodejs/node#60131](https://github.com/nodejs/node/pull/60131)) was backported to v22.22.1, so the `node-active` job (Node 22.x) on `master` started failing as soon as the runner served v22.22.x. PR CI for #8140 was cached on v22.22.0 and stayed green; the post-merge run resolved v22.22.2 and tripped:

```
+ "ArrayBuffer { [Uint8Contents]: <00 00 00 ... 7 more bytes>, [byteLength]: 10, ... }"
- "ArrayBuffer { [Uint8Contents]: <00 00 00 ... 7 more bytes>, byteLength: 10, ... }"
```

Probe `util.inspect(new ArrayBuffer(0))` for `[byteLength]` at runtime so the assertion follows the actual format on whatever patch the runner picks up. No more enumerating release lines as further backports land.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/25119400932/job/73618598749
Refs: https://github.com/nodejs/node/pull/60131
Refs: https://github.com/DataDog/dd-trace-js/pull/8140