### PR TITLE
fix(tracing): fix TypeError in ritm.js when requiring node:-prefixed built-in modules

### DIFF
--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -101,7 +101,7 @@ function Hook (modules, options, onrequire) {
     if (cache[moduleId]) {
       // require.cache was potentially altered externally
       const cacheEntry = require.cache[filename]
-      if (cacheEntry && cacheEntry.exports !== cache[filename].original) {
+      if (cacheEntry && cacheEntry.exports !== cache[moduleId].original) {
         return cacheEntry.exports
       }
 

--- a/packages/dd-trace/test/ritm.spec.js
+++ b/packages/dd-trace/test/ritm.spec.js
@@ -124,4 +124,29 @@ describe('Ritm', () => {
     assert.equal(startListener.callCount, 1)
     assert.equal(endListener.callCount, 1)
   })
+
+  it('should use moduleId as cache key for node:-prefixed built-ins', () => {
+    // Populate RITM cache keyed by normalized moduleId 'util'
+    require('util')
+
+    // Simulate require.cache having an entry for the node:-prefixed filename.
+    // In Node.js 18+, Module._resolveFilename('node:util') returns 'node:util',
+    // so filename differs from moduleId ('util'). Before the fix, the cache
+    // comparison accessed cache[filename] ('node:util') which was undefined,
+    // causing: TypeError: undefined is not an object (evaluating 'cache[filename].original')
+    const prefixedKey = 'node:util'
+    const saved = require.cache[prefixedKey]
+    require.cache[prefixedKey] = { exports: { patched: true } }
+
+    try {
+      const result = require('node:util')
+      assert.deepStrictEqual(result, { patched: true })
+    } finally {
+      if (saved) {
+        require.cache[prefixedKey] = saved
+      } else {
+        delete require.cache[prefixedKey]
+      }
+    }
+  })
 })


### PR DESCRIPTION
This was missed in commit e92e7f0 which refactored cache keys from `filename` to `moduleId`. One occurrence on line 104 was not updated.

Reproduces when dd-trace instruments modules that transitively require node-prefixed built-ins (e.g. @aws-sdk/credential-provider-ini).

### What does this PR do?

Fixes `cache[filename].original` → `cache[moduleId].original` in `packages/dd-trace/src/ritm.js` line 104, aligning it with the rest of the cache key refactoring done in e92e7f0.

### Motivation

Users hitting a `TypeError: undefined is not an object` crash when dd-trace instruments modules that transitively require built-in modules with the `node:` prefix (observed with `@aws-sdk/credential-provider-ini` → `@aws-sdk/credential-provider-login`).

### Additional Notes

Single-line change. All existing ritm tests pass.