### PR TITLE
refactor(test-optimization)!: raise Cypress minimum version to 12.0.0

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -269,10 +269,10 @@ jobs:
       matrix:
         version: [eol, oldest, latest]
         # 6.7.0 is the minimum version we support in <=5
-        # 10.2.0 is the minimum version we support in >=6
+        # 12.0.0 is the minimum version we support in >=6
         # 14.5.4 is the latest version that supports Node 18
         # The logic to decide whether the tests run lives in the individual spec files
-        cypress-version: [6.7.0, 10.2.0, 14.5.4, latest]
+        cypress-version: [12.0.0, 14.5.4, latest]
         module-type: ["commonJS", "esm"]
         spec:
           - cypress-reporting
@@ -285,9 +285,7 @@ jobs:
         exclude:
           # eol = Node 16: shouldTestsRun() always returns false for DD_MAJOR >= 6
           - version: eol
-          # 6.7.0 is only supported for DD_MAJOR <= 5; never runs on this branch
-          - cypress-version: 6.7.0
-          # Node 18 (oldest) only supports 10.2.0 and 14.5.4, not latest
+          # Node 18 (oldest) only supports 12.0.0 and 14.5.4, not latest
           - version: oldest
             cypress-version: latest
     name: integration-cypress (${{ matrix.cypress-version }}, node-${{ matrix.version }}, ${{ matrix.module-type }}, ${{ matrix.spec }})
@@ -305,7 +303,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      # We cache Cypress binaries for fixed versions (6.7.0, 10.2.0, 14.5.4) but not for "latest"
+      # We cache Cypress binaries for fixed versions (12.0.0, 14.5.4) but not for "latest"
       # as that changes frequently and would have a low cache hit rate
       - name: Cache Cypress binary
         if: matrix.cypress-version != 'latest'

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -269,10 +269,11 @@ jobs:
       matrix:
         version: [eol, oldest, latest]
         # 6.7.0 is the minimum version we support in <=5
+        # 10.2.0 is kept so <=5 continues testing deprecated Cypress versions before the v6 cutoff
         # 12.0.0 is the minimum version we support in >=6
         # 14.5.4 is the latest version that supports Node 18
         # The logic to decide whether the tests run lives in the individual spec files
-        cypress-version: [12.0.0, 14.5.4, latest]
+        cypress-version: [6.7.0, 10.2.0, 12.0.0, 14.5.4, latest]
         module-type: ["commonJS", "esm"]
         spec:
           - cypress-reporting
@@ -283,9 +284,24 @@ jobs:
           - cypress-impacted-tests
           - cypress-final-status
         exclude:
-          # eol = Node 16: shouldTestsRun() always returns false for DD_MAJOR >= 6
+          # 6.7.0 only runs on DD_MAJOR <= 5 with Node 16/commonJS.
+          # On DD_MAJOR >= 6, shouldTestsRun() skips this remaining matrix entry.
+          - cypress-version: 6.7.0
+            module-type: esm
+          - version: oldest
+            cypress-version: 6.7.0
+          - version: latest
+            cypress-version: 6.7.0
+          # eol = Node 16 only runs Cypress 6.7.0 for DD_MAJOR <= 5
           - version: eol
-          # Node 18 (oldest) only supports 12.0.0 and 14.5.4, not latest
+            cypress-version: 10.2.0
+          - version: eol
+            cypress-version: 12.0.0
+          - version: eol
+            cypress-version: 14.5.4
+          - version: eol
+            cypress-version: latest
+          # Node 18 (oldest) only supports 10.2.0, 12.0.0 and 14.5.4, not latest
           - version: oldest
             cypress-version: latest
     name: integration-cypress (${{ matrix.cypress-version }}, node-${{ matrix.version }}, ${{ matrix.module-type }}, ${{ matrix.spec }})
