### PR TITLE
chore(crashtracking): integration tests for crashtracker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -277,7 +277,7 @@
 /integration-tests/coverage-fixtures/parent.js @DataDog/lang-platform-js
 /integration-tests/coverage-fixtures/worker.js @DataDog/lang-platform-js
 /integration-tests/coverage-manual-process.spec.js @DataDog/lang-platform-js
-/integration-tests/crashtracking @DataDog/profiling-runtime
+/integration-tests/crashtracking @DataDog/lang-platform-js
 /integration-tests/init.spec.js @DataDog/lang-platform-js
 /integration-tests/package-guardrails.spec.js @DataDog/lang-platform-js
 /integration-tests/package-guardrails/flush.js @DataDog/lang-platform-js
@@ -285,7 +285,7 @@
 
 /packages/datadog-core @DataDog/lang-platform-js
 /packages/datadog-shimmer @DataDog/lang-platform-js
-/packages/dd-trace/*/crashtracking @DataDog/profiling-runtime
+/packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -277,16 +277,15 @@
 /integration-tests/coverage-fixtures/parent.js @DataDog/lang-platform-js
 /integration-tests/coverage-fixtures/worker.js @DataDog/lang-platform-js
 /integration-tests/coverage-manual-process.spec.js @DataDog/lang-platform-js
-/integration-tests/crashtracking @DataDog/libdatadog
+/integration-tests/crashtracking @DataDog/profiling-runtime
 /integration-tests/init.spec.js @DataDog/lang-platform-js
 /integration-tests/package-guardrails.spec.js @DataDog/lang-platform-js
 /integration-tests/package-guardrails/flush.js @DataDog/lang-platform-js
 /integration-tests/startup.spec.js @DataDog/lang-platform-js
 
-
 /packages/datadog-core @DataDog/lang-platform-js
 /packages/datadog-shimmer @DataDog/lang-platform-js
-/packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
+/packages/dd-trace/*/crashtracking @DataDog/profiling-runtime
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -277,15 +277,16 @@
 /integration-tests/coverage-fixtures/parent.js @DataDog/lang-platform-js
 /integration-tests/coverage-fixtures/worker.js @DataDog/lang-platform-js
 /integration-tests/coverage-manual-process.spec.js @DataDog/lang-platform-js
+/integration-tests/crashtracking @DataDog/libdatadog
 /integration-tests/init.spec.js @DataDog/lang-platform-js
 /integration-tests/package-guardrails.spec.js @DataDog/lang-platform-js
 /integration-tests/package-guardrails/flush.js @DataDog/lang-platform-js
 /integration-tests/startup.spec.js @DataDog/lang-platform-js
 
+
 /packages/datadog-core @DataDog/lang-platform-js
 /packages/datadog-shimmer @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
-/integration-tests/crashtracking @DataDog/libdatadog
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -285,6 +285,7 @@
 /packages/datadog-core @DataDog/lang-platform-js
 /packages/datadog-shimmer @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
+/integration-tests/crashtracking @DataDog/libdatadog
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -143,6 +143,31 @@ jobs:
         with:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
+  crashtracking:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [oldest, maintenance, active, latest]
+    name: ${{ github.workflow }} / crashtracking (node-${{ matrix.version }})
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
+      - uses: ./.github/actions/install
+      # Disable core dumps since crashtracking tests intentionally abort
+      - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
+      - run: yarn test:integration:crashtracking
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+
   unit-guardrails:
     runs-on: ubuntu-latest
     permissions:

--- a/integration-tests/crashtracking/crashtracking.spec.js
+++ b/integration-tests/crashtracking/crashtracking.spec.js
@@ -159,8 +159,8 @@ describeNotWindows('crashtracking integration', () => {
         throwFrame.file.includes('uncaught-exception.js'),
         `expected top frame to be uncaught-exception.js, got: ${JSON.stringify(throwFrame)}`
       )
-      assert.ok(throwFrame.line === 7, 'expected line number in top frame (in signal-crash.js)')
-      assert.ok(throwFrame.column === 7, 'expected column number in top frame (in signal-crash.js)')
+      assert.strictEqual(throwFrame.line, 7, 'expected line number in top frame (in signal-crash.js)')
+      assert.strictEqual(throwFrame.column, 7, 'expected column number in top frame (in signal-crash.js)')
     })
   })
 })

--- a/integration-tests/crashtracking/crashtracking.spec.js
+++ b/integration-tests/crashtracking/crashtracking.spec.js
@@ -17,7 +17,7 @@ const describeNotWindows = os.platform() !== 'win32' ? describe : describe.skip
  *
  * @param {string} fixture
  * @param {number} agentPort
