### PR TITLE
ci: activate codecov coverage minimum for PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,4 +4,8 @@ coverage:
   precision: 2
   status:
     project: off
-    patch: off
+    patch:
+      default:
+        target: 95%
+        if_not_found: success
+        if_ci_failed: success

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,7 @@ coverage:
         target: 95%
         if_not_found: success
         if_ci_failed: success
+        # PRs against `vN.x` release branches are typically backports / cherry-picks
+        # where the patch coverage is decided in the source PR; only enforce on master.
+        branches:
+          - master


### PR DESCRIPTION
This activates a minimum for a patch to be covered. With our new integration test coverage, we should always tell the correct combined coverage and this uses that information to set a new standard.

If we run in a situation where the code is covered but this fails, let us identify ways to also cover that code.
