### PR TITLE
fix(hono): skip publishing when env.incoming is missing

### DIFF
--- a/packages/datadog-instrumentations/src/hono.js
+++ b/packages/datadog-instrumentations/src/hono.js
@@ -14,9 +14,15 @@ const enterChannel = channel('apm:hono:middleware:enter')
 const exitChannel = channel('apm:hono:middleware:exit')
 const finishChannel = channel('apm:hono:middleware:finish')
 
+// `app.request()` and non-node adapters call `app.fetch` without an `incoming`
+// IncomingMessage; the APM `web` helpers depend on one, so the wrappers below
+// skip publishing whenever it is missing.
 function wrapFetch (fetch) {
   return function (request, env, executionCtx) {
-    handleChannel.publish({ req: env.incoming })
+    const req = env?.incoming
+    if (req) {
+      handleChannel.publish({ req })
+    }
     return fetch.apply(this, arguments)
   }
 }
@@ -31,8 +37,10 @@ function wrapCompose (compose) {
 
     const instrumentedOnError = (...args) => {
       const [error, context] = args
-      const req = context.env.incoming
-      errorChannel.publish({ req, error })
+      const req = context.env?.incoming
+      if (req) {
+        errorChannel.publish({ req, error })
+      }
       return onError(...args)
     }
 
@@ -62,7 +70,10 @@ function wrapMiddleware (middleware, route) {
     middleware,
     (middleware) =>
       function (context, next) {
-        const req = context.env.incoming
+        const req = context.env?.incoming
+        if (!req) {
+          return middleware.apply(this, arguments)
+        }
         routeChannel.publish({ req, route })
         enterChannel.publish({ req, name, route })
         if (typeof next === 'function') {

--- a/packages/datadog-instrumentations/test/hono.spec.js
+++ b/packages/datadog-instrumentations/test/hono.spec.js
@@ -138,5 +138,49 @@ withVersions('hono', 'hono', version => {
       assert.strictEqual(callArgs.req.url, '/error')
       assert.strictEqual(callArgs.error.message, 'test error')
     })
+
+    // Regression for #8198: Hono's testing helper forwards to
+    // `app.fetch(request, undefined, undefined)`, so `env` and `context.env` are
+    // undefined. The wrappers must not throw and must not publish events with a
+    // missing IncomingMessage (the APM `web` helpers depend on one).
+    describe('without a Node.js IncomingMessage', () => {
+      let localApp
+      let localMiddlewareCalled
+
+      beforeEach(() => {
+        const { Hono } = require(`../../../versions/hono@${version}`).get()
+        localMiddlewareCalled = sinon.stub()
+        localApp = new Hono()
+        localApp.use(async function localNamed (_c, next) {
+          localMiddlewareCalled()
+          await next()
+        })
+        localApp.get('/test', (c) => c.text('OK'))
+        localApp.get('/error', () => { throw new Error('boom') })
+      })
+
+      it('should serve `app.request()` without throwing or publishing', async () => {
+        const res = await localApp.request('/test')
+
+        assert.strictEqual(res.status, 200)
+        assert.strictEqual(await res.text(), 'OK')
+        sinon.assert.calledOnce(localMiddlewareCalled)
+        sinon.assert.notCalled(handleChannelCb)
+        sinon.assert.notCalled(routeChannelCb)
+        sinon.assert.notCalled(enterChannelCb)
+        sinon.assert.notCalled(nextChannelCb)
+        sinon.assert.notCalled(exitChannelCb)
+        sinon.assert.notCalled(finishChannelCb)
+        sinon.assert.notCalled(errorChannelCb)
+      })
+
+      it('should let route errors propagate without publishing to errorChannel', async () => {
+        const res = await localApp.request('/error')
+
+        assert.strictEqual(res.status, 500)
+        sinon.assert.notCalled(errorChannelCb)
+        sinon.assert.notCalled(handleChannelCb)
+      })
+    })
   })
 })


### PR DESCRIPTION
Hono's testing helper `app.request()` and any non-node adapter call `app.fetch(request, undefined, undefined)`, so `env` and `context.env` are undefined. The wrappers dereferenced `env.incoming` unconditionally and threw `TypeError`. That throw is caught by the plugin's `addSub` wrapper, which logs and disables the hono plugin for the rest of the process — every CI Visibility run that loads dd-trace via `--import dd-trace/register.js` silently lost Hono APM coverage after the first `app.request()`.

Each wrapper now reads `env?.incoming` once. When the IncomingMessage is absent there is no Node.js HTTP request to attach a span to, so the instrumentation skips publishing and `wrapMiddleware` short-circuits to the original middleware.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8198