### PR TITLE
chore(iast): Improve stringifyWithRanges performance

### DIFF
--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -9,7 +9,7 @@ const STRINGIFY_SENSITIVE_KEY = STRINGIFY_RANGE_KEY + 'SENSITIVE'
 const STRINGIFY_SENSITIVE_NOT_STRING_KEY = STRINGIFY_SENSITIVE_KEY + 'NOTSTRING'
 
 // eslint-disable-next-line @stylistic/max-len
-const REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING = new RegExp(String.raw`"${STRINGIFY_SENSITIVE_NOT_STRING_KEY}_\d+_([\s0-9.a-zA-Z]*)"`)
+const REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING = new RegExp(String.raw`"${STRINGIFY_SENSITIVE_NOT_STRING_KEY}_\d+_([\s\-+0-9.a-zA-Z]*)"`)
 const REGEX_FOR_STRINGIFY_SENSITIVE = new RegExp(String.raw`${STRINGIFY_SENSITIVE_KEY}_\d+_(\d+)_`)
 const REGEX_FOR_STRINGIFY_RANGE = new RegExp(String.raw`(${STRINGIFY_RANGE_KEY}_\d+_)`)
 
@@ -124,7 +124,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
           theRest = value.slice(rangeKeyIndex)
           const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING.exec(theRest)
 
