### PR TITLE
test(agent): scope mock-agent close handler to its own load()

### DIFF
--- a/packages/datadog-plugin-memcached/test/index.spec.js
+++ b/packages/datadog-plugin-memcached/test/index.spec.js
@@ -21,7 +21,7 @@ describe('Plugin', () => {
     withVersions('memcached', 'memcached', version => {
       afterEach(() => {
         memcached?.end()
-        agent.close({ ritmReset: false })
+        return agent.close({ ritmReset: false })
       })
 
       describe('without configuration', () => {

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -92,7 +92,7 @@ describe('AIGuard SDK', () => {
   afterEach(() => {
     global.fetch = originalFetch
     sinon.restore()
-    agent.close()
+    return agent.close()
   })
 
   const mockFetch = (options) => {

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -17,7 +17,7 @@ describe('dd-trace', () => {
   })
 
   afterEach(() => {
-    agent.close()
+    return agent.close()
   })
 
   it('should record and send a trace to the agent', () => {

--- a/packages/dd-trace/test/git_metadata_tagger.spec.js
+++ b/packages/dd-trace/test/git_metadata_tagger.spec.js
@@ -27,7 +27,7 @@ describe('git metadata tagging', () => {
   })
 
   afterEach(() => {
-    agent.close()
+    return agent.close()
   })
 
   afterEach(() => {

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -52,7 +52,7 @@ const closeAgent = () => {
   delete require.cache[require.resolve('../../src/lambda/runtime/patch.js')]
   delete require.cache[require.resolve('../../src/lambda')]
 
-  agent.close({ ritmReset: true })
+  return agent.close({ ritmReset: true })
 }
 
 describe('lambda', () => {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -429,10 +429,22 @@ module.exports = {
 
     plugins = pluginNames
 
+    // Capture the tracer created in this load() so that a late-firing
+    // 'close' from this server does not clobber state that belongs to
+    // a subsequent load() invocation. agent.close() is not always
+    // awaited, so the previous server's close event can land after the
+    // next load() has already reassigned `tracer`. Each load() builds
+    // a fresh `tracer` via proxyquire, so identity-equality on the
+    // tracer reference uniquely identifies this load(); the integration
+    // name is gated on the same check because it can repeat across
+    // loads of the same plugin and is not safe to compare by string.
+    const loadedTracer = tracer
     server.on('close', () => {
-      tracer = null
+      if (tracer === loadedTracer) {
+        tracer = null
+        currentIntegrationName = null
+      }
       dsmStats = []
-      currentIntegrationName = null
     })
 
     return promise

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -429,15 +429,9 @@ module.exports = {
 
     plugins = pluginNames
 
-    // Capture the tracer created in this load() so that a late-firing
-    // 'close' from this server does not clobber state that belongs to
-    // a subsequent load() invocation. agent.close() is not always
-    // awaited, so the previous server's close event can land after the
-    // next load() has already reassigned `tracer`. Each load() builds
-    // a fresh `tracer` via proxyquire, so identity-equality on the
-    // tracer reference uniquely identifies this load(); the integration
-    // name is gated on the same check because it can repeat across
-    // loads of the same plugin and is not safe to compare by string.
+    // Capture the tracer at load() time; agent.close() is sometimes not
+    // awaited, so this server's close event can land after the next
+    // load() has already reassigned the module-level tracer.
     const loadedTracer = tracer
     server.on('close', () => {
       if (tracer === loadedTracer) {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -437,8 +437,8 @@ module.exports = {
       if (tracer === loadedTracer) {
         tracer = null
         currentIntegrationName = null
+        dsmStats = []
       }
-      dsmStats = []
     })
 
     return promise


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition that produced a flaky `TypeError: Cannot read properties of null (reading 'init')` in mock-agent-based tests, observed once on `AI Guard / macos` (run 25430757047, attempt 1) but possible across any spec that uses [packages/dd-trace/test/plugins/agent.js](https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/test/plugins/agent.js).

**Root cause:** Five spec teardowns called `agent.close()` without returning the resulting Promise to mocha, so the next test's `beforeEach` could start while the prior server was still draining. When the prior server's `'close'` event fired during or after the next `load()`, the registered close-handler nulled the module-level `tracer`/`currentIntegrationName`/`dsmStats` — clobbering the *new* load's state. macOS runners' slower close timing made the race observable; the `await wait(1)` in `load()` normally hid it.

**Fix at the root:** the five teardown sites now return the close promise.

**Defense in depth:** the close-handler in `agent.js` is also scoped to only clear module state when the captured `tracer` reference still matches the current one — guards against any future spec that forgets to await.

### Motivation

Concrete failure on master: `AI Guard / macos` job throwing `TypeError: Cannot read properties of null (reading 'init')` at `packages/dd-trace/test/plugins/agent.js:411`. The same race could intermittently corrupt DSM payloads collected by the new load (a stale close wiping `/v0.1/pipeline_stats` results), surfacing as flaky DSM assertions in plugin tests.

### Additional Notes

Commits, in order:
1. `71d103520` — scope close-handler to the matching `load()` for `tracer` / `currentIntegrationName`.
2. `601bc3060` — trim a 9-line comment block on the guard to 3 lines, aligning to the file's "one short line max" norm.
3. `ae6eaaf60` — extend the same scoping to `dsmStats = []` (caught by Codex adversarial review during pre-push: the unguarded reset could wipe the new load's collected DSM payloads).
4. `c84faae30` — return the close promise in 5 teardown sites (the actual upstream fix). Affected files: `aiguard/index.spec.js`, `dd-trace.spec.js`, `git_metadata_tagger.spec.js`, `datadog-plugin-memcached/test/index.spec.js`, `lambda/index.spec.js` (`closeAgent` helper; the three `return closeAgent()` callers now correctly propagate the promise).

40 AI Guard tests pass over 4 reruns post-fix locally; lambda spec's 12 tests pass; lint clean. Test-only change; no production code touched.