### PR TITLE
fix(cypress): disable EFD for faulty known tests

### DIFF
--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -19,6 +19,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_RETRY_REASON,
   TEST_NAME,
   TEST_HAS_FAILED_ALL_RETRIES,
@@ -378,6 +379,61 @@ moduleTypes.forEach(({
 
             const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
             assert.strictEqual(newTests.length, 0)
+          }, 60000)
+
+        const specToRun = 'cypress/e2e/spec.cy.js'
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              SPEC_PATTERN: specToRun,
+            },
+          }
+        )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
+      it('bails out of EFD if the percentage of new test files is too high', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD,
+            },
+            faulty_session_threshold: 0,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          cypress: {},
+        })
+
+        const envVars = getCiVisEvpProxyConfig(receiver.port)
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            assert.strictEqual(tests.length, 2)
+
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            assert.strictEqual(newTests.length, 0)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, 0)
+
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+            assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
           }, 60000)
 
         const specToRun = 'cypress/e2e/spec.cy.js'

--- a/integration-tests/vitest/vitest.spec.js
+++ b/integration-tests/vitest/vitest.spec.js
@@ -953,6 +953,7 @@ versions.forEach((version) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
             assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
 
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
@@ -963,6 +964,9 @@ versions.forEach((version) => {
             )
             // no new tests
             assert.strictEqual(newTests.length, 0)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, 0)
           })
 
         childProcess = exec(
@@ -1097,6 +1101,7 @@ versions.forEach((version) => {
             assert.ok(testSessionEnd, 'expected test_session_end event in payloads')
             const testSessionEvent = testSessionEnd.content
             assert.strictEqual(testSessionEvent.meta[TEST_STATUS], 'fail')
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSessionEvent.meta))
           }, 60000)
 
         childProcess = exec(

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -36,6 +36,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_EARLY_FLAKE_ABORT_REASON,
   getTestSessionName,
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES,
@@ -55,6 +56,7 @@ const {
   DD_CI_LIBRARY_CONFIGURATION_ERROR,
   TEST_IS_MODIFIED,
   TEST_HAS_DYNAMIC_NAME,
+  getIsFaultyEarlyFlakeDetection,
   DYNAMIC_NAME_RE,
   recordAttemptToFixExecution,
   logAttemptToFixTestExecution,
@@ -326,8 +328,10 @@ class CypressPlugin {
   isFlakyTestRetriesEnabled = false
   flakyTestRetriesCount = 0
   isEarlyFlakeDetectionEnabled = false
+  isEarlyFlakeDetectionFaulty = false
   isKnownTestsEnabled = false
   earlyFlakeDetectionNumRetries = 0
+  earlyFlakeDetectionFaultyThreshold = 0
   testsToSkip = []
   skippedTests = []
   hasForcedToRunSuites = false
@@ -399,8 +403,10 @@ class CypressPlugin {
     this.isFlakyTestRetriesEnabled = false
     this.flakyTestRetriesCount = 0
     this.isEarlyFlakeDetectionEnabled = false
+    this.isEarlyFlakeDetectionFaulty = false
     this.isKnownTestsEnabled = false
     this.earlyFlakeDetectionNumRetries = 0
+    this.earlyFlakeDetectionFaultyThreshold = 0
     this.testsToSkip = []
     this.skippedTests = []
     this.hasForcedToRunSuites = false
@@ -481,6 +487,7 @@ class CypressPlugin {
               isCodeCoverageEnabled,
               isEarlyFlakeDetectionEnabled,
               earlyFlakeDetectionNumRetries,
+              earlyFlakeDetectionFaultyThreshold,
               isFlakyTestRetriesEnabled,
               flakyTestRetriesCount,
               isKnownTestsEnabled,
@@ -493,6 +500,7 @@ class CypressPlugin {
           this.isCodeCoverageEnabled = isCodeCoverageEnabled
           this.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
           this.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
+          this.earlyFlakeDetectionFaultyThreshold = earlyFlakeDetectionFaultyThreshold
           this.isKnownTestsEnabled = isKnownTestsEnabled
           if (isFlakyTestRetriesEnabled && this.isTestIsolationEnabled) {
             this.isFlakyTestRetriesEnabled = true
@@ -665,12 +673,27 @@ class CypressPlugin {
         this.isEarlyFlakeDetectionEnabled = false
         this.isKnownTestsEnabled = false
       } else {
-        if (knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]) {
+        if (knownTestsResponse.knownTests?.[TEST_FRAMEWORK_NAME]) {
           this.knownTestsByTestSuite = knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]
         } else {
           this.isEarlyFlakeDetectionEnabled = false
           this.isKnownTestsEnabled = false
         }
+      }
+    }
+
+    if (this.isKnownTestsEnabled && details.specs) {
+      const testSuites = details.specs.map(({ relative }) => relative)
+      const isFaulty = getIsFaultyEarlyFlakeDetection(
+        testSuites,
+        this.knownTestsByTestSuite,
+        this.earlyFlakeDetectionFaultyThreshold
+      )
+      if (isFaulty) {
+        log.warn('New test detection is disabled because the number of new test files is too high.')
+        this.isEarlyFlakeDetectionEnabled = false
+        this.isEarlyFlakeDetectionFaulty = true
+        this.isKnownTestsEnabled = false
       }
     }
 
@@ -730,6 +753,9 @@ class CypressPlugin {
 
     if (this.isEarlyFlakeDetectionEnabled) {
       testSessionSpanMetadata[TEST_EARLY_FLAKE_ENABLED] = 'true'
+    }
+    if (this.isEarlyFlakeDetectionFaulty) {
+      testSessionSpanMetadata[TEST_EARLY_FLAKE_ABORT_REASON] = 'faulty'
     }
 
     const trimmedCommand = DD_MAJOR < 6 ? this.command : 'cypress run'


### PR DESCRIPTION
### What does this PR do?
Disables Cypress early flake detection and new-test detection when the known-tests response would classify too many selected spec files as new, using the API-provided faulty session threshold. The session is tagged with `test.early_flake.abort_reason=faulty` in that case.

Also tightens Cypress and Vitest integration assertions around known-tests request failures and faulty EFD sessions.

### Motivation
Cypress already stopped EFD when the known-tests request failed, but it did not apply the faulty-session threshold that other frameworks use. That could leave Cypress tagging and retrying new tests when the known-tests data was likely unusable.

### Additional Notes
Validation run locally:
- `./node_modules/.bin/mocha packages/dd-trace/test/plugins/util/test.spec.js --grep "getIsFaultyEarlyFlakeDetection"`
- `CYPRESS_VERSION=14.5.4 CYPRESS_MODULE_TYPE=commonJS ./node_modules/.bin/mocha --timeout 900000 integration-tests/cypress/cypress-efd.spec.js --grep "(does not run EFD if the known tests request fails|bails out of EFD if the percentage of new test files is too high)"`
- `./node_modules/.bin/mocha --timeout 900000 integration-tests/vitest/vitest.spec.js --grep "(does not run EFD if the known tests request fails|bails out of EFD if the percentage of new tests is too high)"`
- `git diff --check`