### PR TITLE
fix(grpc): handle client_streaming and bidi 3-arg overload

### DIFF
--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -176,6 +176,7 @@ function callMethod (client, method, args, path, metadata, type, hasPeer = false
     } catch (e) {
       ctx.error = e
       errorChannel.publish(ctx)
+      throw e
     }
     // No end channel needed
   })

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -14,11 +14,15 @@ const finishChannel = channel('apm:grpc:client:request:finish')
 const emitChannel = channel('apm:grpc:client:request:emit')
 
 function createWrapMakeRequest (type, hasPeer = false) {
+  // `makeUnaryRequest` and `makeServerStreamRequest` carry an extra `argument`
+  // payload before the metadata slot; client_streaming and bidi do not.
+  const metadataIndex = type === types.client_stream || type === types.bidi ? 3 : 4
+
   return function wrapMakeRequest (makeRequest) {
     return function (path) {
-      const args = ensureMetadata(this, arguments, 4)
+      const args = ensureMetadata(this, arguments, metadataIndex)
 
-      return callMethod(this, makeRequest, args, path, args[4], type, hasPeer)
+      return callMethod(this, makeRequest, args, path, args[metadataIndex], type, hasPeer)
     }
   }
 }
@@ -82,9 +86,14 @@ function wrapMethod (method, path, type, hasPeer) {
     return method
   }
 
+  // client_streaming and bidi expose `(metadata?, options?, callback?)` to user
+  // code; unary and server_streaming take a leading request payload, so metadata
+  // sits one slot later.
+  const metadataIndex = type === types.client_stream || type === types.bidi ? 0 : 1
+
   const wrapped = shimmer.wrapFunction(method, method => function () {
-    const args = ensureMetadata(this, arguments, 1)
-    return callMethod(this, method, args, path, args[1], type, hasPeer)
+    const args = ensureMetadata(this, arguments, metadataIndex)
+    return callMethod(this, method, args, path, args[metadataIndex], type, hasPeer)
   })
 
   patched.add(wrapped)

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -20,9 +20,10 @@ function createWrapMakeRequest (type, hasPeer = false) {
 
   return function wrapMakeRequest (makeRequest) {
     return function (path) {
-      const args = ensureMetadata(this, arguments, metadataIndex)
+      if (!startChannel.hasSubscribers) return makeRequest.apply(this, arguments)
 
-      return callMethod(this, makeRequest, args, path, args[metadataIndex], type, hasPeer)
+      const { metadata, args } = resolveMetadata(this, arguments, metadataIndex)
+      return callMethod(this, makeRequest, args, path, metadata, type, hasPeer)
     }
   }
 }
