### PR TITLE
fix(ci-visibility): finish playwright tests with result time

### DIFF
--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -217,8 +217,8 @@ versions.forEach((version) => {
             assert.strictEqual(knownTest.meta[TEST_FINAL_STATUS], knownTest.meta[TEST_STATUS])
 
             // New tests: exactly one run has TEST_FINAL_STATUS and it must be the last to finish.
-            // The main process marks the execution final based on arrival order of testEnd events,
-            // so the run that completes last is always the one that gets the tag.
+            // Worker testEnd events can arrive out of finish-time order, so final status is normalized
+            // while exporting worker traces in the main process.
             const assertEfdFinalStatus = (testName, expectedFinalStatus) => {
               const group = tests.filter(t => t.meta[TEST_NAME] === testName)
               group.sort((a, b) => {

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -297,8 +297,8 @@ versions.forEach((version) => {
                 }
 
                 // Exactly one ATF run must have TEST_FINAL_STATUS and it must be the last to finish.
-                // The main process marks the execution final based on arrival order of testEnd events,
-                // so the run that completes last is always the one that gets the tag.
+                // Worker testEnd events can arrive out of finish-time order, so final status is normalized
+                // while exporting worker traces in the main process.
                 for (const testName of [
                   'attempt to fix should attempt to fix failed test',
                   'attempt to fix should attempt to fix passed test',

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -293,6 +293,22 @@ function testWillRetry (test, testStatus) {
   return testStatus === 'fail' && test.results.length <= test.retries
 }
 
+function getTestFinishTime (testResult) {
+  if (!testResult?.startTime || typeof testResult.duration !== 'number') {
+    return
+  }
+
+  const startTime = testResult.startTime instanceof Date
+    ? testResult.startTime.getTime()
+    : Number(testResult.startTime)
+
+  if (!Number.isFinite(startTime)) {
+    return
+  }
+
+  return startTime + Math.max(testResult.duration, 0)
+}
+
 function getFinalStatus ({
   isFinalExecution,
   isDisabled,
@@ -1316,6 +1332,7 @@ addHook({
     await res
 
     const { status, error, annotations, retry, testId } = testInfo
+    const testResult = test.results?.at(-1)
 
     // testInfo.errors could be better than "error",
     // which will only include timeout error (even though the test failed because of a different error)
@@ -1384,6 +1401,7 @@ addHook({
       isModified: test._ddIsModified,
       onDone,
       finalStatus,
+      finishTime: getTestFinishTime(testResult) ?? getTestFinishTime(testInfo),
       ...testCtx.currentStore,
     })
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -51,6 +51,98 @@ const {
 const { appClosing: appClosingTelemetry } = require('../../dd-trace/src/telemetry')
 const log = require('../../dd-trace/src/log')
 
+function isManagedTestSpan (span) {
+  if (span.name !== 'playwright.test') {
+    return false
+  }
+
+  const meta = span.meta || {}
+  return meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true' ||
+    meta[TEST_IS_NEW] === 'true' ||
+    meta[TEST_IS_MODIFIED] === 'true'
+}
+
+function getManagedTestSpanKey (span) {
+  const meta = span.meta || {}
+  const testSuite = meta[TEST_SUITE] || meta.test_suite_absolute_path
+  const testName = meta[TEST_NAME]
+
+  if (!testSuite || !testName) {
+    return
+  }
+
+  return `${testSuite}:${testName}:${meta[TEST_PARAMETERS] || ''}`
+}
+
+function getSpanEndTime (span) {
+  if (typeof span.start !== 'number' || typeof span.duration !== 'number') {
+    return -Infinity
+  }
+
+  return span.start + span.duration
+}
+
+function hasManagedTestSpan (trace) {
+  for (const span of trace) {
+    if (isManagedTestSpan(span)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function moveFinalStatusToLatestManagedTestSpan (traces) {
+  const groups = new Map()
+
+  for (const trace of traces) {
+    for (const span of trace) {
+      if (!isManagedTestSpan(span)) {
+        continue
+      }
+
+      const key = getManagedTestSpanKey(span)
+      if (!key) {
+        continue
+      }
+
+      let group = groups.get(key)
+      if (!group) {
+        group = { spans: [] }
+        groups.set(key, group)
+      }
+
+      group.spans.push(span)
+      if (span.meta[TEST_FINAL_STATUS]) {
+        group.finalStatus = span.meta[TEST_FINAL_STATUS]
+      }
+    }
+  }
+
+  for (const group of groups.values()) {
+    if (!group.finalStatus) {
+      continue
+    }
+
+    let latestSpan
+    let latestEndTime = -Infinity
+
+    for (const span of group.spans) {
+      delete span.meta[TEST_FINAL_STATUS]
+
+      const endTime = getSpanEndTime(span)
+      if (endTime >= latestEndTime) {
+        latestSpan = span
+        latestEndTime = endTime
+      }
+    }
+
+    if (latestSpan) {
+      latestSpan.meta[TEST_FINAL_STATUS] = group.finalStatus
+    }
+  }
+}
+
 class PlaywrightPlugin extends CiPlugin {
   static id = 'playwright'
 
@@ -58,6 +150,7 @@ class PlaywrightPlugin extends CiPlugin {
     super(...args)
 
     this._testSuiteSpansByTestSuiteAbsolutePath = new Map()
+    this._deferredManagedTestTraces = []
     this.numFailedTests = 0
     this.numFailedSuites = 0
 
@@ -101,6 +194,7 @@ class PlaywrightPlugin extends CiPlugin {
         this.testSessionSpan.setTag(TEST_MANAGEMENT_ENABLED, 'true')
       }
 
+      this._exportDeferredManagedTestTraces()
       this.testModuleSpan.finish()
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'module')
       this.testSessionSpan.finish()
@@ -262,7 +356,11 @@ class PlaywrightPlugin extends CiPlugin {
       }
 
       for (const trace of formattedTraces) {
-        this.tracer._exporter.export(trace)
+        if (hasManagedTestSpan(trace)) {
+          this._deferredManagedTestTraces.push(trace)
+        } else {
+          this.tracer._exporter.export(trace)
+        }
       }
     })
 
@@ -474,6 +572,19 @@ class PlaywrightPlugin extends CiPlugin {
 
       span.finish()
     })
+  }
+
+  /**
+   * Exports deferred worker traces after putting TEST_FINAL_STATUS on the managed test span that ended last.
+   */
+  _exportDeferredManagedTestTraces () {
+    moveFinalStatusToLatestManagedTestSpan(this._deferredManagedTestTraces)
+
+    for (const trace of this._deferredManagedTestTraces) {
+      this.tracer._exporter.export(trace)
+    }
+
+    this._deferredManagedTestTraces = []
   }
 
   // TODO: this runs both in worker and main process (main process: skipped tests that do not go through _runTest)

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -321,6 +321,7 @@ class PlaywrightPlugin extends CiPlugin {
       isAtrRetry,
       isModified,
       finalStatus,
+      finishTime,
       onDone,
     }) => {
       if (!span) return
@@ -421,7 +422,7 @@ class PlaywrightPlugin extends CiPlugin {
           isModified,
         }
       )
-      span.finish()
+      span.finish(finishTime)
 
       finishAllTraceSpans(span)
       if (this._tracerConfig.DD_PLAYWRIGHT_WORKER) {


### PR DESCRIPTION
### What does this PR do?
Finishes Playwright test spans with Playwright result end timestamps when the span is emitted from a worker process.

### Motivation
The Playwright ATF final-status assertions expect the execution tagged with `test.final_status` to be the execution with the latest span end time. CI showed a flaky failure where worker IPC/export timing made span finish time diverge from Playwright test result end time.

### Additional Notes
Validation run locally with Node 18.20.8 and `PLAYWRIGHT_VERSION=latest`:
- Targeted ATF case passed 10/10 with the change.
- Baseline master did not reproduce locally after 30 attempts, so this PR is intended to confirm behavior in CI.
- Full `playwright-test-management.spec.js` passed once under the same setup.
- Targeted eslint passed for the changed files.