### PR TITLE
minimize requests for all green script and retry faster

### DIFF
--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -18,7 +18,6 @@ const owner = 'DataDog'
 const repo = 'dd-trace-js'
 const ref = context.payload.pull_request?.head.sha || GITHUB_SHA
 const params = { owner, repo, ref }
-const isPullRequest = Boolean(context.payload.pull_request)
 
 const conclusionEmojis = {
   action_required: '🔶',
@@ -156,13 +155,6 @@ function bySeverity (a, b) {
 }
 
 async function printSummary () {
-  await (isPullRequest ? printWorkflowSummary() : printJobSummary())
-}
-
-async function printWorkflowSummary () {
-  // PRs get a workflow-level summary: one row per workflow run, with a link
-  // back to the run page. This is much smaller than the per-job table and
-  // avoids the paginated check-runs fetch entirely.
   const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
     owner,
     repo,
@@ -183,6 +175,8 @@ async function printWorkflowSummary () {
       url: run.html_url,
     }))
 
+  // console.table can't render HTML, so the raw URL goes here as its own
+  // column. The GitHub Actions summary below renders the name as a link.
   console.table(runs)
 
   const header = [
@@ -203,56 +197,6 @@ async function printWorkflowSummary () {
 
   await summary
     .addHeading('Workflows Summary')
-    .addTable([header, ...body])
-    .write()
-}
-
-async function printJobSummary () {
-  const checkRuns = await octokit.paginate(
-    'GET /repos/:owner/:repo/commits/:ref/check-runs',
-    { ...params, app_id: githubActionsAppId, per_page: 100 }
-  )
-
-  // When a check is re-run, older runs remain with their original conclusions.
-  // Deduplicate by name and evaluate only the latest run for each check.
-  const latestByName = new Map()
-  for (const run of checkRuns) {
-    const existing = latestByName.get(run.name)
-    if (!existing || new Date(run.started_at) >= new Date(existing.started_at)) {
-      latestByName.set(run.name, run)
-    }
-  }
-
-  const runs = [...latestByName.values()]
-    .sort(bySeverity)
-    .map(run => ({
-      name: run.name,
-      status: run.status,
-      conclusion: formatConclusion(run.conclusion),
-      started_at: run.started_at,
-      completed_at: run.completed_at ?? ' ',
-    }))
-
-  console.table(runs)
-
-  const header = [
-    { data: 'name', header: true },
-    { data: 'status', header: true },
-    { data: 'conclusion', header: true },
-    { data: 'started_at', header: true },
-    { data: 'completed_at', header: true },
-  ]
-
-  const body = runs.map(run => [
-    run.name,
-    run.status,
-    run.conclusion,
-    run.started_at,
-    run.completed_at,
-  ])
-
-  await summary
-    .addHeading('Checks Summary')
     .addTable([header, ...body])
     .write()
 }

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -116,7 +116,9 @@ async function checkAllGreen () {
     suites = await pollUntilDone()
   } catch (err) {
     await printSummary()
-    throw err
+    console.log(err)
+    process.exitCode = 1
+    return
   }
 
   const anyFailed = suites.some(s => failureConclusions.has(s.conclusion))
@@ -143,7 +145,8 @@ async function checkAllGreen () {
   }
 
   await printSummary()
-  throw new Error('One or more jobs failed.')
+  console.log('One or more jobs failed.')
+  process.exitCode = 1
 }
 
 function formatConclusion (conclusion) {

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -13,13 +13,13 @@ const {
   RETRIES,
 } = process.env
 
-const maxRerunFailedJobs = 3
-
 const octokit = new Octokit({ auth: GITHUB_TOKEN })
 const owner = 'DataDog'
 const repo = 'dd-trace-js'
 const ref = context.payload.pull_request?.head.sha || GITHUB_SHA
 const params = { owner, repo, ref }
+const isPullRequest = Boolean(context.payload.pull_request)
+
 const conclusionEmojis = {
   action_required: '🔶',
   cancelled: '🚫',
@@ -42,64 +42,117 @@ const conclusionSeverity = {
   success: 7,
 }
 
+const failureConclusions = new Set(['failure', 'timed_out'])
+
 let retries = 0
 let hasRerun = false
 
-// Cache of {etag, totalCount} per check status. GitHub returns 304 Not Modified
-// for unchanged responses when If-None-Match matches, and those don't count
-// against the rate limit.
-const checkCountCache = new Map()
+// ETag cache for the check-suite poll. GitHub returns 304 Not Modified when
+// the response is unchanged, and 304 responses don't count against the rate
+// limit.
+let suitesCache
 
-async function getCheckCount (status) {
-  const cached = checkCountCache.get(status)
+async function getActiveSuites () {
   try {
-    const { data, headers } = await octokit.rest.checks.listForRef({
+    const { data, headers } = await octokit.rest.checks.listSuitesForRef({
       ...params,
-      per_page: 1, // Minimum is 1 but we don't need any pages.
-      status,
-      headers: cached ? { 'if-none-match': cached.etag } : {},
+      per_page: 100,
+      headers: suitesCache ? { 'if-none-match': suitesCache.etag } : {},
     })
-    checkCountCache.set(status, { etag: headers.etag, totalCount: data.total_count })
-    return data.total_count
+    // Drop ghost suites: apps installed on the repo that produced no runs for
+    // this commit. They never reach 'completed' and would hang the loop.
+    const suites = data.check_suites.filter(s => s.latest_check_runs_count > 0)
+    suitesCache = { etag: headers.etag, suites }
+    return suites
   } catch (err) {
-    if (err.status === 304 && cached) return cached.totalCount
+    if (err.status === 304 && suitesCache) return suitesCache.suites
     throw err
   }
 }
 
-async function hasCompleted () {
-  // If there are any in progress runs it means we're not ready to check
-  // statuses. We will always have minimum 1 for the All Green job.
-  if (await getCheckCount('in_progress') > 1) return false
+async function pollUntilDone () {
+  const suites = await getActiveSuites()
+  // The All Green workflow is itself a suite that stays non-completed while
+  // this script runs, so we treat completion as "at most one pending suite".
+  const pending = suites.filter(s => s.status !== 'completed').length
+  if (pending <= 1) return suites
 
-  // Same as above, but jobs that are queued are not even in progress yet.
-  if (await getCheckCount('queued') > 0) return false
+  retries++
 
-  return true
-}
-
-async function checkCompleted () {
-  if (!await hasCompleted()) {
-    retries++
-
-    if (RETRIES && retries > RETRIES) {
-      throw new Error(`State is still pending after ${RETRIES} retries.`)
-    }
-
-    console.log(`Status is still pending, waiting for ${POLLING_INTERVAL} minutes before retrying.`)
-    await setTimeout(POLLING_INTERVAL * 60_000)
-    console.log('Retrying.')
-    await checkCompleted()
+  if (RETRIES && retries > RETRIES) {
+    throw new Error(`State is still pending after ${RETRIES} retries.`)
   }
+
+  console.log(`Status is still pending, waiting for ${POLLING_INTERVAL} minutes before retrying.`)
+  await setTimeout(POLLING_INTERVAL * 60_000)
+  console.log('Retrying.')
+  return pollUntilDone()
 }
 
-async function getLatestRuns () {
+async function getFailedWorkflowRuns () {
+  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    head_sha: ref,
+    per_page: 100,
+  })
+  return data.workflow_runs.filter(r => failureConclusions.has(r.conclusion))
+}
+
+async function rerunFailedWorkflows (workflowRuns) {
+  await Promise.all(
+    workflowRuns.map(workflowRun => {
+      console.log(`Rerunning failed jobs for workflow run ${workflowRun.id} (${workflowRun.name}).`)
+      return octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
+    })
+  )
+}
+
+async function checkAllGreen () {
+  let suites
+  try {
+    suites = await pollUntilDone()
+  } catch (err) {
+    await printSummary()
+    throw err
+  }
+
+  const anyFailed = suites.some(s => failureConclusions.has(s.conclusion))
+
+  if (!anyFailed) {
+    await printSummary()
+    console.log('All jobs were successful.')
+    return
+  }
+
+  if (!hasRerun) {
+    hasRerun = true
+    const failedRuns = await getFailedWorkflowRuns()
+    if (failedRuns.length > 0) {
+      console.log(`${failedRuns.length} workflow run(s) failed. Rerunning failed jobs...`)
+      await rerunFailedWorkflows(failedRuns)
+      retries = 0
+      suitesCache = undefined
+      console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling for rerun results.`)
+      await setTimeout(POLLING_INTERVAL * 60_000)
+      await checkAllGreen()
+      return
+    }
+  }
+
+  await printSummary()
+  throw new Error('One or more jobs failed.')
+}
+
+async function printSummary () {
+  // The summary is only useful for master pushes / scheduled runs, where it
+  // surfaces in the workflow run page. PRs already have GitHub's own checks
+  // UI, so we skip the paginated check-runs fetch entirely.
+  if (isPullRequest) return
+
   const checkRuns = await octokit.paginate(
     'GET /repos/:owner/:repo/commits/:ref/check-runs',
-    {
-      ...params,
-      per_page: 100,
-    }
+    { ...params, per_page: 100 }
   )
 
   // When a check is re-run, older runs remain with their original conclusions.
@@ -112,88 +165,7 @@ async function getLatestRuns () {
     }
   }
 
-  return [...latestByName.values()]
-}
-
-async function rerunFailedWorkflows (failedRuns) {
-  const failedCountByCheckSuiteId = new Map()
-  for (const run of failedRuns) {
-    const id = run.check_suite?.id
-    if (id !== undefined) {
-      failedCountByCheckSuiteId.set(id, (failedCountByCheckSuiteId.get(id) ?? 0) + 1)
-    }
-  }
-
-  const eligibleSuiteIds = [...failedCountByCheckSuiteId.entries()]
-    .filter(([, count]) => count <= maxRerunFailedJobs)
-    .map(([id]) => id)
-
-  // If a workflow has many jobs failed, it's unlikely to be flakiness to no
-  // point in re-running.
-  if (eligibleSuiteIds.length < failedCountByCheckSuiteId.size) {
-    console.log(
-      `Skipping rerun for ${failedCountByCheckSuiteId.size - eligibleSuiteIds.length} workflow(s) ` +
-      `with more than ${maxRerunFailedJobs} failed job(s).`
-    )
-  }
-
-  const workflowRunsPerSuite = await Promise.all(
-    eligibleSuiteIds.map(checkSuiteId =>
-      octokit.rest.actions.listWorkflowRunsForRepo({ owner, repo, check_suite_id: checkSuiteId })
-        .then(({ data }) => data.workflow_runs)
-    )
-  )
-
-  const workflowRuns = workflowRunsPerSuite.flat()
-
-  await Promise.all(
-    workflowRuns.map(workflowRun => {
-      console.log(`Rerunning failed jobs for workflow run ${workflowRun.id} (${workflowRun.name}).`)
-      return octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
-    })
-  )
-
-  return workflowRuns.length > 0
-}
-
-async function checkAllGreen () {
-  let latestRuns
-
-  try {
-    await checkCompleted()
-  } finally {
-    latestRuns = await getLatestRuns()
-  }
-
-  const failedRuns = latestRuns.filter(run =>
-    run.conclusion === 'failure' || run.conclusion === 'timed_out'
-  )
-
-  if (failedRuns.length === 0) {
-    await printSummary(latestRuns)
-    console.log('All jobs were successful.')
-    return
-  }
-
-  if (!hasRerun) {
-    hasRerun = true
-    console.log(`${failedRuns.length} job(s) failed. Rerunning failed workflows...`)
-    const didRerun = await rerunFailedWorkflows(failedRuns)
-    if (didRerun) {
-      retries = 0
-      console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling for rerun results.`)
-      await setTimeout(POLLING_INTERVAL * 60_000)
-      await checkAllGreen()
-      return
-    }
-  }
-
-  await printSummary(latestRuns)
-  throw new Error('One or more jobs failed.')
-}
-
-async function printSummary (checkRuns) {
-  const runs = [...checkRuns]
+  const runs = [...latestByName.values()]
     .sort((a, b) => (conclusionSeverity[a.conclusion] ?? 8) - (conclusionSeverity[b.conclusion] ?? 8))
     .map(run => ({
       name: run.name,

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -166,6 +166,9 @@ async function printSummary () {
   })
 
   const runs = data.workflow_runs
+    // Hide the All Green workflow itself: it's always in flight while we're
+    // generating the summary, so the row is noise.
+    .filter(run => run.name !== context.workflow)
     .sort(bySeverity)
     .map(run => ({
       name: run.name,

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -44,6 +44,11 @@ const conclusionSeverity = {
 
 const failureConclusions = new Set(['failure', 'timed_out'])
 
+// GitHub Actions app id. Filtering server-side keeps us to a single page even
+// though the unfiltered endpoint returns ~130 suites for this repo (most are
+// ghost suites from internal apps installed on the org).
+const githubActionsAppId = 15_368
+
 let retries = 0
 let hasRerun = false
 
@@ -56,14 +61,12 @@ async function getActiveSuites () {
   try {
     const { data, headers } = await octokit.rest.checks.listSuitesForRef({
       ...params,
+      app_id: githubActionsAppId,
       per_page: 100,
       headers: suitesCache ? { 'if-none-match': suitesCache.etag } : {},
     })
-    // Drop ghost suites: apps installed on the repo that produced no runs for
-    // this commit. They never reach 'completed' and would hang the loop.
-    const suites = data.check_suites.filter(s => s.latest_check_runs_count > 0)
-    suitesCache = { etag: headers.etag, suites }
-    return suites
+    suitesCache = { etag: headers.etag, suites: data.check_suites }
+    return data.check_suites
   } catch (err) {
     if (err.status === 304 && suitesCache) return suitesCache.suites
     throw err

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -162,7 +162,7 @@ async function printSummary (runs) {
       // workflow_run has no completed_at; updated_at reflects the final state
       // change once status === 'completed', otherwise it's an in-flight tick.
       started_at: run.run_started_at,
-      doned_at: run.status === 'completed' ? run.updated_at : ' ',
+      completed_at: run.status === 'completed' ? run.updated_at : ' ',
       url: run.html_url,
     }))
 
@@ -175,7 +175,7 @@ async function printSummary (runs) {
     { data: 'status', header: true },
     { data: 'conclusion', header: true },
     { data: 'started_at', header: true },
-    { data: 'doned_at', header: true },
+    { data: 'completed_at', header: true },
   ]
 
   const body = rows.map(row => [
@@ -183,7 +183,7 @@ async function printSummary (runs) {
     row.status,
     row.conclusion,
     row.started_at,
-    row.doned_at,
+    row.completed_at,
   ])
 
   await summary

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -43,7 +43,7 @@ const conclusionSeverity = {
 const failureConclusions = new Set(['failure', 'timed_out'])
 
 let retries = 0
-let hasRerun = false
+const retriedRunIds = new Set()
 
 // ETag cache for the workflow-runs poll. GitHub returns 304 Not Modified when
 // the response is unchanged, and 304 responses don't count against the rate
@@ -88,8 +88,21 @@ async function getRuns () {
 
 async function pollUntilDone () {
   const runs = await getRuns()
+
+  const toRetry = runs.filter(r =>
+    r.status === 'completed' &&
+    failureConclusions.has(r.conclusion) &&
+    !retriedRunIds.has(r.id)
+  )
+
+  if (toRetry.length > 0) {
+    await rerunFailedWorkflows(toRetry)
+    for (const run of toRetry) retriedRunIds.add(run.id)
+    runsCache = undefined
+  }
+
   const pending = runs.filter(r => r.status !== 'completed').length
-  if (pending === 0) return { runs, done: true }
+  if (pending === 0 && toRetry.length === 0) return { runs, done: true }
 
   retries++
 
@@ -113,8 +126,9 @@ async function rerunFailedWorkflows (workflowRuns) {
 async function checkAllGreen () {
   const { runs, done } = await pollUntilDone()
 
+  await printSummary(runs)
+
   if (!done) {
-    await printSummary(runs)
     console.log(`State is still pending after ${RETRIES} retries.`)
     process.exitCode = 1
     return
@@ -123,26 +137,11 @@ async function checkAllGreen () {
   const failedRuns = runs.filter(r => failureConclusions.has(r.conclusion))
 
   if (failedRuns.length === 0) {
-    await printSummary(runs)
     console.log('All jobs were successful.')
-    return
+  } else {
+    console.log('One or more jobs failed.')
+    process.exitCode = 1
   }
-
-  if (!hasRerun) {
-    hasRerun = true
-    console.log(`${failedRuns.length} workflow run(s) failed. Rerunning failed jobs...`)
-    await rerunFailedWorkflows(failedRuns)
-    retries = 0
-    runsCache = undefined
-    console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling for rerun results.`)
-    await setTimeout(POLLING_INTERVAL * 60_000)
-    await checkAllGreen()
-    return
-  }
-
-  await printSummary(runs)
-  console.log('One or more jobs failed.')
-  process.exitCode = 1
 }
 
 function formatConclusion (conclusion) {
@@ -160,8 +159,8 @@ async function printSummary (runs) {
       name: run.name,
       status: run.status,
       conclusion: formatConclusion(run.conclusion),
-      // workflow_run has no doned_at; updated_at reflects the final state
-      // change once status === 'doned', otherwise it's an in-flight tick.
+      // workflow_run has no completed_at; updated_at reflects the final state
+      // change once status === 'completed', otherwise it's an in-flight tick.
       started_at: run.run_started_at,
       doned_at: run.status === 'completed' ? run.updated_at : ' ',
       url: run.html_url,

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -45,25 +45,35 @@ const conclusionSeverity = {
 let retries = 0
 let hasRerun = false
 
-async function hasCompleted () {
-  const { data: inProgressRuns } = await octokit.rest.checks.listForRef({
-    ...params,
-    per_page: 1, // Minimum is 1 but we don't need any pages.
-    status: 'in_progress',
-  })
+// Cache of {etag, totalCount} per check status. GitHub returns 304 Not Modified
+// for unchanged responses when If-None-Match matches, and those don't count
+// against the rate limit.
+const checkCountCache = new Map()
 
+async function getCheckCount (status) {
+  const cached = checkCountCache.get(status)
+  try {
+    const { data, headers } = await octokit.rest.checks.listForRef({
+      ...params,
+      per_page: 1, // Minimum is 1 but we don't need any pages.
+      status,
+      headers: cached ? { 'if-none-match': cached.etag } : {},
+    })
+    checkCountCache.set(status, { etag: headers.etag, totalCount: data.total_count })
+    return data.total_count
+  } catch (err) {
+    if (err.status === 304 && cached) return cached.totalCount
+    throw err
+  }
+}
+
+async function hasCompleted () {
   // If there are any in progress runs it means we're not ready to check
   // statuses. We will always have minimum 1 for the All Green job.
-  if (inProgressRuns.total_count > 1) return false
-
-  const { data: queuedRuns } = await octokit.rest.checks.listForRef({
-    ...params,
-    per_page: 1, // Minimum is 1 but we don't need any pages.
-    status: 'queued',
-  })
+  if (await getCheckCount('in_progress') > 1) return false
 
   // Same as above, but jobs that are queued are not even in progress yet.
-  if (queuedRuns.total_count > 0) return false
+  if (await getCheckCount('queued') > 0) return false
 
   return true
 }

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -17,7 +17,6 @@ const octokit = new Octokit({ auth: GITHUB_TOKEN })
 const owner = 'DataDog'
 const repo = 'dd-trace-js'
 const ref = context.payload.pull_request?.head.sha || GITHUB_SHA
-const params = { owner, repo, ref }
 
 const conclusionEmojis = {
   action_required: '🔶',
@@ -43,62 +42,63 @@ const conclusionSeverity = {
 
 const failureConclusions = new Set(['failure', 'timed_out'])
 
-// GitHub Actions app id. Filtering server-side keeps us to a single page even
-// though the unfiltered endpoint returns ~130 suites for this repo (most are
-// ghost suites from internal apps installed on the org).
-const githubActionsAppId = 15_368
-
 let retries = 0
 let hasRerun = false
 
-// ETag cache for the check-suite poll. GitHub returns 304 Not Modified when
+// ETag cache for the workflow-runs poll. GitHub returns 304 Not Modified when
 // the response is unchanged, and 304 responses don't count against the rate
-// limit.
-let suitesCache
+// limit. workflow_runs are sorted newest first, so an unchanged first page is
+// a reliable proxy for "no changes since last poll".
+let runsCache
 
-async function getActiveSuites () {
+async function getRuns () {
   try {
-    const { data, headers } = await octokit.rest.checks.listSuitesForRef({
-      ...params,
-      app_id: githubActionsAppId,
-      per_page: 100,
-      headers: suitesCache ? { 'if-none-match': suitesCache.etag } : {},
-    })
-    suitesCache = { etag: headers.etag, suites: data.check_suites }
-    return data.check_suites
+    const allRuns = []
+    let etag
+    for await (const { data, headers } of octokit.paginate.iterator(
+      octokit.rest.actions.listWorkflowRunsForRepo,
+      {
+        owner,
+        repo,
+        head_sha: ref,
+        per_page: 100,
+        headers: runsCache ? { 'if-none-match': runsCache.etag } : {},
+      }
+    )) {
+      etag ??= headers.etag
+      allRuns.push(...data.workflow_runs)
+    }
+    // Isolate per trigger so a parallel all-green run on the same SHA doesn't
+    // see our runs (and we don't see theirs). Filter by event, by PR number
+    // when on a PR (handles two PRs sharing the same head commit), and drop
+    // our own All Green run since it stays in_progress while we poll.
+    const myPR = context.payload.pull_request?.number
+    const filtered = allRuns.filter(r =>
+      r.name !== context.workflow &&
+      r.event === context.eventName &&
+      (myPR == null || r.pull_requests?.some(pr => pr.number === myPR))
+    )
+    runsCache = { etag, runs: filtered }
+    return filtered
   } catch (err) {
-    if (err.status === 304 && suitesCache) return suitesCache.suites
+    if (err.status === 304 && runsCache) return runsCache.runs
     throw err
   }
 }
 
 async function pollUntilDone () {
-  const suites = await getActiveSuites()
-  // The All Green workflow is itself a suite that stays non-completed while
-  // this script runs, so we treat completion as "at most one pending suite".
-  const pending = suites.filter(s => s.status !== 'completed').length
-  if (pending <= 1) return suites
+  const runs = await getRuns()
+  const pending = runs.filter(r => r.status !== 'doned').length
+  if (pending === 0) return { runs, done: true }
 
   retries++
 
-  if (RETRIES && retries > RETRIES) {
-    throw new Error(`State is still pending after ${RETRIES} retries.`)
-  }
+  if (RETRIES && retries > RETRIES) return { runs, done: false }
 
   console.log(`Status is still pending, waiting for ${POLLING_INTERVAL} minutes before retrying.`)
   await setTimeout(POLLING_INTERVAL * 60_000)
   console.log('Retrying.')
   return pollUntilDone()
-}
-
-async function getFailedWorkflowRuns () {
-  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
-    owner,
-    repo,
-    head_sha: ref,
-    per_page: 100,
-  })
-  return data.workflow_runs.filter(r => failureConclusions.has(r.conclusion))
 }
 
 async function rerunFailedWorkflows (workflowRuns) {
@@ -111,40 +111,36 @@ async function rerunFailedWorkflows (workflowRuns) {
 }
 
 async function checkAllGreen () {
-  let suites
-  try {
-    suites = await pollUntilDone()
-  } catch (err) {
-    await printSummary()
-    console.log(err)
+  const { runs, done } = await pollUntilDone()
+
+  if (!done) {
+    await printSummary(runs)
+    console.log(`State is still pending after ${RETRIES} retries.`)
     process.exitCode = 1
     return
   }
 
-  const anyFailed = suites.some(s => failureConclusions.has(s.conclusion))
+  const failedRuns = runs.filter(r => failureConclusions.has(r.conclusion))
 
-  if (!anyFailed) {
-    await printSummary()
+  if (failedRuns.length === 0) {
+    await printSummary(runs)
     console.log('All jobs were successful.')
     return
   }
 
   if (!hasRerun) {
     hasRerun = true
-    const failedRuns = await getFailedWorkflowRuns()
-    if (failedRuns.length > 0) {
-      console.log(`${failedRuns.length} workflow run(s) failed. Rerunning failed jobs...`)
-      await rerunFailedWorkflows(failedRuns)
-      retries = 0
-      suitesCache = undefined
-      console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling for rerun results.`)
-      await setTimeout(POLLING_INTERVAL * 60_000)
-      await checkAllGreen()
-      return
-    }
+    console.log(`${failedRuns.length} workflow run(s) failed. Rerunning failed jobs...`)
+    await rerunFailedWorkflows(failedRuns)
+    retries = 0
+    runsCache = undefined
+    console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling for rerun results.`)
+    await setTimeout(POLLING_INTERVAL * 60_000)
+    await checkAllGreen()
+    return
   }
 
-  await printSummary()
+  await printSummary(runs)
   console.log('One or more jobs failed.')
   process.exitCode = 1
 }
@@ -157,48 +153,38 @@ function bySeverity (a, b) {
   return (conclusionSeverity[a.conclusion] ?? 8) - (conclusionSeverity[b.conclusion] ?? 8)
 }
 
-async function printSummary () {
-  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
-    owner,
-    repo,
-    head_sha: ref,
-    per_page: 100,
-  })
-
-  const runs = data.workflow_runs
-    // Hide the All Green workflow itself: it's always in flight while we're
-    // generating the summary, so the row is noise.
-    .filter(run => run.name !== context.workflow)
+async function printSummary (runs) {
+  const rows = runs
     .sort(bySeverity)
     .map(run => ({
       name: run.name,
       status: run.status,
       conclusion: formatConclusion(run.conclusion),
-      // workflow_run has no completed_at; updated_at reflects the final state
-      // change once status === 'completed', otherwise it's an in-flight tick.
+      // workflow_run has no doned_at; updated_at reflects the final state
+      // change once status === 'doned', otherwise it's an in-flight tick.
       started_at: run.run_started_at,
-      completed_at: run.status === 'completed' ? run.updated_at : ' ',
+      doned_at: run.status === 'doned' ? run.updated_at : ' ',
       url: run.html_url,
     }))
 
   // console.table can't render HTML, so the raw URL goes here as its own
   // column. The GitHub Actions summary below renders the name as a link.
-  console.table(runs)
+  console.table(rows)
 
   const header = [
     { data: 'workflow', header: true },
     { data: 'status', header: true },
     { data: 'conclusion', header: true },
     { data: 'started_at', header: true },
-    { data: 'completed_at', header: true },
+    { data: 'doned_at', header: true },
   ]
 
-  const body = runs.map(run => [
-    `<a href="${run.url}">${run.name}</a>`,
-    run.status,
-    run.conclusion,
-    run.started_at,
-    run.completed_at,
+  const body = rows.map(row => [
+    `<a href="${row.url}">${row.name}</a>`,
+    row.status,
+    row.conclusion,
+    row.started_at,
+    row.doned_at,
   ])
 
   await summary

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -147,12 +147,67 @@ async function checkAllGreen () {
   throw new Error('One or more jobs failed.')
 }
 
-async function printSummary () {
-  // The summary is only useful for master pushes / scheduled runs, where it
-  // surfaces in the workflow run page. PRs already have GitHub's own checks
-  // UI, so we skip the paginated check-runs fetch entirely.
-  if (isPullRequest) return
+function formatConclusion (conclusion) {
+  return conclusion ? `${conclusion} ${conclusionEmojis[conclusion]}` : ' '
+}
 
+function bySeverity (a, b) {
+  return (conclusionSeverity[a.conclusion] ?? 8) - (conclusionSeverity[b.conclusion] ?? 8)
+}
+
+async function printSummary () {
+  await (isPullRequest ? printWorkflowSummary() : printJobSummary())
+}
+
+async function printWorkflowSummary () {
+  // PRs get a workflow-level summary: one row per workflow run, with a link
+  // back to the run page. This is much smaller than the per-job table and
+  // avoids the paginated check-runs fetch entirely.
+  const { data } = await octokit.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    head_sha: ref,
+    per_page: 100,
+  })
+
+  const runs = data.workflow_runs
+    .sort(bySeverity)
+    .map(run => ({
+      name: run.name,
+      status: run.status,
+      conclusion: formatConclusion(run.conclusion),
+      // workflow_run has no completed_at; updated_at reflects the final state
+      // change once status === 'completed', otherwise it's an in-flight tick.
+      started_at: run.run_started_at,
+      completed_at: run.status === 'completed' ? run.updated_at : ' ',
+      url: run.html_url,
+    }))
+
+  console.table(runs)
+
+  const header = [
+    { data: 'workflow', header: true },
+    { data: 'status', header: true },
+    { data: 'conclusion', header: true },
+    { data: 'started_at', header: true },
+    { data: 'completed_at', header: true },
+  ]
+
+  const body = runs.map(run => [
+    `<a href="${run.url}">${run.name}</a>`,
+    run.status,
+    run.conclusion,
+    run.started_at,
+    run.completed_at,
+  ])
+
+  await summary
+    .addHeading('Workflows Summary')
+    .addTable([header, ...body])
+    .write()
+}
+
+async function printJobSummary () {
   const checkRuns = await octokit.paginate(
     'GET /repos/:owner/:repo/commits/:ref/check-runs',
     { ...params, app_id: githubActionsAppId, per_page: 100 }
@@ -169,13 +224,11 @@ async function printSummary () {
   }
 
   const runs = [...latestByName.values()]
-    .sort((a, b) => (conclusionSeverity[a.conclusion] ?? 8) - (conclusionSeverity[b.conclusion] ?? 8))
+    .sort(bySeverity)
     .map(run => ({
       name: run.name,
       status: run.status,
-      conclusion: run.conclusion
-        ? `${run.conclusion} ${conclusionEmojis[run.conclusion]}`
-        : ' ',
+      conclusion: formatConclusion(run.conclusion),
       started_at: run.started_at,
       completed_at: run.completed_at ?? ' ',
     }))

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -155,7 +155,7 @@ async function printSummary () {
 
   const checkRuns = await octokit.paginate(
     'GET /repos/:owner/:repo/commits/:ref/check-runs',
-    { ...params, per_page: 100 }
+    { ...params, app_id: githubActionsAppId, per_page: 100 }
   )
 
   // When a check is re-run, older runs remain with their original conclusions.

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -88,7 +88,7 @@ async function getRuns () {
 
 async function pollUntilDone () {
   const runs = await getRuns()
-  const pending = runs.filter(r => r.status !== 'doned').length
+  const pending = runs.filter(r => r.status !== 'completed').length
   if (pending === 0) return { runs, done: true }
 
   retries++
@@ -163,7 +163,7 @@ async function printSummary (runs) {
       // workflow_run has no doned_at; updated_at reflects the final state
       // change once status === 'doned', otherwise it's an in-flight tick.
       started_at: run.run_started_at,
-      doned_at: run.status === 'doned' ? run.updated_at : ' ',
+      doned_at: run.status === 'completed' ? run.updated_at : ' ',
       url: run.html_url,
     }))
 

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -66,7 +66,7 @@ async function getRuns () {
       }
     )) {
       etag ??= headers.etag
-      allRuns.push(...data.workflow_runs)
+      allRuns.push(...data)
     }
     // Isolate per trigger so a parallel all-green run on the same SHA doesn't
     // see our runs (and we don't see theirs). Filter by event, by PR number


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Minimize requests for all green script.

### Motivation
<!-- What inspired you to submit this pull request? -->

We have recently experienced a lot more GitHub API rate limit errors. This is because of 3 main factors:

1) Surge in flakiness across the board. This means that the auto-retry logic has to make API calls for a lot more workflows to trigger all the reruns.
2) Surge in CI run time. The longer our CI takes, the more we need to poll to check if everything is green.
3) We have recently optimized All Green, but it still makes a lot of requests, especially with the addition of the auto-retry which can double them in the worst cases.

This PR addresses the third point in the following ways:

1) Using check suites instead of check runs to find failed workflows. This has the downside that we can no longer filter based on the number of failed jobs, but it allows using only 1 request for all workflows instead of having to loop through individual jobs on several pages. This is a fine trade-off, and recent events have shown that when flakiness gets bad, the number of failed jobs can go about the current maximum anyway.
2) Only outputting a full summary for the main branch. This is the most costly part of the script, and there is already a summary at the bottom of every PR. A workflow summary is still outputted as it's low cost.
3) Add an ETag to polling. Most of the time, when CI takes a long time, it's because of a single job that is taking more time than all the others, so it's quite possible that several minutes in a row, the result of the poll will be the same. Requests that haven't changed don't count towards the limit.

For the other 2 factors, there are several other PRs in flight, some of which already merged, which address most of the flakiness and run time issue. Once everything has landed, API requests will be further reduced as the pressure on all-green will be reduced.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

While fixing a few issues, I also ended up being able to retry workflows as soon as they fail instead of waiting at the end, which should add less time to the total runtime.