### PR TITLE
test(otel): scope post-finish no-op assertions to mutator keys

### DIFF
--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -425,7 +425,12 @@ describe('OTel Context Manager', () => {
         active.setStatus({ code: 2, message: 'after end' })
         active.updateName('after end')
 
-        assert.deepStrictEqual(ddSpan.context()._tags, {})
+        const tags = ddSpan.context()._tags
+        assert.ok(!('after.end' in tags))
+        assert.ok(!('after.end.batch' in tags))
+        assert.ok(!('error.message' in tags))
+        assert.ok(!('error.type' in tags))
+        assert.ok(!('resource.name' in tags))
         assert.strictEqual(ddSpan._links.length, 0)
         assert.strictEqual(ddSpan._events.length, 0)
       })

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -558,7 +558,11 @@ describe('OTel Span', () => {
     span.recordException(new Error('after end'))
     span.updateName('after end')
 
-    assert.deepStrictEqual(span._ddSpan.context()._tags, {})
+    const { _tags } = span._ddSpan.context()
+    assert.ok(!('after.end' in _tags))
+    assert.ok(!('after.end.batch' in _tags))
+    assert.ok(!(ERROR_MESSAGE in _tags))
+    assert.ok(!(ERROR_TYPE in _tags))
     assert.strictEqual(span._ddSpan._links.length, 0)
     assert.strictEqual(span._ddSpan._events.length, 0)
   })


### PR DESCRIPTION
## Summary

The two `mutation methods are all no-ops` tests added in #8030 pin the OTel `Span` mutator contract via `assert.deepStrictEqual(_tags, {})` after `finish()`. That assertion held on #8030's branch because `SpanProcessor#_erase` still ran `span.context()._tags = {}` per finished span; #8235 dropped the reset because the trace reference is released on the next line and the per-span allocation was never observable. Both branches were green individually; together on master the test asserts a side effect that no longer runs.

The contract under test is "post-finish writes by the OTel mutators do not land on `_tags`/`_links`/`_events`" — enforced by `isWritable(ddSpan)` inside `span-helpers.js` — not "every tag is wiped". This change pins each post-finish mutator's target keys instead.

Refs: #8030, #8235