### PR TITLE
refactor(otel): extract bridge helpers into span-helpers.js

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span-helpers.js
+++ b/packages/dd-trace/src/opentelemetry/span-helpers.js
@@ -1,0 +1,170 @@
+'use strict'
+
+const { ERROR_MESSAGE, ERROR_STACK, ERROR_TYPE, IGNORE_OTEL_ERROR } = require('../constants')
+const DatadogSpanContext = require('../opentracing/span_context')
+const TraceState = require('../opentracing/propagation/tracestate')
+
+const id = require('../id')
+
+/**
+ * @typedef {{ toTraceId: (get128?: boolean) => string, toSpanId: (get128?: boolean) => string }} DatadogContextLike
+ * @typedef {{ _ddContext: import('../opentracing/span_context') }} OtelBridgeSpanContextLike
+ * @typedef {{
+ *   traceId: string,
+ *   spanId: string,
+ *   traceFlags?: number,
+ *   traceState?: { serialize: () => string }
+ * }} OtelSpanContextLike
+ * @typedef {DatadogContextLike | OtelBridgeSpanContextLike | OtelSpanContextLike} LinkContextLike
+ * @typedef {{ context: LinkContextLike, attributes?: Record<string, unknown> }} OtelLink
+ * @typedef {{
+ *   name?: string,
+ *   message?: string,
+ *   stack?: string,
+ *   type?: string,
+ *   escaped?: unknown
+ * }} ExceptionLike
+ * @typedef {{
+ *   addEvent: (name: string, attributes: Record<string, unknown>, timeInput?: unknown) => unknown
+ * }} EventTarget
+ */
+
+/**
+ * Normalize any Datadog/OTel span-context shape to a `DatadogSpanContext`.
+ *
+ * @param {LinkContextLike | undefined | null} context
+ * @returns {import('../opentracing/span_context') | undefined}
+ */
+function normalizeLinkContext (context) {
+  if (!context) return
+
+  const bridgeCtx = /** @type {OtelBridgeSpanContextLike} */ (context)
+  if (bridgeCtx._ddContext) return bridgeCtx._ddContext
+
+  const ddCtx = /** @type {DatadogContextLike} */ (context)
+  if (typeof ddCtx.toTraceId === 'function' && typeof ddCtx.toSpanId === 'function') {
+    return /** @type {import('../opentracing/span_context')} */ (/** @type {unknown} */ (context))
+  }
+
+  const otelCtx = /** @type {OtelSpanContextLike} */ (context)
+  if (typeof otelCtx.traceId !== 'string' || typeof otelCtx.spanId !== 'string') return
+
+  let sampling
+  if (typeof otelCtx.traceFlags === 'number') {
+    sampling = { priority: otelCtx.traceFlags & 1 }
+  }
+
+  let tracestate
+  if (otelCtx.traceState?.serialize) {
+    tracestate = TraceState.fromString(otelCtx.traceState.serialize())
+  }
+
+  return new DatadogSpanContext({
+    traceId: id(otelCtx.traceId, 16),
+    spanId: id(otelCtx.spanId, 16),
+    sampling,
+    tracestate,
+  })
+}
+
+/**
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {string} key
+ * @param {unknown} value
+ * @returns {void}
+ */
+function setOtelAttribute (ddSpan, key, value) {
+  if (key === 'http.response.status_code') {
+    ddSpan.setTag('http.status_code', String(value))
+  }
+
+  ddSpan.setTag(key, value)
+}
+
+/**
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {Record<string, unknown>} attributes
+ * @returns {void}
+ */
+function setOtelAttributes (ddSpan, attributes) {
+  if ('http.response.status_code' in attributes) {
+    attributes['http.status_code'] = String(attributes['http.response.status_code'])
+  }
+
+  ddSpan.addTags(attributes)
+}
+
+/**
+ * Accepts both `{ context, attributes }` and the deprecated `(context, attrs)` form.
+ *
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {LinkContextLike | OtelLink} link
+ * @param {Record<string, unknown>} [attrs]
+ * @returns {void}
+ */
+function addOtelLink (ddSpan, link, attrs) {
+  // TODO: Drop the (context, attrs) form in v6.0.0.
+  const linkObj = link && typeof link === 'object' && 'context' in link
+    ? /** @type {OtelLink} */ (link)
+    : { context: /** @type {LinkContextLike} */ (link), attributes: attrs ?? {} }
+
+  const ddSpanContext = normalizeLinkContext(linkObj.context)
+  if (!ddSpanContext) return
+
+  ddSpan.addLink({ context: ddSpanContext, attributes: linkObj.attributes })
+}
+
+/**
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {EventTarget} eventTarget
+ * @param {ExceptionLike} exception
+ * @param {unknown} [timeInput]
+ * @returns {void}
+ */
+function recordException (ddSpan, eventTarget, exception, timeInput) {
+  ddSpan.addTags({
+    [ERROR_TYPE]: exception.name,
+    [ERROR_MESSAGE]: exception.message,
+    [ERROR_STACK]: exception.stack,
+    [IGNORE_OTEL_ERROR]: ddSpan.context()._tags[IGNORE_OTEL_ERROR] ?? true,
+  })
+
+  /** @type {Record<string, unknown>} */
+  const attributes = {}
+  if (exception.message) attributes['exception.message'] = exception.message
+  if (exception.type) attributes['exception.type'] = exception.type
+  if (exception.escaped) attributes['exception.escaped'] = exception.escaped
+  if (exception.stack) attributes['exception.stacktrace'] = exception.stack
+
+  eventTarget.addEvent(exception.name ?? 'Error', attributes, timeInput)
+}
+
+/**
+ * First-call-wins; no-op on ended spans. Only `code === 2` emits Datadog error tags.
+ *
+ * @param {import('../opentracing/span')} ddSpan
+ * @param {{ ended: boolean, _hasStatus: boolean }} bridgeSpan
+ * @param {{ code?: number, message?: string }} [status]
+ * @returns {void}
+ */
+function setStatus (ddSpan, bridgeSpan, { code, message } = {}) {
+  if (bridgeSpan.ended || bridgeSpan._hasStatus || !code) return
+
+  bridgeSpan._hasStatus = true
+
+  if (code === 2) {
+    ddSpan.addTags({
+      [ERROR_MESSAGE]: message,
+      [IGNORE_OTEL_ERROR]: false,
+    })
+  }
+}
+
+module.exports = {
+  addOtelLink,
+  normalizeLinkContext,
+  recordException,
+  setOtelAttribute,
+  setOtelAttributes,
+  setStatus,
+}

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -9,12 +9,18 @@ const { timeInputToHrTime } = require('../../../../vendor/dist/@opentelemetry/co
 
 const tracer = require('../../')
 const DatadogSpan = require('../opentracing/span')
-const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK, IGNORE_OTEL_ERROR } = require('../constants')
 const { SERVICE_NAME, RESOURCE_NAME, SPAN_KIND } = require('../../../../ext/tags')
 const kinds = require('../../../../ext/kinds')
 
 const id = require('../id')
 const SpanContext = require('./span_context')
