### PR TITLE
chore(config)!: bump default protocolVersion from 0.4 to 0.5 in v6

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -4,6 +4,17 @@ This guide describes the steps to upgrade dd-trace from a major version to the
 next. If you are having any issues related to migrating, please feel free to
 open an issue or contact our [support](https://www.datadoghq.com/support/) team.
 
+## 5.0 to 6.0
+
+### `DD_TRACE_AGENT_PROTOCOL_VERSION` defaults to `0.5`
+
+The default agent protocol version flips from `0.4` to `0.5` (msgpack v2). The
+0.5 encoder is faster on the agent side and is the long-time recommended
+default. v5 keeps `0.4` for backwards compatibility. Set
+`DD_TRACE_AGENT_PROTOCOL_VERSION=0.4` (or `protocolVersion: '0.4'` on
+`tracer.init({...})`) to opt back into the older encoder if your agent is
+pinned below the version that supports `0.5`.
+
 ## 4.0 to 5.0
 
 ### Node 16 is no longer supported

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -392,6 +392,16 @@ function buildExpressServer (agent) {
     })
   })
 
+  app.put('/v0.5/traces', (req, res) => {
+    if (req.body.length === 0) return res.status(200).send()
+    res.status(200).send({ rate_by_service: { 'service:,env:': 1 } })
+    const decoded = msgpack.decode(req.body, { useBigInt64: true })
+    agent.emit('message', {
+      headers: req.headers,
+      payload: expandV05TracePayload(decoded),
+    })
+  })
+
   app.post('/v0.7/config', (req, res) => {
     const {
       client: { products, state },
@@ -587,4 +597,63 @@ function buildExpressServer (agent) {
 function base64 (strOrObj) {
   const str = typeof strOrObj === 'string' ? strOrObj : JSON.stringify(strOrObj)
   return Buffer.from(str).toString('base64')
+}
+
+/**
+ * Re-expand a `/v0.5/traces` payload (`[stringTable, tracesByIndex]`,
+ * with each span as a 12-element positional array referencing strings by
+ * integer index) into the same shape `/v0.4/traces` produces. Lets every
+ * downstream listener keep the 0.4 shape it already understands.
+ *
+ * @param {[string[], unknown[][]]} body
+ * @returns {Array<Array<Record<string, unknown>>>}
+ */
+function expandV05TracePayload (body) {
+  const strings = body[0]
+  const traces = body[1]
+  const expanded = new Array(traces.length)
+  for (let i = 0; i < traces.length; i++) {
+    const trace = traces[i]
+    const expandedTrace = new Array(trace.length)
+    for (let j = 0; j < trace.length; j++) {
+      expandedTrace[j] = expandV05Span(strings, trace[j])
+    }
+    expanded[i] = expandedTrace
+  }
+  return expanded
+}
+
+/**
+ * @param {string[]} strings
+ * @param {unknown[]} span
+ */
+function expandV05Span (strings, span) {
+  const meta = {}
+  const rawMeta = span[9]
+  if (rawMeta) {
+    for (const indexKey of Object.keys(rawMeta)) {
+      meta[strings[Number(indexKey)]] = strings[rawMeta[indexKey]]
+    }
+  }
+  const metrics = {}
+  const rawMetrics = span[10]
+  if (rawMetrics) {
+    for (const indexKey of Object.keys(rawMetrics)) {
+      metrics[strings[Number(indexKey)]] = rawMetrics[indexKey]
+    }
+  }
+  return {
+    service: strings[span[0]],
+    name: strings[span[1]],
+    resource: strings[span[2]],
+    trace_id: span[3],
+    span_id: span[4],
+    parent_id: span[5],
+    start: span[6],
+    duration: span[7],
+    error: span[8],
+    meta,
+    metrics,
+    type: strings[span[11]],
+  }
 }

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -21,6 +21,9 @@ if (DD_MAJOR >= 6) {
   supportedConfigurations.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].internalPropertyName =
     supportedConfigurations.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].configurationNames?.[0]
   delete supportedConfigurations.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0].configurationNames
+
+  // The 0.5 msgpack protocol is faster on the agent side; v5 keeps 0.4 as the conservative default.
+  supportedConfigurations.DD_TRACE_AGENT_PROTOCOL_VERSION[0].default = '0.5'
 } else {
   // Default value for DD_TRACE_STARTUP_LOGS is 'false' in older major versions.
   // This is special handled here until a better solution is found.

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -664,7 +664,7 @@ describe('Config', () => {
       logLevel: 'debug',
       middlewareTracingEnabled: true,
       plugins: true,
-      protocolVersion: '0.4',
+      protocolVersion: DD_MAJOR < 6 ? '0.4' : '0.5',
       tracing: true,
       tags: {
         service: 'node',
@@ -807,7 +807,7 @@ describe('Config', () => {
       { name: 'DD_PROFILING_ENABLED', value: 'false', origin: 'default' },
       { name: 'DD_PROFILING_EXPORTERS', value: 'agent', origin: 'default' },
       { name: 'DD_PROFILING_SOURCE_MAP', value: true, origin: 'default' },
-      { name: 'DD_TRACE_AGENT_PROTOCOL_VERSION', value: '0.4', origin: 'default' },
+      { name: 'DD_TRACE_AGENT_PROTOCOL_VERSION', value: DD_MAJOR < 6 ? '0.4' : '0.5', origin: 'default' },
       {
         name: 'DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP',
         value: config.queryStringObfuscation,

--- a/packages/dd-trace/test/dd-trace.spec.js
+++ b/packages/dd-trace/test/dd-trace.spec.js
@@ -35,8 +35,12 @@ describe('dd-trace', () => {
       assert.strictEqual(payload[0][0].service, 'test')
       assert.strictEqual(payload[0][0].name, 'hello')
       assert.strictEqual(payload[0][0].resource, '/hello/:name')
-      assert.strictEqual(typeof payload[0][0].start, 'bigint')
-      assert.strictEqual(typeof payload[0][0].duration, 'bigint')
+      // Compact-int encoding picks the smallest msgpack int that fits, so
+      // small `duration` values decode as `Number` and large `start`
+      // timestamps decode as `BigInt`. Coerce both to BigInt before checking
+      // the round-trip values so the test is encoding-agnostic.
+      assert.ok(BigInt(payload[0][0].start) > 0n)
+      assert.ok(BigInt(payload[0][0].duration) >= 0n)
       assert.ok(Object.hasOwn(payload[0][0].metrics, SAMPLING_PRIORITY_KEY))
       assert.ok(Object.hasOwn(payload[0][0].meta, DECISION_MAKER_KEY))
     })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -134,6 +134,48 @@ function unformatSpanEvents (span) {
 }
 
 /**
+ * Re-expand a `/v0.5/traces` payload (`[stringTable, tracesByIndex]`,
+ * with each span as a 12-element positional array referencing strings by
+ * integer index) into the same shape `/v0.4/traces` produces (an array of
+ * trace arrays of span maps). Lets every existing handler keep the 0.4
+ * shape it already understands.
+ *
+ * @param {[string[], unknown[][]]} body
+ * @returns {Array<Array<Record<string, unknown>>>}
+ */
+function expandV05TracePayload (body) {
+  const strings = body[0]
+  return body[1].map(trace => trace.map(span => {
+    const meta = {}
+    if (span[9]) {
+      for (const k of Object.keys(span[9])) {
+        meta[strings[Number(k)]] = strings[span[9][k]]
+      }
+    }
+    const metrics = {}
+    if (span[10]) {
+      for (const k of Object.keys(span[10])) {
+        metrics[strings[Number(k)]] = span[10][k]
+      }
+    }
+    return {
+      service: strings[span[0]],
+      name: strings[span[1]],
+      resource: strings[span[2]],
+      trace_id: span[3],
+      span_id: span[4],
+      parent_id: span[5],
+      start: span[6],
+      duration: span[7],
+      error: span[8],
+      meta,
+      metrics,
+      type: strings[span[11]],
+    }
+  }))
+}
+
+/**
  * @param {express.Request} req
  * @param {express.Response} res
  */
@@ -360,7 +402,8 @@ module.exports = {
     })
 
     agent.put('/v0.5/traces', (req, res) => {
-      res.status(404).end()
+      req.body = expandV05TracePayload(req.body)
+      handleTraceRequest(req, res)
     })
 
     agent.put('/v0.4/traces', handleTraceRequest)


### PR DESCRIPTION
## Summary

v5 keeps the conservative `0.4` default for backports; v6 ships `0.5`
(faster msgpack v2 encoder on the agent side). Set
`DD_TRACE_AGENT_PROTOCOL_VERSION=0.4` or `protocolVersion: '0.4'` to opt
back in if the agent is pinned below the version that supports `0.5`.

The previous push surfaced ~30 failing CI jobs that all traced back to
one root cause: both test agent stubs (`packages/dd-trace/test/plugins/agent.js`
and `integration-tests/helpers/fake-agent.js`) only registered
`/v0.4/traces` (the first explicitly returned 404 for `/v0.5/traces`), so
any tracer configured with `protocolVersion: '0.5'` had its payloads
rejected by the test bench and downstream specs timed out
(`Timeout of 60000ms exceeded`, `ECONNREFUSED 127.0.0.1:36201`). The
preceding `test: support /v0.5/traces in test agent stubs` commit adds a
`/v0.5/traces` route to both stubs that decodes the shared-string-table
payload and expands each 12-element positional span back into the 0.4
shape downstream handlers expect, plus relaxes the
`typeof === 'bigint'` checks in `dd-trace.spec.js` to `BigInt(value)` so
compact-int small-`duration` values decoding as `Number` no longer fail
the assertion.

Tracer wire format and decoding contracts are unchanged on the
production path; only the test bench widens.