### PR TITLE
ci(node-crash-report): stay silent when no reports exist

### DIFF
--- a/scripts/node-crash-report.js
+++ b/scripts/node-crash-report.js
@@ -11,12 +11,16 @@ const path = require('node:path')
 
 const inputDir = path.join(os.tmpdir(), 'node-reports')
 
+// Exit silently when there is nothing to print. The action runs on every
+// failure (`if: failure()`) but most failures are unrelated to a Node.js
+// crash, so logging here would add noise that obscures the real upstream
+// error in CI log-surfacing tools.
 if (!fs.existsSync(inputDir)) {
-  process.stdout.write(`No report directory at ${inputDir}, nothing to print.\n`)
   process.exit(0)
 }
 
-let printed = 0
+// If the directory exists but holds no usable reports, the loop simply
+// emits nothing (same rationale as the early-return above).
 for (const file of fs.readdirSync(inputDir)) {
   if (!file.endsWith('.json')) {
     process.stderr.write(`Skipping non-JSON file: ${file}\n`)
@@ -64,9 +68,4 @@ for (const file of fs.readdirSync(inputDir)) {
   ]
 
   process.stdout.write(lines.join('\n') + '\n')
-  printed++
-}
-
-if (printed === 0) {
-  process.stdout.write('No crash reports found.\n')
 }


### PR DESCRIPTION
### What does this PR do?

Updates [scripts/node-crash-report.js](https://github.com/DataDog/dd-trace-js/blob/master/scripts/node-crash-report.js) to silently `return` (still exit 0) when the Node crash report directory is missing or empty, instead of writing "No report directory found, nothing to print." / similar to stdout. The script's behavior on real crash reports is unchanged.

### Motivation

A single `AI Guard / windows` job on master in the last 24h had its surfaced CI Visibility error reported as `No report directory found at C:\Users\RUNNER~1\AppData\Local\Temp\node-reports, nothing to print.` That message was the **success** output of the `node-crash-report` step (which was already exiting 0), but CI Visibility extracted it as "the" error and masked the real upstream failure: a silent `actions/cache@v5.0.5` death in an earlier step that caused `yarn install` and `yarn test:aiguard:ci` to be skipped entirely.

This PR doesn't fix the upstream cache flake (run attempt 2 of the same commit succeeded with no code change — purely environmental). It stops the normal "no reports" output of `node-crash-report` from masking upstream failures going forward.

### Additional Notes

- Verified locally: script still exits 0 in both no-directory and empty-directory cases.
- Workflow semantics under `if: failure()` are preserved.
- Test-only / CI-script change; no runtime behavior change to the npm package.