-          if (regexRes.index === 0) {
+          if (regexRes?.index === 0) {
             const matchValue = regexRes[0]
             const originalValue = regexRes[1]
             const start = outputLength + cleanLength
@@ -145,7 +145,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
           }
         } else if (theRest.startsWith(STRINGIFY_SENSITIVE_KEY)) {
           const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE.exec(theRest)
-          if (regexRes.index === 0) {
+          if (regexRes?.index === 0) {
             const start = outputLength + cleanLength
 
             sensitiveRanges.push({
@@ -164,7 +164,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
           }
         } else {
           const regexRes = REGEX_FOR_STRINGIFY_RANGE.exec(theRest)
-          if (regexRes.index === 0) {
+          if (regexRes?.index === 0) {
             const start = outputLength + cleanLength
             const rangesId = regexRes[1]
 

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -154,7 +154,8 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
           value = value.replace(sensitiveId, originalValue)
         }
 
-        keysRegex.lastIndex = 0
+        // value was mutated by replace(), so resume from the last match start to avoid a stale lastIndex
+        keysRegex.lastIndex = regexRes.index
         regexRes = keysRegex.exec(value)
       }
     }

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -9,8 +9,9 @@ const STRINGIFY_SENSITIVE_KEY = STRINGIFY_RANGE_KEY + 'SENSITIVE'
 const STRINGIFY_SENSITIVE_NOT_STRING_KEY = STRINGIFY_SENSITIVE_KEY + 'NOTSTRING'
 
 // eslint-disable-next-line @stylistic/max-len
-const KEYS_REGEX_WITH_SENSITIVE_RANGES = new RegExp(String.raw`(?:"(${STRINGIFY_RANGE_KEY}_\d+_))|(?:"(${STRINGIFY_SENSITIVE_KEY}_\d+_(\d+)_))|("${STRINGIFY_SENSITIVE_NOT_STRING_KEY}_\d+_([\s0-9.a-zA-Z]*)")`, 'gm')
-const KEYS_REGEX_WITHOUT_SENSITIVE_RANGES = new RegExp(String.raw`"(${STRINGIFY_RANGE_KEY}_\d+_)`, 'gm')
+const REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING = new RegExp(String.raw`"${STRINGIFY_SENSITIVE_NOT_STRING_KEY}_\d+_([\s0-9.a-zA-Z]*)"`)
+const REGEX_FOR_STRINGIFY_SENSITIVE = new RegExp(String.raw`${STRINGIFY_SENSITIVE_KEY}_\d+_(\d+)_`)
+const REGEX_FOR_STRINGIFY_RANGE = new RegExp(String.raw`(${STRINGIFY_RANGE_KEY}_\d+_)`)
 
 const sensitiveValueRegex = new RegExp(/** @type {string} */ (defaults['iast.redactionValuePattern']), 'gmi')
 
@@ -41,7 +42,6 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
     let counter = 0
     const allRanges = {}
     const sensitiveKeysMapping = {}
-
     iterateObject(obj, (val, levelKeys, parent, key) => {
       let currentLevelClone = cloneObj
       for (let i = 0; i < levelKeys.length - 1; i++) {
@@ -108,56 +108,90 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
     value = JSON.stringify(cloneObj, null, 2)
 
     if (counter > 0) {
-      const keysRegex = loadSensitiveRanges
-        ? KEYS_REGEX_WITH_SENSITIVE_RANGES
-        : KEYS_REGEX_WITHOUT_SENSITIVE_RANGES
-      keysRegex.lastIndex = 0
+      const segments = []
+      let outputLength = 0
+      let pos = 0
+      const rangeKeyToFind = `${STRINGIFY_RANGE_KEY}`
+      let rangeKeyIndex = value.indexOf(rangeKeyToFind)
 
-      let regexRes = keysRegex.exec(value)
-      while (regexRes) {
-        const offset = regexRes.index + 1 // +1 to increase the " char
+      while (rangeKeyIndex > -1) {
+        let theRest = value.slice(rangeKeyIndex)
+        let cleanLength = rangeKeyIndex - pos
 
-        if (regexRes[1]) {
-          // is a range
-          const rangesId = regexRes[1]
-          value = value.replace(rangesId, '')
+        if (theRest.startsWith(STRINGIFY_SENSITIVE_NOT_STRING_KEY)) {
+          rangeKeyIndex--
+          cleanLength--
+          theRest = value.slice(rangeKeyIndex)
+          const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING.exec(theRest)
 
-          const updatedRanges = allRanges[rangesId].map(range => {
-            return {
+          if (regexRes.index === 0) {
+            const matchValue = regexRes[0]
+            const originalValue = regexRes[1]
+            const start = outputLength + cleanLength
+
+            sensitiveRanges.push({
+              start,
+              end: start + originalValue.length,
+            })
+            segments.push(value.slice(pos, rangeKeyIndex), originalValue)
+            outputLength += cleanLength + originalValue.length
+            pos = rangeKeyIndex + matchValue.length
+          } else {
+            // can't happen, the only way to this to happen is
+            // if the JSON has a value starting with the value of STRINGIFY_SENSITIVE_NOT_STRING_KEY
+            segments.push(value.slice(pos, rangeKeyIndex + STRINGIFY_SENSITIVE_NOT_STRING_KEY.length + 1))
+            outputLength += cleanLength + STRINGIFY_SENSITIVE_NOT_STRING_KEY.length + 1
+            pos = rangeKeyIndex + STRINGIFY_SENSITIVE_NOT_STRING_KEY.length + 1
+          }
+        } else if (theRest.startsWith(STRINGIFY_SENSITIVE_KEY)) {
+          const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE.exec(theRest)
+          if (regexRes.index === 0) {
+            const start = outputLength + cleanLength
+
+            sensitiveRanges.push({
+              start,
+              end: start + Number.parseInt(regexRes[1]),
+            })
+            segments.push(value.slice(pos, rangeKeyIndex))
+            outputLength += cleanLength
+            pos = rangeKeyIndex + regexRes[0].length
+          } else {
+            // can't happen, the only way to this to happen is
+            // if the JSON has a value starting with the value of STRINGIFY_SENSITIVE_KEY
+            segments.push(value.slice(pos, rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length))
+            outputLength += cleanLength + STRINGIFY_SENSITIVE_KEY.length
+            pos = rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length
+          }
+        } else {
+          const regexRes = REGEX_FOR_STRINGIFY_RANGE.exec(theRest)
+          if (regexRes.index === 0) {
+            const start = outputLength + cleanLength
+            const rangesId = regexRes[1]
+
+            const updatedRanges = allRanges[rangesId].map(range => ({
               ...range,
-              start: range.start + offset,
-              end: range.end + offset,
-            }
-          })
+              start: range.start + start,
+              end: range.end + start,
+            }))
+            ranges.push(...updatedRanges)
 
-          ranges.push(...updatedRanges)
-        } else if (regexRes[2]) {
-          // is a sensitive string literal
-          const sensitiveId = regexRes[2]
-
-          sensitiveRanges.push({
-            start: offset,
-            end: offset + Number.parseInt(regexRes[3]),
-          })
-
-          value = value.replace(sensitiveId, '')
-        } else if (regexRes[4]) {
-          // is a sensitive value (number, null, false, ...)
-          const sensitiveId = regexRes[4]
-          const originalValue = regexRes[5]
-
-          sensitiveRanges.push({
-            start: regexRes.index,
-            end: regexRes.index + originalValue.length,
-          })
-
-          value = value.replace(sensitiveId, originalValue)
+            segments.push(value.slice(pos, rangeKeyIndex))
+            outputLength += cleanLength
+            pos = rangeKeyIndex + regexRes[0].length
+          } else {
+            // can't happen, the only way to this to happen is
+            // if the JSON has a value starting with the value of STRINGIFY_RANGE_KEY
+            segments.push(value.slice(pos, rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length))
+            outputLength += cleanLength + STRINGIFY_SENSITIVE_KEY.length
+            pos = rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length
+          }
         }
 
-        // value was mutated by replace(), so resume from the last match start to avoid a stale lastIndex
-        keysRegex.lastIndex = regexRes.index
-        regexRes = keysRegex.exec(value)
+        rangeKeyIndex = value.indexOf(rangeKeyToFind, pos)
       }
+
+      segments.push(value.slice(pos))
+      value = segments.join('')
     }
   } else {
     value = JSON.stringify(obj, null, 2)

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -181,9 +181,10 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
           } else {
             // can't happen, the only way to this to happen is
             // if the JSON has a value starting with the value of STRINGIFY_RANGE_KEY
-            segments.push(value.slice(pos, rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length))
-            outputLength += cleanLength + STRINGIFY_SENSITIVE_KEY.length
-            pos = rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length
+            // if the JSON has a value starting with the value of STRINGIFY_RANGE_KEY
+            segments.push(value.slice(pos, rangeKeyIndex + STRINGIFY_RANGE_KEY.length))
+            outputLength += cleanLength + STRINGIFY_RANGE_KEY.length
+            pos = rangeKeyIndex + STRINGIFY_RANGE_KEY.length
           }
         }
 

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -111,18 +111,17 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
       const segments = []
       let outputLength = 0
       let pos = 0
-      const rangeKeyToFind = `${STRINGIFY_RANGE_KEY}`
-      let rangeKeyIndex = value.indexOf(rangeKeyToFind)
+      let rangeKeyIndex = value.indexOf(STRINGIFY_RANGE_KEY)
 
       while (rangeKeyIndex > -1) {
-        let theRest = value.slice(rangeKeyIndex)
+        let remainingStringValue = value.slice(rangeKeyIndex)
         let cleanLength = rangeKeyIndex - pos
 
-        if (theRest.startsWith(STRINGIFY_SENSITIVE_NOT_STRING_KEY)) {
+        if (remainingStringValue.startsWith(STRINGIFY_SENSITIVE_NOT_STRING_KEY)) {
           rangeKeyIndex--
           cleanLength--
-          theRest = value.slice(rangeKeyIndex)
-          const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING.exec(theRest)
+          remainingStringValue = value.slice(rangeKeyIndex)
+          const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE_NOT_STRING.exec(remainingStringValue)
 
           if (regexRes?.index === 0) {
             const matchValue = regexRes[0]
@@ -143,8 +142,8 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
             outputLength += cleanLength + STRINGIFY_SENSITIVE_NOT_STRING_KEY.length + 1
             pos = rangeKeyIndex + STRINGIFY_SENSITIVE_NOT_STRING_KEY.length + 1
           }
-        } else if (theRest.startsWith(STRINGIFY_SENSITIVE_KEY)) {
-          const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE.exec(theRest)
+        } else if (remainingStringValue.startsWith(STRINGIFY_SENSITIVE_KEY)) {
+          const regexRes = REGEX_FOR_STRINGIFY_SENSITIVE.exec(remainingStringValue)
           if (regexRes?.index === 0) {
             const start = outputLength + cleanLength
 
@@ -163,7 +162,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
             pos = rangeKeyIndex + STRINGIFY_SENSITIVE_KEY.length
           }
         } else {
-          const regexRes = REGEX_FOR_STRINGIFY_RANGE.exec(theRest)
+          const regexRes = REGEX_FOR_STRINGIFY_RANGE.exec(remainingStringValue)
           if (regexRes?.index === 0) {
             const start = outputLength + cleanLength
             const rangesId = regexRes[1]
@@ -188,7 +187,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
           }
         }
 
-        rangeKeyIndex = value.indexOf(rangeKeyToFind, pos)
+        rangeKeyIndex = value.indexOf(STRINGIFY_RANGE_KEY, pos)
       }
 
       segments.push(value.slice(pos))

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/utils.js
@@ -118,6 +118,7 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
         let cleanLength = rangeKeyIndex - pos
 
         if (remainingStringValue.startsWith(STRINGIFY_SENSITIVE_NOT_STRING_KEY)) {
+          // In this case, we want to remove also the previous " char, because the value is not an string
           rangeKeyIndex--
           cleanLength--
           remainingStringValue = value.slice(rangeKeyIndex)
@@ -179,7 +180,6 @@ function stringifyWithRanges (obj, objRanges, loadSensitiveRanges = false) {
             pos = rangeKeyIndex + regexRes[0].length
           } else {
             // can't happen, the only way to this to happen is
-            // if the JSON has a value starting with the value of STRINGIFY_RANGE_KEY
             // if the JSON has a value starting with the value of STRINGIFY_RANGE_KEY
             segments.push(value.slice(pos, rangeKeyIndex + STRINGIFY_RANGE_KEY.length))
             outputLength += cleanLength + STRINGIFY_RANGE_KEY.length

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -384,6 +384,32 @@ describe('test vulnerabiilty-formatter utils', () => {
           { start: 168, end: 178 },
         ])
       })
+
+      it('Big fully tainted object', () => {
+        const iinfo = { type: 'TEST' }
+        const src = {}
+        const ranges = {}
+
+        function fill (obj, path, depth) {
+          for (let i = 0; i < 6; i++) {
+            const key = `k${i}`
+            const currentPath = path ? `${path}.${key}` : key
+            if (depth === 1) {
+              obj[key] = 'abcdefghij'
+              ranges[currentPath] = [{ start: 0, end: 10, iinfo }]
+            } else {
+              obj[key] = {}
+              fill(obj[key], currentPath, depth - 1)
+            }
+          }
+        }
+
+        fill(src, '', 6)
+
+        const { value } = stringifyWithRanges(src, ranges, true)
+
+        assert.strictEqual(value, JSON.stringify(src, null, 2))
+      })
     })
   })
 })

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -187,7 +187,7 @@ describe('test vulnerabiilty-formatter utils', () => {
           trueKey: true,
           negativeNumberKey: -123,
           shortNumber: 1e-200,
-          longNumber: 1e+200
+          longNumber: 1e+200,
         }
 
         const { value, ranges, sensitiveRanges } = stringifyWithRanges(src, null, true)
@@ -203,7 +203,7 @@ describe('test vulnerabiilty-formatter utils', () => {
           { start: 93, end: 97 },
           { start: 122, end: 126 },
           { start: 145, end: 151 },
-          { start: 169, end: 175 }
+          { start: 169, end: 175 },
         ])
       })
 

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -203,7 +203,7 @@ describe('test vulnerabiilty-formatter utils', () => {
           { start: 93, end: 97 },
           { start: 122, end: 126 },
           { start: 145, end: 151 },
-          { start: 169, end: 175 },
+          { start: 169, end: 175 }
         ])
       })
 
