### PR TITLE
ci: extract shared datadog-ci install action and replace coverage-upload-github-action

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -25,11 +25,15 @@ runs:
       with:
         flags: ${{ inputs.flags }}
 
+    - name: Install datadog-ci
+      if: always()
+      uses: ./.github/actions/datadog-ci
+
     - name: Upload coverage to Datadog
       if: always()
       continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@6c4bd935248daa6f0ef94e3e6ba71ad5ad079998 # v1
-      with:
-        api_key: ${{ inputs.dd_api_key }}
-        files: .
-        flags: ${{ inputs.flags }}
+      shell: bash
+      run: datadog-ci coverage upload ${FLAGS:+--flags "$FLAGS"} .
+      env:
+        DD_API_KEY: ${{ inputs.dd_api_key }}
+        FLAGS: ${{ inputs.flags }}

--- a/.github/actions/datadog-ci/action.yml
+++ b/.github/actions/datadog-ci/action.yml
@@ -1,0 +1,20 @@
+name: Install datadog-ci
+description: Install @datadog/datadog-ci from npm and add it to PATH.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.action_path }}/node_modules
+        key: datadog-ci-${{ hashFiles('.github/actions/datadog-ci/package.json') }}
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: '20'
+
+    - shell: bash
+      run: |
+        yarn install --no-lockfile
+        echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
+      working-directory: ${{ github.action_path }}

--- a/.github/actions/datadog-ci/package.json
+++ b/.github/actions/datadog-ci/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "push-to-test-optimization",
+  "name": "datadog-ci",
   "version": "1.0.0",
   "private": true,
   "dependencies": {

--- a/.github/actions/push_to_test_optimization/action.yml
+++ b/.github/actions/push_to_test_optimization/action.yml
@@ -14,20 +14,7 @@ runs:
       # >  from a forked repository, and are also subject to these restrictions.
       #
       # Which means they do not have access to secrets.
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ${{ github.action_path }}/node_modules
-        key: push-to-test-optimization-${{ hashFiles('.github/actions/push_to_test_optimization/package.json') }}
-    - if: github.actor != 'dependabot[bot]'
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: '20'
-    - if: github.actor != 'dependabot[bot]'
-      shell: bash
-      run: |
-        yarn install --no-lockfile
-        echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
-      working-directory: ${{ github.action_path }}
+      uses: ./.github/actions/datadog-ci
     - if: github.actor != 'dependabot[bot]'
       shell: bash
       run: datadog-ci junit upload --service dd-trace-js-tests .

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,7 @@ updates:
     directories:
       - "/"
       - "/docs"
-      - "/.github/actions/push_to_test_optimization"
+      - "/.github/actions/datadog-ci"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 100


### PR DESCRIPTION
### What does this PR do?

- Removes the `DataDog/coverage-upload-github-action` external dependency from the `coverage` composite action and reimplements the upload step using `datadog-ci` from npm directly (same approach as `push_to_test_optimization`).
- Extracts the shared cache/setup-node/install pattern into a new `.github/actions/datadog-ci` composite action used by both `coverage` and `push_to_test_optimization`, so `@datadog/datadog-ci` is pinned in a single `package.json`.

### Motivation

The main goal was to reduce GitHub API calls in CI. `DataDog/coverage-upload-github-action` was the main culprit: as an external action it pulls `datadog-ci` from GitHub Releases, which hits the GitHub API on every invocation — and the `coverage` action is called ~83 times per full CI run. Reimplementing the upload directly using `datadog-ci` from npm (already the pattern used by `push_to_test_optimization`) eliminates those calls. As a side effect, it also removes an external action dependency and consolidates the duplicated install boilerplate into a single reusable action.

### Additional Notes

The `@datadog/datadog-ci` version (`5.16.0`) is now pinned in `.github/actions/datadog-ci/package.json` — the only place that needs updating for future version bumps.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)