### PR TITLE
docs(appsec): drop v1 trackUserLogin* SDK methods from v6 types

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,6 +4,29 @@ This guide describes the steps to upgrade dd-trace from a major version to the
 next. If you are having any issues related to migrating, please feel free to
 open an issue or contact our [support](https://www.datadoghq.com/support/) team.
 
+## 5.0 to 6.0
+
+### AppSec v1 user-login SDK methods removed from types
+
+`tracer.appsec.trackUserLoginSuccessEvent` and
+`tracer.appsec.trackUserLoginFailureEvent` are no longer part of the v6
+TypeScript surface. Switch to the v2 shape on
+`tracer.appsec.eventTrackingV2`:
+
+```js
+// Before
+tracer.appsec.trackUserLoginSuccessEvent({ id: 'user-1', login: 'alice' })
+tracer.appsec.trackUserLoginFailureEvent('alice', true)
+
+// After
+tracer.appsec.eventTrackingV2.trackUserLoginSuccess('alice', { id: 'user-1' })
+tracer.appsec.eventTrackingV2.trackUserLoginFailure('alice', true)
+```
+
+The runtime methods still exist on the `Appsec` class through the v6 line so
+existing code keeps working; usage continues to be tracked via the
+`login_success` / `login_failure` SDK telemetry counters with `version: v1`.
+
 ## 4.0 to 5.0
 
 ### Node 16 is no longer supported

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -490,14 +490,6 @@ const meta = {
   metakey2: 'metavalue2'
 }
 
-tracer.appsec.trackUserLoginSuccessEvent(user)
-tracer.appsec.trackUserLoginSuccessEvent(user, meta)
-
-tracer.appsec.trackUserLoginFailureEvent('user_id', true)
-tracer.appsec.trackUserLoginFailureEvent('user_id', true, meta)
-tracer.appsec.trackUserLoginFailureEvent('user_id', false)
-tracer.appsec.trackUserLoginFailureEvent('user_id', false, meta)
-
 tracer.appsec.trackCustomEvent('event_name')
 tracer.appsec.trackCustomEvent('event_name', meta)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1615,29 +1615,6 @@ declare namespace tracer {
 
   export interface Appsec {
     /**
-     * Links a successful login event to the current trace. Will link the passed user to the current trace with Appsec.setUser() internally.
-     * @param {User} user Properties of the authenticated user. Accepts custom fields.
-     * @param {[key: string]: string} metadata Custom fields to link to the login success event.
-     *
-     * @beta This method is in beta and could change in future versions.
-     *
-     * @deprecated In favor of eventTrackingV2.trackUserLoginSuccess
-     */
-    trackUserLoginSuccessEvent(user: User, metadata?: { [key: string]: string }): void
-
-    /**
-     * Links a failed login event to the current trace.
-     * @param {string} userId The user id of the attempted login.
-     * @param {boolean} exists If the user id exists.
-     * @param {[key: string]: string} metadata Custom fields to link to the login failure event.
-     *
-     * @beta This method is in beta and could change in future versions.
-     *
-     * @deprecated In favor of eventTrackingV2.trackUserLoginFailure
-     */
-    trackUserLoginFailureEvent(userId: string, exists: boolean, metadata?: { [key: string]: string }): void
-
-    /**
      * Links a custom event to the current trace.
      * @param {string} eventName The name of the event.
      * @param {[key: string]: string} metadata Custom fields to link to the event.


### PR DESCRIPTION
## Summary

The runtime keeps `tracer.appsec.trackUserLoginSuccessEvent` and
`trackUserLoginFailureEvent` so existing code through the v6 line keeps
working; the v6 TypeScript surface stops advertising them so users
autocomplete only the canonical
`eventTrackingV2.{trackUserLoginSuccess,trackUserLoginFailure}`. v1 vs v2
usage is already tracked via SDK telemetry counters.