### PR TITLE
fix(stacktrace): filter dd-trace instrumentation frames for any repo directory name

### DIFF
--- a/packages/dd-trace/src/plugins/util/stacktrace.js
+++ b/packages/dd-trace/src/plugins/util/stacktrace.js
@@ -14,7 +14,7 @@ const NODE_MODULES_PATTERN_START = `node_modules${sep}`
  * In production, these frames are already filtered by isNodeModulesFrame.
  */
 const SHOULD_FILTER_DD_TRACE_INSTRUMENTAION = __filename.endsWith(
-  join(sep, 'dd-trace-js', 'packages', 'dd-trace', 'src', 'plugins', 'util', 'stacktrace.js')
+  join('packages', 'dd-trace', 'src', 'plugins', 'util', 'stacktrace.js')
 )
 
 module.exports = {

--- a/packages/dd-trace/test/plugins/util/stacktrace.spec.js
+++ b/packages/dd-trace/test/plugins/util/stacktrace.spec.js
@@ -409,6 +409,18 @@ describe('stacktrace utils', () => {
       })
     })
 
+    describe('dd-trace instrumentation frames', () => {
+      it('should filter instrumentation frames regardless of the repo directory name', () => {
+        // Regression: previously only filtered when directory was named exactly 'dd-trace-js'
+        for (const repoName of ['dd-trace-js', 'dd-trace-js-1', 'my-dd-trace-fork', 'tracer']) {
+          const instrumentationFrame = `    at wrappedUse (/${repoName}/packages/datadog-instrumentations/src/express.js:144:16)`
+          const userFrame = `    at testCase (/user/app/test.js:10:5)`
+          const stack = `Error: test\n${instrumentationFrame}\n${userFrame}`
+          assert.deepStrictEqual(parseUserLandFrames(stack).length, 1, `failed for repo name: ${repoName}`)
+        }
+      })
+    })
+
     describe('user-land frame', () => {
       it('should should only return user-land frames', () => {
         const stack = genStackTraceWithManyNonUserLandFramesAnd(

--- a/packages/dd-trace/test/plugins/util/stacktrace.spec.js
+++ b/packages/dd-trace/test/plugins/util/stacktrace.spec.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const assert = require('node:assert')
-const { join } = require('node:path')
+const { join, sep } = require('node:path')
 
 const { describe, it } = require('mocha')
 
@@ -413,8 +413,8 @@ describe('stacktrace utils', () => {
       it('should filter instrumentation frames regardless of the repo directory name', () => {
         // Regression: previously only filtered when directory was named exactly 'dd-trace-js'
         for (const repoName of ['dd-trace-js', 'dd-trace-js-1', 'my-dd-trace-fork', 'tracer']) {
-          const path = `/${repoName}/packages/datadog-instrumentations/src/express.js:144:16`
-          const instrumentationFrame = `    at wrappedUse (${path})`
+          const instrFile = join(`${sep}${repoName}`, 'packages', 'datadog-instrumentations', 'src', 'express.js')
+          const instrumentationFrame = `    at wrappedUse (${instrFile}:144:16)`
           const userFrame = '    at testCase (/user/app/test.js:10:5)'
           const stack = `Error: test\n${instrumentationFrame}\n${userFrame}`
           assert.deepStrictEqual(parseUserLandFrames(stack).length, 1, `failed for repo name: ${repoName}`)

--- a/packages/dd-trace/test/plugins/util/stacktrace.spec.js
+++ b/packages/dd-trace/test/plugins/util/stacktrace.spec.js
@@ -413,8 +413,9 @@ describe('stacktrace utils', () => {
       it('should filter instrumentation frames regardless of the repo directory name', () => {
         // Regression: previously only filtered when directory was named exactly 'dd-trace-js'
         for (const repoName of ['dd-trace-js', 'dd-trace-js-1', 'my-dd-trace-fork', 'tracer']) {
-          const instrumentationFrame = `    at wrappedUse (/${repoName}/packages/datadog-instrumentations/src/express.js:144:16)`
-          const userFrame = `    at testCase (/user/app/test.js:10:5)`
+          const path = `/${repoName}/packages/datadog-instrumentations/src/express.js:144:16`
+          const instrumentationFrame = `    at wrappedUse (${path})`
+          const userFrame = '    at testCase (/user/app/test.js:10:5)'
           const stack = `Error: test\n${instrumentationFrame}\n${userFrame}`
           assert.deepStrictEqual(parseUserLandFrames(stack).length, 1, `failed for repo name: ${repoName}`)
         }


### PR DESCRIPTION
### What does this PR do?

Fixes `SHOULD_FILTER_DD_TRACE_INSTRUMENTAION` being `false` when the repo is cloned under a directory name other than `dd-trace-js` (e.g. `dd-trace-js-1`, a fork, etc.).

The check previously matched `__filename` against a hardcoded `dd-trace-js` path segment. Dropping that segment and matching on the stable internal package path (`packages/dd-trace/src/...`) is sufficient and works regardless of the checkout directory name. This also correctly handles the case where the package is installed via an npm alias (e.g. `my-trace@npm:dd-trace`), where the installed path would not contain `dd-trace-js` either — though in that case `isNodeModulesFrame` already covers it.

### Motivation

Running `PLUGINS=express yarn test:plugins` locally would produce 44 failures in `code_origin.spec.js` — the code origin frame would point to `packages/datadog-instrumentations/src/express.js` instead of the test file — because the instrumentation frames were not being filtered. CI was unaffected since it always clones the repo as `dd-trace-js`.

### Additional Notes

- A regression test is included that exercises several checkout directory names including the one that was broken.

semver-patch

---
🤖 Generated with [Claude Code](https://claude.ai/code)