### PR TITLE
pin node version to 24.14.1 for windows in ci

### DIFF
--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -72,7 +72,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
         with:
           cache: "true"

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -75,7 +75,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
         with:
           cache: "true"

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -79,7 +79,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
         with:
           cache: "true"

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -98,7 +98,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
         with:
           cache: "true"

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -84,7 +84,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
         with:
           cache: "true"


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin Node version to 24.24.1 for Windows in CI.

### Motivation
<!-- What inspired you to submit this pull request? -->

The current theory is that we're hitting this issue: https://github.com/nodejs/node/issues/62991. If that is the case, then pinning Node should mitigate the issue in our CI until a fix lands in Node.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


