### PR TITLE
fix(debugger): move process_tags to root of payload

### DIFF
--- a/integration-tests/debugger/tracing-integration.spec.js
+++ b/integration-tests/debugger/tracing-integration.spec.js
@@ -72,14 +72,12 @@ describe('Dynamic Instrumentation', function () {
     })
 
     describe('input messages', function () {
-      it('should include process_tags in snapshot when enabled', function (done) {
+      it('should include process_tags in payload root when enabled', function (done) {
         t.agent.on('debugger-input', ({ payload }) => {
-          const snapshot = payload[0].debugger.snapshot
-
-          // Check for expected process tags keys
-          assert.ok(snapshot.process_tags['entrypoint.name'])
-          assert.ok(snapshot.process_tags['entrypoint.type'])
-          assert.strictEqual(snapshot.process_tags['entrypoint.type'], 'script')
+          // process_tags should be at the root of the payload, not nested under debugger.snapshot
+          assert.ok(payload[0].process_tags['entrypoint.name'])
+          assert.ok(payload[0].process_tags['entrypoint.type'])
+          assert.strictEqual(payload[0].process_tags['entrypoint.type'], 'script')
 
           done()
         })
@@ -98,12 +96,10 @@ describe('Dynamic Instrumentation', function () {
     })
 
     describe('input messages', function () {
-      it('should not include process_tags in snapshot when disabled', function (done) {
+      it('should not include process_tags in payload when disabled', function (done) {
         t.agent.on('debugger-input', ({ payload }) => {
-          const snapshot = payload[0].debugger.snapshot
-
-          // Assert that process_tags are not present
-          assert.strictEqual(snapshot.process_tags, undefined)
+          // Assert that process_tags are not present at the root
+          assert.strictEqual(payload[0].process_tags, undefined)
 
           done()
         })

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -247,10 +247,6 @@ session.on('Debugger.paused', async ({ params }) => {
       language: 'javascript',
     }
 
-    if (config.propagateProcessTags.enabled) {
-      snapshot[processTags.DYNAMIC_INSTRUMENTATION_FIELD_NAME] = processTags.tagsObject
-    }
-
     if (probe.captureSnapshot) {
       if (fatalSnapshotErrors && fatalSnapshotErrors.length > 0) {
         // There was an error collecting the snapshot for this probe, let's not try again
@@ -327,7 +323,11 @@ session.on('Debugger.paused', async ({ params }) => {
 
     ackEmitting(probe)
 
-    send(message, logger, dd, snapshot)
+    const payloadProcessTags = config.propagateProcessTags.enabled
+      ? processTags.tagsObject
+      : undefined
+
+    send(message, logger, dd, snapshot, payloadProcessTags)
   }
 })
 

--- a/packages/dd-trace/src/debugger/devtools_client/send.js
+++ b/packages/dd-trace/src/debugger/devtools_client/send.js
@@ -40,7 +40,7 @@ const jsonBuffer = new JSONBuffer({
   onFlush,
 })
 
-function send (message, logger, dd, snapshot) {
+function send (message, logger, dd, snapshot, processTags) {
   const payload = {
     ddsource,
     hostname,
@@ -51,6 +51,10 @@ function send (message, logger, dd, snapshot) {
     logger,
     dd,
     debugger: { snapshot },
+  }
+
+  if (processTags) {
+    payload.process_tags = processTags
   }
 
   let json = JSON.stringify(payload)


### PR DESCRIPTION
### What does this PR do?

Moves `process_tags` from `debugger.snapshot.process_tags` to the root level of the debugger JSON payload, aligning with all other Datadog tracers.

### Motivation

In #7132 (commit 7a64f41), `process_tags` was added under `debugger.snapshot.process_tags`. However, the backend expects it at the root of the payload (`payload.process_tags`), which is where all other Datadog tracers (Java, Python, .NET, Ruby) place it.

### Additional Notes

- The `process_tags` assignment is moved from `index.js` (on the snapshot object) to `send.js` (on the root payload object)
- Integration test assertions updated to check the root payload instead of `debugger.snapshot`
- Cross-referenced implementations in dd-trace-java (`JsonSnapshotSerializer.java`), dd-trace-py (`_encoding.py`), dd-trace-dotnet (`DebuggerSnapshotCreator.cs`), and dd-trace-rb (`probe_notification_builder.rb`) — all place `process_tags` at the root

🤖 Generated with [Claude Code](https://claude.com/claude-code)