### PR TITLE
fix(propagation): guard link reset on null context in extract

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -29,8 +29,15 @@ function hookFn (http) {
 // `inputURL` may be the user's options object (for the `http.request(options)`
 // shape); never write directly into it. The result is later mutated by
 // `normalizeHeaders` and read by `url.format`, so the merged object must be
-// owned by the tracer.
+// owned by the tracer. Non-object first args (primitives, null, undefined)
+// are returned as-is so `normalizeHeaders` throws and the surrounding
+// try/catch in `instrumentRequest` falls through to the native request;
+// spreading a primitive yields `{}`, which would silently turn an invalid
+// `http.request(123)` into a synthesized localhost request.
 function combineOptions (inputURL, inputOptions) {
+  if (inputURL === null || (typeof inputURL !== 'object' && typeof inputURL !== 'function')) {
+    return inputURL
+  }
   if (inputOptions !== null && typeof inputOptions === 'object') {
     return { ...inputURL, ...inputOptions }
   }

--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -29,12 +29,17 @@ function hookFn (http) {
 // `inputURL` may be the user's options object (for the `http.request(options)`
 // shape); never write directly into it. The result is later mutated by
 // `normalizeHeaders` and read by `url.format`, so the merged object must be
-// owned by the tracer. Non-object first args (primitives, null, undefined)
+// owned by the tracer. `undefined` means "no URL supplied" — Node merges
+// with the options object or its defaults, so build a tracer-owned
+// options-only shape and let tracing proceed. `null`/primitive first args
 // are returned as-is so `normalizeHeaders` throws and the surrounding
 // try/catch in `instrumentRequest` falls through to the native request;
 // spreading a primitive yields `{}`, which would silently turn an invalid
 // `http.request(123)` into a synthesized localhost request.
 function combineOptions (inputURL, inputOptions) {
+  if (inputURL === undefined) {
+    return inputOptions !== null && typeof inputOptions === 'object' ? { ...inputOptions } : {}
+  }
   if (inputURL === null || (typeof inputURL !== 'object' && typeof inputURL !== 'function')) {
     return inputURL
   }

--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -26,10 +26,15 @@ function hookFn (http) {
   return http
 }
 
+// `inputURL` may be the user's options object (for the `http.request(options)`
+// shape); never write directly into it. The result is later mutated by
+// `normalizeHeaders` and read by `url.format`, so the merged object must be
+// owned by the tracer.
 function combineOptions (inputURL, inputOptions) {
-  return inputOptions !== null && typeof inputOptions === 'object'
-    ? Object.assign(inputURL || {}, inputOptions)
-    : inputURL
+  if (inputOptions !== null && typeof inputOptions === 'object') {
+    return { ...inputURL, ...inputOptions }
+  }
+  return { ...inputURL }
 }
 function normalizeHeaders (options) {
   options.headers ??= {}

--- a/packages/datadog-instrumentations/test/http-client-options.spec.js
+++ b/packages/datadog-instrumentations/test/http-client-options.spec.js
@@ -2,9 +2,12 @@
 
 const assert = require('node:assert/strict')
 
+const dc = require('dc-polyfill')
 const { describe, it, before, after } = require('mocha')
 
 const agent = require('../../dd-trace/test/plugins/agent')
+
+const startChannel = dc.channel('apm:http:client:request:start')
 
 describe('http client option ownership', () => {
   let http
@@ -74,4 +77,37 @@ describe('http client option ownership', () => {
     req.on('error', done)
     req.end()
   })
+
+  // Two inputs cover both legs of the wrapper's invalid-input guard: the
+  // `=== null` branch and the `typeof !== 'object'` branch. Spreading either
+  // would yield `{}` and silently synthesize a localhost request.
+  for (const badInput of [123, null]) {
+    it(`falls through to native http.request when first arg is ${String(badInput)}`, () => {
+      let synthesizedStart = false
+      const onStart = (payload) => {
+        if (payload?.args?.originalUrl === badInput) {
+          synthesizedStart = true
+        }
+      }
+      startChannel.subscribe(onStart)
+
+      let req
+      try {
+        try {
+          req = http.request(badInput)
+        } catch {
+          // Native http.request may surface ERR_INVALID_ARG_TYPE on some Node
+          // versions; either outcome is acceptable as long as the wrapper did
+          // not emit a synthesized start event.
+        }
+        if (req) {
+          req.on('error', () => {})
+          req.destroy()
+        }
+        assert.strictEqual(synthesizedStart, false)
+      } finally {
+        startChannel.unsubscribe(onStart)
+      }
+    })
+  }
 })

--- a/packages/datadog-instrumentations/test/http-client-options.spec.js
+++ b/packages/datadog-instrumentations/test/http-client-options.spec.js
@@ -110,4 +110,75 @@ describe('http client option ownership', () => {
       }
     })
   }
+
+  // Pin the accepted leg of the boundary: `undefined` means "no URL" and
+  // Node merges with the options object or its defaults, so the wrapper
+  // must keep tracing on instead of falling through. The two shapes
+  // (`(undefined, callback)` and `(undefined)`) hit both arms of the new
+  // `combineOptions` undefined branch.
+  it('keeps tracing on http.request(undefined, callback)', (done) => {
+    const events = []
+    const onStart = (payload) => {
+      if (payload?.args?.originalUrl === undefined) {
+        events.push(payload)
+      }
+    }
+    startChannel.subscribe(onStart)
+
+    const originalDefaultPort = http.globalAgent.defaultPort
+    http.globalAgent.defaultPort = port
+
+    const cleanup = () => {
+      startChannel.unsubscribe(onStart)
+      http.globalAgent.defaultPort = originalDefaultPort
+    }
+
+    const req = http.request(undefined, (res) => {
+      res.resume()
+      res.on('end', () => {
+        try {
+          assert.strictEqual(events.length, 1)
+          assert.strictEqual(events[0].args.originalUrl, undefined)
+          cleanup()
+          done()
+        } catch (error) {
+          cleanup()
+          done(error)
+        }
+      })
+    })
+    req.on('error', (error) => {
+      cleanup()
+      done(error)
+    })
+    req.end()
+  })
+
+  it('keeps tracing on http.request(undefined) without callback', () => {
+    const events = []
+    const onStart = (payload) => {
+      if (payload?.args?.originalUrl === undefined) {
+        events.push(payload)
+      }
+    }
+    startChannel.subscribe(onStart)
+
+    const originalDefaultPort = http.globalAgent.defaultPort
+    http.globalAgent.defaultPort = port
+
+    let req
+    try {
+      req = http.request(undefined)
+      req.on('error', () => {})
+      req.end()
+      assert.strictEqual(events.length, 1)
+      assert.strictEqual(events[0].args.originalUrl, undefined)
+    } finally {
+      if (req) {
+        req.destroy()
+      }
+      startChannel.unsubscribe(onStart)
+      http.globalAgent.defaultPort = originalDefaultPort
+    }
+  })
 })

--- a/packages/datadog-instrumentations/test/http-client-options.spec.js
+++ b/packages/datadog-instrumentations/test/http-client-options.spec.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, before, after } = require('mocha')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+
+describe('http client option ownership', () => {
+  let http
+  let server
+  let port
+
+  before(async () => {
+    await agent.load('http')
+    // Require http after `agent.load` so the ritm hook actually wraps
+    // `request`/`get` on the module instance the test uses.
+    http = require('node:http')
+
+    server = http.createServer((req, res) => res.end()).listen(0, '127.0.0.1')
+    await new Promise(resolve => server.once('listening', resolve))
+    port = server.address().port
+  })
+
+  after(async () => {
+    server.close()
+    await agent.close()
+  })
+
+  it('does not mutate the caller URL when options carry custom keys', (done) => {
+    const url = new URL(`http://127.0.0.1:${port}/`)
+    const ownProps = Object.getOwnPropertyNames(url)
+    const options = { method: 'GET', headers: { 'x-custom': '1' } }
+
+    const req = http.request(url, options, (res) => {
+      res.resume()
+      res.on('end', () => {
+        try {
+          assert.deepStrictEqual(Object.getOwnPropertyNames(url), ownProps)
+          assert.strictEqual(Object.hasOwn(url, 'headers'), false)
+          assert.strictEqual(Object.hasOwn(url, 'method'), false)
+          done()
+        } catch (error) {
+          done(error)
+        }
+      })
+    })
+    req.on('error', done)
+    req.end()
+  })
+
+  it('does not mutate the caller options object when no URL is provided', (done) => {
+    const options = {
+      protocol: 'http:',
+      host: '127.0.0.1',
+      port,
+      path: '/',
+      method: 'GET',
+    }
+    const snapshot = { ...options }
+
+    const req = http.request(options, (res) => {
+      res.resume()
+      res.on('end', () => {
+        try {
+          assert.deepStrictEqual(options, snapshot)
+          assert.strictEqual(Object.hasOwn(options, 'headers'), false)
+          done()
+        } catch (error) {
+          done(error)
+        }
+      })
+    })
+    req.on('error', done)
+    req.end()
+  })
+})

