### PR TITLE
fix(ci): prevent Buildkite non-PR builds from being tagged as PRs

### DIFF
--- a/packages/dd-trace/src/plugins/util/ci.js
+++ b/packages/dd-trace/src/plugins/util/ci.js
@@ -651,11 +651,11 @@ module.exports = {
         }),
         [CI_NODE_NAME]: BUILDKITE_AGENT_ID,
         [CI_NODE_LABELS]: JSON.stringify(extraTags),
-        [PR_NUMBER]: BUILDKITE_PULL_REQUEST,
         [CI_JOB_ID]: BUILDKITE_JOB_ID,
       }
 
-      if (BUILDKITE_PULL_REQUEST) {
+      if (BUILDKITE_PULL_REQUEST && BUILDKITE_PULL_REQUEST !== 'false') {
+        tags[PR_NUMBER] = BUILDKITE_PULL_REQUEST
         tags[GIT_PULL_REQUEST_BASE_BRANCH] = BUILDKITE_PULL_REQUEST_BASE_BRANCH
       }
     }

--- a/packages/dd-trace/test/plugins/util/test-environment.spec.js
+++ b/packages/dd-trace/test/plugins/util/test-environment.spec.js
@@ -20,6 +20,7 @@ const {
   GIT_PULL_REQUEST_BASE_BRANCH,
   GIT_PULL_REQUEST_BASE_BRANCH_HEAD_SHA,
   GIT_COMMIT_HEAD_SHA,
+  PR_NUMBER,
 } = require('../../../src/plugins/util/tags')
 
 const { getGitMetadata } = proxyquire('../../../src/plugins/util/git', {
@@ -110,6 +111,27 @@ describe('test environment data', () => {
         }
       })
     })
+  })
+
+  it('does not set pr.number on Buildkite when BUILDKITE_PULL_REQUEST is the literal string false', () => {
+    process.env = {
+      BUILDKITE: 'true',
+      BUILDKITE_BUILD_ID: 'buildkite-pipeline-id',
+      BUILDKITE_JOB_ID: 'buildkite-job-id',
+      BUILDKITE_PIPELINE_SLUG: 'buildkite-pipeline-name',
+      BUILDKITE_BUILD_NUMBER: 'buildkite-pipeline-number',
+      BUILDKITE_BUILD_URL: 'https://buildkite-build-url.com',
+      BUILDKITE_BRANCH: 'gh-readonly-queue/main/pr-1234-abcdef0123456789abcdef0123456789abcdef01',
+      BUILDKITE_COMMIT: 'b9f0fb3fdbb94c9d24b2c75b49663122a529e123',
+      BUILDKITE_REPO: 'http://hostname.com/repo.git',
+      BUILDKITE_PULL_REQUEST: 'false',
+      BUILDKITE_PULL_REQUEST_BASE_BRANCH: 'main',
+    }
+
+    const tags = getCIMetadata()
+
+    assert.strictEqual(tags[PR_NUMBER], undefined)
+    assert.strictEqual(tags[GIT_PULL_REQUEST_BASE_BRANCH], undefined)
   })
 })
 


### PR DESCRIPTION
### What does this PR do?

Prevents Buildkite non-PR builds from being tagged as pull request builds in CI Visibility.

### Motivation

Buildkite sets `BUILDKITE_PULL_REQUEST="false"` as a literal string for non-PR builds. Because non-empty strings are truthy in JS, `dd-trace-js` was treating that value as an actual pull request number and emitting:

- `pr.number: "false"`
- `git.pull_request.base_branch`

That causes CI Visibility products, including Code Coverage and Test Optimization, to bucket default-branch Buildkite builds as PR builds instead of branch builds.

This mirrors the existing guard in `datadog-ci`, which only emits PR metadata when `BUILDKITE_PULL_REQUEST !== "false"`. ([link](https://github.com/DataDog/datadog-ci/blob/805f10afd21b519c149c5fd9b872a8c14c83f206/src/helpers/ci.ts#L460-L463))

### Testing

Added a regression test for Buildkite with `BUILDKITE_PULL_REQUEST="false"` and verified that `pr.number` and `git.pull_request.base_branch` are not emitted for non-PR builds.