### PR TITLE
update all green script to fail when any retry failed

### DIFF
--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -101,6 +101,20 @@ async function getRuns () {
 async function pollUntilDone () {
   const runs = await getRuns()
 
+  // Check before modifying retriedRunIds to avoid false positives on freshly requeued runs.
+  const retryFailed = runs.filter(r =>
+    r.status === 'completed' &&
+    failureConclusions.has(r.conclusion) &&
+    retriedRunIds.has(r.id)
+  )
+
+  if (retryFailed.length > 0) {
+    for (const run of retryFailed) {
+      console.error(`Workflow run ${run.id} (${run.name}) failed after retry, failing immediately.`)
+    }
+    return { runs, done: true }
+  }
+
   const toRetry = runs.filter(r =>
     r.status === 'completed' &&
     failureConclusions.has(r.conclusion) &&


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update all green script to fail when any retry failed.

### Motivation
<!-- What inspired you to submit this pull request? -->

The new all green script now reruns workflows as soon as they fail instead of as a batch at the very end. This means that the rerun of a single workflow can be done while other workflows are still in progress. But once a rerun fails, we are guaranteed that all green will eventually fail, so there is no point in leaving it running which just ends up wasting API calls.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


