### PR TITLE
feat(exporter): retry through agent startup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -285,6 +285,7 @@
 /packages/datadog-core @DataDog/lang-platform-js
 /packages/datadog-shimmer @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/common/retry.js @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js

--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -7,38 +7,12 @@ const zlib = require('zlib')
 const { storage } = require('../../../../datadog-core')
 const log = require('../../log')
 const { httpAgent, httpsAgent } = require('../../exporters/common/agents')
+const {
+  RATE_LIMIT_MAX_WAIT_MS,
+  isRetriableNetworkError,
+  singleJitteredDelay,
+} = require('../../exporters/common/retry')
 const { urlToHttpOptions } = require('../../exporters/common/url-to-http-options-polyfill')
-
-const RATE_LIMIT_MAX_WAIT_MS = 30_000
-const RETRY_BASE_MS = 5000
-const RETRY_JITTER_MS = 2500
-
-/**
- * Calculates retry delay with jitter to prevent thundering herd.
- * Delay is RETRY_BASE_MS + random(0, RETRY_JITTER_MS) (e.g. 5–7.5 seconds).
- *
- * @returns {number} Delay in milliseconds
- */
-function getRetryDelay () {
-  return RETRY_BASE_MS + (Math.random() * RETRY_JITTER_MS)
-}
-
-/**
- * Determines if a network error is retriable (transient failures only).
- * ECONNREFUSED is retried because it can be transient (service starting up,
- * restarts, rolling deploys, k8s pod/readiness transitions). ENOTFOUND is
- * excluded as it indicates DNS failure or wrong host and is usually not transient.
- *
- * @param {Error} err - The error to check
- * @returns {boolean}
- */
-function isRetriableNetworkError (err) {
-  if (!err.code) return false
-  return err.code === 'ECONNREFUSED' ||
-    err.code === 'ECONNRESET' ||
-    err.code === 'ETIMEDOUT' ||
-    err.code === 'EPIPE'
-}
 
 function parseUrl (urlObjOrString) {
   if (urlObjOrString !== null && typeof urlObjOrString === 'object') {
@@ -157,7 +131,7 @@ function request (data, options, callback) {
               // ignore
             }
             hasRetried = true
-            setTimeout(makeRequest, getRetryDelay())
+            setTimeout(makeRequest, singleJitteredDelay())
             return
           }
 
@@ -177,7 +151,7 @@ function request (data, options, callback) {
         // Retry on retriable network errors
         if (!hasRetried && isRetriableNetworkError(err)) {
           hasRetried = true
-          setTimeout(makeRequest, getRetryDelay())
+          setTimeout(makeRequest, singleJitteredDelay())
           return
         }
 

--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -37,6 +37,10 @@ function parseUrl (urlObjOrString) {
  * Destroys connections on errors to prevent reuse of bad connections. Preserves
  * original status code across retries for telemetry.
  *
+ * Retry timers stay ref'd. Test-runner plugins block the suite via
+ * `delay: true` channels until this callback fires; an unref'd retry would
+ * let the host exit first and the suite would never run.
+ *
  * @param {string} data - Request body (e.g. JSON string)
  * @param {object} options - { url, path?, method?, headers?, timeout? } (may be mutated)
  * @param {Function} callback - (err, res, statusCode) => void

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -177,7 +177,10 @@ function request (data, options, callback) {
       req.once('error', error => {
         finalize()
         if (attemptIndex < getMaxAttempts() && isRetriableNetworkError(error)) {
-          setTimeout(attempt, getRetryDelay(attemptIndex), attemptIndex + 1)
+          // Unref so a pending retry never keeps the host process alive past
+          // its natural exit point; long-running apps still retry because the
+          // event loop is held open by their own work.
+          setTimeout(attempt, getRetryDelay(attemptIndex), attemptIndex + 1).unref()
         } else {
           callback(error)
         }

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -13,6 +13,12 @@ const log = require('../../log')
 const { urlToHttpOptions } = require('./url-to-http-options-polyfill')
 const docker = require('./docker')
 const { httpAgent, httpsAgent } = require('./agents')
+const {
+  getMaxAttempts,
+  getRetryDelay,
+  isRetriableNetworkError,
+  markEndpointReached,
+} = require('./retry')
 
 const maxActiveBufferSize = 1024 * 1024 * 64
 
@@ -92,6 +98,8 @@ function request (data, options, callback) {
   options.agent = isSecure ? httpsAgent : httpAgent
 
   const onResponse = (res, finalize) => {
+    markEndpointReached()
+
     const chunks = []
 
     res.setTimeout(timeout)
@@ -142,7 +150,10 @@ function request (data, options, callback) {
     })
   }
 
-  const makeRequest = onError => {
+  // Retries always run via setTimeout so the AsyncLocalStorage store survives
+  // the gap before socket.connect(); ALS.run() does not call ALS.enterWith()
+  // outside AsyncContextFrame, so a synchronous re-entry would lose the store.
+  const attempt = attemptIndex => {
     if (!request.writable) {
       log.debug('Maximum number of active requests reached: payload is discarded.')
       return callback(null)
@@ -163,9 +174,13 @@ function request (data, options, callback) {
       req.once('close', finalize)
       req.once('timeout', finalize)
 
-      req.once('error', err => {
+      req.once('error', error => {
         finalize()
-        onError(err)
+        if (attemptIndex < getMaxAttempts() && isRetriableNetworkError(error)) {
+          setTimeout(attempt, getRetryDelay(attemptIndex), attemptIndex + 1)
+        } else {
+          callback(error)
+        }
       })
 
       req.setTimeout(timeout, () => {
@@ -185,14 +200,7 @@ function request (data, options, callback) {
     })
   }
 
-  // The setTimeout is needed to avoid losing the async context in the retry
-  // request before socket.connect() is called. This is a workaround for the
-  // issue that the AsyncLocalStorage.run() method does not call the
-  // AsyncLocalStorage.enterWith() method when not using AsyncContextFrame.
-  //
-  // TODO: Test that this doesn't trace itself on retry when the diagnostics
-  // channel events are available in the agent exporter.
-  makeRequest(() => setTimeout(() => makeRequest(callback)))
+  attempt(1)
 }
 
 function byteLength (data) {

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -98,7 +98,7 @@ function request (data, options, callback) {
   options.agent = isSecure ? httpsAgent : httpAgent
 
   const onResponse = (res, finalize) => {
-    markEndpointReached()
+    markEndpointReached(options)
 
     const chunks = []
 
@@ -176,11 +176,11 @@ function request (data, options, callback) {
 
       req.once('error', error => {
         finalize()
-        if (attemptIndex < getMaxAttempts() && isRetriableNetworkError(error)) {
+        if (attemptIndex < getMaxAttempts(options) && isRetriableNetworkError(error)) {
           // Unref so a pending retry never keeps the host process alive past
           // its natural exit point; long-running apps still retry because the
           // event loop is held open by their own work.
-          setTimeout(attempt, getRetryDelay(attemptIndex), attemptIndex + 1).unref()
+          setTimeout(attempt, getRetryDelay(options, attemptIndex), attemptIndex + 1).unref()
         } else {
           callback(error)
         }

--- a/packages/dd-trace/src/exporters/common/retry.js
+++ b/packages/dd-trace/src/exporters/common/retry.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const RATE_LIMIT_MAX_WAIT_MS = 30_000
+
+const SINGLE_RETRY_BASE_MS = 5000
+const SINGLE_RETRY_JITTER_MS = 2500
+
+const STARTUP_GRACE_MS = 30_000
+const STARTUP_BACKOFF_BASE_MS = 1000
+const STARTUP_BACKOFF_MAX_MS = 8000
+const STARTUP_BACKOFF_JITTER_MS = 500
+const STARTUP_MAX_ATTEMPTS = 5
+const POST_STARTUP_MAX_ATTEMPTS = 2
+
+// `ECONNREFUSED` and `ENOENT` cover the agent-not-yet-listening cases (TCP and
+// UDS). `EAI_AGAIN` covers transient DNS in agentless intake. `ENOTFOUND` is
+// excluded because it usually means a misconfigured host, not a transient state.
+const RETRIABLE_NETWORK_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENOENT',
+  'EPIPE',
+  'ETIMEDOUT',
+])
+
+const startedAtMs = Date.now()
+let endpointReached = false
+
+/**
+ * @param {Error & { code?: string }} error
+ */
+function isRetriableNetworkError (error) {
+  return error?.code !== undefined && RETRIABLE_NETWORK_CODES.has(error.code)
+}
+
+function singleJitteredDelay () {
+  return SINGLE_RETRY_BASE_MS + Math.random() * SINGLE_RETRY_JITTER_MS
+}
+
+function inStartupPhase () {
+  return !endpointReached && (Date.now() - startedAtMs) < STARTUP_GRACE_MS
+}
+
+/**
+ * Wait time before the next attempt when the previous one just failed. Bounded
+ * exponential backoff with small jitter inside the startup grace window;
+ * single 5–7.5 s jittered retry afterwards.
+ *
+ * @param {number} previousAttempt 1-based index of the attempt that just failed.
+ */
+function getRetryDelay (previousAttempt) {
+  if (!inStartupPhase()) return singleJitteredDelay()
+  const exp = Math.min(STARTUP_BACKOFF_MAX_MS, STARTUP_BACKOFF_BASE_MS << (previousAttempt - 1))
+  return exp + Math.random() * STARTUP_BACKOFF_JITTER_MS
+}
+
+function getMaxAttempts () {
+  return inStartupPhase() ? STARTUP_MAX_ATTEMPTS : POST_STARTUP_MAX_ATTEMPTS
+}
+
+function markEndpointReached () {
+  endpointReached = true
+}
+
+module.exports = {
+  RATE_LIMIT_MAX_WAIT_MS,
+  getMaxAttempts,
+  getRetryDelay,
+  isRetriableNetworkError,
+  markEndpointReached,
+  singleJitteredDelay,
+}

--- a/packages/dd-trace/src/exporters/common/retry.js
+++ b/packages/dd-trace/src/exporters/common/retry.js
@@ -25,7 +25,15 @@ const RETRIABLE_NETWORK_CODES = new Set([
 ])
 
 const startedAtMs = Date.now()
-let endpointReached = false
+const reachedEndpoints = new Set()
+
+/**
+ * @typedef {object} EndpointOptions
+ * @property {string} [socketPath]
+ * @property {string} [hostname]
+ * @property {string} [host]
+ * @property {string|number} [port]
+ */
 
 /**
  * @param {Error & { code?: string }} error
@@ -38,8 +46,24 @@ function singleJitteredDelay () {
   return SINGLE_RETRY_BASE_MS + Math.random() * SINGLE_RETRY_JITTER_MS
 }
 
-function inStartupPhase () {
-  return !endpointReached && (Date.now() - startedAtMs) < STARTUP_GRACE_MS
+/**
+ * Stable key identifying the destination so the startup-phase gate is scoped
+ * per endpoint. UDS path beats host:port because both can coexist on the same
+ * options object after `parseUrl` runs.
+ *
+ * @param {EndpointOptions} options
+ */
+function getEndpointKey (options) {
+  if (options.socketPath) return options.socketPath
+  return `${options.hostname || options.host || ''}:${options.port || ''}`
+}
+
+/**
+ * @param {EndpointOptions} options
+ */
+function inStartupPhase (options) {
+  if ((Date.now() - startedAtMs) >= STARTUP_GRACE_MS) return false
+  return !reachedEndpoints.has(getEndpointKey(options))
 }
 
 /**
@@ -47,20 +71,27 @@ function inStartupPhase () {
  * exponential backoff with small jitter inside the startup grace window;
  * single 5–7.5 s jittered retry afterwards.
  *
+ * @param {EndpointOptions} options
  * @param {number} previousAttempt 1-based index of the attempt that just failed.
  */
-function getRetryDelay (previousAttempt) {
-  if (!inStartupPhase()) return singleJitteredDelay()
+function getRetryDelay (options, previousAttempt) {
+  if (!inStartupPhase(options)) return singleJitteredDelay()
   const exp = Math.min(STARTUP_BACKOFF_MAX_MS, STARTUP_BACKOFF_BASE_MS << (previousAttempt - 1))
   return exp + Math.random() * STARTUP_BACKOFF_JITTER_MS
 }
 
-function getMaxAttempts () {
-  return inStartupPhase() ? STARTUP_MAX_ATTEMPTS : POST_STARTUP_MAX_ATTEMPTS
+/**
+ * @param {EndpointOptions} options
+ */
+function getMaxAttempts (options) {
+  return inStartupPhase(options) ? STARTUP_MAX_ATTEMPTS : POST_STARTUP_MAX_ATTEMPTS
 }
 
-function markEndpointReached () {
-  endpointReached = true
+/**
+ * @param {EndpointOptions} options
+ */
+function markEndpointReached (options) {
+  reachedEndpoints.add(getEndpointKey(options))
 }
 
 module.exports = {

--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -55,6 +55,17 @@ describe('git_metadata', () => {
 
     fakeConfig = { apiKey: 'api-key', DD_CIVISIBILITY_GIT_UNSHALLOW_ENABLED: true }
 
+    // Build a copy of the shared request module wired against an instant retry
+    // helper so the retry-success test does not pay the real backoff. The
+    // post-startup retry delay is 5 to 7.5 s and would blow the default mocha
+    // timeout once a previous spec marks the endpoint as reached.
+    const fastRequest = proxyquire('../../../../src/exporters/common/request', {
+      './retry': {
+        ...require('../../../../src/exporters/common/retry'),
+        getRetryDelay: () => 0,
+      },
+    })
+
     gitMetadata = proxyquire('../../../../src/ci-visibility/exporters/git/git_metadata', {
       '../../../plugins/util/git': {
         getLatestCommits: getLatestCommitsStub,
@@ -65,6 +76,7 @@ describe('git_metadata', () => {
         unshallowRepository: unshallowRepositoryStub,
       },
       '../../../config': () => fakeConfig,
+      '../../../exporters/common/request': fastRequest,
     })
   })
 
@@ -369,13 +381,18 @@ describe('git_metadata', () => {
   })
 
   it('should retry if backend temporarily fails', (done) => {
+    // The shared retry helper only treats network errors with a transient `code`
+    // (`ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, …) as retriable; uncoded errors
+    // are no longer retried, matching real production failure modes.
+    const transientError = Object.assign(new Error('Server unavailable'), { code: 'ECONNRESET' })
+
     const scope = nock('https://api.test.com')
       .post('/api/v2/git/repository/search_commits')
-      .replyWithError('Server unavailable')
+      .replyWithError(transientError)
       .post('/api/v2/git/repository/search_commits')
       .reply(200, JSON.stringify({ data: [] }))
       .post('/api/v2/git/repository/packfile')
-      .replyWithError('Server unavailable')
+      .replyWithError(transientError)
       .post('/api/v2/git/repository/packfile')
       .reply(204)
 

--- a/packages/dd-trace/test/ci-visibility/requests/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/request.spec.js
@@ -57,4 +57,19 @@ describe('ci-visibility/requests/request', () => {
       })
     })
   })
+
+  it('should retry on a transient network error and succeed on the next attempt', (done) => {
+    nock('http://localhost:8126')
+      .post('/path')
+      .replyWithError({ code: 'ECONNRESET' })
+      .post('/path')
+      .reply(200, 'ok')
+
+    request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
+      assert.strictEqual(err, null)
+      assert.strictEqual(res, 'ok')
+      assert.strictEqual(statusCode, 200)
+      done()
+    })
+  })
 })

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -43,6 +43,7 @@ describe('request', function () {
   let log
   let docker
   let maxAttempts
+  let retryStubs
 
   beforeEach(() => {
     log = {
@@ -58,14 +59,17 @@ describe('request', function () {
     // deterministic: zero backoff, no startup-phase mutation, attempt count
     // overridable per test.
     maxAttempts = 2
+    retryStubs = {
+      getRetryDelay: sinon.fake.returns(0),
+      getMaxAttempts: sinon.fake(() => maxAttempts),
+      markEndpointReached: sinon.fake(),
+    }
     request = proxyquire('../../../src/exporters/common/request', {
       './docker': docker,
       '../../log': log,
       './retry': {
         ...require('../../../src/exporters/common/retry'),
-        getRetryDelay: () => 0,
-        getMaxAttempts: () => maxAttempts,
-        markEndpointReached: () => {},
+        ...retryStubs,
       },
     })
   })
@@ -251,6 +255,31 @@ describe('request', function () {
     }, (err) => {
       assert.strictEqual(err, error)
       done()
+    })
+  })
+
+  it('passes the per-request options into the retry helpers', (done) => {
+    const error = Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' })
+
+    nock('http://test:123')
+      .put('/path')
+      .replyWithError(error)
+      .put('/path')
+      .reply(200, 'OK')
+
+    const options = {
+      protocol: 'http:',
+      hostname: 'test',
+      port: 123,
+      path: '/path',
+      method: 'PUT',
+    }
+
+    request(Buffer.from(''), options, (err) => {
+      sinon.assert.calledWith(retryStubs.getMaxAttempts, options)
+      sinon.assert.calledWith(retryStubs.getRetryDelay, options, 1)
+      sinon.assert.calledWith(retryStubs.markEndpointReached, options)
+      done(err)
     })
   })
 

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -42,6 +42,7 @@ describe('request', function () {
   let request
   let log
   let docker
+  let maxAttempts
 
   beforeEach(() => {
     log = {
@@ -53,9 +54,19 @@ describe('request', function () {
         carrier['datadog-container-id'] = 'abcd'
       },
     }
+    // The retry policy is exercised in retry.spec.js. Here we keep the integration
+    // deterministic: zero backoff, no startup-phase mutation, attempt count
+    // overridable per test.
+    maxAttempts = 2
     request = proxyquire('../../../src/exporters/common/request', {
       './docker': docker,
       '../../log': log,
+      './retry': {
+        ...require('../../../src/exporters/common/retry'),
+        getRetryDelay: () => 0,
+        getMaxAttempts: () => maxAttempts,
+        markEndpointReached: () => {},
+      },
     })
   })
 
@@ -192,21 +203,72 @@ describe('request', function () {
     })
   })
 
-  it('should not retry more than once', (done) => {
-    const error = new Error('Error ECONNRESET')
+  it('should not retry on a non-retriable error code', (done) => {
+    const error = Object.assign(new Error('not found'), { code: 'ENOTFOUND' })
 
     nock('http://localhost:80')
-      .put('/path')
-      .replyWithError(error)
       .put('/path')
       .replyWithError(error)
 
     request(Buffer.from(''), {
       path: '/path',
       method: 'PUT',
-    }, (err, res) => {
+    }, (err) => {
       assert.strictEqual(err, error)
       done()
+    })
+  })
+
+  it('should not retry on an uncoded error', (done) => {
+    const error = new Error('Error ECONNRESET')
+
+    nock('http://localhost:80')
+      .put('/path')
+      .replyWithError(error)
+
+    request(Buffer.from(''), {
+      path: '/path',
+      method: 'PUT',
+    }, (err) => {
+      assert.strictEqual(err, error)
+      done()
+    })
+  })
+
+  it('should retry on ECONNREFUSED until max attempts and propagate the final error', (done) => {
+    maxAttempts = 5
+
+    const error = Object.assign(new Error('ECONNREFUSED'), { code: 'ECONNREFUSED' })
+
+    nock('http://localhost:80')
+      .put('/path')
+      .times(5)
+      .replyWithError(error)
+
+    request(Buffer.from(''), {
+      path: '/path',
+      method: 'PUT',
+    }, (err) => {
+      assert.strictEqual(err, error)
+      done()
+    })
+  })
+
+  it('should retry on UDS ENOENT (socket file not yet present)', (done) => {
+    const error = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+
+    nock('http://localhost:80')
+      .put('/path')
+      .replyWithError(error)
+      .put('/path')
+      .reply(200, 'OK')
+
+    request(Buffer.from(''), {
+      path: '/path',
+      method: 'PUT',
+    }, (err, res) => {
+      assert.strictEqual(res, 'OK')
+      done(err)
     })
   })
 

--- a/packages/dd-trace/test/exporters/common/retry.spec.js
+++ b/packages/dd-trace/test/exporters/common/retry.spec.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+require('../../setup/core')
+
+const RETRY_PATH = '../../../src/exporters/common/retry'
+
+function loadRetry () {
+  delete require.cache[require.resolve(RETRY_PATH)]
+  return require(RETRY_PATH)
+}
+
+describe('retry', () => {
+  describe('isRetriableNetworkError', () => {
+    const { isRetriableNetworkError } = require(RETRY_PATH)
+
+    it('treats agent-not-listening codes as retriable', () => {
+      for (const code of ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN', 'ENOENT']) {
+        assert.strictEqual(isRetriableNetworkError({ code }), true, `expected ${code} retriable`)
+      }
+    })
+
+    it('rejects misconfiguration codes and uncoded errors', () => {
+      const cases = [{ code: 'ENOTFOUND' }, { code: 'EHOSTUNREACH' }, new Error('plain'), undefined]
+      for (const error of cases) {
+        assert.strictEqual(isRetriableNetworkError(error), false, `expected non-retriable: ${error?.code ?? error}`)
+      }
+    })
+  })
+
+  describe('startup grace window', () => {
+    let clock
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers()
+    })
+
+    afterEach(() => {
+      clock.restore()
+    })
+
+    it('applies bounded exponential backoff with jitter for the first attempts', () => {
+      const retry = loadRetry()
+      sinon.stub(Math, 'random').returns(0)
+
+      try {
+        assert.deepStrictEqual(
+          [retry.getRetryDelay(1), retry.getRetryDelay(2), retry.getRetryDelay(3), retry.getRetryDelay(4),
+            retry.getRetryDelay(5)],
+          [1000, 2000, 4000, 8000, 8000]
+        )
+        assert.strictEqual(retry.getMaxAttempts(), 5)
+      } finally {
+        Math.random.restore()
+      }
+    })
+
+    it('mixes jitter into the backoff', () => {
+      const retry = loadRetry()
+      sinon.stub(Math, 'random').returns(0.5)
+
+      try {
+        assert.strictEqual(retry.getRetryDelay(1), 1250)
+      } finally {
+        Math.random.restore()
+      }
+    })
+
+    it('exits the grace window once the endpoint has answered', () => {
+      const retry = loadRetry()
+      retry.markEndpointReached()
+
+      assert.strictEqual(retry.getMaxAttempts(), 2)
+      assertSingleJitteredRange(retry.getRetryDelay(1))
+    })
+
+    it('exits the grace window once the elapsed time passes the threshold', () => {
+      const retry = loadRetry()
+      clock.tick(30_001)
+
+      assert.strictEqual(retry.getMaxAttempts(), 2)
+      assertSingleJitteredRange(retry.getRetryDelay(1))
+    })
+  })
+
+  describe('singleJitteredDelay', () => {
+    const { singleJitteredDelay } = require(RETRY_PATH)
+
+    it('stays inside the documented 5 to 7.5 second range', () => {
+      for (let attemptIndex = 0; attemptIndex < 100; attemptIndex++) {
+        assertSingleJitteredRange(singleJitteredDelay())
+      }
+    })
+  })
+})
+
+function assertSingleJitteredRange (delayMs) {
+  assert.ok(delayMs >= 5000 && delayMs < 7500, `expected delay in [5000, 7500) ms, got ${delayMs}`)
+}

--- a/packages/dd-trace/test/exporters/common/retry.spec.js
+++ b/packages/dd-trace/test/exporters/common/retry.spec.js
@@ -33,6 +33,10 @@ describe('retry', () => {
   })
 
   describe('startup grace window', () => {
+    const agent = { hostname: 'agent', port: 8126 }
+    const intake = { hostname: 'intake', port: 443 }
+    const uds = { socketPath: '/var/run/datadog/apm.socket' }
+
     let clock
 
     beforeEach(() => {
@@ -49,11 +53,11 @@ describe('retry', () => {
 
       try {
         assert.deepStrictEqual(
-          [retry.getRetryDelay(1), retry.getRetryDelay(2), retry.getRetryDelay(3), retry.getRetryDelay(4),
-            retry.getRetryDelay(5)],
+          [retry.getRetryDelay(agent, 1), retry.getRetryDelay(agent, 2), retry.getRetryDelay(agent, 3),
+            retry.getRetryDelay(agent, 4), retry.getRetryDelay(agent, 5)],
           [1000, 2000, 4000, 8000, 8000]
         )
-        assert.strictEqual(retry.getMaxAttempts(), 5)
+        assert.strictEqual(retry.getMaxAttempts(agent), 5)
       } finally {
         Math.random.restore()
       }
@@ -64,26 +68,61 @@ describe('retry', () => {
       sinon.stub(Math, 'random').returns(0.5)
 
       try {
-        assert.strictEqual(retry.getRetryDelay(1), 1250)
+        assert.strictEqual(retry.getRetryDelay(agent, 1), 1250)
       } finally {
         Math.random.restore()
       }
     })
 
-    it('exits the grace window once the endpoint has answered', () => {
+    it('exits the grace window for the marked endpoint only', () => {
       const retry = loadRetry()
-      retry.markEndpointReached()
+      retry.markEndpointReached(agent)
 
-      assert.strictEqual(retry.getMaxAttempts(), 2)
-      assertSingleJitteredRange(retry.getRetryDelay(1))
+      assert.strictEqual(retry.getMaxAttempts(agent), 2)
+      assertSingleJitteredRange(retry.getRetryDelay(agent, 1))
+
+      assert.strictEqual(retry.getMaxAttempts(intake), 5)
     })
 
-    it('exits the grace window once the elapsed time passes the threshold', () => {
+    it('scopes the gate by socketPath without collapsing TCP endpoints', () => {
       const retry = loadRetry()
-      clock.tick(30_001)
+      retry.markEndpointReached(uds)
 
-      assert.strictEqual(retry.getMaxAttempts(), 2)
-      assertSingleJitteredRange(retry.getRetryDelay(1))
+      assert.strictEqual(retry.getMaxAttempts(uds), 2)
+      assert.strictEqual(retry.getMaxAttempts(agent), 5)
+    })
+
+    it('falls back to options.host when options.hostname is absent', () => {
+      const retry = loadRetry()
+      const hostOnly = { host: 'agent', port: 8126 }
+      retry.markEndpointReached(hostOnly)
+
+      assert.strictEqual(retry.getMaxAttempts(hostOnly), 2)
+      assert.strictEqual(retry.getMaxAttempts(agent), 2)
+    })
+
+    it('groups bare options without hostname/host/port under a single key', () => {
+      const retry = loadRetry()
+      retry.markEndpointReached({})
+
+      assert.strictEqual(retry.getMaxAttempts({}), 2)
+      assert.strictEqual(retry.getMaxAttempts(agent), 5)
+    })
+
+    it('keeps the grace window open at the last accepted millisecond', () => {
+      const retry = loadRetry()
+      clock.tick(29_999)
+
+      assert.strictEqual(retry.getMaxAttempts(agent), 5)
+    })
+
+    it('exits the grace window for every endpoint once the elapsed time passes the threshold', () => {
+      const retry = loadRetry()
+      clock.tick(30_000)
+
+      assert.strictEqual(retry.getMaxAttempts(agent), 2)
+      assert.strictEqual(retry.getMaxAttempts(intake), 2)
+      assertSingleJitteredRange(retry.getRetryDelay(agent, 1))
     })
   })
 


### PR DESCRIPTION
This fixes the agent-startup race that drops payloads when a pod boots before the Datadog agent is listening. The shared HTTP request used by every exporter retried exactly once on the next tick, so a ~2-4 s window of `ECONNREFUSED` / `ENOENT` / `socket hang up` against the agent was enough to drop the first payloads -- the symptom users hit on k8s rolling deploys and sidecar startup.

For the first 30 s of the process (or until the first response arrives), retriable transport errors back off through 1 s, 2 s, 4 s, 8 s with small jitter, up to five attempts. Beyond the window the policy collapses to a single 5-7.5 s jittered retry. UDS `ENOENT` and transient `EAI_AGAIN` join the retriable set; uncoded errors no longer retry.

Drive-by fix:

* CI-Visibility's request now consumes `isRetriableNetworkError` and the jitter constants from the shared retry helper instead of keeping a duplicate copy.

Fixes: https://github.com/DataDog/dd-trace-js/issues/5669