### PR TITLE
bench(aws-sdk): add inject and response-body benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,8 @@
 /packages/dd-trace/test/plugins/util/inferred_proxy.spec.js @DataDog/serverless-aws @DataDog/apm-serverless
 
 # IDM
+/benchmark/sirun/plugin-aws-sdk/ @DataDog/apm-idm-js
+
 /integration-tests/esbuild/ @DataDog/apm-idm-js
 /integration-tests/webpack/ @DataDog/apm-idm-js
 /integration-tests/pino.spec.js @DataDog/apm-idm-js

--- a/benchmark/sirun/plugin-aws-sdk/README.md
+++ b/benchmark/sirun/plugin-aws-sdk/README.md
@@ -1,0 +1,8 @@
+This benchmark measures the per-AWS-SDK-call work in
+`packages/datadog-plugin-aws-sdk/src/base.js` and the EventBridge / Lambda service
+plugins. Every traced AWS SDK call hits this code, so per-call savings compound for a
+large customer subset.
+
+The plugin internals are exercised directly via `Object.create(Plugin.prototype)` so
+the hot loop never touches diagnostic channels or a real tracer; a tiny stub
+`tracer.inject` populates the carrier the same way the real propagator would.

--- a/benchmark/sirun/plugin-aws-sdk/index.js
+++ b/benchmark/sirun/plugin-aws-sdk/index.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const BaseAwsSdkPlugin = require('../../../packages/datadog-plugin-aws-sdk/src/base')
+const EventBridge = require('../../../packages/datadog-plugin-aws-sdk/src/services/eventbridge')
+const Lambda = require('../../../packages/datadog-plugin-aws-sdk/src/services/lambda')
+
+const { VARIANT } = process.env
+
+const ITERATIONS = 2_000_000
+
+// Plugin reads `this.tracer` via a getter that forwards to `this._tracer`; wire the
+// stub through the underscore field so the public access path stays intact.
+const fakeSpan = {}
+const fakeTracer = {
+  inject (span, format, carrier) {
+    carrier['x-datadog-trace-id'] = '1234567890'
+    carrier['x-datadog-parent-id'] = '987654321'
+    carrier['x-datadog-sampling-priority'] = '1'
+    carrier['x-datadog-tags'] = '_dd.p.dm=-1,_dd.p.tid=1234567890abcdef'
+  },
+}
+
+const RESPONSE = {
+  $metadata: { httpStatusCode: 200, requestId: 'req-aaaaaaaaaa', attempts: 1, totalRetryDelay: 0 },
+  request: { operation: 'sendMessage', params: {} },
+  requestId: 'req-aaaaaaaaaa',
+  ResponseMetadata: { RequestId: 'req-bbbbbbbbbb' },
+  MessageId: 'msg-cccccccccc',
+  SequenceNumber: '987654321',
+  Messages: [{ MessageId: 'msg-1', Body: 'payload-1' }, { MessageId: 'msg-2', Body: 'payload-2' }],
+  Body: 'payload-top',
+}
+
+const EVENTBRIDGE_DETAIL_JSON = JSON.stringify({
+  orderId: 'order-1234567890',
+  customerId: 'cust-987654321',
+  items: 5,
+  total: 1234.56,
+  currency: 'USD',
+  region: 'us-east-1',
+})
+
+if (VARIANT === 'extract-response-body') {
+  const plugin = Object.create(BaseAwsSdkPlugin.prototype)
+  // Pre-flight: confirm extractResponseBody strips the SDK envelope keys; catches
+  // a silent breakage where the response shape no longer matches the function.
+  const sanityBody = plugin.extractResponseBody(RESPONSE)
+  assert.equal(sanityBody.$metadata, undefined)
+  assert.equal(sanityBody.MessageId, 'msg-cccccccccc')
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    plugin.extractResponseBody(RESPONSE)
+  }
+} else if (VARIANT === 'eventbridge-inject-detail') {
+  const plugin = Object.create(EventBridge.prototype)
+  plugin._tracer = fakeTracer
+  const sanityRequest = {
+    operation: 'putEvents',
+    params: { Entries: [{ Detail: EVENTBRIDGE_DETAIL_JSON }] },
+  }
+  plugin.requestInject(fakeSpan, sanityRequest)
+  assert.ok(sanityRequest.params.Entries[0].Detail.includes('_datadog'),
+    'EventBridge requestInject did not embed _datadog')
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    const request = {
+      operation: 'putEvents',
+      params: { Entries: [{ Detail: EVENTBRIDGE_DETAIL_JSON }] },
+    }
+    plugin.requestInject(fakeSpan, request)
+  }
+} else if (VARIANT === 'lambda-inject-no-context') {
+  const plugin = Object.create(Lambda.prototype)
+  plugin._tracer = fakeTracer
+  const sanityRequest = { operation: 'invoke', params: { FunctionName: 'my-fn' } }
+  plugin.requestInject(fakeSpan, sanityRequest)
+  assert.ok(sanityRequest.params.ClientContext, 'Lambda requestInject did not set ClientContext')
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    const request = { operation: 'invoke', params: { FunctionName: 'my-fn' } }
+    plugin.requestInject(fakeSpan, request)
+  }
+}

--- a/benchmark/sirun/plugin-aws-sdk/meta.json
+++ b/benchmark/sirun/plugin-aws-sdk/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "plugin-aws-sdk",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 30,
+  "instructions": true,
+  "variants": {
+    "extract-response-body": { "env": { "VARIANT": "extract-response-body" } },
+    "eventbridge-inject-detail": { "env": { "VARIANT": "eventbridge-inject-detail" } },
+    "lambda-inject-no-context": { "env": { "VARIANT": "lambda-inject-no-context" } }
+  }
+}


### PR DESCRIPTION
Every traced AWS SDK call hits `BaseAwsSdkPlugin#extractResponseBody` and the per-service `requestInject`. Three variants drive the plugin internals via `Object.create(Plugin.prototype)` with a synchronous `tracer.inject` stub: `extract-response-body` (SQS / SNS envelope shape), `eventbridge-inject-detail` (JSON-mutating inject path), and `lambda-inject-no-context` (the dominant Lambda invoke shape).