@@ -402,7 +402,7 @@ describe('test vulnerabiilty-formatter utils', () => {
         const src = {}
         const ranges = {}
 
-        function fill(obj, path, depth) {
+        function fill (obj, path, depth) {
           for (let i = 0; i < 6; i++) {
             const key = `k${i}`
             const currentPath = path ? `${path}.${key}` : key

--- a/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
+++ b/packages/dd-trace/test/appsec/iast/vulnerability-formatter/utils.spec.js
@@ -179,7 +179,16 @@ describe('test vulnerabiilty-formatter utils', () => {
 
     describe('loadSensitiveRanges = true', () => {
       it('Undefined ranges', () => {
-        const src = { key: 'value', numberKey: 123, nullKey: null, falseKey: false, trueKey: true }
+        const src = {
+          key: 'value',
+          numberKey: 123,
+          nullKey: null,
+          falseKey: false,
+          trueKey: true,
+          negativeNumberKey: -123,
+          shortNumber: 1e-200,
+          longNumber: 1e+200
+        }
 
         const { value, ranges, sensitiveRanges } = stringifyWithRanges(src, null, true)
 
@@ -192,6 +201,9 @@ describe('test vulnerabiilty-formatter utils', () => {
           { start: 53, end: 57 },
           { start: 73, end: 78 },
           { start: 93, end: 97 },
+          { start: 122, end: 126 },
+          { start: 145, end: 151 },
+          { start: 169, end: 175 },
         ])
       })
 
@@ -390,7 +402,7 @@ describe('test vulnerabiilty-formatter utils', () => {
         const src = {}
         const ranges = {}
 
-        function fill (obj, path, depth) {
+        function fill(obj, path, depth) {
           for (let i = 0; i < 6; i++) {
             const key = `k${i}`
             const currentPath = path ? `${path}.${key}` : key


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Improves  the performance of stringifyWithRanges iast utils method, it was iterating from the beginning in each regexp match causing an overhead.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
With this changes, the time needed for the execution of the new test `Big fully tainted object` goes from `32606ms` to `128ms` in my computer.
[APPSEC-62645]


[APPSEC-62645]: https://datadoghq.atlassian.net/browse/APPSEC-62645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