### PR TITLE
ci(benchmarks): bump microbenchmark splits from 5 to 6

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -67,6 +67,8 @@ check-big-regressions:
 
 benchmark:
   extends: .benchmarks
+  # The number of GROUP rows per MAJOR_VERSION must equal SPLITS. If you change
+  # one, change the other — otherwise variants get silently skipped.
   parallel:
     matrix:
       - MAJOR_VERSION: 18
@@ -79,6 +81,8 @@ benchmark:
         GROUP: 4
       - MAJOR_VERSION: 18
         GROUP: 5
+      - MAJOR_VERSION: 18
+        GROUP: 6
       - MAJOR_VERSION: 20
         GROUP: 1
       - MAJOR_VERSION: 20
@@ -89,6 +93,8 @@ benchmark:
         GROUP: 4
       - MAJOR_VERSION: 20
         GROUP: 5
+      - MAJOR_VERSION: 20
+        GROUP: 6
       - MAJOR_VERSION: 22
         GROUP: 1
       - MAJOR_VERSION: 22
@@ -99,6 +105,8 @@ benchmark:
         GROUP: 4
       - MAJOR_VERSION: 22
         GROUP: 5
+      - MAJOR_VERSION: 22
+        GROUP: 6
       - MAJOR_VERSION: 24
         GROUP: 1
       - MAJOR_VERSION: 24
@@ -109,8 +117,10 @@ benchmark:
         GROUP: 4
       - MAJOR_VERSION: 24
         GROUP: 5
+      - MAJOR_VERSION: 24
+        GROUP: 6
   variables:
-    SPLITS: 5
+    SPLITS: 6
 
 benchmark-serverless:
   stage: benchmarks


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Raises `SPLITS` from `5` to `6` in `.gitlab/benchmarks.yml` and adds a `GROUP: 6` row to the parallel matrix for each Node major (18, 20, 22, 24). Also adds a short comment next to the matrix reminding future editors that the number of `GROUP` rows per major must equal `SPLITS`.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is the same pressure that #7983 relieved in April by bumping `SPLITS` from 4 → 5. Since then the sirun variant count has crept back up:

| PR | Change | Net variants |
|---|---|---|
| #7983 | bump `SPLITS` 4 → 5 (previous fix) | 91 |
| #8089 | `bench: add plugin-graphql-long sirun benchmark` | +6 |
| #8205 | `bench(encoding): cover native and legacy span-events paths` | +3 |
| #8203 | `bench(propagation): add extract and inject benchmarks` | +5 (new dir) |
| #8202 | `bench(dsm): add Data Streams Monitoring pathway benchmark` | +5 (new dir) |
| #8201 | `bench(aws-sdk): add inject and response-body benchmarks` | +3 (new dir) |
| #8200 | `bench(llmobs): add writer flush benchmark` | +2 (new dir) |
| #8199 | `bench(spans): cover tags-and-otel construction shape` | +2 |
| **master today** | | **109 / 120** |

Feature branches that add variants tips `GROUP_SIZE` to 25 and CI fails with:

```
Run benchmarks  | Group size 25 exceeds available CPU cores (24 from nproc)
```

Bumping `SPLITS` to 6 raises the ceiling to `6 × 24 = 144` variants, restoring headroom and unblocking benchmark CI.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


