### PR TITLE
fix(express): use the host's path-to-regexp dialect for route tagging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -108,8 +108,6 @@ updates:
       - dependency-name: "jest-docblock"
         # 30.0.0 onwards only supports Node.js 18.14.x and above
         update-types: ["version-update:semver-major"]
-        # The path-to-regexp version has to be the same as used in express v4.
-      - dependency-name: "path-to-regexp"
       - dependency-name: "lru-cache"
         # 11.0.0 onwards only supports Node.js 20 and above
         update-types: ["version-update:semver-major"]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -85,7 +85,6 @@
 "node-gyp-build","https://github.com/prebuild/node-gyp-build","['MIT']","['Mathias Buus']"
 "opentracing","https://github.com/opentracing/opentracing-javascript","['Apache-2.0']","['opentracing']"
 "oxc-parser","https://github.com/oxc-project/oxc","['MIT']","['Boshen and oxc contributors']"
-"path-to-regexp","https://github.com/pillarjs/path-to-regexp","['MIT']","['pillarjs']"
 "pprof-format","https://github.com/DataDog/pprof-format","['MIT']","['Datadog Inc.']"
 "protobufjs","https://github.com/protobufjs/protobuf.js","['BSD-3-Clause']","['Daniel Wirtz']"
 "queue-tick","https://github.com/mafintosh/queue-tick","['MIT']","['Mathias Buus']"

