### PR TITLE
feat(crashtracking): capture and report uncaught exceptions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -294,7 +294,7 @@
 /integration-tests/coverage-fixtures/parent.js @DataDog/lang-platform-js
 /integration-tests/coverage-fixtures/worker.js @DataDog/lang-platform-js
 /integration-tests/coverage-manual-process.spec.js @DataDog/lang-platform-js
-/integration-tests/crashtracking @DataDog/lang-platform-js
+/integration-tests/crashtracking/ @DataDog/lang-platform-js
 /integration-tests/init.spec.js @DataDog/lang-platform-js
 /integration-tests/mocha-parallel-files-fixtures/ @DataDog/lang-platform-js
 /integration-tests/mocha-parallel-files.spec.js @DataDog/lang-platform-js
@@ -308,7 +308,6 @@
 /packages/datadog-shimmer @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
 /packages/dd-trace/src/exporters/common/retry.js @DataDog/lang-platform-js
-/integration-tests/crashtracking @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -294,6 +294,7 @@
 /integration-tests/coverage-fixtures/parent.js @DataDog/lang-platform-js
 /integration-tests/coverage-fixtures/worker.js @DataDog/lang-platform-js
 /integration-tests/coverage-manual-process.spec.js @DataDog/lang-platform-js
+/integration-tests/crashtracking @DataDog/lang-platform-js
 /integration-tests/init.spec.js @DataDog/lang-platform-js
 /integration-tests/mocha-parallel-files-fixtures/ @DataDog/lang-platform-js
 /integration-tests/mocha-parallel-files.spec.js @DataDog/lang-platform-js
@@ -307,6 +308,7 @@
 /packages/datadog-shimmer @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
 /packages/dd-trace/src/exporters/common/retry.js @DataDog/lang-platform-js
+/integration-tests/crashtracking @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -150,6 +150,31 @@ jobs:
         with:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
+  crashtracking:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [oldest, maintenance, active, latest]
+    name: ${{ github.workflow }} / crashtracking (node-${{ matrix.version }})
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
+      - uses: ./.github/actions/install
+      # Disable core dumps since crashtracking tests intentionally abort
+      - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
+      - run: yarn test:integration:crashtracking
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+
   unit-guardrails:
     runs-on: ubuntu-latest
     permissions:

