### PR TITLE
fix(plugin-mysql): destructure CLIENT_PORT_KEY from the constants module

### DIFF
--- a/packages/datadog-plugin-mysql/src/index.js
+++ b/packages/datadog-plugin-mysql/src/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { storage } = require('../../datadog-core')
-const CLIENT_PORT_KEY = require('../../dd-trace/src/constants')
+const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 class MySQLPlugin extends DatabasePlugin {

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -93,6 +93,9 @@ describe('Plugin', () => {
                 component: 'mysql',
                 '_dd.integration': 'mysql',
               },
+              metrics: {
+                'network.destination.port': 3306,
+              },
             }, { spanResourceMatch: /SELECT 1 \+ 1 AS solution/ })
             .then(done)
             .catch(done)


### PR DESCRIPTION
## Summary

The plugin imported the whole `constants` module as `CLIENT_PORT_KEY`,
so `[CLIENT_PORT_KEY]: ctx.conf.port` coerced the module to its
string form and tagged every mysql / mysql2 span with a literal
`[object Object]: <port>` metric instead of
`network.destination.port`. Peer-service computation, downstream
filters, and any product feature keyed off `network.destination.port`
have had no port to read on this plugin since v0.