### PR TITLE
perf(propagation): rewrite tracestate parser to be linear

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/tracestate.js
+++ b/packages/dd-trace/src/opentracing/propagation/tracestate.js
@@ -1,19 +1,45 @@
 'use strict'
 
-const traceStateRegex = /[ \t]*([^=]+)=([ \t]*[^, \t]+)[ \t]*(,|$)/gim
-const traceStateDataRegex = /([^:]+):([^;]+)(;|$)/gim
+// W3C Trace Context §3.3.1.2: max 32 list-members.
+// https://www.w3.org/TR/trace-context/#tracestate-header-field-values
+const MAX_LIST_MEMBERS = 32
+const WHITESPACE = /[ \t]/
 
-function fromString (Type, regex, value) {
+/**
+ * Parse a separator-delimited string into key/value entries.
+ *
+ * @param {string} value
+ * @param {string} fieldSeparator Between entries.
+ * @param {string} pairSeparator Between key and value within an entry.
+ * @param {boolean} rejectValueWhitespace Drop entries whose value contains internal whitespace.
+ * @returns {[string, string][]} Entries in reverse of wire order.
+ */
+function parseEntries (value, fieldSeparator, pairSeparator, rejectValueWhitespace) {
+  const segments = value.split(fieldSeparator)
+  segments.length = Math.min(segments.length, MAX_LIST_MEMBERS)
+
+  const entries = []
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index]
+    const splitIndex = segment.indexOf(pairSeparator)
+    if (splitIndex === -1) continue
+    const key = segment.slice(0, splitIndex).trim()
+    if (!key || WHITESPACE.test(key)) continue
+    const entryValue = segment.slice(splitIndex + 1).trim()
+    if (!entryValue || rejectValueWhitespace && WHITESPACE.test(entryValue)) continue
+    entries.push([key, entryValue])
+  }
+  // Reverse so the Map's insertion order is reverse of wire order. `toString`
+  // prepends as it iterates, which yields the original wire order back.
+  entries.reverse()
+  return entries
+}
+
+function fromString (Type, value, fieldSeparator, pairSeparator, rejectValueWhitespace) {
   if (typeof value !== 'string' || !value.length) {
     return new Type()
   }
-
-  const values = []
-  for (const row of value.matchAll(regex)) {
-    values.unshift(row.slice(1, 3))
-  }
-
-  return new Type(values)
+  return new Type(parseEntries(value, fieldSeparator, pairSeparator, rejectValueWhitespace))
 }
 
 function toString (map, pairSeparator, fieldSeparator) {
@@ -52,7 +78,7 @@ class TraceStateData extends Map {
   }
 
   static fromString (value) {
-    return fromString(TraceStateData, traceStateDataRegex, value)
+    return fromString(TraceStateData, value, ';', ':', false)
   }
 
   toString () {
@@ -92,7 +118,7 @@ class TraceState extends Map {
   }
 
   static fromString (value) {
-    return fromString(TraceState, traceStateRegex, value)
+    return fromString(TraceState, value, ',', '=', true)
   }
 
   toString () {

--- a/packages/dd-trace/src/opentracing/propagation/tracestate.js
+++ b/packages/dd-trace/src/opentracing/propagation/tracestate.js
@@ -27,8 +27,9 @@ function parseEntries (value, fieldSeparator, pairSeparator, rejectValueTabs) {
     if (splitIndex === -1) continue
     const key = segment.slice(0, splitIndex).trim()
     if (!key || WHITESPACE.test(key)) continue
-    const entryValue = segment.slice(splitIndex + 1).trim()
-    // W3C §3.3.1.3.2: chr = %x20 / nblk-chr; tab is in neither, but space is.
+    // W3C §3.3.1.3.2: value = 0*255(chr) nblk-chr; chr = %x20 / nblk-chr (no tab).
+    // Leading 0x20 is part of value; trailing whitespace is OWS.
+    const entryValue = segment.slice(splitIndex + 1).trimEnd()
     if (!entryValue || rejectValueTabs && entryValue.includes('\t')) continue
     entries.push([key, entryValue])
   }

--- a/packages/dd-trace/src/opentracing/propagation/tracestate.js
+++ b/packages/dd-trace/src/opentracing/propagation/tracestate.js
@@ -11,10 +11,10 @@ const WHITESPACE = /[ \t]/
  * @param {string} value
  * @param {string} fieldSeparator Between entries.
  * @param {string} pairSeparator Between key and value within an entry.
- * @param {boolean} rejectValueWhitespace Drop entries whose value contains internal whitespace.
+ * @param {boolean} rejectValueTabs Drop entries whose value contains an internal tab.
  * @returns {[string, string][]} Entries in reverse of wire order.
  */
-function parseEntries (value, fieldSeparator, pairSeparator, rejectValueWhitespace) {
+function parseEntries (value, fieldSeparator, pairSeparator, rejectValueTabs) {
   const segments = value.split(fieldSeparator)
   segments.length = Math.min(segments.length, MAX_LIST_MEMBERS)
 
@@ -28,7 +28,8 @@ function parseEntries (value, fieldSeparator, pairSeparator, rejectValueWhitespa
     const key = segment.slice(0, splitIndex).trim()
     if (!key || WHITESPACE.test(key)) continue
     const entryValue = segment.slice(splitIndex + 1).trim()
-    if (!entryValue || rejectValueWhitespace && WHITESPACE.test(entryValue)) continue
+    // W3C §3.3.1.3.2: chr = %x20 / nblk-chr; tab is in neither, but space is.
+    if (!entryValue || rejectValueTabs && entryValue.includes('\t')) continue
     entries.push([key, entryValue])
   }
   // Reverse so the Map's insertion order is reverse of wire order. `toString`
@@ -37,11 +38,11 @@ function parseEntries (value, fieldSeparator, pairSeparator, rejectValueWhitespa
   return entries
 }
 
-function fromString (Type, value, fieldSeparator, pairSeparator, rejectValueWhitespace) {
+function fromString (Type, value, fieldSeparator, pairSeparator, rejectValueTabs) {
   if (typeof value !== 'string' || !value.length) {
     return new Type()
   }
-  return new Type(parseEntries(value, fieldSeparator, pairSeparator, rejectValueWhitespace))
+  return new Type(parseEntries(value, fieldSeparator, pairSeparator, rejectValueTabs))
 }
 
 function toString (map, pairSeparator, fieldSeparator) {

--- a/packages/dd-trace/src/opentracing/propagation/tracestate.js
+++ b/packages/dd-trace/src/opentracing/propagation/tracestate.js
@@ -18,6 +18,8 @@ function parseEntries (value, fieldSeparator, pairSeparator, rejectValueWhitespa
   const segments = value.split(fieldSeparator)
   segments.length = Math.min(segments.length, MAX_LIST_MEMBERS)
 
+  // TODO: We should extract dd no matter at what position and move it to the front of the list.
+  // Extract up 31 additional entries.
   const entries = []
   for (let index = 0; index < segments.length; index++) {
     const segment = segments[index]

--- a/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
@@ -97,6 +97,11 @@ describe('TraceState', () => {
     assert.strictEqual(ts.size, 32)
   })
 
+  it('should accept internal spaces but drop tabs in tracestate values per W3C Trace Context §3.3.1.3.2', () => {
+    const ts = TraceState.fromString('a=hello world,b=bye\tworld,c=ok')
+    assert.strictEqual(ts.toString(), 'a=hello world,c=ok')
+  })
+
   it('should ignore non-conformant input that contains no list-members', () => {
     const ts = TraceState.fromString('a'.repeat(16_000))
     assert.strictEqual(ts.size, 0)

--- a/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
@@ -102,6 +102,13 @@ describe('TraceState', () => {
     assert.strictEqual(ts.toString(), 'a=hello world,c=ok')
   })
 
+  it('should preserve leading 0x20 but strip trailing whitespace per W3C Trace Context §3.3.1.3.2', () => {
+    // value = 0*255(chr) nblk-chr; chr includes 0x20, so the first character can be a space.
+    // Trailing whitespace is OWS around the comma (or header end), not part of the value.
+    const ts = TraceState.fromString('a= leading,b=trailing ,c=ok')
+    assert.strictEqual(ts.toString(), 'a= leading,b=trailing,c=ok')
+  })
+
   it('should ignore non-conformant input that contains no list-members', () => {
     const ts = TraceState.fromString('a'.repeat(16_000))
     assert.strictEqual(ts.size, 0)

--- a/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/tracestate.spec.js
@@ -90,4 +90,15 @@ describe('TraceState', () => {
     // Vendor key should move to the front on modification
     assert.strictEqual(ts.toString(), 'other=bleh')
   })
+
+  it('should cap parsing at 32 list-members per W3C Trace Context §3.3.1.2', () => {
+    const header = Array.from({ length: 33 }, (_, index) => `k${index}=v${index}`).join(',')
+    const ts = TraceState.fromString(header)
+    assert.strictEqual(ts.size, 32)
+  })
+
+  it('should ignore non-conformant input that contains no list-members', () => {
+    const ts = TraceState.fromString('a'.repeat(16_000))
+    assert.strictEqual(ts.size, 0)
+  })
 })


### PR DESCRIPTION
Refs: https://www.w3.org/TR/trace-context/#tracestate-header-field-values

