### PR TITLE
refactor(config)!: gate experimental.appsec, plugins, ingestion shape…

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -68,6 +68,19 @@ the existing `'b3multi'` value. The legacy `'b3 single header'` spelling is
 still accepted on `DD_TRACE_PROPAGATION_STYLE` and the programmatic option as
 a quiet alias for `'b3'`; prefer the canonical `'b3'` going forward.
 
+### `experimental.appsec` configuration removed
+
+The `experimental.appsec.*` programmatic aliases (and
+`experimental.appsec.standalone.enabled`) have been removed. Use the canonical
+top-level `appsec.*` fields, and `apmTracingEnabled` (or
+`DD_APM_TRACING_ENABLED`) to control standalone ASM mode.
+
+### `ingestion` option removed
+
+The `ingestion: { sampleRate, rateLimit }` wrapper has been removed. Set
+`sampleRate` and `rateLimit` directly on the top-level `TracerOptions` object,
+or use `DD_TRACE_SAMPLE_RATE` / `DD_TRACE_RATE_LIMIT`.
+
 ## 4.0 to 5.0
 
 ### Node 16 is no longer supported

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -46,10 +46,6 @@ tracer.init({
   version: '1.0.0',
   url: 'http://localhost',
   runtimeMetrics: true,
-  ingestion: {
-    sampleRate: 0.5,
-    rateLimit: 500
-  },
   experimental: {
     exporter: 'log'
   },
@@ -149,13 +145,6 @@ tracer.init({
 });
 
 tracer.init({
-  experimental: {
-    appsec: {
-      standalone: {
-        enabled: true
-      }
-    }
-  },
   iast: {
     enabled: true,
     requestSampling: 50,

--- a/eslint-rules/eslint-config-names-sync.mjs
+++ b/eslint-rules/eslint-config-names-sync.mjs
@@ -6,13 +6,23 @@ import ts from 'typescript'
 
 const require = createRequire(import.meta.url)
 const { DD_MAJOR } = require('../version.js')
-const { applyMajorVersionAliasFilters } = require('../packages/dd-trace/src/config/major-version-filters.js')
+const applyMajorOverrides = require('../packages/dd-trace/src/config/major-overrides.js')
 
 const IGNORED_CONFIGURATION_NAMES = new Set([
   // v6 drops `experimental.b3` from `index.d.ts`; v5 still consumes the env var.
   'experimental.b3',
   'tracePropagationStyle',
   'tracing',
+])
+// Configuration name prefixes that are intentionally only present in
+// `supported-configurations.json` for v5 backports and stripped at runtime in
+// v6. Keep these out of the `index.d.ts` ↔ JSON parity check.
+const IGNORED_CONFIGURATION_NAME_PREFIXES = [
+  'experimental.appsec.',
+  'ingestion.',
+]
+const IGNORED_CONFIGURATION_LEAVES = new Set([
+  'experimental.appsec',
 ])
 const UNSUPPORTED_CONFIGURATION_ROOTS = new Set([
   'isCiVisibility',
@@ -83,7 +93,7 @@ function createInspectionResult (overrides) {
 function getSupportedConfigurationInfo (filePath) {
   const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
   const supportedConfigurations = parsed?.supportedConfigurations
-  applyMajorVersionAliasFilters(supportedConfigurations, DD_MAJOR)
+  applyMajorOverrides(supportedConfigurations, DD_MAJOR)
 
   const names = new Set()
   const primaryEnvTargets = new Map()
@@ -121,14 +131,19 @@ function getSupportedConfigurationInfo (filePath) {
       }
 
       for (const name of entry.configurationNames ?? []) {
-        if (typeof name === 'string' && !IGNORED_CONFIGURATION_NAMES.has(name)) {
-          // Deprecated entries opt out of the cross-check against `index.d.ts` so a
-          // major-version drop of the public type does not strand the env var here.
-          if (!entry.deprecated) {
-            names.add(name)
-          }
-          targets.add(name)
+        if (typeof name !== 'string' || IGNORED_CONFIGURATION_NAMES.has(name)) {
+          continue
         }
+        if (IGNORED_CONFIGURATION_LEAVES.has(name)) {
+          continue
+        }
+        if (IGNORED_CONFIGURATION_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+          continue
+        }
+        if (!entry.deprecated) {
+          names.add(name)
+        }
+        targets.add(name)
       }
     }
 
@@ -484,6 +499,14 @@ function getIndexDtsConfigurationNames (filePath, supportedConfigurationInfo) {
 
   for (const ignoredConfigurationName of IGNORED_CONFIGURATION_NAMES) {
     names.delete(ignoredConfigurationName)
+  }
+  for (const leaf of IGNORED_CONFIGURATION_LEAVES) {
+    names.delete(leaf)
+  }
+  for (const name of names) {
+    if (IGNORED_CONFIGURATION_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+      names.delete(name)
+    }
   }
 
   return names

--- a/index.d.ts
+++ b/index.d.ts
@@ -700,28 +700,6 @@ declare namespace tracer {
     protocolVersion?: string
 
     /**
-     * Deprecated in favor of the global versions of the variables provided under this option
-     *
-     * @deprecated
-     * @hidden
-     */
-    ingestion?: {
-      /**
-       * Controls the ingestion sample rate (between 0 and 1) between the agent and the backend.
-       * @env DD_TRACE_SAMPLE_RATE
-       * Programmatic configuration takes precedence over the environment variables listed above.
-       */
-      sampleRate?: number
-
-      /**
-       * Controls the ingestion rate limit between the agent and the backend. Defaults to deferring the decision to the agent.
-       * @env DD_TRACE_RATE_LIMIT
-       * Programmatic configuration takes precedence over the environment variables listed above.
-       */
-      rateLimit?: number
-    };
-
-    /**
      * Whether to enable inferred proxy services.
      * @default false
      * @env DD_TRACE_INFERRED_PROXY_SERVICES_ENABLED
@@ -757,28 +735,6 @@ declare namespace tracer {
        * Programmatic configuration takes precedence over the environment variables listed above.
        */
       enableGetRumData?: boolean
-
-      /**
-       * Configuration of the AppSec. Can be a boolean as an alias to `appsec.enabled`.
-       * @deprecated Please use the non-experimental `appsec` option instead.
-       */
-      appsec?: boolean | {
-        /**
-         * Configuration of Standalone ASM mode
-         * Deprecated in favor of `apmTracingEnabled`.
-         *
-         * @deprecated Please use `apmTracingEnabled` instead.
-         */
-        standalone?: {
-          /**
-           * Whether to enable Standalone ASM.
-           * @default false
-           * @env DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED
-           * Programmatic configuration takes precedence over the environment variables listed above.
-           */
-          enabled?: boolean
-        }
-      } | TracerOptions['appsec'],
 
       aiguard?: {
         /**

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -4,19 +4,18 @@ const dns = require('dns')
 const util = require('util')
 
 const { DD_MAJOR } = require('../../../../version')
-const { applyMajorVersionAliasFilters } = require('./major-version-filters')
 const { parsers, transformers, telemetryTransformers, setWarnInvalidValue } = require('./parsers')
+const applyMajorOverrides = require('./major-overrides')
 const {
   supportedConfigurations,
 } = /** @type {import('./helper').SupportedConfigurationsJson} */ (require('./supported-configurations.json'))
+
+applyMajorOverrides(supportedConfigurations, DD_MAJOR)
 
 let log
 let seqId = 0
 const configWithOrigin = new Map()
 const parseErrors = new Map()
-
-// Idempotent; mirrors the call in `helper.js` so either module load order produces the same shape.
-applyMajorVersionAliasFilters(supportedConfigurations, DD_MAJOR)
 
 if (DD_MAJOR < 6) {
   // Default value for DD_TRACE_STARTUP_LOGS is 'false' in older major versions.

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -21,16 +21,13 @@
  */
 
 const { deprecate } = require('util')
-
 const { DD_MAJOR } = require('../../../../version')
-const { applyMajorVersionAliasFilters } = require('./major-version-filters')
+const applyMajorOverrides = require('./major-overrides')
 const {
   supportedConfigurations,
 } = /** @type {SupportedConfigurationsJson} */ (require('./supported-configurations.json'))
 
-// Apply v6 env-alias deletions before the `aliases` / `aliasToCanonical` snapshot below; otherwise
-// `getEnvironmentVariables()` keeps rewriting the deprecated env vars to their canonical names.
-applyMajorVersionAliasFilters(supportedConfigurations, DD_MAJOR)
+applyMajorOverrides(supportedConfigurations, DD_MAJOR)
 
 /**
  * Types for environment variable handling.

--- a/packages/dd-trace/src/config/major-overrides.js
+++ b/packages/dd-trace/src/config/major-overrides.js
@@ -4,37 +4,33 @@
  * @typedef {import('./helper').SupportedConfigurationsJson['supportedConfigurations']} SupportedConfigurations
  */
 
+const EXPERIMENTAL_APPSEC_PREFIX = 'experimental.appsec'
 const EXPERIMENTAL_IAST_PREFIX = 'experimental.iast'
-
-const filtered = new WeakSet()
+const INGESTION_PREFIX = 'ingestion.'
 
 /**
- * Shared between `helper.js` / `defaults.js` (runtime) and `eslint-config-names-sync` (lint) so
- * the JSON ↔ `index.d.ts` sync check uses the same view as the runtime parser. Idempotent on a
- * per-object basis so callers don't have to coordinate load order.
- *
  * @param {SupportedConfigurations} supportedConfigurations Mutated in place.
  * @param {number} majorVersion
  */
-function applyMajorVersionAliasFilters (supportedConfigurations, majorVersion) {
-  if (filtered.has(supportedConfigurations)) return
-  filtered.add(supportedConfigurations)
-
+function applyMajorOverrides (supportedConfigurations, majorVersion) {
   if (majorVersion < 6) return
 
-  // v6 strips both the bare `experimental.iast` alias and its nested forms so
-  // `#applyOptions` warns "Unknown option" instead of writing user-supplied
-  // objects into `iast.enabled` via the bare alias.
   for (const entries of Object.values(supportedConfigurations)) {
     for (const entry of entries) {
       if (Array.isArray(entry.configurationNames)) {
         entry.configurationNames = entry.configurationNames.filter(
-          (name) => name !== EXPERIMENTAL_IAST_PREFIX && !name.startsWith(`${EXPERIMENTAL_IAST_PREFIX}.`)
+          (name) =>
+            name !== EXPERIMENTAL_APPSEC_PREFIX &&
+            name !== EXPERIMENTAL_IAST_PREFIX &&
+            !name.startsWith(`${EXPERIMENTAL_APPSEC_PREFIX}.`) &&
+            !name.startsWith(`${EXPERIMENTAL_IAST_PREFIX}.`) &&
+            !name.startsWith(INGESTION_PREFIX)
         )
+        if (entry.configurationNames.length === 0) delete entry.configurationNames
       }
     }
   }
-
+  delete supportedConfigurations.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED
   delete supportedConfigurations.DD_TRACE_EXPERIMENTAL_B3_ENABLED
 
   /* eslint-disable eslint-rules/eslint-env-aliases */
@@ -62,10 +58,6 @@ function applyMajorVersionAliasFilters (supportedConfigurations, majorVersion) {
 }
 
 /**
- * Filter aliases on a canonical entry in-place. `dropPredicate` may be a string (exact match) or
- * a function called per alias. No-op when the canonical is missing so this stays usable against
- * the eslint sync test fixtures.
- *
  * @param {SupportedConfigurations[string] | undefined} entries
  * @param {string | ((alias: string) => boolean)} dropPredicate
  */
@@ -79,4 +71,4 @@ function dropAlias (entries, dropPredicate) {
   if (entry.aliases.length === 0) delete entry.aliases
 }
 
-module.exports = { applyMajorVersionAliasFilters }
+module.exports = applyMajorOverrides

--- a/packages/dd-trace/src/config/major-overrides.js
+++ b/packages/dd-trace/src/config/major-overrides.js
@@ -68,7 +68,9 @@ function dropAlias (entries, dropPredicate) {
     ? (alias) => alias === dropPredicate
     : dropPredicate
   entry.aliases = entry.aliases.filter((alias) => !matches(alias))
-  if (entry.aliases.length === 0) delete entry.aliases
+  if (entry.aliases.length === 0) {
+    delete entry.aliases
+  }
 }
 
 module.exports = applyMajorOverrides

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -205,13 +205,12 @@ describe('Config', () => {
       )
     })
 
-    itV6Filter('applyMajorVersionAliasFilters is idempotent on the same supportedConfigurations object', () => {
+    itV6Filter('applyMajorOverrides is idempotent on the same supportedConfigurations object', () => {
       const fresh = proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
-      const { applyMajorVersionAliasFilters } =
-        proxyquire.noPreserveCache()('../../src/config/major-version-filters', {})
+      const applyMajorOverrides = proxyquire.noPreserveCache()('../../src/config/major-overrides', {})
       const supported = fresh.supportedConfigurations
       assert.ok('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in supported)
-      applyMajorVersionAliasFilters(supported, 6)
+      applyMajorOverrides(supported, 6)
       assert.strictEqual('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in supported, false)
       assert.strictEqual('DD_TRACE_EXPERIMENTAL_B3_ENABLED' in supported, false)
       assert.strictEqual('DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED' in supported, false)
@@ -221,7 +220,7 @@ describe('Config', () => {
       assert.ok(!runtimeIdEntry.aliases?.includes('DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED'))
 
       const beforeKeyCount = Object.keys(supported).length
-      applyMajorVersionAliasFilters(supported, 6)
+      applyMajorOverrides(supported, 6)
       assert.strictEqual(Object.keys(supported).length, beforeKeyCount)
     })
 
@@ -2369,7 +2368,7 @@ describe('Config', () => {
     assert.strictEqual(config.url.toString(), 'https://agent2:6218/')
   })
 
-  it('should give priority to non-experimental options', () => {
+  ;(DD_MAJOR < 6 ? it : it.skip)('should give priority to non-experimental options', () => {
     const config = getConfig({
       appsec: {
         apiSecurity: {
@@ -2517,6 +2516,61 @@ describe('Config', () => {
       },
       telemetryVerbosity: 'DEBUG',
     })
+  })
+
+  ;(DD_MAJOR < 6 ? it.skip : it)(
+    'should drop the experimental.appsec programmatic shape in v6 (bare and nested)',
+    () => {
+      const config = getConfig({
+        experimental: {
+          appsec: {
+            enabled: true,
+            rateLimit: 42,
+            rules: 'some-rules.json',
+            standalone: { enabled: true },
+          },
+        },
+      })
+
+      assert.strictEqual(config.appsec.enabled, undefined)
+      assert.strictEqual(config.appsec.rateLimit, 100)
+      assert.strictEqual(config.appsec.rules, undefined)
+      assert.strictEqual(config.apmTracingEnabled, true)
+
+      sinon.assert.calledWith(
+        log.warn,
+        'Unknown option %s with value %o',
+        'experimental.appsec',
+        sinon.match({ enabled: true, rateLimit: 42 })
+      )
+    }
+  )
+
+  ;(DD_MAJOR < 6 ? it.skip : it)('should drop the bare experimental.appsec boolean alias in v6', () => {
+    const config = getConfig({
+      experimental: { appsec: true },
+    })
+
+    assert.strictEqual(config.appsec.enabled, undefined)
+    sinon.assert.calledWith(log.warn, 'Unknown option %s with value %o', 'experimental.appsec', true)
+  })
+
+  ;(DD_MAJOR < 6 ? it.skip : it)('should drop the ingestion programmatic shape in v6', () => {
+    const config = getConfig({
+      ingestion: {
+        sampleRate: 0.5,
+        rateLimit: 500,
+      },
+    })
+
+    assert.strictEqual(config.sampleRate, undefined)
+    assert.strictEqual(config.rateLimit, 100)
+    sinon.assert.calledWith(
+      log.warn,
+      'Unknown option %s with value %o',
+      'ingestion',
+      sinon.match({ sampleRate: 0.5, rateLimit: 500 })
+    )
   })
 
   it('should give priority to the options especially url', () => {
@@ -3442,11 +3496,33 @@ describe('Config', () => {
   })
 
   context('standalone', () => {
-    it('should disable apm tracing with legacy DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED', () => {
+    const itLegacyStandalone = DD_MAJOR < 6 ? it : it.skip
+    const itV6Standalone = DD_MAJOR < 6 ? it.skip : it
+
+    itLegacyStandalone('should disable apm tracing with legacy DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED', () => {
       process.env.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED = '1'
 
       const config = getConfig()
       assert.strictEqual(config.apmTracingEnabled, false)
+    })
+
+    itLegacyStandalone('should disable apm tracing with legacy experimental.appsec.standalone.enabled option', () => {
+      process.env.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED = '0'
+
+      const config = getConfig({ experimental: { appsec: { standalone: { enabled: true } } } })
+      assert.strictEqual(config.apmTracingEnabled, false)
+    })
+
+    itV6Standalone('should ignore legacy DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED in v6', () => {
+      process.env.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED = '1'
+
+      const config = getConfig()
+      assert.strictEqual(config.apmTracingEnabled, true)
+    })
+
+    itV6Standalone('should ignore legacy experimental.appsec.standalone.enabled programmatic option in v6', () => {
+      const config = getConfig({ experimental: { appsec: { standalone: { enabled: true } } } })
+      assert.strictEqual(config.apmTracingEnabled, true)
     })
 
     it('should win DD_APM_TRACING_ENABLED', () => {
@@ -3457,19 +3533,12 @@ describe('Config', () => {
       assert.strictEqual(config.apmTracingEnabled, true)
     })
 
-    it('should disable apm tracing with legacy experimental.appsec.standalone.enabled option', () => {
-      process.env.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED = '0'
-
-      const config = getConfig({ experimental: { appsec: { standalone: { enabled: true } } } })
-      assert.strictEqual(config.apmTracingEnabled, false)
-    })
-
     it('should win apmTracingEnabled option', () => {
       process.env.DD_EXPERIMENTAL_APPSEC_STANDALONE_ENABLED = 'true'
 
       const config = getConfig({
         apmTracingEnabled: false,
-        experimental: { appsec: { standalone: { enabled: true } } },
+        ...DD_MAJOR < 6 && { experimental: { appsec: { standalone: { enabled: true } } } },
       })
       assert.strictEqual(config.apmTracingEnabled, false)
     })

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -210,14 +210,16 @@ describe('Config', () => {
       const applyMajorOverrides = proxyquire.noPreserveCache()('../../src/config/major-overrides', {})
       const supported = fresh.supportedConfigurations
       assert.ok('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in supported)
+      supported.DD_PROFILING_CPU_ENABLED[0].aliases.push('DD_PROFILING_TEST_ALIAS')
       applyMajorOverrides(supported, 6)
       assert.strictEqual('DD_PROFILING_EXPERIMENTAL_CPU_ENABLED' in supported, false)
       assert.strictEqual('DD_TRACE_EXPERIMENTAL_B3_ENABLED' in supported, false)
       assert.strictEqual('DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED' in supported, false)
       const cpuEntry = supported.DD_PROFILING_CPU_ENABLED[0]
       assert.ok(!cpuEntry.aliases?.some((alias) => alias.startsWith('DD_PROFILING_EXPERIMENTAL_')))
+      assert.deepStrictEqual(cpuEntry.aliases, ['DD_PROFILING_TEST_ALIAS'])
       const runtimeIdEntry = supported.DD_RUNTIME_METRICS_RUNTIME_ID_ENABLED[0]
-      assert.ok(!runtimeIdEntry.aliases?.includes('DD_TRACE_EXPERIMENTAL_RUNTIME_ID_ENABLED'))
+      assert.strictEqual(runtimeIdEntry.aliases, undefined)
 
       const beforeKeyCount = Object.keys(supported).length
       applyMajorOverrides(supported, 6)


### PR DESCRIPTION
…s off in v6

Gates three long-`@deprecated` programmatic config shapes for v6 in defaults.js; v5 keeps them.

