### PR TITLE
[test optimization] Use head SHA for test optimization dispatch

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -34,6 +34,8 @@ jobs:
         run: yarn bench:e2e:test-optimization
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          TEST_ENVIRONMENT_REF_TO_TEST: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          TEST_ENVIRONMENT_REF_NAME: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
 
   integration:
     strategy:

--- a/benchmark/e2e-test-optimization/benchmark-run.js
+++ b/benchmark/e2e-test-optimization/benchmark-run.js
@@ -41,13 +41,16 @@ const parseGitHubJsonResponse = ({ body, endpoint, res }) => {
   }
 }
 
-function getBranchUnderTest () {
-  /**
-   * GITHUB_HEAD_REF is only set for `pull_request` events
-   * GITHUB_REF_NAME is used for `push` events
-   * More info in: https://docs.github.com/en/actions/learn-github-actions/environment-variables
-   */
-  return process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF_NAME
+function getRefToTest () {
+  if (!process.env.TEST_ENVIRONMENT_REF_TO_TEST) {
+    throw new Error('TEST_ENVIRONMENT_REF_TO_TEST is required to trigger test-environment')
+  }
+
+  return process.env.TEST_ENVIRONMENT_REF_TO_TEST
+}
+
+function getRefName () {
+  return process.env.TEST_ENVIRONMENT_REF_NAME || getRefToTest()
 }
 
 const getCommonHeaders = () => {
@@ -60,13 +63,13 @@ const getCommonHeaders = () => {
 }
 
 const triggerWorkflow = () => {
-  console.log(`Branch under test: ${getBranchUnderTest()}`)
+  console.log(`Commit SHA under test: ${getRefToTest()} in ${getRefName()}`)
   return new Promise((resolve, reject) => {
     // eslint-disable-next-line
     let response = ''
     const body = JSON.stringify({
       ref: 'main',
-      inputs: { branch: getBranchUnderTest() },
+      inputs: { sha: getRefToTest() },
     })
     const request = https.request(
       DISPATCH_WORKFLOW_URL,


### PR DESCRIPTION
### What does this PR do?
- Pass the ref to test and its display name explicitly into the e2e test optimization benchmark runner.
- Use the pull request head SHA for PR runs and `github.sha` for non-PR runs.
- Dispatch the benchmark target with that SHA instead of deriving the ref inside `benchmark-run.js` from GitHub environment variables.

### Motivation
The benchmark target installs `dd-trace` from the ref it receives. When that ref is a mutable branch name, retries can resolve to a different commit, which can make failures hard to reproduce and create flaky behavior. Passing the head SHA makes the install target immutable and keeps retries consistent.

