### PR TITLE
fix(otel): honor DD_TRACE_OTEL_ENABLED=false and OTEL_SDK_DISABLED=false

### DIFF
--- a/packages/datadog-instrumentations/src/otel-sdk-trace.js
+++ b/packages/datadog-instrumentations/src/otel-sdk-trace.js
@@ -3,14 +3,10 @@
 const shimmer = require('../../datadog-shimmer')
 const tracer = require('../../dd-trace')
 const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
+const { isFalse, isTrue } = require('../../dd-trace/src/util')
 const { addHook } = require('./helpers/instrument')
 
-const otelSdkEnabled = getValueFromEnvSources('DD_TRACE_OTEL_ENABLED') ||
-getValueFromEnvSources('OTEL_SDK_DISABLED')
-  ? !getValueFromEnvSources('OTEL_SDK_DISABLED')
-  : undefined
-
-if (otelSdkEnabled) {
+if (isOtelSdkEnabled()) {
   addHook({
     name: '@opentelemetry/sdk-trace-node',
     file: 'build/src/NodeTracerProvider.js',
@@ -21,4 +17,13 @@ if (otelSdkEnabled) {
     })
     return mod
   })
+}
+
+function isOtelSdkEnabled () {
+  // Datadog explicit opt-out wins over every OTel signal; check it first.
+  const ddTraceOtelEnabled = getValueFromEnvSources('DD_TRACE_OTEL_ENABLED')
+  if (isFalse(ddTraceOtelEnabled)) return false
+  const otelSdkDisabled = getValueFromEnvSources('OTEL_SDK_DISABLED')
+  if (isTrue(otelSdkDisabled)) return false
+  return isTrue(ddTraceOtelEnabled) || isFalse(otelSdkDisabled)
 }

--- a/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
+++ b/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
@@ -1,0 +1,96 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+const proxyquire = require('proxyquire').noPreserveCache()
+const sinon = require('sinon')
+
+describe('otel-sdk-trace', () => {
+  /**
+   * Re-load `otel-sdk-trace.js` with the supplied env values stubbed in via
+   * `getValueFromEnvSources` and report what `addHook` saw.
+   *
+   * @param {{ ddTraceOtelEnabled?: string, otelSdkDisabled?: string }} env
+   * @param {{ TracerProvider?: unknown }} [tracerStub]
+   * @returns {{ addHook: sinon.SinonSpy, wrap: sinon.SinonSpy }}
+   */
+  function loadWithEnv (env, tracerStub = {}) {
+    const addHook = sinon.spy()
+    const wrap = sinon.spy()
+    const values = {
+      DD_TRACE_OTEL_ENABLED: env.ddTraceOtelEnabled,
+      OTEL_SDK_DISABLED: env.otelSdkDisabled,
+    }
+    proxyquire('../src/otel-sdk-trace', {
+      '../../datadog-shimmer': { wrap },
+      '../../dd-trace': tracerStub,
+      '../../dd-trace/src/config/helper': {
+        getValueFromEnvSources: (name) => values[name],
+      },
+      './helpers/instrument': { addHook },
+    })
+    return { addHook, wrap }
+  }
+
+  describe('gate precedence', () => {
+    it('disables when DD_TRACE_OTEL_ENABLED is the explicit opt-out', () => {
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'false' }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: '0' }).addHook.called, false)
+    })
+
+    it('keeps DD opt-out winning even when OTEL_SDK_DISABLED=false opts in', () => {
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'false', otelSdkDisabled: 'false' }).addHook.called, false)
+    })
+
+    it('disables when OTEL_SDK_DISABLED is the explicit opt-out', () => {
+      assert.equal(loadWithEnv({ otelSdkDisabled: 'true' }).addHook.called, false)
+      assert.equal(loadWithEnv({ otelSdkDisabled: '1' }).addHook.called, false)
+    })
+
+    it('keeps OTel opt-out winning even when DD_TRACE_OTEL_ENABLED=true opts in', () => {
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'true', otelSdkDisabled: 'true' }).addHook.called, false)
+    })
+
+    it('enables when DD_TRACE_OTEL_ENABLED is the explicit opt-in', () => {
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'true' }).addHook.called, true)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: '1' }).addHook.called, true)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'true', otelSdkDisabled: 'false' }).addHook.called, true)
+    })
+
+    it('enables when OTEL_SDK_DISABLED=false is the OTel positive opt-in', () => {
+      assert.equal(loadWithEnv({ otelSdkDisabled: 'false' }).addHook.called, true)
+      assert.equal(loadWithEnv({ otelSdkDisabled: '0' }).addHook.called, true)
+    })
+
+    it('stays disabled by default when neither env var is set', () => {
+      assert.equal(loadWithEnv({}).addHook.called, false)
+    })
+
+    it('stays disabled for unrecognized values on either side', () => {
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'maybe', otelSdkDisabled: 'sure' }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: '' }).addHook.called, false)
+    })
+  })
+
+  describe('hook registration', () => {
+    it('wraps NodeTracerProvider with the dd-trace TracerProvider', () => {
+      const tracerProvider = function FakeTracerProvider () {}
+      const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: 'true' }, { TracerProvider: tracerProvider })
+
+      sinon.assert.calledOnce(addHook)
+      const [hookOptions, transform] = addHook.firstCall.args
+      assert.deepStrictEqual(hookOptions, {
+        name: '@opentelemetry/sdk-trace-node',
+        file: 'build/src/NodeTracerProvider.js',
+        versions: ['*'],
+      })
+
+      const mod = { NodeTracerProvider: function OriginalProvider () {} }
+      assert.equal(transform(mod), mod)
+
+      sinon.assert.calledOnceWithExactly(wrap, mod, 'NodeTracerProvider', sinon.match.func)
+      assert.equal(wrap.firstCall.args[2](), tracerProvider)
+    })
+  })
+})

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -11,21 +11,16 @@ const runtimeMetrics = require('../runtime_metrics')
 const log = require('../log')
 const { storage } = require('../../../datadog-core')
 const telemetryMetrics = require('../telemetry/metrics')
