### PR TITLE
[test optimization] Use duration buckets for playwright EFD retries

### DIFF
--- a/integration-tests/ci-visibility/playwright-efd-duration/efd-duration-test.js
+++ b/integration-tests/ci-visibility/playwright-efd-duration/efd-duration-test.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { test, expect } = require('@playwright/test')
+
+test.describe('efd duration retries', () => {
+  test('instant test', async () => {
+    expect(1 + 1).toBe(2)
+  })
+
+  test('slightly slow test', async () => {
+    await new Promise(resolve => setTimeout(resolve, 11_000))
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/integration-tests/ci-visibility/playwright-efd-projects/project-duration-test.js
+++ b/integration-tests/ci-visibility/playwright-efd-projects/project-duration-test.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { test, expect } = require('@playwright/test')
+
+test.describe('efd project duration', () => {
+  test('project scoped test', async ({ browserName }, testInfo) => {
+    if (browserName && testInfo.project.name === 'second-chromium') {
+      await new Promise(resolve => setTimeout(resolve, 6_000))
+    }
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/integration-tests/ci-visibility/playwright-efd-repeat-duration/repeat-duration-test.js
+++ b/integration-tests/ci-visibility/playwright-efd-repeat-duration/repeat-duration-test.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { test, expect } = require('@playwright/test')
+
+test.describe('efd repeat duration', () => {
+  test('repeat-scoped test', async () => {
+    if (test.info().repeatEachIndex === 0) {
+      await new Promise(resolve => setTimeout(resolve, 6_000))
+    }
+
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/integration-tests/ci-visibility/playwright-efd-repeat/repeat-each-test.js
+++ b/integration-tests/ci-visibility/playwright-efd-repeat/repeat-each-test.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { test, expect } = require('@playwright/test')
+
+test.describe('efd repeat each', () => {
+  test('native repeat test', async () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -23,6 +23,15 @@ if (process.env.ADD_EXTRA_PLAYWRIGHT_PROJECT) {
   })
 }
 
+if (process.env.ADD_DUPLICATE_PLAYWRIGHT_PROJECT) {
+  projects.push({
+    name: 'second-chromium',
+    use: {
+      ...devices['Desktop Chrome'],
+    },
+  })
+}
+
 const config = {
   baseURL: process.env.PW_BASE_URL,
   testDir: process.env.TEST_DIR || './ci-visibility/playwright-tests',

--- a/integration-tests/playwright/playwright-efd.spec.js
+++ b/integration-tests/playwright/playwright-efd.spec.js
@@ -22,6 +22,7 @@ const {
   TEST_RETRY_REASON,
   TEST_HAS_FAILED_ALL_RETRIES,
   TEST_NAME,
+  TEST_BROWSER_NAME,
   TEST_RETRY_REASON_TYPES,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR } = require('../../version')
@@ -197,6 +198,226 @@ versions.forEach((version) => {
             env: {
               ...getCiVisAgentlessConfig(receiver.port),
               PW_BASE_URL: `http://localhost:${webAppPort}`,
+            },
+          }
+        )
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
+      it('uses the retry count from the matching slow_test_retries bucket', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+              '10s': 1,
+              '30s': 0,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          playwright: {},
+        })
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            const slowTests = tests.filter(test =>
+              test.meta[TEST_NAME] === 'efd duration retries slightly slow test'
+            )
+            assert.strictEqual(slowTests.length, 1)
+            assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+            assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
+          }, 45_000)
+
+        childProcess = exec(
+          './node_modules/.bin/playwright test -c playwright.config.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: './ci-visibility/playwright-efd-duration',
+              PLAYWRIGHT_WORKERS: '2',
+            },
+          }
+        )
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
+      it('keeps duration retry counts scoped by Playwright project', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+              '10s': 0,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          playwright: {},
+        })
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const projectTests = tests.filter(test =>
+              test.meta[TEST_NAME] === 'efd project duration project scoped test'
+            )
+            const fastProjectTests = projectTests.filter(test => test.meta[TEST_BROWSER_NAME] === 'chromium')
+            const slowProjectTests = projectTests.filter(test => test.meta[TEST_BROWSER_NAME] === 'second-chromium')
+
+            assert.strictEqual(fastProjectTests.length, 3)
+            assert.strictEqual(
+              fastProjectTests.filter(test => test.meta[TEST_IS_RETRY] === 'true').length,
+              2
+            )
+            assert.strictEqual(slowProjectTests.length, 1)
+            assert.strictEqual(slowProjectTests[0].meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(slowProjectTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+            assert.ok(!(TEST_IS_RETRY in slowProjectTests[0].meta))
+          }, 60_000)
+
+        childProcess = exec(
+          './node_modules/.bin/playwright test -c playwright.config.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: './ci-visibility/playwright-efd-projects',
+              ADD_DUPLICATE_PLAYWRIGHT_PROJECT: '1',
+              PLAYWRIGHT_WORKERS: '2',
+            },
+          }
+        )
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
+      it('does not treat native repeat-each executions as EFD retries', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 0,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          playwright: {},
+        })
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const repeatedTests = tests.filter(test =>
+              test.meta[TEST_NAME] === 'efd repeat each native repeat test'
+            )
+
+            assert.strictEqual(repeatedTests.length, 3)
+            for (const repeatedTest of repeatedTests) {
+              assert.strictEqual(repeatedTest.meta[TEST_IS_NEW], 'true')
+              assert.ok(!(TEST_IS_RETRY in repeatedTest.meta))
+              assert.ok(!(TEST_RETRY_REASON in repeatedTest.meta))
+            }
+          }, 45_000)
+
+        childProcess = exec(
+          './node_modules/.bin/playwright test -c playwright.config.js --repeat-each=3',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: './ci-visibility/playwright-efd-repeat',
+              PLAYWRIGHT_WORKERS: '2',
+            },
+          }
+        )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
+      it('keeps duration retry counts scoped by native repeat-each index', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+              '10s': 0,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          playwright: {},
+        })
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const repeatedTests = tests.filter(test =>
+              test.meta[TEST_NAME] === 'efd repeat duration repeat-scoped test'
+            )
+
+            assert.strictEqual(repeatedTests.length, 4)
+            for (const repeatedTest of repeatedTests) {
+              assert.strictEqual(repeatedTest.meta[TEST_IS_NEW], 'true')
+            }
+
+            const slowRepeatTests = repeatedTests.filter(
+              test => test.meta[TEST_EARLY_FLAKE_ABORT_REASON] === 'slow'
+            )
+            assert.strictEqual(slowRepeatTests.length, 1)
+            assert.ok(!(TEST_IS_RETRY in slowRepeatTests[0].meta))
+
+            const retriedTests = repeatedTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, 2)
+            for (const retriedTest of retriedTests) {
+              assert.strictEqual(retriedTest.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+            }
+
+            const fastOriginalTests = repeatedTests.filter(test =>
+              !(TEST_IS_RETRY in test.meta) && !(TEST_EARLY_FLAKE_ABORT_REASON in test.meta)
+            )
+            assert.strictEqual(fastOriginalTests.length, 1)
+          }, 60_000)
+
+        childProcess = exec(
+          './node_modules/.bin/playwright test -c playwright.config.js --repeat-each=2',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: './ci-visibility/playwright-efd-repeat-duration',
+              PLAYWRIGHT_WORKERS: '1',
             },
           }
         )
