### PR TITLE
ci: pipe GraphQL variables via stdin so commit-on-branch pushes don't…

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -207,24 +207,26 @@ jobs:
           DIR: ${{ runner.temp }}/supported-integrations
         run: |
           set -euo pipefail
-          variables="$(jq -c -n \
+          # gh's `-f variables=<json>` does not parse the value as JSON; build
+          # the `{query, variables}` body with jq and pipe via `--input -`.
+          jq -nc \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg branch "$BRANCH" \
             --arg expected "$EXPECTED" \
             --arg json "$(base64 -w 0 "$DIR/supported_versions_output.json")" \
             --arg csv "$(base64 -w 0 "$DIR/supported_versions_table.csv")" \
-            '{ input: {
-              branch: { repositoryNameWithOwner: $repo, branchName: $branch },
-              message: { headline: "chore: update supported-integrations" },
-              expectedHeadOid: $expected,
-              fileChanges: { additions: [
-                { path: "supported_versions_output.json", contents: $json },
-                { path: "supported_versions_table.csv", contents: $csv }
-              ] }
-            } }')"
-          gh api graphql \
-            -f query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }' \
-            -f "variables=$variables" >/dev/null
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }",
+              variables: { input: {
+                branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                message: { headline: "chore: update supported-integrations" },
+                expectedHeadOid: $expected,
+                fileChanges: { additions: [
+                  { path: "supported_versions_output.json", contents: $json },
+                  { path: "supported_versions_table.csv", contents: $csv }
+                ] }
+              } }
+            }' | gh api graphql --input - >/dev/null
 
   yarn-dedupe:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-3rdparty-licenses.yml
+++ b/.github/workflows/update-3rdparty-licenses.yml
@@ -157,26 +157,23 @@ jobs:
 
           echo "🤖 Bot-created PR detected. Auto-committing LICENSE-3rdparty.csv changes..."
 
-          contents="$(base64 -w 0 LICENSE-3rdparty.csv)"
-
-          variables="$(jq -c \
+          # gh's `-f variables=<json>` does not parse the value as JSON; build
+          # the `{query, variables}` body with jq and pipe via `--input -`.
+          jq -nc \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg branch "$GITHUB_HEAD_REF" \
             --arg msg "Update LICENSE-3rdparty.csv" \
             --arg expected "$EXPECTED_HEAD_OID" \
             --arg path "LICENSE-3rdparty.csv" \
-            --arg contents "$contents" \
+            --arg contents "$(base64 -w 0 LICENSE-3rdparty.csv)" \
             '{
-              input: {
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: { input: {
                 branch: { repositoryNameWithOwner: $repo, branchName: $branch },
                 message: { headline: $msg },
                 expectedHeadOid: $expected,
                 fileChanges: { additions: [{ path: $path, contents: $contents }] }
-              }
-            }'
-          )"
-
-          query='mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }'
-          gh api graphql -f query="$query" -f variables="$variables" -q '.data.createCommitOnBranch.commit.url' >/dev/null
+              } }
+            }' | gh api graphql --input - -q '.data.createCommitOnBranch.commit.url' >/dev/null
 
           echo "✅ Successfully committed and pushed LICENSE-3rdparty.csv updates"


### PR DESCRIPTION
… fail

`gh api graphql -f variables="$variables"` forwards the value as a string instead of parsing it as JSON; GitHub returns the misleading `Variable $input ... was provided invalid value`. Latest failure: run 25309510001 on PR #8246. The same pattern lives in `update-3rdparty-licenses`; that job's push step rarely fires so nobody noticed.

Drive-by fix: `update-3rdparty-licenses` also had `jq -c` instead of `jq -nc`, silently producing empty output on a runner with no stdin.
