### PR TITLE
ci(project): use rochdev/actionlint fork to avoid unnecessary API calls

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: ./.github/actions/node/latest
       - name: actionlint
         id: actionlint
-        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+        # TODO: Switch back to raven-actions/actionlint once
+        #       https://github.com/raven-actions/actionlint/pull/63 lands.
+        uses: rochdev/actionlint@1036c45c2ac9f15a8e8b0851ba7f25808a820f51
         with:
           matcher: true
           fail-on-error: true


### PR DESCRIPTION
## Summary

`raven-actions/actionlint` always hits the GitHub Releases API (`GET /repos/rhysd/actionlint/releases/tags/...`) on every run, even when a version is pinned. This switches to a fork ([rochdev/actionlint](https://github.com/rochdev/actionlint)) that skips that call.

A TODO is left to switch back to `raven-actions/actionlint` once https://github.com/raven-actions/actionlint/pull/63 lands upstream.

## Test plan

- [ ] Verify the `actionlint` job passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)