-const { getValueFromEnvSources } = require('../config/helper')
-const { isTrue } = require('../util')
 const SpanContext = require('./span_context')
 
 const dateNow = Date.now
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
 
-const DD_TRACE_EXPERIMENTAL_STATE_TRACKING = isTrue(getValueFromEnvSources('DD_TRACE_EXPERIMENTAL_STATE_TRACKING'))
-const DD_TRACE_EXPERIMENTAL_SPAN_COUNTS = isTrue(getValueFromEnvSources('DD_TRACE_EXPERIMENTAL_SPAN_COUNTS'))
-
 const unfinishedRegistry = createRegistry('unfinished')
 const finishedRegistry = createRegistry('finished')
 
-const OTEL_ENABLED = isTrue(getValueFromEnvSources('DD_TRACE_OTEL_ENABLED'))
+let OTEL_ENABLED = false
 const ALLOWED = new Set(['string', 'number', 'boolean'])
 
 const integrationCounters = {
@@ -55,7 +50,11 @@ function getIntegrationCounter (event, integration) {
 }
 
 class DatadogSpan {
+  #parentTracer
+
   constructor (tracer, processor, prioritySampler, fields, debug) {
+    OTEL_ENABLED = tracer._config.DD_TRACE_OTEL_ENABLED
+
     const operationName = fields.operationName
     const parent = fields.parent || null
     // TODO(BridgeAR): Investigate why this is causing a performance regression
@@ -63,7 +62,7 @@ class DatadogSpan {
     const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
 
-    this._parentTracer = tracer
+    this.#parentTracer = tracer
     this._debug = debug
     this._processor = processor
     this._prioritySampler = prioritySampler
@@ -94,7 +93,7 @@ class DatadogSpan {
       attributes: this._sanitizeAttributes(link.attributes),
     })) ?? []
 
-    if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
+    if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.increment('runtime.node.spans.unfinished')
       runtimeMetrics.increment('runtime.node.spans.unfinished.by.name', `span_name:${operationName}`)
 
@@ -104,16 +103,8 @@ class DatadogSpan {
       unfinishedRegistry.register(this, operationName, this)
     }
 
-    // Nullish operator is used here because both `tracer` and `tracer._config`
-    // can be null and there are tests passing invalid values to the `Span`
-    // constructor which still succeed today. Part of the problem is that `Span`
-    // stores only the tracer and not the config, so anything that needs the
-    // config has to read it from the tracer stored on the span, including
-    // even `Span` itself in this case.
-    //
-    // TODO: Refactor Tracer/Span + tests to avoid having to do nullish checks.
-    if (tracer?._config?.DD_TRACE_SPAN_LEAK_DEBUG > 0) {
-      require('../spanleak').addSpan(this, operationName)
+    if (tracer._config.DD_TRACE_SPAN_LEAK_DEBUG > 0) {
+      require('../spanleak').addSpan(this)
     }
 
     if (startCh.hasSubscribers) {
@@ -124,7 +115,7 @@ class DatadogSpan {
   [util.inspect.custom] () {
     return {
       ...this,
-      _parentTracer: `[${this._parentTracer.constructor.name}]`,
+      parentTracer: `[${this.#parentTracer.constructor.name}]`,
       _prioritySampler: `[${this._prioritySampler.constructor.name}]`,
       _processor: `[${this._processor.constructor.name}]`,
     }
@@ -156,7 +147,7 @@ class DatadogSpan {
   }
 
   tracer () {
-    return this._parentTracer
+    return this.#parentTracer
   }
 
   setOperationName (name) {
@@ -254,14 +245,14 @@ class DatadogSpan {
       return
     }
 
-    if (DD_TRACE_EXPERIMENTAL_STATE_TRACKING && !this._spanContext._tags['service.name']) {
+    if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_STATE_TRACKING && !this._spanContext._tags['service.name']) {
       log.error('Finishing invalid span: %s', this)
     }
 
     getIntegrationCounter('spans_finished', this._integrationName).inc()
     this._spanContext._tags['_dd.integration'] = this._integrationName
 
-    if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
+    if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.decrement('runtime.node.spans.unfinished')
       runtimeMetrics.decrement('runtime.node.spans.unfinished.by.name', `span_name:${this._name}`)
       runtimeMetrics.increment('runtime.node.spans.finished')
@@ -336,7 +327,7 @@ class DatadogSpan {
     let startTime
 
     let baggage = {}
-    const propagationBehavior = this._parentTracer?._config?.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
+    const propagationBehavior = this.#parentTracer._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
     if (parent && parent._isRemote && propagationBehavior !== 'continue') {
       baggage = parent._baggageItems
       parent = null

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -25,7 +25,7 @@ const DD_TRACE_EXPERIMENTAL_SPAN_COUNTS = isTrue(getValueFromEnvSources('DD_TRAC
 const unfinishedRegistry = createRegistry('unfinished')
 const finishedRegistry = createRegistry('finished')
 
-const OTEL_ENABLED = !!getValueFromEnvSources('DD_TRACE_OTEL_ENABLED')
+const OTEL_ENABLED = isTrue(getValueFromEnvSources('DD_TRACE_OTEL_ENABLED'))
 const ALLOWED = new Set(['string', 'number', 'boolean'])
 
 const integrationCounters = {

--- a/packages/dd-trace/src/spanleak.js
+++ b/packages/dd-trace/src/spanleak.js
@@ -85,7 +85,6 @@ module.exports.addSpan = function (span) {
   const expiration = now + LIFETIME
   const wrapped = new WeakRef(span)
   spans.add(wrapped, expiration)
-  // registry.register(span, span._name)
 }
 
 function isEnabled () {

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -3,6 +3,8 @@
 const assert = require('node:assert/strict')
 
 const { before, describe, it } = require('mocha')
+
+const getConfig = require('../../src/config')
 const {
   encodeUnicode,
   getFunctionArguments,
@@ -147,29 +149,31 @@ describe('util', () => {
 
   describe('spanHasError', () => {
     let Span
+    let tracer
     let ps
 
     before(() => {
       Span = require('../../src/opentracing/span')
+      tracer = { _config: getConfig() }
       ps = {
         sample () {},
       }
     })
 
     it('returns false when there is no error', () => {
-      const span = new Span(null, null, ps, {})
+      const span = new Span(tracer, null, ps, {})
       assert.strictEqual(spanHasError(span), false)
     })
 
     it('returns true if the span has an "error" tag', () => {
-      const span = new Span(null, null, ps, {})
+      const span = new Span(tracer, null, ps, {})
       span.setTag('error', true)
       assert.strictEqual(spanHasError(span), true)
     })
 
     it('returns true if the span has the error properties as tags', () => {
       const err = new Error('boom')
-      const span = new Span(null, null, ps, {})
+      const span = new Span(tracer, null, ps, {})
 
       span.setTag('error.type', err.name)
       span.setTag('error.msg', err.message)

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -33,7 +33,7 @@ describe('Span', () => {
     id.onFirstCall().returns('123')
     id.onSecondCall().returns('456')
 
-    tracer = {}
+    tracer = { _config: getConfig() }
 
     processor = {
       process: sinon.stub(),
@@ -499,21 +499,13 @@ describe('Span', () => {
       })
 
       it('should not propagate baggage items when Trace_Propagation_Behavior_Extract is set to ignore', () => {
-        tracer = {
-          _config: {
-            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore',
-          },
-        }
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore' } }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, {})
       })
 
       it('should propagate baggage items when Trace_Propagation_Behavior_Extract is set to restart', () => {
-        tracer = {
-          _config: {
-            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart',
-          },
-        }
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar' })
       })

--- a/packages/dd-trace/test/standalone/index.spec.js
+++ b/packages/dd-trace/test/standalone/index.spec.js
@@ -8,6 +8,7 @@ const proxyquire = require('proxyquire')
 const { channel } = require('dc-polyfill')
 
 require('../setup/core')
+const getConfig = require('../../src/config')
 const standalone = require('../../src/standalone')
 const DatadogSpan = require('../../src/opentracing/span')
 
@@ -40,7 +41,7 @@ describe('Disabled APM Tracing or Standalone', () => {
       },
     }
 
-    tracer = {}
+    tracer = { _config: getConfig() }
     processor = {}
     prioritySampler = {}
   })

--- a/packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js
+++ b/packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js
@@ -8,6 +8,7 @@ const proxyquire = require('proxyquire')
 
 require('../setup/core')
 const { USER_KEEP, AUTO_KEEP } = require('../../../../ext/priority')
+const getConfig = require('../../src/config')
 const DatadogSpan = require('../../src/opentracing/span')
 const TraceSourcePrioritySampler = require('../../src/standalone/tracesource_priority_sampler')
 const { TRACE_SOURCE_PROPAGATION_KEY } = require('../../src/constants')
@@ -36,7 +37,8 @@ describe('Disabled APM Tracing or Standalone - TraceSourcePrioritySampler', () =
 
   describe('sample', () => {
     it('should provide the context when invoking _getPriorityFromTags', () => {
-      const span = new DatadogSpan({}, {}, prioritySampler, {
+      const tracer = { _config: getConfig() }
+      const span = new DatadogSpan(tracer, {}, prioritySampler, {
         operationName: 'operation',
       })
 


### PR DESCRIPTION
The auto-instrumentation gate in `otel-sdk-trace.js` and the `otel_enabled` telemetry tag in `opentracing/span.js` checked these env vars for truthiness, which makes the string `'false'` truthy. Three combinations behaved wrongly:

1. `DD_TRACE_OTEL_ENABLED=false` alone still enabled instrumentation.
2. `OTEL_SDK_DISABLED=false` did not enable it, even though the OTel spec uses it as a positive opt-in.
3. `DD_TRACE_OTEL_ENABLED=true OTEL_SDK_DISABLED=false` did not enable it.

The opt-in default ("instrument only when explicitly asked") is preserved.

Fixes: https://github.com/DataDog/dd-trace-js/issues/4873