### PR TITLE
fix(otel): return a non-recording span when the inner tracer is the noop

### DIFF
--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -3,6 +3,8 @@
 const api = require('@opentelemetry/api')
 const { sanitizeAttributes } = require('../../../../vendor/dist/@opentelemetry/core')
 
+const tracer = require('../../')
+
 const id = require('../id')
 const log = require('../log')
 const DatadogSpanContext = require('../opentracing/span_context')
@@ -138,6 +140,14 @@ class Tracer {
         : this._createSpanContextForNewSpan(parentSpanContext)
     } else {
       spanContext = new SpanContext()
+    }
+
+    // init() didn't finish setting up real tracing (e.g. DD_TRACE_ENABLED=false,
+    // or init() was never called), so the inner tracer is still the noop.
+    // DatadogSpan can't construct without a processor + prioritySampler, so fall
+    // through to a non-recording span; the SpanContext still propagates.
+    if (!tracer._tracingInitialized) {
+      return api.trace.wrapSpanContext(spanContext)
     }
 
     const spanKind = options.kind || api.SpanKind.INTERNAL

--- a/packages/dd-trace/test/opentelemetry/tracer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer.spec.js
@@ -15,6 +15,7 @@ require('../../').init()
 const TracerProvider = require('../../src/opentelemetry/tracer_provider')
 const Tracer = require('../../src/opentelemetry/tracer')
 const Span = require('../../src/opentelemetry/span')
+const NoopTracer = require('../../src/noop/tracer')
 const DatadogSpan = require('../../src/opentracing/span')
 const tracer = require('../../')
 
@@ -71,6 +72,30 @@ describe('OTel Tracer', () => {
 
     const ddSpanContext = span._ddSpan.context()
     assert.strictEqual(ddSpanContext._tags.foo, 'bar')
+  })
+
+  it('returns a non-recording span when the inner tracer is the noop', () => {
+    const originalTracer = tracer._tracer
+    const originalInitialized = tracer._tracingInitialized
+    tracer._tracer = new NoopTracer()
+    tracer._tracingInitialized = false
+    try {
+      const otelTracer = new Tracer({}, {}, new TracerProvider())
+      const span = otelTracer.startSpan('name', { attributes: { foo: 'bar' } })
+
+      assert.strictEqual(span instanceof Span, false)
+      assert.strictEqual(span.isRecording(), false)
+      assert.ok(api.trace.isSpanContextValid(span.spanContext()))
+
+      span.setAttribute('after', 'create')
+      span.setAttributes({ baz: 'qux' })
+      span.addEvent('event')
+      span.recordException(new Error('oops'))
+      span.end()
+    } finally {
+      tracer._tracer = originalTracer
+      tracer._tracingInitialized = originalInitialized
+    }
   })
 
   it('should pass through span kind', () => {


### PR DESCRIPTION
When `tracer.init()` is never called or runs with `DD_TRACE_ENABLED=false`, the proxy's inner tracer stays a `NoopTracer` (no `_processor`, no `_prioritySampler`). The OTel bridge still constructs a `DatadogSpan` against it; the bridge `Span` constructor's first `setAttributes` call crashes inside `_addTags` with `Cannot read properties of undefined (reading 'sample')`.

The bridge now returns `api.trace.wrapSpanContext(spanContext)` instead -- the shape OTel uses for a `NOT_RECORD` sampling decision. Propagation keeps working, mutation methods become no-ops, and the disabled path never allocates a `DatadogSpan`.

Fixes: https://github.com/DataDog/dd-trace-js/issues/3854

