### PR TITLE
fix(config): align inferred service name with agent normalization

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -39,6 +39,7 @@ const {
   parseErrors,
   generateTelemetry,
 } = require('./defaults')
+const { normalizeService } = require('./normalize-service')
 const { transformers } = require('./parsers')
 
 const RUNTIME_ID = uuid()
@@ -513,7 +514,7 @@ class Config extends ConfigBase {
         const NX_TASK_TARGET_PROJECT = getEnvironmentVariable('NX_TASK_TARGET_PROJECT')
         if (NX_TASK_TARGET_PROJECT) {
           if (this.DD_ENABLE_NX_SERVICE_NAME) {
-            setAndTrack(this, 'service', NX_TASK_TARGET_PROJECT)
+            setAndTrack(this, 'service', normalizeService(NX_TASK_TARGET_PROJECT) || 'node')
             isServiceNameInferred = true
           } else if (DD_MAJOR < 6) {
             log.warn(
@@ -536,7 +537,8 @@ class Config extends ConfigBase {
             )
           : undefined
 
-        setAndTrack(this, 'service', serverlessName || pkg.name || 'node')
+        const inferred = normalizeService(serverlessName) || normalizeService(pkg.name) || 'node'
+        setAndTrack(this, 'service', inferred)
         this.tags.service ??= /** @type {string} */ (this.service)
         isServiceNameInferred = true
       }

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -537,8 +537,7 @@ class Config extends ConfigBase {
             )
           : undefined
 
-        const inferred = normalizeService(serverlessName) || normalizeService(pkg.name) || 'node'
-        setAndTrack(this, 'service', inferred)
+        setAndTrack(this, 'service', normalizeService(serverlessName) || normalizeService(pkg.name) || 'node')
         this.tags.service ??= /** @type {string} */ (this.service)
         isServiceNameInferred = true
       }

--- a/packages/dd-trace/src/config/normalize-service.js
+++ b/packages/dd-trace/src/config/normalize-service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const MAX_SERVICE_LENGTH = 100
+
+/**
+ * Normalize an inferred service name so APM and runtime metrics agree.
+ *
+ * The trace agent normalizes span service names on the wire, but the
+ * DogStatsD client uses a different tag-value sanitizer, so an inferred
+ * `@scope/name` package name appears as `scope/name` in APM and
+ * `_scope/name` in runtime metrics. Pre-normalizing pins both consumers
+ * (and telemetry / process tags) to the same value.
+ *
+ * @see https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/traceutil/normalize.go
+ * @param {string | undefined} name
+ */
+function normalizeService (name) {
+  if (!name) return
+
+  let normalized = name.toLowerCase()
+    .replaceAll(/[^a-z0-9_:./-]/g, '_')
+    .replace(/^[^a-z0-9]+/, '')
+
+  if (normalized.length > MAX_SERVICE_LENGTH) {
+    normalized = normalized.slice(0, MAX_SERVICE_LENGTH)
+  }
+
+  return normalized
+}
+
+module.exports = { normalizeService }

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -884,6 +884,24 @@ describe('Config', () => {
     assert.strictEqual(config.tags.service, 'test')
   })
 
+  it('should normalize the inferred service name from package.json', () => {
+    pkg.name = '@Scope/My-Service'
+
+    const config = getConfig()
+
+    assert.strictEqual(config.service, 'scope/my-service')
+    assert.strictEqual(config.tags.service, 'scope/my-service')
+  })
+
+  it('should fall back to "node" when the inferred service name normalizes to empty', () => {
+    pkg.name = '@@@'
+
+    const config = getConfig()
+
+    assert.strictEqual(config.service, 'node')
+    assert.strictEqual(config.tags.service, 'node')
+  })
+
   it('should initialize from the default version', () => {
     pkg.version = '1.2.3'
 

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -3961,6 +3961,16 @@ rules:
       }
     })
 
+    it('should fall back to "node" when NX_TASK_TARGET_PROJECT normalizes to empty', () => {
+      process.env.DD_ENABLE_NX_SERVICE_NAME = 'true'
+      process.env.NX_TASK_TARGET_PROJECT = '@@@'
+      pkg.name = 'default-service'
+
+      const config = getConfig()
+
+      assert.strictEqual(config.service, 'node')
+    })
+
     it('should warn about v6 behavior change when NX_TASK_TARGET_PROJECT is set without explicit config', () => {
       process.env.NX_TASK_TARGET_PROJECT = 'my-nx-project'
       delete process.env.DD_ENABLE_NX_SERVICE_NAME

--- a/packages/dd-trace/test/config/normalize-service.spec.js
+++ b/packages/dd-trace/test/config/normalize-service.spec.js
@@ -44,9 +44,4 @@ describe('normalizeService', () => {
     const longName = 'a'.repeat(150)
     assert.strictEqual(normalizeService(longName).length, 100)
   })
-
-  it('returns undefined when normalization produces an empty string', () => {
-    assert.strictEqual(normalizeService('@@@@'), undefined)
-    assert.strictEqual(normalizeService('---'), undefined)
-  })
 })

--- a/packages/dd-trace/test/config/normalize-service.spec.js
+++ b/packages/dd-trace/test/config/normalize-service.spec.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const { normalizeService } = require('../../src/config/normalize-service')
+
+describe('normalizeService', () => {
+  it('returns undefined for falsy input', () => {
+    assert.strictEqual(normalizeService(''), undefined)
+    assert.strictEqual(normalizeService(undefined), undefined)
+    assert.strictEqual(normalizeService(null), undefined)
+  })
+
+  it('passes already-valid service names through unchanged', () => {
+    assert.strictEqual(normalizeService('my-service'), 'my-service')
+    assert.strictEqual(normalizeService('payments_api'), 'payments_api')
+    assert.strictEqual(normalizeService('a_b:c.d/e-f'), 'a_b:c.d/e-f')
+  })
+
+  it('lowercases uppercase input', () => {
+    assert.strictEqual(normalizeService('MyService'), 'myservice')
+    assert.strictEqual(normalizeService('PAYMENTS-API'), 'payments-api')
+  })
+
+  it('strips leading @ from npm scope notation', () => {
+    assert.strictEqual(normalizeService('@scope/name'), 'scope/name')
+    assert.strictEqual(normalizeService('@datadog/agent'), 'datadog/agent')
+  })
+
+  it('replaces disallowed characters with underscore', () => {
+    assert.strictEqual(normalizeService('hello world'), 'hello_world')
+    assert.strictEqual(normalizeService('foo!bar?'), 'foo_bar_')
+  })
+
+  it('strips leading non-alphanumeric runs', () => {
+    assert.strictEqual(normalizeService('___leading'), 'leading')
+    assert.strictEqual(normalizeService('---name'), 'name')
+    assert.strictEqual(normalizeService('@@@nested'), 'nested')
+  })
+
+  it('truncates to 100 characters', () => {
+    const longName = 'a'.repeat(150)
+    assert.strictEqual(normalizeService(longName).length, 100)
+  })
+
+  it('returns undefined when normalization produces an empty string', () => {
+    assert.strictEqual(normalizeService('@@@@'), undefined)
+    assert.strictEqual(normalizeService('---'), undefined)
+  })
+})


### PR DESCRIPTION
The runtime-metrics service tag diverged from APM whenever the service name was inferred from `package.json`. The trace agent normalizes span service names on the wire (lowercases, strips the leading `@` of npm scope notation), but the DogStatsD client applies a different tag-value sanitizer, so `@scope/name` showed up as `scope/name` in APM and `_scope/name` in runtime metrics, breaking dashboard correlation. Apply the agent's normalization at the inference site only — `package.json` name, the serverless function-name env vars, and `NX_TASK_TARGET_PROJECT`. Explicit user-set values (`DD_SERVICE`, `options.service`, `OTEL_SERVICE_NAME`, `DD_TAGS`) stay untouched; the agent still normalizes those for the span path on the wire, and silently rewriting a value the user typed would be a separate decision.

As a side effect, inferred uppercase package names like `MyApp` now appear lowercased in both APM and runtime metrics; previously runtime metrics preserved the original case while APM did not.

Fixes: https://github.com/DataDog/dd-trace-js/issues/3589

