### PR TITLE
fix(kafkajs): read clusterId from existing metadata, stop mutating user input

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -1112,6 +1112,28 @@ function assertUUID (actual, msg = 'not a valid UUID') {
   assert.match(actual, /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/, msg)
 }
 
+/**
+ * Recursively `Object.freeze` an object plus everything reachable from it. Use
+ * in tests when an instrumentation contract says "we won't mutate this": any
+ * accidental write to the value or its nested structures throws synchronously
+ * under strict mode, so the test fails at the offending assignment instead of
+ * far downstream via deep-equality.
+ *
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+function deepFreeze (value) {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value
+  }
+  Object.freeze(value)
+  for (const key of Reflect.ownKeys(value)) {
+    deepFreeze(value[key])
+  }
+  return value
+}
+
 module.exports = {
   ANY_NUMBER,
   ANY_STRING,
@@ -1120,6 +1142,7 @@ module.exports = {
   hookFile,
   assertObjectContains,
   assertUUID,
+  deepFreeze,
   stopProc,
   spawnProc,
   spawnProcAndExpectExit,

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -7,7 +7,7 @@ const {
   addHook,
   channel,
 } = require('./helpers/instrument')
-const { cloneMessages, cloneMessagesForInjection } = require('./helpers/kafka')
+const { cloneMessages } = require('./helpers/kafka')
 
 // Create channels for Confluent Kafka JavaScript
 const channels = {
@@ -221,9 +221,7 @@ function instrumentKafkaJS (kafkaJS) {
                     if (payload && Array.isArray(payload.messages)) {
                       outgoingPayload = {
                         ...payload,
-                        messages: disableHeaderInjection
-                          ? cloneMessages(payload.messages)
-                          : cloneMessagesForInjection(payload.messages),
+                        messages: cloneMessages(payload.messages, !disableHeaderInjection),
                       }
                     }
 

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -7,7 +7,7 @@ const {
   addHook,
   channel,
 } = require('./helpers/instrument')
-const { cloneMessagesForInjection } = require('./helpers/kafka')
+const { cloneMessages, cloneMessagesForInjection } = require('./helpers/kafka')
 
 // Create channels for Confluent Kafka JavaScript
 const channels = {
@@ -214,12 +214,16 @@ function instrumentKafkaJS (kafkaJS) {
                     // Hand the underlying client a shallow clone so neither
                     // injection nor the client's auto-fields (it sets
                     // `headers: null` on messages without headers) ever
-                    // touch caller-owned objects.
+                    // touch caller-owned objects. With injection disabled the
+                    // clone must not seed `headers: {}` either: brokers that
+                    // reject any header field cannot recover otherwise.
                     let outgoingPayload = payload
                     if (payload && Array.isArray(payload.messages)) {
                       outgoingPayload = {
                         ...payload,
-                        messages: cloneMessagesForInjection(payload.messages),
+                        messages: disableHeaderInjection
+                          ? cloneMessages(payload.messages)
+                          : cloneMessagesForInjection(payload.messages),
                       }
                     }
 

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -7,6 +7,7 @@ const {
   addHook,
   channel,
 } = require('./helpers/instrument')
+const { cloneMessagesForInjection } = require('./helpers/kafka')
 
 // Create channels for Confluent Kafka JavaScript
 const channels = {
@@ -25,8 +26,6 @@ const channels = {
   batchConsumerError: channel('apm:confluentinc-kafka-javascript:consume-batch:error'),
   batchConsumerCommit: channel('apm:confluentinc-kafka-javascript:consume-batch:commit'),
 }
-
-const disabledHeaderWeakSet = new WeakSet()
 
 // we need to store the offset per partition per topic for the consumer to track offsets for DSM
 const latestConsumerOffsets = new Map()
@@ -205,52 +204,65 @@ function instrumentKafkaJS (kafkaJS) {
 
               // Wrap the send method of the producer
               if (producer && typeof producer.send === 'function') {
+                let disableHeaderInjection = false
                 shimmer.wrap(producer, 'send', function wrapSend (send) {
                   return function wrappedSend (payload) {
                     if (!channels.producerStart.hasSubscribers) {
                       return send.apply(this, arguments)
                     }
 
+                    // Hand the underlying client a shallow clone so neither
+                    // injection nor the client's auto-fields (it sets
+                    // `headers: null` on messages without headers) ever
+                    // touch caller-owned objects.
+                    let outgoingPayload = payload
+                    if (payload && Array.isArray(payload.messages)) {
+                      outgoingPayload = {
+                        ...payload,
+                        messages: cloneMessagesForInjection(payload.messages),
+                      }
+                    }
+
                     const ctx = {
-                      topic: payload?.topic,
-                      messages: payload?.messages || [],
+                      topic: outgoingPayload?.topic,
+                      messages: outgoingPayload?.messages || [],
                       bootstrapServers: kafka._ddBrokers,
-                      disableHeaderInjection: disabledHeaderWeakSet.has(producer),
+                      disableHeaderInjection,
                     }
 
                     return channels.producerStart.runStores(ctx, () => {
                       try {
-                        const result = send.apply(this, arguments)
+                        const result = send.call(this, outgoingPayload)
 
                         result.then((res) => {
                           ctx.result = res
                           channels.producerCommit.publish(ctx)
                           channels.producerFinish.publish(ctx)
-                        }, (err) => {
-                          if (err) {
-                            // Fixes bug where we would inject message headers for kafka brokers
-                            // that don't support headers (version <0.11). On the error, we disable
-                            // header injection. Tnfortunately the error name / type is not more specific.
-                            // This approach is implemented by other tracers as well.
-                            if (err.name === 'KafkaJSError' && err.type === 'ERR_UNKNOWN') {
-                              disabledHeaderWeakSet.add(producer)
+                        }, (error) => {
+                          if (error) {
+                            // KafkaJS-compat reports `ERR_UNKNOWN` for brokers
+                            // <0.11 that cannot parse headers. Stop injecting
+                            // for this producer; subsequent sends to the same
+                            // broker succeed.
+                            if (error.name === 'KafkaJSError' && error.type === 'ERR_UNKNOWN') {
+                              disableHeaderInjection = true
                               log.error(
                                 // eslint-disable-next-line @stylistic/max-len
                                 'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
                               )
                             }
-                            ctx.error = err
+                            ctx.error = error
                             channels.producerError.publish(ctx)
                           }
                           channels.producerFinish.publish(ctx)
                         })
 
                         return result
-                      } catch (e) {
-                        ctx.error = e
+                      } catch (error) {
+                        ctx.error = error
                         channels.producerError.publish(ctx)
                         channels.producerFinish.publish(ctx)
-                        throw e
+                        throw error
                       }
                     })
                   }

--- a/packages/datadog-instrumentations/src/helpers/kafka.js
+++ b/packages/datadog-instrumentations/src/helpers/kafka.js
@@ -1,0 +1,36 @@
+'use strict'
+
+// Produce API key 0; v0–v2 use the legacy MessageSet format with no header
+// field, so trace headers can only be carried on v3+ (Kafka >=0.11).
+const PRODUCE_API_KEY = 0
+const PRODUCE_VERSION_WITH_HEADERS = 3
+
+/**
+ * @param {Array<unknown>} messages
+ */
+function cloneMessagesForInjection (messages) {
+  const result = new Array(messages.length)
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    result[i] = (message === null || typeof message !== 'object')
+      ? message
+      : { ...message, headers: message.headers ? { ...message.headers } : {} }
+  }
+  return result
+}
+
+/**
+ * @param {{ versions?: Record<number, { minVersion: number, maxVersion: number }> } | undefined} brokerPool
+ *   kafkajs's `cluster.brokerPool`. `versions` is populated once the seed
+ *   broker handshakes; before that, the answer is unknown and we return
+ *   `true` so the caller defaults to injection.
+ */
+function brokerSupportsMessageHeaders (brokerPool) {
+  const produce = brokerPool?.versions?.[PRODUCE_API_KEY]
+  return !produce || produce.maxVersion >= PRODUCE_VERSION_WITH_HEADERS
+}
+
+module.exports = {
+  brokerSupportsMessageHeaders,
+  cloneMessagesForInjection,
+}