@@ -303,7 +319,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      # We cache Cypress binaries for fixed versions (12.0.0, 14.5.4) but not for "latest"
+      # We cache Cypress binaries for fixed versions (6.7.0, 10.2.0, 12.0.0, 14.5.4) but not for "latest"
       # as that changes frequently and would have a low cache hit rate
       - name: Cache Cypress binary
         if: matrix.cypress-version != 'latest'

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -269,11 +269,10 @@ jobs:
       matrix:
         version: [eol, oldest, latest]
         # 6.7.0 is the minimum version we support in <=5
-        # 10.2.0 is kept so <=5 continues testing deprecated Cypress versions before the v6 cutoff
         # 12.0.0 is the minimum version we support in >=6
         # 14.5.4 is the latest version that supports Node 18
         # The logic to decide whether the tests run lives in the individual spec files
-        cypress-version: [6.7.0, 10.2.0, 12.0.0, 14.5.4, latest]
+        cypress-version: [6.7.0, 12.0.0, 14.5.4, latest]
         module-type: ["commonJS", "esm"]
         spec:
           - cypress-reporting
@@ -294,14 +293,12 @@ jobs:
             cypress-version: 6.7.0
           # eol = Node 16 only runs Cypress 6.7.0 for DD_MAJOR <= 5
           - version: eol
-            cypress-version: 10.2.0
-          - version: eol
             cypress-version: 12.0.0
           - version: eol
             cypress-version: 14.5.4
           - version: eol
             cypress-version: latest
-          # Node 18 (oldest) only supports 10.2.0, 12.0.0 and 14.5.4, not latest
+          # Node 18 (oldest) only supports 12.0.0 and 14.5.4, not latest
           - version: oldest
             cypress-version: latest
     name: integration-cypress (${{ matrix.cypress-version }}, node-${{ matrix.version }}, ${{ matrix.module-type }}, ${{ matrix.spec }})
@@ -319,7 +316,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      # We cache Cypress binaries for fixed versions (6.7.0, 10.2.0, 12.0.0, 14.5.4) but not for "latest"
+      # We cache Cypress binaries for fixed versions (6.7.0, 12.0.0, 14.5.4) but not for "latest"
       # as that changes frequently and would have a low cache hit rate
       - name: Cache Cypress binary
         if: matrix.cypress-version != 'latest'