--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -66,9 +66,9 @@ class DogStatsDClient {
   flush () {
     const queue = this._enqueue()
 
-    log.debug('Flushing %s metrics via', queue.length, this._httpOptions ? 'HTTP' : 'UDP')
+    if (queue.length === 0) return
 
-    if (this._queue.length === 0) return
+    log.debug('Flushing %s metrics via %s', queue.length, this._httpOptions ? 'HTTP' : 'UDP')
 
     this._queue = []
 

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -410,9 +410,11 @@ class TextMapPropagator {
     }
 
     if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'ignore') {
-      context._links = []
+      // `context` is null when no extractor matched; the fallback below picks up
+      // the SQSD context if present, otherwise the request runs untraced.
+      if (context) context._links = []
     } else {
-      if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'restart') {
+      if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'restart' && context) {
         context._links = []
         context._links.push({
           context,

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -29,6 +29,7 @@ describe('dogstatsd', () => {
   let sockets
   let assertData
   let docker
+  let log
 
   beforeEach((done) => {
     udp6 = {
@@ -70,10 +71,12 @@ describe('dogstatsd', () => {
     })
 
     docker = {}
+    log = { debug: sinon.stub(), error: sinon.stub() }
 
     const dogstatsd = proxyquire.noPreserveCache().noCallThru()('../src/dogstatsd', {
       dgram,
       './exporters/common/docker': docker,
+      './log': log,
     })
     DogStatsDClient = dogstatsd.DogStatsDClient
     CustomMetrics = dogstatsd.CustomMetrics
@@ -228,6 +231,27 @@ describe('dogstatsd', () => {
     sinon.assert.notCalled(udp4.send)
     sinon.assert.notCalled(udp6.send)
     sinon.assert.notCalled(dns.lookup)
+    sinon.assert.notCalled(log.debug)
+  })
+
+  it('logs the metric count and the UDP transport on a non-empty flush', () => {
+    client = createDogStatsDClient()
+
+    client.gauge('test.avg', 1)
+    client.flush()
+
+    assert.deepStrictEqual(log.debug.firstCall.args, ['Flushing %s metrics via %s', 1, 'UDP'])
+  })
+
+  it('logs the metric count and the HTTP transport on a non-empty flush', () => {
+    client = createDogStatsDClient({
+      metricsProxyUrl: `http://localhost:${httpPort}`,
+    })
+
+    client.gauge('test.avg', 1)
+    client.flush()
+
+    assert.deepStrictEqual(log.debug.firstCall.args, ['Flushing %s metrics via %s', 1, 'HTTP'])
   })
 
   it('should not flush if the dns lookup fails', () => {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -1787,6 +1787,45 @@ describe('TextMapPropagator', () => {
 
         assert.deepStrictEqual(getAllBaggageItems(), {})
       })
+
+      it('returns null without throwing when ignore mode has no matching extractors', () => {
+        process.env.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT = 'ignore'
+        config = getConfigFresh({
+          tracePropagationStyle: { extract: ['tracecontext', 'datadog'] },
+        })
+        propagator = new TextMapPropagator(config)
+
+        assert.strictEqual(propagator.extract({}), null)
+      })
+
+      it('returns null without throwing when restart mode has no matching extractors', () => {
+        process.env.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT = 'restart'
+        config = getConfigFresh({
+          tracePropagationStyle: { extract: ['tracecontext', 'datadog'] },
+        })
+        propagator = new TextMapPropagator(config)
+
+        assert.strictEqual(propagator.extract({}), null)
+      })
+
+      it('falls back to the SQSD context in ignore mode when no extractors match', () => {
+        process.env.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT = 'ignore'
+        config = getConfigFresh({
+          tracePropagationStyle: { extract: ['tracecontext', 'datadog'] },
+        })
+        propagator = new TextMapPropagator(config)
+        const sqsdCarrier = {
+          'x-aws-sqsd-attr-_datadog': JSON.stringify({
+            'x-datadog-trace-id': '123',
+            'x-datadog-parent-id': '456',
+          }),
+        }
+
+        const extracted = propagator.extract(sqsdCarrier)
+
+        assert.strictEqual(extracted.toTraceId(), '123')
+        assert.strictEqual(extracted.toSpanId(), '456')
+      })
     })
   })
 })


### PR DESCRIPTION
With `tracePropagationBehaviorExtract='ignore'` or `'restart'` and zero
matching extractors, `_extractSpanContext` wrote `context._links = []`
on a `null` context and threw on every extract. Guard the assignment
so the function falls through to the SQSD fallback or returns `null`
without taking the request down.