### PR TITLE
fix(mongodb-core): drop banned for-in walk over user query input

### DIFF
--- a/packages/datadog-plugin-bullmq/src/consumer.js
+++ b/packages/datadog-plugin-bullmq/src/consumer.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const log = require('../../dd-trace/src/log')
 const ConsumerPlugin = require('../../dd-trace/src/plugins/consumer')
 const { getMessageSize } = require('../../dd-trace/src/datastreams')
 
@@ -73,8 +74,8 @@ class BullmqConsumerPlugin extends ConsumerPlugin {
       job.opts.telemetry.metadata = JSON.stringify(metadata)
 
       return ddCarrier
-    } catch {
-      // Ignore malformed metadata
+    } catch (error) {
+      log.warn('bullmq: skipping _datadog extract on malformed telemetry.metadata: %s', error.message)
     }
   }
 }

--- a/packages/datadog-plugin-bullmq/src/producer.js
+++ b/packages/datadog-plugin-bullmq/src/producer.js
@@ -1,7 +1,21 @@
 'use strict'
 
+const log = require('../../dd-trace/src/log')
 const ProducerPlugin = require('../../dd-trace/src/plugins/producer')
 const { DsmPathwayCodec, getMessageSize } = require('../../dd-trace/src/datastreams')
+
+// Customer-controlled metadata may be malformed JSON. Returning a fresh `{}`
+// on parse failure keeps the publish path alive instead of throwing into
+// `Queue.add` / `Queue.addBulk`.
+function parseTelemetryMetadata (raw) {
+  if (!raw) return {}
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    log.warn('bullmq: ignoring malformed telemetry.metadata: %s', error.message)
+    return {}
+  }
+}
 
 class BaseBullmqProducerPlugin extends ProducerPlugin {
   static id = 'bullmq'
@@ -45,9 +59,9 @@ class BaseBullmqProducerPlugin extends ProducerPlugin {
   _injectIntoOpts (span, opts) {
     const carrier = {}
     this.tracer.inject(span, 'text_map', carrier)
-    const existing = opts.telemetry?.metadata ? JSON.parse(opts.telemetry.metadata) : {}
-    existing._datadog = carrier
-    opts.telemetry = { metadata: JSON.stringify(existing), omitContext: true }
+    const metadata = parseTelemetryMetadata(opts.telemetry?.metadata)
+    metadata._datadog = carrier
+    opts.telemetry = { metadata: JSON.stringify(metadata), omitContext: true }
   }
 
   setProducerCheckpoint (span, ctx) {
@@ -56,10 +70,10 @@ class BaseBullmqProducerPlugin extends ProducerPlugin {
     const dataStreamsContext = this.tracer.setCheckpoint(edgeTags, span, payloadSize)
 
     if (optsTarget && typeof optsTarget === 'object') {
-      const existing = optsTarget.telemetry?.metadata ? JSON.parse(optsTarget.telemetry.metadata) : {}
-      DsmPathwayCodec.encode(dataStreamsContext, existing._datadog || existing)
-      if (!existing._datadog) existing._datadog = {}
-      optsTarget.telemetry = { metadata: JSON.stringify(existing), omitContext: true }
+      const metadata = parseTelemetryMetadata(optsTarget.telemetry?.metadata)
+      DsmPathwayCodec.encode(dataStreamsContext, metadata._datadog || metadata)
+      if (!metadata._datadog) metadata._datadog = {}
+      optsTarget.telemetry = { metadata: JSON.stringify(metadata), omitContext: true }
     }
   }
 
@@ -161,10 +175,10 @@ class QueueAddBulkPlugin extends BaseBullmqProducerPlugin {
       const payloadSize = getMessageSize(job.data)
       const dataStreamsContext = this.tracer.setCheckpoint(edgeTags, span, payloadSize)
       job.opts = job.opts || {}
-      const existing = job.opts.telemetry?.metadata ? JSON.parse(job.opts.telemetry.metadata) : {}
-      DsmPathwayCodec.encode(dataStreamsContext, existing._datadog || existing)
-      if (!existing._datadog) existing._datadog = {}
-      job.opts.telemetry = { metadata: JSON.stringify(existing), omitContext: true }
+      const metadata = parseTelemetryMetadata(job.opts.telemetry?.metadata)
+      DsmPathwayCodec.encode(dataStreamsContext, metadata._datadog || metadata)
+      if (!metadata._datadog) metadata._datadog = {}
+      job.opts.telemetry = { metadata: JSON.stringify(metadata), omitContext: true }
     }
   }
 }

--- a/packages/datadog-plugin-bullmq/test/consumer-extract.spec.js
+++ b/packages/datadog-plugin-bullmq/test/consumer-extract.spec.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+describe('bullmq consumer _extractDatadog', () => {
+  let log
+  let BullmqConsumerPlugin
+
+  beforeEach(() => {
+    log = { warn: sinon.stub(), error: sinon.stub() }
+    BullmqConsumerPlugin = proxyquire('../src/consumer', {
+      '../../dd-trace/src/log': log,
+    })
+  })
+
+  it('returns the carrier when metadata is well-formed JSON with _datadog', () => {
+    const job = {
+      opts: {
+        telemetry: {
+          metadata: JSON.stringify({ _datadog: { 'x-datadog-trace-id': '1' }, other: 'kept' }),
+        },
+      },
+    }
+
+    const carrier = BullmqConsumerPlugin.prototype._extractDatadog(job)
+
+    assert.deepStrictEqual(carrier, { 'x-datadog-trace-id': '1' })
+    assert.deepStrictEqual(JSON.parse(job.opts.telemetry.metadata), { other: 'kept' })
+    sinon.assert.notCalled(log.warn)
+  })
+
+  it('warns and does not throw on a malformed metadata JSON string', () => {
+    const job = { opts: { telemetry: { metadata: '{not json' } } }
+
+    const result = BullmqConsumerPlugin.prototype._extractDatadog(job)
+
+    assert.strictEqual(result, undefined)
+    sinon.assert.calledOnce(log.warn)
+    assert.match(log.warn.firstCall.args[0], /malformed telemetry\.metadata/)
+  })
+
+  it('returns undefined without warning when metadata is missing', () => {
+    const result = BullmqConsumerPlugin.prototype._extractDatadog({ opts: {} })
+
+    assert.strictEqual(result, undefined)
+    sinon.assert.notCalled(log.warn)
+  })
+})

--- a/packages/datadog-plugin-bullmq/test/producer-inject.spec.js
+++ b/packages/datadog-plugin-bullmq/test/producer-inject.spec.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+describe('bullmq producer telemetry metadata injection', () => {
+  let log
+  let plugins
+
+  beforeEach(() => {
+    log = { warn: sinon.stub(), error: sinon.stub() }
+    plugins = proxyquire('../src/producer', {
+      '../../dd-trace/src/log': log,
+    })
+  })
+
+  function buildPluginInstance () {
+    const [QueueAddPlugin] = plugins
+    const tracer = {
+      inject: sinon.stub().callsFake((span, format, carrier) => {
+        carrier['x-datadog-trace-id'] = '1'
+      }),
+    }
+    return Object.create(QueueAddPlugin.prototype, {
+      tracer: { value: tracer },
+    })
+  }
+
+  it('keeps publishing when telemetry.metadata is malformed JSON', () => {
+    const instance = buildPluginInstance()
+    const opts = { telemetry: { metadata: '{not json' } }
+
+    instance._injectIntoOpts({}, opts)
+
+    const result = JSON.parse(opts.telemetry.metadata)
+    assert.deepStrictEqual(result._datadog, { 'x-datadog-trace-id': '1' })
+    assert.strictEqual(opts.telemetry.omitContext, true)
+    sinon.assert.calledOnce(log.warn)
+    assert.match(log.warn.firstCall.args[0], /malformed telemetry\.metadata/)
+  })
+
+  it('preserves existing metadata when telemetry.metadata is well-formed JSON', () => {
+    const instance = buildPluginInstance()
+    const opts = { telemetry: { metadata: JSON.stringify({ keep: 'me' }) } }
+
+    instance._injectIntoOpts({}, opts)
+
+    const result = JSON.parse(opts.telemetry.metadata)
+    assert.deepStrictEqual(result, {
+      keep: 'me',
+      _datadog: { 'x-datadog-trace-id': '1' },
+    })
+    sinon.assert.notCalled(log.warn)
+  })
+})

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -160,10 +160,9 @@ function limitDepth (input) {
       input, output, depth,
     } = queue.pop()
     const nextDepth = depth + 1
-    for (const key in input) {
-      if (typeof input[key] === 'function') continue
-
+    for (const key of Object.keys(input)) {
       let child = input[key]
+      if (typeof child === 'function') continue
 
       if (isBSON(child)) {
         child = typeof child.toJSON === 'function' ? child.toJSON() : '?'

--- a/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+const sinon = require('sinon')
+
+const MongodbCorePlugin = require('../src/index')
+
+// `limitDepth` is module-private; exercise it through `bindStart`, the only
+// caller that observably surfaces its output (as `meta['mongodb.query']`).
+function callBindStart (ctx) {
+  const startSpan = sinon.stub().returns({ finish () {} })
+  const self = {
+    config: { heartbeatEnabled: true, queryInResourceName: false },
+    operationName: () => 'mongodb.query',
+    serviceName: () => ({ name: 'svc' }),
+    startSpan,
+    injectDbmComment: () => undefined,
+  }
+  MongodbCorePlugin.prototype.bindStart.call(self, ctx)
+  return startSpan.firstCall.args[1].meta['mongodb.query']
+}
+
+describe('mongodb-core query depth limiter', () => {
+  it('does not walk inherited prototype keys on the query input', () => {
+    const polluted = Object.create({ inheritedKey: 'leak' })
+    polluted.ownKey = 'kept'
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: polluted },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { ownKey: 'kept' })
+  })
+
+  it('does not walk inherited prototype keys on a nested object', () => {
+    const nested = Object.create({ inheritedNested: 'leak' })
+    nested.ownNested = 'kept'
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { outer: nested } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { outer: { ownNested: 'kept' } })
+  })
+})


### PR DESCRIPTION
`limitDepth` walked an arbitrary user query object with
`for (const key in input)`, which enumerates inherited prototype
keys. Switch to `Object.keys(input)` so only own enumerable keys
are walked, and reorder the `typeof child === 'function'` guard so
we read `input[key]` once.