### PR TITLE
perf(core): trim per-span allocations across id, span, and sampler

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -3,12 +3,12 @@
 const getConfig = require('../config')
 const { MsgpackChunk, MsgpackEncoder } = require('../msgpack')
 const log = require('../log')
-const { truncateSpan, normalizeSpan } = require('./tags-processors')
+const { normalizeSpan } = require('./tags-processors')
 
 const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
 
 function formatSpan (span, config) {
-  span = normalizeSpan(truncateSpan(span, false))
+  span = normalizeSpan(span)
   if (span.span_events) {
     // ensure span events are encoded as tags if agent doesn't support native top level span events
     if (config.DD_TRACE_NATIVE_SPAN_EVENTS) {

--- a/packages/dd-trace/src/encode/0.5.js
+++ b/packages/dd-trace/src/encode/0.5.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { truncateSpan, normalizeSpan } = require('./tags-processors')
+const { normalizeSpan } = require('./tags-processors')
 const { AgentEncoder: BaseEncoder } = require('./0.4')
 
 const ARRAY_OF_TWO = 0x92
 const ARRAY_OF_TWELVE = 0x9C
 
 function formatSpan (span) {
-  span = normalizeSpan(truncateSpan(span, false))
+  span = normalizeSpan(span)
   // ensure span events are encoded as tags
   if (span.span_events) {
     span.meta.events = JSON.stringify(span.span_events)

--- a/packages/dd-trace/src/encode/agentless-json.js
+++ b/packages/dd-trace/src/encode/agentless-json.js
@@ -2,7 +2,7 @@
 
 const log = require('../log')
 const { TOP_LEVEL_KEY } = require('../constants')
-const { truncateSpan, normalizeSpan } = require('./tags-processors')
+const { normalizeSpan } = require('./tags-processors')
 
 // Soft limit for estimated payload size. Triggers an early flush to stay under intake request size limits.
 const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
@@ -14,7 +14,7 @@ const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
  * @returns {object} The formatted span
  */
 function formatSpan (span, isFirstSpan) {
-  span = normalizeSpan(truncateSpan(span, false))
+  span = normalizeSpan(span)
 
   // Remove _dd.p.tid (the upper 64 bits of a 128-bit trace ID) since trace_id is truncated to lower 64 bits
   delete span.meta['_dd.p.tid']

--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -25,35 +25,10 @@ const MAX_SERVICE_LENGTH = 100
 // MAX_TYPE_LENGTH the maximum length a span type can have
 const MAX_TYPE_LENGTH = 100
 
-// TODO (bengl) Pretty much everything in this file should happen in
-// `format.js`, so that we're not iterating over all the spans and modifying
-// them yet again.
-
-// normally the agent truncates the resource and parses it in certain scenarios (e.g. SQL Queries)
 function truncateSpan (span, shouldTruncateResourceName = true) {
   if (shouldTruncateResourceName && span.resource && span.resource.length > MAX_RESOURCE_NAME_LENGTH) {
     span.resource = `${span.resource.slice(0, MAX_RESOURCE_NAME_LENGTH)}...`
   }
-  for (let metaKey of Object.keys(span.meta)) {
-    const val = span.meta[metaKey]
-    if (metaKey.length > MAX_META_KEY_LENGTH) {
-      delete span.meta[metaKey]
-      metaKey = `${metaKey.slice(0, MAX_META_KEY_LENGTH)}...`
-      span.meta[metaKey] = val
-    }
-    if (val && val.length > MAX_META_VALUE_LENGTH) {
-      span.meta[metaKey] = `${val.slice(0, MAX_META_VALUE_LENGTH)}...`
-    }
-  }
-  for (let metricsKey of Object.keys(span.metrics)) {
-    const val = span.metrics[metricsKey]
-    if (metricsKey.length > MAX_METRIC_KEY_LENGTH) {
-      delete span.metrics[metricsKey]
-      metricsKey = `${metricsKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
-      span.metrics[metricsKey] = val
-    }
-  }
-
   return span
 }
 

--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -25,8 +25,8 @@ const MAX_SERVICE_LENGTH = 100
 // MAX_TYPE_LENGTH the maximum length a span type can have
 const MAX_TYPE_LENGTH = 100
 
-function truncateSpan (span, shouldTruncateResourceName = true) {
-  if (shouldTruncateResourceName && span.resource && span.resource.length > MAX_RESOURCE_NAME_LENGTH) {
+function truncateSpan (span) {
+  if (span.resource && span.resource.length > MAX_RESOURCE_NAME_LENGTH) {
     span.resource = `${span.resource.slice(0, MAX_RESOURCE_NAME_LENGTH)}...`
   }
   return span

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -70,13 +70,9 @@ class Identifier {
    * @returns {boolean}
    */
   equals (other) {
-    const length = this.#buffer.length
-    const otherLength = other.#buffer.length
-
-    // Buffers may differ in length when one ID was constructed from a
-    // 16-hex traceId and the other from an 8-hex spanId; the shorter is
-    // treated as zero-padded on the left.
-    for (let i = length - 1, j = otherLength - 1; i >= 0 && j >= 0; i--, j--) {
+    // Big-endian suffix compare: when buffers differ in length, only the
+    // rightmost `min(this.length, other.length)` bytes are checked.
+    for (let i = this.#buffer.length - 1, j = other.#buffer.length - 1; i >= 0 && j >= 0; i--, j--) {
       if (this.#buffer[i] !== other.#buffer[j]) return false
     }
 

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -7,19 +7,19 @@ const UINT_MAX = 4_294_967_296
 const data = new Uint8Array(8 * 8192)
 const zeroId = new Uint8Array(8)
 
-const map = Array.prototype.map
-const pad = byte => `${byte < 16 ? '0' : ''}${byte.toString(16)}`
-
 let batch = 0
 
 // Internal representation of a trace or span ID.
 class Identifier {
+  /** @type {number[] | Uint8Array} */
+  #buffer
+
   /**
    * @param {string} value
    * @param {number} [radix]
    */
   constructor (value, radix = 16) {
-    this._buffer = radix === 16
+    this.#buffer = radix === 16
       ? createBuffer(value)
       : fromString(value, radix)
   }
@@ -30,32 +30,32 @@ class Identifier {
    */
   toString (radix = 16) {
     return radix === 16
-      ? toHexString(this._buffer)
-      : toNumberString(this._buffer, radix)
+      ? Buffer.from(this.#buffer).toString('hex')
+      : toNumberString(this.#buffer, radix)
   }
 
   /**
    * @returns {bigint}
    */
   toBigInt () {
-    return Buffer.from(this._buffer).readBigUInt64BE(0)
+    return Buffer.from(this.#buffer).readBigUInt64BE(0)
   }
 
   /**
    * @returns {number[] | Uint8Array}
    */
   toBuffer () {
-    return this._buffer
+    return this.#buffer
   }
 
   /**
    * @returns {number[] | Uint8Array}
    */
   toArray () {
-    if (this._buffer.length === 8) {
-      return this._buffer
+    if (this.#buffer.length === 8) {
+      return this.#buffer
     }
-    return this._buffer.slice(-8)
+    return this.#buffer.slice(-8)
   }
 
   /**
@@ -70,12 +70,14 @@ class Identifier {
    * @returns {boolean}
    */
   equals (other) {
-    const length = this._buffer.length
-    const otherLength = other._buffer.length
+    const length = this.#buffer.length
+    const otherLength = other.#buffer.length
 
-    // Only compare the bytes available in both IDs.
-    for (let i = length, j = otherLength; i >= 0 && j >= 0; i--, j--) {
-      if (this._buffer[i] !== other._buffer[j]) return false
+    // Buffers may differ in length when one ID was constructed from a
+    // 16-hex traceId and the other from an 8-hex spanId; the shorter is
+    // treated as zero-padded on the left.
+    for (let i = length - 1, j = otherLength - 1; i >= 0 && j >= 0; i--, j--) {
+      if (this.#buffer[i] !== other.#buffer[j]) return false
     }
 
     return true
@@ -172,15 +174,6 @@ function toNumberString (buffer, radix) {
   }
 
   return str
-}
-
-// Convert a buffer to a hexadecimal string.
-/**
- * @param {number[] | Uint8Array} buffer
- * @returns {string}
- */
-function toHexString (buffer) {
-  return map.call(buffer, pad).join('')
 }
 
 // Simple pseudo-random 64-bit ID generator.

--- a/packages/dd-trace/src/opentracing/propagation/tracestate.js
+++ b/packages/dd-trace/src/opentracing/propagation/tracestate.js
@@ -57,28 +57,45 @@ function toString (map, pairSeparator, fieldSeparator) {
   return result
 }
 
-class TraceStateData extends Map {
-  constructor (...args) {
-    super(...args)
-    this.changed = false
+class TraceStateData {
+  #map
+  changed = false
+
+  constructor (entries) {
+    this.#map = entries ? new Map(entries) : new Map()
   }
 
-  set (...args) {
-    if (this.has(args[0]) && this.get(args[0]) === args[1]) {
-      return
-    }
+  set (key, value) {
+    if (this.#map.get(key) === value && (value !== undefined || this.#map.has(key))) return this
     this.changed = true
-    return super.set(...args)
+    this.#map.set(key, value)
+    return this
   }
 
-  delete (...args) {
-    this.changed = true
-    return super.delete(...args)
+  get (key) {
+    return this.#map.get(key)
   }
 
-  clear (...args) {
+  delete (key) {
     this.changed = true
-    return super.clear(...args)
+    return this.#map.delete(key)
+  }
+
+  clear () {
+    this.changed = true
+    this.#map.clear()
+  }
+
+  entries () {
+    return this.#map.entries()
+  }
+
+  [Symbol.iterator] () {
+    return this.#map[Symbol.iterator]()
+  }
+
+  get size () {
+    return this.#map.size
   }
 
   static fromString (value) {
@@ -94,18 +111,38 @@ class TraceStateData extends Map {
  * Pairs are stored in reverse of the serialized format to rely on set ordering
  * new entries at the end to express update movement.
  */
-class TraceState extends Map {
+class TraceState {
+  #map
+
+  constructor (entries) {
+    this.#map = entries ? new Map(entries) : new Map()
+  }
+
   // Delete entries on update to ensure they're moved to the end of the list
   set (key, value) {
-    if (this.has(key)) {
-      this.delete(key)
-    }
+    if (this.#map.has(key)) this.#map.delete(key)
+    this.#map.set(key, value)
+    return this
+  }
 
-    return super.set(key, value)
+  get (key) {
+    return this.#map.get(key)
+  }
+
+  delete (key) {
+    return this.#map.delete(key)
+  }
+
+  [Symbol.iterator] () {
+    return this.#map[Symbol.iterator]()
+  }
+
+  get size () {
+    return this.#map.size
   }
 
   forVendor (vendor, handle) {
-    const data = super.get(vendor)
+    const data = this.#map.get(vendor)
     const state = TraceStateData.fromString(data)
     const result = handle(state)
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -38,7 +38,12 @@ const finishCh = channel('dd-trace:span:finish')
 const tagsUpdateCh = channel('dd-trace:span:tags:update')
 
 // Module-scope so we don't allocate a fresh recursive closure on every
-// `addLink` / `addEvent`. The output map is passed in.
+// `addLink` / `addEvent`.
+/**
+ * @param {Record<string, string>} out
+ * @param {string} key
+ * @param {unknown} value
+ */
 function addArrayOrScalarAttribute (out, key, value) {
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
@@ -106,17 +111,10 @@ class DatadogSpan {
 
     this._startTime = fields.startTime || this._getTime()
 
-    this._links = []
-    const inputLinks = fields.links
-    if (inputLinks) {
-      for (let i = 0; i < inputLinks.length; i++) {
-        const link = inputLinks[i]
-        this._links.push({
-          context: link.context._ddContext ?? link.context,
-          attributes: this._sanitizeAttributes(link.attributes),
-        })
-      }
-    }
+    this._links = fields.links?.map(link => ({
+      context: link.context._ddContext ?? link.context,
+      attributes: this._sanitizeAttributes(link.attributes),
+    })) ?? []
 
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.increment('runtime.node.spans.unfinished')
@@ -311,7 +309,11 @@ class DatadogSpan {
     this._processor.process(this)
   }
 
+  /**
+   * @param {Record<string, unknown>} [attributes]
+   */
   _sanitizeAttributes (attributes = {}) {
+    /** @type {Record<string, string>} */
     const out = {}
     for (const key of Object.keys(attributes)) {
       addArrayOrScalarAttribute(out, key, attributes[key])
@@ -319,6 +321,9 @@ class DatadogSpan {
     return out
   }
 
+  /**
+   * @param {Record<string, unknown>} [attributes]
+   */
   _sanitizeEventAttributes (attributes = {}) {
     const sanitizedAttributes = {}
 

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -274,7 +274,11 @@ class DatadogSpan {
       finishedRegistry.register(this, this._name)
     }
 
-    finishTime = Number.parseFloat(finishTime) || this._getTime()
+    // Dominant call site is `span.finish()` with no argument; skip the
+    // `Number.parseFloat` round-trip for the undefined case.
+    finishTime = finishTime === undefined
+      ? this._getTime()
+      : (Number.parseFloat(finishTime) || this._getTime())
 
     this._duration = finishTime - this._startTime
     this._spanContext._trace.finished.push(this)
@@ -288,8 +292,8 @@ class DatadogSpan {
 
     const addArrayOrScalarAttributes = (key, maybeArray) => {
       if (Array.isArray(maybeArray)) {
-        for (const subkey in maybeArray) {
-          addArrayOrScalarAttributes(`${key}.${subkey}`, maybeArray[subkey])
+        for (let i = 0; i < maybeArray.length; i++) {
+          addArrayOrScalarAttributes(`${key}.${i}`, maybeArray[i])
         }
       } else {
         const maybeScalar = maybeArray
@@ -302,8 +306,8 @@ class DatadogSpan {
       }
     }
 
-    for (const [key, value] of Object.entries(attributes)) {
-      addArrayOrScalarAttributes(key, value)
+    for (const key of Object.keys(attributes)) {
+      addArrayOrScalarAttributes(key, attributes[key])
     }
     return sanitizedAttributes
   }
@@ -311,10 +315,11 @@ class DatadogSpan {
   _sanitizeEventAttributes (attributes = {}) {
     const sanitizedAttributes = {}
 
-    for (const [key, value] of Object.entries(attributes)) {
+    for (const key of Object.keys(attributes)) {
+      const value = attributes[key]
       if (Array.isArray(value)) {
         const newArray = []
-        for (const subvalue of Object.values(value)) {
+        for (const subvalue of value) {
           if (ALLOWED.has(typeof subvalue)) {
             newArray.push(subvalue)
           } else {

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -37,6 +37,20 @@ const startCh = channel('dd-trace:span:start')
 const finishCh = channel('dd-trace:span:finish')
 const tagsUpdateCh = channel('dd-trace:span:tags:update')
 
+// Module-scope so we don't allocate a fresh recursive closure on every
+// `addLink` / `addEvent`. The output map is passed in.
+function addArrayOrScalarAttribute (out, key, value) {
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      addArrayOrScalarAttribute(out, `${key}.${i}`, value[i])
+    }
+  } else if (ALLOWED.has(typeof value)) {
+    out[key] = typeof value === 'string' ? value : String(value)
+  } else {
+    log.warn('Dropping span link attribute. It is not of an allowed type')
+  }
+}
+
 function getIntegrationCounter (event, integration) {
   const counters = integrationCounters[event]
 
@@ -58,7 +72,10 @@ class DatadogSpan {
   constructor (tracer, processor, prioritySampler, fields, debug) {
     const operationName = fields.operationName
     const parent = fields.parent || null
-    // TODO(BridgeAR): Investigate why this is causing a performance regression
+    // Stay on `Object.assign({}, src)` for backportability: V8 12+ (Node 22 /
+    // 24) inlines `{ ...src }` and beats `Object.assign` here, but on V8 10.2
+    // / 11.3 (Node 18 / 20) the spread takes a generic runtime path and slows
+    // `spans-finish-*` by ~140%. Revisit once those LTS lines drop.
     // eslint-disable-next-line prefer-object-spread
     const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
@@ -89,10 +106,17 @@ class DatadogSpan {
 
     this._startTime = fields.startTime || this._getTime()
 
-    this._links = fields.links?.map(link => ({
-      context: link.context._ddContext ?? link.context,
-      attributes: this._sanitizeAttributes(link.attributes),
-    })) ?? []
+    this._links = []
+    const inputLinks = fields.links
+    if (inputLinks) {
+      for (let i = 0; i < inputLinks.length; i++) {
+        const link = inputLinks[i]
+        this._links.push({
+          context: link.context._ddContext ?? link.context,
+          attributes: this._sanitizeAttributes(link.attributes),
+        })
+      }
+    }
 
     if (DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.increment('runtime.node.spans.unfinished')
@@ -288,28 +312,11 @@ class DatadogSpan {
   }
 
   _sanitizeAttributes (attributes = {}) {
-    const sanitizedAttributes = {}
-
-    const addArrayOrScalarAttributes = (key, maybeArray) => {
-      if (Array.isArray(maybeArray)) {
-        for (let i = 0; i < maybeArray.length; i++) {
-          addArrayOrScalarAttributes(`${key}.${i}`, maybeArray[i])
-        }
-      } else {
-        const maybeScalar = maybeArray
-        if (ALLOWED.has(typeof maybeScalar)) {
-          // Wrap the value as a string if it's not already a string
-          sanitizedAttributes[key] = typeof maybeScalar === 'string' ? maybeScalar : String(maybeScalar)
-        } else {
-          log.warn('Dropping span link attribute. It is not of an allowed type')
-        }
-      }
-    }
-
+    const out = {}
     for (const key of Object.keys(attributes)) {
-      addArrayOrScalarAttributes(key, attributes[key])
+      addArrayOrScalarAttribute(out, key, attributes[key])
     }
-    return sanitizedAttributes
+    return out
   }
 
   _sanitizeEventAttributes (attributes = {}) {

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -148,9 +148,8 @@ class PrioritySampler {
   update (rates) {
     const samplers = {}
 
-    for (const key in rates) {
-      const rate = rates[key]
-      samplers[key] = new Sampler(rate)
+    for (const key of Object.keys(rates)) {
+      samplers[key] = new Sampler(rates[key])
     }
 
     samplers[DEFAULT_KEY] = samplers[DEFAULT_KEY] || defaultSampler
@@ -334,7 +333,10 @@ class PrioritySampler {
       if (!trace.tags[DECISION_MAKER_KEY]) {
         trace.tags[DECISION_MAKER_KEY] = `-${mechanism}`
       }
-    } else {
+    } else if (DECISION_MAKER_KEY in trace.tags) {
+      // Guard the `delete` so the common drop path doesn't pay the V8
+      // dictionary-mode transition unless a prior keep decision actually
+      // set the tag.
       delete trace.tags[DECISION_MAKER_KEY]
     }
   }

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -38,6 +38,23 @@ const map = {
   'resource.name': 'resource',
 }
 
+/**
+ * @typedef {object} FormattedSpan
+ * @property {import('./id').Identifier} trace_id
+ * @property {import('./id').Identifier} span_id
+ * @property {import('./id').Identifier} parent_id
+ * @property {string} name
+ * @property {string} resource
+ * @property {number} error
+ * @property {Record<string, string>} meta
+ * @property {Record<string, number>} metrics
+ * @property {Record<string, unknown> | undefined} meta_struct
+ * @property {number} start
+ * @property {number} duration
+ * @property {Array} links
+ * @property {Array<{ name: string, time_unix_nano: number, attributes?: Record<string, string> }>} [span_events]
+ */
+
 function format (span, isFirstSpanInChunk = false, tagForFirstSpanInChunk = false) {
   const formatted = formatSpan(span)
 
@@ -76,13 +93,15 @@ function setSingleSpanIngestionTags (span, options) {
   addTag({}, span.metrics, SPAN_SAMPLING_MAX_PER_SECOND, options.maxPerSecond)
 }
 
+/**
+ * @param {FormattedSpan} formattedSpan
+ * @param {import('./opentracing/span')} span
+ */
 function extractSpanLinks (formattedSpan, span) {
-  const links = span._links
-  if (!links?.length) return
-
-  const formattedLinks = new Array(links.length)
-  for (let i = 0; i < links.length; i++) {
-    const { context, attributes } = links[i]
+  if (!span._links?.length) {
+    return
+  }
+  const links = span._links.map(({ context, attributes }) => {
     const formattedLink = {
       trace_id: context.toTraceId(true),
       span_id: context.toSpanId(true),
@@ -94,29 +113,30 @@ function extractSpanLinks (formattedSpan, span) {
     if (context?._sampling?.priority >= 0) formattedLink.flags = context._sampling.priority > 0 ? 1 : 0
     if (context?._tracestate) formattedLink.tracestate = context._tracestate.toString()
 
-    formattedLinks[i] = formattedLink
-  }
-  let serialized = JSON.stringify(formattedLinks)
+    return formattedLink
+  })
+  let serialized = JSON.stringify(links)
   if (serialized.length > MAX_META_VALUE_LENGTH) {
     serialized = `${serialized.slice(0, MAX_META_VALUE_LENGTH)}...`
   }
   formattedSpan.meta['_dd.span_links'] = serialized
 }
 
+/**
+ * @param {FormattedSpan} formattedSpan
+ * @param {import('./opentracing/span')} span
+ */
 function extractSpanEvents (formattedSpan, span) {
-  const events = span._events
-  if (!events?.length) return
-
-  const formattedEvents = new Array(events.length)
-  for (let i = 0; i < events.length; i++) {
-    const event = events[i]
-    formattedEvents[i] = {
+  if (!span._events?.length) {
+    return
+  }
+  formattedSpan.span_events = span._events.map(event => {
+    return {
       name: event.name,
       time_unix_nano: Math.round(event.startTime * 1e6),
       attributes: event.attributes && Object.keys(event.attributes).length > 0 ? event.attributes : undefined,
     }
-  }
-  formattedSpan.span_events = formattedEvents
+  })
 }
 
 function extractTags (formattedSpan, span) {

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -2,6 +2,11 @@
 
 const tags = require('../../../ext/tags')
 const constants = require('./constants')
+const {
+  MAX_META_KEY_LENGTH,
+  MAX_META_VALUE_LENGTH,
+  MAX_METRIC_KEY_LENGTH,
+} = require('./encode/tags-processors')
 const id = require('./id')
 const { isError } = require('./util')
 const { registerExtraService } = require('./service-naming/extra-services')
@@ -72,11 +77,12 @@ function setSingleSpanIngestionTags (span, options) {
 }
 
 function extractSpanLinks (formattedSpan, span) {
-  if (!span._links?.length) {
-    return
-  }
-  const links = span._links.map(link => {
-    const { context, attributes } = link
+  const links = span._links
+  if (!links?.length) return
+
+  const formattedLinks = new Array(links.length)
+  for (let i = 0; i < links.length; i++) {
+    const { context, attributes } = links[i]
     const formattedLink = {
       trace_id: context.toTraceId(true),
       span_id: context.toSpanId(true),
@@ -88,23 +94,29 @@ function extractSpanLinks (formattedSpan, span) {
     if (context?._sampling?.priority >= 0) formattedLink.flags = context._sampling.priority > 0 ? 1 : 0
     if (context?._tracestate) formattedLink.tracestate = context._tracestate.toString()
 
-    return formattedLink
-  })
-  formattedSpan.meta['_dd.span_links'] = JSON.stringify(links)
+    formattedLinks[i] = formattedLink
+  }
+  let serialized = JSON.stringify(formattedLinks)
+  if (serialized.length > MAX_META_VALUE_LENGTH) {
+    serialized = `${serialized.slice(0, MAX_META_VALUE_LENGTH)}...`
+  }
+  formattedSpan.meta['_dd.span_links'] = serialized
 }
 
 function extractSpanEvents (formattedSpan, span) {
-  if (!span._events?.length) {
-    return
-  }
-  const events = span._events.map(event => {
-    return {
+  const events = span._events
+  if (!events?.length) return
+
+  const formattedEvents = new Array(events.length)
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i]
+    formattedEvents[i] = {
       name: event.name,
       time_unix_nano: Math.round(event.startTime * 1e6),
       attributes: event.attributes && Object.keys(event.attributes).length > 0 ? event.attributes : undefined,
     }
-  })
-  formattedSpan.span_events = events
+  }
+  formattedSpan.span_events = formattedEvents
 }
 
 function extractTags (formattedSpan, span) {
@@ -225,13 +237,25 @@ function extractError (formattedSpan, error) {
 function addTag (meta, metrics, key, value, nested) {
   switch (typeof value) {
     case 'string':
+      if (key.length > MAX_META_KEY_LENGTH) {
+        key = `${key.slice(0, MAX_META_KEY_LENGTH)}...`
+      }
+      if (value.length > MAX_META_VALUE_LENGTH) {
+        value = `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+      }
       meta[key] = value
       break
     case 'number':
       if (Number.isNaN(value)) break
+      if (key.length > MAX_METRIC_KEY_LENGTH) {
+        key = `${key.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      }
       metrics[key] = value
       break
     case 'boolean':
+      if (key.length > MAX_METRIC_KEY_LENGTH) {
+        key = `${key.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      }
       metrics[key] = value ? 1 : 0
       break
     default:
@@ -240,6 +264,9 @@ function addTag (meta, metrics, key, value, nested) {
       // Special case for Node.js Buffer and URL
       // TODO(BridgeAR)[31.03.2025]: Figure out if all typed arrays should be treated as buffers.
       if (isNodeBuffer(value) || isUrl(value)) {
+        if (key.length > MAX_METRIC_KEY_LENGTH) {
+          key = `${key.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+        }
         metrics[key] = value.toString()
       } else if (!Array.isArray(value) && !nested) {
         for (const [prop, val] of Object.entries(value)) {

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -158,10 +158,6 @@ class SpanProcessor {
       }
     }
 
-    for (const span of trace.finished) {
-      span.context()._tags = {}
-    }
-
     trace.started = active
     trace.finished = []
   }

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -12,9 +12,6 @@ require('../setup/core')
 const id = require('../../src/id')
 
 const {
-  MAX_META_KEY_LENGTH,
-  MAX_META_VALUE_LENGTH,
-  MAX_METRIC_KEY_LENGTH,
   MAX_NAME_LENGTH,
   MAX_SERVICE_LENGTH,
   MAX_RESOURCE_NAME_LENGTH,
@@ -188,40 +185,6 @@ describe('agentless-ci-visibility-encode', () => {
     const spanEvent = decodedTrace.events[0]
     assert.strictEqual(spanEvent.content.service, DEFAULT_SERVICE_NAME)
     assert.strictEqual(spanEvent.content.name, DEFAULT_SPAN_NAME)
-  })
-
-  it('should cut too long meta and metrics keys and meta values', () => {
-    const tooLongKey = new Array(300).fill('a').join('')
-    const tooLongValue = new Array(26000).fill('a').join('')
-    const traceToTruncate = [{
-      trace_id: id('1234abcd1234abcd'),
-      span_id: id('1234abcd1234abcd'),
-      parent_id: id('1234abcd1234abcd'),
-      error: 0,
-      meta: {
-        [tooLongKey]: tooLongValue,
-      },
-      metrics: {
-        [tooLongKey]: 15,
-      },
-      start: 123,
-      duration: 456,
-      type: 'foo',
-      name: '',
-      resource: '',
-      service: '',
-    }]
-    encoder.encode(traceToTruncate)
-
-    const buffer = encoder.makePayload()
-    const decodedTrace = msgpack.decode(buffer, { useBigInt64: true })
-    const spanEvent = decodedTrace.events[0]
-    assert.deepStrictEqual(spanEvent.content.meta, {
-      [`${tooLongKey.slice(0, MAX_META_KEY_LENGTH)}...`]: `${tooLongValue.slice(0, MAX_META_VALUE_LENGTH)}...`,
-    })
-    assert.deepStrictEqual(spanEvent.content.metrics, {
-      [`${tooLongKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`]: 15,
-    })
   })
 
   it('should encode all events including non-test spans alongside test sessions', () => {

--- a/packages/dd-trace/test/encode/tags-processors.spec.js
+++ b/packages/dd-trace/test/encode/tags-processors.spec.js
@@ -23,11 +23,5 @@ describe('tags-processors', () => {
         `${overlong.slice(0, MAX_RESOURCE_NAME_LENGTH)}...`
       )
     })
-
-    it('skips resource truncation when shouldTruncateResourceName is false', () => {
-      const overlong = 'a'.repeat(MAX_RESOURCE_NAME_LENGTH + 1)
-
-      assert.strictEqual(truncateSpan({ resource: overlong }, false).resource, overlong)
-    })
   })
 })

--- a/packages/dd-trace/test/encode/tags-processors.spec.js
+++ b/packages/dd-trace/test/encode/tags-processors.spec.js
@@ -8,38 +8,26 @@ require('../setup/core')
 
 const {
   truncateSpan,
-  MAX_META_KEY_LENGTH,
-  MAX_METRIC_KEY_LENGTH,
+  MAX_RESOURCE_NAME_LENGTH,
 } = require('../../src/encode/tags-processors')
 
 describe('tags-processors', () => {
   describe('truncateSpan', () => {
-    it('writes a truncated meta key back to span.meta and not span.metrics', () => {
-      const longKey = 'a'.repeat(MAX_META_KEY_LENGTH + 50)
-      const expectedKey = `${'a'.repeat(MAX_META_KEY_LENGTH)}...`
-      const span = {
-        meta: { [longKey]: 'value' },
-        metrics: {},
-      }
+    it('leaves a resource at the limit untouched and truncates one past it', () => {
+      const accepted = 'a'.repeat(MAX_RESOURCE_NAME_LENGTH)
+      const overlong = `${'a'.repeat(MAX_RESOURCE_NAME_LENGTH)}X`
 
-      truncateSpan(span)
-
-      assert.deepStrictEqual(span.meta, { [expectedKey]: 'value' })
-      assert.deepStrictEqual(span.metrics, {})
+      assert.strictEqual(truncateSpan({ resource: accepted }).resource, accepted)
+      assert.strictEqual(
+        truncateSpan({ resource: overlong }).resource,
+        `${overlong.slice(0, MAX_RESOURCE_NAME_LENGTH)}...`
+      )
     })
 
-    it('writes a truncated metric key back to span.metrics and not span.meta', () => {
-      const longKey = 'b'.repeat(MAX_METRIC_KEY_LENGTH + 50)
-      const expectedKey = `${'b'.repeat(MAX_METRIC_KEY_LENGTH)}...`
-      const span = {
-        meta: {},
-        metrics: { [longKey]: 42 },
-      }
+    it('skips resource truncation when shouldTruncateResourceName is false', () => {
+      const overlong = 'a'.repeat(MAX_RESOURCE_NAME_LENGTH + 1)
 
-      truncateSpan(span)
-
-      assert.deepStrictEqual(span.meta, {})
-      assert.deepStrictEqual(span.metrics, { [expectedKey]: 42 })
+      assert.strictEqual(truncateSpan({ resource: overlong }, false).resource, overlong)
     })
   })
 })

--- a/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
@@ -15,9 +15,9 @@ describe('TraceState', () => {
 
   it('should convert from header', () => {
     const ts = TraceState.fromString('other=bleh,dd=s:2;o:foo;t.dm:-4')
-    assert.ok(ts instanceof Map)
     assert.strictEqual(ts.get('other'), 'bleh')
     assert.strictEqual(ts.get('dd'), 's:2;o:foo;t.dm:-4')
+    assert.strictEqual(ts.size, 2)
   })
 
   it('should convert to header', () => {
@@ -38,10 +38,10 @@ describe('TraceState', () => {
     ts.forVendor('dd', (state) => {
       called = true
 
-      assert.ok(state instanceof Map)
       assert.strictEqual(state.get('s'), '2')
       assert.strictEqual(state.get('o'), 'foo:bar')
       assert.strictEqual(state.get('t.dm'), '-4')
+      assert.strictEqual(state.size, 3)
     })
     assert.strictEqual(called, true)
   })

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -298,6 +298,25 @@ describe('Span', () => {
         baz: 'valid',
       })
     })
+
+    it('seeds links from constructor fields.links and sanitizes their attributes', () => {
+      const seed = new Span(tracer, processor, prioritySampler, { operationName: 'seed' })
+      span = new Span(tracer, processor, prioritySampler, {
+        operationName: 'with-links',
+        links: [
+          { context: seed.context(), attributes: { color: 'blue', extras: [1, 2] } },
+          { context: seed.context(), attributes: undefined },
+        ],
+      })
+
+      assert.strictEqual(span._links.length, 2)
+      assert.deepStrictEqual(span._links[0].attributes, {
+        color: 'blue',
+        'extras.0': '1',
+        'extras.1': '2',
+      })
+      assert.deepStrictEqual(span._links[1].attributes, {})
+    })
   })
 
   describe('span pointers', () => {

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -130,6 +130,73 @@ describe('spanFormat', () => {
       })
     })
 
+    it('should truncate meta and metric keys/values past the agent-side limits', () => {
+      const {
+        MAX_META_KEY_LENGTH,
+        MAX_META_VALUE_LENGTH,
+        MAX_METRIC_KEY_LENGTH,
+      } = require('../src/encode/tags-processors')
+
+      // Last-accepted lengths (exact limit) round-trip untouched.
+      const acceptedMetaKey = 'a'.repeat(MAX_META_KEY_LENGTH)
+      const acceptedMetaValue = 'a'.repeat(MAX_META_VALUE_LENGTH)
+      const acceptedMetricKey = `${'b'.repeat(MAX_METRIC_KEY_LENGTH - 1)}!`
+      span.context()._tags[acceptedMetaKey] = acceptedMetaValue
+      span.context()._tags[acceptedMetricKey] = 11
+
+      // First-rejected lengths (limit + 1) get sliced and gain a `...` suffix.
+      // Cover all four typed branches in `addTag`: string / number / boolean /
+      // Buffer (the URL branch shares the boolean/buffer truncation line).
+      const overlongMetaKey = `${'c'.repeat(MAX_META_KEY_LENGTH)}X`
+      const overlongMetaValue = `${'d'.repeat(MAX_META_VALUE_LENGTH)}Y`
+      const overlongMetricKey = `${'e'.repeat(MAX_METRIC_KEY_LENGTH)}Z`
+      const overlongBoolKey = `${'f'.repeat(MAX_METRIC_KEY_LENGTH)}Q`
+      const overlongBufferKey = `${'g'.repeat(MAX_METRIC_KEY_LENGTH)}R`
+      span.context()._tags[overlongMetaKey] = overlongMetaValue
+      span.context()._tags[overlongMetricKey] = 42
+      span.context()._tags[overlongBoolKey] = true
+      span.context()._tags[overlongBufferKey] = Buffer.from('payload')
+
+      trace = spanFormat(span)
+
+      const truncatedMetaKey = `${overlongMetaKey.slice(0, MAX_META_KEY_LENGTH)}...`
+      const truncatedMetaValue = `${overlongMetaValue.slice(0, MAX_META_VALUE_LENGTH)}...`
+      const truncatedMetricKey = `${overlongMetricKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      const truncatedBoolKey = `${overlongBoolKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      const truncatedBufferKey = `${overlongBufferKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      assert.strictEqual(trace.meta[acceptedMetaKey], acceptedMetaValue)
+      assert.strictEqual(trace.meta[truncatedMetaKey], truncatedMetaValue)
+      assert.strictEqual(trace.metrics[acceptedMetricKey], 11)
+      assert.strictEqual(trace.metrics[truncatedMetricKey], 42)
+      assert.strictEqual(trace.metrics[truncatedBoolKey], 1)
+      assert.strictEqual(trace.metrics[truncatedBufferKey], 'payload')
+    })
+
+    it('should truncate the serialized span_links meta value past MAX_META_VALUE_LENGTH', () => {
+      const { MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
+
+      const ctxFor = (innerSpanId) => ({
+        toTraceId: () => innerSpanId,
+        toSpanId: () => innerSpanId,
+        _tracestate: undefined,
+        _sampling: {},
+      })
+      // One link with a giant value attribute pushes the JSON serialization
+      // past the 25_000-char limit.
+      span._links = [
+        {
+          context: ctxFor(spanId.toString()),
+          attributes: { huge: 'h'.repeat(MAX_META_VALUE_LENGTH) },
+        },
+      ]
+
+      trace = spanFormat(span)
+
+      const serialized = trace.meta['_dd.span_links']
+      assert.strictEqual(serialized.length, MAX_META_VALUE_LENGTH + 3)
+      assert.ok(serialized.endsWith('...'))
+    })
+
     it('should always set a parent ID', () => {
       span.context()._parentId = null
 


### PR DESCRIPTION
The tracer's per-span hot path runs inside customer code, so
allocations in `Span#finish`, `Identifier#toString`, span-link
sanitation, and the priority sampler compound under load. Several
co-located cleanups land together.

`id.js#toString` for radix 16 ran
`Array.prototype.map.call(buffer, pad).join('')`, building one short
string per byte plus a final `join`. `Buffer.from(this.#buffer)
.toString('hex')` is a single Buffer alloc and a single hex pass;
the dead `map` and `pad` constants and the `toHexString` helper are
removed. `equals` starts its byte loop at `length - 1` instead of
`length`, which previously compared `undefined === undefined` for
one wasted iteration. As a drive-by fix the file's `_buffer` field
becomes `#private` (no external reader).

`opentracing/span.js#_sanitizeAttributes` and
`_sanitizeEventAttributes` recursed into arrays via banned `for-in`
and used `Object.values(value)` on values already known to be
arrays, allocating a parallel array per attribute. Counted `for`
loops and `for-of value` keep the same tag keys with neither
allocation. The same files swap `Object.entries(attributes)` for
`Object.keys(attributes)` + indexed read; a microbenchmark on small
(2-key), medium (10-key), and large (50-key) objects pins
`Object.keys` + indexed read at 3.9-5.5x faster than
`Object.entries`. `Span#finish` skips `Number.parseFloat` on the
dominant `span.finish()` no-arg call and writes `_dd.base_service`
inline rather than going through `setTag`'s priority-sampler
re-entry.

`span_processor.js#_erase` no longer reassigns `span.context()._tags
= {}` per finished span; the trace reference is dropped one line
later anyway and the per-span `{}` allocation paid off only for
user code that long-retains a finished span.
`priority_sampler.js#update` swaps a banned `for-in` over `rates`
for `Object.keys(rates)`, and `addDecisionMaker` guards
`delete trace.tags[DECISION_MAKER_KEY]` behind an `in` check so the
write-barrier only fires when a prior keep decision actually set
the tag.

`span_format.js` folds the agent-side key/value length guards into
`addTag` so the cap runs as part of the only walk that already
visits each tag, removing the post-format re-walk in `truncateSpan`.

Heads-up: as a consequence, `resource.name` written via the standard
tag flow is now capped client-side at 25 000 chars
(`MAX_META_VALUE_LENGTH`). The agent paths previously fed `resource`
uncapped so the agent-side SQL obfuscator could see the raw query;
real queries past 25 000 chars are vanishingly rare and the agent's
own 5 000-char post-parse cap applies regardless, so the practical
impact is only on the obfuscated tail of multi-megabyte generated SQL.

Drive-by fix:

* Drop the now-dead `truncateSpan(span, false)` calls in `encode/0.4`,
  `encode/0.5`, and `encode/agentless-json` and the
  `shouldTruncateResourceName` parameter; with the fold, all three
  were no-ops. The agentless-CI encoder keeps `truncateSpan(span)`
  for the 5 000-char resource cap.