### PR TITLE
fix(propagation): enforce baggageMax* caps on extract

### DIFF
--- a/packages/dd-trace/src/baggage.js
+++ b/packages/dd-trace/src/baggage.js
@@ -66,8 +66,18 @@ function removeAllBaggageItems () {
   return EMPTY_STORE
 }
 
+/**
+ * @param {BaggageStore} items Frozen in place; do not mutate after.
+ */
+function setAllBaggageItems (items) {
+  Object.freeze(items)
+  baggageStorage.enterWith(items)
+  return items
+}
+
 module.exports = {
   setBaggageItem,
+  setAllBaggageItems,
   getBaggageItem,
   getAllBaggageItems,
   removeBaggageItem,

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -2,7 +2,7 @@
 
 const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const { storage } = require('../../../datadog-core')
-const { getAllBaggageItems, setAllBaggageItems } = require('../baggage')
+const { getAllBaggageItems, setAllBaggageItems, removeAllBaggageItems } = require('../baggage')
 
 const SpanContext = require('./span_context')
 
@@ -72,6 +72,8 @@ class ContextManager {
         items[key] = entry.value
       }
       setAllBaggageItems(items)
+    } else {
+      removeAllBaggageItems()
     }
     if (span && span._ddSpan) {
       const ddSpan = span._ddSpan

--- a/packages/dd-trace/src/opentelemetry/context_manager.js
+++ b/packages/dd-trace/src/opentelemetry/context_manager.js
@@ -2,7 +2,7 @@
 
 const { trace, ROOT_CONTEXT, propagation } = require('@opentelemetry/api')
 const { storage } = require('../../../datadog-core')
-const { getAllBaggageItems, setBaggageItem, removeAllBaggageItems } = require('../baggage')
+const { getAllBaggageItems, setAllBaggageItems } = require('../baggage')
 
 const SpanContext = require('./span_context')
 
@@ -64,13 +64,14 @@ class ContextManager {
       return this._store.run(context, cb, ...args)
     }
     const baggages = propagation.getBaggage(context)
-    let baggageItems = []
-    if (baggages) {
-      baggageItems = baggages.getAllEntries()
-    }
-    removeAllBaggageItems()
-    for (const baggage of baggageItems) {
-      setBaggageItem(baggage[0], baggage[1].value)
+    const baggageItems = baggages ? baggages.getAllEntries() : []
+    if (baggageItems.length > 0) {
+      /** @type {Record<string, string>} */
+      const items = {}
+      for (const [key, entry] of baggageItems) {
+        items[key] = entry.value
+      }
+      setAllBaggageItems(items)
     }
     if (span && span._ddSpan) {
       const ddSpan = span._ddSpan

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -7,7 +7,7 @@ const DatadogSpanContext = require('../span_context')
 const log = require('../../log')
 const tags = require('../../../../../ext/tags')
 const { getConfiguredEnvName } = require('../../config/helper')
-const { setBaggageItem, getAllBaggageItems, removeAllBaggageItems } = require('../../baggage')
+const { setAllBaggageItems, getAllBaggageItems, removeAllBaggageItems } = require('../../baggage')
 const telemetryMetrics = require('../../telemetry/metrics')
 
 const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../../ext/priority')
@@ -166,6 +166,7 @@ class TextMapPropagator {
         }
       }
     }
+
     if (this._hasPropagationStyle('inject', 'baggage')) {
       let baggage = ''
       let itemCounter = 0
@@ -675,11 +676,29 @@ class TextMapPropagator {
   _extractBaggageItems (carrier, spanContext) {
     removeAllBaggageItems()
     if (!this._hasPropagationStyle('extract', 'baggage')) return
-    if (!carrier?.baggage) return
-    const baggages = carrier.baggage.split(',')
+    const baggageHeader = carrier?.baggage
+    const header = Array.isArray(baggageHeader) ? baggageHeader.join(',') : baggageHeader
+    if (!header) return
+
+    const baggages = header.split(',')
     const baggageTagKeys = new Set(this._config.baggageTagKeys)
     const tagAllKeys = baggageTagKeys.has('*')
+    /** @type {Record<string, string> | undefined} */
+    let items
+    let itemCount = 0
+    let byteCount = 0
+
     for (const keyValue of baggages) {
+      if (itemCount >= this._config.baggageMaxItems) {
+        tracerMetrics.count('context_header.truncated', ['truncation_reason:baggage_item_count_exceeded']).inc()
+        break
+      }
+      // Charge the comma slot before the empty-entry skip so a `,,,,,foo=bar` can't iterate for free.
+      byteCount += keyValue.length + 1
+      if (byteCount > this._config.baggageMaxBytes) {
+        tracerMetrics.count('context_header.truncated', ['truncation_reason:baggage_byte_count_exceeded']).inc()
+        break
+      }
       if (!keyValue) continue
 
       // Per W3C baggage, list-members can contain optional properties after `;`.
@@ -692,7 +711,6 @@ class TextMapPropagator {
       const eqIdx = member.indexOf('=')
       if (eqIdx === -1) {
         tracerMetrics.count('context_header_style.malformed', ['header_style:baggage']).inc()
-        removeAllBaggageItems()
         return
       }
 
@@ -701,7 +719,6 @@ class TextMapPropagator {
 
       if (!baggageTokenExpr.test(key) || !value) {
         tracerMetrics.count('context_header_style.malformed', ['header_style:baggage']).inc()
-        removeAllBaggageItems()
         return
       }
       try {
@@ -710,15 +727,19 @@ class TextMapPropagator {
         const bytes = value.replaceAll(percentByte, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
         value = Buffer.from(bytes, 'binary').toString('utf8')
       }
+      items ??= {}
+      items[key] = value
+      itemCount++
 
       if (spanContext && (tagAllKeys || baggageTagKeys.has(key))) {
         spanContext._trace.tags['baggage.' + key] = value
       }
-      setBaggageItem(key, value)
     }
 
-    // Successfully extracted baggage
-    tracerMetrics.count('context_header_style.extracted', ['header_style:baggage']).inc()
+    if (items) {
+      setAllBaggageItems(items)
+      tracerMetrics.count('context_header_style.extracted', ['header_style:baggage']).inc()
+    }
   }
 
   _extractSamplingPriority (carrier, spanContext) {

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -174,6 +174,21 @@ describe('OTel Context Manager', () => {
     assert.deepStrictEqual(propagation.getActiveBaggage(), undefined)
   })
 
+  it('should silently drop otel baggage that targets Object.prototype.__proto__', () => {
+    const entries = { foo: { value: 'bar' } }
+    Object.defineProperty(entries, '__proto__', {
+      value: { value: 'poison' }, writable: true, enumerable: true, configurable: true,
+    })
+    const baggage = propagation.createBaggage(entries)
+    const contextWithBaggage = propagation.setBaggage(context.active(), baggage)
+    api.context.with(contextWithBaggage, () => {
+      const baggageItems = getAllBaggageItems()
+      assert.strictEqual(Object.getOwnPropertyDescriptor(baggageItems, '__proto__'), undefined)
+      assert.strictEqual(Object.getPrototypeOf(baggageItems), Object.prototype)
+      assert.deepStrictEqual({ ...baggageItems }, { foo: 'bar' })
+    })
+  })
+
   it('should return active span', () => {
     const otelTracer = getTracer()
     otelTracer.startActiveSpan('otel', (span) => {

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach } = require('mocha')
 const { context, propagation, trace, ROOT_CONTEXT } = require('@opentelemetry/api')
 const api = require('@opentelemetry/api')
-const { getAllBaggageItems, setBaggageItem, removeBaggageItem } = require('../../src/baggage')
+const { getAllBaggageItems, removeAllBaggageItems, removeBaggageItem, setBaggageItem } = require('../../src/baggage')
 
 require('../setup/core')
 const ContextManager = require('../../src/opentelemetry/context_manager')
@@ -172,6 +172,15 @@ describe('OTel Context Manager', () => {
     })
     removeBaggageItem('key2')
     assert.deepStrictEqual(propagation.getActiveBaggage(), undefined)
+  })
+
+  it('should clear dd baggage when entering an otel context with no baggage', () => {
+    removeAllBaggageItems()
+    setBaggageItem('outer', 'value')
+    assert.deepStrictEqual(getAllBaggageItems(), { outer: 'value' })
+    api.context.with(ROOT_CONTEXT, () => {
+      assert.deepStrictEqual(getAllBaggageItems(), {})
+    })
   })
 
   it('should silently drop otel baggage that targets Object.prototype.__proto__', () => {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -1100,6 +1100,136 @@ describe('TextMapPropagator', () => {
         sinon.assert.called(tracerMetrics.count().inc)
         assert.deepStrictEqual(getAllBaggageItems(), {})
       })
+
+      it('should drop excess baggage items when the carrier has too many pairs', () => {
+        const entries = []
+        for (let index = 0; index < config.baggageMaxItems + 1; index++) {
+          entries.push(`key${index}=${index}`)
+        }
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: entries.join(','),
+        }
+
+        propagator.extract(carrier)
+
+        assert.strictEqual(Object.keys(getAllBaggageItems()).length, config.baggageMaxItems)
+        sinon.assert.calledWith(tracerMetrics.count,
+          'context_header.truncated',
+          ['truncation_reason:baggage_item_count_exceeded']
+        )
+        sinon.assert.calledWith(tracerMetrics.count, 'context_header_style.extracted', ['header_style:baggage'])
+      })
+
+      it('should drop a single carrier baggage item that already exceeds the byte cap', () => {
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: `foo=${'a'.repeat(config.baggageMaxBytes)}`,
+        }
+
+        propagator.extract(carrier)
+
+        assert.deepStrictEqual(getAllBaggageItems(), {})
+        sinon.assert.calledWith(tracerMetrics.count,
+          'context_header.truncated',
+          ['truncation_reason:baggage_byte_count_exceeded']
+        )
+        sinon.assert.neverCalledWith(tracerMetrics.count,
+          'context_header_style.extracted', ['header_style:baggage'])
+      })
+
+      it('should truncate later baggage items when their bytes would exceed the cap', () => {
+        const half = config.baggageMaxBytes / 2
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: `key1=${'a'.repeat(half)},key2=${'b'.repeat(half)}`,
+        }
+
+        propagator.extract(carrier)
+
+        assert.deepStrictEqual(getAllBaggageItems(), { key1: 'a'.repeat(half) })
+        sinon.assert.calledWith(tracerMetrics.count,
+          'context_header.truncated',
+          ['truncation_reason:baggage_byte_count_exceeded']
+        )
+        sinon.assert.calledWith(tracerMetrics.count, 'context_header_style.extracted', ['header_style:baggage'])
+      })
+
+      it('should clear pre-existing baggage when the carrier baggage header is rejected', () => {
+        setBaggageItem('stale', 'leftover')
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: `foo=${'a'.repeat(config.baggageMaxBytes)}`,
+        }
+
+        propagator.extract(carrier)
+
+        assert.deepStrictEqual(getAllBaggageItems(), {})
+      })
+
+      it('should silently drop carrier baggage that targets Object.prototype.__proto__', () => {
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: '__proto__=poison,foo=bar',
+        }
+
+        propagator.extract(carrier)
+
+        const baggageItems = getAllBaggageItems()
+        assert.strictEqual(Object.getOwnPropertyDescriptor(baggageItems, '__proto__'), undefined)
+        assert.strictEqual(Object.getPrototypeOf(baggageItems), Object.prototype)
+        assert.deepStrictEqual({ ...baggageItems }, { foo: 'bar' })
+      })
+
+      it('should join multi-value baggage headers from array carriers', () => {
+        // Lambda hands repeated headers in via `event.multiValueHeaders` as `string[]`.
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: ['userId=alice', 'serverNode=DF%2028,isProduction=false'],
+        }
+
+        propagator.extract(carrier)
+
+        assert.deepStrictEqual(getAllBaggageItems(), {
+          userId: 'alice',
+          serverNode: 'DF 28',
+          isProduction: 'false',
+        })
+      })
+
+      it('should ignore an empty array carrier baggage header', () => {
+        setBaggageItem('stale', 'leftover')
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: [],
+        }
+
+        propagator.extract(carrier)
+
+        assert.deepStrictEqual(getAllBaggageItems(), {})
+      })
+
+      it('should freeze the extracted baggage store so readers cannot mutate it', () => {
+        const carrier = {
+          'x-datadog-trace-id': '123',
+          'x-datadog-parent-id': '456',
+          baggage: 'foo=bar',
+        }
+
+        propagator.extract(carrier)
+
+        const baggageItems = getAllBaggageItems()
+        assert.ok(Object.isFrozen(baggageItems))
+        assert.throws(() => { baggageItems.foo = 'tampered' }, TypeError)
+        assert.throws(() => { baggageItems.added = 'value' }, TypeError)
+      })
     })
 
     it('should create span links when traces have inconsistent traceids', () => {


### PR DESCRIPTION
The extract path didn't share the inject path's `baggageMaxItems` / `baggageMaxBytes` caps, so it walked every entry of the peer header and committed each one through a `setBaggageItem` spread plus one AsyncLocalStorage `enterWith` per item. It also threw on `string[]` carriers like AWS Lambda's `event.multiValueHeaders`.

Mirror the inject-side caps, join multi-value carriers per W3C Baggage 3.5, and commit extracted entries through a new `setAllBaggageItems` helper the OpenTelemetry bridge also consumes. The helper freezes the store in place to match `baggage.js`'s existing immutability invariant.


