### PR TITLE
test: mocha retries issue

### DIFF
--- a/packages/dd-trace/test/mocha-hooks.spec.js
+++ b/packages/dd-trace/test/mocha-hooks.spec.js
@@ -85,6 +85,40 @@ describe('mocha hooks setup', () => {
     assert.deepStrictEqual(getPassTitles(result), ['still runs'])
   })
 
+  it('suppresses after each errors when a failed test is retried', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        afterEach(() => {
+          throw new Error('cleanup failed')
+        })
+
+        it('fails for the real reason', function () {
+          this.retries(1)
+          throw new Error('test failed')
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('suppresses after all errors when a failed test is retried', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        after(() => {
+          throw new Error('cleanup failed')
+        })
+
+        it('fails for the real reason', function () {
+          this.retries(1)
+          throw new Error('test failed')
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
   it('suppresses after each errors when a before each in the same suite already failed', async () => {
     const result = await runFixture(`
       describe('suite', () => {
@@ -119,6 +153,26 @@ describe('mocha hooks setup', () => {
     `)
 
     assert.deepStrictEqual(getFailureMessages(result), ['inner test failed'])
+  })
+
+  it('suppresses outer after all errors when a nested before all already failed', async () => {
+    const result = await runFixture(`
+      describe('outer suite', () => {
+        after(() => {
+          throw new Error('outer cleanup failed')
+        })
+
+        describe('inner suite', () => {
+          before(() => {
+            throw new Error('inner setup failed')
+          })
+
+          it('does something', () => {})
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['inner setup failed'])
   })
 
   it('suppresses outer after each errors when a nested before each already failed', async () => {
@@ -160,13 +214,80 @@ describe('mocha hooks setup', () => {
 
     assert.deepStrictEqual(getFailureMessages(result), ['inner cleanup failed'])
   })
+
+  it('suppresses promise-returning after each errors after a test failure', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        afterEach(() => {
+          return Promise.reject(new Error('cleanup failed'))
+        })
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('suppresses callback after each errors after a test failure', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        afterEach((done) => {
+          done(new Error('cleanup failed'))
+        })
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('suppresses root after all errors after a root test failure', async () => {
+    const result = await runFixture(`
+      after(() => {
+        throw new Error('cleanup failed')
+      })
+
+      it('fails for the real reason', () => {
+        throw new Error('test failed')
+      })
+    `)
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+  })
+
+  it('does not let a suppressed after each error change bail behavior', async () => {
+    const result = await runFixture(`
+      describe('suite', () => {
+        afterEach(function () {
+          if (this.currentTest.title === 'fails for the real reason') {
+            throw new Error('cleanup failed')
+          }
+        })
+
+        it('fails for the real reason', () => {
+          throw new Error('test failed')
+        })
+
+        it('is skipped by bail', () => {})
+      })
+    `, ['--bail'])
+
+    assert.deepStrictEqual(getFailureMessages(result), ['test failed'])
+    assert.deepStrictEqual(getPassTitles(result), [])
+  })
 })
 
 /**
  * @param {string} body
  * @returns {Promise<MochaJsonResult>}
  */
-async function runFixture (body) {
+async function runFixture (body, args = []) {
   const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'dd-trace-mocha-hooks-'))
   const fixture = path.join(tmpdir, 'fixture.spec.js')
   fs.writeFileSync(fixture, `'use strict'
@@ -177,7 +298,7 @@ ${body}
 `)
 
   try {
-    const { stdout } = await execFileMocha(fixture)
+    const { stdout } = await execFileMocha(fixture, args)
     return JSON.parse(stdout)
   } finally {
     fs.rmSync(tmpdir, { force: true, recursive: true })
@@ -186,11 +307,17 @@ ${body}
 
 /**
  * @param {string} fixture
+ * @param {string[]} args
  * @returns {Promise<{ stdout: string }>}
  */
-async function execFileMocha (fixture) {
+async function execFileMocha (fixture, args) {
+  // Keep the fixture runner isolated from this repo's .mocharc.js. The repo config
+  // enables allowUncaught and mocha-multi-reporters, while these assertions need
+  // plain Mocha behavior with JSON emitted on stdout.
+  const mochaArgs = [mochaBin, '--no-config', '--reporter', 'json', ...args, fixture]
+
   try {
-    return await execFileAsync(process.execPath, [mochaBin, '--no-config', '--reporter', 'json', fixture])
+    return await execFileAsync(process.execPath, mochaArgs)
   } catch (err) {
     if (!err || typeof err !== 'object' || !('stdout' in err) || typeof err.stdout !== 'string') throw err
     return { stdout: err.stdout }

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -14,19 +14,18 @@ const failedTests = new WeakSet()
 if (!patched.has(Runner.prototype)) {
   patched.add(Runner.prototype)
 
+  const emit = Runner.prototype.emit
   const fail = Runner.prototype.fail
-  const runTest = Runner.prototype.runTest
   const runHook = Hook.prototype.run
 
   /**
    * @this {Mocha.Runner}
-   * @param {(err?: Error) => void} fn
+   * @param {string} event
+   * @param {...unknown} args
    */
-  Runner.prototype.runTest = function patchedRunTest (fn) {
-    return runTest.call(this, (err) => {
-      if (err && this.test) failedTests.add(this.test)
-      return fn(err)
-    })
+  Runner.prototype.emit = function patchedEmit (event, ...args) {
+    if (event === 'retry' && args[0]) failedTests.add(args[0])
+    return emit.call(this, event, ...args)
   }
 
   /**

--- a/packages/dd-trace/test/setup/mocha-hooks.js
+++ b/packages/dd-trace/test/setup/mocha-hooks.js
@@ -15,7 +15,19 @@ if (!patched.has(Runner.prototype)) {
   patched.add(Runner.prototype)
 
   const fail = Runner.prototype.fail
+  const runTest = Runner.prototype.runTest
   const runHook = Hook.prototype.run
+
+  /**
+   * @this {Mocha.Runner}
+   * @param {(err?: Error) => void} fn
+   */
+  Runner.prototype.runTest = function patchedRunTest (fn) {
+    return runTest.call(this, (err) => {
+      if (err && this.test) failedTests.add(this.test)
+      return fn(err)
+    })
+  }
 
   /**
    * @this {Mocha.Runner}


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?

According to the failed [test](https://github.com/DataDog/dd-trace-js/actions/runs/25148561380/job/73714551759): the test error was not recorded before `afterEach` ran, so the cleanup error became the only reported failure.

I reproduced that case in `mocha-hooks.spec.js` with a retried failing test, then fixed it by marking failed test attempts in `Runner.prototype.runTest` before Mocha decides whether to retry.

Expand the coverage to include the other use cases

### Additional Notes

The issue was identified and fixed by Claude


