### PR TITLE
fix(net): restore Socket.emit after the connect handshake

### DIFF
--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -48,13 +48,19 @@ addHook({ name: 'net' }, (net) => {
       setupListeners(this, protocol, ctx, finishCh, errorCh)
 
       const emit = this.emit
+      let pendingReadyEvents = 2
       this.emit = shimmer.wrapFunction(emit, emit => function (eventName) {
         switch (eventName) {
           case 'ready':
           case 'connect':
+            if (--pendingReadyEvents === 0) this.emit = emit
             return readyCh.runStores(ctx, () => {
               return emit.apply(this, arguments)
             })
+          case 'error':
+          case 'close':
+            this.emit = emit
+            return emit.apply(this, arguments)
           default:
             return emit.apply(this, arguments)
         }

--- a/packages/datadog-plugin-net/test/epipe-crash.spec.js
+++ b/packages/datadog-plugin-net/test/epipe-crash.spec.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { fork } = require('node:child_process')
+const path = require('node:path')
+
+const { describe, it } = require('mocha')
+
+/**
+ * @param {string} fixtureName
+ * @returns {Promise<{ code: number | null, stderr: string }>}
+ */
+function runFixture (fixtureName) {
+  return new Promise((resolve) => {
+    const child = fork(
+      path.join(__dirname, 'epipe-crash', fixtureName),
+      {
+        stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+        env: {
+          ...process.env,
+          DD_TRACE_AGENT_PORT: '0',
+        },
+      }
+    )
+
+    let stderr = ''
+    child.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    child.on('exit', (code) => {
+      resolve({ code, stderr })
+    })
+  })
+}
+
+describe('net instrumentation stack attribution', () => {
+  it('keeps dd-trace out of unhandled socket-error stack traces', async () => {
+    const { code, stderr } = await runFixture('with-tracer.js')
+
+    assert.notStrictEqual(code, 0, 'process should crash with no error listener')
+    assert.match(stderr, /ECONNRESET|EPIPE/)
+    assert.doesNotMatch(stderr, /datadog-instrumentations\/src\/net\.js/)
+  }).timeout(10_000)
+
+  it('matches the baseline crash without the tracer', async () => {
+    const { code, stderr } = await runFixture('without-tracer.js')
+
+    assert.notStrictEqual(code, 0, 'process should crash with no error listener')
+    assert.match(stderr, /ECONNRESET|EPIPE/)
+    assert.doesNotMatch(stderr, /datadog-instrumentations/)
+  }).timeout(10_000)
+})

--- a/packages/datadog-plugin-net/test/epipe-crash/with-tracer.js
+++ b/packages/datadog-plugin-net/test/epipe-crash/with-tracer.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const tracer = require('../../../dd-trace')
+tracer.init({
+  plugins: false,
+})
+tracer.use('net')
+tracer.use('dns')
+
+// eslint-disable-next-line import/order
+const net = require('node:net')
+
+const server = net.createServer((serverSocket) => {
+  serverSocket.on('data', () => serverSocket.resetAndDestroy())
+})
+
+server.listen(0, () => {
+  const port = server.address().port
+  const client = new net.Socket()
+
+  client.connect(port, 'localhost', () => {
+    client.write('first')
+    client.write('second')
+    setTimeout(() => {
+      client.write('third')
+      client.write('fourth')
+    }, 100)
+  })
+
+  setTimeout(() => {
+    server.close()
+    client.destroy()
+    process.exit(0)
+  }, 3000)
+})

--- a/packages/datadog-plugin-net/test/epipe-crash/without-tracer.js
+++ b/packages/datadog-plugin-net/test/epipe-crash/without-tracer.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const net = require('node:net')
+
+const server = net.createServer((serverSocket) => {
+  serverSocket.on('data', () => serverSocket.resetAndDestroy())
+})
+
+server.listen(0, () => {
+  const port = server.address().port
+  const client = new net.Socket()
+
+  client.connect(port, 'localhost', () => {
+    client.write('first')
+    client.write('second')
+    setTimeout(() => {
+      client.write('third')
+      client.write('fourth')
+    }, 100)
+  })
+
+  setTimeout(() => {
+    server.close()
+    client.destroy()
+    process.exit(0)
+  }, 3000)
+})


### PR DESCRIPTION
Drops `datadog-instrumentations/src/net.js` from the stack trace of unhandled
socket errors. The crash itself is unchanged: a socket without an `'error'`
listener still terminates the process, which is upstream behaviour. The dd-trace
frame just made the integration look like the cause — see the customer report
in #3866 ("I have no way to check it was emitted by the library").

The wrap on `Socket.emit` only needs to live until `'ready'` and `'connect'`
bind the parent context (see `addTraceBind('ready', …)` in `tcp.js`). It now
restores the original emit after both have fired, and on `'error'` / `'close'`
for the pre-connect failure path, instead of staying for the lifetime of the
socket.

A counter is needed because Node fires `'connect'` then `'ready'` in two
separate `emit` calls; restoring on the first would lose the parent-context
binding for user listeners attached via `socket.on('ready', …)`.

Fixes: https://github.com/DataDog/dd-trace-js/issues/3866