### PR TITLE
ci(codeql): skip workflow for non-production file changes and merge queue

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,32 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, mq-working-branch-master-*]
+    # Exclude merge-queue branches: PRs are already scanned before merge.
+    branches: [master]
+    # Mirror the paths-ignore in .github/codeql_config.yml so the workflow
+    # does not launch at all (and avoids GitHub API calls) when only
+    # non-production files change.
+    paths-ignore:
+      - 'benchmark/**'
+      - 'integration-tests/**'
+      - 'node-upstream-tests/**'
+      - 'packages/**/test/**'
+      - 'scripts/**'
+      - 'vendor/dist/**'
+      - 'docs/**'
+      - '**.md'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
+    paths-ignore:
+      - 'benchmark/**'
+      - 'integration-tests/**'
+      - 'node-upstream-tests/**'
+      - 'packages/**/test/**'
+      - 'scripts/**'
+      - 'vendor/dist/**'
+      - 'docs/**'
+      - '**.md'
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary

- Add `paths-ignore` to the `push` and `pull_request` triggers in `codeql-analysis.yml`, mirroring the exclusions already defined in `.github/codeql_config.yml`. The workflow will no longer start (and make GitHub API calls) when only tests, docs, scripts, benchmark, or vendor files change.
- Remove `mq-working-branch-master-*` from the `push` trigger. PRs are already scanned before entering the merge queue, so rescanning each merge-queue batch is redundant.
- Add comments explaining that the `paths-ignore` values are sourced from `.github/codeql_config.yml`.

## Test plan

- [ ] Verify that a PR touching only `packages/**/test/**` or `docs/` does not trigger the CodeQL workflow.
- [ ] Verify that a PR touching source files under `packages/dd-trace/src/` still triggers CodeQL.
- [ ] Verify that pushes to `master` still trigger CodeQL when production files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)