### PR TITLE
test: ignore Node http socketErrorListener leak

### DIFF
--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -73,11 +73,7 @@ temporaryWarningExceptions.add = (warning) => {
 // `'warning'` event sees it, so real leaks still throw below.
 const originalEmitWarning = process.emitWarning
 process.emitWarning = function patchedEmitWarning (warning, ...args) {
-  if (
-    typeof warning === 'object' &&
-    warning?.name === 'MaxListenersExceededWarning' &&
-    isNodeHttpSocketLeak(warning)
-  ) {
+  if (warning?.name === 'MaxListenersExceededWarning' && isNodeHttpSocketLeak(warning)) {
     warning.emitter.setMaxListeners(0)
     return
   }

--- a/packages/dd-trace/test/setup/core.js
+++ b/packages/dd-trace/test/setup/core.js
@@ -66,6 +66,24 @@ temporaryWarningExceptions.add = (warning) => {
   return originalAdd(warning)
 }
 
+// Suppress Node's HTTP keep-alive `socketErrorListener` leak (introduced by
+// https://github.com/nodejs/node/pull/61770; fix at
+// https://github.com/nodejs/node/pull/62872 not yet released in v24.x). Bump
+// the leaking socket's limit and drop the warning before stderr or the
+// `'warning'` event sees it, so real leaks still throw below.
+const originalEmitWarning = process.emitWarning
+process.emitWarning = function patchedEmitWarning (warning, ...args) {
+  if (
+    typeof warning === 'object' &&
+    warning?.name === 'MaxListenersExceededWarning' &&
+    isNodeHttpSocketLeak(warning)
+  ) {
+    warning.emitter.setMaxListeners(0)
+    return
+  }
+  return originalEmitWarning.call(this, warning, ...args)
+}
+
 process.on('warning', (warning) => {
   if (warning.name === 'MaxListenersExceededWarning') {
     throw warning
@@ -83,6 +101,28 @@ process.on('warning', (warning) => {
     throw warning
   }
 })
+
+/**
+ * Detect the Node.js HTTP keep-alive socket error listener leak by its only
+ * stable signature: two or more listeners named `socketErrorListener` on the
+ * same emitter for event `error`. Once the upstream fix ships the duplicates
+ * disappear and this returns false again, so real leaks resume throwing.
+ *
+ * @param {Error & { emitter?: NodeJS.EventEmitter, type?: string }} warning
+ * @returns {boolean}
+ */
+function isNodeHttpSocketLeak (warning) {
+  if (warning.type !== 'error' || typeof warning.emitter?.listeners !== 'function') {
+    return false
+  }
+  let count = 0
+  for (const listener of warning.emitter.listeners('error')) {
+    if (listener.name === 'socketErrorListener' && ++count > 1) {
+      return true
+    }
+  }
+  return false
+}
 
 // Make this file a module for type-aware tooling. It is intentionally imported
 // for side effects only.


### PR DESCRIPTION
This stops `MaxListenersExceededWarning` from crashing the test process on Node v24.15.0, which leaks an internal `socketErrorListener` on every keep-alive agent socket reuse. Tests that issue several requests through the same socket — `instrumentation-http` and the RASP fastify blocking suite are the current victims — pile up enough listeners to trip our strict `defaultMaxListeners=6` and crash via the warning rethrow.

Detect the leak by its stable signature: two or more listeners named `socketErrorListener` on the same emitter for event `error`. The upstream fix is merged on Node `main` but not yet released in v24.x; once it ships the duplicates disappear and the detector returns false again, so real listener leaks resume throwing.

Refs: https://github.com/nodejs/node/pull/61770
Refs: https://github.com/nodejs/node/pull/62872
