### PR TITLE
fix(graphql): make the resolve span the active scope inside resolvers

### DIFF
--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -271,6 +271,10 @@ class GraphQLExecutePlugin extends TracingPlugin {
     const loc = this.config.source && document && fieldNode && fieldNode.loc
     const source = loc && document.slice(loc.start, loc.end)
 
+    // ctx form: startSpan records field.currentStore = { ...activeStore, span }
+    // (reused for legacyStorage.run) without entering it — an enterWith here
+    // would leak the scope past the synchronous resolver body. callInAsyncScope
+    // runs the resolver in that store so the resolve span is its active scope.
     const span = this.startSpan('graphql.resolve', {
       service: this.config.service,
       resource: `${fieldName}:${returnType}`,
@@ -283,7 +287,9 @@ class GraphQLExecutePlugin extends TracingPlugin {
         'graphql.field.type': baseTypeName,
         'graphql.source': source,
       },
-    }, false)
+    }, field)
+
+    field.span = span
 
     if (fieldNode && this.config.variables && fieldNode.arguments) {
       const variables = this.config.variables(variableValues)
@@ -388,15 +394,20 @@ function wrapResolve (resolve) {
         pathString,
         collapsedKey: collapsedKey ?? pathString,
         span: null,
+        // Populated by startResolveSpan via startSpan's ctx form: currentStore is
+        // the resolve span's store, reused for legacyStorage.run on every sibling.
+        parentStore: null,
+        currentStore: null,
       }
       rootCtx.fields.set(fieldKey, field)
     }
 
     // Collapsed siblings still publish updateField (master's contract: one
     // publish per resolver call, even when the span is collapsed) and route
