### PR TITLE
feat(test-optimization)!: default Nx and Lage names

### DIFF
--- a/packages/dd-trace/src/ci-visibility/lage.js
+++ b/packages/dd-trace/src/ci-visibility/lage.js
@@ -2,6 +2,7 @@
 
 const { getEnvironmentVariable } = require('../config/helper')
 const { isTrue } = require('../util')
+const { DD_MAJOR } = require('../../../../version')
 
 /**
  * Returns the current Lage package name if the Lage package name override is enabled.
@@ -9,7 +10,7 @@ const { isTrue } = require('../util')
  * @returns {string|undefined}
  */
 function getLagePackageName () {
-  if (!isTrue(getEnvironmentVariable('DD_ENABLE_LAGE_PACKAGE_NAME'))) {
+  if (DD_MAJOR < 6 && !isTrue(getEnvironmentVariable('DD_ENABLE_LAGE_PACKAGE_NAME'))) {
     return
   }
 

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -513,7 +513,7 @@ class Config extends ConfigBase {
       } else {
         const NX_TASK_TARGET_PROJECT = getEnvironmentVariable('NX_TASK_TARGET_PROJECT')
         if (NX_TASK_TARGET_PROJECT) {
-          if (this.DD_ENABLE_NX_SERVICE_NAME) {
+          if (DD_MAJOR >= 6 || this.DD_ENABLE_NX_SERVICE_NAME) {
             setAndTrack(this, 'service', normalizeService(NX_TASK_TARGET_PROJECT) || 'node')
             isServiceNameInferred = true
           } else if (DD_MAJOR < 6) {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -53,7 +53,11 @@ describe('Config', () => {
   }
 
   // Reload the config module with each call to getConfig to ensure we get a new instance of the config.
-  const getConfig = (options) => {
+  const getConfig = (options, overrides = {}) => {
+    const {
+      ddMajor = DD_MAJOR,
+    } = overrides
+
     log = proxyquire('../../src/log', {})
     sinon.spy(log, 'info')
     sinon.spy(log, 'warn')
@@ -77,6 +81,7 @@ describe('Config', () => {
       'node:fs': fs,
       './helper': configHelper,
       '../pkg': pkg,
+      '../../../../version': { DD_MAJOR: ddMajor },
     })(options)
   }
 
@@ -3904,7 +3909,7 @@ rules:
       assert.strictEqual(config.service, 'explicit-service')
     })
 
-    it('should not use NX_TASK_TARGET_PROJECT when DD_ENABLE_NX_SERVICE_NAME is falsy', () => {
+    it('should use NX_TASK_TARGET_PROJECT by default in v6', () => {
       const cases = ['false', '0', undefined]
 
       for (const ddIsNx of cases) {
@@ -3917,7 +3922,26 @@ rules:
         process.env.NX_TASK_TARGET_PROJECT = 'my-nx-project'
         pkg.name = 'default-service'
 
-        const config = getConfig()
+        const config = getConfig(undefined, { ddMajor: 6 })
+
+        assert.strictEqual(config.service, 'my-nx-project')
+      }
+    })
+
+    it('should not use NX_TASK_TARGET_PROJECT when DD_ENABLE_NX_SERVICE_NAME is falsy in v5', () => {
+      const cases = ['false', '0', undefined]
+
+      for (const ddIsNx of cases) {
+        if (ddIsNx === undefined) {
+          delete process.env.DD_ENABLE_NX_SERVICE_NAME
+        } else {
+          process.env.DD_ENABLE_NX_SERVICE_NAME = ddIsNx
+        }
+
+        process.env.NX_TASK_TARGET_PROJECT = 'my-nx-project'
+        pkg.name = 'default-service'
+
+        const config = getConfig(undefined, { ddMajor: 5 })
 
         assert.strictEqual(config.service, 'default-service')
         assert.notStrictEqual(config.service, 'my-nx-project')
@@ -3954,24 +3978,31 @@ rules:
       assert.strictEqual(config.service, 'node')
     })
 
-    it('should warn about v6 behavior change when NX_TASK_TARGET_PROJECT is set without explicit config', () => {
+    it('should warn about v6 behavior change in v5 when NX_TASK_TARGET_PROJECT is set without explicit config', () => {
       process.env.NX_TASK_TARGET_PROJECT = 'my-nx-project'
       delete process.env.DD_ENABLE_NX_SERVICE_NAME
       delete process.env.DD_SERVICE
       pkg.name = 'default-service'
 
-      getConfig()
+      getConfig(undefined, { ddMajor: 5 })
 
-      if (DD_MAJOR < 6) {
-        assert.strictEqual(log.warn.called, true)
-        const warningMessage = log.warn.args[0][0]
-        assert.match(warningMessage, /NX_TASK_TARGET_PROJECT is set but no service name was configured/)
-        assert.match(warningMessage, /In v6, NX_TASK_TARGET_PROJECT will be used as the default service name/)
-        assert.match(warningMessage, /Set DD_ENABLE_NX_SERVICE_NAME=true to opt-in/)
-      } else {
-        // In v6+, no warning should be issued
-        assert.strictEqual(log.warn.called, false)
-      }
+      assert.strictEqual(log.warn.called, true)
+      const warningMessage = log.warn.args[0][0]
+      assert.match(warningMessage, /NX_TASK_TARGET_PROJECT is set but no service name was configured/)
+      assert.match(warningMessage, /In v6, NX_TASK_TARGET_PROJECT will be used as the default service name/)
+      assert.match(warningMessage, /Set DD_ENABLE_NX_SERVICE_NAME=true to opt-in/)
+    })
+
+    it('should not warn in v6 when NX_TASK_TARGET_PROJECT is set without explicit config', () => {
+      process.env.NX_TASK_TARGET_PROJECT = 'my-nx-project'
+      delete process.env.DD_ENABLE_NX_SERVICE_NAME
+      delete process.env.DD_SERVICE
+      pkg.name = 'default-service'
+
+      const config = getConfig(undefined, { ddMajor: 6 })
+
+      assert.strictEqual(config.service, 'my-nx-project')
+      assert.strictEqual(log.warn.called, false)
     })
 
     it('should not warn when DD_ENABLE_NX_SERVICE_NAME is explicitly set', () => {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -120,6 +120,22 @@ describe('getTestSessionName', () => {
 
     assert.strictEqual(getTestSessionName({}, 'jest', {}), 'lage-package-b')
   })
+
+  it('returns the current Lage package name by default in v6', () => {
+    process.env.LAGE_PACKAGE_NAME = 'lage-package'
+
+    assert.strictEqual(getTestSessionName({}, 'jest', {}), 'lage-package')
+  })
+
+  it('does not return the current Lage package name by default in v5', () => {
+    process.env.LAGE_PACKAGE_NAME = 'lage-package'
+
+    const { getLageTestSessionName } = proxyquire.noPreserveCache()('../../../src/ci-visibility/lage', {
+      '../../../../version': { DD_MAJOR: 5 },
+    })
+
+    assert.strictEqual(getLageTestSessionName(), undefined)
+  })
 })
 
 describe('attempt to fix summary', () => {

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -90,6 +90,16 @@ describe('getTestSuitePath', () => {
 describe('getTestSessionName', () => {
   let originalEnv
 
+  function getTestSessionNameWithMajor (ddMajor) {
+    const lage = proxyquire.noPreserveCache()('../../../src/ci-visibility/lage', {
+      '../../../../version': { DD_MAJOR: ddMajor },
+    })
+
+    return proxyquire.noPreserveCache()('../../../src/plugins/util/test', {
+      '../../ci-visibility/lage': lage,
+    }).getTestSessionName
+  }
+
   beforeEach(() => {
     originalEnv = { ...process.env }
     delete process.env.DD_ENABLE_LAGE_PACKAGE_NAME
@@ -123,18 +133,16 @@ describe('getTestSessionName', () => {
 
   it('returns the current Lage package name by default in v6', () => {
     process.env.LAGE_PACKAGE_NAME = 'lage-package'
+    const getTestSessionName = getTestSessionNameWithMajor(6)
 
     assert.strictEqual(getTestSessionName({}, 'jest', {}), 'lage-package')
   })
 
   it('does not return the current Lage package name by default in v5', () => {
     process.env.LAGE_PACKAGE_NAME = 'lage-package'
+    const getTestSessionName = getTestSessionNameWithMajor(5)
 
-    const { getLageTestSessionName } = proxyquire.noPreserveCache()('../../../src/ci-visibility/lage', {
-      '../../../../version': { DD_MAJOR: 5 },
-    })
-
-    assert.strictEqual(getLageTestSessionName(), undefined)
+    assert.strictEqual(getTestSessionName({}, 'jest', {}), 'jest')
   })
 })
 


### PR DESCRIPTION
### What does this PR do?
Makes v6 use `NX_TASK_TARGET_PROJECT` as the default service name when no service is explicitly configured, and `LAGE_PACKAGE_NAME` as the default test session name when `DD_TEST_SESSION_NAME` is not set.

v5 behavior stays opt-in through `DD_ENABLE_NX_SERVICE_NAME` and `DD_ENABLE_LAGE_PACKAGE_NAME`.

### Motivation
These opt-in env vars were added to avoid breaking existing customers. v6 can take the breaking default behavior while keeping v5 compatible.