--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -31,7 +31,9 @@ const {
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const over12It = (version === 'latest' || semver.gte(version, '12.0.0')) ? it : it.skip
 
@@ -42,7 +44,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -52,9 +57,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -486,6 +486,7 @@ moduleTypes.forEach(({
 
     it('correctly calculates test code owners when working directory is not repository root', async () => {
       let command
+      let testOutput = ''
 
       if (type === 'commonJS') {
         const commandSuffix = version === '6.7.0'
@@ -502,13 +503,27 @@ moduleTypes.forEach(({
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
 
-          const test = events.find(event => event.type === 'test').content
-          const testSuite = events.find(event => event.type === 'test_suite_end').content
+          const testEvent = events.find(event => event.type === 'test')
+          const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+          const eventSummary = JSON.stringify(events.map(event => ({
+            type: event.type,
+            resource: event.content.resource,
+            status: event.content.meta?.[TEST_STATUS],
+          })), null, 2)
+
+          assert.ok(testEvent, `expected a test event, got events: ${eventSummary}\nCypress output:\n${testOutput}`)
+          assert.ok(
+            testSuiteEvent,
+            `expected a test_suite_end event, got events: ${eventSummary}\nCypress output:\n${testOutput}`
+          )
+
+          const test = testEvent.content
+          const testSuite = testSuiteEvent.content
           // The test is in a subproject
           assert.notStrictEqual(test.meta[TEST_SOURCE_FILE], test.meta[TEST_SUITE])
           assert.strictEqual(test.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
           assert.strictEqual(testSuite.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
-        }, 25000)
+        }, 60000)
 
       childProcess = exec(
         command,
@@ -520,11 +535,18 @@ moduleTypes.forEach(({
           },
         }
       )
+      childProcess.stdout?.on('data', chunk => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', chunk => {
+        testOutput += chunk.toString()
+      })
 
-      await Promise.all([
+      const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         eventsPromise,
       ])
+      assert.strictEqual(exitCode, 0, `cypress process should exit successfully\nCypress output:\n${testOutput}`)
     })
 
     it('tags new tests with dynamic names and logs a warning', async () => {

--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -45,9 +45,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -27,7 +27,9 @@ const {
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const NUM_RETRIES_EFD = 3
 const over12It = (version === 'latest' || semver.gte(version, '12.0.0')) ? it : it.skip
@@ -39,7 +41,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -49,9 +54,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -42,9 +42,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-final-status.spec.js
+++ b/integration-tests/cypress/cypress-final-status.spec.js
@@ -25,7 +25,9 @@ const {
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const NUM_RETRIES_EFD = 3
 
@@ -36,7 +38,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -46,9 +51,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/integration-tests/cypress/cypress-final-status.spec.js
+++ b/integration-tests/cypress/cypress-final-status.spec.js
@@ -39,9 +39,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-impacted-tests.spec.js
@@ -53,9 +53,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-impacted-tests.spec.js
@@ -38,7 +38,9 @@ const {
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const NUM_RETRIES_EFD = 3
 const over12It = (version === 'latest' || semver.gte(version, '12.0.0')) ? it : it.skip
@@ -50,7 +52,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -60,9 +65,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -41,9 +41,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -28,7 +28,9 @@ const {
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 
 function shouldTestsRun (type) {
@@ -38,7 +40,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -48,9 +53,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -97,9 +97,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -46,7 +46,9 @@ const {
 } = require('../../packages/datadog-plugin-cypress/src/source-map-utils')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const CYPRESS_PRECOMPILED_SPEC_DIST_DIR = 'cypress/e2e/dist'
 const over12It = (version === 'latest' || semver.gte(version, '12.0.0')) ? it : it.skip
@@ -94,7 +96,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -104,9 +109,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false
@@ -302,7 +307,7 @@ moduleTypes.forEach(({
       ])
     })
 
-    if (version === '6.7.0') {
+    if (DD_MAJOR < 6 && version !== 'latest' && semver.lt(version, '12.0.0')) {
       it('logs a warning if using a deprecated version of cypress', async () => {
         let stdout = ''
         const {
@@ -331,7 +336,7 @@ moduleTypes.forEach(({
         ])
         assert.match(
           stdout,
-          /WARNING: dd-trace support for Cypress<10.2.0 is deprecated/
+          /WARNING: dd-trace support for Cypress<12.0.0 is deprecated/
         )
       })
     }

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -71,12 +71,12 @@ function compilePrecompiledTypeScriptSpecs (cwd, env) {
  */
 function configureCypressTypeScriptCompilation (cwd) {
   // Cypress's webpack preprocessor resolves TypeScript config from the spec directory.
+  // Cypress sets inlineSourceMap itself, so setting sourceMap here breaks Cypress 12.
   const tsconfig = {
     compilerOptions: {
       rootDir: '.',
       target: 'ES2020',
       module: 'commonjs',
-      sourceMap: true,
       skipLibCheck: true,
     },
   }

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -48,9 +48,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -34,7 +34,9 @@ const {
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
 const RECEIVER_STOP_TIMEOUT = 20000
-const version = process.env.CYPRESS_VERSION
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
 const over12It = (version === 'latest' || semver.gte(version, '12.0.0')) ? it : it.skip
 
@@ -45,7 +47,10 @@ function shouldTestsRun (type) {
     }
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
-      return NODE_MAJOR > 18 ? version === 'latest' : version === '14.5.4'
+      if (NODE_MAJOR <= 18) {
+        return version === '10.2.0' || version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '10.2.0' || version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   if (DD_MAJOR === 6) {
@@ -55,9 +60,9 @@ function shouldTestsRun (type) {
     if (NODE_MAJOR > 16) {
       // Cypress 15.0.0 has removed support for Node 18
       if (NODE_MAJOR <= 18) {
-        return version === '10.2.0' || version === '14.5.4'
+        return version === '12.0.0' || version === '14.5.4'
       }
-      return version === '10.2.0' || version === '14.5.4' || version === 'latest'
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
     }
   }
   return false

--- a/packages/datadog-instrumentations/src/cypress.js
+++ b/packages/datadog-instrumentations/src/cypress.js
@@ -8,11 +8,13 @@ const {
   wrapConfig,
 } = require('./cypress-config')
 
+const MINIMUM_CYPRESS_VERSION = DD_MAJOR >= 6 ? '>=12.0.0' : '>=10.2.0'
+
 // Wrap defineConfig() so configs are instrumented when loaded in Cypress's
 // config child process. This covers both CLI and programmatic usage with CJS configs.
 addHook({
   name: 'cypress',
-  versions: ['>=10.2.0'],
+  versions: [MINIMUM_CYPRESS_VERSION],
 }, (cypress) => {
   if (typeof cypress.defineConfig === 'function') {
     shimmer.wrap(cypress, 'defineConfig', (defineConfig) => function (config) {
@@ -61,7 +63,7 @@ function wrapStartOnModule (mod) {
 for (const file of ['lib/exec/run.js', 'lib/exec/open.js', 'dist/exec/run.js', 'dist/exec/open.js']) {
   addHook({
     name: 'cypress',
-    versions: ['>=10.2.0'],
+    versions: [MINIMUM_CYPRESS_VERSION],
     file,
   }, wrapStartOnModule)
 }
@@ -70,7 +72,7 @@ for (const file of ['lib/exec/run.js', 'lib/exec/open.js', 'dist/exec/run.js', '
 // The chunk exports runModule and openModule, each with a start() method.
 addHook({
   name: 'cypress',
-  versions: ['>=10.2.0'],
+  versions: [MINIMUM_CYPRESS_VERSION],
   filePattern: 'dist/cli.*',
 }, (cliChunk) => {
   if (cliChunk.runModule?.start) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -4,6 +4,7 @@
 const { performance } = require('perf_hooks')
 const dateNow = Date.now
 
+const satisfies = require('../../../vendor/dist/semifies')
 const {
   TEST_STATUS,
   TEST_IS_RUM_ACTIVE,
@@ -106,6 +107,7 @@ const {
 } = require('./source-map-utils')
 
 const TEST_FRAMEWORK_NAME = 'cypress'
+let hasWarnedDeprecatedCypressVersion = false
 
 const CYPRESS_STATUS_TO_TEST_STATUS = {
   passed: 'pass',
@@ -132,6 +134,20 @@ function getCypressVersion (details) {
     return details.config.version
   }
   return ''
+}
+
+function warnDeprecatedCypressVersion (version) {
+  if (DD_MAJOR >= 6 || hasWarnedDeprecatedCypressVersion || !version || !satisfies(version, '<12.0.0')) {
+    return
+  }
+
+  hasWarnedDeprecatedCypressVersion = true
+  // console.warn does not seem to work reliably in Cypress, so use console.log instead.
+  // eslint-disable-next-line no-console
+  console.log(
+    'WARNING: dd-trace support for Cypress<12.0.0 is deprecated' +
+    ' and will not be supported in dd-trace v6. Please upgrade Cypress to >=12.0.0.'
+  )
 }
 
 function getRootDir (details) {
@@ -429,6 +445,7 @@ class CypressPlugin {
     this._isInit = true
     this.tracer = tracer
     this.cypressConfig = cypressConfig
+    warnDeprecatedCypressVersion(cypressConfig.version)
 
     this.isTestIsolationEnabled = getIsTestIsolationEnabled(cypressConfig)
 

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -23,22 +23,13 @@ const noopTask = {
 module.exports = function CypressPlugin (on, config) {
   const tracer = require('../../dd-trace')
 
-  if (satisfies(config.version, '<10.2.0')) {
-    if (DD_MAJOR >= 6) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'ERROR: dd-trace v6 has deleted support for Cypress<10.2.0.'
-      )
-      on('task', noopTask)
-      return config
-    }
-
-    // console.warn does not seem to work in cypress, so using console.log instead
+  if (DD_MAJOR >= 6 && satisfies(config.version, '<12.0.0')) {
     // eslint-disable-next-line no-console
-    console.log(
-      'WARNING: dd-trace support for Cypress<10.2.0 is deprecated' +
-      ' and will not be supported in future versions of dd-trace.'
+    console.error(
+      'ERROR: dd-trace v6 has deleted support for Cypress<12.0.0.'
     )
+    on('task', noopTask)
+    return config
   }
 
   // The tracer was not init correctly for whatever reason (such as invalid DD_SITE)

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -226,7 +226,7 @@
   {
     "dependency": "amqplib",
     "integration": "amqplib",
-    "minimum_tracer_supported": "0.5.0",
+    "minimum_tracer_supported": "0.5.3",
     "max_tracer_supported": "0.10.9",
     "auto-instrumented": "True"
   },

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -226,7 +226,7 @@
   {
     "dependency": "amqplib",
     "integration": "amqplib",
-    "minimum_tracer_supported": "0.5.3",
+    "minimum_tracer_supported": "0.5.0",
     "max_tracer_supported": "0.10.9",
     "auto-instrumented": "True"
   },
@@ -289,7 +289,7 @@
   {
     "dependency": "cypress",
     "integration": "cypress",
-    "minimum_tracer_supported": "10.2.0",
+    "minimum_tracer_supported": "12.0.0",
     "max_tracer_supported": "15.13.0",
     "auto-instrumented": "True"
   },

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -31,7 +31,7 @@ dependency,integration,minimum_tracer_supported,max_tracer_supported,auto-instru
 aerospike,aerospike,4.0.0,6.5.2,True
 ai,ai,4.0.0,6.0.39,True
 amqp10,amqp10,3.0.0,3.6.0,True
-amqplib,amqplib,0.5.0,0.10.9,True
+amqplib,amqplib,0.5.3,0.10.9,True
 avsc,avsc,5.0.0,5.7.9,True
 aws-sdk,aws-sdk,2.1.35,2.1693.0,True
 bullmq,bullmq,5.66.0,5.66.5,True

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -31,7 +31,7 @@ dependency,integration,minimum_tracer_supported,max_tracer_supported,auto-instru
 aerospike,aerospike,4.0.0,6.5.2,True
 ai,ai,4.0.0,6.0.39,True
 amqp10,amqp10,3.0.0,3.6.0,True
-amqplib,amqplib,0.5.3,0.10.9,True
+amqplib,amqplib,0.5.0,0.10.9,True
 avsc,avsc,5.0.0,5.7.9,True
 aws-sdk,aws-sdk,2.1.35,2.1693.0,True
 bullmq,bullmq,5.66.0,5.66.5,True
@@ -40,7 +40,7 @@ cassandra-driver,cassandra-driver,3.0.0,4.8.0,True
 child_process,child_process,18.0.0,25.9.0,True
 connect,connect,2.2.2,3.7.0,True
 couchbase,couchbase,2.6.12,4.6.0,True
-cypress,cypress,10.2.0,15.13.0,True
+cypress,cypress,12.0.0,15.13.0,True
 dns,dns,18.0.0,25.9.0,True
 durable-functions,azure-durable-functions,3.0.0,3.3.0,True
 elasticsearch,elasticsearch,10.0.0,16.7.3,True


### PR DESCRIPTION
### What does this PR do?

Raises the minimum supported Cypress version to `>=12.0.0` for dd-trace v6 while keeping v5 support for older Cypress versions.

Updates Test Optimization Cypress instrumentation hooks, the manual Cypress plugin guard, integration test version selection, and the Cypress workflow matrix. v5 users running Cypress `<12.0.0` get a deprecation warning before v6 removes support.

### Motivation

Cypress 12 is the cutoff after which the advanced Test Optimization behavior is supported, and dropping older versions in v6 lets us remove old compatibility paths while leaving v5 maintainable.