@@ -647,7 +868,7 @@ versions.forEach((version) => {
               assert.strictEqual(passedFlakyTests[0].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.ext)
               const failedFlakyTests = oldFlakyTests.filter(test => test.meta[TEST_STATUS] === 'fail')
               assert.strictEqual(failedFlakyTests.length, 1)
-            }),
+            }, 60_000),
         ])
       })
 

--- a/integration-tests/playwright/playwright-impacted-tests.spec.js
+++ b/integration-tests/playwright/playwright-impacted-tests.spec.js
@@ -201,7 +201,7 @@ versions.forEach((version) => {
               assert.strictEqual(retriedTestNew, isNew ? NUM_RETRIES_EFD * 2 : 0)
               assert.strictEqual(retriedTestsWithReason, NUM_RETRIES_EFD * 2)
             }
-          }, 25000)
+          }, 60000)
 
       const runImpactedTest = async (
         { isModified, isEfd = false, isNew = false },
@@ -264,6 +264,7 @@ versions.forEach((version) => {
               enabled: true,
               slow_test_retries: {
                 '5s': NUM_RETRIES_EFD,
+                '10s': NUM_RETRIES_EFD,
               },
             },
             known_tests_enabled: true,

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -3,6 +3,7 @@
 // Capture real timers at module load time, before any test can install fake timers.
 const realSetTimeout = setTimeout
 
+const { performance } = require('node:perf_hooks')
 const satisfies = require('../../../vendor/dist/semifies')
 
 const shimmer = require('../../datadog-shimmer')
@@ -12,6 +13,8 @@ const {
   PLAYWRIGHT_WORKER_TRACE_PAYLOAD_CODE,
   getIsFaultyEarlyFlakeDetection,
   DYNAMIC_NAME_RE,
+  getEfdRetryCount,
+  getMaxEfdRetryCount,
   recordAttemptToFixExecution,
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
@@ -68,6 +71,7 @@ let remainingTestsByFile = {}
 let isKnownTestsEnabled = false
 let isEarlyFlakeDetectionEnabled = false
 let earlyFlakeDetectionNumRetries = 0
+let earlyFlakeDetectionSlowTestRetries = {}
 let isEarlyFlakeDetectionFaulty = false
 let earlyFlakeDetectionFaultyThreshold = 0
 let isFlakyTestRetriesEnabled = false
@@ -83,10 +87,19 @@ let testsReportedInGenerateSummary = new Set()
 const newTestsWithDynamicNames = new Set()
 const attemptToFixExecutions = new Map()
 const loggedAttemptToFixTests = new Set()
+const efdManagedTestKeys = new Set()
+const efdRetryCountByTestKey = new Map()
+const efdRetryCountRequestsByTestKey = new Map()
+const efdRetryTestsById = new Map()
+const efdScheduledOriginalTestKeys = new Set()
+const efdStartedOriginalTestKeys = new Set()
+const efdSlowAbortedTests = new Set()
 let rootDir = ''
 let sessionProjects = []
 
 const MINIMUM_SUPPORTED_VERSION_RANGE_EFD = '>=1.38.0' // TODO: remove this once we drop support for v5
+const EFD_RETRY_COUNT_REQUEST = 'ddEfdRetryCountRequest'
+const EFD_RETRY_COUNT_RESPONSE = 'ddEfdRetryCountResponse'
 
 function isValidKnownTests (receivedKnownTests) {
   return !!receivedKnownTests.playwright
@@ -95,6 +108,222 @@ function isValidKnownTests (receivedKnownTests) {
 function getTestFullyQualifiedName (test) {
   const fullname = getTestFullname(test)
   return `${test._requireFile} ${fullname}`
+}
+
+/**
+ * @param {object} test
+ * @returns {string|undefined}
+ */
+function getTestProjectKey (test) {
+  const { _projectIndex, _projectId } = test
+  if (_projectIndex !== undefined) {
+    return `index:${_projectIndex}`
+  }
+  if (_projectId !== undefined) {
+    return `id:${_projectId}`
+  }
+
+  const projectSuite = getSuiteType(test, 'project')
+  const projectName = projectSuite?._fullProject?.project?.name ||
+    projectSuite?._fullProject?.name ||
+    projectSuite?.title
+  if (projectName) {
+    return `name:${projectName}`
+  }
+}
+
+/**
+ * @param {object} test
+ * @returns {number|undefined}
+ */
+function getTestEfdRepeatEachIndex (test) {
+  if (Object.hasOwn(test, '_ddEfdOriginalRepeatEachIndex')) {
+    return test._ddEfdOriginalRepeatEachIndex
+  }
+  return test.repeatEachIndex
+}
+
+/**
+ * @param {object} test
+ * @returns {string|undefined}
+ */
+function getTestRepeatEachKey (test) {
+  const repeatEachIndex = getTestEfdRepeatEachIndex(test)
+  if (repeatEachIndex !== undefined) {
+    return `repeat:${repeatEachIndex}`
+  }
+}
+
+/**
+ * @param {object} test
+ * @returns {string}
+ */
+function getTestEfdKey (test) {
+  const projectKey = getTestProjectKey(test)
+  const repeatEachKey = getTestRepeatEachKey(test)
+  const testFqn = getTestFullyQualifiedName(test)
+  return [projectKey, repeatEachKey, testFqn].filter(Boolean).join(' ')
+}
+
+function getConfiguredEfdRetryCount () {
+  if (!earlyFlakeDetectionSlowTestRetries || !Object.keys(earlyFlakeDetectionSlowTestRetries).length) {
+    return earlyFlakeDetectionNumRetries
+  }
+  return getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries)
+}
+
+function markEfdManagedTest (test) {
+  test._ddIsEfdManagedTest = true
+  test._ddEfdSlowTestRetries = earlyFlakeDetectionSlowTestRetries
+  efdManagedTestKeys.add(getTestEfdKey(test))
+}
+
+function markEfdRetryTest (test, retryIndex, originalTest) {
+  test._ddIsEfdRetry = true
+  test._ddEfdRetryIndex = retryIndex
+  if (originalTest) {
+    test._ddEfdOriginalRepeatEachIndex = getTestEfdRepeatEachIndex(originalTest)
+  }
+}
+
+function registerEfdRetryTest (test) {
+  if (!test._ddIsEfdRetry) {
+    return
+  }
+
+  efdRetryTestsById.set(test.id, {
+    retryIndex: test._ddEfdRetryIndex,
+    testEfdKey: getTestEfdKey(test),
+  })
+}
+
+function getTestEfdSlowTestRetries (test) {
+  return test._ddEfdSlowTestRetries || earlyFlakeDetectionSlowTestRetries
+}
+
+function isTestEfdManaged (test) {
+  return !!test._ddIsEfdManagedTest || (
+    (test._ddIsNew || test._ddIsModified) &&
+    !test._ddIsAttemptToFix &&
+    isEarlyFlakeDetectionEnabled
+  )
+}
+
+function getFileSuiteRepeatEachIndex (fileSuite) {
+  const test = fileSuite.allTests()[0]
+  return test ? getTestEfdRepeatEachIndex(test) || 0 : 0
+}
+
+function getEfdRetryRepeatEachIndex (fileSuite, projectSuite, retryIndex, retryCount) {
+  const nativeRepeatEach = projectSuite._fullProject?.project?.repeatEach || 1
+  const originalRepeatEachIndex = getFileSuiteRepeatEachIndex(fileSuite)
+  return nativeRepeatEach + (originalRepeatEachIndex * retryCount) + retryIndex - 1
+}
+
+function getEfdRetryCountForTest (test) {
+  return efdRetryCountByTestKey.get(getTestEfdKey(test)) ?? getConfiguredEfdRetryCount()
+}
+
+function setEfdRetryCountForTest (test, retryCount) {
+  const testEfdKey = getTestEfdKey(test)
+  efdRetryCountByTestKey.set(testEfdKey, retryCount)
+
+  const requests = efdRetryCountRequestsByTestKey.get(testEfdKey)
+  if (requests) {
+    efdRetryCountRequestsByTestKey.delete(testEfdKey)
+    for (const resolveRequest of requests) {
+      resolveRequest(retryCount)
+    }
+  }
+}
+
+function sendEfdRetryCountToWorker (workerProcess, testId, retryIndex, retryCount) {
+  workerProcess.send({
+    type: EFD_RETRY_COUNT_RESPONSE,
+    testId,
+    isEfdRetry: retryIndex !== undefined,
+    retryIndex,
+    retryCount,
+  })
+}
+
+function sendEfdRetryCountToWorkerWhenAvailable (workerProcess, testId) {
+  const efdRetryTest = efdRetryTestsById.get(testId)
+  if (!efdRetryTest) {
+    sendEfdRetryCountToWorker(workerProcess, testId)
+    return
+  }
+
+  const { retryIndex, testEfdKey } = efdRetryTest
+
+  if (!testEfdKey || !efdManagedTestKeys.has(testEfdKey)) {
+    sendEfdRetryCountToWorker(workerProcess, testId)
+    return
+  }
+
+  const retryCount = efdRetryCountByTestKey.get(testEfdKey)
+  if (retryCount !== undefined) {
+    sendEfdRetryCountToWorker(workerProcess, testId, retryIndex, retryCount)
+    return
+  }
+
+  if (!efdStartedOriginalTestKeys.has(testEfdKey) && !efdScheduledOriginalTestKeys.has(testEfdKey)) {
+    sendEfdRetryCountToWorker(workerProcess, testId, retryIndex, 0)
+    return
+  }
+
+  if (!efdRetryCountRequestsByTestKey.has(testEfdKey)) {
+    efdRetryCountRequestsByTestKey.set(testEfdKey, [])
+  }
+  efdRetryCountRequestsByTestKey.get(testEfdKey).push((retryCount) => {
+    sendEfdRetryCountToWorker(workerProcess, testId, retryIndex, retryCount)
+  })
+}
+
+/**
+ * @param {object} test
+ * @returns {boolean}
+ */
+function shouldRequestEfdRetryCount (test) {
+  // The main process remains the source of truth. repeatEachIndex is only used as
+  // a cheap worker-side filter so first executions do not block on coordination.
+  return test._ddIsEfdRetry || test.repeatEachIndex > 0
+}
+
+function waitForEfdRetryCount (test) {
+  if (!process.send || !shouldRequestEfdRetryCount(test)) {
+    return Promise.resolve()
+  }
+
+  const testEfdKey = getTestEfdKey(test)
+  return new Promise(resolve => {
+    const messageHandler = (message) => {
+      if (message?.type === EFD_RETRY_COUNT_RESPONSE && message.testId === test.id) {
+        if (message.isEfdRetry) {
+          test._ddIsEfdRetry = true
+          test._ddEfdRetryIndex = message.retryIndex
+          test._ddEfdRetryCount = message.retryCount
+          efdRetryCountByTestKey.set(testEfdKey, message.retryCount)
+        }
+        process.removeListener('message', messageHandler)
+        resolve()
+      }
+    }
+
+    process.on('message', messageHandler)
+    process.send({
+      type: EFD_RETRY_COUNT_REQUEST,
+      testId: test.id,
+    })
+  })
+}
+
+function shouldSkipEfdRetry (test) {
+  if (!test._ddIsEfdRetry) {
+    return false
+  }
+  const retryCount = test._ddEfdRetryCount ?? efdRetryCountByTestKey.get(getTestEfdKey(test))
+  return retryCount !== undefined && test._ddEfdRetryIndex > retryCount
 }
 
 function getTestProperties (test) {
@@ -125,14 +354,17 @@ function getSuiteType (test, type) {
 }
 
 // Copy of Suite#_deepClone but with a function to filter tests
-function deepCloneSuite (suite, filterTest, tags = []) {
+function deepCloneSuite (suite, filterTest, tags = [], configureCopiedTest) {
   const copy = suite._clone()
   for (const entry of suite._entries) {
     if (entry.constructor.name === 'Suite') {
-      copy._addSuite(deepCloneSuite(entry, filterTest, tags))
+      copy._addSuite(deepCloneSuite(entry, filterTest, tags, configureCopiedTest))
     } else {
       if (filterTest(entry)) {
         const copiedTest = entry._clone()
+        if (configureCopiedTest) {
+          configureCopiedTest(copiedTest, entry)
+        }
         for (const tag of tags) {
           const resolvedTag = typeof tag === 'function' ? tag(entry) : tag
 
@@ -303,6 +535,7 @@ function getFinalStatus ({
   isAttemptToFix,
   hasFailedAllRetries,
   hasFailedAttemptToFixRetries,
+  hasPassedAnyEfdAttempt,
   testStatus,
 }) {
   if (!isFinalExecution) {
@@ -311,8 +544,11 @@ function getFinalStatus ({
   if (isDisabled || isQuarantined || testStatus === 'skip') {
     return 'skip'
   }
-  if (isAtrRetry || isEfdManagedTest) {
+  if (isAtrRetry) {
     return hasFailedAllRetries ? 'fail' : 'pass'
+  }
+  if (isEfdManagedTest) {
+    return hasPassedAnyEfdAttempt ? 'pass' : 'fail'
   }
   if (isAttemptToFix) {
     return hasFailedAttemptToFixRetries ? 'fail' : 'pass'
@@ -349,6 +585,14 @@ function testBeginHandler (test, browserName, shouldCreateTestSpan) {
 
   if (_type === 'beforeAll' || _type === 'afterAll') {
     return
+  }
+  if (shouldSkipEfdRetry(test)) {
+    test._ddShouldSkipEfdRetry = true
+    return
+  }
+  test._ddStartTime = performance.now()
+  if (isTestEfdManaged(test) && !test._ddIsEfdRetry) {
+    efdStartedOriginalTestKeys.add(getTestEfdKey(test))
   }
   // this means that a skipped test is being handled
   if (!remainingTestsByFile[testSuiteAbsolutePath].length) {
@@ -391,6 +635,45 @@ function testBeginHandler (test, browserName, shouldCreateTestSpan) {
   }
 }
 
+function finishTestSuiteIfDone (testSuiteAbsolutePath, projects) {
+  if (!shouldFinishTestSuite(testSuiteAbsolutePath)) {
+    return
+  }
+
+  const skippedTests = remainingTestsByFile[testSuiteAbsolutePath]
+    .filter(test => test.expectedStatus === 'skipped')
+
+  for (const test of skippedTests) {
+    const browserName = getBrowserNameFromProjects(projects, test)
+    testSkipCh.publish({
+      testName: getTestFullname(test),
+      testSuiteAbsolutePath,
+      testSourceFileAbsolutePath: test.location.file,
+      testSourceLine: test.location.line,
+      browserName,
+      isNew: test._ddIsNew,
+      isDisabled: test._ddIsDisabled,
+      isModified: test._ddIsModified,
+      isQuarantined: test._ddIsQuarantined,
+    })
+  }
+  remainingTestsByFile[testSuiteAbsolutePath] = []
+
+  const testStatuses = testSuiteToTestStatuses.get(testSuiteAbsolutePath)
+  let testSuiteStatus = 'pass'
+  if (testStatuses?.includes('fail')) {
+    testSuiteStatus = 'fail'
+  } else if (testStatuses?.every(status => status === 'skip')) {
+    testSuiteStatus = 'skip'
+  }
+
+  const suiteError = getTestSuiteError(testSuiteAbsolutePath)
+  const testSuiteCtx = testSuiteToCtx.get(testSuiteAbsolutePath)
+  if (testSuiteCtx) {
+    testSuiteFinishCh.publish({ status: testSuiteStatus, error: suiteError, ...testSuiteCtx.currentStore })
+  }
+}
+
 function testEndHandler ({
   test,
   annotations,
@@ -420,16 +703,37 @@ function testEndHandler ({
     return
   }
 
+  if (test._ddShouldSkipEfdRetry || shouldSkipEfdRetry(test)) {
+    test._ddShouldSkipEfdRetry = true
+    remainingTestsByFile[testSuiteAbsolutePath] = remainingTestsByFile[testSuiteAbsolutePath]
+      .filter(currentTest => currentTest !== test)
+    finishTestSuiteIfDone(testSuiteAbsolutePath, projects)
+    return
+  }
+
+  const isEfdManagedTest = isTestEfdManaged(test)
   const testFqn = getTestFullyQualifiedName(test)
-  const testStatuses = testsToTestStatuses.get(testFqn) || []
+  const testStatusKey = isEfdManagedTest ? getTestEfdKey(test) : testFqn
+  const testStatuses = testsToTestStatuses.get(testStatusKey) || []
 
   if (testStatuses.length === 0) {
-    testsToTestStatuses.set(testFqn, [testStatus])
+    testsToTestStatuses.set(testStatusKey, [testStatus])
     if (test._ddIsNew && DYNAMIC_NAME_RE.test(getTestFullname(test))) {
       newTestsWithDynamicNames.add(`${getTestSuitePath(test._requireFile, rootDir)} › ${getTestFullname(test)}`)
     }
   } else {
     testStatuses.push(testStatus)
+  }
+
+  const testEfdKey = getTestEfdKey(test)
+  if (isEfdManagedTest && !test._ddIsEfdRetry && !efdRetryCountByTestKey.has(testEfdKey)) {
+    const testResult = results.at(-1)
+    const duration = testResult?.duration > 0 ? testResult.duration : performance.now() - test._ddStartTime
+    const retryCount = getEfdRetryCount(duration, getTestEfdSlowTestRetries(test))
+    setEfdRetryCountForTest(test, retryCount)
+    if (retryCount === 0) {
+      efdSlowAbortedTests.add(testEfdKey)
+    }
   }
 
   const testProperties = getTestProperties(test)
@@ -460,7 +764,8 @@ function testEndHandler ({
   }
 
   // Check if all EFD retries failed
-  if (testStatuses.length === earlyFlakeDetectionNumRetries + 1 &&
+  const efdRetryCount = getEfdRetryCountForTest(test)
+  if (efdRetryCount > 0 && testStatuses.length === efdRetryCount + 1 &&
     (test._ddIsNew || test._ddIsModified) &&
     test._ddIsEfdRetry &&
     testStatuses.every(status => status === 'fail')) {
@@ -480,9 +785,6 @@ function testEndHandler ({
   if (shouldCreateTestSpan) {
     const testResult = results.at(-1)
     const testCtx = testToCtx.get(test)
-    const isEfdManagedTest = (test._ddIsNew || test._ddIsModified) &&
-      !test._ddIsAttemptToFix &&
-      isEarlyFlakeDetectionEnabled
     const isAtrRetry = testResult?.retry > 0 &&
       isFlakyTestRetriesEnabled &&
       !test._ddIsAttemptToFix &&
@@ -497,6 +799,7 @@ function testEndHandler ({
       isAttemptToFix: test._ddIsAttemptToFix,
       hasFailedAllRetries: test._ddHasFailedAllRetries,
       hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
+      hasPassedAnyEfdAttempt: testStatuses.includes('pass'),
       testStatus,
     })
 
@@ -520,6 +823,7 @@ function testEndHandler ({
         isAtrRetry,
         isModified: test._ddIsModified,
         finalStatus,
+        earlyFlakeAbortReason: efdSlowAbortedTests.has(testEfdKey) ? 'slow' : undefined,
         ...testCtx.currentStore,
       })
     }
@@ -540,38 +844,7 @@ function testEndHandler ({
       .filter(currentTest => currentTest !== test)
   }
 
-  if (shouldFinishTestSuite(testSuiteAbsolutePath)) {
-    const skippedTests = remainingTestsByFile[testSuiteAbsolutePath]
-      .filter(test => test.expectedStatus === 'skipped')
-
-    for (const test of skippedTests) {
-      const browserName = getBrowserNameFromProjects(projects, test)
-      testSkipCh.publish({
-        testName: getTestFullname(test),
-        testSuiteAbsolutePath,
-        testSourceFileAbsolutePath: test.location.file,
-        testSourceLine: test.location.line,
-        browserName,
-        isNew: test._ddIsNew,
-        isDisabled: test._ddIsDisabled,
-        isModified: test._ddIsModified,
-        isQuarantined: test._ddIsQuarantined,
-      })
-    }
-    remainingTestsByFile[testSuiteAbsolutePath] = []
-
-    const testStatuses = testSuiteToTestStatuses.get(testSuiteAbsolutePath)
-    let testSuiteStatus = 'pass'
-    if (testStatuses.includes('fail')) {
-      testSuiteStatus = 'fail'
-    } else if (testStatuses.every(status => status === 'skip')) {
-      testSuiteStatus = 'skip'
-    }
-
-    const suiteError = getTestSuiteError(testSuiteAbsolutePath)
-    const testSuiteCtx = testSuiteToCtx.get(testSuiteAbsolutePath)
-    testSuiteFinishCh.publish({ status: testSuiteStatus, error: suiteError, ...testSuiteCtx.currentStore })
-  }
+  finishTestSuiteIfDone(testSuiteAbsolutePath, projects)
 }
 
 function dispatcherRunWrapper (run) {
@@ -579,6 +852,39 @@ function dispatcherRunWrapper (run) {
     remainingTestsByFile = getTestsBySuiteFromTestsById(this._testById)
     return run.apply(this, arguments)
   }
+}
+
+function deferEfdRetryGroups (testGroups) {
+  const groupsWithOriginalTests = []
+  const efdRetryOnlyGroups = []
+
+  for (const group of testGroups) {
+    const originalTests = []
+    const efdRetryTests = []
+
+    for (const test of group.tests) {
+      if (test._ddIsEfdRetry) {
+        efdRetryTests.push(test)
+      } else {
+        originalTests.push(test)
+        if (isTestEfdManaged(test)) {
+          efdScheduledOriginalTestKeys.add(getTestEfdKey(test))
+        }
+      }
+    }
+
+    if (efdRetryTests.length && originalTests.length) {
+      group.tests = [...originalTests, ...efdRetryTests]
+    }
+
+    if (originalTests.length) {
+      groupsWithOriginalTests.push(group)
+    } else {
+      efdRetryOnlyGroups.push(group)
+    }
+  }
+
+  return [...groupsWithOriginalTests, ...efdRetryOnlyGroups]
 }
 
 function dispatcherRunWrapperNew (run) {
@@ -593,12 +899,17 @@ function dispatcherRunWrapperNew (run) {
       testGroups = testGroups.filter(group => group.tests.length > 0)
     }
 
+    if (isEarlyFlakeDetectionEnabled) {
+      testGroups = deferEfdRetryGroups(testGroups)
+    }
+
     if (!this._allTests) {
       // Removed in https://github.com/microsoft/playwright/commit/1e52c37b254a441cccf332520f60225a5acc14c7
       // Not available from >=1.44.0
       this._ddAllTests = testGroups.flatMap(g => g.tests)
     }
     remainingTestsByFile = getTestsBySuiteFromTestGroups(testGroups)
+    arguments[0] = testGroups
     return run.apply(this, arguments)
   }
 }
@@ -638,7 +949,6 @@ function dispatcherHook (dispatcherExport) {
         )
       }
     })
-
     return worker
   })
   return dispatcherExport
@@ -690,14 +1000,11 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
       // above) and mark the execution final once the count reaches the expected total.
       // This mirrors how ATF finality is detected and centralizes the decision in the
       // main process, so workers only need to act on the _ddIsFinalExecution flag.
-      const isEfdManagedTest = (test._ddIsNew || test._ddIsModified) &&
-        !test._ddIsAttemptToFix &&
-        isEarlyFlakeDetectionEnabled
+      const isEfdManagedTest = isTestEfdManaged(test)
       let isFinalExecution
       if (isEfdManagedTest) {
-        const testFqn = getTestFullyQualifiedName(test)
-        const efdTestStatuses = testsToTestStatuses.get(testFqn) || []
-        isFinalExecution = efdTestStatuses.length === earlyFlakeDetectionNumRetries + 1
+        const efdTestStatuses = testsToTestStatuses.get(getTestEfdKey(test)) || []
+        isFinalExecution = efdTestStatuses.length === getEfdRetryCountForTest(test) + 1
       } else if (test._ddIsAttemptToFix) {
         isFinalExecution = !!(test._ddHasPassedAttemptToFixRetries || test._ddHasFailedAttemptToFixRetries)
       } else {
@@ -722,10 +1029,11 @@ function dispatcherHookNew (dispatcherExport, runWrapper) {
           _ddIsModified: test._ddIsModified,
           _ddIsFinalExecution: isFinalExecution,
           _ddIsEfdManagedTest: isEfdManagedTest,
+          _ddEarlyFlakeAbortReason: efdSlowAbortedTests.has(getTestEfdKey(test)) ? 'slow' : undefined,
+          _ddHasPassedAnyEfdAttempt: (testsToTestStatuses.get(getTestEfdKey(test)) || []).includes('pass'),
         },
       })
     })
-
     return worker
   })
   return dispatcherExport
@@ -751,6 +1059,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
         isKnownTestsEnabled = libraryConfig.isKnownTestsEnabled
         isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
         earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
+        earlyFlakeDetectionSlowTestRetries = libraryConfig.earlyFlakeDetectionSlowTestRetries ?? {}
         earlyFlakeDetectionFaultyThreshold = libraryConfig.earlyFlakeDetectionFaultyThreshold
         isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
         flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
@@ -900,6 +1209,13 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
     remainingTestsByFile = {}
     quarantinedButNotAttemptToFixFqns = new Set()
     testsReportedInGenerateSummary = new Set()
+    efdManagedTestKeys.clear()
+    efdRetryCountByTestKey.clear()
+    efdRetryCountRequestsByTestKey.clear()
+    efdRetryTestsById.clear()
+    efdScheduledOriginalTestKeys.clear()
+    efdStartedOriginalTestKeys.clear()
+    efdSlowAbortedTests.clear()
 
     // TODO: we can trick playwright into thinking the session passed by returning
     // 'passed' here. We might be able to use this for both EFD and Test Management tests.
@@ -1001,12 +1317,29 @@ addHook({
  * - we execute `applyRepeatEachIndex` for each of these cloned file suites
  * - we add the cloned file suites to the project suite
  */
-function applyRetriesToTests (fileSuitesWithTestsToRetry, filterTest, tagsToApply, numRetries) {
+function applyRetriesToTests (
+  fileSuitesWithTestsToRetry,
+  filterTest,
+  tagsToApply,
+  numRetries,
+  configureCopiedTest,
+  getRetryRepeatEachIndex
+) {
   for (const [fileSuite, projectSuite] of fileSuitesWithTestsToRetry.entries()) {
     for (let repeatEachIndex = 1; repeatEachIndex <= numRetries; repeatEachIndex++) {
-      const copyFileSuite = deepCloneSuite(fileSuite, filterTest, tagsToApply)
-      applyRepeatEachIndex(projectSuite._fullProject, copyFileSuite, repeatEachIndex + 1)
+      const copyFileSuite = deepCloneSuite(fileSuite, filterTest, tagsToApply, (copiedTest, originalTest) => {
+        if (configureCopiedTest) {
+          configureCopiedTest(copiedTest, originalTest, repeatEachIndex)
+        }
+      })
+      const retryRepeatEachIndex = getRetryRepeatEachIndex
+        ? getRetryRepeatEachIndex(fileSuite, projectSuite, repeatEachIndex, numRetries)
+        : repeatEachIndex + 1
+      applyRepeatEachIndex(projectSuite._fullProject, copyFileSuite, retryRepeatEachIndex)
       projectSuite._addSuite(copyFileSuite)
+      for (const copiedTest of copyFileSuite.allTests()) {
+        registerEfdRetryTest(copiedTest)
+      }
     }
   }
 }
@@ -1091,6 +1424,7 @@ addHook({
       for (const impactedTest of impactedTests) {
         impactedTest._ddIsModified = true
         if (isEarlyFlakeDetectionEnabled && impactedTest.expectedStatus !== 'skipped') {
+          markEfdManagedTest(impactedTest)
           const fileSuite = getSuiteType(impactedTest, 'file')
           if (!fileSuitesWithImpactedTestsToProjects.has(fileSuite)) {
             fileSuitesWithImpactedTestsToProjects.set(fileSuite, getSuiteType(impactedTest, 'project'))
@@ -1106,7 +1440,12 @@ addHook({
           '_ddIsEfdRetry',
           (test) => (isKnownTestsEnabled && isNewTest(test) ? '_ddIsNew' : null),
         ],
-        earlyFlakeDetectionNumRetries
+        getConfiguredEfdRetryCount(),
+        (copiedTest, originalTest, retryIndex) => {
+          markEfdRetryTest(copiedTest, retryIndex, originalTest)
+          markEfdManagedTest(copiedTest)
+        },
+        getEfdRetryRepeatEachIndex
       )
     }
 
@@ -1130,6 +1469,7 @@ addHook({
           if (isEarlyFlakeDetectionEnabled && newTest.expectedStatus !== 'skipped' && !newTest._ddIsModified) {
             // Prevent ATR or `--retries` from retrying new tests if EFD is enabled
             newTest.retries = 0
+            markEfdManagedTest(newTest)
             const fileSuite = getSuiteType(newTest, 'file')
             if (!fileSuitesWithNewTestsToProjects.has(fileSuite)) {
               fileSuitesWithNewTestsToProjects.set(fileSuite, getSuiteType(newTest, 'project'))
@@ -1141,7 +1481,12 @@ addHook({
           fileSuitesWithNewTestsToProjects,
           isNewTest,
           ['_ddIsNew', '_ddIsEfdRetry'],
-          earlyFlakeDetectionNumRetries
+          getConfiguredEfdRetryCount(),
+          (copiedTest, originalTest, retryIndex) => {
+            markEfdRetryTest(copiedTest, retryIndex, originalTest)
+            markEfdManagedTest(copiedTest)
+          },
+          getEfdRetryRepeatEachIndex
         )
       }
     }
@@ -1177,6 +1522,10 @@ addHook({
 
     // We add a new listener to `this.process`, which is represents the worker
     this.process.on('message', (message) => {
+      if (message?.type === EFD_RETRY_COUNT_REQUEST) {
+        sendEfdRetryCountToWorkerWhenAvailable(this.process, message.testId)
+        return
+      }
       // These messages are [code, payload]. The payload is test data
       if (Array.isArray(message) && message[0] === PLAYWRIGHT_WORKER_TRACE_PAYLOAD_CODE) {
         workerReportCh.publish(message[1])
@@ -1235,9 +1584,15 @@ addHook({
   const stepInfoByStepId = {}
 
   shimmer.wrap(workerPackage.WorkerMain.prototype, '_runTest', _runTest => async function (test) {
+    await waitForEfdRetryCount(test)
+    if (shouldSkipEfdRetry(test)) {
+      test._ddShouldSkipEfdRetry = true
+      test.expectedStatus = 'skipped'
+    }
     if (test.expectedStatus === 'skipped') {
       return _runTest.apply(this, arguments)
     }
+    test._ddStartTime = performance.now()
     steps = []
 
     const {
@@ -1320,6 +1675,21 @@ addHook({
     await res
 
     const { status, error, annotations, retry, testId } = testInfo
+    const testEfdKey = getTestEfdKey(test)
+    const isEfdManagedTest = isTestEfdManaged(test)
+    if (isEfdManagedTest && !test._ddIsEfdRetry && !efdRetryCountByTestKey.has(testEfdKey)) {
+      const duration = test.results?.at(-1)?.duration > 0
+        ? test.results.at(-1).duration
+        : performance.now() - test._ddStartTime
+      const retryCount = getEfdRetryCount(
+        duration,
+        getTestEfdSlowTestRetries(test)
+      )
+      setEfdRetryCountForTest(test, retryCount)
+      if (retryCount === 0) {
+        efdSlowAbortedTests.add(testEfdKey)
+      }
+    }
 
     // testInfo.errors could be better than "error",
     // which will only include timeout error (even though the test failed because of a different error)
@@ -1365,6 +1735,7 @@ addHook({
       isAttemptToFix: test._ddIsAttemptToFix,
       hasFailedAllRetries: test._ddHasFailedAllRetries,
       hasFailedAttemptToFixRetries: test._ddHasFailedAttemptToFixRetries,
+      hasPassedAnyEfdAttempt: test._ddHasPassedAnyEfdAttempt,
       testStatus: STATUS_TO_TEST_STATUS[status],
     })
 
@@ -1388,6 +1759,7 @@ addHook({
       isModified: test._ddIsModified,
       onDone,
       finalStatus,
+      earlyFlakeAbortReason: test._ddEarlyFlakeAbortReason,
       ...testCtx.currentStore,
     })
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -321,6 +321,7 @@ class PlaywrightPlugin extends CiPlugin {
       isAtrRetry,
       isModified,
       finalStatus,
+      earlyFlakeAbortReason,
       onDone,
     }) => {
       if (!span) return
@@ -383,6 +384,9 @@ class PlaywrightPlugin extends CiPlugin {
       }
       if (finalStatus) {
         span.setTag(TEST_FINAL_STATUS, finalStatus)
+      }
+      if (earlyFlakeAbortReason) {
+        span.setTag(TEST_EARLY_FLAKE_ABORT_REASON, earlyFlakeAbortReason)
       }
       for (const step of steps) {
         const stepStartTime = step.startTime.getTime()


### PR DESCRIPTION
### What does this PR do?

Updates Playwright Early Flake Detection clone execution to use the `slow_test_retries` duration buckets returned by the settings API.

Propagates the retry thresholds to Playwright workers, and marks tests with `test.early_flake.abort_reason=slow` when the selected bucket aborts additional retries.

### Motivation

Jest, Mocha, Cucumber, and Vitest already limit EFD retry attempts based on the duration of the first test execution. Playwright should apply the same API-driven retry bucket behavior so slow tests do not keep scheduling unnecessary EFD retries.

### Additional Notes

Stack: 4/5. This is now the base PR for the remaining Cypress PR after #8288 merged.
