### PR TITLE
test(kafkajs): wait for leaders on createTopics to fix DSM flakes

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -79,7 +79,7 @@ describe('Plugin', () => {
           topicBOut = `topic-b-out-${randomUUID()}`
           admin = kafka.admin()
           await admin.createTopics({
-            waitForLeaders: false,
+            waitForLeaders: true,
             topics: [testTopic, topicAIn, topicAOut, topicBIn, topicBOut].map(topic => ({
               topic,
               numPartitions: 1,

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -53,7 +53,7 @@ describe('Plugin', () => {
           testTopic = `test-topic-${randomUUID()}`
           admin = kafka.admin()
           await admin.createTopics({
-            waitForLeaders: false,
+            waitForLeaders: true,
             topics: [{
               topic: testTopic,
               numPartitions: 1,


### PR DESCRIPTION
## Summary

- Three DSM tests in `packages/datadog-plugin-kafkajs/test/dsm.spec.js` have been flaking on master with `KafkaJSProtocolError: This server does not host this topic-partition`, thrown from `consumer.subscribe()` in `beforeEach` (`checkpoints` line 103, `concurrent context isolation` line 206, `backlogs` line 259).
- Root cause: `admin.createTopics({ waitForLeaders: false, ... })` returns as soon as the controller acks topic creation, before partition leaders are elected and propagated. The immediate `consumer.subscribe()` then lands a metadata refresh on a broker that does not yet host the partition leader.
- Fix: flip `waitForLeaders` to `true` (also the kafkajs default) in both `dsm.spec.js` and `index.spec.js` (same anti-pattern, masked there by producer-first test ordering).

## Test plan

- [x] Verified locally with **20 consecutive green runs** of `PLUGINS=kafkajs SPEC=dsm npm run test:plugins` — zero failures, no `metadata/v0/response.js` errors in any iteration
- [x] Single full run of `dsm.spec.js` — 15/15 passing
- [ ] CI green
- [ ] Monitor Test Optimization for 1–2 days post-merge to confirm the three flaky tests no longer appear under `@DataDog/data-streams-monitoring` codeowner

🤖 Generated with [Claude Code](https://claude.com/claude-code)