### PR TITLE
fix(appsec): Fix regression on Stripe instrumentation 

### DIFF
--- a/packages/datadog-instrumentations/src/stripe.js
+++ b/packages/datadog-instrumentations/src/stripe.js
@@ -58,35 +58,49 @@ function wrapConstructEventAsync (constructEventAsync) {
   }
 }
 
+function instrumentStripeInstance (stripe) {
+  if (typeof stripe.checkout?.sessions?.create === 'function') {
+    shimmer.wrap(stripe.checkout.sessions, 'create', wrapSessionCreate)
+  }
+  if (typeof stripe.paymentIntents?.create === 'function') {
+    shimmer.wrap(stripe.paymentIntents, 'create', wrapPaymentIntentCreate)
+  }
+  if (typeof stripe.webhooks?.constructEvent === 'function') {
+    shimmer.wrap(stripe.webhooks, 'constructEvent', wrapConstructEvent)
+  }
+  if (typeof stripe.webhooks?.constructEventAsync === 'function') {
+    shimmer.wrap(stripe.webhooks, 'constructEventAsync', wrapConstructEventAsync)
+  }
+}
+
+// stripe <22: the constructor mutates this (when invoked with 'new') and
+// returns nothing; without 'new' it delegates to 'new Stripe(...)' and returns
+// that result. We need to instrument whichever object actually got populated
+function wrapLegacyStripe (Stripe) {
+  return function wrappedStripe () {
+    const result = Stripe.apply(this, arguments)
+    const stripe = this instanceof Stripe ? this : result
+    instrumentStripeInstance(stripe)
+    return stripe
+  }
+}
+
+// stripe >=22: the constructor is a factory that always returns a fresh Stripe
+// instance regardless of 'new', so we just instrument and forward the result
 function wrapStripe (Stripe) {
   return function wrappedStripe () {
-    let stripe = Stripe.apply(this, arguments)
-
-    // to support both with and without "new" operator syntax
-    if (this instanceof Stripe) {
-      stripe = this
-    }
-
-    if (typeof stripe.checkout?.sessions?.create === 'function') {
-      shimmer.wrap(stripe.checkout.sessions, 'create', wrapSessionCreate)
-    }
-    if (typeof stripe.paymentIntents?.create === 'function') {
-      shimmer.wrap(stripe.paymentIntents, 'create', wrapPaymentIntentCreate)
-    }
-    if (typeof stripe.webhooks?.constructEvent === 'function') {
-      shimmer.wrap(stripe.webhooks, 'constructEvent', wrapConstructEvent)
-    }
-    if (typeof stripe.webhooks?.constructEventAsync === 'function') {
-      shimmer.wrap(stripe.webhooks, 'constructEventAsync', wrapConstructEventAsync)
-    }
-
+    const stripe = Stripe.apply(this, arguments)
+    instrumentStripeInstance(stripe)
     return stripe
   }
 }
 
 addHook({
   name: 'stripe',
-  versions: ['9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '>=20.0.0'],
-}, Stripe => {
-  return shimmer.wrapFunction(Stripe, wrapStripe)
-})
+  versions: ['9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '>=20.0.0 <22'],
+}, Stripe => shimmer.wrapFunction(Stripe, wrapLegacyStripe))
+
+addHook({
+  name: 'stripe',
+  versions: ['>=22'],
+}, Stripe => shimmer.wrapFunction(Stripe, wrapStripe))