--- a/integration-tests/crashtracking/crashtracking.spec.js
+++ b/integration-tests/crashtracking/crashtracking.spec.js
@@ -1,0 +1,166 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { fork } = require('node:child_process')
+const os = require('node:os')
+const path = require('node:path')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+
+const { FakeAgent } = require('../helpers')
+
+const describeNotWindows = os.platform() !== 'win32' ? describe : describe.skip
+
+/**
+ * Spawn a fixture process that will crash. We don't use spawnProc here because it rejects when the
+ * child exits with a non-zero code or a signal, but the crashing processes are expected to do that
+ *
+ * @param {string} fixture
+ * @param {number} agentPort
+ * @returns {Promise<void>}
+ */
+function spawnCrashFixture (fixture, agentPort) {
+  const proc = fork(path.join(__dirname, fixture), [], {
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      DD_TRACE_AGENT_PORT: String(agentPort),
+      DD_TRACE_STARTUP_LOGS: 'false',
+    },
+  })
+
+  return new Promise((resolve) => {
+    proc.once('exit', resolve)
+  })
+}
+
+/**
+ * Subscribe to crash telemetry on the fake agent and return a promise that resolves once both
+ * the ping (DEBUG) and the full report (ERROR) have arrived.
+ *
+ * We need to
+ *  - start the crashing program
+ *  - attach a listener to the fake agent to collect incoming telemetry
+ * This can be a source of a race and made the test flaky because the program could
+ * crash and emit telemetry before the listener attaches
+ *
+ * So, we register the listener synchronously before starting the crashing program.
+ * @param {FakeAgent} agent
+ * @param {number} [timeout]
+ * @returns {Promise<{ping: object, report: object}>}
+ */
+function collectCrashLogs (agent, timeout = 10_000) {
+  let ping
+  let report
+
+  return new Promise((resolve, reject) => {
+    const onTelemetry = ({ payload }) => {
+      if (payload.request_type !== 'logs') return
+
+      for (const log of payload.payload.logs) {
+        let msg
+        try {
+          msg = JSON.parse(log.message)
+        } catch {
+          continue
+        }
+
+        if (log.level === 'DEBUG') {
+          ping = msg
+        } else if (log.level === 'ERROR') {
+          report = msg
+        }
+
+        if (ping && report) {
+          cleanup()
+          resolve({ ping, report })
+          return
+        }
+      }
+    }
+
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timeout waiting for crash telemetry'))
+    }, timeout)
+
+    function cleanup () {
+      clearTimeout(timer)
+      agent.removeListener('telemetry', onTelemetry)
+    }
+
+    agent.on('telemetry', onTelemetry)
+  })
+}
+
+describeNotWindows('crashtracking integration', () => {
+  let agent
+
+  beforeEach(async () => {
+    agent = await new FakeAgent().start()
+  })
+
+  afterEach(async () => {
+    await agent.stop()
+  })
+
+  describe('unix signal crash', () => {
+    it('sends a crash report and a ping with a native stack to the telemetry endpoint', async () => {
+      const logsPromise = collectCrashLogs(agent)
+      const exitPromise = spawnCrashFixture('signal-crash.js', agent.port)
+
+      const [{ ping, report }] = await Promise.all([logsPromise, exitPromise])
+
+      // Ping
+      assert.strictEqual(ping.kind, 'UnixSignal')
+      assert.ok(ping.message.includes('SIGABRT'))
+
+      // Full report
+      assert.strictEqual(report.error.kind, 'UnixSignal')
+      assert.ok(report.error.message.includes('SIGABRT'))
+      assert.strictEqual(report.error.source_type, 'Crashtracking')
+
+      // Stack frames
+      const { frames } = report.error.stack
+      assert.ok(frames.length > 0, 'expected at least one stack frame')
+
+      // The crashing frame is the call to kill at the top.
+      const topFrame = frames[0]
+      assert.ok(
+        topFrame.function && topFrame.function.toLowerCase().includes('kill'),
+        `expected top frame to be the kill syscall, got: ${JSON.stringify(topFrame)}`
+      )
+    })
+  })
+
+  describe('uncaught exception', () => {
+    it('sends a crash report and a ping with a JS stack to the telemetry endpoint', async () => {
+      const logsPromise = collectCrashLogs(agent)
+      const exitPromise = spawnCrashFixture('uncaught-exception.js', agent.port)
+
+      const [{ ping, report }] = await Promise.all([logsPromise, exitPromise])
+
+      // Ping
+      assert.strictEqual(ping.kind, 'UnhandledException')
+
+      // Full report
+      assert.strictEqual(report.error.kind, 'UnhandledException')
+      assert.ok(report.error.message.includes('TypeError'))
+      assert.ok(report.error.message.includes('integration test uncaught exception'))
+      assert.strictEqual(report.error.source_type, 'Crashtracking')
+
+      // Stack frames JS frames carry file/line/column/function
+      const { frames } = report.error.stack
+      assert.ok(frames.length > 0, 'expected at least one stack frame')
+
+      // The top frame is the throw site of the error in uncaught-exception.js
+      const throwFrame = frames[0]
+      assert.ok(
+        throwFrame.file.includes('uncaught-exception.js'),
+        `expected top frame to be uncaught-exception.js, got: ${JSON.stringify(throwFrame)}`
+      )
+      assert.strictEqual(throwFrame.line, 7, 'expected line number in top frame (in signal-crash.js)')
+      assert.strictEqual(throwFrame.column, 7, 'expected column number in top frame (in signal-crash.js)')
+    })
+  })
+})

--- a/integration-tests/crashtracking/signal-crash.js
+++ b/integration-tests/crashtracking/signal-crash.js
@@ -1,0 +1,7 @@
+'use strict'
+
+require('../../packages/dd-trace').init({
+  crashtracking: { enabled: true },
+})
+
+process.kill(process.pid, 'SIGABRT')

