### PR TITLE
fix(esm): expose 'tracer' as an ESM named export

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -268,6 +268,7 @@
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/encode/ @DataDog/lang-platform-js
+/packages/dd-trace/test/esm-named-exports.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/exporter.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/exporters/ @DataDog/lang-platform-js
 /packages/dd-trace/test/external-logger/ @DataDog/lang-platform-js

--- a/packages/dd-trace/index.js
+++ b/packages/dd-trace/index.js
@@ -30,9 +30,10 @@ if (!global._ddtrace) {
     configurable: true,
     writable: true,
   })
-
-  global._ddtrace.default = global._ddtrace
-  global._ddtrace.tracer = global._ddtrace
 }
 
 module.exports = global._ddtrace
+// Static aliases so cjs-module-lexer surfaces them as ESM named exports
+// (`import { tracer } from 'dd-trace'`).
+module.exports.tracer = global._ddtrace
+module.exports.default = global._ddtrace

--- a/packages/dd-trace/test/esm-named-exports.spec.js
+++ b/packages/dd-trace/test/esm-named-exports.spec.js
@@ -3,12 +3,13 @@
 const assert = require('node:assert/strict')
 const { spawnSync } = require('node:child_process')
 const path = require('node:path')
+const { pathToFileURL } = require('node:url')
 
 const { describe, it } = require('mocha')
 
 require('./setup/core')
 
-const ddTraceEntry = path.resolve(__dirname, '..', 'index.js')
+const ddTraceEntry = pathToFileURL(path.resolve(__dirname, '..', 'index.js')).href
 
 describe('ESM named exports', () => {
   it('exposes `tracer` and `default` to ESM consumers', () => {

--- a/packages/dd-trace/test/esm-named-exports.spec.js
+++ b/packages/dd-trace/test/esm-named-exports.spec.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const path = require('node:path')
+
+const { describe, it } = require('mocha')
+
+require('./setup/core')
+
+const ddTraceEntry = path.resolve(__dirname, '..', 'index.js')
+
+describe('ESM named exports', () => {
+  it('exposes `tracer` and `default` to ESM consumers', () => {
+    const script = `
+      import tracerDefault, { tracer } from ${JSON.stringify(ddTraceEntry)}
+
+      if (tracerDefault !== tracer) {
+        process.stderr.write('default !== tracer\\n')
+        process.exit(2)
+      }
+      if (typeof tracer.init !== 'function') {
+        process.stderr.write('tracer.init is not a function\\n')
+        process.exit(3)
+      }
+      process.stdout.write('ok')
+    `
+
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    const detail = `child exited with ${result.status}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+    assert.equal(result.status, 0, detail)
+    assert.equal(result.stdout, 'ok')
+  })
+})


### PR DESCRIPTION
`import { tracer } from 'dd-trace'` previously threw `SyntaxError: Named export 'tracer' not found` at instantiation. Node's ESM loader detects named exports from CJS modules with `cjs-module-lexer`, which only recognises top-level `module.exports.X = …` patterns. The aliases were written as `global._ddtrace.tracer = …` — a runtime property of the singleton proxy that happens to also be `module.exports`, invisible to the lexer. Runtime semantics are unchanged.

Fixes: https://github.com/DataDog/dd-trace-js/issues/4814