### PR TITLE
[test optimizaton] Use duration buckets for vitest EFD retries

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -36,4 +36,10 @@ describe('early flake detection', () => {
       expect(sum(1, 2)).to.equal(numLastAttempt++ === 3 ? 3 : 4)
     })
   }
+  if (process.env.SHOULD_ADD_SLOW_DURATION_TEST) {
+    test('slightly slow duration bucket test', async () => {
+      await new Promise(resolve => setTimeout(resolve, 5100))
+      expect(sum(1, 2)).to.equal(3)
+    }, 7000)
+  }
 })

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -809,6 +809,67 @@ versions.forEach((version) => {
         })
       })
 
+      it('uses the retry count from the matching slow_test_retries bucket', (done) => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+              '10s': 0,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          vitest: {},
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(test => test.content)
+
+            const instantTests = tests.filter(test =>
+              test.meta[TEST_NAME] === 'early flake detection can retry tests that always pass'
+            )
+            assert.strictEqual(instantTests.length, 3)
+            assert.strictEqual(
+              instantTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd).length,
+              2
+            )
+
+            const slowTests = tests.filter(test =>
+              test.meta[TEST_NAME] === 'early flake detection slightly slow duration bucket test'
+            )
+            assert.strictEqual(slowTests.length, 1)
+            assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+            assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
+          }, 70_000)
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              SHOULD_ADD_SLOW_DURATION_TEST: '1',
+            },
+          }
+        )
+
+        childProcess.on('exit', (exitCode) => {
+          eventsPromise.then(() => {
+            assert.strictEqual(exitCode, 0)
+            done()
+          }).catch(done)
+        })
+      })
+
       it('fails if all the attempts fail', (done) => {
         receiver.setSettings({
           early_flake_detection: {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -4,6 +4,7 @@
 const realSetTimeout = setTimeout
 
 const path = require('node:path')
+const { performance } = require('node:perf_hooks')
 
 const shimmer = require('../../datadog-shimmer')
 const log = require('../../dd-trace/src/log')
@@ -12,6 +13,8 @@ const {
   VITEST_WORKER_LOGS_PAYLOAD_CODE,
   DYNAMIC_NAME_RE,
   getTestSuitePath,
+  getEfdRetryCount,
+  getMaxEfdRetryCount,
   recordAttemptToFixExecution,
   collectTestOptimizationSummariesFromTraces,
   logAttemptToFixTestExecution,
@@ -61,6 +64,10 @@ const disabledTasks = new WeakSet()
 const quarantinedTasks = new WeakSet()
 const attemptToFixTasks = new WeakSet()
 const modifiedTasks = new WeakSet()
+const efdDeterminedRetries = new WeakMap()
+const efdSlowAbortedTasks = new WeakSet()
+const efdExecutionStartByTask = new WeakMap()
+const efdSkippedRetryResults = new WeakMap()
 const attemptToFixExecutions = new Map()
 const loggedAttemptToFixTests = new Set()
 let isRetryReasonEfd = false
@@ -71,6 +78,7 @@ let isFlakyTestRetriesEnabled = false
 let flakyTestRetriesCount = 0
 let isEarlyFlakeDetectionEnabled = false
 let earlyFlakeDetectionNumRetries = 0
+let earlyFlakeDetectionSlowTestRetries = {}
 let isEarlyFlakeDetectionFaulty = false
 let isKnownTestsEnabled = false
 let isTestManagementTestsEnabled = false
@@ -86,6 +94,13 @@ let isSessionStarted = false
 let vitestPool = null
 
 const BREAKPOINT_HIT_GRACE_PERIOD_MS = 400
+
+function getConfiguredEfdRetryCount (slowTestRetries, fallbackRetryCount) {
+  if (!slowTestRetries || !Object.keys(slowTestRetries).length) {
+    return fallbackRetryCount
+  }
+  return getMaxEfdRetryCount(slowTestRetries)
+}
 
 function getTestCommand () {
   return `vitest ${process.argv.slice(2).join(' ')}`
@@ -110,6 +125,7 @@ function getProvidedContext () {
       _ddIsDiEnabled,
       _ddKnownTests: knownTests,
       _ddEarlyFlakeDetectionNumRetries: numRepeats,
+      _ddEarlyFlakeDetectionSlowTestRetries: slowTestRetries,
       _ddIsKnownTestsEnabled: isKnownTestsEnabled,
       _ddIsTestManagementTestsEnabled: isTestManagementTestsEnabled,
       _ddTestManagementAttemptToFixRetries: testManagementAttemptToFixRetries,
@@ -125,6 +141,7 @@ function getProvidedContext () {
       isEarlyFlakeDetectionEnabled: _ddIsEarlyFlakeDetectionEnabled,
       knownTests,
       numRepeats,
+      slowTestRetries: slowTestRetries ?? {},
       isKnownTestsEnabled,
       isTestManagementTestsEnabled,
       testManagementAttemptToFixRetries,
@@ -141,6 +158,7 @@ function getProvidedContext () {
       isEarlyFlakeDetectionEnabled: false,
       knownTests: {},
       numRepeats: 0,
+      slowTestRetries: {},
       isKnownTestsEnabled: false,
       isTestManagementTestsEnabled: false,
       testManagementAttemptToFixRetries: 0,
@@ -331,6 +349,7 @@ function getSortWrapper (sort, frameworkVersion) {
         flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
         isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
         earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
+        earlyFlakeDetectionSlowTestRetries = libraryConfig.earlyFlakeDetectionSlowTestRetries ?? {}
         isDiEnabled = libraryConfig.isDiEnabled
         isKnownTestsEnabled = libraryConfig.isKnownTestsEnabled
         isTestManagementTestsEnabled = libraryConfig.isTestManagementEnabled
@@ -389,7 +408,9 @@ function getSortWrapper (sort, frameworkVersion) {
               workspaceProject._provided._ddIsKnownTestsEnabled = isKnownTestsEnabled
               workspaceProject._provided._ddKnownTests = knownTests
               workspaceProject._provided._ddIsEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
-              workspaceProject._provided._ddEarlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
+              workspaceProject._provided._ddEarlyFlakeDetectionNumRetries =
+                getConfiguredEfdRetryCount(earlyFlakeDetectionSlowTestRetries, earlyFlakeDetectionNumRetries)
+              workspaceProject._provided._ddEarlyFlakeDetectionSlowTestRetries = earlyFlakeDetectionSlowTestRetries
             } catch {
               log.warn('Could not send known tests to workers so Early Flake Detection will not work.')
             }
@@ -721,7 +742,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
         onDone: (isImpacted) => {
           if (isImpacted) {
             if (isEarlyFlakeDetectionEnabled) {
-              isRetryReasonEfd = task.repeats !== numRepeats
+              isRetryReasonEfd = true
               task.repeats = numRepeats
             }
             modifiedTasks.add(task)
@@ -739,7 +760,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
         onDone: (isNew) => {
           if (isNew && !attemptToFixTasks.has(task)) {
             if (isEarlyFlakeDetectionEnabled && !modifiedTasks.has(task)) {
-              isRetryReasonEfd = task.repeats !== numRepeats
+              isRetryReasonEfd = true
               task.repeats = numRepeats
             }
             newTasks.add(task)
@@ -811,6 +832,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
       isTestManagementTestsEnabled,
       testManagementTests,
       isFlakyTestRetriesEnabled,
+      slowTestRetries,
     } = getProvidedContext()
 
     if (isKnownTestsEnabled) {
@@ -832,6 +854,39 @@ function wrapVitestTestRunner (VitestTestRunner) {
     }
 
     const { retry: numAttempt, repeats: numRepetition } = retryInfo
+    const isEfdManagedTask = isEarlyFlakeDetectionEnabled && taskToStatuses.has(task) && !attemptToFixTasks.has(task)
+
+    if (isEfdManagedTask && numRepetition > 0 && !efdDeterminedRetries.has(task)) {
+      const previousExecutionStart = efdExecutionStartByTask.get(task)
+      const duration = previousExecutionStart === undefined
+        ? task.result?.duration ?? 0
+        : performance.now() - previousExecutionStart
+      const retryCount = getEfdRetryCount(duration, slowTestRetries)
+      efdDeterminedRetries.set(task, retryCount)
+      task.repeats = retryCount
+      if (retryCount === 0) {
+        efdSlowAbortedTasks.add(task)
+      }
+    }
+
+    const efdRetryCount = efdDeterminedRetries.get(task)
+    if (isEfdManagedTask && efdRetryCount !== undefined && numRepetition > efdRetryCount) {
+      if (task.result) {
+        efdSkippedRetryResults.set(task, {
+          ...task.result,
+          errors: task.result.errors?.slice(),
+        })
+      }
+      if (vitestSetFn) {
+        const noop = function () {}
+        noop.__ddTraceWrapped = true
+        vitestSetFn(task, noop)
+      }
+      return onBeforeTryTask.apply(this, arguments)
+    }
+    if (isEfdManagedTask) {
+      efdExecutionStartByTask.set(task, performance.now())
+    }
 
     // We finish the previous test here because we know it has failed already
     if (numAttempt > 0) {
@@ -985,21 +1040,48 @@ function wrapVitestTestRunner (VitestTestRunner) {
 
   // test finish (only passed tests)
   shimmer.wrap(VitestTestRunner.prototype, 'onAfterTryTask', onAfterTryTask =>
-    async function (task, { retry: retryCount }) {
+    async function (task, retryInfo) {
       if (!testPassCh.hasSubscribers && !testErrorCh.hasSubscribers && !testSkipCh.hasSubscribers) {
         return onAfterTryTask.apply(this, arguments)
       }
       const result = await onAfterTryTask.apply(this, arguments)
 
-      const { testManagementAttemptToFixRetries } = getProvidedContext()
+      const {
+        isEarlyFlakeDetectionEnabled,
+        testManagementAttemptToFixRetries,
+        slowTestRetries,
+      } = getProvidedContext()
 
-      const status = getVitestTestStatus(task, retryCount)
+      const status = getVitestTestStatus(task, retryInfo.retry)
       const ctx = taskToCtx.get(task)
 
       const { isDiEnabled } = getProvidedContext()
 
-      if (isDiEnabled && retryCount > 1) {
+      if (efdSkippedRetryResults.has(task)) {
+        task.result = efdSkippedRetryResults.get(task)
+        efdSkippedRetryResults.delete(task)
+        return result
+      }
+
+      if (isDiEnabled && retryInfo.retry > 1) {
         await waitForHitProbe()
+      }
+
+      if (
+        isEarlyFlakeDetectionEnabled &&
+        (retryInfo.repeats ?? 0) === 0 &&
+        taskToStatuses.has(task) &&
+        !attemptToFixTasks.has(task) &&
+        !efdDeterminedRetries.has(task)
+      ) {
+        const executionStart = efdExecutionStartByTask.get(task)
+        const duration = executionStart === undefined ? task.result?.duration ?? 0 : performance.now() - executionStart
+        const retryCount = getEfdRetryCount(duration, slowTestRetries)
+        efdDeterminedRetries.set(task, retryCount)
+        task.repeats = retryCount
+        if (retryCount === 0) {
+          efdSlowAbortedTasks.add(task)
+        }
       }
 
       let attemptToFixPassed = false
@@ -1234,6 +1316,7 @@ addHook({
             testPassCh.publish({
               task,
               finalStatus: isSkippedByTestManagement ? 'skip' : 'pass',
+              earlyFlakeAbortReason: efdSlowAbortedTasks.has(task) ? 'slow' : undefined,
               ...testCtx.currentStore,
             })
           }
@@ -1255,8 +1338,9 @@ addHook({
             providedContext.isEarlyFlakeDetectionEnabled && (newTasks.has(task) || modifiedTasks.has(task))
           if (isEfdRetry) {
             const statuses = taskToStatuses.get(task)
-            // statuses only includes repetitions (not the initial run), so we check against numRepeats (not +1)
-            if (statuses && statuses.length === providedContext.numRepeats &&
+            const efdRetryCount = efdDeterminedRetries.get(task) ?? providedContext.numRepeats
+            // statuses only includes repetitions (not the initial run), so we check against retry count (not +1)
+            if (efdRetryCount > 0 && statuses && statuses.length === efdRetryCount &&
               statuses.every(status => status === 'fail')) {
               hasFailedAllRetries = true
             }
@@ -1297,6 +1381,7 @@ addHook({
               hasFailedAllRetries,
               attemptToFixFailed,
               finalStatus,
+              earlyFlakeAbortReason: efdSlowAbortedTasks.has(task) ? 'slow' : undefined,
               ...testCtx.currentStore,
             })
           }

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -213,12 +213,15 @@ class VitestPlugin extends CiPlugin {
       return ctx.currentStore
     })
 
-    this.addSub('ci:vitest:test:pass', ({ span, task, finalStatus }) => {
+    this.addSub('ci:vitest:test:pass', ({ span, task, finalStatus, earlyFlakeAbortReason }) => {
       if (span) {
         this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'test', this.getTestTelemetryTags(span))
         span.setTag(TEST_STATUS, 'pass')
         if (finalStatus) {
           span.setTag(TEST_FINAL_STATUS, finalStatus)
+        }
+        if (earlyFlakeAbortReason) {
+          span.setTag(TEST_EARLY_FLAKE_ABORT_REASON, earlyFlakeAbortReason)
         }
         span.finish(this.taskToFinishTime.get(task))
         finishAllTraceSpans(span)
@@ -234,6 +237,7 @@ class VitestPlugin extends CiPlugin {
       hasFailedAllRetries,
       attemptToFixFailed,
       finalStatus,
+      earlyFlakeAbortReason,
     }) => {
       if (!span) {
         return
@@ -261,6 +265,9 @@ class VitestPlugin extends CiPlugin {
       }
       if (finalStatus) {
         span.setTag(TEST_FINAL_STATUS, finalStatus)
+      }
+      if (earlyFlakeAbortReason) {
+        span.setTag(TEST_EARLY_FLAKE_ABORT_REASON, earlyFlakeAbortReason)
       }
       if (duration) {
         span.finish(span._startTime + duration - MILLISECONDS_TO_SUBTRACT_FROM_FAILED_TEST_DURATION) // milliseconds


### PR DESCRIPTION
### What does this PR do?

Updates Vitest Early Flake Detection repeat scheduling to use the `slow_test_retries` duration buckets returned by the settings API.

Avoids reporting skipped excess EFD repeats once the first execution duration selects a lower retry count, and marks tests with `test.early_flake.abort_reason=slow` when the selected bucket aborts additional retries.

### Motivation

Jest, Mocha, and Cucumber already limit EFD retry attempts based on the duration of the first test execution. Vitest should apply the same API-driven retry bucket behavior so slow tests do not keep scheduling unnecessary EFD retries.

### Additional Notes

Stack: 3/5. This is now the base PR for the remaining framework PRs after #8287 merged.