--- a/packages/datadog-instrumentations/src/helpers/kafka.js
+++ b/packages/datadog-instrumentations/src/helpers/kafka.js
@@ -15,33 +15,27 @@ const PRODUCE_VERSION_WITH_HEADERS = 3
 const clientToCluster = new WeakMap()
 
 /**
+ * Shallow-clone each message and its headers so the boundary, kafkajs, and
+ * the user never share the same nested objects. With `ensureHeaders` true
+ * (header injection enabled) messages without `headers` get an empty object
+ * the producer plugin can inject into; with it false (broker rejected
+ * headers) the absence of `headers` is preserved so brokers that fail on any
+ * header field can recover.
+ *
  * @param {Array<unknown>} messages
+ * @param {boolean} ensureHeaders
  */
-function cloneMessages (messages) {
+function cloneMessages (messages, ensureHeaders) {
   const result = new Array(messages.length)
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i]
     if (message === null || typeof message !== 'object') {
       result[i] = message
+    } else if (message.headers) {
+      result[i] = { ...message, headers: { ...message.headers } }
     } else {
-      result[i] = message.headers
-        ? { ...message, headers: { ...message.headers } }
-        : { ...message }
+      result[i] = ensureHeaders ? { ...message, headers: {} } : { ...message }
     }
-  }
-  return result
-}
-
-/**
- * @param {Array<unknown>} messages
- */
-function cloneMessagesForInjection (messages) {
-  const result = new Array(messages.length)
-  for (let i = 0; i < messages.length; i++) {
-    const message = messages[i]
-    result[i] = (message === null || typeof message !== 'object')
-      ? message
-      : { ...message, headers: message.headers ? { ...message.headers } : {} }
   }
   return result
 }
@@ -61,5 +55,4 @@ module.exports = {
   brokerSupportsMessageHeaders,
   clientToCluster,
   cloneMessages,
-  cloneMessagesForInjection,
 }

--- a/packages/datadog-instrumentations/src/helpers/kafka.js
+++ b/packages/datadog-instrumentations/src/helpers/kafka.js
@@ -17,6 +17,24 @@ const clientToCluster = new WeakMap()
 /**
  * @param {Array<unknown>} messages
  */