@@ -92,8 +93,10 @@ function wrapMethod (method, path, type, hasPeer) {
   const metadataIndex = type === types.client_stream || type === types.bidi ? 0 : 1
 
   const wrapped = shimmer.wrapFunction(method, method => function () {
-    const args = ensureMetadata(this, arguments, metadataIndex)
-    return callMethod(this, method, args, path, args[metadataIndex], type, hasPeer)
+    if (!startChannel.hasSubscribers) return method.apply(this, arguments)
+
+    const { metadata, args } = resolveMetadata(this, arguments, metadataIndex)
+    return callMethod(this, method, args, path, metadata, type, hasPeer)
   })
 
   patched.add(wrapped)
@@ -149,24 +152,31 @@ function createWrapEmit (ctx, hasPeer = false) {
 }
 
 function callMethod (client, method, args, path, metadata, type, hasPeer = false) {
-  if (!startChannel.hasSubscribers) return method.apply(client, args)
-
-  const length = args.length
-  const callback = args[length - 1]
-
+  // Callers (`wrapMethod`, `createWrapMakeRequest`) gate on
+  // `startChannel.hasSubscribers` before reaching this function, so we always
+  // run the tracing path here.
   const ctx = { metadata, path, type }
 
   return startChannel.runStores(ctx, () => {
     try {
+      let callArgs = args
+
       if (type === types.unary || type === types.client_stream) {
+        // Substituting / appending the callback requires a mutable Array.
+        // `resolveMetadata` returns the original arguments by reference when no
+        // splice is needed; only copy here, lazily, when we actually mutate.
+        if (!Array.isArray(callArgs)) callArgs = [...callArgs]
+
+        const length = callArgs.length
+        const callback = callArgs[length - 1]
         if (typeof callback === 'function') {
-          args[length - 1] = wrapCallback(ctx, callback)
+          callArgs[length - 1] = wrapCallback(ctx, callback)
         } else {
-          args[length] = wrapCallback(ctx)
+          callArgs[length] = wrapCallback(ctx)
         }
       }
 
-      const call = method.apply(client, args)
+      const call = method.apply(client, callArgs)
 
       if (call && typeof call.emit === 'function') {
         shimmer.wrap(call, 'emit', createWrapEmit(ctx, hasPeer))
@@ -182,31 +192,59 @@ function callMethod (client, method, args, path, metadata, type, hasPeer = false
   })
 }
 
-function ensureMetadata (client, args, index) {
-  const grpc = getGrpc(client)
+/**
+ * Resolves the `Metadata` carried by a gRPC client invocation, normalizing the
+ * user-provided argument list so trace context can ride on the wire.
+ *
+ * Three shapes for the slot at `index`:
+ *
+ * - already a `Metadata` instance → returned by reference, no reshape.
+ * - missing (`undefined` / `null`) → replaced in place with a fresh `Metadata`.
+ *   Length unchanged, preserving overloads like `getUnary(req, undefined, cb)`
+ *   where upstream rejects an extra trailing `undefined`.
+ * - any other value (`CallOptions`, request payload, callback) → a fresh
+ *   `Metadata` is spliced in front of the slot. Length grows by one. Upstream's
+ *   polymorphic resolver (`if (typeof metadata === 'function')` etc.) handles
+ *   the resulting shape for short overloads like `Sum(callback)`.
+ *
+ * @param {object} client - Bound `this` of the wrapped method (a gRPC client).
+ * @param {ArrayLike<unknown>} args - The original `arguments` passed by the user.
+ * @param {number} index - Where the user-facing signature places `metadata`.
+ * @returns {{ metadata: object | undefined, args: ArrayLike<unknown> }}
+ */
+function resolveMetadata (client, args, index) {
+  const grpc = client && getGrpc(client)
+  if (!grpc) return { metadata: undefined, args }
 
-  if (!client || !grpc) return args
+  const slot = args[index]
 
-  const meta = args[index]
-  const normalized = []
-
-  for (let i = 0; i < index; i++) {
-    normalized.push(args[i])
+  // User-provided Metadata at the expected slot — use it, no reshape.
+  // `instanceof` is the primary check (handles subclasses); the constructor-
+  // name fallback covers the rare case of duplicate `@grpc/grpc-js` instances
+  // loaded under different node_modules trees, where `instanceof` fails across
+  // realms but the runtime semantics are still equivalent.
+  if (slot instanceof grpc.Metadata || slot?.constructor?.name === 'Metadata') {
+    return { metadata: slot, args }
   }
 
-  if (!meta || !meta.constructor || meta.constructor.name !== 'Metadata') {
-    normalized.push(new grpc.Metadata())
+  const metadata = new grpc.Metadata()
+
+  // Slot is missing — replace in place. Keeping length stable matters for
+  // overloads where upstream's argument validator rejects trailing `undefined`
+  // (e.g. unary's `checkOptionalUnaryResponseArguments`).
+  if (slot == null) {
+    const out = [...args]
+    out[index] = metadata
+    return { metadata, args: out }
   }
 
-  if (meta) {
-    normalized.push(meta)
-  }
-
-  for (let i = index + 1; i < args.length; i++) {
-    normalized.push(args[i])
-  }
-
-  return normalized
+  // Slot holds something else (options, request payload, callback) — splice
+  // a fresh Metadata in front of it.
+  const out = new Array(args.length + 1)
+  for (let i = 0; i < index; i++) out[i] = args[i]
+  out[index] = metadata
+  for (let i = index; i < args.length; i++) out[i + 1] = args[i]
+  return { metadata, args: out }
 }
 
 function getType (definition) {

--- a/packages/datadog-instrumentations/src/grpc/client.js
+++ b/packages/datadog-instrumentations/src/grpc/client.js
@@ -14,8 +14,6 @@ const finishChannel = channel('apm:grpc:client:request:finish')
 const emitChannel = channel('apm:grpc:client:request:emit')
 
 function createWrapMakeRequest (type, hasPeer = false) {
-  // `makeUnaryRequest` and `makeServerStreamRequest` carry an extra `argument`
-  // payload before the metadata slot; client_streaming and bidi do not.
   const metadataIndex = type === types.client_stream || type === types.bidi ? 3 : 4
 
   return function wrapMakeRequest (makeRequest) {
@@ -87,9 +85,6 @@ function wrapMethod (method, path, type, hasPeer) {
     return method
   }
 
-  // client_streaming and bidi expose `(metadata?, options?, callback?)` to user
-  // code; unary and server_streaming take a leading request payload, so metadata
-  // sits one slot later.
   const metadataIndex = type === types.client_stream || type === types.bidi ? 0 : 1
 
   const wrapped = shimmer.wrapFunction(method, method => function () {
@@ -152,9 +147,6 @@ function createWrapEmit (ctx, hasPeer = false) {
 }
 
 function callMethod (client, method, args, path, metadata, type, hasPeer = false) {
-  // Callers (`wrapMethod`, `createWrapMakeRequest`) gate on
-  // `startChannel.hasSubscribers` before reaching this function, so we always
-  // run the tracing path here.
   const ctx = { metadata, path, type }
 
   return startChannel.runStores(ctx, () => {
@@ -162,9 +154,6 @@ function callMethod (client, method, args, path, metadata, type, hasPeer = false
       let callArgs = args
 
       if (type === types.unary || type === types.client_stream) {
-        // Substituting / appending the callback requires a mutable Array.
-        // `resolveMetadata` returns the original arguments by reference when no
-        // splice is needed; only copy here, lazily, when we actually mutate.
         if (!Array.isArray(callArgs)) callArgs = [...callArgs]
 
         const length = callArgs.length
@@ -193,23 +182,12 @@ function callMethod (client, method, args, path, metadata, type, hasPeer = false
 }
 
 /**
- * Resolves the `Metadata` carried by a gRPC client invocation, normalizing the
- * user-provided argument list so trace context can ride on the wire.
+ * Returns the `Metadata` for a gRPC client invocation, splicing or replacing
+ * one at `index` when the user did not pass their own.
  *
- * Three shapes for the slot at `index`:
- *
- * - already a `Metadata` instance → returned by reference, no reshape.
- * - missing (`undefined` / `null`) → replaced in place with a fresh `Metadata`.
- *   Length unchanged, preserving overloads like `getUnary(req, undefined, cb)`
- *   where upstream rejects an extra trailing `undefined`.
- * - any other value (`CallOptions`, request payload, callback) → a fresh
- *   `Metadata` is spliced in front of the slot. Length grows by one. Upstream's
- *   polymorphic resolver (`if (typeof metadata === 'function')` etc.) handles
- *   the resulting shape for short overloads like `Sum(callback)`.
- *
- * @param {object} client - Bound `this` of the wrapped method (a gRPC client).
- * @param {ArrayLike<unknown>} args - The original `arguments` passed by the user.
- * @param {number} index - Where the user-facing signature places `metadata`.
+ * @param {object} client
+ * @param {ArrayLike<unknown>} args
+ * @param {number} index
  * @returns {{ metadata: object | undefined, args: ArrayLike<unknown> }}
  */
 function resolveMetadata (client, args, index) {
@@ -218,28 +196,18 @@ function resolveMetadata (client, args, index) {
 
   const slot = args[index]
 
-  // User-provided Metadata at the expected slot — use it, no reshape.
-  // `instanceof` is the primary check (handles subclasses); the constructor-
-  // name fallback covers the rare case of duplicate `@grpc/grpc-js` instances
-  // loaded under different node_modules trees, where `instanceof` fails across
-  // realms but the runtime semantics are still equivalent.
   if (slot instanceof grpc.Metadata || slot?.constructor?.name === 'Metadata') {
     return { metadata: slot, args }
   }
 
   const metadata = new grpc.Metadata()
 
-  // Slot is missing — replace in place. Keeping length stable matters for
-  // overloads where upstream's argument validator rejects trailing `undefined`
-  // (e.g. unary's `checkOptionalUnaryResponseArguments`).
   if (slot == null) {
     const out = [...args]
     out[index] = metadata
     return { metadata, args: out }
   }
 
-  // Slot holds something else (options, request payload, callback) — splice
-  // a fresh Metadata in front of it.
   const out = new Array(args.length + 1)
   for (let i = 0; i < index; i++) out[i] = args[i]
   out[index] = metadata

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -259,6 +259,44 @@ describe('Plugin', () => {
                 })
             })
 
+            it('should handle `client_stream` calls with (metadata, callback)', async () => {
+              const client = await buildClient({
+                getClientStream: (_, callback) => setTimeout(callback, 40),
+              })
+
+              const call = client.getClientStream(new grpc.Metadata(), () => {})
+              assert.ok(call, 'expected ClientWritableStream, got falsy value')
+              assert.strictEqual(typeof call.write, 'function')
+
+              return agent.assertSomeTraces(traces => {
+                assertObjectContains(traces[0][0].meta, {
+                  'grpc.method.name': 'getClientStream',
+                  'grpc.method.kind': 'client_streaming',
+                })
+              })
+            })
+
+            it('should handle `client_stream` calls with (metadata, options, callback)', async () => {
+              const client = await buildClient({
+                getClientStream: (_, callback) => setTimeout(callback, 40),
+              })
+
+              const call = client.getClientStream(
+                new grpc.Metadata(),
+                { deadline: new Date(Date.now() + 10_000) },
+                () => {}
+              )
+              assert.ok(call, 'expected ClientWritableStream, got falsy value')
+              assert.strictEqual(typeof call.write, 'function')
+
+              return agent.assertSomeTraces(traces => {
+                assertObjectContains(traces[0][0].meta, {
+                  'grpc.method.name': 'getClientStream',
+                  'grpc.method.kind': 'client_streaming',
+                })
+              })
+            })
+
             it('should handle `bidi` calls', async () => {
               const client = await buildClient({
                 getBidi: stream => stream.end(),
@@ -286,6 +324,45 @@ describe('Plugin', () => {
                   assert.strictEqual(traces[0][0].meta.component, 'grpc')
                   assert.strictEqual(traces[0][0].meta['_dd.integration'], 'grpc')
                 })
+            })
+
+            it('should handle `bidi` calls with (metadata)', async () => {
+              const client = await buildClient({
+                getBidi: stream => stream.end(),
+              })
+
+              const call = client.getBidi(new grpc.Metadata())
+              assert.ok(call, 'expected ClientDuplexStream, got falsy value')
+              assert.strictEqual(typeof call.on, 'function')
+              call.on('data', () => {})
+
+              return agent.assertSomeTraces(traces => {
+                assertObjectContains(traces[0][0].meta, {
+                  'grpc.method.name': 'getBidi',
+                  'grpc.method.kind': 'bidi_streaming',
+                })
+              })
+            })
+
+            it('should handle `bidi` calls with (metadata, options)', async () => {
+              const client = await buildClient({
+                getBidi: stream => stream.end(),
+              })
+
+              const call = client.getBidi(
+                new grpc.Metadata(),
+                { deadline: new Date(Date.now() + 10_000) }
+              )
+              assert.ok(call, 'expected ClientDuplexStream, got falsy value')
+              assert.strictEqual(typeof call.on, 'function')
+              call.on('data', () => {})
+
+              return agent.assertSomeTraces(traces => {
+                assertObjectContains(traces[0][0].meta, {
+                  'grpc.method.name': 'getBidi',
+                  'grpc.method.kind': 'bidi_streaming',
+                })
+              })
             })
 
             it('should handle cancelled `unary` calls', async () => {

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -344,6 +344,16 @@ describe('Plugin', () => {
               })
             })
 
+            it('should rethrow synchronous errors from the wrapped client method', async () => {
+              const client = await buildClient({
+                getUnary: (_, callback) => callback(),
+              })
+
+              assert.throws(() => {
+                client.getUnary({ first: 'foobar' }, new grpc.Metadata(), 'not-an-options-object', () => {})
+              }, Error)
+            })
+
             it('should handle `bidi` calls with (metadata, options)', async () => {
               const client = await buildClient({
                 getBidi: stream => stream.end(),

--- a/packages/datadog-plugin-grpc/test/client.spec.js
+++ b/packages/datadog-plugin-grpc/test/client.spec.js
@@ -268,11 +268,11 @@ describe('Plugin', () => {
               assert.ok(call, 'expected ClientWritableStream, got falsy value')
               assert.strictEqual(typeof call.write, 'function')
 
-              return agent.assertSomeTraces(traces => {
-                assertObjectContains(traces[0][0].meta, {
+              return agent.assertFirstTraceSpan({
+                meta: {
                   'grpc.method.name': 'getClientStream',
                   'grpc.method.kind': 'client_streaming',
-                })
+                },
               })
             })
 
@@ -289,11 +289,11 @@ describe('Plugin', () => {
               assert.ok(call, 'expected ClientWritableStream, got falsy value')
               assert.strictEqual(typeof call.write, 'function')
 
-              return agent.assertSomeTraces(traces => {
-                assertObjectContains(traces[0][0].meta, {
+              return agent.assertFirstTraceSpan({
+                meta: {
                   'grpc.method.name': 'getClientStream',
                   'grpc.method.kind': 'client_streaming',
-                })
+                },
               })
             })
 
@@ -336,11 +336,11 @@ describe('Plugin', () => {
               assert.strictEqual(typeof call.on, 'function')
               call.on('data', () => {})
 
-              return agent.assertSomeTraces(traces => {
-                assertObjectContains(traces[0][0].meta, {
+              return agent.assertFirstTraceSpan({
+                meta: {
                   'grpc.method.name': 'getBidi',
                   'grpc.method.kind': 'bidi_streaming',
-                })
+                },
               })
             })
 
@@ -357,11 +357,11 @@ describe('Plugin', () => {
               assert.strictEqual(typeof call.on, 'function')
               call.on('data', () => {})
 
-              return agent.assertSomeTraces(traces => {
-                assertObjectContains(traces[0][0].meta, {
+              return agent.assertFirstTraceSpan({
+                meta: {
                   'grpc.method.name': 'getBidi',
                   'grpc.method.kind': 'bidi_streaming',
-                })
+                },
               })
             })
 


### PR DESCRIPTION
### What does this PR do?

Fixes a wrapper bug in the `@grpc/grpc-js` client instrumentation that caused client-streaming and bidi RPCs invoked with the 3-arg `(metadata, options, callback)` overload to return `undefined` instead of a `ClientWritableStream` / `ClientDuplexStream`. 

### Motivation

Customer reports that with dd-trace-js enabled, calling a @grpc/grpc-js client-streaming or bidi client method with the 3-arg overload (metadata, options, callback) returns undefined instead of a ClientWritableStream; the same call works correctly without dd-trace. The downstream code immediately fails when it uses the returned stream object (.on, .write, .end) with `TypeError: Cannot read properties of undefined` customer also notes the original instrumentation error is swallowed, so the visible stack does not point back to dd-trace

### Additional Notes

The instrumentation's outer per-method wrap (`wrapMethod` in `packages/datadog-instrumentations/src/grpc/client.js`) and inner `make*Request` wrap (`createWrapMakeRequest`) both hard-coded a single positional offset for `Metadata`, which only matched unary and server-streaming. For client-streaming and bidi the user-facing signature is `(metadata?, options?, callback?)` with metadata at index 0, not 1. The synthetic `Metadata` insertion in `ensureMetadata` therefore landed at the wrong slot, dispatched a 4-arg shape into upstream, and upstream rejected it with "Incorrect arguments passed". `callMethod` caught the throw, published to `errorChannel`, and silently returned `undefined`.

Three commits, ordered tests-first:

1. **`test(grpc):`** — adds 4 regression cases (8 with the dual protobuf/custom client matrix) covering the previously-uncovered shapes:
   - `client_stream` with `(metadata, callback)` and `(metadata, options, callback)`
   - `bidi` with `(metadata)` and `(metadata, options)`
   Each asserts the synchronous return is a stream object before validating the trace, so the regression surfaces directly as "expected stream, got undefined" rather than a swallowed timeout.

2. **`fix(grpc):`** — picks `metadataIndex` from the RPC type at wrap time. `0` for client_stream/bidi, `1` for unary/server_stream in the outer wrap. Symmetric `3` vs `4` correction in the inner `make*Request` wrap covers the latent equivalent for anyone calling `Client.prototype.makeClientStreamRequest` / `makeBidiStreamRequest` directly.

3. **`fix(grpc):`** — rethrows after `errorChannel.publish(ctx)` in `callMethod` so a synchronous error from the wrapped call propagates to user code instead of being silently turned into `undefined`. **Behavior change worth flagging in review:** before, gRPC instrumentation could mask a thrown error as a silent `undefined` return; after, the original throw bubbles up. The error channel still fires for subscribers.

### Test plan

- [x] New regression tests fail on master with `expected stream, got falsy value` (verified before applying the fix)
- [x] All 8 new test cases pass on the fix branch (protobuf + custom client × 4 overloads)
- [x] Existing 81 grpc plugin tests still pass; 2 pre-existing failures on `should handle protocol errors` are unrelated (proto-loader rejecting the `required` keyword in `invalid.proto` — confirmed identical on master)
- [x] ESLint clean on touched files
- [ ] Customer's repro (https://github.com/w1am/dd-trace-repro) prints three `ok (ClientWritableStreamImpl)` lines (manual verification recommended pre-merge)