### PR TITLE
refactor(config): drop more internalPropertyName aliases

### DIFF
--- a/benchmark/sirun/propagation/index.js
+++ b/benchmark/sirun/propagation/index.js
@@ -22,7 +22,7 @@ const propagator = new TextMapPropagator({
   baggageMaxBytes: 8192,
   tagsHeaderMaxLength: 512,
   tracePropagationExtractFirst: false,
-  tracePropagationBehaviorExtract: 'continue',
+  DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'continue',
   baggageTagKeys: ['user.id', 'session.id', 'account.id'],
 })
 

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -149,7 +149,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
         }
         this.addResponseTags(span, response)
 
-        if (this._tracerConfig?.trace?.aws?.addSpanPointers) {
+        if (this._tracerConfig?.DD_TRACE_AWS_ADD_SPAN_POINTERS) {
           this.addSpanPointers(span, response)
         }
       })

--- a/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/dynamodb.js
@@ -118,7 +118,7 @@ class DynamoDb extends BaseAwsSdkPlugin {
       return this.dynamoPrimaryKeyConfig
     }
 
-    const configStr = this._tracerConfig?.trace?.dynamoDb?.tablePrimaryKeys
+    const configStr = this._tracerConfig?.DD_TRACE_DYNAMODB_TABLE_PRIMARY_KEYS
     if (!configStr) {
       log.warn(
         // eslint-disable-next-line @stylistic/max-len

--- a/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/dynamodb.spec.js
@@ -703,7 +703,7 @@ describe('Plugin', () => {
 
       it('should parse valid config with single table', () => {
         const configStr = '{"Table1": ["key1", "key2"]}'
-        dynamoDbInstance._tracerConfig = { trace: { dynamoDb: { tablePrimaryKeys: configStr } } }
+        dynamoDbInstance._tracerConfig = { DD_TRACE_DYNAMODB_TABLE_PRIMARY_KEYS: configStr }
 
         const result = dynamoDbInstance.getPrimaryKeyConfig()
         assert.deepStrictEqual(result, {
@@ -713,7 +713,7 @@ describe('Plugin', () => {
 
       it('should parse valid config with multiple tables', () => {
         const configStr = '{"Table1": ["key1"], "Table2": ["key2", "key3"]}'
-        dynamoDbInstance._tracerConfig = { trace: { dynamoDb: { tablePrimaryKeys: configStr } } }
+        dynamoDbInstance._tracerConfig = { DD_TRACE_DYNAMODB_TABLE_PRIMARY_KEYS: configStr }
 
         const result = dynamoDbInstance.getPrimaryKeyConfig()
         assert.deepStrictEqual(result, {
@@ -724,7 +724,7 @@ describe('Plugin', () => {
 
       it('should fail for invalid entries', () => {
         const configStr = '{"Table1": {"key1": 42}, "Table42": ["key1"], "Table2": ["key1", "key2", "key3"]}'
-        dynamoDbInstance._tracerConfig = { trace: { dynamoDb: { tablePrimaryKeys: configStr } } }
+        dynamoDbInstance._tracerConfig = { DD_TRACE_DYNAMODB_TABLE_PRIMARY_KEYS: configStr }
 
         const result = dynamoDbInstance.getPrimaryKeyConfig()
         assert.deepStrictEqual(result, {

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -64,7 +64,7 @@ class GrpcClientPlugin extends ClientPlugin {
 
   error ({ span = this.activeSpan, error }) {
     this.addCode(span, error.code)
-    if (error.code && !this._tracerConfig.grpc.client.error.statuses.includes(error.code)) {
+    if (error.code && !this._tracerConfig.DD_GRPC_CLIENT_ERROR_STATUSES.includes(error.code)) {
       return
     }
     this.addError(error, span)

--- a/packages/datadog-plugin-grpc/src/server.js
+++ b/packages/datadog-plugin-grpc/src/server.js
@@ -70,7 +70,7 @@ class GrpcServerPlugin extends ServerPlugin {
     if (!span) return
 
     this.addCode(span, error.code)
-    if (error.code && !this._tracerConfig.grpc.server.error.statuses.includes(error.code)) {
+    if (error.code && !this._tracerConfig.DD_GRPC_SERVER_ERROR_STATUSES.includes(error.code)) {
       return
     }
     this.addError(error)

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -16,7 +16,7 @@ const { defaults } = require('../../dd-trace/src/config/defaults')
 const { NODE_MAJOR } = require('../../../version')
 const getService = require('./service')
 
-const GRPC_CLIENT_ERROR_STATUSES = defaults['grpc.client.error.statuses']
+const GRPC_CLIENT_ERROR_STATUSES = defaults.DD_GRPC_CLIENT_ERROR_STATUSES
 
 const pkgs = NODE_MAJOR > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
@@ -365,7 +365,7 @@ describe('Plugin', () => {
             })
 
             it('should ignore errors not set by DD_GRPC_CLIENT_ERROR_STATUSES', async () => {
-              tracer._tracer._config.grpc.client.error.statuses = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+              tracer._tracer._config.DD_GRPC_CLIENT_ERROR_STATUSES = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
               const client = await buildClient({
                 getUnary: (_, callback) => callback(new Error('foobar')),
               })
@@ -376,8 +376,7 @@ describe('Plugin', () => {
                 .assertSomeTraces(traces => {
                   assert.strictEqual(traces[0][0].error, 0)
                   assert.strictEqual(traces[0][0].metrics['grpc.status.code'], 2)
-                  tracer._tracer._config.grpc.client.error.statuses =
-                  GRPC_CLIENT_ERROR_STATUSES
+                  tracer._tracer._config.DD_GRPC_CLIENT_ERROR_STATUSES = GRPC_CLIENT_ERROR_STATUSES
                 })
             })
 

--- a/packages/datadog-plugin-grpc/test/server.spec.js
+++ b/packages/datadog-plugin-grpc/test/server.spec.js
@@ -14,7 +14,7 @@ const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/c
 const { defaults } = require('../../dd-trace/src/config/defaults')
 const { NODE_MAJOR } = require('../../../version')
 
-const GRPC_SERVER_ERROR_STATUSES = defaults['grpc.server.error.statuses']
+const GRPC_SERVER_ERROR_STATUSES = defaults.DD_GRPC_SERVER_ERROR_STATUSES
 
 const pkgs = NODE_MAJOR > 14 ? ['@grpc/grpc-js'] : ['grpc', '@grpc/grpc-js']
 
@@ -285,7 +285,7 @@ describe('Plugin', () => {
         })
 
         it('should ignore errors not set by DD_GRPC_SERVER_ERROR_STATUSES', async () => {
-          tracer._tracer._config.grpc.server.error.statuses = [6, 7, 8, 9, 10, 11, 12, 13]
+          tracer._tracer._config.DD_GRPC_SERVER_ERROR_STATUSES = [6, 7, 8, 9, 10, 11, 12, 13]
           const client = await buildClient({
             getUnary: (_, callback) => {
               const metadata = new grpc.Metadata()
@@ -312,7 +312,7 @@ describe('Plugin', () => {
             .assertSomeTraces(traces => {
               assert.strictEqual(traces[0][0].error, 0)
               assert.strictEqual(traces[0][0].metrics['grpc.status.code'], 5)
-              tracer._tracer._config.grpc.server.error.statuses = GRPC_SERVER_ERROR_STATUSES
+              tracer._tracer._config.DD_GRPC_SERVER_ERROR_STATUSES = GRPC_SERVER_ERROR_STATUSES
             })
         })
 

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -70,7 +70,7 @@ class AIGuard extends NoopAIGuard {
   constructor (tracer, config) {
     super()
 
-    if (!config.apiKey || !config.appKey) {
+    if (!config.apiKey || !config.DD_APP_KEY) {
       log.error('AIGuard: missing api and/or app keys, use env DD_API_KEY and DD_APP_KEY')
       this.#initialized = false
       return
@@ -78,7 +78,7 @@ class AIGuard extends NoopAIGuard {
     this.#tracer = tracer
     this.#headers = {
       'DD-API-KEY': config.apiKey,
-      'DD-APPLICATION-KEY': config.appKey,
+      'DD-APPLICATION-KEY': config.DD_APP_KEY,
       'DD-AI-GUARD-VERSION': tracerVersion,
       'DD-AI-GUARD-SOURCE': 'SDK',
       'DD-AI-GUARD-LANGUAGE': 'nodejs',

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -5,7 +5,6 @@ export interface GeneratedConfig {
   _DD_APM_TRACING_AGENTLESS_ENABLED: boolean;
   apiKey: string | undefined;
   apmTracingEnabled: boolean;
-  appKey: string | undefined;
   appsec: {
     apiSecurity: {
       downstreamBodyAnalysisSampleRate: number;
@@ -63,9 +62,6 @@ export interface GeneratedConfig {
       };
     };
   };
-  crashtracking: {
-    enabled: boolean;
-  };
   dbm: {
     injectSqlBaseHash: boolean;
   };
@@ -74,6 +70,7 @@ export interface GeneratedConfig {
   DD_AGENTLESS_LOG_SUBMISSION_ENABLED: boolean;
   DD_AGENTLESS_LOG_SUBMISSION_URL: string | undefined;
   DD_APM_FLUSH_DEADLINE_MILLISECONDS: number;
+  DD_APP_KEY: string | undefined;
   DD_AZURE_RESOURCE_GROUP: string | undefined;
   DD_CIVISIBILITY_AGENTLESS_ENABLED: boolean;
   DD_CIVISIBILITY_AGENTLESS_URL: string | undefined;
@@ -87,9 +84,11 @@ export interface GeneratedConfig {
   DD_CIVISIBILITY_TEST_COMMAND: string | undefined;
   DD_CIVISIBILITY_TEST_MODULE_ID: string | undefined;
   DD_CIVISIBILITY_TEST_SESSION_ID: string | undefined;
+  DD_CRASHTRACKING_ENABLED: boolean;
   DD_CUSTOM_TRACE_ID: string | undefined;
   DD_ENABLE_LAGE_PACKAGE_NAME: boolean;
   DD_ENABLE_NX_SERVICE_NAME: boolean;
+  DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: boolean;
   DD_EXPERIMENTAL_TEST_OPT_GIT_CACHE_DIR: string;
   DD_EXPERIMENTAL_TEST_OPT_GIT_CACHE_ENABLED: boolean;
   DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE: string;
@@ -111,12 +110,22 @@ export interface GeneratedConfig {
   DD_GIT_PULL_REQUEST_BASE_BRANCH_SHA: string | undefined;
   DD_GIT_REPOSITORY_URL: string | undefined;
   DD_GIT_TAG: string | undefined;
+  DD_GRPC_CLIENT_ERROR_STATUSES: number[];
+  DD_GRPC_SERVER_ERROR_STATUSES: number[];
+  DD_HEAP_SNAPSHOT_COUNT: number;
+  DD_HEAP_SNAPSHOT_DESTINATION: string;
+  DD_HEAP_SNAPSHOT_INTERVAL: number;
   DD_INJECT_FORCE: boolean;
   DD_INJECTION_ENABLED: string | undefined;
   DD_INSTRUMENTATION_CONFIG_ID: string | undefined;
+  DD_INSTRUMENTATION_INSTALL_ID: string | undefined;
+  DD_INSTRUMENTATION_INSTALL_TIME: string | undefined;
+  DD_INSTRUMENTATION_INSTALL_TYPE: string | undefined;
+  DD_INTERNAL_PROFILING_LONG_LIVED_THRESHOLD: number;
   DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED: boolean;
   DD_LAMBDA_HANDLER: string | undefined;
   DD_LOGS_OTEL_ENABLED: boolean;
+  DD_METRICS_OTEL_ENABLED: boolean;
   DD_MINI_AGENT_PATH: string | undefined;
   DD_PIPELINE_EXECUTION_ID: string | undefined;
   DD_PLAYWRIGHT_WORKER: string | undefined;
@@ -166,6 +175,7 @@ export interface GeneratedConfig {
   DD_TRACE_APOLLO_SERVER_FASTIFY_ENABLED: boolean;
   DD_TRACE_APOLLO_SUBGRAPH_ENABLED: boolean;
   DD_TRACE_AVSC_ENABLED: boolean;
+  DD_TRACE_AWS_ADD_SPAN_POINTERS: boolean;
   DD_TRACE_AWS_SDK_AWS_BATCH_PROPAGATION_ENABLED: boolean;
   DD_TRACE_AWS_SDK_AWS_ENABLED: boolean;
   DD_TRACE_AWS_SDK_BATCH_PROPAGATION_ENABLED: boolean;
@@ -229,6 +239,7 @@ export interface GeneratedConfig {
   DD_TRACE_DISABLED_INSTRUMENTATIONS: string;
   DD_TRACE_DISABLED_PLUGINS: string | undefined;
   DD_TRACE_DNS_ENABLED: boolean;
+  DD_TRACE_DYNAMODB_TABLE_PRIMARY_KEYS: string | undefined;
   DD_TRACE_ELASTIC_ELASTICSEARCH_ENABLED: boolean;
   DD_TRACE_ELASTIC_TRANSPORT_ENABLED: boolean;
   DD_TRACE_ELASTICSEARCH_ENABLED: boolean;
@@ -316,6 +327,7 @@ export interface GeneratedConfig {
   DD_TRACE_MULTER_ENABLED: boolean;
   DD_TRACE_MYSQL_ENABLED: boolean;
   DD_TRACE_MYSQL2_ENABLED: boolean;
+  DD_TRACE_NATIVE_SPAN_EVENTS: boolean;
   DD_TRACE_NET_ENABLED: boolean;
   DD_TRACE_NEXT_ENABLED: boolean;
   DD_TRACE_NODE_CHILD_PROCESS_ENABLED: boolean;
@@ -344,6 +356,7 @@ export interface GeneratedConfig {
   DD_TRACE_PROCESS_ENABLED: boolean;
   DD_TRACE_PROMISE_ENABLED: boolean;
   DD_TRACE_PROMISE_JS_ENABLED: boolean;
+  DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: "continue" | "restart" | "ignore";
   DD_TRACE_PROPAGATION_EXTRACT_FIRST: boolean;
   DD_TRACE_PROPAGATION_STYLE: string[];
   DD_TRACE_PROTOBUFJS_ENABLED: boolean;
@@ -417,24 +430,7 @@ export interface GeneratedConfig {
   flakyTestRetriesCount: number;
   flushInterval: number;
   flushMinSpans: number;
-  grpc: {
-    client: {
-      error: {
-        statuses: number[];
-      };
-    };
-    server: {
-      error: {
-        statuses: number[];
-      };
-    };
-  };
   headerTags: string[];
-  heapSnapshot: {
-    count: number;
-    destination: string;
-    interval: number;
-  };
   hostname: string;
   iast: {
     dbRowsToTaint: number;
@@ -453,11 +449,6 @@ export interface GeneratedConfig {
     telemetryVerbosity: string;
   };
   inferredProxyServicesEnabled: boolean;
-  installSignature: {
-    id: string | undefined;
-    time: string | undefined;
-    type: string | undefined;
-  };
   isEarlyFlakeDetectionEnabled: boolean;
   isFlakyTestRetriesEnabled: boolean;
   isGitUploadEnabled: boolean;
@@ -511,15 +502,10 @@ export interface GeneratedConfig {
   OTEL_TRACES_EXPORTER: "none" | "otlp" | undefined;
   OTEL_TRACES_SAMPLER: "always_on" | "always_off" | "traceidratio" | "parentbased_always_on" | "parentbased_always_off" | "parentbased_traceidratio";
   OTEL_TRACES_SAMPLER_ARG: number | undefined;
-  otelMetricsEnabled: boolean;
   peerServiceMapping: Record<string, string>;
   port: string | number;
   profiling: {
     enabled: 'true' | 'false' | 'auto';
-    longLivedThreshold: number;
-  };
-  propagateProcessTags: {
-    enabled: boolean;
   };
   protocolVersion: string;
   queryStringObfuscation: string;
@@ -562,18 +548,8 @@ export interface GeneratedConfig {
     metrics: boolean;
   };
   testManagementAttemptToFixRetries: number;
-  trace: {
-    aws: {
-      addSpanPointers: boolean;
-    };
-    dynamoDb: {
-      tablePrimaryKeys: string | undefined;
-    };
-    nativeSpanEvents: boolean;
-  };
   traceId128BitGenerationEnabled: boolean;
   traceId128BitLoggingEnabled: boolean;
-  tracePropagationBehaviorExtract: "continue" | "restart" | "ignore";
   tracePropagationStyle: {
     extract: string[];
     inject: string[];

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -358,10 +358,10 @@ class Config extends ConfigBase {
     if (this.DD_LOGS_OTEL_ENABLED) {
       setAndTrack(this, 'logInjection', false)
     }
-    if (this.otelMetricsEnabled &&
+    if (this.DD_METRICS_OTEL_ENABLED &&
         trackedConfigOrigins.has('OTEL_METRICS_EXPORTER') &&
         this.OTEL_METRICS_EXPORTER === 'none') {
-      setAndTrack(this, 'otelMetricsEnabled', false)
+      setAndTrack(this, 'DD_METRICS_OTEL_ENABLED', false)
     }
 
     if (this.OTEL_TRACES_EXPORTER === 'otlp' && this.protocolVersion && this.protocolVersion !== '0.4') {
@@ -560,7 +560,7 @@ class Config extends ConfigBase {
 
     if (IS_SERVERLESS) {
       setAndTrack(this, 'telemetry.enabled', false)
-      setAndTrack(this, 'crashtracking.enabled', false)
+      setAndTrack(this, 'DD_CRASHTRACKING_ENABLED', false)
       setAndTrack(this, 'remoteConfig.enabled', false)
     }
 

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -421,8 +421,7 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null,
-        "internalPropertyName": "appKey"
+        "default": null
       }
     ],
     "DD_AZURE_RESOURCE_GROUP": [
@@ -595,8 +594,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "true",
-        "internalPropertyName": "crashtracking.enabled"
+        "default": "true"
       }
     ],
     "DD_CUSTOM_TRACE_ID": [
@@ -770,8 +768,7 @@
       {
         "implementation": "B",
         "type": "boolean",
-        "default": "true",
-        "internalPropertyName": "propagateProcessTags.enabled"
+        "default": "true"
       }
     ],
     "DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE": [
@@ -926,7 +923,6 @@
         "implementation": "C",
         "type": "string",
         "default": "1-16",
-        "internalPropertyName": "grpc.client.error.statuses",
         "transform": "setGRPCRange"
       }
     ],
@@ -935,7 +931,6 @@
         "implementation": "C",
         "type": "string",
         "default": "2-16",
-        "internalPropertyName": "grpc.server.error.statuses",
         "transform": "setGRPCRange"
       }
     ],
@@ -943,24 +938,21 @@
       {
         "implementation": "A",
         "type": "int",
-        "default": "0",
-        "internalPropertyName": "heapSnapshot.count"
+        "default": "0"
       }
     ],
     "DD_HEAP_SNAPSHOT_DESTINATION": [
       {
         "implementation": "A",
         "type": "string",
-        "default": "",
-        "internalPropertyName": "heapSnapshot.destination"
+        "default": ""
       }
     ],
     "DD_HEAP_SNAPSHOT_INTERVAL": [
       {
         "implementation": "A",
         "type": "int",
-        "default": "3600",
-        "internalPropertyName": "heapSnapshot.interval"
+        "default": "3600"
       }
     ],
     "DD_IAST_DB_ROWS_TO_TAINT": [
@@ -1124,24 +1116,21 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null,
-        "internalPropertyName": "installSignature.id"
+        "default": null
       }
     ],
     "DD_INSTRUMENTATION_INSTALL_TIME": [
       {
         "implementation": "A",
         "type": "string",
-        "default": null,
-        "internalPropertyName": "installSignature.time"
+        "default": null
       }
     ],
     "DD_INSTRUMENTATION_INSTALL_TYPE": [
       {
         "implementation": "A",
         "type": "string",
-        "default": null,
-        "internalPropertyName": "installSignature.type"
+        "default": null
       }
     ],
     "DD_INSTRUMENTATION_TELEMETRY_ENABLED": [
@@ -1159,8 +1148,7 @@
       {
         "implementation": "A",
         "type": "int",
-        "default": "30000",
-        "internalPropertyName": "profiling.longLivedThreshold"
+        "default": "30000"
       }
     ],
     "DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED": [
@@ -1257,8 +1245,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "false",
-        "internalPropertyName": "otelMetricsEnabled"
+        "default": "false"
       }
     ],
     "DD_MINI_AGENT_PATH": [
@@ -1942,8 +1929,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "true",
-        "internalPropertyName": "trace.aws.addSpanPointers"
+        "default": "true"
       }
     ],
     "DD_TRACE_AWS_SDK_AWS_BATCH_PROPAGATION_ENABLED": [
@@ -2475,8 +2461,7 @@
       {
         "implementation": "A",
         "type": "string",
-        "default": null,
-        "internalPropertyName": "trace.dynamoDb.tablePrimaryKeys"
+        "default": null
       }
     ],
     "DD_TRACE_ELASTICSEARCH_ENABLED": [
@@ -3174,8 +3159,7 @@
       {
         "implementation": "A",
         "type": "boolean",
-        "default": "false",
-        "internalPropertyName": "trace.nativeSpanEvents"
+        "default": "false"
       }
     ],
     "DD_TRACE_NET_ENABLED": [
@@ -3418,8 +3402,7 @@
         "type": "string",
         "allowed": "continue|restart|ignore",
         "transform": "toLowerCase",
-        "default": "continue",
-        "internalPropertyName": "tracePropagationBehaviorExtract"
+        "default": "continue"
       }
     ],
     "DD_TRACE_PROPAGATION_EXTRACT_FIRST": [

--- a/packages/dd-trace/src/debugger/config.js
+++ b/packages/dd-trace/src/debugger/config.js
@@ -9,7 +9,7 @@ module.exports = function getDebuggerConfig (config, inputPath) {
     hostname: config.hostname,
     logLevel: config.logLevel,
     port: config.port,
-    propagateProcessTags: config.propagateProcessTags,
+    propagateProcessTags: { enabled: config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED },
     repositoryUrl: config.repositoryUrl,
     runtimeId: config.tags['runtime-id'],
     service: config.service,

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -11,7 +11,7 @@ function formatSpan (span, config) {
   span = normalizeSpan(truncateSpan(span, false))
   if (span.span_events) {
     // ensure span events are encoded as tags if agent doesn't support native top level span events
-    if (config.trace.nativeSpanEvents) {
+    if (config.DD_TRACE_NATIVE_SPAN_EVENTS) {
       formatSpanEvents(span)
     } else {
       span.meta.events = JSON.stringify(span.span_events)

--- a/packages/dd-trace/src/heap_snapshots.js
+++ b/packages/dd-trace/src/heap_snapshots.js
@@ -8,11 +8,11 @@ const { threadId } = require('worker_threads')
 const log = require('./log')
 
 async function scheduleSnapshot (config, total) {
-  if (total > config.heapSnapshot.count) return
+  if (total > config.DD_HEAP_SNAPSHOT_COUNT) return
 
-  await setTimeout(config.heapSnapshot.interval * 1000, null, { ref: false })
+  await setTimeout(config.DD_HEAP_SNAPSHOT_INTERVAL * 1000, null, { ref: false })
   await clearMemory()
-  writeHeapSnapshot(getName(config.heapSnapshot.destination))
+  writeHeapSnapshot(getName(config.DD_HEAP_SNAPSHOT_DESTINATION))
   await scheduleSnapshot(config, total + 1)
 }
 
@@ -49,7 +49,7 @@ module.exports = {
    * @param {import('./config/config-base')} config - Tracer configuration
    */
   async start (config) {
-    const destination = config.heapSnapshot.destination
+    const destination = config.DD_HEAP_SNAPSHOT_DESTINATION
 
     try {
       await scheduleSnapshot(config, 1)

--- a/packages/dd-trace/src/openfeature/eval-metrics-hook.js
+++ b/packages/dd-trace/src/openfeature/eval-metrics-hook.js
@@ -30,7 +30,7 @@ const COUNTER_UNIT = '{evaluation}'
  * If counter creation fails (e.g. the OTel API is not yet available), the call
  * is silently skipped and retried on the next `finally()` invocation.
  *
- * When `config.otelMetricsEnabled` is false, `finally()` is always a no-op.
+ * When `config.DD_METRICS_OTEL_ENABLED` is false, `finally()` is always a no-op.
  */
 class EvalMetricsHook {
   #enabled = false
@@ -40,7 +40,7 @@ class EvalMetricsHook {
    * @param {import('../config')} config - Tracer configuration object
    */
   constructor (config) {
-    this.#enabled = config.otelMetricsEnabled === true
+    this.#enabled = config.DD_METRICS_OTEL_ENABLED === true
   }
 
   /**

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -408,10 +408,10 @@ class TextMapPropagator {
       }
     }
 
-    if (this._config.tracePropagationBehaviorExtract === 'ignore') {
+    if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'ignore') {
       context._links = []
     } else {
-      if (this._config.tracePropagationBehaviorExtract === 'restart') {
+      if (this._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT === 'restart') {
         context._links = []
         context._links.push({
           context,

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -336,7 +336,8 @@ class DatadogSpan {
     let startTime
 
     let baggage = {}
-    if (parent && parent._isRemote && this._parentTracer?._config?.tracePropagationBehaviorExtract !== 'continue') {
+    const propagationBehavior = this._parentTracer?._config?.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
+    if (parent && parent._isRemote && propagationBehavior !== 'continue') {
       baggage = parent._baggageItems
       parent = null
     }
@@ -375,7 +376,7 @@ class DatadogSpan {
           .padEnd(16, '0')
       }
 
-      if (this._parentTracer?._config?.tracePropagationBehaviorExtract === 'restart') {
+      if (propagationBehavior === 'restart') {
         spanContext._baggageItems = baggage
       }
     }

--- a/packages/dd-trace/src/profiling/ssi-heuristics.js
+++ b/packages/dd-trace/src/profiling/ssi-heuristics.js
@@ -14,12 +14,12 @@ class SSIHeuristics {
    * @param {import('../config/config-base')} config - Tracer configuration
    */
   constructor (config) {
-    const longLivedThreshold = config.profiling.longLivedThreshold || DEFAULT_LONG_LIVED_THRESHOLD
+    const longLivedThreshold = config.DD_INTERNAL_PROFILING_LONG_LIVED_THRESHOLD || DEFAULT_LONG_LIVED_THRESHOLD
     if (typeof longLivedThreshold !== 'number' || longLivedThreshold <= 0) {
       this.longLivedThreshold = DEFAULT_LONG_LIVED_THRESHOLD
       log.warn(
         'Invalid SSIHeuristics.longLivedThreshold value: %s. Using default value:',
-        config.profiling.longLivedThreshold,
+        config.DD_INTERNAL_PROFILING_LONG_LIVED_THRESHOLD,
         DEFAULT_LONG_LIVED_THRESHOLD
       )
     } else {

--- a/packages/dd-trace/src/propagation-hash/index.js
+++ b/packages/dd-trace/src/propagation-hash/index.js
@@ -33,7 +33,7 @@ class PropagationHashManager {
    * @returns {boolean}
    */
   isEnabled () {
-    return this._config?.propagateProcessTags?.enabled === true
+    return this._config?.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED === true
   }
 
   /**

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -113,11 +113,11 @@ class Tracer extends NoopProxy {
       const propagationHash = require('./propagation-hash')
       propagationHash.configure(config)
 
-      if (config.crashtracking.enabled) {
+      if (config.DD_CRASHTRACKING_ENABLED) {
         require('./crashtracking').start(config)
       }
 
-      if (config.heapSnapshot.count > 0) {
+      if (config.DD_HEAP_SNAPSHOT_COUNT > 0) {
         require('./heap_snapshots').start(config)
       }
 
@@ -229,7 +229,7 @@ class Tracer extends NoopProxy {
         initializeOpenTelemetryLogs(config)
       }
 
-      if (config.otelMetricsEnabled) {
+      if (config.DD_METRICS_OTEL_ENABLED) {
         const { initializeOpenTelemetryMetrics } = require('./opentelemetry/metrics')
         initializeOpenTelemetryMetrics(config)
       }

--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -42,7 +42,7 @@ module.exports = {
     this.stop()
     const clientConfig = DogStatsDClient.generateClientConfig(config)
 
-    if (config.propagateProcessTags?.enabled) {
+    if (config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED) {
       for (const tag of processTags.tagsArray) {
         clientConfig.tags.push(tag)
       }

--- a/packages/dd-trace/src/span_processor.js
+++ b/packages/dd-trace/src/span_processor.js
@@ -25,7 +25,7 @@ class SpanProcessor {
     this._spanSampler = new SpanSampler(config.sampler)
     this._gitMetadataTagger = new GitMetadataTagger(config)
 
-    this._processTags = config.propagateProcessTags?.enabled
+    this._processTags = config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED
       ? processTags.serialized
       : false
   }

--- a/packages/dd-trace/src/telemetry/telemetry.js
+++ b/packages/dd-trace/src/telemetry/telemetry.js
@@ -163,12 +163,14 @@ function getProducts (config) {
  * @param {import('../config/config-base')} config
  */
 function getInstallSignature (config) {
-  const { installSignature: sig } = config
-  if (sig && (sig.id || sig.time || sig.type)) {
+  const id = config.DD_INSTRUMENTATION_INSTALL_ID
+  const time = config.DD_INSTRUMENTATION_INSTALL_TIME
+  const type = config.DD_INSTRUMENTATION_INSTALL_TYPE
+  if (id || time || type) {
     return {
-      install_id: sig.id,
-      install_time: sig.time,
-      install_type: sig.type,
+      install_id: id,
+      install_time: time,
+      install_type: type,
     }
   }
 }

--- a/packages/dd-trace/src/tracer_metadata.js
+++ b/packages/dd-trace/src/tracer_metadata.js
@@ -14,7 +14,7 @@ function storeConfig (config) {
     const { containerId } = require('./exporters/common/docker')
     const processTags = require('./process-tags')
 
-    const processTagsSerialized = config.propagateProcessTags?.enabled
+    const processTagsSerialized = config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED
       ? (processTags.serialized || null)
       : null
 

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -25,7 +25,7 @@ describe('AIGuard SDK', () => {
     service: 'ai_guard_demo',
     env: 'test',
     apiKey: 'API_KEY',
-    appKey: 'APP_KEY',
+    DD_APP_KEY: 'APP_KEY',
     protocolVersion: '0.4',
     experimental: {
       aiguard: {
@@ -118,7 +118,7 @@ describe('AIGuard SDK', () => {
           'Content-Type': 'application/json',
           'Content-Length': Buffer.byteLength(postData),
           'DD-API-KEY': config.apiKey,
-          'DD-APPLICATION-KEY': config.appKey,
+          'DD-APPLICATION-KEY': config.DD_APP_KEY,
           'DD-AI-GUARD-VERSION': tracerVersion,
           'DD-AI-GUARD-SOURCE': 'SDK',
           'DD-AI-GUARD-LANGUAGE': 'nodejs',

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -19,8 +19,8 @@ const { assertObjectContains } = require('../../../../integration-tests/helpers'
 const { DD_MAJOR } = require('../../../../version')
 const StableConfig = require('../../src/config/stable')
 
-const GRPC_CLIENT_ERROR_STATUSES = defaults['grpc.client.error.statuses']
-const GRPC_SERVER_ERROR_STATUSES = defaults['grpc.server.error.statuses']
+const GRPC_CLIENT_ERROR_STATUSES = defaults.DD_GRPC_CLIENT_ERROR_STATUSES
+const GRPC_SERVER_ERROR_STATUSES = defaults.DD_GRPC_SERVER_ERROR_STATUSES
 
 describe('Config', () => {
   let log
@@ -560,7 +560,7 @@ describe('Config', () => {
 
     assertObjectContains(config, {
       apmTracingEnabled: true,
-      appKey: undefined,
+      DD_APP_KEY: undefined,
       appsec: {
         apiSecurity: {
           enabled: true,
@@ -608,9 +608,7 @@ describe('Config', () => {
           },
         },
       },
-      crashtracking: {
-        enabled: true,
-      },
+      DD_CRASHTRACKING_ENABLED: true,
       debug: false,
       dogstatsd: {
         hostname: '127.0.0.1',
@@ -636,11 +634,9 @@ describe('Config', () => {
       },
       flushInterval: 2000,
       flushMinSpans: 1000,
-      heapSnapshot: {
-        count: 0,
-        destination: '',
-        interval: 3600,
-      },
+      DD_HEAP_SNAPSHOT_COUNT: 0,
+      DD_HEAP_SNAPSHOT_DESTINATION: '',
+      DD_HEAP_SNAPSHOT_INTERVAL: 3600,
       iast: {
         enabled: false,
         redactionEnabled: true,
@@ -652,11 +648,9 @@ describe('Config', () => {
         },
       },
       DD_INJECT_FORCE: false,
-      installSignature: {
-        id: undefined,
-        time: undefined,
-        type: undefined,
-      },
+      DD_INSTRUMENTATION_INSTALL_ID: undefined,
+      DD_INSTRUMENTATION_INSTALL_TIME: undefined,
+      DD_INSTRUMENTATION_INSTALL_TYPE: undefined,
       instrumentationSource: 'manual',
       DD_INSTRUMENTATION_CONFIG_ID: undefined,
       llmobs: {
@@ -691,12 +685,12 @@ describe('Config', () => {
       spanRemoveIntegrationFromService: false,
       traceId128BitGenerationEnabled: true,
       traceId128BitLoggingEnabled: true,
-      tracePropagationBehaviorExtract: 'continue',
+      DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'continue',
     })
     assert.deepStrictEqual(config.dynamicInstrumentation.redactedIdentifiers, [])
     assert.deepStrictEqual(config.dynamicInstrumentation.redactionExcludedIdentifiers, [])
-    assert.deepStrictEqual(config.grpc.client.error.statuses, GRPC_CLIENT_ERROR_STATUSES)
-    assert.deepStrictEqual(config.grpc.server.error.statuses, GRPC_SERVER_ERROR_STATUSES)
+    assert.deepStrictEqual(config.DD_GRPC_CLIENT_ERROR_STATUSES, GRPC_CLIENT_ERROR_STATUSES)
+    assert.deepStrictEqual(config.DD_GRPC_SERVER_ERROR_STATUSES, GRPC_SERVER_ERROR_STATUSES)
     assert.deepStrictEqual(config.DD_INJECTION_ENABLED, undefined)
     assert.deepStrictEqual(config.serviceMapping, {})
     assert.deepStrictEqual(config.tracePropagationStyle.extract, ['datadog', 'tracecontext', 'baggage'])
@@ -1021,7 +1015,7 @@ describe('Config', () => {
 
     assertObjectContains(config, {
       apmTracingEnabled: false,
-      appKey: 'myAppKey',
+      DD_APP_KEY: 'myAppKey',
       appsec: {
         apiSecurity: {
           enabled: true,
@@ -1071,9 +1065,7 @@ describe('Config', () => {
           },
         },
       },
-      crashtracking: {
-        enabled: false,
-      },
+      DD_CRASHTRACKING_ENABLED: false,
       debug: true,
       dogstatsd: {
         hostname: 'dsd-agent',
@@ -1100,11 +1092,9 @@ describe('Config', () => {
         exporter: 'log',
       },
       hostname: 'agent',
-      heapSnapshot: {
-        count: 1,
-        destination: '/tmp',
-        interval: 1800,
-      },
+      DD_HEAP_SNAPSHOT_COUNT: 1,
+      DD_HEAP_SNAPSHOT_DESTINATION: '/tmp',
+      DD_HEAP_SNAPSHOT_INTERVAL: 1800,
       iast: {
         dbRowsToTaint: 2,
         deduplicationEnabled: false,
@@ -1155,16 +1145,15 @@ describe('Config', () => {
       },
       traceId128BitGenerationEnabled: true,
       traceId128BitLoggingEnabled: true,
-      tracePropagationBehaviorExtract: 'restart',
+      DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart',
       tracing: true,
       version: '1.0.0',
     })
-    assert.deepStrictEqual(config.grpc.client.error.statuses, [3, 13, 400, 401, 402, 403])
-    assert.deepStrictEqual(config.grpc.server.error.statuses, [3, 13, 400, 401, 402, 403])
-    assert.deepStrictEqual(
-      config.installSignature,
-      { id: '68e75c48-57ca-4a12-adfc-575c4b05fcbe', type: 'k8s_single_step', time: '1703188212' }
-    )
+    assert.deepStrictEqual(config.DD_GRPC_CLIENT_ERROR_STATUSES, [3, 13, 400, 401, 402, 403])
+    assert.deepStrictEqual(config.DD_GRPC_SERVER_ERROR_STATUSES, [3, 13, 400, 401, 402, 403])
+    assert.strictEqual(config.DD_INSTRUMENTATION_INSTALL_ID, '68e75c48-57ca-4a12-adfc-575c4b05fcbe')
+    assert.strictEqual(config.DD_INSTRUMENTATION_INSTALL_TYPE, 'k8s_single_step')
+    assert.strictEqual(config.DD_INSTRUMENTATION_INSTALL_TIME, '1703188212')
     assert.deepStrictEqual(config.peerServiceMapping, { c: 'cc', d: 'dd' })
     assert.deepStrictEqual(config.sampler, {
       sampleRate: 0.5,
@@ -1421,7 +1410,7 @@ describe('Config', () => {
 
     const config = getConfig()
 
-    assert.deepStrictEqual(config.crashtracking.enabled, true)
+    assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, true)
   })
 
   it('should disable crash tracking for SSI when configured', () => {
@@ -1430,7 +1419,7 @@ describe('Config', () => {
 
     const config = getConfig()
 
-    assert.deepStrictEqual(config.crashtracking.enabled, false)
+    assert.strictEqual(config.DD_CRASHTRACKING_ENABLED, false)
   })
 
   it('should prioritize DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE over DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING', () => {
@@ -1869,24 +1858,24 @@ describe('Config', () => {
 
     let config = getConfig()
 
-    assert.deepStrictEqual(config.grpc.client.error.statuses, [3, 13, 400, 401, 402, 403])
-    assert.deepStrictEqual(config.grpc.server.error.statuses, [3, 13, 400, 401, 402, 403])
+    assert.deepStrictEqual(config.DD_GRPC_CLIENT_ERROR_STATUSES, [3, 13, 400, 401, 402, 403])
+    assert.deepStrictEqual(config.DD_GRPC_SERVER_ERROR_STATUSES, [3, 13, 400, 401, 402, 403])
 
     process.env.DD_GRPC_CLIENT_ERROR_STATUSES = '1'
     process.env.DD_GRPC_SERVER_ERROR_STATUSES = '1'
 
     config = getConfig()
 
-    assert.deepStrictEqual(config.grpc.client.error.statuses, [1])
-    assert.deepStrictEqual(config.grpc.server.error.statuses, [1])
+    assert.deepStrictEqual(config.DD_GRPC_CLIENT_ERROR_STATUSES, [1])
+    assert.deepStrictEqual(config.DD_GRPC_SERVER_ERROR_STATUSES, [1])
 
     process.env.DD_GRPC_CLIENT_ERROR_STATUSES = '2,10,13-15'
     process.env.DD_GRPC_SERVER_ERROR_STATUSES = '2,10,13-15'
 
     config = getConfig()
 
-    assert.deepStrictEqual(config.grpc.client.error.statuses, [2, 10, 13, 14, 15])
-    assert.deepStrictEqual(config.grpc.server.error.statuses, [2, 10, 13, 14, 15])
+    assert.deepStrictEqual(config.DD_GRPC_CLIENT_ERROR_STATUSES, [2, 10, 13, 14, 15])
+    assert.deepStrictEqual(config.DD_GRPC_SERVER_ERROR_STATUSES, [2, 10, 13, 14, 15])
   })
 
   context('peer service tagging', () => {
@@ -3730,12 +3719,10 @@ apm_configuration_default:
       let config = getConfig()
       assertObjectContains(config, {
         apiKey: 'local-api-key',
-        appKey: 'local-app-key',
-        installSignature: {
-          id: 'local-install-id',
-          time: '1234567890',
-          type: 'local_install',
-        },
+        DD_APP_KEY: 'local-app-key',
+        DD_INSTRUMENTATION_INSTALL_ID: 'local-install-id',
+        DD_INSTRUMENTATION_INSTALL_TIME: '1234567890',
+        DD_INSTRUMENTATION_INSTALL_TYPE: 'local_install',
         cloudPayloadTagging: {
           request: [],
           maxDepth: 5,
@@ -3750,10 +3737,8 @@ apm_configuration_default:
       config = getConfig()
       assertObjectContains(config, {
         apiKey: 'env-api-key',
-        appKey: 'env-app-key',
-        installSignature: {
-          id: 'env-install-id',
-        },
+        DD_APP_KEY: 'env-app-key',
+        DD_INSTRUMENTATION_INSTALL_ID: 'env-install-id',
         cloudPayloadTagging: {
           maxDepth: 7,
         },
@@ -3782,12 +3767,10 @@ rules:
       config = getConfig()
       assertObjectContains(config, {
         apiKey: 'fleet-api-key',
-        appKey: 'fleet-app-key',
-        installSignature: {
-          id: 'fleet-install-id',
-          time: '9999999999',
-          type: 'fleet_install',
-        },
+        DD_APP_KEY: 'fleet-app-key',
+        DD_INSTRUMENTATION_INSTALL_ID: 'fleet-install-id',
+        DD_INSTRUMENTATION_INSTALL_TIME: '9999999999',
+        DD_INSTRUMENTATION_INSTALL_TYPE: 'fleet_install',
         cloudPayloadTagging: {
           request: undefined,
           response: [],

--- a/packages/dd-trace/test/datastreams/processor.spec.js
+++ b/packages/dd-trace/test/datastreams/processor.spec.js
@@ -322,7 +322,7 @@ describe('DataStreamsProcessor', () => {
     processTags.initialize()
 
     // Configure and enable the feature
-    propagationHash.configure({ propagateProcessTags: { enabled: true } })
+    propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
     processor.recordCheckpoint(mockCheckpoint)
     processor.onInterval()
@@ -345,7 +345,7 @@ describe('DataStreamsProcessor', () => {
     const propagationHash = require('../../src/propagation-hash')
 
     // Ensure the feature is disabled
-    propagationHash.configure({ propagateProcessTags: { enabled: false } })
+    propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false })
 
     processor.recordCheckpoint(mockCheckpoint)
     processor.onInterval()

--- a/packages/dd-trace/test/debugger/index.spec.js
+++ b/packages/dd-trace/test/debugger/index.spec.js
@@ -232,7 +232,7 @@ describe('debugger/index', () => {
         inputPath: '/debugger/v2/input',
         logLevel: 'info',
         port: 8126,
-        propagateProcessTags: undefined,
+        propagateProcessTags: { enabled: undefined },
         repositoryUrl: 'https://github.com/test/repo',
         runtimeId: 'test-runtime-id',
         service: 'test-service',

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -28,7 +28,7 @@ describe('encode', () => {
       logger = {
         debug: sinon.stub(),
       }
-      const getConfig = () => ({ trace: { nativeSpanEvents: false } })
+      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: false })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
         '../log': logger,
         '../config': getConfig,
@@ -489,7 +489,7 @@ describe('encode', () => {
         debug: sinon.spy(),
       }
 
-      const getConfig = () => ({ trace: { nativeSpanEvents: true } })
+      const getConfig = () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: true })
       const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
         '../log': logger,
         '../config': getConfig,

--- a/packages/dd-trace/test/heap_snapshots.spec.js
+++ b/packages/dd-trace/test/heap_snapshots.spec.js
@@ -19,11 +19,9 @@ describe('Heap Snapshots', () => {
     const interval = setInterval(() => {}, 1000)
 
     await start({
-      heapSnapshot: {
-        count: 3,
-        destination,
-        interval: 1,
-      },
+      DD_HEAP_SNAPSHOT_COUNT: 3,
+      DD_HEAP_SNAPSHOT_DESTINATION: destination,
+      DD_HEAP_SNAPSHOT_INTERVAL: 1,
     })
 
     clearInterval(interval)

--- a/packages/dd-trace/test/openfeature/eval-metrics-hook.spec.js
+++ b/packages/dd-trace/test/openfeature/eval-metrics-hook.spec.js
@@ -41,8 +41,8 @@ describe('EvalMetricsHook', () => {
     })
   })
 
-  function makeConfig (otelMetricsEnabled = true) {
-    return { otelMetricsEnabled }
+  function makeConfig (DD_METRICS_OTEL_ENABLED = true) {
+    return { DD_METRICS_OTEL_ENABLED }
   }
 
   function hookContext (flagKey = 'flag') {

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -39,7 +39,7 @@ describe('OpenTelemetry Meter Provider', () => {
 
     metrics.disable()
     const config = getConfigFresh()
-    if (config.otelMetricsEnabled) {
+    if (config.DD_METRICS_OTEL_ENABLED) {
       const { initializeOpenTelemetryMetrics } =
         proxyquire.noPreserveCache()('../../src/opentelemetry/metrics', {})
       initializeOpenTelemetryMetrics(config)

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -501,7 +501,7 @@ describe('Span', () => {
       it('should not propagate baggage items when Trace_Propagation_Behavior_Extract is set to ignore', () => {
         tracer = {
           _config: {
-            tracePropagationBehaviorExtract: 'ignore',
+            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore',
           },
         }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
@@ -511,7 +511,7 @@ describe('Span', () => {
       it('should propagate baggage items when Trace_Propagation_Behavior_Extract is set to restart', () => {
         tracer = {
           _config: {
-            tracePropagationBehaviorExtract: 'restart',
+            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart',
           },
         }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })

--- a/packages/dd-trace/test/process-tags.spec.js
+++ b/packages/dd-trace/test/process-tags.spec.js
@@ -276,8 +276,7 @@ describe('process-tags', () => {
       const processTagsModule = require('../src/process-tags')
       processTagsModule.initialize()
 
-      assert.ok(config.propagateProcessTags)
-      assert.strictEqual(config.propagateProcessTags.enabled, true)
+      assert.strictEqual(config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, true)
 
       SpanProcessor = require('../src/span_processor')
       const processor = new SpanProcessor(undefined, undefined, config)
@@ -293,8 +292,7 @@ describe('process-tags', () => {
       const processTagsModule = require('../src/process-tags')
       processTagsModule.initialize()
 
-      assert.ok(config.propagateProcessTags)
-      assert.strictEqual(config.propagateProcessTags.enabled, false)
+      assert.strictEqual(config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, false)
 
       SpanProcessor = require('../src/span_processor')
       const processor = new SpanProcessor(undefined, undefined, config)
@@ -309,8 +307,7 @@ describe('process-tags', () => {
       const processTagsModule = require('../src/process-tags')
       processTagsModule.initialize()
 
-      assert.ok(config.propagateProcessTags)
-      assert.strictEqual(config.propagateProcessTags.enabled, true)
+      assert.strictEqual(config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, true)
 
       SpanProcessor = require('../src/span_processor')
       const processor = new SpanProcessor(undefined, undefined, config)

--- a/packages/dd-trace/test/propagation-hash.spec.js
+++ b/packages/dd-trace/test/propagation-hash.spec.js
@@ -18,7 +18,7 @@ describe('PropagationHashManager', () => {
 
   describe('configure', () => {
     it('should store the configuration', () => {
-      const config = { propagateProcessTags: { enabled: true } }
+      const config = { DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true }
       propagationHash.configure(config)
       assert.strictEqual(propagationHash.isEnabled(), true)
     })
@@ -35,19 +35,19 @@ describe('PropagationHashManager', () => {
     })
 
     it('should return false when propagateProcessTags is disabled', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: false } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false })
       assert.strictEqual(propagationHash.isEnabled(), false)
     })
 
     it('should return true when propagateProcessTags is enabled', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
       assert.strictEqual(propagationHash.isEnabled(), true)
     })
   })
 
   describe('updateContainerTagsHash', () => {
     it('should update the container tags hash', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
       propagationHash.updateContainerTagsHash('container123')
 
       const hash1 = propagationHash.getHash()
@@ -60,7 +60,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should not recompute hash if container tags are the same', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
       propagationHash.updateContainerTagsHash('container123')
 
       const hash1 = propagationHash.getHash()
@@ -75,7 +75,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should handle null container tags hash', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
       propagationHash.updateContainerTagsHash(null)
 
       const hash = propagationHash.getHash()
@@ -85,12 +85,12 @@ describe('PropagationHashManager', () => {
 
   describe('getHash', () => {
     it('should return null when feature is disabled', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: false } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false })
       assert.strictEqual(propagationHash.getHash(), null)
     })
 
     it('should compute and cache hash from process tags only', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hash = propagationHash.getHash()
       assert.ok(hash, 'Hash should be computed')
@@ -102,7 +102,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should compute hash from process tags + container tags', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashWithoutContainer = propagationHash.getHash()
       propagationHash.updateContainerTagsHash('container123')
@@ -116,12 +116,12 @@ describe('PropagationHashManager', () => {
 
   describe('getHashString', () => {
     it('should return null when feature is disabled', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: false } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false })
       assert.strictEqual(propagationHash.getHashString(), null)
     })
 
     it('should return hex string representation of hash', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashString = propagationHash.getHashString()
       assert.ok(hashString, 'Hash string should exist')
@@ -130,7 +130,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should cache the hex string representation', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashString1 = propagationHash.getHashString()
       const hashString2 = propagationHash.getHashString()
@@ -139,7 +139,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should recompute hex string when hash changes', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashString1 = propagationHash.getHashString()
       propagationHash.updateContainerTagsHash('container123')
@@ -149,7 +149,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should match BigInt toString(16)', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hash = propagationHash.getHash()
       const hashString = propagationHash.getHashString()
@@ -160,12 +160,12 @@ describe('PropagationHashManager', () => {
 
   describe('getHashBase64', () => {
     it('should return null when feature is disabled', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: false } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false })
       assert.strictEqual(propagationHash.getHashBase64(), null)
     })
 
     it('should return base64 string representation of hash', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashBase64 = propagationHash.getHashBase64()
       assert.ok(hashBase64, 'Hash base64 should exist')
@@ -174,7 +174,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should cache the base64 string representation', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashBase64First = propagationHash.getHashBase64()
       const hashBase64Second = propagationHash.getHashBase64()
@@ -183,7 +183,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should recompute base64 string when hash changes', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashBase64First = propagationHash.getHashBase64()
       propagationHash.updateContainerTagsHash('container123')
@@ -193,7 +193,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should be convertible back to BigInt', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hash = propagationHash.getHash()
       const hashBase64 = propagationHash.getHashBase64()
@@ -206,7 +206,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should produce 8-byte base64 string', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hashBase64 = propagationHash.getHashBase64()
       const buffer = Buffer.from(hashBase64, 'base64')
@@ -217,7 +217,7 @@ describe('PropagationHashManager', () => {
 
   describe('cache invalidation', () => {
     it('should invalidate cache when container tags change', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       const hash1 = propagationHash.getHash()
       const hashString1 = propagationHash.getHashString()
@@ -235,7 +235,7 @@ describe('PropagationHashManager', () => {
     })
 
     it('should not invalidate cache if container tags are unchanged', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
       propagationHash.updateContainerTagsHash('container123')
       const hash1 = propagationHash.getHash()
@@ -249,7 +249,7 @@ describe('PropagationHashManager', () => {
 
   describe('edge cases', () => {
     it('should handle empty container tags', () => {
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
       propagationHash.updateContainerTagsHash('')
 
       const hash = propagationHash.getHash()
@@ -259,7 +259,7 @@ describe('PropagationHashManager', () => {
     it('should return null for empty input when both process tags and container tags are empty', () => {
       // This test would require mocking process-tags module to return empty string
       // For now, we assume process tags always have some value
-      propagationHash.configure({ propagateProcessTags: { enabled: true } })
+      propagationHash.configure({ DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
       const hash = propagationHash.getHash()
       assert.ok(hash, 'Hash should be computed from process tags')
     })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -157,7 +157,7 @@ describe('TracerProxy', () => {
       apmTracingEnabled: false,
       appsec: {},
       iast: {},
-      crashtracking: {},
+      DD_CRASHTRACKING_ENABLED: false,
       dynamicInstrumentation: {},
       remoteConfig: {
         enabled: true,
@@ -167,7 +167,6 @@ describe('TracerProxy', () => {
       },
       setRemoteConfig: sinon.spy(),
       llmobs: {},
-      heapSnapshot: {},
     }
     Config = sinon.stub().returns(config)
 

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -261,7 +261,7 @@ function createGarbage (count = 50) {
         })
 
         it('should include process tags when propagateProcessTags is enabled', function () {
-          config.propagateProcessTags = { enabled: true }
+          config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED = true
 
           runtimeMetrics.stop()
           runtimeMetrics.start(config)
@@ -272,7 +272,7 @@ function createGarbage (count = 50) {
         })
 
         it('should not include process tags when propagateProcessTags is disabled', function () {
-          config.propagateProcessTags = { enabled: false }
+          config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED = false
 
           runtimeMetrics.stop()
           runtimeMetrics.start(config)

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -195,7 +195,7 @@ describe('SpanProcessor', () => {
 
   it('should add span tags to first span in a chunk', () => {
     config.flushMinSpans = 2
-    config.propagateProcessTags = { enabled: true }
+    config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED = true
     const processor = new SpanProcessor(exporter, prioritySampler, config)
     trace.started = [activeSpan, finishedSpan, finishedSpan, finishedSpan, finishedSpan]
     trace.finished = [finishedSpan, finishedSpan, finishedSpan, finishedSpan]

--- a/packages/dd-trace/test/telemetry/index.spec.js
+++ b/packages/dd-trace/test/telemetry/index.spec.js
@@ -141,11 +141,9 @@ describe('telemetry', () => {
         service_1: 'remapped_service_1',
         service_2: 'remapped_service_2',
       },
-      installSignature: {
-        id: '68e75c48-57ca-4a12-adfc-575c4b05fcbe',
-        type: 'k8s_single_step',
-        time: '1703188212',
-      },
+      DD_INSTRUMENTATION_INSTALL_ID: '68e75c48-57ca-4a12-adfc-575c4b05fcbe',
+      DD_INSTRUMENTATION_INSTALL_TYPE: 'k8s_single_step',
+      DD_INSTRUMENTATION_INSTALL_TIME: '1703188212',
     }, {
       _pluginsByName: pluginsByName,
     })

--- a/packages/dd-trace/test/tracer_metadata.spec.js
+++ b/packages/dd-trace/test/tracer_metadata.spec.js
@@ -20,7 +20,7 @@ describe('tracer_metadata', () => {
     service: 'test-service',
     env: 'test-env',
     version: '1.0.0',
-    propagateProcessTags: { enabled: false },
+    DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false,
   }
 
   beforeEach(() => {
@@ -65,14 +65,14 @@ describe('tracer_metadata', () => {
   })
 
   it('passes null for process_tags when propagateProcessTags is disabled', () => {
-    storeConfig({ ...baseConfig, propagateProcessTags: { enabled: false } })
+    storeConfig({ ...baseConfig, DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: false })
 
     const args = TracerMetadataStub.firstCall.args
     assert.strictEqual(args[6], null)
   })
 
   it('passes serialized process tags when propagateProcessTags is enabled', () => {
-    storeConfig({ ...baseConfig, propagateProcessTags: { enabled: true } })
+    storeConfig({ ...baseConfig, DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: true })
 
     const args = TracerMetadataStub.firstCall.args
     assert.strictEqual(args[6], 'tag1:val1,tag2:val2')


### PR DESCRIPTION
Continues #8211: Seventeen aliases go this time, including the first nested namespaces to collapse into their flat `DD_*` env-var names: `heapSnapshot.*`, `installSignature.*`, `crashtracking.enabled`, `propagateProcessTags.enabled`, and three sub-paths under `trace.*`.

Two consumers needed a small adjustment because they read sub-objects rather than scalars: `getDebuggerConfig` constructs the worker's `{ propagateProcessTags: { enabled } }` shape itself so the worker schema keeps working unchanged, and `getInstallSignature` reads the three `DD_INSTRUMENTATION_INSTALL_*` fields directly instead of destructuring a `config.installSignature` object that no longer exists.

Telemetry origin, defaults, and value parsing are unchanged. `generated-config-types.d.ts` is regenerated to match.

Refs: https://github.com/DataDog/dd-trace-js/pull/8211