--- a/packages/datadog-instrumentations/test/stripe.spec.js
+++ b/packages/datadog-instrumentations/test/stripe.spec.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const crypto = require('node:crypto')
+
+const dc = require('dc-polyfill')
+const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+
+const WEBHOOK_SECRET = 'whsec_hbar_c_137'
+
+function signedWebhookPayload (data, secret = WEBHOOK_SECRET) {
+  const timestamp = Date.now()
+  const payload = JSON.stringify(data)
+  const signature = crypto.createHmac('sha256', secret).update(`${timestamp}.${payload}`).digest('hex')
+
+  return {
+    payload,
+    header: `t=${timestamp},v1=${signature}`,
+  }
+}
+
+withVersions('stripe', 'stripe', version => {
+  describe('stripe instrumentation', () => {
+    const constructEventFinishCh = dc.channel('datadog:stripe:constructEvent:finish')
+    let Stripe
+
+    before(() => agent.load(['http'], { client: false }))
+
+    before(() => {
+      Stripe = require(`../../../versions/stripe@${version}`).get()
+    })
+
+    after(() => agent.close({ ritmReset: false }))
+
+    describe('client construction', () => {
+      it('returns a fully-formed Stripe instance with `new`', () => {
+        const stripe = new Stripe('sk_test_FAKE')
+
+        assert.equal(typeof stripe.checkout?.sessions?.create, 'function')
+        assert.equal(typeof stripe.paymentIntents?.create, 'function')
+        assert.equal(typeof stripe.webhooks?.constructEvent, 'function')
+        assert.equal(typeof stripe.webhooks?.constructEventAsync, 'function')
+      })
+
+      it('returns a fully-formed Stripe instance without `new` (call-style)', () => {
+        const stripe = Stripe('sk_test_FAKE')
+
+        assert.equal(typeof stripe.checkout?.sessions?.create, 'function')
+        assert.equal(typeof stripe.paymentIntents?.create, 'function')
+        assert.equal(typeof stripe.webhooks?.constructEvent, 'function')
+        assert.equal(typeof stripe.webhooks?.constructEventAsync, 'function')
+      })
+    })
+  })
+})

--- a/packages/datadog-instrumentations/test/stripe.spec.js
+++ b/packages/datadog-instrumentations/test/stripe.spec.js
@@ -1,31 +1,14 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const crypto = require('node:crypto')
 
-const dc = require('dc-polyfill')
-const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
-const sinon = require('sinon')
+const { after, before, describe, it } = require('mocha')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
-const WEBHOOK_SECRET = 'whsec_hbar_c_137'
-
-function signedWebhookPayload (data, secret = WEBHOOK_SECRET) {
-  const timestamp = Date.now()
-  const payload = JSON.stringify(data)
-  const signature = crypto.createHmac('sha256', secret).update(`${timestamp}.${payload}`).digest('hex')
-
-  return {
-    payload,
-    header: `t=${timestamp},v1=${signature}`,
-  }
-}
-
 withVersions('stripe', 'stripe', version => {
   describe('stripe instrumentation', () => {
-    const constructEventFinishCh = dc.channel('datadog:stripe:constructEvent:finish')
     let Stripe
 
     before(() => agent.load(['http'], { client: false }))

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -200,7 +200,7 @@
     "sharedb": "5.2.2",
     "sinon": "21.0.1",
     "sqlite3": "5.1.7",
-    "stripe": "20.1.0",
+    "stripe": "22.1.0",
     "tedious": "19.2.0",
     "tinypool": "2.1.0",
     "typescript": "6.0.2",


### PR DESCRIPTION
### What does this PR do?
Fixes a regression in the `stripe` instrumentation.

The wrapping logic is split into two version paths:
- `wrapLegacyStripe` for stripe <22. The constructor mutates this (with `new`) and returns undefined; whitout `new` (call style constructor) it delegates to new Striope(...) and returns the result. The wraper instruments the object actually populated.
- `wrapStripe` for stripe 22+. The constructor is a factory that always returns a Stripe instance regardless of `new`, so the wrapper just instruments the returned value.

A new instrumentation unit test has been added to cover both invocation styles.
 
### Motivation
User-reported bug: with stripe@22, calls like `stripe.webhooks.constructEvent` and `stripe.subscriptions.retrieve` throw `TypeError: Cannot read properties of undefined`, because the resulting client has no instance properties at all.

### Additional Notes
Fixes https://github.com/DataDog/dd-trace-js/issues/8151

[APPSEC-62577](https://datadoghq.atlassian.net/browse/APPSEC-62577)

[APPSEC-62577]: https://datadoghq.atlassian.net/browse/APPSEC-62577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