### PR TITLE
bench(encoding): cover native and legacy span-events paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -238,6 +238,8 @@
 
 /.github/actions/ @DataDog/lang-platform-js
 
+/benchmark/sirun/encoding/ @DataDog/lang-platform-js
+
 /integration-tests/bun/ @DataDog/lang-platform-js
 /integration-tests/coverage/ @DataDog/lang-platform-js
 /integration-tests/coverage-child-process.spec.js @DataDog/lang-platform-js

--- a/benchmark/sirun/encoding/index.js
+++ b/benchmark/sirun/encoding/index.js
@@ -1,7 +1,10 @@
 'use strict'
 
+const assert = require('node:assert/strict')
+
 const {
   ENCODER_VERSION,
+  WITH_SPAN_EVENTS = 'none',
 } = process.env
 
 const { AgentEncoder } = require(`../../../packages/dd-trace/src/encode/${ENCODER_VERSION}`)
@@ -36,14 +39,47 @@ function createSpan (parent) {
 }
 
 const trace = []
-for (let parent = null, i = 0; i < 30; i++) {
+for (let parent = null, index = 0; index < 30; index++) {
   const span = createSpan(parent)
   trace.push(span)
   parent = span
 }
 
+const ATTR_TEMPLATE_HTTP_OK = { attempt: 1, ratio: 0.5, ok: true, kind: 'http.client', codes: [200, 204] }
+const ATTR_TEMPLATE_HTTP_ERR = { attempt: 2, ratio: 0.6, ok: false, kind: 'http.server', codes: [500, 503] }
+const ATTR_TEMPLATE_DB = { attempt: 3, ratio: 0.7, ok: true, kind: 'db.query', codes: [42] }
+
+// `encoder.encode` consumes its input: the legacy path deletes `span.span_events`
+// after writing `meta.events`; the native path wraps each attribute primitive into
+// a typed object that the next pass would then drop. Rebuilding per iteration is
+// the only way to measure the same encoder work on every iteration.
+function attachFreshEvents () {
+  for (const span of trace) {
+    span.span_events = [
+      { name: 'http.attempt', time_unix_nano: 1_415_926_535_897, attributes: { ...ATTR_TEMPLATE_HTTP_OK } },
+      { name: 'http.failure', time_unix_nano: 1_415_926_535_898, attributes: { ...ATTR_TEMPLATE_HTTP_ERR } },
+      { name: 'db.query', time_unix_nano: 1_415_926_535_899, attributes: { ...ATTR_TEMPLATE_DB } },
+    ]
+  }
+}
+
 const encoder = new AgentEncoder(writer)
 
-for (let j = 0; j < 5000; j++) {
-  encoder.encode(trace)
+// One pre-flight cycle to confirm encoder.encode actually advances state; catches a
+// silent breakage where the fixture or loader skipped the encode path.
+if (WITH_SPAN_EVENTS !== 'none') attachFreshEvents()
+encoder.encode(trace)
+assert.equal(encoder.count(), 1)
+assert.ok(encoder._traceBytes.length > 0)
+encoder._reset()
+
+if (WITH_SPAN_EVENTS === 'none') {
+  for (let iteration = 0; iteration < 5000; iteration++) {
+    encoder.encode(trace)
+  }
+} else {
+  for (let iteration = 0; iteration < 5000; iteration++) {
+    attachFreshEvents()
+    encoder.encode(trace)
+  }
 }

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -6,7 +6,19 @@
   "instructions": true,
   "iterations": 22,
   "variants": {
-    "0.4": { "env": { "ENCODER_VERSION": "0.4" } },
-    "0.5": { "env": { "ENCODER_VERSION": "0.5" } }
+    "0.4": { "env": { "ENCODER_VERSION": "0.4", "WITH_SPAN_EVENTS": "none" } },
+    "0.5": { "env": { "ENCODER_VERSION": "0.5", "WITH_SPAN_EVENTS": "none" } },
+    "0.4-events-native": {
+      "baseline": "0.4",
+      "env": { "ENCODER_VERSION": "0.4", "WITH_SPAN_EVENTS": "native", "DD_TRACE_NATIVE_SPAN_EVENTS": "true" }
+    },
+    "0.4-events-legacy": {
+      "baseline": "0.4",
+      "env": { "ENCODER_VERSION": "0.4", "WITH_SPAN_EVENTS": "legacy", "DD_TRACE_NATIVE_SPAN_EVENTS": "false" }
+    },
+    "0.5-events-legacy": {
+      "baseline": "0.5",
+      "env": { "ENCODER_VERSION": "0.5", "WITH_SPAN_EVENTS": "legacy" }
+    }
   }
 }


### PR DESCRIPTION
Today's 0.4 / 0.5 variants only exercise the no-events shape; the
native and legacy `span_events` paths can regress silently. Three
new variants attach 3 events with 4 typed attributes per span,
rebuilt per iteration because the encoder consumes the input on
every call.