### PR TITLE
fix(encode): write truncated meta keys back to span.meta

### DIFF
--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -34,18 +34,18 @@ function truncateSpan (span, shouldTruncateResourceName = true) {
   if (shouldTruncateResourceName && span.resource && span.resource.length > MAX_RESOURCE_NAME_LENGTH) {
     span.resource = `${span.resource.slice(0, MAX_RESOURCE_NAME_LENGTH)}...`
   }
-  for (let metaKey in span.meta) {
+  for (let metaKey of Object.keys(span.meta)) {
     const val = span.meta[metaKey]
     if (metaKey.length > MAX_META_KEY_LENGTH) {
       delete span.meta[metaKey]
       metaKey = `${metaKey.slice(0, MAX_META_KEY_LENGTH)}...`
-      span.metrics[metaKey] = val
+      span.meta[metaKey] = val
     }
     if (val && val.length > MAX_META_VALUE_LENGTH) {
       span.meta[metaKey] = `${val.slice(0, MAX_META_VALUE_LENGTH)}...`
     }
   }
-  for (let metricsKey in span.metrics) {
+  for (let metricsKey of Object.keys(span.metrics)) {
     const val = span.metrics[metricsKey]
     if (metricsKey.length > MAX_METRIC_KEY_LENGTH) {
       delete span.metrics[metricsKey]

--- a/packages/dd-trace/test/encode/tags-processors.spec.js
+++ b/packages/dd-trace/test/encode/tags-processors.spec.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+require('../setup/core')
+
+const {
+  truncateSpan,
+  MAX_META_KEY_LENGTH,
+  MAX_METRIC_KEY_LENGTH,
+} = require('../../src/encode/tags-processors')
+
+describe('tags-processors', () => {
+  describe('truncateSpan', () => {
+    it('writes a truncated meta key back to span.meta and not span.metrics', () => {
+      const longKey = 'a'.repeat(MAX_META_KEY_LENGTH + 50)
+      const expectedKey = `${'a'.repeat(MAX_META_KEY_LENGTH)}...`
+      const span = {
+        meta: { [longKey]: 'value' },
+        metrics: {},
+      }
+
+      truncateSpan(span)
+
+      assert.deepStrictEqual(span.meta, { [expectedKey]: 'value' })
+      assert.deepStrictEqual(span.metrics, {})
+    })
+
+    it('writes a truncated metric key back to span.metrics and not span.meta', () => {
+      const longKey = 'b'.repeat(MAX_METRIC_KEY_LENGTH + 50)
+      const expectedKey = `${'b'.repeat(MAX_METRIC_KEY_LENGTH)}...`
+      const span = {
+        meta: {},
+        metrics: { [longKey]: 42 },
+      }
+
+      truncateSpan(span)
+
+      assert.deepStrictEqual(span.meta, {})
+      assert.deepStrictEqual(span.metrics, { [expectedKey]: 42 })
+    })
+  })
+})


### PR DESCRIPTION
`tags-processors.js#truncateSpan` deleted an over-long meta key from `span.meta` and re-inserted the truncated key into `span.metrics`, which is the numeric-only map. Anything reading `span.metrics` then saw a string value where it expected a number; anything reading `span.meta` lost the tag entirely. The parallel metrics loop right below already mirrors back into `span.metrics`; the meta loop must mirror to `span.meta` to match.

Drive-by fix:

* Adjusted for-in to prevent iterating over inherited keys.