### PR TITLE
fix(propagation): tighten W3C trace-context inject and extract correc…

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -538,8 +538,9 @@ class TextMapPropagator {
       const [, version, traceId, spanId, flags, tail] = matches
       const traceparent = { version }
       // W3C Trace Context §3.3.1.1: multiple tracestate fields MUST be combined per RFC 7230 §3.2.2.
+      // `filter` drops non-string members (Symbol, throwing-toString) that would crash `join`.
       const rawTracestate = Array.isArray(carrier.tracestate)
-        ? carrier.tracestate.join(',')
+        ? carrier.tracestate.filter(item => typeof item === 'string').join(',')
         : carrier.tracestate
       const tracestate = TraceState.fromString(rawTracestate)
       if (invalidSegment.test(traceId)) return null

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -299,7 +299,7 @@ class TextMapPropagator {
     const {
       _sampling: { priority, mechanism },
       _tracestate: ts = new TraceState(),
-      _trace: { origin, tags },
+      _trace: { origin, tags: traceTags },
     } = spanContext
 
     carrier[traceparentKey] = spanContext.toTraceparent()
@@ -326,8 +326,8 @@ class TextMapPropagator {
         state.set('o', originValue)
       }
 
-      for (const key of Object.keys(tags)) {
-        const tagValueRaw = tags[key]
+      for (const key of Object.keys(traceTags)) {
+        const tagValueRaw = traceTags[key]
         if (!tagValueRaw || !key.startsWith('_dd.p.')) continue
 
         const tagKey = 't.' + key.slice(6)
@@ -530,14 +530,18 @@ class TextMapPropagator {
 
   _extractTraceparentContext (carrier) {
     const headerValue = carrier[traceparentKey]
-    if (!headerValue) {
+    if (typeof headerValue !== 'string') {
       return null
     }
     const matches = headerValue.trim().match(traceparentExpr)
-    if (matches?.length) {
-      const [version, traceId, spanId, flags, tail] = matches.slice(1)
+    if (matches !== null) {
+      const [, version, traceId, spanId, flags, tail] = matches
       const traceparent = { version }
-      const tracestate = TraceState.fromString(carrier.tracestate)
+      // W3C Trace Context §3.3.1.1: multiple tracestate fields MUST be combined per RFC 7230 §3.2.2.
+      const rawTracestate = Array.isArray(carrier.tracestate)
+        ? carrier.tracestate.join(',')
+        : carrier.tracestate
+      const tracestate = TraceState.fromString(rawTracestate)
       if (invalidSegment.test(traceId)) return null
       if (invalidSegment.test(spanId)) return null
 
@@ -551,7 +555,7 @@ class TextMapPropagator {
         traceId: id(traceId, 16),
         spanId: id(spanId, 16),
         isRemote: true,
-        sampling: { priority: Number.parseInt(flags, 10) & 1 ? 1 : 0 },
+        sampling: { priority: Number.parseInt(flags, 16) & 1 ? 1 : 0 },
         traceparent,
         tracestate,
       })
@@ -577,7 +581,7 @@ class TextMapPropagator {
               break
             }
             case 'o':
-              spanContext._trace.origin = value
+              spanContext._trace.origin = value.replaceAll('~', '=')
               break
             case 't.dm': {
               const mechanism = Math.abs(Number.parseInt(value, 10))

--- a/packages/dd-trace/src/opentracing/propagation/tracestate.js
+++ b/packages/dd-trace/src/opentracing/propagation/tracestate.js
@@ -15,8 +15,7 @@ const WHITESPACE = /[ \t]/
  * @returns {[string, string][]} Entries in reverse of wire order.
  */
 function parseEntries (value, fieldSeparator, pairSeparator, rejectValueTabs) {
-  const segments = value.split(fieldSeparator)
-  segments.length = Math.min(segments.length, MAX_LIST_MEMBERS)
+  const segments = value.split(fieldSeparator, MAX_LIST_MEMBERS)
 
   // TODO: We should extract dd no matter at what position and move it to the front of the list.
   // Extract up 31 additional entries.

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -1665,6 +1665,34 @@ describe('TextMapPropagator', () => {
         assert.strictEqual(spanContext._tracestate.get('vendor2'), 'value2')
       })
 
+      it('should ignore non-string members when extracting array-valued tracestate', () => {
+        textMap.traceparent = '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
+        textMap.tracestate = [
+          Symbol('x'),
+          'dd=s:1',
+          { toString () { throw new Error('boom') } },
+        ]
+        config.tracePropagationStyle.extract = ['tracecontext']
+
+        const spanContext = propagator.extract(textMap)
+        assert.strictEqual(spanContext._traceId.toString(16), '1111aaaa2222bbbb3333cccc4444dddd')
+        assert.strictEqual(spanContext._spanId.toString(16), '5555eeee6666ffff')
+        assert.strictEqual(spanContext._sampling.priority, 1)
+        assert.strictEqual(spanContext._tracestate.get('dd'), 's:1')
+      })
+
+      it('should extract a valid context when array-valued tracestate has only non-string members', () => {
+        textMap.traceparent = '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
+        textMap.tracestate = [Symbol('x'), 42, { toString () { throw new Error('nope') } }]
+        config.tracePropagationStyle.extract = ['tracecontext']
+
+        const spanContext = propagator.extract(textMap)
+        assert.strictEqual(spanContext._traceId.toString(16), '1111aaaa2222bbbb3333cccc4444dddd')
+        assert.strictEqual(spanContext._spanId.toString(16), '5555eeee6666ffff')
+        assert.strictEqual(spanContext._sampling.priority, 1)
+        assert.strictEqual(spanContext._tracestate.size, 0)
+      })
+
       it('should ignore non-string traceparent values without crashing', () => {
         config.tracePropagationStyle.extract = ['tracecontext']
         for (const value of [['00-bad'], { foo: 'bar' }, 42, true]) {

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -1622,6 +1622,56 @@ describe('TextMapPropagator', () => {
         assert.strictEqual(spanContext._trace.tags['_dd.p.tid'], '1111aaaa2222bbbb')
       })
 
+      it('should derive sampled bit from base-16 trace-flags per W3C §3.2.2.5', () => {
+        // Sampled bit is the lower-nibble parity of the byte. Pin every
+        // lower-nibble outcome plus upper nibbles that defeat base-10
+        // parseInt: 1a-1f makes it stop after the leading digit, a-f as
+        // upper nibble makes it return NaN.
+        const cases = [
+          ['00', 0], ['01', 1], ['02', 0], ['03', 1], ['04', 0], ['05', 1],
+          ['06', 0], ['07', 1], ['08', 0], ['09', 1],
+          ['0a', 0], ['0b', 1], ['0c', 0], ['0d', 1], ['0e', 0], ['0f', 1],
+          ['1a', 0], ['1c', 0], ['1e', 0], ['1f', 1],
+          ['ab', 1], ['cd', 1], ['fe', 0], ['ff', 1],
+        ]
+        config.tracePropagationStyle.extract = ['tracecontext']
+        for (const [flags, sampled] of cases) {
+          const carrier = { traceparent: `00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-${flags}` }
+          const spanContext = propagator.extract(carrier)
+          assert.strictEqual(spanContext._sampling.priority, sampled, `flags=${flags}`)
+        }
+      })
+
+      it('should round-trip origin = through tracestate ~ encoding', () => {
+        textMap.traceparent = '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
+        textMap.tracestate = 'dd=o:foo~bar'
+        config.tracePropagationStyle.extract = ['tracecontext']
+
+        const carrier = {}
+        const spanContext = propagator.extract(textMap)
+        assert.strictEqual(spanContext._trace.origin, 'foo=bar')
+
+        propagator.inject(spanContext, carrier)
+        assert.match(carrier.tracestate, /o:foo~bar/)
+      })
+
+      it('should combine array-valued tracestate per W3C §3.3.1.1 / RFC 7230 §3.2.2', () => {
+        textMap.traceparent = '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01'
+        textMap.tracestate = ['vendor1=value1', 'vendor2=value2']
+        config.tracePropagationStyle.extract = ['tracecontext']
+
+        const spanContext = propagator.extract(textMap)
+        assert.strictEqual(spanContext._tracestate.get('vendor1'), 'value1')
+        assert.strictEqual(spanContext._tracestate.get('vendor2'), 'value2')
+      })
+
+      it('should ignore non-string traceparent values without crashing', () => {
+        config.tracePropagationStyle.extract = ['tracecontext']
+        for (const value of [['00-bad'], { foo: 'bar' }, 42, true]) {
+          assert.strictEqual(propagator.extract({ traceparent: value }), null)
+        }
+      })
+
       it('should skip extracting upper bits for 64-bit trace IDs', () => {
         textMap.traceparent = '00-00000000000000003333cccc4444dddd-5555eeee6666ffff-01'
         config.tracePropagationStyle.extract = ['tracecontext']
@@ -1675,6 +1725,22 @@ describe('TextMapPropagator', () => {
         propagator.inject(spanContext, carrier)
 
         assert.match(carrier.tracestate, /p:4444eeee6666aaaa/)
+      })
+
+      it('should propagate last datadog id from _dd.parent_id when tracestate has no p entry', () => {
+        textMap['x-datadog-trace-id'] = '61185'
+        textMap['x-datadog-parent-id'] = '15'
+        textMap.traceparent = '00-0000000000000000000000000000ef01-0000000000011ef0-01'
+        config.tracePropagationStyle.extract = ['datadog', 'tracecontext']
+
+        const carrier = {}
+        const spanContext = propagator.extract(textMap)
+        assert.strictEqual(spanContext._isRemote, true)
+        assert.strictEqual(spanContext._trace.tags['_dd.parent_id'], '000000000000000f')
+
+        propagator.inject(spanContext, carrier)
+
+        assert.match(carrier.tracestate, /dd=[^,]*p:000000000000000f/)
       })
 
       it('should fix _dd.p.dm if invalid (non-hyphenated) input is received', () => {


### PR DESCRIPTION
…tness

Five corner cases in the W3C trace-context propagator silently dropped or corrupted data on inject and extract.

1. `_injectTraceparent` destructured `_trace: { origin, tags }`, shadowing the module-level `tags` constant; `tags.DD_PARENT_ID` then resolved against the trace-tags object (`undefined`) instead of `_dd.parent_id`, so the remote-span `state.set('p', ...)` branch never fired. The bug was masked by the tracestate round-trip and surfaced when `_resolveTraceContextConflicts` set `_dd.parent_id` from datadog headers without a corresponding `p:` entry in tracestate. Rename the destructured binding to `traceTags`.

2. W3C §3.2.2.5: `trace-flags` is hex. `Number.parseInt(flags, 10) & 1` miscomputes the sampled bit whenever the lower nibble is `b`/`d`/`f` (parseInt returns 0) or whenever any nibble is in `a..f` (parseInt returns `NaN`). Concrete misreads include `0b`/`0d`/`0f` (sampled=1, returned 0), `1a`/`1c`/`1e` (sampled=0, returned 1), and `ab`/`ff`.

3. Inject encodes the origin's `=` as `~` because W3C §3.3.1.3.2 excludes `=` from the value grammar; the `t.<tag>` extract path reverses this, the `case 'o':` arm did not, so `=` characters in custom origins were silently lost across hops. Mirror the tag-value decode.

4. W3C §3.3.1.1 / RFC 7230 §3.2.2: receivers MUST combine multiple `tracestate` header fields. Array-preserving carriers can surface `carrier.tracestate` as a string array; `TraceState.fromString` rejected non-strings and returned an empty state, dropping every vendor entry past the first header. Join the array on `,`.

5. `_extractTraceparentContext` did `if (!headerValue) return null` and then `headerValue.trim().match(...)`, throwing `TypeError` whenever the carrier surfaced `traceparent` as a non-string. Switch the guard to `typeof !== 'string'`.

Drive-by fix:

* `String#match` returns `null` or a non-empty array, so `matches?.length` is a no-op guard and `matches.slice(1)` allocates a 5-element array purely to skip the full-match capture. Destructure with a leading hole and check `matches !== null`.
