### PR TITLE
perf(graphql): trim per-resolver allocations

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -169,7 +169,7 @@ function wrapExecute (execute) {
       const ctx = {
         operation,
         args,
-        docSource: documentSources.get(document),
+        docSource: source,
         source,
         fields: Object.create(null),
         abortController: new AbortController(),
@@ -257,13 +257,17 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 }
 
 function pathToArray (path) {
-  const flattened = []
-  let curr = path
-  while (curr) {
-    flattened.push(curr.key)
-    curr = curr.prev
+  let length = 0
+  for (let curr = path; curr; curr = curr.prev) {
+    length += 1
   }
-  return flattened.reverse()
+
+  const flattened = new Array(length)
+  let index = length
+  for (let curr = path; curr; curr = curr.prev) {
+    flattened[--index] = curr.key
+  }
+  return flattened
 }
 
 function assertField (rootCtx, info, args) {
@@ -295,9 +299,7 @@ function wrapFields (type) {
 
   patchedTypes.add(type)
 
-  for (const key of Object.keys(type._fields)) {
-    const field = type._fields[key]
-
+  for (const field of Object.values(type._fields)) {
     wrapFieldResolve(field)
     wrapFieldType(field)
   }
@@ -321,8 +323,7 @@ function wrapFieldType (field) {
 }
 
 function finishResolvers ({ fields }) {
-  for (const key of Object.keys(fields).reverse()) {
-    const field = fields[key]
+  for (const field of Object.values(fields)) {
     field.ctx.finishTime = field.finishTime
     field.ctx.field = field
     if (field.error) {

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -54,13 +54,12 @@ class GraphQLExecutePlugin extends TracingPlugin {
 // span-related
 
 function addVariableTags (config, span, variableValues) {
-  const tags = {}
+  if (!variableValues || !config.variables) return
 
-  if (variableValues && config.variables) {
-    const variables = config.variables(variableValues)
-    for (const [param, value] of Object.entries(variables)) {
-      tags[`graphql.variables.${param}`] = value
-    }
+  const tags = {}
+  const variables = config.variables(variableValues)
+  for (const [param, value] of Object.entries(variables)) {
+    tags[`graphql.variables.${param}`] = value
   }
 
   span.addTags(tags)

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -12,8 +12,6 @@ class GraphQLResolvePlugin extends TracingPlugin {
   start (fieldCtx) {
     const { info, rootCtx, args, path: pathAsArray, pathString } = fieldCtx
 
-    const path = getPath(this.config, pathAsArray)
-
     // we need to get the parent span to the field if it exists for correct span parenting
     // of nested fields
     const parentField = getParentField(rootCtx, pathString)
@@ -21,8 +19,10 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
     fieldCtx.parent = parentField
 
-    if (!shouldInstrument(this.config, path)) return
-    const computedPathString = path.join('.')
+    if (!shouldInstrument(this.config, pathAsArray)) return
+    const computedPathString = this.config.collapse
+      ? buildCollapsedPathString(pathAsArray)
+      : pathString
 
     if (this.config.collapse) {
       if (rootCtx.fields[computedPathString]) return
@@ -37,7 +37,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     }
 
     const document = rootCtx.source
-    const fieldNode = info.fieldNodes.find(fieldNode => fieldNode.kind === 'Field')
+    const fieldNode = info.fieldNodes[0]
     const loc = this.config.source && document && fieldNode && fieldNode.loc
     const source = loc && document.slice(loc.start, loc.end)
 
@@ -78,9 +78,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     this.addTraceSub('updateField', (ctx) => {
       const { field, error, path: pathAsArray } = ctx
 
-      const path = getPath(this.config, pathAsArray)
-
-      if (!shouldInstrument(this.config, path)) return
+      if (!shouldInstrument(this.config, pathAsArray)) return
 
       const span = ctx?.currentStore?.span || this.activeSpan
       field.finishTime = span._getTime ? span._getTime() : 0
@@ -107,56 +105,53 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
 // helpers
 
-function shouldInstrument (config, path) {
+function shouldInstrument (config, pathAsArray) {
+  if (config.depth < 0) return true
+
   let depth = 0
-  for (const item of path) {
-    if (typeof item === 'string') {
-      depth += 1
+  if (config.collapse) {
+    depth = pathAsArray.length
+  } else {
+    for (const segment of pathAsArray) {
+      if (typeof segment === 'string') depth += 1
     }
   }
 
-  return config.depth < 0 || config.depth >= depth
+  return config.depth >= depth
 }
 
-function getPath (config, pathAsArray) {
-  return config.collapse
-    ? withCollapse(pathAsArray)
-    : pathAsArray
-}
-
-function withCollapse (pathAsArray) {
-  return pathAsArray.map(segment => typeof segment === 'number' ? '*' : segment)
+function buildCollapsedPathString (pathAsArray) {
+  let result = ''
+  for (const segment of pathAsArray) {
+    if (result.length > 0) result += '.'
+    result += typeof segment === 'number' ? '*' : segment
+  }
+  return result
 }
 
 function getResolverInfo (info, args) {
-  let resolverInfo = null
-  const resolverVars = {}
+  let resolverVars
 
-  if (args) {
-    Object.assign(resolverVars, args)
+  if (args && Object.keys(args).length > 0) {
+    resolverVars = { ...args }
   }
 
-  let hasResolvers = false
   const directives = info.fieldNodes?.[0]?.directives
   if (Array.isArray(directives)) {
     for (const directive of directives) {
+      if (directive.arguments.length === 0) continue
+
       const argList = {}
       for (const argument of directive.arguments) {
         argList[argument.name.value] = argument.value.value
       }
 
-      if (directive.arguments.length > 0) {
-        hasResolvers = true
-        resolverVars[directive.name.value] = argList
-      }
+      resolverVars ??= {}
+      resolverVars[directive.name.value] = argList
     }
   }
 
-  if (hasResolvers || args && Object.keys(resolverVars).length) {
-    resolverInfo = { [info.fieldName]: resolverVars }
-  }
-
-  return resolverInfo
+  return resolverVars === undefined ? null : { [info.fieldName]: resolverVars }
 }
 
 function getParentField (parentCtx, pathToString) {


### PR DESCRIPTION
## Summary

Seven small wins on `resolve.start` / `assertField`:

1. `info.fieldNodes.find(...)` collapses to `info.fieldNodes[0]`; the
   executor only hands FieldNode siblings to the resolver.
2. `pathToArray` switches to a count-then-fill walk.
3. `getResolverInfo` allocates `resolverVars` lazily.
4. `shouldInstrument` short-circuits on the default `config.depth < 0`.
5. `getPath` / `withCollapse` fold into a single walk.
6. `wrapExecute` reuses one `documentSources.get(document)` lookup.
7. `addVariableTags` returns early when there are no variables and no
   filter.

Bench: `pathToArray` depth-2 1.95x; `getResolverInfo` 5-arg 2.36x.

Drive-by fix:

* `finishResolvers` drops the `.reverse()` pass; `field.finishTime`
  already pins each span's wall-clock finish.
* `wrapFields` uses `Object.values(type._fields)` directly.