### PR TITLE
bench(propagation): add extract and inject benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -159,6 +159,8 @@
 # API SDK Capabilities
 /eslint-rules/ @DataDog/apm-sdk-capabilities-js
 
+/benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
+
 /integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry-logs.spec.js @DataDog/apm-sdk-capabilities-js

--- a/benchmark/sirun/propagation/README.md
+++ b/benchmark/sirun/propagation/README.md
@@ -1,0 +1,3 @@
+This benchmark measures the wire-protocol propagation hot path that fires on every
+traced HTTP request: extract on incoming, inject on outgoing. Both go through
+`text_map.js` and `tracestate.js`, the broadest customer surface in the library.

--- a/benchmark/sirun/propagation/index.js
+++ b/benchmark/sirun/propagation/index.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const id = require('../../../packages/dd-trace/src/id')
+const SpanContext = require('../../../packages/dd-trace/src/opentracing/span_context')
+const TextMapPropagator = require('../../../packages/dd-trace/src/opentracing/propagation/text_map')
+
+const { VARIANT } = process.env
+
+const ITERATIONS = 300_000
+
+// Duck-typed config keeps the bench out of the full `Config` singleton (telemetry
+// registration, env reads). The propagator only reads the fields below.
+const propagator = new TextMapPropagator({
+  tracePropagationStyle: {
+    extract: ['datadog', 'tracecontext', 'baggage'],
+    inject: ['datadog', 'tracecontext', 'baggage'],
+  },
+  legacyBaggageEnabled: false,
+  baggageMaxItems: 64,
+  baggageMaxBytes: 8192,
+  tagsHeaderMaxLength: 512,
+  tracePropagationExtractFirst: false,
+  tracePropagationBehaviorExtract: 'continue',
+  baggageTagKeys: ['user.id', 'session.id', 'account.id'],
+})
+
+// Realistic incoming carrier: traceparent + 4-vendor tracestate + 4-key baggage. Most
+// production baggage is plain ASCII (tenant / user / session / locale); the percent
+// variant lives below for the slow-path no-regression check.
+const EXTRACT_CARRIER_ASCII = {
+  traceparent: '00-1234567890abcdef1234567890abcdef-1234567890abcdef-01',
+  tracestate: 'dd=s:2;p:abc,vendor1=k1:v1,vendor2=k1:v1;k2:v2,foo=bar',
+  baggage: 'tenant=acme,user=ada,session=abcdef0123456789,locale=en-US',
+}
+
+const EXTRACT_CARRIER_PERCENT = {
+  ...EXTRACT_CARRIER_ASCII,
+  baggage: 'tenant=acme%20corp,path=%2Forders%2Fnew,note=hello%20world',
+}
+
+const injectContext = new SpanContext({
+  traceId: id('1234567890abcdef'),
+  spanId: id('abcdef1234567890'),
+  sampling: { priority: 1 },
+  baggageItems: { tenant: 'acme', user: 'ada', session: 'abcdef0123456789' },
+  trace: {
+    tags: { '_dd.p.dm': '-1', '_dd.p.tid': '1234567890abcdef' },
+    started: [],
+    finished: [],
+  },
+})
+
+// Pre-flight: confirm extract / inject are doing real work; catches a silent
+// breakage where the duck-typed config is missing a field the propagator now reads.
+const sanityExtract = propagator.extract(EXTRACT_CARRIER_ASCII)
+assert.ok(sanityExtract?._traceId, 'extract returned no trace id')
+
+const sanityInjected = {}
+propagator.inject(injectContext, sanityInjected)
+assert.ok(sanityInjected.traceparent && sanityInjected['x-datadog-trace-id'], 'inject populated no headers')
+
+if (VARIANT === 'extract' || VARIANT === 'extract-baggage-ascii') {
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    propagator.extract(EXTRACT_CARRIER_ASCII)
+  }
+} else if (VARIANT === 'extract-baggage-percent') {
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    propagator.extract(EXTRACT_CARRIER_PERCENT)
+  }
+} else if (VARIANT === 'inject') {
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    propagator.inject(injectContext, {})
+  }
+} else if (VARIANT === 'extract-inject') {
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    const extracted = propagator.extract(EXTRACT_CARRIER_ASCII)
+    propagator.inject(extracted, {})
+  }
+}

--- a/benchmark/sirun/propagation/meta.json
+++ b/benchmark/sirun/propagation/meta.json
@@ -1,0 +1,15 @@
+{
+  "name": "propagation",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 30,
+  "instructions": true,
+  "variants": {
+    "extract": { "env": { "VARIANT": "extract" } },
+    "inject": { "env": { "VARIANT": "inject" } },
+    "extract-inject": { "env": { "VARIANT": "extract-inject" } },
+    "extract-baggage-ascii": { "baseline": "extract", "env": { "VARIANT": "extract-baggage-ascii" } },
+    "extract-baggage-percent": { "baseline": "extract", "env": { "VARIANT": "extract-baggage-percent" } }
+  }
+}


### PR DESCRIPTION
Wire-protocol propagation is the broadest customer hot path -- extract
on every incoming traced request, inject on every outgoing one -- and
has no sirun coverage. Five variants drive the real `TextMapPropagator`
against a realistic 4-vendor `tracestate` and a 4-key baggage carrier;
ASCII and percent-encoded baggage variants cover both branches of the
`decodeURIComponent` gating path.