-    // through callInAsyncScope so the abort signal stops them mid-flight.
+    // through callInAsyncScope so the abort signal stops them mid-flight and
+    // they re-enter the first sibling's store (shared graphql.resolve scope).
     if (!isFirst) {
-      return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, (err) => {
+      return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, field.currentStore, (err) => {
         if (updateFieldCh.hasSubscribers) {
           updateFieldCh.publish({ rootCtx, field, error: err, pathString: field.pathString })
         }
@@ -406,9 +417,8 @@ function wrapResolve (resolve) {
     const executeSpan = rootCtx.executeSpan
     const startTime = executeSpan._getTime()
     const span = rootCtx.plugin.startResolveSpan(field, rootCtx, executeSpan, startTime)
-    field.span = span
 
-    return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, (err, res) => {
+    return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, field.currentStore, (err, res) => {
       const endTime = executeSpan._getTime()
       rootCtx.plugin.finishResolveSpan(span, field, err, res, endTime || startTime)
       if (updateFieldCh.hasSubscribers) {
@@ -446,16 +456,18 @@ function wrapFieldType (field) {
   wrapFields(unwrapped)
 }
 
-function callInAsyncScope (fn, thisArg, args, abortController, cb) {
-  cb ??= () => {}
-
+// Runs the resolver inside `store` (the resolve span's store) so
+// `tracer.scope().active()` inside the resolver is the graphql.resolve span.
+// legacyStorage.run scopes only the synchronous resolver body: a returned
+// promise unwinds the frame, so its continuation runs in the parent scope.
+function callInAsyncScope (fn, thisArg, args, abortController, store, cb) {
   if (abortController?.signal.aborted) {
     cb(null, null)
     throw new AbortError('Aborted')
   }
 
   try {
-    const result = fn.apply(thisArg, args)
+    const result = legacyStorage.run(store, () => fn.apply(thisArg, args))
     if (typeof result?.then === 'function') {
       return result.then(
         res => { cb(null, res); return res },

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -404,10 +404,12 @@ function wrapResolve (resolve) {
 
     // Collapsed siblings still publish updateField (master's contract: one
     // publish per resolver call, even when the span is collapsed) and route
-    // through callInAsyncScope so the abort signal stops them mid-flight and
-    // they re-enter the first sibling's store (shared graphql.resolve scope).
+    // through callInAsyncScope so the abort signal stops them mid-flight. They
+    // run in the parent store, not field.currentStore: the first sibling's
+    // synchronous resolver already finished the shared graphql.resolve span, so
+    // re-entering its store would parent user spans to a closed span.
     if (!isFirst) {
-      return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, field.currentStore, (err) => {
+      return callInAsyncScope(resolve, this, arguments, rootCtx.abortController, field.parentStore, (err) => {
         if (updateFieldCh.hasSubscribers) {
           updateFieldCh.publish({ rootCtx, field, error: err, pathString: field.pathString })
         }

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -271,10 +271,9 @@ class GraphQLExecutePlugin extends TracingPlugin {
     const loc = this.config.source && document && fieldNode && fieldNode.loc
     const source = loc && document.slice(loc.start, loc.end)
 
-    // ctx form: startSpan records field.currentStore = { ...activeStore, span }
-    // (reused for legacyStorage.run) without entering it — an enterWith here
-    // would leak the scope past the synchronous resolver body. callInAsyncScope
-    // runs the resolver in that store so the resolve span is its active scope.
+    // ctx form: startSpan sets field.currentStore = { ...activeStore, span }
+    // without entering it. Only the field's first resolver call runs in that
+    // store (isFirst check in wrapResolve); siblings use field.parentStore.
     const span = this.startSpan('graphql.resolve', {
       service: this.config.service,
       resource: `${fieldName}:${returnType}`,
@@ -394,8 +393,8 @@ function wrapResolve (resolve) {
         pathString,
         collapsedKey: collapsedKey ?? pathString,
         span: null,
-        // Populated by startResolveSpan via startSpan's ctx form: currentStore is
-        // the resolve span's store, reused for legacyStorage.run on every sibling.
+        // Set by startResolveSpan; currentStore is used by the first resolver
+        // call only, siblings use parentStore (see the isFirst check below).
         parentStore: null,
         currentStore: null,
       }
@@ -458,10 +457,8 @@ function wrapFieldType (field) {
   wrapFields(unwrapped)
 }
 
-// Runs the resolver inside `store` (the resolve span's store) so
-// `tracer.scope().active()` inside the resolver is the graphql.resolve span.
-// legacyStorage.run scopes only the synchronous resolver body: a returned
-// promise unwinds the frame, so its continuation runs in the parent scope.
+// Runs the resolver inside `store`, including any code after an internal
+// `await`. A `.then()` the caller attaches afterward runs outside `store`.
 function callInAsyncScope (fn, thisArg, args, abortController, store, cb) {
   if (abortController?.signal.aborted) {
     cb(null, null)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1203,6 +1203,46 @@ describe('Plugin', () => {
           graphql.graphql({ schema, source, rootValue }).catch(done)
         })
 
+        it('should make the resolve span the active scope inside resolvers', async () => {
+          const localSchema = graphql.buildSchema(`
+            type Query { outer: Outer }
+            type Outer { inner: String }
+          `)
+
+          const captures = {}
+          const captureActive = label => {
+            const span = tracer.scope().active()
+            captures[label] = {
+              name: span?.context()._name,
+              resource: span?.context().getTag('resource.name'),
+            }
+          }
+
+          const rootValue = {
+            outer () {
+              captureActive('outer')
+              return {
+                inner () {
+                  captureActive('inner')
+                  return 'value'
+                },
+              }
+            },
+          }
+
+          const result = await graphql.graphql({
+            schema: localSchema,
+            source: '{ outer { inner } }',
+            rootValue,
+          })
+
+          assert.strictEqual(result.data?.outer?.inner, 'value')
+          assert.deepStrictEqual(captures, {
+            outer: { name: 'graphql.resolve', resource: 'outer:Outer' },
+            inner: { name: 'graphql.resolve', resource: 'inner:String' },
+          })
+        })
+
         it('should run returned promise in the parent context', () => {
           const schema = graphql.buildSchema(`
             type Query {
@@ -2175,6 +2215,50 @@ describe('Plugin', () => {
           } finally {
             startCh.unsubscribe(handler)
           }
+        })
+
+        it('should run depth-gated resolvers in the parent scope and still resolve the data', async () => {
+          const localSchema = graphql.buildSchema(`
+            type Query { outer: Outer }
+            type Outer { middle: Middle }
+            type Middle { inner: String }
+          `)
+
+          const captures = {}
+          const captureActive = label => {
+            captures[label] = tracer.scope().active()?.context()._name
+          }
+
+          const rootValue = {
+            outer () {
+              captureActive('outer')
+              return {
+                middle () {
+                  captureActive('middle')
+                  return {
+                    inner () {
+                      captureActive('inner')
+                      return 'value'
+                    },
+                  }
+                },
+              }
+            },
+          }
+
+          const result = await graphql.graphql({
+            schema: localSchema,
+            source: '{ outer { middle { inner } } }',
+            rootValue,
+          })
+
+          assert.ok(!('errors' in result), `Unexpected per-field errors: ${JSON.stringify(result.errors)}`)
+          assert.strictEqual(result.data?.outer?.middle?.inner, 'value')
+          assert.deepStrictEqual(captures, {
+            outer: 'graphql.resolve',
+            middle: 'graphql.resolve',
+            inner: expectedSchema.server.opName,
+          })
         })
       })
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -948,6 +948,60 @@ describe('Plugin', () => {
           }
         })
 
+        it('parents user spans from every sibling of a collapsed list under a live span', async () => {
+          const Item = new graphql.GraphQLObjectType({
+            name: 'Item',
+            fields: {
+              name: {
+                type: graphql.GraphQLString,
+                resolve () {
+                  tracer.trace('user.work', () => {})
+                  return 'value'
+                },
+              },
+            },
+          })
+          const localSchema = new graphql.GraphQLSchema({
+            query: new graphql.GraphQLObjectType({
+              name: 'Query',
+              fields: {
+                items: {
+                  type: new graphql.GraphQLList(Item),
+                  resolve: () => [{}, {}],
+                },
+              },
+            }),
+          })
+
+          const [, result] = await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              const collapsed = spans.find(span => span.meta?.['graphql.field.path'] === 'items.*.name')
+              const userSpans = spans.filter(span => span.name === 'user.work')
+              const byId = new Map(spans.map(span => [span.span_id.toString(), span]))
+
+              assert.ok(collapsed, 'expected one collapsed items.*.name span')
+              assert.strictEqual(userSpans.length, 2, 'expected one user span per sibling resolver')
+
+              for (const userSpan of userSpans) {
+                const parent = byId.get(userSpan.parent_id.toString())
+                assert.ok(parent, 'user span must parent to a span in the same trace, not an orphaned closed span')
+                const parentStart = BigInt(parent.start)
+                const parentEnd = parentStart + BigInt(parent.duration)
+                const childStart = BigInt(userSpan.start)
+                const childEnd = childStart + BigInt(userSpan.duration)
+                assert.ok(
+                  childStart >= parentStart && childEnd <= parentEnd,
+                  'user span must be contained within its live parent, not start after it finished',
+                )
+              }
+            }, { spanResourceMatch: /items:\[Item]/ }),
+            graphql.graphql({ schema: localSchema, source: '{ items { name } }' }),
+          ])
+
+          assert.ok(!('errors' in result), `Unexpected per-field errors: ${JSON.stringify(result.errors)}`)
+        })
+
         it('should instrument list field resolvers', () => {
           const source = `{
             friends {


### PR DESCRIPTION
`tracer.startSpan(...)` calls inside a graphql resolver parented under `graphql.execute` instead of the field's `graphql.resolve` span, because the resolve plugin populated `fieldCtx.currentStore` without entering it on `storage('legacy')`. Migrate the resolve channel to the same `runStores` + `bindStart` shape `wrapExecute` already uses in this file: the plugin's `bindStart` returns the new store on first encounter, the parent ALS store on depth/collapse-filtered fields, and the cached store when the same field is revisited (collapsed list siblings).

`apm:graphql:resolve:start` subscribers (today: IAST taint-tracking) now fire once per resolver invocation rather than once per field path. For non-collapsed queries that is unchanged; for collapsed list fields it tags every sibling's args instead of only the first.

Co-authored-by: Luciano Leggieri <lleggieri@atlassian.com> @lukiano
Refs: https://github.com/DataDog/dd-trace-js/pull/7624

