### PR TITLE
fix(debugger): move process_tags to payload root

### DIFF
--- a/integration-tests/debugger/tracing-integration.spec.js
+++ b/integration-tests/debugger/tracing-integration.spec.js
@@ -72,14 +72,13 @@ describe('Dynamic Instrumentation', function () {
     })
 
     describe('input messages', function () {
-      it('should include process_tags in snapshot when enabled', function (done) {
+      it('should include process_tags at root level when enabled', function (done) {
         t.agent.on('debugger-input', ({ payload }) => {
-          const snapshot = payload[0].debugger.snapshot
+          const { process_tags: processTags } = payload[0]
 
-          // Check for expected process tags keys
-          assert.ok(snapshot.process_tags['entrypoint.name'])
-          assert.ok(snapshot.process_tags['entrypoint.type'])
-          assert.strictEqual(snapshot.process_tags['entrypoint.type'], 'script')
+          assert.strictEqual(typeof processTags, 'string')
+          assert.ok(processTags.includes('entrypoint.name:'))
+          assert.ok(processTags.includes('entrypoint.type:script'))
 
           done()
         })
@@ -98,12 +97,9 @@ describe('Dynamic Instrumentation', function () {
     })
 
     describe('input messages', function () {
-      it('should not include process_tags in snapshot when disabled', function (done) {
+      it('should not include process_tags when disabled', function (done) {
         t.agent.on('debugger-input', ({ payload }) => {
-          const snapshot = payload[0].debugger.snapshot
-
-          // Assert that process_tags are not present
-          assert.strictEqual(snapshot.process_tags, undefined)
+          assert.strictEqual(payload[0].process_tags, undefined)
 
           done()
         })

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -247,10 +247,6 @@ session.on('Debugger.paused', async ({ params }) => {
       language: 'javascript',
     }
 
-    if (config.propagateProcessTags.enabled) {
-      snapshot[processTags.DYNAMIC_INSTRUMENTATION_FIELD_NAME] = processTags.tagsObject
-    }
-
     if (probe.captureSnapshot) {
       if (fatalSnapshotErrors && fatalSnapshotErrors.length > 0) {
         // There was an error collecting the snapshot for this probe, let's not try again
@@ -327,7 +323,8 @@ session.on('Debugger.paused', async ({ params }) => {
 
     ackEmitting(probe)
 
-    send(message, logger, dd, snapshot)
+    send(message, logger, dd, snapshot,
+      config.propagateProcessTags.enabled ? processTags.serialized : undefined)
   }
 })
 

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -40,7 +40,7 @@ const jsonBuffer = new JSONBuffer({
   onFlush,
 })
 
-function send (message, logger, dd, snapshot) {
+function send (message, logger, dd, snapshot, processTags) {
   const payload = {
     ddsource,
     hostname,
@@ -50,6 +50,7 @@ function send (message, logger, dd, snapshot) {
       : message,
     logger,
     dd,
+    process_tags: processTags,
     debugger: { snapshot },
   }
 

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -269,6 +269,26 @@ describe('input message http requests', function () {
     done()
   })
 
+  it('should include process_tags at root level when provided', function () {
+    const processTags = 'entrypoint.name:banana,entrypoint.type:script'
+    send(message, logger, dd, snapshot, processTags)
+
+    const writtenJson = jsonBufferWrite.getCall(0).args[0]
+    const written = JSON.parse(writtenJson)
+
+    assert.strictEqual(written.process_tags, processTags)
+    assert.strictEqual(written.debugger.snapshot.process_tags, undefined)
+  })
+
+  it('should not include process_tags when not provided', function () {
+    send(message, logger, dd, snapshot)
+
+    const writtenJson = jsonBufferWrite.getCall(0).args[0]
+    const written = JSON.parse(writtenJson)
+
+    assert.strictEqual(written.process_tags, undefined)
+  })
+
   describe('snapshot pruning', function () {
     const largeSnapshot = {
       id: '123',


### PR DESCRIPTION
### What does this PR do?

Fixes the placement and format of `process_tags` in the Live Debugger / Dynamic Instrumentation payload.

Previously, `process_tags` was incorrectly added inside `debugger.snapshot` as a JavaScript object. This PR moves it to the root level of the intake payload and serializes it as a comma-separated string, matching the [RFC](https://docs.google.com/document/d/1AFdLUuVk70i0bJd5335-RxqsvwAV9ovAqcO2z5mEMbA) and the implementations in the other client libraries.

**Before:**
```json
{
  "service": "my-service",
  "debugger": {
    "snapshot": {
      "process_tags": { "entrypoint.name": "foo", "entrypoint.type": "script" }
    }
  }
}
```

**After:**
```json
{
  "service": "my-service",
  "process_tags": "entrypoint.name:foo,entrypoint.type:script",
  "debugger": {
    "snapshot": { }
  }
}
```

### Motivation

The original implementation in #7132 placed `process_tags` in the wrong location (`debugger.snapshot.process_tags`) using the wrong format (object instead of comma-separated string). This doesn't match the RFC spec or any of the other tracer libraries, which all place it at the root of the payload as a string.
