### PR TITLE
bench(spans): cover tags-and-otel construction shape

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,7 @@
 /eslint-rules/ @DataDog/apm-sdk-capabilities-js
 
 /benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/spans/ @DataDog/apm-sdk-capabilities-js
 
 /integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -17,6 +17,22 @@
         "DD_TRACE_SCOPE": "noop",
         "FINISH": "later"
       }
+    },
+    "finish-immediately-with-tags": {
+      "baseline": "finish-immediately",
+      "env": {
+        "DD_TRACE_SCOPE": "noop",
+        "FINISH": "now",
+        "SHAPE": "tags"
+      }
+    },
+    "finish-immediately-with-tags-and-otel": {
+      "baseline": "finish-immediately",
+      "env": {
+        "DD_TRACE_SCOPE": "noop",
+        "FINISH": "now",
+        "SHAPE": "tags-and-otel"
+      }
     }
   }
 }

--- a/benchmark/sirun/spans/spans.js
+++ b/benchmark/sirun/spans/spans.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const assert = require('node:assert/strict')
+
 const tracer = require('../../..').init()
 
 tracer._tracer._processor.process = function process (span) {
@@ -7,21 +9,65 @@ tracer._tracer._processor.process = function process (span) {
   this._erase(trace)
 }
 
-const { FINISH } = process.env
+const { FINISH, SHAPE = 'plain' } = process.env
 
 const spans = []
 
-for (let i = 0; i < 100000; i++) {
-  const span = tracer.startSpan('some.span.name', {})
-  if (FINISH === 'now') {
-    span.finish()
-  } else {
-    spans.push(span)
+// Span sanitizes link / event attributes inline; reusing the pre-built objects across
+// iterations is safe and matches plugin-emitted span construction.
+const TAGS = { service: 'svc', env: 'prod', 'http.method': 'GET' }
+const LINK_TARGET = tracer.startSpan('link-target')
+const LINK_CONTEXT = LINK_TARGET.context()
+const LINK_ATTRIBUTES = { 'event.kind': 'fork', priority: 1, ok: true }
+const EVENT_ATTRIBUTES = { attempt: 1, ok: true, code: 200 }
+
+const FIELDS_WITH_TAGS = { tags: TAGS }
+const FIELDS_WITH_TAGS_AND_LINKS = {
+  tags: TAGS,
+  links: [{ context: LINK_CONTEXT, attributes: LINK_ATTRIBUTES }],
+}
+
+// Pre-flight: confirm tags / links / events actually attach; catches a silent
+// breakage where the construction shape stopped propagating.
+const sanitySpan = tracer.startSpan('sanity.span', FIELDS_WITH_TAGS_AND_LINKS)
+sanitySpan.addEvent('sanity-event', EVENT_ATTRIBUTES)
+assert.equal(sanitySpan.context()._tags.service, 'svc')
+assert.equal(sanitySpan._links.length, 1)
+assert.equal(sanitySpan._events.length, 1)
+sanitySpan.finish()
+
+if (SHAPE === 'tags') {
+  for (let iteration = 0; iteration < 100_000; iteration++) {
+    const span = tracer.startSpan('some.span.name', FIELDS_WITH_TAGS)
+    if (FINISH === 'now') {
+      span.finish()
+    } else {
+      spans.push(span)
+    }
+  }
+} else if (SHAPE === 'tags-and-otel') {
+  for (let iteration = 0; iteration < 100_000; iteration++) {
+    const span = tracer.startSpan('some.span.name', FIELDS_WITH_TAGS_AND_LINKS)
+    span.addEvent('event-name', EVENT_ATTRIBUTES)
+    if (FINISH === 'now') {
+      span.finish()
+    } else {
+      spans.push(span)
+    }
+  }
+} else {
+  for (let iteration = 0; iteration < 100_000; iteration++) {
+    const span = tracer.startSpan('some.span.name', {})
+    if (FINISH === 'now') {
+      span.finish()
+    } else {
+      spans.push(span)
+    }
   }
 }
 
 if (FINISH !== 'now') {
-  for (let i = 0; i < 100000; i++) {
-    spans[i].finish()
+  for (let index = 0; index < 100_000; index++) {
+    spans[index].finish()
   }
 }


### PR DESCRIPTION
Today's variants pass `{}` to `startSpan`, so the per-span copy of `fields.tags` and the `fields.links?.map` conversion never fire even though every plugin-emitted span sets at least one of them. Two new variants pass tags (and links, on the OTel variant) at construction and append events afterwards.

I also added a safety net with the assertions to make sure changes are detected early on.