### PR TITLE
Revert "ci(codeql): skip workflow for non-production file changes and…

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,32 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    # Exclude merge-queue branches: PRs are already scanned before merge.
-    branches: [master]
-    # Mirror the paths-ignore in .github/codeql_config.yml so the workflow
-    # does not launch at all (and avoids GitHub API calls) when only
-    # non-production files change.
-    paths-ignore:
-      - 'benchmark/**'
-      - 'integration-tests/**'
-      - 'node-upstream-tests/**'
-      - 'packages/**/test/**'
-      - 'scripts/**'
-      - 'vendor/dist/**'
-      - 'docs/**'
-      - '**.md'
+    branches: [master, mq-working-branch-master-*]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
-    paths-ignore:
-      - 'benchmark/**'
-      - 'integration-tests/**'
-      - 'node-upstream-tests/**'
-      - 'packages/**/test/**'
-      - 'scripts/**'
-      - 'vendor/dist/**'
-      - 'docs/**'
-      - '**.md'
 
 jobs:
   analyze:


### PR DESCRIPTION
… merge queue (#8277)"

This reverts commit 6ce26351629178b16e68a6ad815ae2b015acf96e.

This is a mandatory branch protection check.