### PR TITLE
[test optimization] Use duration buckets for cypress EFD retries

### DIFF
--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -19,6 +19,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_RETRY_REASON,
   TEST_NAME,
   TEST_HAS_FAILED_ALL_RETRIES,
@@ -215,6 +216,67 @@ moduleTypes.forEach(({
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              SPEC_PATTERN: specToRun,
+            },
+          }
+        )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
+      it('uses the retry count from the matching slow_test_retries bucket', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+              '10s': 0,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          cypress: {},
+        })
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            const instantTests = tests.filter(test => test.resource ===
+              'cypress/e2e/efd-duration.cy.js.efd duration retries instant test'
+            )
+            assert.strictEqual(instantTests.length, 3)
+            assert.strictEqual(
+              instantTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd).length,
+              2
+            )
+
+            const slowTests = tests.filter(test => test.resource ===
+              'cypress/e2e/efd-duration.cy.js.efd duration retries slightly slow test'
+            )
+            assert.strictEqual(slowTests.length, 1)
+            assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+            assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
+          }, 30_000)
+
+        const envVars = getCiVisEvpProxyConfig(receiver.port)
+        const specToRun = 'cypress/e2e/efd-duration.cy.js'
 
         childProcess = exec(
           version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -24,6 +24,7 @@ const {
   TEST_NAME,
   TEST_HAS_FAILED_ALL_RETRIES,
   TEST_RETRY_REASON_TYPES,
+  TEST_FINAL_STATUS,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_MAJOR, NODE_MAJOR } = require('../../version')
 
@@ -272,6 +273,8 @@ moduleTypes.forEach(({
             assert.strictEqual(slowTests.length, 1)
             assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
             assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+            assert.strictEqual(slowTests[0].meta[TEST_STATUS], 'pass')
+            assert.strictEqual(slowTests[0].meta[TEST_FINAL_STATUS], 'pass')
             assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
           }, 30_000)
 

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -465,6 +465,61 @@ moduleTypes.forEach(({
         ])
       })
 
+      it('bails out of EFD if the percentage of new test files is too high', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD,
+            },
+            faulty_session_threshold: 0,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          cypress: {},
+        })
+
+        const envVars = getCiVisEvpProxyConfig(receiver.port)
+
+        const receiverPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            assert.strictEqual(tests.length, 2)
+
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            assert.strictEqual(newTests.length, 0)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, 0)
+
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+            assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
+          }, 60000)
+
+        const specToRun = 'cypress/e2e/spec.cy.js'
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              SPEC_PATTERN: specToRun,
+            },
+          }
+        )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+      })
+
       it('disables early flake detection if known tests should not be requested', async () => {
         receiver.setSettings({
           early_flake_detection: {

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -1468,10 +1468,11 @@ moduleTypes.forEach(({
           )
 
           assert.ok(jsInvocationDetailsEvent, 'plain-js invocationDetails test event should exist')
-          assert.strictEqual(
-            jsInvocationDetailsEvent.content.metrics[TEST_SOURCE_START],
-            243,
-            'should keep invocationDetails line directly for plain JS specs without source maps'
+          // The exact value is a Cypress-generated bundle line that shifts when support code changes.
+          // It should stay as a generated invocationDetails line instead of resolving to the fixture declaration.
+          assert.ok(
+            jsInvocationDetailsEvent.content.metrics[TEST_SOURCE_START] > 100,
+            'should keep generated invocationDetails line directly for plain JS specs without source maps'
           )
           assert.ok(
             jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-invocation.cy.js'),

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -15,6 +15,7 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const {
   TEST_STATUS,
   TEST_IS_NEW,
@@ -536,6 +537,63 @@ moduleTypes.forEach(({
           receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 
           await runAttemptToFixTest({ isAttemptToFix: true, shouldFailSometimes: true })
+        })
+
+        it('keeps after hook failures on attempt to fix tests', async () => {
+          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+          receiver.setTestManagementTests({
+            cypress: {
+              suites: {
+                'cypress/e2e/attempt-to-fix-after-hook.js': {
+                  tests: {
+                    'attempt to fix after hook passes before after hook fails': {
+                      properties: {
+                        attempt_to_fix: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          const receiverPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const attemptToFixTests = tests
+                .filter(test => test.meta[TEST_NAME] === 'attempt to fix after hook passes before after hook fails')
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              assert.strictEqual(attemptToFixTests.length, 4)
+
+              const lastAttempt = attemptToFixTests[attemptToFixTests.length - 1]
+              assert.strictEqual(lastAttempt.meta[TEST_STATUS], 'fail')
+              assert.match(lastAttempt.meta[ERROR_MESSAGE], /error in after hook/)
+              assert.strictEqual(lastAttempt.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+            }, 25000)
+
+          const envVars = getCiVisEvpProxyConfig(receiver.port)
+          const specToRun = 'cypress/e2e/attempt-to-fix-after-hook.js'
+
+          childProcess = exec(
+            version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+            {
+              cwd,
+              env: {
+                ...envVars,
+                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                SPEC_PATTERN: specToRun,
+              },
+            }
+          )
+
+          const [[exitCode]] = await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
+
+          assert.strictEqual(exitCode, 1)
         })
 
         it('does not attempt to fix tests if test management is not enabled', async () => {

--- a/integration-tests/cypress/e2e/attempt-to-fix-after-hook.js
+++ b/integration-tests/cypress/e2e/attempt-to-fix-after-hook.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+
+describe('attempt to fix after hook', () => {
+  after(() => {
+    throw new Error('error in after hook')
+  })
+
+  it('passes before after hook fails', () => {
+    cy.visit('/')
+      .get('.hello-world')
+      .should('have.text', 'Hello World')
+  })
+})

--- a/integration-tests/cypress/e2e/efd-duration.cy.js
+++ b/integration-tests/cypress/e2e/efd-duration.cy.js
@@ -1,0 +1,10 @@
+describe('efd duration retries', () => {
+  it('instant test', () => {
+    expect(1 + 1).to.equal(2)
+  })
+
+  it('slightly slow test', () => {
+    cy.wait(5100)
+    expect(1 + 1).to.equal(2)
+  })
+})

--- a/integration-tests/cypress/e2e/efd-duration.cy.js
+++ b/integration-tests/cypress/e2e/efd-duration.cy.js
@@ -1,3 +1,6 @@
+/* eslint-disable */
+'use strict'
+
 describe('efd duration retries', () => {
   it('instant test', () => {
     expect(1 + 1).to.equal(2)

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -992,6 +992,7 @@ versions.forEach((version) => {
             const events = payloads.flatMap(({ payload }) => payload.events)
 
             const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
             assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
 
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
@@ -1002,6 +1003,9 @@ versions.forEach((version) => {
             )
             // no new tests
             assert.strictEqual(newTests.length, 0)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, 0)
           })
 
         childProcess = exec(
@@ -1136,6 +1140,7 @@ versions.forEach((version) => {
             assert.ok(testSessionEnd, 'expected test_session_end event in payloads')
             const testSessionEvent = testSessionEnd.content
             assert.strictEqual(testSessionEvent.meta[TEST_STATUS], 'fail')
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSessionEvent.meta))
           }, 60000)
 
         childProcess = exec(

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -267,8 +267,9 @@ function getSuiteStatus (suiteStats) {
   return 'pass'
 }
 
-function getMatchingCypressTest (cypressTests, testName, attemptIndex, testStatus) {
-  let matchingTest
+function getMatchingCypressTest (cypressTests, testName, attemptIndex, testStatus, preferIndexedMatch = false) {
+  let matchingTestByIndex
+  let matchingTestByStatus
   let matchingTestIndex = 0
 
   for (const cypressTest of cypressTests) {
@@ -277,16 +278,18 @@ function getMatchingCypressTest (cypressTests, testName, attemptIndex, testStatu
     }
 
     if (matchingTestIndex === attemptIndex) {
-      matchingTest = cypressTest
+      matchingTestByIndex = cypressTest
     }
     matchingTestIndex++
 
-    if (CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state] === testStatus) {
-      return cypressTest
+    if (!matchingTestByStatus && CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state] === testStatus) {
+      matchingTestByStatus = cypressTest
     }
   }
 
-  return matchingTest
+  return preferIndexedMatch
+    ? matchingTestByIndex || matchingTestByStatus
+    : matchingTestByStatus || matchingTestByIndex
 }
 
 function isCypressHookFailure (cypressTest) {
@@ -1065,7 +1068,7 @@ class CypressPlugin {
         const isLastAttempt = attemptIndex === finishedTestAttempts.length - 1
         const isDatadogManagedAttempt = finishedTest.isEfdManagedTest || finishedTest.isAttemptToFix
         const cypressTest = isDatadogManagedAttempt
-          ? getMatchingCypressTest(cypressTests, testName, attemptIndex, finishedTest.testStatus) ||
+          ? getMatchingCypressTest(cypressTests, testName, attemptIndex, finishedTest.testStatus, isLastAttempt) ||
             cypressTests.find(test => test.title.join(' ') === testName)
           : cypressTests.find(test => test.title.join(' ') === testName)
         if (!cypressTest) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -36,6 +36,7 @@ const {
   TEST_IS_NEW,
   TEST_IS_RETRY,
   TEST_EARLY_FLAKE_ENABLED,
+  TEST_EARLY_FLAKE_ABORT_REASON,
   getTestSessionName,
   TEST_SESSION_NAME,
   TEST_LEVEL_EVENT_TYPES,
@@ -59,6 +60,8 @@ const {
   recordAttemptToFixExecution,
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
+  getEfdRetryCount,
+  getMaxEfdRetryCount,
   getPullRequestBaseBranch,
   TEST_FINAL_STATUS,
 } = require('../../dd-trace/src/plugins/util/test')
@@ -328,6 +331,9 @@ class CypressPlugin {
   isEarlyFlakeDetectionEnabled = false
   isKnownTestsEnabled = false
   earlyFlakeDetectionNumRetries = 0
+  earlyFlakeDetectionSlowTestRetries = {}
+  efdRetryCountByTest = {}
+  efdSlowAbortedTests = {}
   testsToSkip = []
   skippedTests = []
   hasForcedToRunSuites = false
@@ -401,6 +407,9 @@ class CypressPlugin {
     this.isEarlyFlakeDetectionEnabled = false
     this.isKnownTestsEnabled = false
     this.earlyFlakeDetectionNumRetries = 0
+    this.earlyFlakeDetectionSlowTestRetries = {}
+    this.efdRetryCountByTest = {}
+    this.efdSlowAbortedTests = {}
     this.testsToSkip = []
     this.skippedTests = []
     this.hasForcedToRunSuites = false
@@ -481,6 +490,7 @@ class CypressPlugin {
               isCodeCoverageEnabled,
               isEarlyFlakeDetectionEnabled,
               earlyFlakeDetectionNumRetries,
+              earlyFlakeDetectionSlowTestRetries,
               isFlakyTestRetriesEnabled,
               flakyTestRetriesCount,
               isKnownTestsEnabled,
@@ -493,6 +503,7 @@ class CypressPlugin {
           this.isCodeCoverageEnabled = isCodeCoverageEnabled
           this.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
           this.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
+          this.earlyFlakeDetectionSlowTestRetries = earlyFlakeDetectionSlowTestRetries ?? {}
           this.isKnownTestsEnabled = isKnownTestsEnabled
           if (isFlakyTestRetriesEnabled && this.isTestIsolationEnabled) {
             this.isFlakyTestRetriesEnabled = true
@@ -531,6 +542,70 @@ class CypressPlugin {
       this.getTestSuiteProperties(testSuite)?.[testName]?.properties || {}
 
     return { isAttemptToFix, isDisabled, isQuarantined }
+  }
+
+  /**
+   * Returns how many EFD retries must be scheduled before the first duration is known.
+   *
+   * @returns {number}
+   */
+  getConfiguredEfdRetryCount () {
+    const { earlyFlakeDetectionSlowTestRetries } = this
+    if (!earlyFlakeDetectionSlowTestRetries || !Object.keys(earlyFlakeDetectionSlowTestRetries).length) {
+      return this.earlyFlakeDetectionNumRetries
+    }
+    return getMaxEfdRetryCount(earlyFlakeDetectionSlowTestRetries)
+  }
+
+  /**
+   * Returns the selected EFD retry count for a test, or the scheduling count if it has not run yet.
+   *
+   * @param {string} testSuite
+   * @param {string} testName
+   * @returns {number}
+   */
+  getEfdRetryCountForTest (testSuite, testName) {
+    const testSuiteRetries = this.efdRetryCountByTest[testSuite]
+    if (!testSuiteRetries || testSuiteRetries[testName] === undefined) {
+      return this.getConfiguredEfdRetryCount()
+    }
+    return testSuiteRetries[testName]
+  }
+
+  /**
+   * Stores the selected EFD retry count for a test after its first execution duration is known.
+   *
+   * @param {string} testSuite
+   * @param {string} testName
+   * @param {number | undefined} duration
+   * @returns {number}
+   */
+  setEfdRetryCountForTest (testSuite, testName, duration) {
+    if (!this.efdRetryCountByTest[testSuite]) {
+      this.efdRetryCountByTest[testSuite] = {}
+    }
+    const retryCount = getEfdRetryCount(duration ?? 0, this.earlyFlakeDetectionSlowTestRetries)
+    this.efdRetryCountByTest[testSuite][testName] = retryCount
+    if (retryCount === 0) {
+      if (!this.efdSlowAbortedTests[testSuite]) {
+        this.efdSlowAbortedTests[testSuite] = {}
+      }
+      this.efdSlowAbortedTests[testSuite][testName] = true
+    }
+    return retryCount
+  }
+
+  /**
+   * Returns whether an EFD retry clone is beyond the selected retry count and should be discarded.
+   *
+   * @param {string} testSuite
+   * @param {string} testName
+   * @param {number} efdRetryIndex
+   * @returns {boolean}
+   */
+  shouldSkipEfdRetry (testSuite, testName, efdRetryIndex) {
+    const testSuiteRetries = this.efdRetryCountByTest[testSuite]
+    return testSuiteRetries?.[testName] !== undefined && efdRetryIndex > testSuiteRetries[testName]
   }
 
   getTestSuiteSpan ({ testSuite, testSuiteAbsolutePath }) {
@@ -1042,7 +1117,8 @@ class CypressPlugin {
         const suitePayload = {
           isEarlyFlakeDetectionEnabled: this.isEarlyFlakeDetectionEnabled,
           knownTestsForSuite: this.knownTestsByTestSuite?.[testSuite] || [],
-          earlyFlakeDetectionNumRetries: this.earlyFlakeDetectionNumRetries,
+          earlyFlakeDetectionNumRetries: this.getConfiguredEfdRetryCount(),
+          earlyFlakeDetectionSlowTestRetries: this.earlyFlakeDetectionSlowTestRetries,
           isKnownTestsEnabled: this.isKnownTestsEnabled,
           isTestManagementEnabled: this.isTestManagementTestsEnabled,
           testManagementAttemptToFixRetries: this.testManagementAttemptToFixRetries,
@@ -1058,7 +1134,10 @@ class CypressPlugin {
         return suitePayload
       },
       'dd:beforeEach': (test) => {
-        const { testName, testSuite } = test
+        const { testName, testSuite, isEfdRetry, efdRetryIndex } = test
+        if (isEfdRetry && this.shouldSkipEfdRetry(testSuite, testName, efdRetryIndex)) {
+          return { shouldSkip: true, shouldDiscard: true }
+        }
         const shouldSkip = this.testsToSkip.some(test => {
           return testName === test.name && testSuite === test.suite
         })
@@ -1115,6 +1194,7 @@ class CypressPlugin {
           isEfdRetry,
           isAttemptToFix,
           isModified,
+          duration,
           isQuarantined: isQuarantinedFromSupport,
           isDisabled: isDisabledFromSupport,
         } = test
@@ -1147,6 +1227,14 @@ class CypressPlugin {
         }
         const testStatuses = this.testStatuses[testName]
         const activeSpanTags = this.activeTestSpan.context()._tags
+
+        const isEfdManagedTest = (isNew || isModified) && this.isEarlyFlakeDetectionEnabled && !isAttemptToFix
+        if (isEfdManagedTest && !isEfdRetry && this.efdRetryCountByTest[testSuite]?.[testName] === undefined) {
+          const retryCount = this.setEfdRetryCountForTest(testSuite, testName, duration)
+          if (retryCount === 0) {
+            this.activeTestSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'slow')
+          }
+        }
 
         if (error) {
           this.activeTestSpan.setTag('error', error)
@@ -1199,9 +1287,10 @@ class CypressPlugin {
           }
         }
         // Check if all EFD retries failed
-        if ((isNew || isModified) && this.earlyFlakeDetectionNumRetries > 0) {
-          const isLastEfdAttempt = testStatuses.length === this.earlyFlakeDetectionNumRetries + 1
-          if (isLastEfdAttempt && testStatuses.every(status => status === 'fail')) {
+        if (isEfdManagedTest) {
+          const efdRetryCount = this.getEfdRetryCountForTest(testSuite, testName)
+          const isLastEfdAttempt = testStatuses.length === efdRetryCount + 1
+          if (efdRetryCount > 0 && isLastEfdAttempt && testStatuses.every(status => status === 'fail')) {
             this.activeTestSpan.setTag(TEST_HAS_FAILED_ALL_RETRIES, 'true')
           }
         }

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -1056,12 +1056,9 @@ class CypressPlugin {
 
     for (const [testName, finishedTestAttempts] of Object.entries(finishedTestsByTestName)) {
       for (const [attemptIndex, finishedTest] of finishedTestAttempts.entries()) {
-        const cypressTest = getMatchingCypressTest(
-          cypressTests,
-          testName,
-          attemptIndex,
-          finishedTest.testStatus
-        )
+        const cypressTest = finishedTest.isEfdManagedTest || finishedTest.isAttemptToFix
+          ? getMatchingCypressTest(cypressTests, testName, attemptIndex, finishedTest.testStatus)
+          : cypressTests.find(test => test.title.join(' ') === testName)
         if (!cypressTest) {
           continue
         }

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -56,6 +56,7 @@ const {
   DD_CI_LIBRARY_CONFIGURATION_ERROR,
   TEST_IS_MODIFIED,
   TEST_HAS_DYNAMIC_NAME,
+  getIsFaultyEarlyFlakeDetection,
   DYNAMIC_NAME_RE,
   recordAttemptToFixExecution,
   logAttemptToFixTestExecution,
@@ -351,11 +352,13 @@ class CypressPlugin {
   isFlakyTestRetriesEnabled = false
   flakyTestRetriesCount = 0
   isEarlyFlakeDetectionEnabled = false
+  isEarlyFlakeDetectionFaulty = false
   isKnownTestsEnabled = false
   earlyFlakeDetectionNumRetries = 0
   earlyFlakeDetectionSlowTestRetries = {}
   efdRetryCountByTest = {}
   efdSlowAbortedTests = {}
+  earlyFlakeDetectionFaultyThreshold = 0
   testsToSkip = []
   skippedTests = []
   hasForcedToRunSuites = false
@@ -427,11 +430,13 @@ class CypressPlugin {
     this.isFlakyTestRetriesEnabled = false
     this.flakyTestRetriesCount = 0
     this.isEarlyFlakeDetectionEnabled = false
+    this.isEarlyFlakeDetectionFaulty = false
     this.isKnownTestsEnabled = false
     this.earlyFlakeDetectionNumRetries = 0
     this.earlyFlakeDetectionSlowTestRetries = {}
     this.efdRetryCountByTest = {}
     this.efdSlowAbortedTests = {}
+    this.earlyFlakeDetectionFaultyThreshold = 0
     this.testsToSkip = []
     this.skippedTests = []
     this.hasForcedToRunSuites = false
@@ -513,6 +518,7 @@ class CypressPlugin {
               isEarlyFlakeDetectionEnabled,
               earlyFlakeDetectionNumRetries,
               earlyFlakeDetectionSlowTestRetries,
+              earlyFlakeDetectionFaultyThreshold,
               isFlakyTestRetriesEnabled,
               flakyTestRetriesCount,
               isKnownTestsEnabled,
@@ -526,6 +532,7 @@ class CypressPlugin {
           this.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
           this.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
           this.earlyFlakeDetectionSlowTestRetries = earlyFlakeDetectionSlowTestRetries ?? {}
+          this.earlyFlakeDetectionFaultyThreshold = earlyFlakeDetectionFaultyThreshold
           this.isKnownTestsEnabled = isKnownTestsEnabled
           if (isFlakyTestRetriesEnabled && this.isTestIsolationEnabled) {
             this.isFlakyTestRetriesEnabled = true
@@ -762,12 +769,27 @@ class CypressPlugin {
         this.isEarlyFlakeDetectionEnabled = false
         this.isKnownTestsEnabled = false
       } else {
-        if (knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]) {
+        if (knownTestsResponse.knownTests?.[TEST_FRAMEWORK_NAME]) {
           this.knownTestsByTestSuite = knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]
         } else {
           this.isEarlyFlakeDetectionEnabled = false
           this.isKnownTestsEnabled = false
         }
+      }
+    }
+
+    if (this.isKnownTestsEnabled && details.specs) {
+      const testSuites = details.specs.map(({ relative }) => relative)
+      const isFaulty = getIsFaultyEarlyFlakeDetection(
+        testSuites,
+        this.knownTestsByTestSuite,
+        this.earlyFlakeDetectionFaultyThreshold
+      )
+      if (isFaulty) {
+        log.warn('New test detection is disabled because the number of new test files is too high.')
+        this.isEarlyFlakeDetectionEnabled = false
+        this.isEarlyFlakeDetectionFaulty = true
+        this.isKnownTestsEnabled = false
       }
     }
 
@@ -827,6 +849,9 @@ class CypressPlugin {
 
     if (this.isEarlyFlakeDetectionEnabled) {
       testSessionSpanMetadata[TEST_EARLY_FLAKE_ENABLED] = 'true'
+    }
+    if (this.isEarlyFlakeDetectionFaulty) {
+      testSessionSpanMetadata[TEST_EARLY_FLAKE_ABORT_REASON] = 'faulty'
     }
 
     const trimmedCommand = DD_MAJOR < 6 ? this.command : 'cypress run'

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -266,6 +266,28 @@ function getSuiteStatus (suiteStats) {
   return 'pass'
 }
 
+function getMatchingCypressTest (cypressTests, testName, attemptIndex, testStatus) {
+  let matchingTest
+  let matchingTestIndex = 0
+
+  for (const cypressTest of cypressTests) {
+    if (cypressTest.title.join(' ') !== testName) {
+      continue
+    }
+
+    if (matchingTestIndex === attemptIndex) {
+      matchingTest = cypressTest
+    }
+    matchingTestIndex++
+
+    if (CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state] === testStatus) {
+      return cypressTest
+    }
+  }
+
+  return matchingTest
+}
+
 const FINAL_STATUS_RETRY_KIND = {
   none: 'none',
   atr: 'atr',
@@ -1009,9 +1031,12 @@ class CypressPlugin {
 
     for (const [testName, finishedTestAttempts] of Object.entries(finishedTestsByTestName)) {
       for (const [attemptIndex, finishedTest] of finishedTestAttempts.entries()) {
-        // TODO: there could be multiple if there have been retries!
-        // potentially we need to match the test status!
-        const cypressTest = cypressTests.find(test => test.title.join(' ') === testName)
+        const cypressTest = getMatchingCypressTest(
+          cypressTests,
+          testName,
+          attemptIndex,
+          finishedTest.testStatus
+        )
         if (!cypressTest) {
           continue
         }
@@ -1019,7 +1044,8 @@ class CypressPlugin {
         // by early flake detection. Cypress is unaware of this so .attempts does not necessarily have
         // the same length as `finishedTestAttempts`
         let cypressTestStatus = CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state]
-        if (cypressTest.attempts && cypressTest.attempts[attemptIndex]) {
+        if (!finishedTest.isEfdManagedTest && !finishedTest.isAttemptToFix &&
+          cypressTest.attempts && cypressTest.attempts[attemptIndex]) {
           cypressTestStatus = CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.attempts[attemptIndex].state]
           const isAtrRetry = attemptIndex > 0 &&
             this.isFlakyTestRetriesEnabled &&
@@ -1035,6 +1061,9 @@ class CypressPlugin {
               finishedTest.testSpan.setTag(TEST_RETRY_REASON, TEST_RETRY_REASON_TYPES.ext)
             }
           }
+        }
+        if (finishedTest.isEfdManagedTest && finishedTest.testStatus !== 'skip' && cypressTestStatus === 'skip') {
+          cypressTestStatus = finishedTest.testStatus
         }
         if (cypressTest.displayError) {
           latestError = new Error(cypressTest.displayError)
@@ -1216,7 +1245,19 @@ class CypressPlugin {
           }
           this.tracer._tracer._exporter.exportCoverage(formattedCoverage)
         }
-        const testStatus = CYPRESS_STATUS_TO_TEST_STATUS[state]
+        const isEfdManagedTest = (isNew || isModified) && this.isEarlyFlakeDetectionEnabled && !isAttemptToFix
+        let testStatus = CYPRESS_STATUS_TO_TEST_STATUS[state]
+        let didAbortSlowEfdRetries = false
+        if (isEfdManagedTest && !isEfdRetry && this.efdRetryCountByTest[testSuite]?.[testName] === undefined) {
+          const retryCount = this.setEfdRetryCountForTest(testSuite, testName, duration)
+          if (retryCount === 0) {
+            didAbortSlowEfdRetries = true
+            this.activeTestSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'slow')
+          }
+        }
+        if (didAbortSlowEfdRetries && testStatus === 'skip' && !error && duration > 0) {
+          testStatus = 'pass'
+        }
         this.activeTestSpan.setTag(TEST_STATUS, testStatus)
 
         // Save the test status to know if it has passed all retries
@@ -1227,14 +1268,6 @@ class CypressPlugin {
         }
         const testStatuses = this.testStatuses[testName]
         const activeSpanTags = this.activeTestSpan.context()._tags
-
-        const isEfdManagedTest = (isNew || isModified) && this.isEarlyFlakeDetectionEnabled && !isAttemptToFix
-        if (isEfdManagedTest && !isEfdRetry && this.efdRetryCountByTest[testSuite]?.[testName] === undefined) {
-          const retryCount = this.setEfdRetryCountForTest(testSuite, testName, duration)
-          if (retryCount === 0) {
-            this.activeTestSpan.setTag(TEST_EARLY_FLAKE_ABORT_REASON, 'slow')
-          }
-        }
 
         if (error) {
           this.activeTestSpan.setTag('error', error)
@@ -1341,6 +1374,7 @@ class CypressPlugin {
           finishTime: this._now(),
           testSpan: this.activeTestSpan,
           isEfdRetry,
+          isEfdManagedTest,
           isAttemptToFix,
         }
         if (this.finishedTestsByFile[testSuite]) {

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -289,6 +289,11 @@ function getMatchingCypressTest (cypressTests, testName, attemptIndex, testStatu
   return matchingTest
 }
 
+function isCypressHookFailure (cypressTest) {
+  return CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state] === 'fail' &&
+    /\bhook\b/.test(String(cypressTest.displayError || ''))
+}
+
 const FINAL_STATUS_RETRY_KIND = {
   none: 'none',
   atr: 'atr',
@@ -1056,6 +1061,8 @@ class CypressPlugin {
 
     for (const [testName, finishedTestAttempts] of Object.entries(finishedTestsByTestName)) {
       for (const [attemptIndex, finishedTest] of finishedTestAttempts.entries()) {
+        // We can check if this is the last attempt regardless of the retry mechanism
+        const isLastAttempt = attemptIndex === finishedTestAttempts.length - 1
         const isDatadogManagedAttempt = finishedTest.isEfdManagedTest || finishedTest.isAttemptToFix
         const cypressTest = isDatadogManagedAttempt
           ? getMatchingCypressTest(cypressTests, testName, attemptIndex, finishedTest.testStatus) ||
@@ -1067,7 +1074,8 @@ class CypressPlugin {
         // finishedTests can include multiple tests with the same name if they have been retried
         // by early flake detection. Cypress is unaware of this so .attempts does not necessarily have
         // the same length as `finishedTestAttempts`
-        let cypressTestStatus = isDatadogManagedAttempt
+        const shouldUseCapturedStatus = isDatadogManagedAttempt && !(isLastAttempt && isCypressHookFailure(cypressTest))
+        let cypressTestStatus = shouldUseCapturedStatus
           ? finishedTest.testStatus
           : CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state]
         if (!finishedTest.isEfdManagedTest && !finishedTest.isAttemptToFix &&
@@ -1100,6 +1108,9 @@ class CypressPlugin {
         if (cypressTestStatus !== finishedTest.testStatus && (!isQuarantinedTest || finishedTest.isAttemptToFix)) {
           finishedTest.testSpan.setTag(TEST_STATUS, cypressTestStatus)
           finishedTest.testSpan.setTag('error', latestError)
+          if (finishedTest.isAttemptToFix && cypressTestStatus === 'fail') {
+            finishedTest.testSpan.setTag(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED, 'false')
+          }
         }
         if (this.itrCorrelationId) {
           finishedTest.testSpan.setTag(ITR_CORRELATION_ID, this.itrCorrelationId)
@@ -1119,8 +1130,6 @@ class CypressPlugin {
           finishedTest.testSpan.setTag(TEST_CODE_OWNERS, codeOwners)
         }
 
-        // We can check if this is the last attempt regardless of the retry mechanism
-        const isLastAttempt = attemptIndex === finishedTestAttempts.length - 1
         if (isLastAttempt) {
           const testSpanTags = finishedTest.testSpan.context()._tags
           const retryKind = getFinalStatusRetryKind({

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -1056,8 +1056,10 @@ class CypressPlugin {
 
     for (const [testName, finishedTestAttempts] of Object.entries(finishedTestsByTestName)) {
       for (const [attemptIndex, finishedTest] of finishedTestAttempts.entries()) {
-        const cypressTest = finishedTest.isEfdManagedTest || finishedTest.isAttemptToFix
-          ? getMatchingCypressTest(cypressTests, testName, attemptIndex, finishedTest.testStatus)
+        const isDatadogManagedAttempt = finishedTest.isEfdManagedTest || finishedTest.isAttemptToFix
+        const cypressTest = isDatadogManagedAttempt
+          ? getMatchingCypressTest(cypressTests, testName, attemptIndex, finishedTest.testStatus) ||
+            cypressTests.find(test => test.title.join(' ') === testName)
           : cypressTests.find(test => test.title.join(' ') === testName)
         if (!cypressTest) {
           continue
@@ -1065,7 +1067,9 @@ class CypressPlugin {
         // finishedTests can include multiple tests with the same name if they have been retried
         // by early flake detection. Cypress is unaware of this so .attempts does not necessarily have
         // the same length as `finishedTestAttempts`
-        let cypressTestStatus = CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state]
+        let cypressTestStatus = isDatadogManagedAttempt
+          ? finishedTest.testStatus
+          : CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.state]
         if (!finishedTest.isEfdManagedTest && !finishedTest.isAttemptToFix &&
           cypressTest.attempts && cypressTest.attempts[attemptIndex]) {
           cypressTestStatus = CYPRESS_STATUS_TO_TEST_STATUS[cypressTest.attempts[attemptIndex].state]

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -79,6 +79,9 @@ function getRetriedTests (test, numRetries, tags) {
     // TODO: signal in framework logs that this is a retry.
     // TODO: Change it so these tests are allowed to fail.
     const clonedTest = test.clone()
+    if (tags.includes('_ddIsEfdRetry')) {
+      clonedTest._ddEfdRetryIndex = retryIndex + 1
+    }
     for (const tag of tags) {
       if (tag) {
         clonedTest[tag] = true
@@ -173,7 +176,12 @@ beforeEach(function () {
   cy.task('dd:beforeEach', {
     testName,
     testSuite: Cypress.mocha.getRootSuite().file,
-  }).then(({ traceId, shouldSkip }) => {
+    isEfdRetry: Cypress.mocha.getRunner().suite.ctx.currentTest._ddIsEfdRetry,
+    efdRetryIndex: Cypress.mocha.getRunner().suite.ctx.currentTest._ddEfdRetryIndex,
+  }).then(({ traceId, shouldSkip, shouldDiscard }) => {
+    if (shouldDiscard) {
+      this.currentTest._ddShouldDiscard = true
+    }
     if (traceId) {
       cy.setCookie(DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME, traceId).then(() => {
         // When testIsolation:false, the page is not reset between tests, so the RUM session
@@ -242,6 +250,9 @@ after(() => {
 
 afterEach(function () {
   const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
+  if (currentTest._ddShouldDiscard) {
+    return
+  }
   const testName = currentTest.fullTitle()
 
   // Check if this was a test management test that we suppressed the failure for.
@@ -267,6 +278,7 @@ afterEach(function () {
     isEfdRetry: currentTest._ddIsEfdRetry,
     isAttemptToFix: currentTest._ddIsAttemptToFix,
     isModified: currentTest._ddIsModified,
+    duration: currentTest.duration,
     // Mark suppressed tests so the plugin can tag them with the correct test management reason.
     isQuarantined: isTestManagementTestThatFailed && suppressedTestFailure.isQuarantined,
     isDisabled: isTestManagementTestThatFailed && suppressedTestFailure.isDisabled,


### PR DESCRIPTION
### What does this PR do?

Updates Cypress Early Flake Detection clone scheduling to use the `slow_test_retries` duration buckets returned by the settings API.

Discards excess Cypress EFD clones once the first execution duration selects a lower retry count, and marks tests with `test.early_flake.abort_reason=slow` when the selected bucket aborts additional retries.

Also disables Cypress new-test detection and EFD retries when the known-tests response indicates too many new test files, marking the test session with `test.early_flake.abort_reason=faulty`.

### Motivation

Jest, Mocha, Cucumber, Vitest, and Playwright already limit EFD retry attempts based on the duration of the first test execution. Cypress should apply the same API-driven retry bucket behavior so slow tests do not keep scheduling unnecessary EFD retries.

### Additional Notes

Stack: 5/5. This is the final framework PR after #8289 merged.