+function cloneMessages (messages) {
+  const result = new Array(messages.length)
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    if (message === null || typeof message !== 'object') {
+      result[i] = message
+    } else {
+      result[i] = message.headers
+        ? { ...message, headers: { ...message.headers } }
+        : { ...message }
+    }
+  }
+  return result
+}
+
+/**
+ * @param {Array<unknown>} messages
+ */
 function cloneMessagesForInjection (messages) {
   const result = new Array(messages.length)
   for (let i = 0; i < messages.length; i++) {
@@ -42,5 +60,6 @@ function brokerSupportsMessageHeaders (brokerPool) {
 module.exports = {
   brokerSupportsMessageHeaders,
   clientToCluster,
+  cloneMessages,
   cloneMessagesForInjection,
 }

--- a/packages/datadog-instrumentations/src/helpers/kafka.js
+++ b/packages/datadog-instrumentations/src/helpers/kafka.js
@@ -5,6 +5,15 @@
 const PRODUCE_API_KEY = 0
 const PRODUCE_VERSION_WITH_HEADERS = 3
 
+// Side-table mapping a kafkajs producer/consumer to the cluster captured at
+// creation time. The boundary uses it to read `cluster.brokerPool` lazily on
+// first send/consume instead of opening a parallel admin connection. A
+// WeakMap keeps the kafkajs object itself untouched: no Symbol-keyed
+// property to leak through `Reflect.ownKeys`, no string-keyed underscore for
+// user serializers to pick up, and the entry drops as soon as the producer
+// is GC'd.
+const clientToCluster = new WeakMap()
+
 /**
  * @param {Array<unknown>} messages
  */
@@ -32,5 +41,6 @@ function brokerSupportsMessageHeaders (brokerPool) {
 
 module.exports = {
   brokerSupportsMessageHeaders,
+  clientToCluster,
   cloneMessagesForInjection,
 }

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -10,6 +10,7 @@ const {
 const {
   brokerSupportsMessageHeaders,
   clientToCluster,
+  cloneMessages,
   cloneMessagesForInjection,
 } = require('./helpers/kafka')
 
@@ -109,12 +110,15 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
       const topic = arg0?.topic
       const inputMessages = Array.isArray(arg0?.messages) ? arg0.messages : []
 
-      // Hand kafkajs and the plugin a shallow clone so injection writes to a
-      // tracer-owned object instead of the caller's. Skip the clone when
-      // injection is off; nothing downstream mutates the array.
+      // Hand kafkajs and the plugin a shallow clone so injection never
+      // touches caller-owned objects. With injection disabled the clone must
+      // not seed `headers: {}` either: brokers that reject any header field
+      // cannot recover otherwise.
       let messages = inputMessages
-      if (!disableHeaderInjection && inputMessages.length > 0) {
-        messages = cloneMessagesForInjection(inputMessages)
+      if (inputMessages.length > 0) {
+        messages = disableHeaderInjection
+          ? cloneMessages(inputMessages)
+          : cloneMessagesForInjection(inputMessages)
         args[0] = { ...arg0, messages }
       }
 

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -11,7 +11,6 @@ const {
   brokerSupportsMessageHeaders,
   clientToCluster,
   cloneMessages,
-  cloneMessagesForInjection,
 } = require('./helpers/kafka')
 
 const producerStartCh = channel('apm:kafkajs:produce:start')
@@ -116,9 +115,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
       // cannot recover otherwise.
       let messages = inputMessages
       if (inputMessages.length > 0) {
-        messages = disableHeaderInjection
-          ? cloneMessages(inputMessages)
-          : cloneMessagesForInjection(inputMessages)
+        messages = cloneMessages(inputMessages, !disableHeaderInjection)
         args[0] = { ...arg0, messages }
       }
 

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -9,6 +9,7 @@ const {
 } = require('./helpers/instrument')
 const {
   brokerSupportsMessageHeaders,
+  clientToCluster,
   cloneMessagesForInjection,
 } = require('./helpers/kafka')
 
@@ -26,16 +27,13 @@ const batchConsumerStartCh = channel('apm:kafkajs:consume-batch:start')
 const batchConsumerFinishCh = channel('apm:kafkajs:consume-batch:finish')
 const batchConsumerErrorCh = channel('apm:kafkajs:consume-batch:error')
 
-// Capture the cluster instance kafkajs creates per producer/consumer so the
-// boundary can read `cluster.brokerPool.metadata.clusterId` lazily instead of
-// opening a parallel admin connection.
-const kCluster = Symbol('dd-trace.kafkajs.cluster')
+const noop = () => {}
 
 addHook({ name: 'kafkajs', file: 'src/producer/index.js', versions: ['>=1.4'] }, (createProducer) =>
   shimmer.wrapFunction(createProducer, original => function wrappedCreateProducer (params) {
     const producer = original(params)
     if (params?.cluster) {
-      producer[kCluster] = params.cluster
+      clientToCluster.set(producer, params.cluster)
     }
     return producer
   })
@@ -45,7 +43,7 @@ addHook({ name: 'kafkajs', file: 'src/consumer/index.js', versions: ['>=1.4'] },
   shimmer.wrapFunction(createConsumer, original => function wrappedCreateConsumer (params) {
     const consumer = original(params)
     if (params?.cluster) {
-      consumer[kCluster] = params.cluster
+      clientToCluster.set(consumer, params.cluster)
     }
     return consumer
   })
@@ -65,13 +63,14 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     const producer = createProducer.apply(this, arguments)
     const originalSend = producer.send
     const bootstrapServers = this._brokers
-    const cluster = producer[kCluster]
+    const cluster = clientToCluster.get(producer)
 
     let disableHeaderInjection = false
 
-    const refreshHeaderSupport = () => {
-      if (!disableHeaderInjection && !brokerSupportsMessageHeaders(cluster?.brokerPool)) {
+    let refreshHeaderSupport = () => {
+      if (!brokerSupportsMessageHeaders(cluster?.brokerPool)) {
         disableHeaderInjection = true
+        refreshHeaderSupport = noop
         log.info('kafkajs broker negotiated Produce <v3; tracer header injection disabled.')
       }
     }
@@ -145,6 +144,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
                 // UNKNOWN (server error code -1).
                 if (error.name === 'KafkaJSProtocolError' && error.type === 'UNKNOWN') {
                   disableHeaderInjection = true
+                  refreshHeaderSupport = noop
                   log.error(
                     // eslint-disable-next-line @stylistic/max-len
                     'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
@@ -174,7 +174,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     }
 
     const consumer = createConsumer.apply(this, arguments)
-    const cluster = consumer[kCluster]
+    const cluster = clientToCluster.get(consumer)
     const groupId = arguments[0].groupId
 
     const readClusterId = () => cluster?.brokerPool?.metadata?.clusterId

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -7,6 +7,10 @@ const {
   channel,
   addHook,
 } = require('./helpers/instrument')
+const {
+  brokerSupportsMessageHeaders,
+  cloneMessagesForInjection,
+} = require('./helpers/kafka')
 
 const producerStartCh = channel('apm:kafkajs:produce:start')
 const producerCommitCh = channel('apm:kafkajs:produce:commit')
@@ -22,7 +26,30 @@ const batchConsumerStartCh = channel('apm:kafkajs:consume-batch:start')
 const batchConsumerFinishCh = channel('apm:kafkajs:consume-batch:finish')
 const batchConsumerErrorCh = channel('apm:kafkajs:consume-batch:error')
 
-const disabledHeaderWeakSet = new WeakSet()
+// Capture the cluster instance kafkajs creates per producer/consumer so the
+// boundary can read `cluster.brokerPool.metadata.clusterId` lazily instead of
+// opening a parallel admin connection.
+const kCluster = Symbol('dd-trace.kafkajs.cluster')
+
+addHook({ name: 'kafkajs', file: 'src/producer/index.js', versions: ['>=1.4'] }, (createProducer) =>
+  shimmer.wrapFunction(createProducer, original => function wrappedCreateProducer (params) {
+    const producer = original(params)
+    if (params?.cluster) {
+      producer[kCluster] = params.cluster
+    }
+    return producer
+  })
+)
+
+addHook({ name: 'kafkajs', file: 'src/consumer/index.js', versions: ['>=1.4'] }, (createConsumer) =>
+  shimmer.wrapFunction(createConsumer, original => function wrappedCreateConsumer (params) {
+    const consumer = original(params)
+    if (params?.cluster) {
+      consumer[kCluster] = params.cluster
+    }
+    return consumer
+  })
+)
 
 addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKafka) => {
   class Kafka extends BaseKafka {
@@ -34,79 +61,110 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     }
   }
 
-  shimmer.wrap(Kafka.prototype, 'producer', createProducer => function (...args) {
-    const producer = createProducer.apply(this, args)
-    const send = producer.send
+  shimmer.wrap(Kafka.prototype, 'producer', createProducer => function () {
+    const producer = createProducer.apply(this, arguments)
+    const originalSend = producer.send
     const bootstrapServers = this._brokers
+    const cluster = producer[kCluster]
 
-    const kafkaClusterIdPromise = getKafkaClusterId(this)
+    let disableHeaderInjection = false
+
+    const refreshHeaderSupport = () => {
+      if (!disableHeaderInjection && !brokerSupportsMessageHeaders(cluster?.brokerPool)) {
+        disableHeaderInjection = true
+        log.info('kafkajs broker negotiated Produce <v3; tracer header injection disabled.')
+      }
+    }
 
     producer.send = function (...args) {
-      const wrappedSend = (clusterId) => {
-        const { topic, messages = [] } = args[0]
-
-        const ctx = {
-          bootstrapServers,
-          clusterId,
-          disableHeaderInjection: disabledHeaderWeakSet.has(producer),
-          messages,
-          topic,
-        }
-
-        for (const message of messages) {
-          if (message !== null && typeof message === 'object' && !ctx.disableHeaderInjection) {
-            message.headers = message.headers || {}
-          }
-        }
-
-        return producerStartCh.runStores(ctx, () => {
-          try {
-            const result = send.apply(this, args)
-            result.then(
-              (res) => {
-                ctx.result = res
-                producerFinishCh.publish(ctx)
-                producerCommitCh.publish(ctx)
-              },
-              (err) => {
-                ctx.error = err
-                if (err) {
-                  // Fixes bug where we would inject message headers for kafka brokers that don't support headers
-                  // (version <0.11). On the error, we disable header injection.
-                  // Unfortunately the error name / type is not more specific.
-                  // This approach is implemented by other tracers as well.
-                  if (err.name === 'KafkaJSProtocolError' && err.type === 'UNKNOWN') {
-                    disabledHeaderWeakSet.add(producer)
-                    log.error(
-                      // eslint-disable-next-line @stylistic/max-len
-                      'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
-                    )
-                  }
-                  producerErrorCh.publish(err)
-                }
-                producerFinishCh.publish(ctx)
-              })
-
-            return result
-          } catch (e) {
-            ctx.error = e
-            producerErrorCh.publish(ctx)
-            producerFinishCh.publish(ctx)
-            throw e
-          }
-        })
+      if (!producerStartCh.hasSubscribers) {
+        return originalSend.apply(this, args)
       }
 
-      if (isPromise(kafkaClusterIdPromise)) {
-        // promise is not resolved
-        return kafkaClusterIdPromise.then((clusterId) => {
-          return wrappedSend(clusterId)
-        })
+      // Fast path: kafkajs has fetched metadata, so versions and clusterId are
+      // already on the broker pool.
+      const metadata = cluster?.brokerPool?.metadata
+      if (metadata) {
+        refreshHeaderSupport()
+        return runSend.call(this, args, metadata.clusterId)
       }
 
-      // promise is already resolved
-      return wrappedSend(kafkaClusterIdPromise)
+      // Slow path, taken at most once per producer connect cycle. Prime the
+      // metadata fetch kafkajs's send would do internally a few stack frames
+      // later. `sharedPromiseTo` collapses our call and kafkajs's call into a
+      // single round trip, so total latency is unchanged.
+      if (typeof cluster?.refreshMetadataIfNecessary !== 'function') {
+        return runSend.call(this, args)
+      }
+      return cluster.refreshMetadataIfNecessary().then(
+        () => {
+          refreshHeaderSupport()
+          return runSend.call(this, args, cluster.brokerPool?.metadata?.clusterId)
+        },
+        () => runSend.call(this, args)
+      )
     }
+
+    function runSend (args, clusterId) {
+      const arg0 = args[0]
+      const topic = arg0?.topic
+      const inputMessages = Array.isArray(arg0?.messages) ? arg0.messages : []
+
+      // Hand kafkajs and the plugin a shallow clone so injection writes to a
+      // tracer-owned object instead of the caller's. Skip the clone when
+      // injection is off; nothing downstream mutates the array.
+      let messages = inputMessages
+      if (!disableHeaderInjection && inputMessages.length > 0) {
+        messages = cloneMessagesForInjection(inputMessages)
+        args[0] = { ...arg0, messages }
+      }
+
+      const ctx = {
+        bootstrapServers,
+        clusterId,
+        disableHeaderInjection,
+        messages,
+        topic,
+      }
+
+      return producerStartCh.runStores(ctx, () => {
+        try {
+          const result = originalSend.apply(this, args)
+          result.then(
+            (res) => {
+              ctx.result = res
+              producerFinishCh.publish(ctx)
+              producerCommitCh.publish(ctx)
+            },
+            (error) => {
+              ctx.error = error
+              if (error) {
+                // Safety net for mixed-version clusters where the seed broker
+                // advertised Produce v3+ but the leader we shipped to could
+                // not parse the headers, surfacing as KafkaJSProtocolError
+                // UNKNOWN (server error code -1).
+                if (error.name === 'KafkaJSProtocolError' && error.type === 'UNKNOWN') {
+                  disableHeaderInjection = true
+                  log.error(
+                    // eslint-disable-next-line @stylistic/max-len
+                    'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
+                  )
+                }
+                producerErrorCh.publish(error)
+              }
+              producerFinishCh.publish(ctx)
+            }
+          )
+          return result
+        } catch (error) {
+          ctx.error = error
+          producerErrorCh.publish(ctx)
+          producerFinishCh.publish(ctx)
+          throw error
+        }
+      })
+    }
+
     return producer
   })
 
@@ -115,24 +173,26 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
       return createConsumer.apply(this, args)
     }
 
-    const kafkaClusterIdPromise = getKafkaClusterId(this)
-    let resolvedClusterId = null
+    const consumer = createConsumer.apply(this, arguments)
+    const cluster = consumer[kCluster]
+    const groupId = arguments[0].groupId
 
-    const eachMessageExtractor = (args, clusterId) => {
+    const readClusterId = () => cluster?.brokerPool?.metadata?.clusterId
+
+    const eachMessageExtractor = (args) => {
       const { topic, partition, message } = args[0]
-      return { topic, partition, message, groupId, clusterId }
+      return { topic, partition, message, groupId, clusterId: readClusterId() }
     }
 
-    const eachBatchExtractor = (args, clusterId) => {
+    const eachBatchExtractor = (args) => {
       const { batch } = args[0]
       const { topic, partition, messages } = batch
-      return { topic, partition, messages, groupId, clusterId }
+      return { topic, partition, messages, groupId, clusterId: readClusterId() }
     }
-
-    const consumer = createConsumer.apply(this, args)
 
     consumer.on(consumer.events.COMMIT_OFFSETS, (event) => {
       const { payload: { groupId: commitGroupId, topics } } = event
+      const clusterId = readClusterId()
       const commitList = []
       for (const { topic, partitions } of topics) {
         for (const { partition, offset } of partitions) {
@@ -141,7 +201,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
             partition,
             offset,
             topic,
-            clusterId: resolvedClusterId,
+            clusterId,
           })
         }
       }
@@ -149,118 +209,67 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     })
 
     const run = consumer.run
-    const groupId = args[0].groupId
 
     consumer.run = function ({ eachMessage, eachBatch, ...runArgs }) {
-      const wrapConsume = (clusterId) => {
-        // In kafkajs COMMIT_OFFSETS always happens in the context of one synchronous run
-        // So this will always reference a correct cluster id
-        resolvedClusterId = clusterId
-        return run({
-          eachMessage: wrappedCallback(
-            eachMessage,
-            consumerStartCh,
-            consumerFinishCh,
-            consumerErrorCh,
-            eachMessageExtractor,
-            clusterId
-          ),
-          eachBatch: wrappedCallback(
-            eachBatch,
-            batchConsumerStartCh,
-            batchConsumerFinishCh,
-            batchConsumerErrorCh,
-            eachBatchExtractor,
-            clusterId
-          ),
-          ...runArgs,
-        })
-      }
-
-      if (isPromise(kafkaClusterIdPromise)) {
-        // promise is not resolved
-        return kafkaClusterIdPromise.then((clusterId) => {
-          return wrapConsume(clusterId)
-        })
-      }
-
-      // promise is already resolved
-      return wrapConsume(kafkaClusterIdPromise)
+      return run({
+        eachMessage: wrappedCallback(
+          eachMessage,
+          consumerStartCh,
+          consumerFinishCh,
+          consumerErrorCh,
+          eachMessageExtractor
+        ),
+        eachBatch: wrappedCallback(
+          eachBatch,
+          batchConsumerStartCh,
+          batchConsumerFinishCh,
+          batchConsumerErrorCh,
+          eachBatchExtractor
+        ),
+        ...runArgs,
+      })
     }
+
     return consumer
   })
+
   return Kafka
 })
 
-const wrappedCallback = (fn, startCh, finishCh, errorCh, extractArgs, clusterId) => {
-  return typeof fn === 'function'
-    ? function (...args) {
-      const extractedArgs = extractArgs(args, clusterId)
-      const ctx = {
-        extractedArgs,
-      }
-
-      return startCh.runStores(ctx, () => {
-        try {
-          const result = fn.apply(this, args)
-          if (result && typeof result.then === 'function') {
-            result.then(
-              (res) => {
-                ctx.result = res
-                finishCh.publish(ctx)
-              },
-              (err) => {
-                ctx.error = err
-                if (err) {
-                  errorCh.publish(ctx)
-                }
-                finishCh.publish(ctx)
-              })
-          } else {
-            finishCh.publish(ctx)
-          }
-          return result
-        } catch (e) {
-          ctx.error = e
-          errorCh.publish(ctx)
-          finishCh.publish(ctx)
-          throw e
-        }
-      })
+const wrappedCallback = (fn, startCh, finishCh, errorCh, extractArgs) => {
+  if (typeof fn !== 'function') return fn
+  return function (...args) {
+    const ctx = {
+      extractedArgs: extractArgs(args),
     }
-    : fn
-}
 
-const getKafkaClusterId = (kafka) => {
-  if (kafka._ddKafkaClusterId) {
-    return kafka._ddKafkaClusterId
-  }
-
-  if (!kafka.admin) {
-    return null
-  }
-
-  const admin = kafka.admin()
-
-  if (!admin.describeCluster) {
-    return null
-  }
-
-  return admin.connect()
-    .then(() => {
-      return admin.describeCluster()
+    return startCh.runStores(ctx, () => {
+      try {
+        const result = fn.apply(this, args)
+        if (result && typeof result.then === 'function') {
+          result.then(
+            (res) => {
+              ctx.result = res
+              finishCh.publish(ctx)
+            },
+            (error) => {
+              ctx.error = error
+              if (error) {
+                errorCh.publish(ctx)
+              }
+              finishCh.publish(ctx)
+            }
+          )
+        } else {
+          finishCh.publish(ctx)
+        }
+        return result
+      } catch (error) {
+        ctx.error = error
+        errorCh.publish(ctx)
+        finishCh.publish(ctx)
+        throw error
+      }
     })
-    .then((clusterInfo) => {
-      const clusterId = clusterInfo?.clusterId
-      kafka._ddKafkaClusterId = clusterId
-      admin.disconnect()
-      return clusterId
-    })
-    .catch((error) => {
-      throw error
-    })
-}
-
-function isPromise (obj) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function'
+  }
 }

--- a/packages/datadog-instrumentations/test/helpers/kafka.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/kafka.spec.js
@@ -6,65 +6,46 @@ const { describe, it } = require('mocha')
 const {
   brokerSupportsMessageHeaders,
   cloneMessages,
-  cloneMessagesForInjection,
 } = require('../../src/helpers/kafka')
 
 describe('helpers/kafka', () => {
   describe('cloneMessages', () => {
     it('returns a fresh array; the input is not the output', () => {
       const input = [{ key: 'k', value: 'v' }]
-      const output = cloneMessages(input)
+      const output = cloneMessages(input, false)
       assert.notStrictEqual(output, input)
       assert.notStrictEqual(output[0], input[0])
     })
 
-    it('keeps the headers field absent when the input has no headers', () => {
+    it('keeps the headers field absent when ensureHeaders is false and input has none', () => {
       const input = [{ key: 'k', value: 'v' }]
-      const [cloned] = cloneMessages(input)
+      const [cloned] = cloneMessages(input, false)
       assert.strictEqual(Object.hasOwn(cloned, 'headers'), false)
       assert.strictEqual(input[0].headers, undefined)
     })
 
-    it('shallow-clones existing headers so caller mutations stay isolated', () => {
-      const headers = { foo: 'bar' }
-      const [cloned] = cloneMessages([{ key: 'k', value: 'v', headers }])
-      assert.notStrictEqual(cloned.headers, headers)
-      assert.deepStrictEqual(cloned.headers, headers)
-    })
-
-    it('passes non-object entries through unchanged', () => {
-      const sentinel = Symbol('not-a-message')
-      const input = [null, sentinel, 0, '']
-      assert.deepStrictEqual(cloneMessages(input), [null, sentinel, 0, ''])
-    })
-  })
-
-  describe('cloneMessagesForInjection', () => {
-    it('returns a fresh array; the input is not the output', () => {
+    it('seeds an empty headers object when ensureHeaders is true and input has none', () => {
       const input = [{ key: 'k', value: 'v' }]
-      const output = cloneMessagesForInjection(input)
-      assert.notStrictEqual(output, input)
-      assert.notStrictEqual(output[0], input[0])
-    })
-
-    it('seeds an empty headers object when the input has no headers', () => {
-      const input = [{ key: 'k', value: 'v' }]
-      const [cloned] = cloneMessagesForInjection(input)
+      const [cloned] = cloneMessages(input, true)
       assert.deepStrictEqual(cloned.headers, {})
       assert.strictEqual(input[0].headers, undefined)
     })
 
     it('shallow-clones existing headers so caller mutations stay isolated', () => {
       const headers = { foo: 'bar' }
-      const [cloned] = cloneMessagesForInjection([{ key: 'k', value: 'v', headers }])
-      assert.notStrictEqual(cloned.headers, headers)
-      assert.deepStrictEqual(cloned.headers, headers)
+      const [withHeaders] = cloneMessages([{ key: 'k', value: 'v', headers }], false)
+      const [withInjection] = cloneMessages([{ key: 'k', value: 'v', headers }], true)
+      assert.notStrictEqual(withHeaders.headers, headers)
+      assert.notStrictEqual(withInjection.headers, headers)
+      assert.deepStrictEqual(withHeaders.headers, headers)
+      assert.deepStrictEqual(withInjection.headers, headers)
     })
 
-    it('passes non-object entries through unchanged', () => {
+    it('passes non-object entries through unchanged regardless of ensureHeaders', () => {
       const sentinel = Symbol('not-a-message')
       const input = [null, sentinel, 0, '']
-      assert.deepStrictEqual(cloneMessagesForInjection(input), [null, sentinel, 0, ''])
+      assert.deepStrictEqual(cloneMessages(input, false), [null, sentinel, 0, ''])
+      assert.deepStrictEqual(cloneMessages(input, true), [null, sentinel, 0, ''])
     })
   })
 

--- a/packages/datadog-instrumentations/test/helpers/kafka.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/kafka.spec.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it } = require('mocha')
+
+const {
+  brokerSupportsMessageHeaders,
+  cloneMessagesForInjection,
+} = require('../../src/helpers/kafka')
+
+describe('helpers/kafka', () => {
+  describe('cloneMessagesForInjection', () => {
+    it('returns a fresh array; the input is not the output', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const output = cloneMessagesForInjection(input)
+      assert.notStrictEqual(output, input)
+      assert.notStrictEqual(output[0], input[0])
+    })
+
+    it('seeds an empty headers object when the input has no headers', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const [cloned] = cloneMessagesForInjection(input)
+      assert.deepStrictEqual(cloned.headers, {})
+      assert.strictEqual(input[0].headers, undefined)
+    })
+
+    it('shallow-clones existing headers so caller mutations stay isolated', () => {
+      const headers = { foo: 'bar' }
+      const [cloned] = cloneMessagesForInjection([{ key: 'k', value: 'v', headers }])
+      assert.notStrictEqual(cloned.headers, headers)
+      assert.deepStrictEqual(cloned.headers, headers)
+    })
+
+    it('passes non-object entries through unchanged', () => {
+      const sentinel = Symbol('not-a-message')
+      const input = [null, sentinel, 0, '']
+      assert.deepStrictEqual(cloneMessagesForInjection(input), [null, sentinel, 0, ''])
+    })
+  })
+
+  describe('brokerSupportsMessageHeaders', () => {
+    it('returns true when versions have not yet been negotiated', () => {
+      assert.strictEqual(brokerSupportsMessageHeaders(undefined), true)
+      assert.strictEqual(brokerSupportsMessageHeaders({}), true)
+      assert.strictEqual(brokerSupportsMessageHeaders({ versions: {} }), true)
+    })
+
+    it('returns true when the broker advertises Produce v3+', () => {
+      assert.strictEqual(
+        brokerSupportsMessageHeaders({ versions: { 0: { minVersion: 0, maxVersion: 3 } } }),
+        true
+      )
+      assert.strictEqual(
+        brokerSupportsMessageHeaders({ versions: { 0: { minVersion: 0, maxVersion: 9 } } }),
+        true
+      )
+    })
+
+    it('returns false when the broker only supports the legacy MessageSet format', () => {
+      assert.strictEqual(
+        brokerSupportsMessageHeaders({ versions: { 0: { minVersion: 0, maxVersion: 2 } } }),
+        false
+      )
+    })
+  })
+})

--- a/packages/datadog-instrumentations/test/helpers/kafka.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/kafka.spec.js
@@ -5,10 +5,40 @@ const { describe, it } = require('mocha')
 
 const {
   brokerSupportsMessageHeaders,
+  cloneMessages,
   cloneMessagesForInjection,
 } = require('../../src/helpers/kafka')
 
 describe('helpers/kafka', () => {
+  describe('cloneMessages', () => {
+    it('returns a fresh array; the input is not the output', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const output = cloneMessages(input)
+      assert.notStrictEqual(output, input)
+      assert.notStrictEqual(output[0], input[0])
+    })
+
+    it('keeps the headers field absent when the input has no headers', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const [cloned] = cloneMessages(input)
+      assert.strictEqual(Object.hasOwn(cloned, 'headers'), false)
+      assert.strictEqual(input[0].headers, undefined)
+    })
+
+    it('shallow-clones existing headers so caller mutations stay isolated', () => {
+      const headers = { foo: 'bar' }
+      const [cloned] = cloneMessages([{ key: 'k', value: 'v', headers }])
+      assert.notStrictEqual(cloned.headers, headers)
+      assert.deepStrictEqual(cloned.headers, headers)
+    })
+
+    it('passes non-object entries through unchanged', () => {
+      const sentinel = Symbol('not-a-message')
+      const input = [null, sentinel, 0, '']
+      assert.deepStrictEqual(cloneMessages(input), [null, sentinel, 0, ''])
+    })
+  })
+
   describe('cloneMessagesForInjection', () => {
     it('returns a fresh array; the input is not the output', () => {
       const input = [{ key: 'k', value: 'v' }]

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
@@ -288,24 +288,61 @@ describe('Plugin', () => {
           })
 
           it('should hit an error for the first send and not inject headers in later sends', async () => {
-            const testMessages = [{ key: 'key1', value: 'test1' }]
-            const testMessages2 = [{ key: 'key2', value: 'test2' }]
+            const dc = require('dc-polyfill')
+            const { deepFreeze } = require('../../../integration-tests/helpers')
+
+            const startCh = dc.channel('apm:confluentinc-kafka-javascript:produce:start')
+
+            // Snapshot headers at publish time. The underlying client
+            // converts each cloned message's `headers` to an array-of-pairs
+            // form before shipping, so the live reference would show that
+            // post-conversion shape; we want the bindStart-time injection
+            // result instead.
+            const headerSnapshots = []
+            const captureStart = (ctx) => {
+              const snapshot = ctx.messages.map((m) => (
+                m && typeof m === 'object' && m.headers ? { ...m.headers } : undefined
+              ))
+              headerSnapshots.push(snapshot)
+            }
+            startCh.subscribe(captureStart)
+
+            // Deep-freeze the user's input on both sends; any boundary or
+            // library write to the array, its messages, or their headers
+            // throws synchronously.
+            const testMessages = deepFreeze([{ key: 'key1', value: 'test1' }])
+            const testMessages2 = deepFreeze([{ key: 'key2', value: 'test2' }])
 
             try {
-              await producer.send({ topic: testTopic, messages: testMessages })
-              assert.fail('First producer.send() should have thrown an error')
-            } catch (e) {
-              assert.strictEqual(e, error)
+              try {
+                await producer.send({ topic: testTopic, messages: testMessages })
+                assert.fail('First producer.send() should have thrown an error')
+              } catch (e) {
+                assert.strictEqual(e, error)
+              }
+
+              const firstHeaders = headerSnapshots.find(
+                (snapshot) => snapshot[0] && Object.hasOwn(snapshot[0], 'x-datadog-trace-id')
+              )
+              assert.ok(firstHeaders, 'expected a captured batch with x-datadog-trace-id')
+
+              const sendsBefore = headerSnapshots.length
+              produceStub.restore()
+
+              const result = await producer.send({ topic: testTopic, messages: testMessages2 })
+
+              // After the broker reports ERR_UNKNOWN the producer skips
+              // injection. The boundary still clones, so the underlying
+              // client's `headers: null` post-publish mutation lands on the
+              // clone, not on the user's frozen array.
+              const injectedAfterError = headerSnapshots
+                .slice(sendsBefore)
+                .filter((snap) => snap[0] && Object.hasOwn(snap[0], 'x-datadog-trace-id'))
+              assert.strictEqual(injectedAfterError.length, 0)
+              assert.notStrictEqual(result, undefined)
+            } finally {
+              startCh.unsubscribe(captureStart)
             }
-            // Verify headers were injected in the first attempt
-            assert.ok(Object.hasOwn(testMessages[0].headers[0], 'x-datadog-trace-id'))
-
-            // restore the stub to allow the next send to succeed
-            produceStub.restore()
-
-            const result = await producer.send({ topic: testTopic, messages: testMessages2 })
-            assert.strictEqual(testMessages2[0].headers, null)
-            assert.notStrictEqual(result, undefined)
           })
         })
       })

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
@@ -314,12 +314,10 @@ describe('Plugin', () => {
             const testMessages2 = deepFreeze([{ key: 'key2', value: 'test2' }])
 
             try {
-              try {
-                await producer.send({ topic: testTopic, messages: testMessages })
-                assert.fail('First producer.send() should have thrown an error')
-              } catch (e) {
-                assert.strictEqual(e, error)
-              }
+              await assert.rejects(
+                producer.send({ topic: testTopic, messages: testMessages }),
+                error
+              )
 
               const firstHeaders = headerSnapshots.find(
                 (snapshot) => snapshot[0] && Object.hasOwn(snapshot[0], 'x-datadog-trace-id')

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
@@ -299,11 +299,14 @@ describe('Plugin', () => {
             // post-conversion shape; we want the bindStart-time injection
             // result instead.
             const headerSnapshots = []
+            const headerPresence = []
             const captureStart = (ctx) => {
-              const snapshot = ctx.messages.map((m) => (
+              headerSnapshots.push(ctx.messages.map((m) => (
                 m && typeof m === 'object' && m.headers ? { ...m.headers } : undefined
-              ))
-              headerSnapshots.push(snapshot)
+              )))
+              headerPresence.push(ctx.messages.map((m) => (
+                m && typeof m === 'object' ? Object.hasOwn(m, 'headers') : null
+              )))
             }
             startCh.subscribe(captureStart)
 
@@ -332,11 +335,14 @@ describe('Plugin', () => {
               // After the broker reports ERR_UNKNOWN the producer skips
               // injection. The boundary still clones, so the underlying
               // client's `headers: null` post-publish mutation lands on the
-              // clone, not on the user's frozen array.
+              // clone, not on the user's frozen array. The clone must not
+              // seed `headers: {}` either: brokers that reject any header
+              // field cannot recover otherwise.
               const injectedAfterError = headerSnapshots
                 .slice(sendsBefore)
                 .filter((snap) => snap[0] && Object.hasOwn(snap[0], 'x-datadog-trace-id'))
               assert.strictEqual(injectedAfterError.length, 0)
+              assert.deepStrictEqual(headerPresence[sendsBefore], [false])
               assert.notStrictEqual(result, undefined)
             } finally {
               startCh.unsubscribe(captureStart)

--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -17,17 +17,11 @@ const { assertObjectContains } = require('../../../integration-tests/helpers')
 
 const testKafkaClusterId = '5L6g3nShT-eMCtK--X86sw'
 
-const getDsmPathwayHash = (testTopic, clusterIdAvailable, isProducer, parentHash) => {
-  let edgeTags
-  if (isProducer) {
-    edgeTags = ['direction:out', 'topic:' + testTopic, 'type:kafka']
-  } else {
-    edgeTags = ['direction:in', 'group:test-group', 'topic:' + testTopic, 'type:kafka']
-  }
-
-  if (clusterIdAvailable) {
-    edgeTags.push(`kafka_cluster_id:${testKafkaClusterId}`)
-  }
+const getDsmPathwayHash = (testTopic, isProducer, parentHash) => {
+  const edgeTags = isProducer
+    ? ['direction:out', 'topic:' + testTopic, 'type:kafka']
+    : ['direction:in', 'group:test-group', 'topic:' + testTopic, 'type:kafka']
+  edgeTags.push(`kafka_cluster_id:${testKafkaClusterId}`)
   edgeTags.sort()
   return computePathwayHash('test', 'tester', edgeTags, parentHash, propagationHash.getHash())
 }
@@ -45,7 +39,6 @@ describe('Plugin', () => {
       let admin
       let tracer
       let Kafka
-      let clusterIdAvailable
       let expectedProducerHash
       let expectedConsumerHash
       let testTopic
@@ -86,9 +79,8 @@ describe('Plugin', () => {
               replicationFactor: 1,
             })),
           })
-          clusterIdAvailable = semver.intersects(version, '>=1.13')
-          expectedProducerHash = getDsmPathwayHash(testTopic, clusterIdAvailable, true, ENTRY_PARENT_HASH)
-          expectedConsumerHash = getDsmPathwayHash(testTopic, clusterIdAvailable, false, expectedProducerHash)
+          expectedProducerHash = getDsmPathwayHash(testTopic, true, ENTRY_PARENT_HASH)
+          expectedConsumerHash = getDsmPathwayHash(testTopic, false, expectedProducerHash)
         })
 
         describe('checkpoints', () => {
@@ -310,15 +302,11 @@ describe('Plugin', () => {
               assert.strictEqual(runArg?.offset, commitMeta.offset)
               assert.strictEqual(runArg?.partition, commitMeta.partition)
               assert.strictEqual(runArg?.topic, commitMeta.topic)
-              const expectedBacklog = {
+              assertObjectContains(runArg, {
                 type: 'kafka_commit',
                 consumer_group: 'test-group',
-              }
-              // kafka_cluster_id is only available in kafkajs >=1.13
-              if (clusterIdAvailable) {
-                expectedBacklog.kafka_cluster_id = testKafkaClusterId
-              }
-              assertObjectContains(runArg, expectedBacklog)
+                kafka_cluster_id: testKafkaClusterId,
+              })
             })
           }
 
@@ -327,10 +315,7 @@ describe('Plugin', () => {
             sinon.assert.calledOnce(setOffsetSpy)
             const runArg = setOffsetSpy.lastCall.args[0]
             assert.strictEqual(runArg.topic, testTopic)
-            // kafka_cluster_id is only available in kafkajs >=1.13
-            if (clusterIdAvailable) {
-              assert.strictEqual(runArg.kafka_cluster_id, testKafkaClusterId)
-            }
+            assert.strictEqual(runArg.kafka_cluster_id, testKafkaClusterId)
           })
         })
       })

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -12,7 +12,7 @@ const { withNamingSchema, withPeerService, withVersions } = require('../../dd-tr
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { assertObjectContains } = require('../../../integration-tests/helpers')
+const { assertObjectContains, deepFreeze } = require('../../../integration-tests/helpers')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -32,12 +32,10 @@ describe('Plugin', () => {
       let tracer
       let Kafka
       let Broker
-      let clusterIdAvailable
       let testTopic
 
       describe('without configuration', () => {
         const messages = [{ key: 'key1', value: 'test2' }]
-        const messages2 = [{ key: 'key2', value: 'test3' }]
 
         beforeEach(async () => {
           tracer = require('../../dd-trace')
@@ -60,23 +58,20 @@ describe('Plugin', () => {
               replicationFactor: 1,
             }],
           })
-          clusterIdAvailable = semver.intersects(version, '>=1.13')
         })
 
         describe('producer', () => {
           it('should be instrumented', async () => {
-            const meta = {
-              'span.kind': 'producer',
-              component: 'kafkajs',
-              'messaging.destination.name': testTopic,
-              'messaging.kafka.bootstrap.servers': '127.0.0.1:9092',
-            }
-            if (clusterIdAvailable) meta['kafka.cluster_id'] = testKafkaClusterId
-
             const expectedSpanPromise = expectSpanWithDefaults({
               name: expectedSchema.send.opName,
               service: expectedSchema.send.serviceName,
-              meta,
+              meta: {
+                'span.kind': 'producer',
+                component: 'kafkajs',
+                'messaging.destination.name': testTopic,
+                'messaging.kafka.bootstrap.servers': '127.0.0.1:9092',
+                'kafka.cluster_id': testKafkaClusterId,
+              },
               metrics: {
                 'kafka.batch_size': messages.length,
               },
@@ -132,6 +127,67 @@ describe('Plugin', () => {
               return expectedSpanPromise
             }
           })
+          it('should not mutate user-supplied message objects', async () => {
+            // Deep-freezing the input means any accidental write to a
+            // message, its headers, or the array itself throws synchronously.
+            const userMessages = deepFreeze([
+              { key: 'key', value: 'value', headers: { foo: 'bar' } },
+              { key: 'key2', value: 'value2' },
+            ])
+
+            await sendMessages(kafka, testTopic, userMessages)
+          })
+
+          it('should not call Kafka.admin from instrumentation during normal send', async () => {
+            // Spy after the test setup has already created topics; from here
+            // on no internal admin connection should be opened.
+            const adminSpy = sinon.spy(kafka, 'admin')
+            try {
+              await sendMessages(kafka, testTopic, messages)
+              assert.strictEqual(adminSpy.callCount, 0)
+            } finally {
+              adminSpy.restore()
+            }
+          })
+
+          it('should disable header injection when broker advertises Produce <v3', async () => {
+            const startCh = dc.channel('apm:kafkajs:produce:start')
+            const sentMessageBatches = []
+            const captureStart = (ctx) => sentMessageBatches.push({
+              messages: ctx.messages,
+              disableHeaderInjection: ctx.disableHeaderInjection,
+            })
+            startCh.subscribe(captureStart)
+
+            const producer = kafka.producer()
+            await producer.connect()
+
+            try {
+              // Reach into kafkajs's broker pool and downgrade the negotiated
+              // Produce version. We can't ask the docker broker to pretend to
+              // be <0.11; lying locally is enough to drive the proactive
+              // header-support check.
+              const clusterSymbol = Object.getOwnPropertySymbols(producer).find(
+                (sym) => sym.description === 'dd-trace.kafkajs.cluster'
+              )
+              const cluster = producer[clusterSymbol]
+              cluster.brokerPool.versions[0].maxVersion = 2
+
+              const userMessages = [{ key: 'k', value: 'v' }]
+              await producer.send({ topic: testTopic, messages: userMessages })
+
+              assert.strictEqual(sentMessageBatches.length, 1)
+              assert.strictEqual(sentMessageBatches[0].disableHeaderInjection, true)
+              // Boundary skips the clone when injection is off, so the user's
+              // array reaches the channel untouched.
+              assert.strictEqual(sentMessageBatches[0].messages, userMessages)
+              assert.strictEqual(userMessages[0].headers, undefined)
+            } finally {
+              await producer.disconnect()
+              startCh.unsubscribe(captureStart)
+            }
+          })
+
           // Dynamic broker list support added in 1.14/2.0 (https://github.com/tulios/kafkajs/commit/62223)
           if (semver.intersects(version, '>=1.14')) {
             it('should not extract bootstrap servers when initialized with a function', async () => {
@@ -190,16 +246,34 @@ describe('Plugin', () => {
             })
 
             it('should hit an error for the first send and not inject headers in later sends', async () => {
-              await assert.rejects(producer.send({ topic: testTopic, messages }), error)
+              const startCh = dc.channel('apm:kafkajs:produce:start')
+              const sentMessageBatches = []
+              const captureStart = (ctx) => sentMessageBatches.push(ctx.messages)
+              startCh.subscribe(captureStart)
 
-              assert.ok(Object.hasOwn(messages[0].headers, 'x-datadog-trace-id'))
+              // Freeze both batches: any boundary or plugin write to the
+              // user's array, its messages, or their headers throws here.
+              const firstBatch = deepFreeze([{ key: 'key1', value: 'test2' }])
+              const secondBatch = deepFreeze([{ key: 'key2', value: 'test3' }])
 
-              // restore the stub to allow the next send to succeed
-              sendRequestStub.restore()
+              try {
+                await assert.rejects(producer.send({ topic: testTopic, messages: firstBatch }), error)
 
-              const result2 = await producer.send({ topic: testTopic, messages: messages2 })
-              assert.strictEqual(messages2[0].headers, undefined)
-              assert.strictEqual(result2[0].errorCode, 0)
+                // The first send injects trace headers into the cloned
+                // batch that kafkajs serializes.
+                assert.ok(Object.hasOwn(sentMessageBatches[0][0].headers, 'x-datadog-trace-id'))
+
+                sendRequestStub.restore()
+
+                const result2 = await producer.send({ topic: testTopic, messages: secondBatch })
+
+                // After UNKNOWN the boundary still clones (so frozen input
+                // stays untouched) but the plugin skips injection.
+                assert.strictEqual(sentMessageBatches[1][0].headers, undefined)
+                assert.strictEqual(result2[0].errorCode, 0)
+              } finally {
+                startCh.unsubscribe(captureStart)
+              }
             })
           })
 
@@ -421,19 +495,17 @@ describe('Plugin', () => {
           })
 
           it('should be instrumented', async () => {
-            const meta = {
-              'span.kind': 'consumer',
-              component: 'kafkajs',
-              'kafka.topic': testTopic,
-              'messaging.destination.name': testTopic,
-              'messaging.system': 'kafka',
-            }
-            if (clusterIdAvailable) meta['kafka.cluster_id'] = testKafkaClusterId
-
             const expectedSpanPromise = expectSpanWithDefaults({
               name: expectedSchema.receive.opName,
               service: expectedSchema.receive.serviceName,
-              meta,
+              meta: {
+                'span.kind': 'consumer',
+                component: 'kafkajs',
+                'kafka.topic': testTopic,
+                'messaging.destination.name': testTopic,
+                'messaging.system': 'kafka',
+                'kafka.cluster_id': testKafkaClusterId,
+              },
               metrics: {
                 'messaging.batch.message_count': batchMessages.length,
               },
@@ -492,19 +564,17 @@ describe('Plugin', () => {
             const messagesWithHeaders = [
               { key: 'key1', value: 'test1', headers: { 'x-custom-header': 'value' } },
             ]
-            const meta = {
-              'span.kind': 'consumer',
-              component: 'kafkajs',
-              'kafka.topic': testTopic,
-              'messaging.destination.name': testTopic,
-              'messaging.system': 'kafka',
-            }
-            if (clusterIdAvailable) meta['kafka.cluster_id'] = testKafkaClusterId
-
             const expectedSpanPromise = expectSpanWithDefaults({
               name: expectedSchema.receive.opName,
               service: expectedSchema.receive.serviceName,
-              meta,
+              meta: {
+                'span.kind': 'consumer',
+                component: 'kafkajs',
+                'kafka.topic': testTopic,
+                'messaging.destination.name': testTopic,
+                'messaging.system': 'kafka',
+                'kafka.cluster_id': testKafkaClusterId,
+              },
               resource: testTopic,
               error: 0,
               type: 'worker',

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -12,6 +12,7 @@ const { withNamingSchema, withPeerService, withVersions } = require('../../dd-tr
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const { clientToCluster } = require('../../datadog-instrumentations/src/helpers/kafka')
 const { assertObjectContains, deepFreeze } = require('../../../integration-tests/helpers')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
@@ -127,6 +128,7 @@ describe('Plugin', () => {
               return expectedSpanPromise
             }
           })
+
           it('should not mutate user-supplied message objects', async () => {
             // Deep-freezing the input means any accidental write to a
             // message, its headers, or the array itself throws synchronously.
@@ -167,10 +169,7 @@ describe('Plugin', () => {
               // Produce version. We can't ask the docker broker to pretend to
               // be <0.11; lying locally is enough to drive the proactive
               // header-support check.
-              const clusterSymbol = Object.getOwnPropertySymbols(producer).find(
-                (sym) => sym.description === 'dd-trace.kafkajs.cluster'
-              )
-              const cluster = producer[clusterSymbol]
+              const cluster = clientToCluster.get(producer)
               cluster.brokerPool.versions[0].maxVersion = 2
 
               const userMessages = [{ key: 'k', value: 'v' }]

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -177,9 +177,14 @@ describe('Plugin', () => {
 
               assert.strictEqual(sentMessageBatches.length, 1)
               assert.strictEqual(sentMessageBatches[0].disableHeaderInjection, true)
-              // Boundary skips the clone when injection is off, so the user's
-              // array reaches the channel untouched.
-              assert.strictEqual(sentMessageBatches[0].messages, userMessages)
+              // Boundary clones with `cloneMessages` when injection is off,
+              // so the channel sees a fresh array whose entries have no
+              // `headers` field at all (no `{}` seeding) and the user's
+              // array stays untouched.
+              const [clonedMessage] = sentMessageBatches[0].messages
+              assert.notStrictEqual(sentMessageBatches[0].messages, userMessages)
+              assert.notStrictEqual(clonedMessage, userMessages[0])
+              assert.strictEqual(Object.hasOwn(clonedMessage, 'headers'), false)
               assert.strictEqual(userMessages[0].headers, undefined)
             } finally {
               await producer.disconnect()
@@ -266,9 +271,13 @@ describe('Plugin', () => {
 
                 const result2 = await producer.send({ topic: testTopic, messages: secondBatch })
 
-                // After UNKNOWN the boundary still clones (so frozen input
-                // stays untouched) but the plugin skips injection.
-                assert.strictEqual(sentMessageBatches[1][0].headers, undefined)
+                // After UNKNOWN the boundary clones with `cloneMessages`
+                // (frozen input stays untouched) and the clone has no
+                // `headers` field at all — brokers that reject any header
+                // field can recover.
+                const [clonedAfterDisable] = sentMessageBatches[1]
+                assert.notStrictEqual(clonedAfterDisable, secondBatch[0])
+                assert.strictEqual(Object.hasOwn(clonedAfterDisable, 'headers'), false)
                 assert.strictEqual(result2[0].errorCode, 0)
               } finally {
                 startCh.unsubscribe(captureStart)


### PR DESCRIPTION
Three coordinated changes to the kafka producer wrap:

1. The cluster id discovery used a separate admin connection whose
   `describeCluster()` rejection wasn't awaited, surfacing as
   `process.unhandledRejection`. Read
   `cluster.brokerPool.metadata.clusterId` instead, priming it on first
   send via `cluster.refreshMetadataIfNecessary()`; `sharedPromiseTo`
   collapses our call with kafkajs's internal one, so total latency is
   unchanged.

2. Header injection mutated caller-owned `message.headers` in place. The
   boundary now hands kafkajs and the plugin a shallow clone instead.

3. The Produce request didn't carry headers until v3 (Kafka 0.11), so
   injecting on older brokers either wastes work or trips
   `UNKNOWN_SERVER_ERROR` on a per-leader version mismatch. Read
   `cluster.brokerPool.versions[0].maxVersion` and skip injection when
   the broker negotiated <v3; the existing UNKNOWN handler stays as a
   safety net for mixed-version clusters.

Refs: #5837
Refs: #5270