--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -56,7 +56,6 @@ if (Number(process.env.EVERYTHING)) {
     'nyc',
     'octokit',
     'opentracing',
-    'path-to-regexp',
     'pprof-format',
     'protobufjs',
     'proxyquire',

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -3,6 +3,7 @@
 const shimmer = require('../../datadog-shimmer')
 const { createWrapRouterMethod } = require('./router')
 const { addHook, channel, tracingChannel } = require('./helpers/instrument')
+const { getCompileToRegexp } = require('./path-to-regexp')
 const {
   setRouterMountPath,
   markAppMounted,
@@ -25,8 +26,6 @@ function wrapHandle (handle) {
     return handle.apply(this, arguments)
   }
 }
-
-const wrapRouterMethod = createWrapRouterMethod('express')
 
 const responseJsonChannel = channel('datadog:express:response:json:start')
 
@@ -163,6 +162,8 @@ addHook({ name: 'express', versions: ['>=4'], file: 'lib/express.js' }, express 
 // It would otherwise produce spans for router and express, and so duplicating them.
 // We now fall back to router instrumentation
 addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express => {
+  const wrapRouterMethod = createWrapRouterMethod('express', getCompileToRegexp())
+
   shimmer.wrap(express.Router, 'use', wrapRouterMethod)
   shimmer.wrap(express.Router, 'route', wrapRouterMethod)
 

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -118,6 +118,7 @@ module.exports = {
   passport: () => require('../passport'),
   'passport-http': () => require('../passport-http'),
   'passport-local': () => require('../passport-local'),
+  'path-to-regexp': () => require('../path-to-regexp'),
   pg: () => require('../pg'),
   pino: () => require('../pino'),
   'pino-pretty': () => require('../pino'),

--- a/packages/datadog-instrumentations/src/path-to-regexp.js
+++ b/packages/datadog-instrumentations/src/path-to-regexp.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const { addHook } = require('./helpers/instrument')
+
+/** @type {((pattern: string | RegExp) => RegExp | undefined) | undefined} */
+let compileToRegexp
+
+addHook({ name: 'path-to-regexp', versions: ['*'] }, moduleExports => {
+  // 0.1.x and 6.x: `module.exports = (path, ...) => RegExp`.
+  // 7.x: `module.exports = { pathToRegexp(path, ...) => RegExp }`.
+  // 8.x: `module.exports = { pathToRegexp(path, ...) => { regexp, keys } }`.
+  const compile = typeof moduleExports === 'function'
+    ? moduleExports
+    : (typeof moduleExports?.pathToRegexp === 'function' ? moduleExports.pathToRegexp : undefined)
+
+  if (compile !== undefined) {
+    compileToRegexp = pattern => {
+      let result
+      try {
+        result = compile(pattern)
+      } catch {
+        return
+      }
+      const regex = result?.regexp ?? result
+      if (regex instanceof RegExp) return regex
+    }
+  }
+
+  return moduleExports
+})
+
+/**
+ * Returns whatever path-to-regexp compile adapter the host most recently
+ * loaded. Capture this once at addHook fire time so each express/router
+ * instance keeps the dialect that was current when its routes were wrapped;
+ * a later host load that swaps the global compile won't retroactively change
+ * already-wrapped routers. `undefined` when the host has not loaded
+ * path-to-regexp yet, or never if it does not depend on it.
+ */
+function getCompileToRegexp () {
+  return compileToRegexp
+}
+
+module.exports = { getCompileToRegexp }

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const METHODS = [...require('http').METHODS.map(v => v.toLowerCase()), 'all']
-const pathToRegExp = require('../../../vendor/dist/path-to-regexp')
 const shimmer = require('../../datadog-shimmer')
 const { addHook, channel } = require('./helpers/instrument')
+const { getCompileToRegexp } = require('./path-to-regexp')
 
 const {
   getRouterMountPaths,
@@ -19,23 +19,28 @@ const {
 } = require('./helpers/router-helper')
 
 function isFastStar (layer, matchers) {
-  return layer.regexp?.fast_star ?? matchers.some(matcher => matcher.path === '*')
+  return layer.regexp?.fast_star ?? matchers.hasStarPath
 }
 
 function isFastSlash (layer, matchers) {
-  return layer.regexp?.fast_slash ?? matchers.some(matcher => matcher.path === '/')
+  return layer.regexp?.fast_slash ?? matchers.hasSlashPath
 }
 
 // TODO: Move this function to a shared file between Express and Router
-function createWrapRouterMethod (name) {
+/**
+ * @param {string} name Channel namespace (`apm:<name>:middleware:*`).
+ * @param {((pattern: string | RegExp) => RegExp | undefined) | undefined} compile
+ *   Host-resolved path-to-regexp compile adapter, or undefined when the host
+ *   instance ships no path-to-regexp. Captured here so each express/router
+ *   instance keeps the dialect it actually loaded.
+ */
+function createWrapRouterMethod (name, compile) {
   const enterChannel = channel(`apm:${name}:middleware:enter`)
   const exitChannel = channel(`apm:${name}:middleware:exit`)
   const finishChannel = channel(`apm:${name}:middleware:finish`)
   const errorChannel = channel(`apm:${name}:middleware:error`)
   const nextChannel = channel(`apm:${name}:middleware:next`)
   const routeAddedChannel = channel(`apm:${name}:route:added`)
-
-  const regexpCache = Object.create(null)
 
   function wrapLayerHandle (layer, original) {
     original._name = original._name || layer.name
@@ -55,13 +60,16 @@ function createWrapRouterMethod (name) {
 
       let route
 
-      if (matchers) {
-        // Try to guess which path actually matched
-        for (const matcher of matchers) {
-          if (matcher.test(layer)) {
-            route = matcher.path
-
-            break
+      if (matchers?.length && !isFastStar(layer, matchers) && !isFastSlash(layer, matchers)) {
+        if (matchers.length === 1) {
+          // The host already matched this layer; the lone pattern is the route.
+          route = matchers[0].path
+        } else {
+          for (const matcher of matchers) {
+            if (matcher.regex?.test(layer.path)) {
+              route = matcher.path
+              break
+            }
           }
         }
       }
@@ -124,25 +132,35 @@ function createWrapRouterMethod (name) {
       return []
     }
 
-    return arg.map(pattern => ({
-      path: pattern instanceof RegExp ? `(${pattern})` : pattern,
-      test: layer => {
-        const matchers = getLayerMatchers(layer)
-        return !isFastStar(layer, matchers) &&
-          !isFastSlash(layer, matchers) &&
-          cachedPathToRegExp(pattern).test(layer.path)
-      },
-    }))
-  }
-
-  function cachedPathToRegExp (pattern) {
-    const maybeCached = regexpCache[pattern]
-    if (maybeCached) {
-      return maybeCached
+    if (arg.length === 1) {
+      const pattern = arg[0]
+      const path = pattern instanceof RegExp ? `(${pattern})` : pattern
+      const matchers = [{ path }]
+      matchers.hasStarPath = path === '*'
+      matchers.hasSlashPath = path === '/'
+      return matchers
     }
-    const regexp = pathToRegExp(pattern)
-    regexpCache[pattern] = regexp
-    return regexp
+
+    // hasStarPath/hasSlashPath cache the lookups isFastStar/isFastSlash
+    // would otherwise re-run on every request.
+    let hasStarPath = false
+    let hasSlashPath = false
+    const matchers = arg.map(pattern => {
+      const isRegExp = pattern instanceof RegExp
+      const path = isRegExp ? `(${pattern})` : pattern
+      if (path === '*') {
+        hasStarPath = true
+      } else if (path === '/') {
+        hasSlashPath = true
+      }
+      return {
+        path,
+        regex: isRegExp ? pattern : compile?.(pattern),
+      }
+    })
+    matchers.hasStarPath = hasStarPath
+    matchers.hasSlashPath = hasSlashPath
+    return matchers
   }
 
   function wrapMethod (original) {
@@ -218,9 +236,9 @@ function createWrapRouterMethod (name) {
   return wrapMethod
 }
 
-const wrapRouterMethod = createWrapRouterMethod('router')
-
 addHook({ name: 'router', versions: ['>=1 <2'] }, Router => {
+  const wrapRouterMethod = createWrapRouterMethod('router', getCompileToRegexp())
+
   shimmer.wrap(Router.prototype, 'use', wrapRouterMethod)
   shimmer.wrap(Router.prototype, 'route', wrapRouterMethod)
 
@@ -230,6 +248,8 @@ addHook({ name: 'router', versions: ['>=1 <2'] }, Router => {
 const queryParserReadCh = channel('datadog:query:read:finish')
 
 addHook({ name: 'router', versions: ['>=2'] }, Router => {
+  const wrapRouterMethod = createWrapRouterMethod('router', getCompileToRegexp())
+
   const WrappedRouter = shimmer.wrapFunction(Router, function (originalRouter) {
     return function wrappedMethod () {
       const router = originalRouter.apply(this, arguments)

--- a/packages/datadog-instrumentations/test/express-multi-version.spec.js
+++ b/packages/datadog-instrumentations/test/express-multi-version.spec.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { existsSync } = require('node:fs')
+const { join } = require('node:path')
+
+const axios = require('axios')
+const dc = require('dc-polyfill')
+const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+
+const express4Dir = join(__dirname, '..', '..', '..', 'versions', 'express@4')
+const express5Dir = join(__dirname, '..', '..', '..', 'versions', 'express@>=5.0.0')
+
+const describeOrSkip = existsSync(express4Dir) && existsSync(express5Dir)
+  ? describe
+  : describe.skip
+
+// Express 4 ships path-to-regexp 0.1.x; express 5 ships 8.x. Each is loaded
+// once in this process; the wrappers must capture the dialect that was
+// current when the host's addHook fired so the second load doesn't
+// retroactively swap the first.
+describeOrSkip('express path-to-regexp dialect across versions', () => {
+  const enterEvents = []
+
+  const captureExpress = ({ route }) => enterEvents.push({ kind: 'express', route })
+  const captureRouter = ({ route }) => enterEvents.push({ kind: 'router', route })
+
+  let express4
+  let express5
+  let appListeners
+
+  before(() => agent.load(['express', 'router', 'http'], { client: false }))
+
+  before(() => {
+    express5 = require(express5Dir).get()
+    express4 = require(express4Dir).get()
+
+    dc.channel('apm:express:middleware:enter').subscribe(captureExpress)
+    dc.channel('apm:router:middleware:enter').subscribe(captureRouter)
+  })
+
+  after(() => {
+    dc.channel('apm:express:middleware:enter').unsubscribe(captureExpress)
+    dc.channel('apm:router:middleware:enter').unsubscribe(captureRouter)
+    return agent.close({ ritmReset: false })
+  })
+
+  beforeEach(() => {
+    enterEvents.length = 0
+    appListeners = []
+  })
+
+  afterEach(() => {
+    for (const listener of appListeners) {
+      listener.close()
+    }
+  })
+
+  /**
+   * @param {import('http').Server} listener
+   * @returns {Promise<number>} The bound port.
+   */
+  function listenOn (listener) {
+    appListeners.push(listener)
+    return new Promise(resolve => listener.once('listening', () => resolve(listener.address().port)))
+  }
+
+  it('isolates each version\'s dialect when both are loaded in the same process', async () => {
+    // `/*splat` is express-5 syntax. path-to-regexp 8.x compiles it to a
+    // regex that matches anything; 0.1.x compiles it to a regex that
+    // requires the URL to end in the literal "splat". A successful tag on
+    // the express-5 app proves its wrapper kept the 8.x compile, even
+    // though express 4 (and its 0.1.x) was loaded into the same process.
+    const app5 = express5()
+    app5.use(['/api/users', '/*splat'], (req, res) => res.end())
+
+    // The express-4 app uses a multi-pattern array of plain paths (which
+    // both dialects accept) so this side stays a sanity check rather than
+    // a dialect-specific assertion.
+    const app4 = express4()
+    app4.use(['/users', '/products'], (req, res) => res.end())
+
+    const [port5, port4] = await Promise.all([
+      listenOn(app5.listen(0, 'localhost')),
+      listenOn(app4.listen(0, 'localhost')),
+    ])
+
+    await Promise.all([
+      axios.get(`http://localhost:${port5}/anything/here`),
+      axios.get(`http://localhost:${port4}/users`),
+    ])
+
+    const fromExpress5 = enterEvents.filter(e => e.kind === 'router')
+    const fromExpress4 = enterEvents.filter(e => e.kind === 'express')
+
+    assert.ok(
+      fromExpress5.some(e => e.route === '/*splat'),
+      `express 5 should match /*splat via 8.x; events from router=${JSON.stringify(fromExpress5)}`,
+    )
+    assert.ok(
+      fromExpress4.some(e => e.route === '/users'),
+      `express 4 should match /users via 0.1.x; events from express=${JSON.stringify(fromExpress4)}`,
+    )
+  })
+})

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -157,6 +157,13 @@ class RouterPlugin extends WebPlugin {
 }
 
 function isMoreSpecificThan (routeA, routeB) {
+  // Concrete paths beat catch-all wildcards (`/*splat`, `/api/*`) on the same
+  // request so that `/foo/bar` wins over `/foo/*splat` regardless of length.
+  if (routeA && routeB) {
+    const aWild = hasWildcard(routeA)
+    const bWild = hasWildcard(routeB)
+    if (aWild !== bWild) return !aWild
+  }
   if (!routeIsRegex(routeA) && routeIsRegex(routeB)) {
     return true
   }
@@ -165,6 +172,12 @@ function isMoreSpecificThan (routeA, routeB) {
 
 function routeIsRegex (route) {
   return route.includes('(/')
+}
+
+function hasWildcard (route) {
+  // RegExp routes are encoded as `(/.../)` and may legitimately contain `*`,
+  // so only treat plain string patterns as wildcards.
+  return !routeIsRegex(route) && route.includes('*')
 }
 
 module.exports = RouterPlugin

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -26,7 +26,6 @@
         "module-details-from-path": "^1.0.4",
         "mutexify": "^1.4.0",
         "opentracing": ">=0.14.7",
-        "path-to-regexp": "^0.1.12",
         "pprof-format": "^2.1.1",
         "protobufjs": "^8.0.1",
         "retry": "^0.13.1",
@@ -638,6 +637,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -733,12 +733,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
     },
     "node_modules/pprof-format": {
       "version": "2.2.1",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -23,7 +23,6 @@
     "module-details-from-path": "^1.0.4",
     "mutexify": "^1.4.0",
     "opentracing": ">=0.14.7",
-    "path-to-regexp": "^0.1.12",
     "pprof-format": "^2.1.1",
     "protobufjs": "^8.0.1",
     "retry": "^0.13.1",


### PR DESCRIPTION
http.route is missing or wrong on spans for express-5 syntax routes because the vendored path-to-regexp@0.1.x produces regexes that never match live request paths.

Three coordinated pieces close it:

1. A new `path-to-regexp` instrumentation captures the host's compile function — adapter for the 0.1.x/6.x function export and the 7.x/8.x `{ pathToRegexp }` shape — and `router.js` / `express.js` capture it in a closure at addHook fire time. Each express/router instance keeps the dialect that was current when its routes were wrapped, so apps with both express 4 (path-to-regexp 0.1.x) and express 5 (8.x) loaded each get the right syntax.
2. `router.js` skips the disambiguation regex entirely on the common single-matcher mount. The host already matched this layer, so the lone pattern is the route; the regex re-ran the same check per request. Multi-matcher arrays precompile their regexes at registration time and cache `hasStarPath`/`hasSlashPath` on the matchers list so `isFastStar`/`isFastSlash` skip the per-request `.some()` lookup.
3. The router plugin deprioritizes wildcard paths (`/*splat`, `/api/*`) so concrete paths still beat catch-alls. The vendored 0.1.x used to filter those out as a side effect of the dialect mismatch.

Drops the vendored path-to-regexp dependency, its dependabot pin, its LICENSE entry, and its sirun startup-bench inclusion.

Fixes: https://github.com/DataDog/dd-trace-js/issues/5887
