### PR TITLE
ci: refresh Node patch versions on cross-window cache restores

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -24,7 +24,7 @@ runs:
 
     # Cache a tiny file containing the exact Node.js version resolved by a previous run.
     # Key rotates every 20 minutes (epoch / 1200) so patches are picked up regularly.
-    # On cache hit, we pass the exact version to setup-node and skip the HTTP manifest lookup.
+    # On cache hit, install the cached patch and skip the manifest lookup.
     - name: Compute cache key
       id: cache-key
       shell: bash
@@ -34,7 +34,6 @@ runs:
       with:
         path: /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
         key: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-${{ steps.cache-key.outputs.block }}
-        restore-keys: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-
     - name: Read cached version
       id: cached
       shell: bash
@@ -45,9 +44,9 @@ runs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        # Use the exact cached version when available, otherwise fall back to the requested version.
+        # Cache hit installs the cached patch directly. Otherwise pass the major; the cached
+        # patch is a semver-exact spec, so check-latest would not upgrade it.
         node-version: ${{ steps.cached.outputs.version || steps.node-version.outputs.version }}
-        # Resolve the latest patch on master when no cached version exists.
         check-latest: ${{ steps.cached.outputs.version == '' }}
         registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}
 


### PR DESCRIPTION
This fixes a stale-patch loop where the Node setup action's 20-minute key rotation was a no-op. 24.15.0 and 22.22.1 took ~2 weeks to land in CI after release.

Two bugs interact. The cache step's restore-keys omits the time block, so every cross-window run partial-matches the previous cache and restores the prior resolved patch. The setup-node step then keys check-latest off file existence rather than cache-hit, so it passes the cached patch with check-latest=true. Because semver matches an exact spec only against itself, check-latest never upgrades 24.14.0 to 24.15.0; the save step re-pins the stale value under the new key. New patches only land when the cache is fully evicted.

Pass the major (not the cached patch) whenever the cache misses exactly, and gate that on cache-hit. Exact hits within a 20-minute window still install the cached patch and skip the manifest lookup; cross-window runs go through the manifest, and the save step captures the upgraded patch under the new key.
