### PR TITLE
docs(appsec): drop deprecated extended-headers and rasp.bodyCollection types in v6

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,6 +13,18 @@ The deprecated `whitelist` / `blacklist` plugin options on the `http`, `ioredis`
 surface. Use `allowlist` / `blocklist` instead — both have been the canonical
 names for several majors.
 
+### AppSec extended-data-collection programmatic config removed from types
+
+`appsec.extendedHeadersCollection.{enabled,redaction,maxHeaders}` and
+`appsec.rasp.bodyCollection` are no longer part of the v6 TypeScript surface.
+Configure these features through the Datadog UI and Remote Configuration
+instead — the runtime keeps consuming the values pushed by RC.
+
+The matching `DD_APPSEC_COLLECT_ALL_HEADERS`,
+`DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED`,
+`DD_APPSEC_MAX_COLLECTED_HEADERS`, and `DD_APPSEC_RASP_COLLECT_REQUEST_BODY`
+environment variables are deprecated in v6 and will follow in a future major.
+
 ## 4.0 to 5.0
 
 ### Node 16 is no longer supported

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -124,18 +124,12 @@ tracer.init({
       endpointCollectionMessageLimit: 300
     },
     rasp: {
-      enabled: true,
-      bodyCollection: true
+      enabled: true
     },
     stackTrace: {
       enabled: true,
       maxStackTraces: 5,
       maxDepth: 42
-    },
-    extendedHeadersCollection: {
-      enabled: true,
-      redaction: false,
-      maxHeaders: 42
     }
   },
   iast: {

--- a/eslint-rules/eslint-config-names-sync.mjs
+++ b/eslint-rules/eslint-config-names-sync.mjs
@@ -114,7 +114,11 @@ function getSupportedConfigurationInfo (filePath) {
 
       for (const name of entry.configurationNames ?? []) {
         if (typeof name === 'string' && !IGNORED_CONFIGURATION_NAMES.has(name)) {
-          names.add(name)
+          // Deprecated entries opt out of the cross-check against `index.d.ts` so a
+          // major-version drop of the public type does not strand the env var here.
+          if (!entry.deprecated) {
+            names.add(name)
+          }
           targets.add(name)
         }
       }

--- a/eslint-rules/eslint-config-names-sync.test.mjs
+++ b/eslint-rules/eslint-config-names-sync.test.mjs
@@ -46,6 +46,11 @@ ruleTester.run('eslint-config-names-sync', rule, {
       code: '',
       options: [getFixtureOptions('internal-env-and-ignored-names')],
     },
+    {
+      filename: path.join(fixturesDirectory, 'deprecated-skips-cross-check', 'lint-anchor.js'),
+      code: '',
+      options: [getFixtureOptions('deprecated-skips-cross-check')],
+    },
   ],
   invalid: [
     {

--- a/eslint-rules/fixtures/config-names-sync/deprecated-skips-cross-check/index.d.ts
+++ b/eslint-rules/fixtures/config-names-sync/deprecated-skips-cross-check/index.d.ts
@@ -1,0 +1,8 @@
+declare namespace tracer {
+  export interface TracerOptions {
+    /**
+     * @env DD_KEPT
+     */
+    kept?: boolean
+  }
+}

--- a/eslint-rules/fixtures/config-names-sync/deprecated-skips-cross-check/supported-configurations.json
+++ b/eslint-rules/fixtures/config-names-sync/deprecated-skips-cross-check/supported-configurations.json
@@ -1,0 +1,19 @@
+{
+  "supportedConfigurations": {
+    "DD_KEPT": [
+      {
+        "configurationNames": [
+          "kept"
+        ]
+      }
+    ],
+    "DD_DROPPED_FROM_TYPES": [
+      {
+        "configurationNames": [
+          "dropped"
+        ],
+        "deprecated": true
+      }
+    ]
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1070,15 +1070,6 @@ declare namespace tracer {
          * Programmatic configuration takes precedence over the environment variables listed above.
          */
         enabled?: boolean,
-
-        /** Whether to enable request body collection on RASP event
-         * @default false
-         *
-         * @deprecated Use UI and Remote Configuration to enable extended data collection
-         * @env DD_APPSEC_RASP_COLLECT_REQUEST_BODY
-         * Programmatic configuration takes precedence over the environment variables listed above.
-         */
-        bodyCollection?: boolean
       },
       /**
        * Configuration for stack trace reporting
@@ -1105,39 +1096,6 @@ declare namespace tracer {
          */
         maxDepth?: number,
       },
-      /**
-       * Configuration for extended headers collection tied to security events
-       *
-       * @deprecated Use UI and Remote Configuration to enable extended data collection
-       */
-      extendedHeadersCollection?: {
-        /** Whether to enable extended headers collection
-         * @default false
-         *
-         * @deprecated Use UI and Remote Configuration to enable extended data collection
-         * @env DD_APPSEC_COLLECT_ALL_HEADERS
-         * Programmatic configuration takes precedence over the environment variables listed above.
-         */
-        enabled: boolean,
-
-        /** Whether to redact collected headers
-         * @default true
-         *
-         * @deprecated Use UI and Remote Configuration to enable extended data collection
-         * @env DD_APPSEC_HEADER_COLLECTION_REDACTION_ENABLED
-         * Programmatic configuration takes precedence over the environment variables listed above.
-         */
-        redaction: boolean,
-
-        /** Specifies the maximum number of headers collected.
-         * @default 50
-         *
-         * @deprecated Use UI and Remote Configuration to enable extended data collection
-         * @env DD_APPSEC_MAX_COLLECTED_HEADERS
-         * Programmatic configuration takes precedence over the environment variables listed above.
-         */
-        maxHeaders: number,
-      }
     }
 
     /**

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -254,7 +254,8 @@
           "appsec.extendedHeadersCollection.redaction",
           "experimental.appsec.extendedHeadersCollection.redaction"
         ],
-        "default": "true"
+        "default": "true",
+        "deprecated": true
       }
     ],
     "DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML": [
@@ -289,7 +290,8 @@
           "appsec.extendedHeadersCollection.maxHeaders",
           "experimental.appsec.extendedHeadersCollection.maxHeaders"
         ],
-        "default": "50"
+        "default": "50",
+        "deprecated": true
       }
     ],
     "DD_APPSEC_MAX_STACK_TRACES": [


### PR DESCRIPTION
## Summary

The extended-data-collection knobs are now Datadog UI / Remote Configuration
only. Drop the deprecated programmatic fields from the v6 TypeScript surface;
the runtime keeps consuming values pushed via RC and the env vars stay
accepted on v5.