### PR TITLE
fix(llmobs): guard JSON.parse on streamed tool-call arguments

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/anthropic/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/anthropic/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { UNKNOWN_MODEL_PROVIDER } = require('../../constants/tags')
+const { safeJsonParse } = require('../../util')
 const LLMObsPlugin = require('../base')
 const { appendMessage } = require('./util')
 
@@ -69,7 +70,7 @@ class AnthropicLLMObsPlugin extends LLMObsPlugin {
             const type = response.content[response.content.length - 1].type
             if (type === 'tool_use') {
               const input = response.content[response.content.length - 1].input ?? '{}'
-              response.content[response.content.length - 1].input = JSON.parse(input)
+              response.content[response.content.length - 1].input = safeJsonParse(input, {})
             }
             break
           }
@@ -171,14 +172,9 @@ class AnthropicLLMObsPlugin extends LLMObsPlugin {
       if (typeof text === 'string') {
         outputMessages.push({ content: text, role })
       } else if (block.type === 'tool_use') {
-        let input = block.input
-        if (typeof input === 'string') {
-          input = JSON.parse(input)
-        }
-
         const toolCall = {
           name: block.name,
-          arguments: input,
+          arguments: safeJsonParse(block.input, {}),
           toolId: block.id,
           type: block.type,
         }

--- a/packages/dd-trace/src/llmobs/plugins/openai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/index.js
@@ -7,6 +7,7 @@ const {
   INSTRUMENTATION_METHOD_AUTO,
   UNKNOWN_MODEL_PROVIDER,
 } = require('../../constants/tags')
+const { safeJsonParse } = require('../../util')
 const {
   extractChatTemplateFromInstructions,
   normalizePromptVariables,
@@ -213,14 +214,14 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
       if (message.function_call) {
         const functionCallInfo = {
           name: message.function_call.name,
-          arguments: JSON.parse(message.function_call.arguments),
+          arguments: safeJsonParse(message.function_call.arguments),
         }
         outputMessages.push({ content, role, toolCalls: [functionCallInfo] })
       } else if (message.tool_calls) {
         const toolCallsInfo = []
         for (const toolCall of message.tool_calls) {
           const toolCallInfo = {
-            arguments: JSON.parse(toolCall.function.arguments),
+            arguments: safeJsonParse(toolCall.function.arguments),
             name: toolCall.function.name,
             toolId: toolCall.id,
             type: toolCall.type,
@@ -277,22 +278,12 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
             inputMessages.push({ role, content })
           }
         } else if (item.type === 'function_call') {
-          // Function call: convert to message with tool_calls
-          // Parse arguments if it's a JSON string
-          let parsedArgs = item.arguments
-          if (typeof parsedArgs === 'string') {
-            try {
-              parsedArgs = JSON.parse(parsedArgs)
-            } catch {
-              parsedArgs = {}
-            }
-          }
           inputMessages.push({
             role: 'assistant',
             toolCalls: [{
               toolId: item.call_id,
               name: item.name,
-              arguments: parsedArgs,
+              arguments: safeJsonParse(item.arguments, {}),
               type: item.type,
             }],
           })
@@ -354,21 +345,12 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
           })
         } else if (item.type === 'function_call') {
           // Handle function_call type (responses API tool calls)
-          let args = item.arguments
-          // Parse arguments if it's a JSON string
-          if (typeof args === 'string') {
-            try {
-              args = JSON.parse(args)
-            } catch {
-              args = {}
-            }
-          }
           outputMessages.push({
             role: 'assistant',
             toolCalls: [{
               toolId: item.call_id,
               name: item.name,
-              arguments: args,
+              arguments: safeJsonParse(item.arguments, {}),
               type: item.type,
             }],
           })
@@ -390,23 +372,12 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
 
           // Extract tool calls if present in message.tool_calls
           if (Array.isArray(item.tool_calls)) {
-            outputMsg.toolCalls = item.tool_calls.map(tc => {
-              let args = tc.function?.arguments || tc.arguments
-              // Parse arguments if it's a JSON string
-              if (typeof args === 'string') {
-                try {
-                  args = JSON.parse(args)
-                } catch {
-                  args = {}
-                }
-              }
-              return {
-                toolId: tc.id,
-                name: tc.function?.name || tc.name,
-                arguments: args,
-                type: tc.type || 'function_call',
-              }
-            })
+            outputMsg.toolCalls = item.tool_calls.map(tc => ({
+              toolId: tc.id,
+              name: tc.function?.name || tc.name,
+              arguments: safeJsonParse(tc.function?.arguments || tc.arguments, {}),
+              type: tc.type || 'function_call',
+            }))
           }
 
           outputMessages.push(outputMsg)

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -174,9 +174,21 @@ function spanHasError (span) {
   return !!(tags.error || tags['error.type'])
 }
 
+// LLM SDKs stream tool-call argument JSON across SSE chunks; a malformed
+// accumulation would otherwise throw straight into the chunk subscriber.
+function safeJsonParse (value, fallback) {
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return fallback === undefined ? value : fallback
+  }
+}
+
 module.exports = {
   encodeUnicode,
   validateKind,
   getFunctionArguments,
+  safeJsonParse,
   spanHasError,
 }

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -6,6 +6,7 @@ const { before, describe, it } = require('mocha')
 const {
   encodeUnicode,
   getFunctionArguments,
+  safeJsonParse,
   validateKind,
   spanHasError,
 } = require('../../src/llmobs/util')
@@ -142,6 +143,27 @@ describe('util', () => {
 
         assert.deepStrictEqual(getFunctionArguments(foo, ['fn', 'ctx']), { fn: 'fn', ctx: 'ctx' })
       })
+    })
+  })
+
+  describe('safeJsonParse', () => {
+    it('parses valid JSON strings', () => {
+      assert.deepStrictEqual(safeJsonParse('{"a":1,"b":[2,3]}'), { a: 1, b: [2, 3] })
+    })
+
+    it('returns the explicit fallback on malformed JSON', () => {
+      assert.deepStrictEqual(safeJsonParse('{not json', {}), {})
+    })
+
+    it('returns the input string when no fallback is provided and parsing fails', () => {
+      assert.strictEqual(safeJsonParse('{not json'), '{not json')
+    })
+
+    it('returns non-string inputs unchanged without parsing', () => {
+      const obj = { already: 'parsed' }
+      assert.strictEqual(safeJsonParse(obj), obj)
+      assert.strictEqual(safeJsonParse(undefined), undefined)
+      assert.strictEqual(safeJsonParse(null), null)
     })
   })
 


### PR DESCRIPTION
OpenAI streams `function_call.arguments` and
`tool_calls[].function.arguments` accumulated across SSE chunks;
Anthropic does the same with `content_block_delta` `partial_json`
deltas and the non-streaming `tool_use` block. A malformed
accumulation would otherwise throw straight into the
diagnostic-channel chunk subscriber. Both plugins now route parses
through a shared `safeJsonParse(value, fallback)` helper in
`llmobs/util.js`.