### PR TITLE
add fail-fast: false to jobs with matrix

### DIFF
--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -93,6 +93,7 @@ jobs:
   integration:
     name: ${{ github.workflow }} / integration (node-${{ matrix.version }})
     strategy:
+      fail-fast: false
       matrix:
         version: [maintenance, active, latest]
     runs-on: ubuntu-latest

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         node-version: [oldest, maintenance, active, latest]
     steps:

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -27,11 +27,14 @@ jobs:
   aerospike:
     name: aerospike (${{ matrix.aerospike-version }}, node-${{ matrix.node-version }})
     strategy:
+      fail-fast: false
       matrix:
         node-version: [eol]
         range: [">=4.0.0 <5.2.0"]
         aerospike-version: [ce-5.7.0.15]
-        image: ["aerospike@sha256:f1fbfd8788f840fc10805690bd1352b4a99acbc4c6d113912357b4211dcf56a4"] # ce-5.7.0.15
+        image: [
+            "aerospike@sha256:f1fbfd8788f840fc10805690bd1352b4a99acbc4c6d113912357b4211dcf56a4",
+          ] # ce-5.7.0.15
         test-image: [ubuntu-22.04]
         include:
           - node-version: 18
@@ -250,6 +253,7 @@ jobs:
 
   confluentinc-kafka-javascript:
     strategy:
+      fail-fast: false
       matrix:
         # using node versions matrix since this plugin testing fails due to install differences between node versions
         node-version: [18, 20, 22]
@@ -328,6 +332,7 @@ jobs:
 
   couchbase:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [eol]
         range:
@@ -561,6 +566,7 @@ jobs:
 
   http:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [oldest, maintenance, latest]
     runs-on: ubuntu-latest
@@ -616,6 +622,7 @@ jobs:
 
   kafkajs:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [oldest, latest]
     runs-on: ubuntu-latest
@@ -1096,6 +1103,7 @@ jobs:
 
   prisma:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - node-version: 18

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -32,9 +32,7 @@ jobs:
         node-version: [eol]
         range: [">=4.0.0 <5.2.0"]
         aerospike-version: [ce-5.7.0.15]
-        image: [
-            "aerospike@sha256:f1fbfd8788f840fc10805690bd1352b4a99acbc4c6d113912357b4211dcf56a4",
-          ] # ce-5.7.0.15
+        image: ["aerospike@sha256:f1fbfd8788f840fc10805690bd1352b4a99acbc4c6d113912357b4211dcf56a4"] # ce-5.7.0.15
         test-image: [ubuntu-22.04]
         include:
           - node-version: 18

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -453,6 +453,7 @@ jobs:
 
   integration:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, maintenance, active, latest]
     name: ${{ github.workflow }} / integration (node-${{ matrix.version }})

--- a/.github/workflows/custom-node-version-dispatch.yml
+++ b/.github/workflows/custom-node-version-dispatch.yml
@@ -53,6 +53,7 @@ env:
 jobs:
   run-nightly:
     strategy:
+      fail-fast: false
       matrix:
         workflow:
           - apm-integrations

--- a/.github/workflows/debugger.yml
+++ b/.github/workflows/debugger.yml
@@ -18,6 +18,7 @@ jobs:
   ubuntu:
     name: ${{ github.workflow }} / ubuntu (node-${{ matrix.version }})
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, maintenance, active, latest]
     runs-on: ubuntu-latest

--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   sdk:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, maintenance, active, latest]
     runs-on: ubuntu-latest

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   unit:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, maintenance, active, latest]
     name: ${{ github.workflow }} / unit (node-${{ matrix.version }})

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -39,6 +39,7 @@ jobs:
 
   integration:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, maintenance, active, latest]
     name: ${{ github.workflow }} / integration (node-${{ matrix.version }})
@@ -72,6 +73,7 @@ jobs:
 
   integration-playwright:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [oldest, latest]
         playwright-version: [oldest, latest]
@@ -136,6 +138,7 @@ jobs:
 
   integration-mocha:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, latest]
         # "oldest" is 5.2.0 in <=5 and 8.0.0 in >=6
@@ -166,6 +169,7 @@ jobs:
 
   integration-jest:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, latest]
         # "oldest" is 24.8.0 in <=5 and 28.0.0 in >=6
@@ -196,6 +200,7 @@ jobs:
 
   integration-cucumber:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, latest]
         cucumber-version: [7.0.0, latest]
@@ -225,6 +230,7 @@ jobs:
 
   integration-selenium:
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, latest]
     runs-on: ubuntu-latest
@@ -270,6 +276,7 @@ jobs:
 
   integration-cypress:
     strategy:
+      fail-fast: false
       matrix:
         version: [eol, oldest, latest]
         # 6.7.0 is the minimum version we support in <=5
@@ -347,6 +354,7 @@ jobs:
     permissions:
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         version: [oldest, latest]
     env:


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?

`fail-fast: false` was already present on some jobs, I've added it on all of them

### Motivation

By default, GHA cancel a job in a matrix if another job in the same matrix fails. In consequence : 

* PR author can't know the full map of failure when a job fails, making harder the investigation
* and job are reported to Ci Visibility as a failure. Not a huge deal, but it add noise when dealing with failure.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


