### PR TITLE
refactor pino instrumentation to always use the same symbol

### DIFF
--- a/packages/datadog-instrumentations/src/pino.js
+++ b/packages/datadog-instrumentations/src/pino.js
@@ -34,22 +34,6 @@ function wrapAsJson (asJson) {
   }
 }
 
-function wrapMixin (mixin) {
-  const ch = channel('apm:pino:log')
-  return function mixinWithTrace () {
-    let obj = {}
-
-    if (mixin) {
-      obj = mixin.apply(this, arguments)
-    }
-
-    const payload = { message: obj }
-    ch.publish(payload)
-
-    return payload.message
-  }
-}
-
 function wrapPrettifyObject (prettifyObject) {
   const ch = channel('apm:pino:log')
   return function prettifyObjectWithTrace (input) {
@@ -81,26 +65,18 @@ addHook({ name: 'pino', versions: ['2 - 3', '4'], patchDefault: true }, (pino) =
   return wrapped
 })
 
-addHook({ name: 'pino', versions: ['>=5 <5.14.0'], patchDefault: true }, (pino) => {
+addHook({ name: 'pino', versions: ['>=5 <6.8.0'], patchDefault: true }, (pino) => {
   const asJsonSym = ((pino.default || pino)?.symbols.asJsonSym) || 'asJson'
 
-  const wrapped = shimmer.wrapFunction(pino, pino => wrapPino(asJsonSym, wrapAsJson, pino))
-
-  return wrapped
-})
-
-addHook({ name: 'pino', versions: ['>=5.14.0 <6.8.0'] }, (pino) => {
-  const mixinSym = (pino.default || pino).symbols.mixinSym
-
-  const wrapped = shimmer.wrapFunction(pino, pino => wrapPino(mixinSym, wrapMixin, pino.default || pino))
+  const wrapped = shimmer.wrapFunction(pino, pino => wrapPino(asJsonSym, wrapAsJson, pino.default || pino))
 
   return wrapped
 })
 
 addHook({ name: 'pino', versions: ['>=6.8.0'], patchDefault: false }, (pino) => {
-  const mixinSym = pino.symbols.mixinSym
+  const asJsonSym = pino.symbols.asJsonSym
 
-  const wrapped = shimmer.wrapFunction(pino, pino => wrapPino(mixinSym, wrapMixin, pino))
+  const wrapped = shimmer.wrapFunction(pino, pino => wrapPino(asJsonSym, wrapAsJson, pino))
   wrapped.pino = wrapped
   wrapped.default = wrapped
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Refactor pino instrumentation to always use the same symbol.

### Motivation
<!-- What inspired you to submit this pull request? -->

Mixins are the official feature to alter log records at runtime, so that's what we used in recent versions of Pino. In older versions where it's not available, we used the internal symbol instead. However, we are in the process of adding features that require attributes that are not available to the record yet at the point when the mixin runs, so we should always go through the internal symbol instead. This also makes the instrumentation consistent in what it makes available to the plugin.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