- * @returns {{ proc: ChildProcess, exitPromise: Promise<void> }}
+ * @returns {Promise<void>}
  */
 function spawnCrashFixture (fixture, agentPort) {
   const proc = fork(path.join(__dirname, fixture), [], {
@@ -29,11 +29,9 @@ function spawnCrashFixture (fixture, agentPort) {
     },
   })
 
-  const exitPromise = new Promise((resolve) => {
-    proc.once('exit', (code, signal) => resolve({ code, signal }))
+  return new Promise((resolve) => {
+    proc.once('exit', resolve)
   })
-
-  return { proc, exitPromise }
 }
 
 /**
@@ -109,7 +107,7 @@ describeNotWindows('crashtracking integration', () => {
   describe('unix signal crash', () => {
     it('sends a crash report and a ping with a native stack to the telemetry endpoint', async () => {
       const logsPromise = collectCrashLogs(agent)
-      const { exitPromise } = spawnCrashFixture('signal-crash.js', agent.port)
+      const exitPromise = spawnCrashFixture('signal-crash.js', agent.port)
 
       const [{ ping, report }] = await Promise.all([logsPromise, exitPromise])
 
@@ -138,7 +136,7 @@ describeNotWindows('crashtracking integration', () => {
   describe('uncaught exception', () => {
     it('sends a crash report and a ping with a JS stack to the telemetry endpoint', async () => {
       const logsPromise = collectCrashLogs(agent)
-      const { exitPromise } = spawnCrashFixture('uncaught-exception.js', agent.port)
+      const exitPromise = spawnCrashFixture('uncaught-exception.js', agent.port)
 
       const [{ ping, report }] = await Promise.all([logsPromise, exitPromise])
 
@@ -161,8 +159,8 @@ describeNotWindows('crashtracking integration', () => {
         throwFrame.file.includes('uncaught-exception.js'),
         `expected top frame to be uncaught-exception.js, got: ${JSON.stringify(throwFrame)}`
       )
-      assert.ok(typeof throwFrame.line === 'number', 'expected line number in top frame')
-      assert.ok(typeof throwFrame.column === 'number', 'expected column number in top frame')
+      assert.ok(throwFrame.line === 7, 'expected line number in top frame (in signal-crash.js)')
+      assert.ok(throwFrame.column === 7, 'expected column number in top frame (in signal-crash.js)')
     })
   })
 })

--- a/integration-tests/crashtracking/crashtracking.spec.js
+++ b/integration-tests/crashtracking/crashtracking.spec.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { fork } = require('node:child_process')
+const os = require('node:os')
+const path = require('node:path')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+
+const { FakeAgent } = require('../helpers')
+
+const describeNotWindows = os.platform() !== 'win32' ? describe : describe.skip
+
+/**
+ * Spawn a fixture process that will crash. We don't use spawnProc here because it rejects when the
+ * child exits with a non-zero code or a signal, but the crashing processes are expected to do that
+ *
+ * @param {string} fixture
+ * @param {number} agentPort
+ * @returns {{ proc: ChildProcess, exitPromise: Promise<void> }}
+ */
+function spawnCrashFixture (fixture, agentPort) {
+  const proc = fork(path.join(__dirname, fixture), [], {
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      DD_TRACE_AGENT_PORT: String(agentPort),
+      DD_TRACE_STARTUP_LOGS: 'false',
+    },
+  })
+
+  const exitPromise = new Promise((resolve) => {
+    proc.once('exit', (code, signal) => resolve({ code, signal }))
+  })
+
+  return { proc, exitPromise }
+}
+
+/**
+ * Subscribe to crash telemetry on the fake agent and return a promise that resolves once both
+ * the ping (DEBUG) and the full report (ERROR) have arrived.
+ *
+ * We need to
+ *  - start the crashing program
+ *  - attach a listener to the fake agent to collect incoming telemetry
+ * This can be a source of a race and made the test flaky because the program could
+ * crash and emit telemetry before the listener attaches
+ *
+ * So, we register the listener synchronously before starting the crashing program.
+ * @param {FakeAgent} agent
+ * @param {number} [timeout]
+ * @returns {Promise<{ping: object, report: object}>}
+ */
+function collectCrashLogs (agent, timeout = 10_000) {
+  let ping
+  let report
+
+  return new Promise((resolve, reject) => {
+    const onTelemetry = ({ payload }) => {
+      if (payload.request_type !== 'logs') return
+
+      for (const log of payload.payload.logs) {
+        let msg
+        try {
+          msg = JSON.parse(log.message)
+        } catch {
+          continue
+        }
+
+        if (log.level === 'DEBUG') {
+          ping = msg
+        } else if (log.level === 'ERROR') {
+          report = msg
+        }
+
+        if (ping && report) {
+          cleanup()
+          resolve({ ping, report })
+          return
+        }
+      }
+    }
+
+    const timer = setTimeout(() => {
+      cleanup()
+      reject(new Error('Timeout waiting for crash telemetry'))
+    }, timeout)
+
+    function cleanup () {
+      clearTimeout(timer)
+      agent.removeListener('telemetry', onTelemetry)
+    }
+
+    agent.on('telemetry', onTelemetry)
+  })
+}
+
+describeNotWindows('crashtracking integration', () => {
+  let agent
+
+  beforeEach(async () => {
+    agent = await new FakeAgent().start()
+  })
+
+  afterEach(async () => {
+    await agent.stop()
+  })
+
+  describe('unix signal crash', () => {
+    it('sends a crash report and a ping with a native stack to the telemetry endpoint', async () => {
+      const logsPromise = collectCrashLogs(agent)
+      const { exitPromise } = spawnCrashFixture('signal-crash.js', agent.port)
+
+      const [{ ping, report }] = await Promise.all([logsPromise, exitPromise])
+
+      // Ping
+      assert.strictEqual(ping.kind, 'UnixSignal')
+      assert.ok(ping.message.includes('SIGABRT'))
+
+      // Full report
+      assert.strictEqual(report.error.kind, 'UnixSignal')
+      assert.ok(report.error.message.includes('SIGABRT'))
+      assert.strictEqual(report.error.source_type, 'Crashtracking')
+
+      // Stack frames
+      const { frames } = report.error.stack
+      assert.ok(frames.length > 0, 'expected at least one stack frame')
+
+      // The crashing frame is the call to kill at the top.
+      const topFrame = frames[0]
+      assert.ok(
+        topFrame.function && topFrame.function.toLowerCase().includes('kill'),
+        `expected top frame to be the kill syscall, got: ${JSON.stringify(topFrame)}`
+      )
+    })
+  })
+
+  describe('uncaught exception', () => {
+    it('sends a crash report and a ping with a JS stack to the telemetry endpoint', async () => {
+      const logsPromise = collectCrashLogs(agent)
+      const { exitPromise } = spawnCrashFixture('uncaught-exception.js', agent.port)
+
+      const [{ ping, report }] = await Promise.all([logsPromise, exitPromise])
+
+      // Ping
+      assert.strictEqual(ping.kind, 'UnhandledException')
+
+      // Full report
+      assert.strictEqual(report.error.kind, 'UnhandledException')
+      assert.ok(report.error.message.includes('TypeError'))
+      assert.ok(report.error.message.includes('integration test uncaught exception'))
+      assert.strictEqual(report.error.source_type, 'Crashtracking')
+
+      // Stack frames JS frames carry file/line/column/function
+      const { frames } = report.error.stack
+      assert.ok(frames.length > 0, 'expected at least one stack frame')
+
+      // The top frame is the throw site of the error in uncaught-exception.js
+      const throwFrame = frames[0]
+      assert.ok(
+        throwFrame.file.includes('uncaught-exception.js'),
+        `expected top frame to be uncaught-exception.js, got: ${JSON.stringify(throwFrame)}`
+      )
+      assert.ok(typeof throwFrame.line === 'number', 'expected line number in top frame')
+      assert.ok(typeof throwFrame.column === 'number', 'expected column number in top frame')
+    })
+  })
+})

--- a/integration-tests/crashtracking/signal-crash.js
+++ b/integration-tests/crashtracking/signal-crash.js
@@ -1,0 +1,7 @@
+'use strict'
+
+require('../../packages/dd-trace').init({
+  crashtracking: { enabled: true },
+})
+
+process.kill(process.pid, 'SIGABRT')

--- a/integration-tests/crashtracking/uncaught-exception.js
+++ b/integration-tests/crashtracking/uncaught-exception.js
@@ -1,0 +1,7 @@
+'use strict'
+
+require('../../packages/dd-trace').init({
+  crashtracking: { enabled: true },
+})
+
+throw new TypeError('integration test uncaught exception')

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "test:integration:aiguard:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/aiguard/*.spec.js\"",
     "test:integration:appsec": "mocha --timeout 60000 \"integration-tests/appsec/*.spec.js\"",
     "test:integration:appsec:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/appsec/*.spec.js\"",
+    "test:integration:crashtracking": "mocha --timeout 60000 \"integration-tests/crashtracking/*.spec.js\"",
     "test:integration:bun": "mocha --timeout 60000 \"integration-tests/bun/*.spec.js\"",
     "test:integration:cucumber": "mocha --timeout 60000 \"integration-tests/cucumber/*.spec.js\"",
     "test:integration:cucumber:coverage": "node ./integration-tests/coverage/run-suite.js --timeout 60000 \"integration-tests/cucumber/*.spec.js\"",

--- a/packages/dd-trace/src/crashtracking/crashtracker.js
+++ b/packages/dd-trace/src/crashtracking/crashtracker.js
@@ -70,7 +70,7 @@ class Crashtracker {
   #getConfig (config) {
     const url = getAgentUrl(config)
 
-    // Out-of-process symbolication currently (crashtracker 27.0.0) works on
+    // Out-of-process symbolication currently works on
     // Linux only, does not work on Mac.
     const resolveMode = require('os').platform === 'linux'
       ? 'EnabledWithSymbolsInReceiver'


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
This PR adds simple e2e integration testing for the node js crashtracker. Our current unit tests test that the libdatadog API is correctly called with stubs, but never validate the whole flow from crash -> report emission. Since we already have harnesses such as `TestAgent`, why not add this now? :)


### Motivation
Our integration testing only stubs

### Additional Notes
The whole thing I am doing to avoid flaky tests when attaching a listener on the FakeAgent to listen to telemetry from the crashing program is agent generated