+const {
+  addOtelLink,
+  recordException,
+  setOtelAttribute,
+  setOtelAttributes,
+  setStatus,
+} = require('./span-helpers')
 
 // The one built into OTel rounds so we lose sub-millisecond precision.
 function hrTimeToMilliseconds (time) {
@@ -195,33 +201,17 @@ class Span {
   }
 
   setAttribute (key, value) {
-    if (key === 'http.response.status_code') {
-      this._ddSpan.setTag('http.status_code', value.toString())
-    }
-
-    this._ddSpan.setTag(key, value)
+    setOtelAttribute(this._ddSpan, key, value)
     return this
   }
 
   setAttributes (attributes) {
-    if ('http.response.status_code' in attributes) {
-      attributes['http.status_code'] = attributes['http.response.status_code'].toString()
-    }
-
-    this._ddSpan.addTags(attributes)
+    setOtelAttributes(this._ddSpan, attributes)
     return this
   }
 
   addLink (link, attrs) {
-    // TODO: Remove this once we remove addLink(context, attrs) in v6.0.0
-    if (link instanceof SpanContext) {
-      link = { context: link, attributes: attrs ?? {} }
-    }
-
-    const { context, attributes } = link
-    // Extract dd context
-    const ddSpanContext = context._ddContext
-    this._ddSpan.addLink({ context: ddSpanContext, attributes })
+    addOtelLink(this._ddSpan, link, attrs)
     return this
   }
 
@@ -244,16 +234,8 @@ class Span {
     return this.addLink(zeroContext, attributes)
   }
 
-  setStatus ({ code, message }) {
-    if (!this.ended && !this._hasStatus && code) {
-      this._hasStatus = true
-      if (code === 2) {
-        this._ddSpan.addTags({
-          [ERROR_MESSAGE]: message,
-          [IGNORE_OTEL_ERROR]: false,
-        })
-      }
-    }
+  setStatus (status) {
+    setStatus(this._ddSpan, this, status)
     return this
   }
 
@@ -291,18 +273,8 @@ class Span {
   }
 
   recordException (exception, timeInput) {
-    this._ddSpan.addTags({
-      [ERROR_TYPE]: exception.name,
-      [ERROR_MESSAGE]: exception.message,
-      [ERROR_STACK]: exception.stack,
-      [IGNORE_OTEL_ERROR]: this._ddSpan.context()._tags[IGNORE_OTEL_ERROR] ?? true,
-    })
-    const attributes = {}
-    if (exception.message) attributes['exception.message'] = exception.message
-    if (exception.type) attributes['exception.type'] = exception.type
-    if (exception.escaped) attributes['exception.escaped'] = exception.escaped
-    if (exception.stack) attributes['exception.stacktrace'] = exception.stack
-    this.addEvent(exception.name, attributes, timeInput)
+    // Route through `this.addEvent` so its time-input conversion applies.
+    recordException(this._ddSpan, this, exception, timeInput)
   }
 
   get duration () {

--- a/packages/dd-trace/src/opentelemetry/tracer.js
+++ b/packages/dd-trace/src/opentelemetry/tracer.js
@@ -5,47 +5,12 @@ const { sanitizeAttributes } = require('../../../../vendor/dist/@opentelemetry/c
 
 const id = require('../id')
 const log = require('../log')
-const DatadogSpanContext = require('../opentracing/span_context')
 const TextMapPropagator = require('../opentracing/propagation/text_map')
 const TraceState = require('../opentracing/propagation/tracestate')
 const SpanContext = require('./span_context')
 const Span = require('./span')
 const Sampler = require('./sampler')
-
-function normalizeLinkContext (context) {
-  if (!context) return
-
-  // OTel API bridge SpanContext wrapper
-  if (context._ddContext) return context._ddContext
-
-  // Datadog span context
-  if (typeof context.toTraceId === 'function' && typeof context.toSpanId === 'function') {
-    return context
-  }
-
-  // Standard OTel SpanContext (traceId/spanId)
-  if (typeof context.traceId !== 'string' || typeof context.spanId !== 'string') {
-    // Invalid
-    return
-  }
-
-  let sampling
-  if (typeof context.traceFlags === 'number') {
-    sampling = { priority: context.traceFlags & 1 }
-  }
-
-  let tracestate
-  if (context.traceState?.serialize) {
-    tracestate = TraceState.fromString(context.traceState.serialize())
-  }
-
-  return new DatadogSpanContext({
-    traceId: id(context.traceId, 16),
-    spanId: id(context.spanId, 16),
-    sampling,
-    tracestate,
-  })
-}
+const { normalizeLinkContext } = require('./span-helpers')
 
 class Tracer {
   constructor (library, config, tracerProvider) {


### PR DESCRIPTION
Pulls the OTel-to-Datadog translation logic out of `span.js` and `tracer.js` into a single `span-helpers.js` module exposing: `normalizeLinkContext`, `setOtelAttribute`, `setOtelAttributes`, `addOtelLink`, `recordException`, `setStatus`.

No behavior change. Consolidating these small helpers in one place keeps the OTel-bridge translation layer easy to reason about and lets future bridge objects reuse the same logic without duplication.