### PR TITLE
Add `truncate` type to database plugin interfaces

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -400,6 +400,8 @@ tracer.use('playwright');
 tracer.use('pg');
 tracer.use('pg', { service: params => `${params.host}-${params.database}` });
 tracer.use('pg', { appendComment: true });
+tracer.use('pg', { truncate: true });
+tracer.use('pg', { truncate: 5000 });
 tracer.use('pino');
 tracer.use('prisma');
 tracer.use('protobufjs');

--- a/index.d.ts
+++ b/index.d.ts
@@ -1998,6 +1998,20 @@ declare namespace tracer {
     interface Instrumentation extends Integration, Analyzable {}
 
     /** @hidden */
+    interface DatabaseInstrumentation extends Instrumentation {
+      /**
+       * Truncate the resource name (e.g. the query) to the given length.
+       * When set to `true`, truncates to 5000 characters (matching the
+       * Datadog agent's default). When set to a number, truncates to that
+       * many characters. This can help prevent large queries from blocking
+       * the event loop during trace encoding.
+       *
+       * @default false
+       */
+      truncate?: boolean | number;
+    }
+
+    /** @hidden */
     interface Http extends Instrumentation {
       /**
        * List of URLs/paths that should be instrumented.
@@ -2217,7 +2231,7 @@ declare namespace tracer {
     }
 
     /** @hidden */
-    interface Prisma extends Instrumentation {}
+    interface Prisma extends DatabaseInstrumentation {}
 
     /** @hidden */
     interface PrismaClient extends Prisma {}
@@ -2982,7 +2996,7 @@ declare namespace tracer {
      * This plugin automatically instruments the
      * [pg](https://node-postgres.com/) module.
      */
-    interface pg extends Instrumentation {
+    interface pg extends DatabaseInstrumentation {
       /**
        * The service name to be used for this plugin. If a function is used, it will be passed the connection parameters and its return value will be used as the service name.
        */


### PR DESCRIPTION
### What does this PR do?

Adds the `truncate` option to the TypeScript type definitions for all database plugin interfaces.

### Motivation

The `DatabasePlugin` base class already supports a `truncate` option via its `maybeTruncate()` method (in `packages/dd-trace/src/plugins/database.js`), but this was missing from the TypeScript definitions in `index.d.ts`. This means TypeScript users get a compile error when trying to use the option:

```typescript
// TS2353: Object literal may only specify known properties,
// and 'truncate' does not exist in type 'pg'.
tracer.use("pg", { truncate: true });
```

The `truncate` option is important for preventing event loop blocking. When large SQL queries (e.g. bulk INSERTs with inlined arrays or large `WHERE IN` clauses) are captured as span resource names, the synchronous msgpack encoding in the trace writer can block the event loop for seconds. Since resource name truncation was removed from the agentful encoder in #2781, plugin-level truncation via `maybeTruncate()` is the recommended way to cap resource name size on the client side.

### Changes

- Introduces a `DatabaseInstrumentation` interface (extending `Instrumentation`) with a `truncate?: boolean | number` property
- Updates all database plugin interfaces to extend `DatabaseInstrumentation`:
  `aerospike`, `cassandra_driver`, `couchbase`, `elasticsearch`, `mongodb_core`, `mongoose`, `mysql`, `mysql2`, `mariadb`, `oracledb`, `pg`, `prisma`, `tedious`
- Adds type tests for `truncate` usage with `pg`, `mysql`, and `mysql2`

### Plugin Checklist

- [ ] Unit tests.
- [x] TypeScript [definitions][1].
- [x] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/documentation/blob/master/content/en/tracing/trace_collection/library_config/nodejs.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js