### PR TITLE
test: decouple request specs from nock 13 internals

### DIFF
--- a/packages/dd-trace/test/ci-visibility/requests/request.spec.js
+++ b/packages/dd-trace/test/ci-visibility/requests/request.spec.js
@@ -29,12 +29,14 @@ describe('ci-visibility/requests/request', () => {
 
   describe('statusCode preservation across retries', () => {
     it('should preserve 429 status code when the retry fails with a network error', (done) => {
+      const networkError = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' })
+
       // x-ratelimit-reset: '0' → reset is in the past → waitMs = max(0, 0 − Date.now()) = 0
       nock('http://localhost:8126')
         .post('/path')
         .reply(429, 'rate limited', { 'x-ratelimit-reset': '0' })
         .post('/path')
-        .replyWithError({ code: 'ECONNRESET' })
+        .replyWithError(networkError)
 
       request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
         assert.ok(err)
@@ -44,11 +46,13 @@ describe('ci-visibility/requests/request', () => {
     })
 
     it('should preserve 5xx status code when the retry fails with a network error', (done) => {
+      const networkError = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' })
+
       nock('http://localhost:8126')
         .post('/path')
         .reply(503, 'service unavailable')
         .post('/path')
-        .replyWithError({ code: 'ECONNRESET' })
+        .replyWithError(networkError)
 
       request('{}', { url: 'http://localhost:8126', path: '/path' }, (err, res, statusCode) => {
         assert.ok(err)
@@ -59,9 +63,11 @@ describe('ci-visibility/requests/request', () => {
   })
 
   it('should retry on a transient network error and succeed on the next attempt', (done) => {
+    const networkError = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' })
+
     nock('http://localhost:8126')
       .post('/path')
-      .replyWithError({ code: 'ECONNRESET' })
+      .replyWithError(networkError)
       .post('/path')
       .reply(200, 'ok')
 

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -137,21 +137,33 @@ describe('request', function () {
     })
   })
 
-  // TODO: use fake timers to avoid delaying tests
-  it('should timeout after 2 seconds by default', function (done) {
-    nock('http://localhost:80')
-      .put('/path')
-      .times(2)
-      .delay(2001)
-      .reply(200)
+  // Live timeout → abort → retry → 'socket hang up' is covered by
+  // `should have a configurable timeout` below at timeout: 100. Here we only
+  // need to pin the default constant, which is faster and avoids waiting
+  // for a real timer.
+  it('defaults the request timeout to 2 seconds', (done) => {
+    const sandbox = sinon.createSandbox()
+    const realRequest = http.request
+    let observedTimeout
+    sandbox.replace(http, 'request', function (...args) {
+      const req = realRequest.apply(this, args)
+      const originalSetTimeout = req.setTimeout
+      req.setTimeout = function (timeout, callback) {
+        observedTimeout = timeout
+        return originalSetTimeout.call(this, timeout, callback)
+      }
+      return req
+    })
+
+    nock('http://localhost:80').put('/path').reply(200, 'OK')
 
     request(Buffer.from(''), {
       path: '/path',
       method: 'PUT',
-    }, err => {
-      assert.ok(err instanceof Error)
-      assert.strictEqual(err.message, 'socket hang up')
-      done()
+    }, (err) => {
+      sandbox.restore()
+      assert.strictEqual(observedTimeout, 2000)
+      done(err)
     })
   })
 
@@ -192,9 +204,11 @@ describe('request', function () {
   })
 
   it('should retry', (done) => {
+    const error = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET' })
+
     nock('http://localhost:80')
       .put('/path')
-      .replyWithError({ code: 'ECONNRESET' })
+      .replyWithError(error)
       .put('/path')
       .reply(200, 'OK')
 
@@ -374,30 +388,45 @@ describe('request', function () {
       })
   })
 
+  // unix:<path> URLs go through parseUrl(), which extracts the socket path
+  // and hands it to http.request via options.socketPath. Assert that mapping
+  // directly via the http.request spy.
   it('should parse unix domain sockets properly', (done) => {
     const sock = '/tmp/unix_socket'
+    const sandbox = sinon.createSandbox()
+    sandbox.spy(http, 'request')
+
+    maxAttempts = 1
 
     request(
       Buffer.from(''), {
         url: 'unix:' + sock,
         method: 'PUT',
       },
-      (err, _) => {
-        assert.strictEqual(err.address, sock)
+      () => {
+        const callOptions = http.request.getCall(0).args[0]
+        sandbox.restore()
+        assert.strictEqual(callOptions.socketPath, sock)
         done()
       })
   })
 
   it('should parse windows named pipes properly', (done) => {
     const pipe = '//./pipe/datadogtrace'
+    const sandbox = sinon.createSandbox()
+    sandbox.spy(http, 'request')
+
+    maxAttempts = 1
 
     request(
       Buffer.from(''), {
         url: 'unix:' + pipe,
         method: 'PUT',
       },
-      (err, _) => {
-        assert.strictEqual(err.address, pipe)
+      () => {
+        const callOptions = http.request.getCall(0).args[0]
+        sandbox.restore()
+        assert.strictEqual(callOptions.socketPath, pipe)
         done()
       })
   })


### PR DESCRIPTION
Three nock 13 simulation details leak into the test setup and break under nock 14's mswjs/interceptors backend.

1. Replace plain-object `replyWithError({ code: 'ECONNRESET' })` at the four remaining sites with real `Error` instances. nock 14 stopped auto-promoting these into `Error`s, so the request never sees a retriable failure and the test hangs.

2. UDS / windows-pipe parse tests assert directly on `options.socketPath` via a `http.request` spy. That is the contract `parseUrl()` owes the caller for `unix:` URLs.

3. `defaults the request timeout to 2 seconds` switches to a `http.request` spy. mswjs creates a `ClientRequest` subclass whose own setTimeout swallows the abort path, so a real-timer test cannot fire here; live timeout coverage stays in `should have a configurable timeout`.

Refs: https://github.com/DataDog/dd-trace-js/pull/8280