--- a/integration-tests/crashtracking/uncaught-exception.js
+++ b/integration-tests/crashtracking/uncaught-exception.js
@@ -1,0 +1,7 @@
+'use strict'
+
+require('../../packages/dd-trace').init({
+  crashtracking: { enabled: true },
+})
+
+throw new TypeError('integration test uncaught exception')

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:integration:aiguard:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/aiguard/*.spec.js\"",
     "test:integration:appsec": "mocha --timeout 60000 \"integration-tests/appsec/*.spec.js\"",
     "test:integration:appsec:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/appsec/*.spec.js\"",
+    "test:integration:crashtracking": "mocha --timeout 60000 \"integration-tests/crashtracking/*.spec.js\"",
     "test:integration:bun": "mocha --timeout 60000 \"integration-tests/bun/*.spec.js\"",
     "test:integration:cucumber": "mocha --timeout 60000 \"integration-tests/cucumber/*.spec.js\"",
     "test:integration:cucumber:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/cucumber/*.spec.js\"",

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -49,7 +49,7 @@ class Crashtracker {
       try {
         binding.reportUncaughtExceptionMonitor(error, origin)
       } catch (e) {
-        log.error('Error reporting uncaught exception to crashtracker', e)
+        process.stderr.write('Error reporting uncaught exception to crashtracker', e)
       }
     })
   }

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -70,7 +70,7 @@ class Crashtracker {
   #getConfig (config) {
     const url = getAgentUrl(config)
 
-    // Out-of-process symbolication currently (crashtracker 27.0.0) works on
+    // Out-of-process symbolication currently works on
     // Linux only, does not work on Mac.
     const resolveMode = require('os').platform === 'linux'
       ? 'EnabledWithSymbolsInReceiver'

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -40,6 +40,18 @@ class Crashtracker {
     } catch (e) {
       log.error('Error initializing crashtracker', e)
     }
+
+    this.#trackUnhandledExceptions()
+  }
+
+  #trackUnhandledExceptions () {
+    process.once('uncaughtExceptionMonitor', (error, origin) => {
+      try {
+        binding.reportUncaughtExceptionMonitor(error, origin)
+      } catch (e) {
+        log.error('Error reporting uncaught exception to crashtracker', e)
+      }
+    })
   }
 
   withProfilerSerializing (f) {

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { EOL } = require('node:os')
+
 // Load binding first to not import other modules if it throws
 const libdatadog = require('@datadog/libdatadog')
 const binding = libdatadog.load('crashtracker')
@@ -29,19 +31,17 @@ class Crashtracker {
   start (config) {
     if (this.#started) return this.configure(config)
 
-    this.#started = true
-
     try {
       binding.init(
         this.#getConfig(config),
         this.#getReceiverConfig(),
         this.#getMetadata(config)
       )
+      this.#started = true
+      this.#trackUnhandledExceptions()
     } catch (e) {
       log.error('Error initializing crashtracker', e)
     }
-
-    this.#trackUnhandledExceptions()
   }
 
   #trackUnhandledExceptions () {
@@ -49,7 +49,7 @@ class Crashtracker {
       try {
         binding.reportUncaughtExceptionMonitor(error, origin)
       } catch (e) {
-        process.stderr.write('Error reporting uncaught exception to crashtracker', e)
+        process.stderr.write(`Error reporting uncaught exception to crashtracker: ${e.toString()}${EOL}`)
       }
     })
   }

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -119,6 +119,7 @@ describeNotWindows('crashtracker', () => {
 
   describe('uncaughtExceptionMonitor', () => {
     it('should register a listener on start', () => {
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
       crashtracker.start(config)
 
       assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 1)
@@ -138,16 +139,6 @@ describeNotWindows('crashtracker', () => {
       process.emit('uncaughtExceptionMonitor', error, 'uncaughtException')
 
       sinon.assert.calledOnceWithExactly(binding.reportUncaughtExceptionMonitor, error, 'uncaughtException')
-    })
-
-    it('should handle errors thrown by the binding without crashing', () => {
-      crashtracker.start(config)
-
-      binding.reportUncaughtExceptionMonitor.throws(new Error('native error'))
-
-      process.emit('uncaughtExceptionMonitor', new Error('boom'), 'uncaughtException')
-
-      sinon.assert.called(log.error)
     })
   })
 

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -39,6 +39,7 @@ describeNotWindows('crashtracker', () => {
     sinon.stub(binding, 'init')
     sinon.stub(binding, 'updateConfig')
     sinon.stub(binding, 'updateMetadata')
+    sinon.stub(binding, 'reportUncaughtExceptionMonitor')
 
     crashtracker = proxyquire('../../src/crashtracking/crashtracker', {
       '../log': log,
@@ -49,6 +50,8 @@ describeNotWindows('crashtracker', () => {
     binding.init.restore()
     binding.updateConfig.restore()
     binding.updateMetadata.restore()
+    binding.reportUncaughtExceptionMonitor.restore()
+    process.removeAllListeners('uncaughtExceptionMonitor')
   })
 
   describe('start', () => {
@@ -111,6 +114,40 @@ describeNotWindows('crashtracker', () => {
       crashtracker.configure(null)
 
       crashtracker.configure(config)
+    })
+  })
+
+  describe('uncaughtExceptionMonitor', () => {
+    it('should register a listener on start', () => {
+      crashtracker.start(config)
+
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 1)
+    })
+
+    it('should not register a listener when start is called multiple times', () => {
+      crashtracker.start(config)
+      crashtracker.start(config)
+
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 1)
+    })
+
+    it('should forward the error and origin to the binding', () => {
+      crashtracker.start(config)
+
+      const error = new Error('boom')
+      process.emit('uncaughtExceptionMonitor', error, 'uncaughtException')
+
+      sinon.assert.calledOnceWithExactly(binding.reportUncaughtExceptionMonitor, error, 'uncaughtException')
+    })
+
+    it('should handle errors thrown by the binding without crashing', () => {
+      crashtracker.start(config)
+
+      binding.reportUncaughtExceptionMonitor.throws(new Error('native error'))
+
+      process.emit('uncaughtExceptionMonitor', new Error('boom'), 'uncaughtException')
+
+      sinon.assert.called(log.error)
     })
   })
 

--- a/packages/dd-trace/test/crashtracking/crashtracker.spec.js
+++ b/packages/dd-trace/test/crashtracking/crashtracker.spec.js
@@ -47,11 +47,11 @@ describeNotWindows('crashtracker', () => {
   })
 
   afterEach(() => {
+    process.removeAllListeners('uncaughtExceptionMonitor')
     binding.init.restore()
     binding.updateConfig.restore()
     binding.updateMetadata.restore()
     binding.reportUncaughtExceptionMonitor.restore()
-    process.removeAllListeners('uncaughtExceptionMonitor')
   })
 
   describe('start', () => {
@@ -80,7 +80,12 @@ describeNotWindows('crashtracker', () => {
     it('should handle errors', () => {
       crashtracker.start(null)
 
+      sinon.assert.calledOnce(log.error)
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
+
       crashtracker.start(config)
+
+      sinon.assert.calledOnce(binding.init)
     })
 
     it('should handle unix sockets', () => {
@@ -139,6 +144,15 @@ describeNotWindows('crashtracker', () => {
       process.emit('uncaughtExceptionMonitor', error, 'uncaughtException')
 
       sinon.assert.calledOnceWithExactly(binding.reportUncaughtExceptionMonitor, error, 'uncaughtException')
+    })
+
+    it('should not register a listener when init fails', () => {
+      binding.init.throws(new Error('init failed'))
+
+      crashtracker.start(config)
+
+      sinon.assert.calledOnce(log.error)
+      assert.strictEqual(process.listenerCount('uncaughtExceptionMonitor'), 0)
     })
   })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
We register the crashtracker `reportUncaughtExceptionMonitor` callback to `process.once('uncaughtExceptionMonitor' ...)` on crashtracker init. This allows us to report program crashes due to uncaught exceptions.

### Motivation
We would like to catch and report non unix signal based crashes

### Additional Notes
Stubbed unit tests included in this PR. More end to end integration style testing for crashtracking _in general_ added in [chore(crashtracking): integration tests for crashtracker](https://github.com/DataDog/dd-trace-js/pull/8178)


