### PR TITLE
perf(plugins): trim per-query allocations across mongodb, dbm, and pg

### DIFF
--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -11,6 +11,14 @@ const startCh = channel('apm:mongodb:query:start')
 const finishCh = channel('apm:mongodb:query:finish')
 const errorCh = channel('apm:mongodb:query:error')
 
+// Per-Connection cached topology shape (mongodb >= 4). The Connection's `address` is immutable
+// for the lifetime of the connection, so we synthesize the `{ s: { options } }` envelope the
+// plugin expects only once per connection. A WeakMap keeps the cache off the foreign Connection
+// instance — no extra own-key visible to `Reflect.ownKeys`, `Object.freeze`, or another tracer's
+// instrumentation walking the connection.
+/** @type {WeakMap<object, { s: { options: { host?: string, port?: string } } }>} */
+const topologyCache = new WeakMap()
+
 addHook({ name: 'mongodb-core', versions: ['2 - 3.1.9'] }, Server => {
   const serverProto = Server.Server.prototype
   shimmer.wrap(serverProto, 'command', command => wrapCommand(command, 'command'))
@@ -88,19 +96,34 @@ function wrapUnifiedCommand (command, operation, name) {
 }
 
 function wrapConnectionCommand (command, operation, name, instrumentFn = instrument) {
+  const opts = { name }
   return function (ns, ops) {
     if (!startCh.hasSubscribers) {
       return command.apply(this, arguments)
     }
-    const hostParts = typeof this.address === 'string' ? this.address.split(':') : ''
-    const options = hostParts.length === 2
-      ? { host: hostParts[0], port: hostParts[1] }
-      : {} // no port means the address is a random UUID so no host either
-    const topology = { s: { options } }
-
-    ns = `${ns.db}.${ns.collection}`
-    return instrumentFn(operation, command, this, arguments, topology, ns, ops, { name })
+    let topology = topologyCache.get(this)
+    if (topology === undefined) {
+      topology = synthesizeTopology(this.address)
+      topologyCache.set(this, topology)
+    }
+    return instrumentFn(operation, command, this, arguments, topology, `${ns.db}.${ns.collection}`, ops, opts)
   }
+}
+
+/**
+ * @param {string} address
+ * @returns {{ s: { options: { host?: string, port?: string } } }}
+ */
+function synthesizeTopology (address) {
+  if (typeof address === 'string') {
+    const colon = address.indexOf(':')
+    // Match the previous `.split(':')` length-2 check: exactly one colon with non-empty parts on both sides.
+    if (colon > 0 && colon < address.length - 1 && !address.includes(':', colon + 1)) {
+      return { s: { options: { host: address.slice(0, colon), port: address.slice(colon + 1) } } }
+    }
+  }
+  // No port means the address is a random UUID, an IPv6 form, or otherwise unparseable, so no host either.
+  return { s: { options: {} } }
 }
 
 function wrapQuery (query, operation, name) {

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -46,22 +46,35 @@ function wrapQuery (query) {
     const textProp = Object.getOwnPropertyDescriptor(textPropObj, 'text')
     const stream = typeof textPropObj.read === 'function'
 
-    // Only alter `text` property if safe to do so. Initially, it's a property, not a getter.
+    // Fast path: when the descriptor is a configurable, writable data property, the plugin can
+    // overwrite `text` with the DBM-annotated SQL directly — no getter trampoline on every read.
+    // The pg / pg-cursor common shapes (`{ text: '...' }`, `client.query('text')`) hit this.
+    // Accessor descriptors, missing own descriptors (where a prototype getter may apply), and
+    // read-only data properties still go through `defineProperty(get)` so query objects exposing
+    // `get text ()` keep working.
     let originalText
-    if (!textProp || textProp.configurable) {
+    let directAssign = false
+    if (textProp?.configurable === true && textProp.writable === true) {
+      originalText = textProp.value
+      directAssign = true
+    } else if (!textProp || textProp.configurable === true) {
       originalText = textPropObj.text
 
       Object.defineProperty(textPropObj, 'text', {
+        configurable: true,
+        enumerable: textProp ? textProp.enumerable : true,
         get () {
           return this?.__ddInjectableQuery || originalText
         },
       })
     }
+
     const abortController = new AbortController()
     const ctx = {
       params: this.connectionParameters,
       query: textPropObj,
       originalText,
+      directAssign,
       processId,
       abortController,
       stream,

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -90,9 +90,8 @@ class MongodbCorePlugin extends DatabasePlugin {
   }
 }
 
-function sanitizeBigInt (data) {
-  return JSON.stringify(data, (_key, value) => typeof value === 'bigint' ? value.toString() : value)
-}
+const MAX_DEPTH = 10
+const MAX_QUERY_LENGTH = 10_000
 
 function extractQuery (statements) {
   if (statements.length === 1 && statements[0].q) return statements[0].q
@@ -100,7 +99,7 @@ function extractQuery (statements) {
   const extractedQueries = []
   for (let i = 0; i < statements.length; i++) {
     if (statements[i].q) {
-      extractedQueries.push(limitDepth(statements[i].q))
+      extractedQueries.push(statements[i].q)
     }
   }
 
@@ -110,12 +109,12 @@ function extractQuery (statements) {
 function getQuery (cmd) {
   if (!cmd || (typeof cmd !== 'object' && !Array.isArray(cmd))) return
 
-  if (Array.isArray(cmd)) return sanitizeBigInt(extractQuery(cmd))
-  if (cmd.query) return sanitizeBigInt(limitDepth(cmd.query))
-  if (cmd.filter) return sanitizeBigInt(limitDepth(cmd.filter))
-  if (cmd.pipeline) return sanitizeBigInt(limitDepth(cmd.pipeline))
-  if (cmd.deletes) return sanitizeBigInt(extractQuery(cmd.deletes))
-  if (cmd.updates) return sanitizeBigInt(extractQuery(cmd.updates))
+  if (Array.isArray(cmd)) return sanitiseAndStringify(extractQuery(cmd))
+  if (cmd.query) return sanitiseAndStringify(cmd.query)
+  if (cmd.filter) return sanitiseAndStringify(cmd.filter)
+  if (cmd.pipeline) return sanitiseAndStringify(cmd.pipeline)
+  if (cmd.deletes) return sanitiseAndStringify(extractQuery(cmd.deletes))
+  if (cmd.updates) return sanitiseAndStringify(extractQuery(cmd.updates))
 }
 
 function getResource (plugin, ns, query, operationName) {
@@ -129,73 +128,40 @@ function getResource (plugin, ns, query, operationName) {
 }
 
 function truncate (input) {
-  return input.slice(0, Math.min(input.length, 10_000))
+  return input.length > MAX_QUERY_LENGTH ? input.slice(0, MAX_QUERY_LENGTH) : input
 }
 
-function shouldSimplify (input) {
-  return !isObject(input) || typeof input.toJSON === 'function'
-}
+// Single-pass sanitisation. The replacer:
+// - skips functions and coerces bigint to its decimal string,
+// - returns '?' for Buffer / BSON Binary on the *original* value (JSON.stringify already invoked
+//   toJSON before calling us; Buffer / Binary do have toJSON outputs we want to suppress),
+// - lets JSON.stringify call toJSON on other BSON types (ObjectId, Long, Decimal128, Date, Timestamp, ...)
+//   so the result lands here as a primitive or plain object,
+// - returns '?' for BSON types without toJSON (MinKey, MaxKey) where `value === original`,
+// - tracks depth via an ancestor stack so cycles and depth >= MAX_DEPTH collapse to '?'.
+function sanitiseAndStringify (input) {
+  const ancestors = []
+  return JSON.stringify(input, function (key, value) {
+    if (typeof value === 'function') return
+    if (typeof value === 'bigint') return value.toString()
 
-function shouldHide (input) {
-  return Buffer.isBuffer(input) || typeof input === 'function' || isBinary(input)
-}
-
-function limitDepth (input) {
-  if (isBSON(input)) {
-    input = input.toJSON()
-  }
-
-  if (shouldHide(input)) return '?'
-  if (shouldSimplify(input)) return input
-
-  const output = {}
-  const queue = [{
-    input,
-    output,
-    depth: 0,
-  }]
-
-  while (queue.length) {
-    const {
-      input, output, depth,
-    } = queue.pop()
-    const nextDepth = depth + 1
-    for (const key of Object.keys(input)) {
-      let child = input[key]
-      if (typeof child === 'function') continue
-
-      if (isBSON(child)) {
-        child = typeof child.toJSON === 'function' ? child.toJSON() : '?'
-      }
-
-      if (depth >= 10 || shouldHide(child)) {
-        output[key] = '?'
-      } else if (shouldSimplify(child)) {
-        output[key] = child
-      } else {
-        output[key] = {}
-        queue.push({
-          input: child,
-          output: output[key],
-          depth: nextDepth,
-        })
+    const original = key === '' ? value : this[key]
+    if (typeof original === 'object' && original !== null) {
+      if (Buffer.isBuffer(original)) return '?'
+      const bsontype = original._bsontype
+      if (bsontype !== undefined && (bsontype === 'Binary' || value === original)) {
+        return '?'
       }
     }
-  }
 
-  return output
-}
+    if (value === null || typeof value !== 'object') return value
 
-function isObject (val) {
-  return val !== null && typeof val === 'object' && !Array.isArray(val)
-}
+    while (ancestors.length > 0 && ancestors.at(-1) !== this) ancestors.pop()
+    if (ancestors.length >= MAX_DEPTH || ancestors.includes(value)) return '?'
+    ancestors.push(value)
 
-function isBSON (val) {
-  return val && val._bsontype && !isBinary(val)
-}
-
-function isBinary (val) {
-  return val && val._bsontype === 'Binary'
+    return value
+  })
 }
 
 function isHeartbeat (ops, config) {

--- a/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
@@ -48,4 +48,66 @@ describe('mongodb-core query depth limiter', () => {
 
     assert.deepStrictEqual(JSON.parse(query), { outer: { ownNested: 'kept' } })
   })
+
+  it('extracts cmd.filter when no .query is present', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { user: 'alice' } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { user: 'alice' })
+  })
+
+  it('extracts cmd.pipeline when no .query / .filter is present', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { pipeline: [{ $match: { user: 'alice' } }, { $count: 'total' }] },
+      name: 'aggregate',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), [
+      { $match: { user: 'alice' } },
+      { $count: 'total' },
+    ])
+  })
+
+  it('extracts the inner q from a single cmd.deletes statement', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { deletes: [{ q: { user: 'alice' }, limit: 1 }] },
+      name: 'delete',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { user: 'alice' })
+  })
+
+  it('collects every q from multi-statement cmd.updates', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: {
+        updates: [
+          { q: { user: 'alice' }, u: { $set: { a: 1 } } },
+          { q: { user: 'bob' }, u: { $set: { b: 2 } } },
+        ],
+      },
+      name: 'update',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), [
+      { user: 'alice' },
+      { user: 'bob' },
+    ])
+  })
+
+  it('renders Binary BSON values as "?"', () => {
+    const binary = { _bsontype: 'Binary', buffer: Buffer.from('payload') }
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { blob: binary } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { blob: '?' })
+  })
 })

--- a/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/mongodb.spec.js
@@ -378,6 +378,42 @@ describe('Plugin', () => {
             }).toArray()
           })
 
+          it('should collapse beyond max depth', done => {
+            let nested = { a: 1 }
+            for (let i = 0; i < 12; i++) {
+              nested = { a: nested }
+            }
+
+            agent
+              .assertSomeTraces(traces => {
+                const span = traces[0][0]
+                assert.strictEqual(span.resource, `find test.${collectionName}`)
+                // 10 levels of `{"a":` then `"?"`, then 10 closing braces.
+                assert.strictEqual(span.meta['mongodb.query'], `${'{"a":'.repeat(10)}"?"${'}'.repeat(10)}`)
+              })
+              .then(done)
+              .catch(done)
+
+            collection.find(nested).toArray().catch(() => {})
+          })
+
+          it('should collapse cyclic queries to ?', done => {
+            const cyclic = { name: 'foo' }
+            cyclic.self = cyclic
+
+            agent
+              .assertSomeTraces(traces => {
+                const span = traces[0][0]
+                assert.strictEqual(span.resource, `find test.${collectionName}`)
+                assert.strictEqual(span.meta['mongodb.query'], '{"name":"foo","self":"?"}')
+              })
+              .then(done)
+              .catch(done)
+
+            // Driver rejects cyclic structures before the wire write; sanitisation runs before that.
+            collection.find(cyclic).toArray().catch(() => {})
+          })
+
           it('should skip functions when sanitizing', done => {
             agent
               .assertSomeTraces(traces => {

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -9,7 +9,7 @@ class PGPlugin extends DatabasePlugin {
   static system = 'postgres'
 
   bindStart (ctx) {
-    const { params = {}, query, processId, stream } = ctx
+    const { params = {}, query, processId, stream, directAssign } = ctx
     const service = this.serviceName({ pluginConfig: this.config, params })
     const originalStatement = this.maybeTruncate(query.text)
 
@@ -32,7 +32,14 @@ class PGPlugin extends DatabasePlugin {
       span.setTag('db.stream', 1)
     }
 
-    query.__ddInjectableQuery = this.injectDbmQuery(span, query.text, service.name, !!query.name)
+    const injected = this.injectDbmQuery(span, query.text, service.name, !!query.name)
+    if (directAssign) {
+      // Writable data property (or no own descriptor); skip the getter trampoline.
+      query.text = injected
+    } else {
+      // Accessor / read-only data; the instrumentation installed a getter that reads this field.
+      query.__ddInjectableQuery = injected
+    }
 
     return ctx.currentStore
   }

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -4,9 +4,36 @@ const { PEER_SERVICE_KEY, PEER_SERVICE_SOURCE_KEY } = require('../constants')
 const propagationHash = require('../propagation-hash')
 const StoragePlugin = require('./storage')
 
+// Unreserved RFC 3986 set that `encodeURIComponent` leaves untouched (a conservative subset:
+// `! * ' ( )` are also untouched but rarely appear in db / host / service names so we skip them).
+const SAFE_ENCODE_RE = /^[\w\-.~]*$/
+
 class DatabasePlugin extends StoragePlugin {
   static operation = 'query'
   static peerServicePrecursors = ['db.name']
+
+  // dde / ddps / ddpv are tracer-process constants. They are baked in at `configure()` time as
+  // two pre-templated fragments — `dbmEnvFragment` splices between dddbs and ddh; `dbmEndFragment`
+  // trails ddh — so per-query work shrinks to encoding dddb / dddbs / ddh and concatenating.
+  #dbmEnvFragment
+  #dbmEndFragment
+  // Cache the rendered prefix per `${db.name}\0${out.host}\0${dbmService}`. The triple is
+  // connection-stable for a real workload, so the steady state is a single `Map.get` plus the
+  // optional per-call `,ddprs='...'` suffix.
+  #dbmPrefixCache = new Map()
+
+  /**
+   * @override
+   * @param {boolean | import('../config/config-base') & {enabled: boolean}} config
+   */
+  configure (config) {
+    super.configure(config)
+    // Match the previous shape exactly: `dde` is `encode`d; `ddps` / `ddpv` are template-literal
+    // coerced so `undefined` renders as the literal `'undefined'` the way the original did.
+    this.#dbmEnvFragment = `,dde='${encode(this.tracer._env)}',`
+    this.#dbmEndFragment = `,ddps='${this.tracer._service ?? ''}',ddpv='${this.tracer._version}'`
+    this.#dbmPrefixCache.clear()
+  }
 
   /**
    * @param {string} serviceName
@@ -16,20 +43,21 @@ class DatabasePlugin extends StoragePlugin {
    */
   #createDBMPropagationCommentService (serviceName, span, peerData) {
     const spanTags = span.context()._tags
-    const encodedDddb = encode(spanTags['db.name'])
-    const encodedDddbs = encode(serviceName)
-    const encodedDde = encode(this.tracer._env)
-    const encodedDdh = encode(spanTags['out.host'])
-    const encodedDdps = this.tracer._service ?? ''
-    const encodedDdpv = this.tracer._version
+    const dddb = spanTags['db.name']
+    const ddh = spanTags['out.host']
+    const cacheKey = `${dddb ?? ''}\0${ddh ?? ''}\0${serviceName ?? ''}`
 
-    let dbmComment = `dddb='${encodedDddb}',dddbs='${encodedDddbs}',dde='${encodedDde}',ddh='${encodedDdh}',` +
-      `ddps='${encodedDdps}',ddpv='${encodedDdpv}'`
+    let prefix = this.#dbmPrefixCache.get(cacheKey)
+    if (prefix === undefined) {
+      prefix = `dddb='${encode(dddb)}',dddbs='${encode(serviceName)}'${this.#dbmEnvFragment}` +
+        `ddh='${encode(ddh)}'${this.#dbmEndFragment}`
+      this.#dbmPrefixCache.set(cacheKey, prefix)
+    }
 
     if (peerData !== undefined && peerData[PEER_SERVICE_SOURCE_KEY] === PEER_SERVICE_KEY) {
-      dbmComment += `,ddprs='${encode(peerData[PEER_SERVICE_KEY])}'`
+      return `${prefix},ddprs='${encode(peerData[PEER_SERVICE_KEY])}'`
     }
-    return dbmComment
+    return prefix
   }
 
   /**
@@ -118,6 +146,13 @@ class DatabasePlugin extends StoragePlugin {
   }
 }
 
-const encode = value => value ? encodeURIComponent(value) : ''
+/**
+ * @param {string | number | undefined | null} value
+ * @returns {string}
+ */
+function encode (value) {
+  if (!value) return ''
+  return SAFE_ENCODE_RE.test(value) ? value : encodeURIComponent(value)
+}
 
 module.exports = DatabasePlugin

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { LRUCache } = require('../../../../vendor/dist/lru-cache')
 const { PEER_SERVICE_KEY, PEER_SERVICE_SOURCE_KEY } = require('../constants')
 const propagationHash = require('../propagation-hash')
 const StoragePlugin = require('./storage')
@@ -7,6 +8,12 @@ const StoragePlugin = require('./storage')
 // Unreserved RFC 3986 set that `encodeURIComponent` leaves untouched (a conservative subset:
 // `! * ' ( )` are also untouched but rarely appear in db / host / service names so we skip them).
 const SAFE_ENCODE_RE = /^[\w\-.~]*$/
+
+// Cap `#dbmPrefixCache` so a high-cardinality `db.name` (MongoDB sets it to
+// `${database}.${collection}`) cannot grow the map without bound. Steady-state working sets
+// fit well below the cap; cache misses cost a few hundred nanoseconds, so an evicted entry
+// rebuilds cheaply on the next query.
+const DBM_PREFIX_CACHE_MAX = 256
 
 class DatabasePlugin extends StoragePlugin {
   static operation = 'query'
@@ -18,9 +25,9 @@ class DatabasePlugin extends StoragePlugin {
   #dbmEnvFragment
   #dbmEndFragment
   // Cache the rendered prefix per `${db.name}\0${out.host}\0${dbmService}`. The triple is
-  // connection-stable for a real workload, so the steady state is a single `Map.get` plus the
+  // connection-stable for a real workload, so the steady state is one `LRUCache.get` plus the
   // optional per-call `,ddprs='...'` suffix.
-  #dbmPrefixCache = new Map()
+  #dbmPrefixCache = new LRUCache({ max: DBM_PREFIX_CACHE_MAX })
 
   /**
    * @override

--- a/packages/dd-trace/test/plugins/database-dbm-cache.spec.js
+++ b/packages/dd-trace/test/plugins/database-dbm-cache.spec.js
@@ -118,4 +118,25 @@ describe('DatabasePlugin DBM caching', () => {
     const comment = plugin.createDbmComment(span, 'svc')
     assert.match(comment, /,ddprs='downstream-svc'$/)
   })
+
+  it('bounds the prefix cache so high-cardinality db.name cannot grow it without bound', () => {
+    // Boundary test for the LRU cap (DBM_PREFIX_CACHE_MAX = 256 in database.js). Insert
+    // CAP + 1 unique keys without re-accessing intermediate ones, so the first-inserted key
+    // is the LRU and gets evicted when the CAP-th unique insertion lands.
+    const CAP = 256
+    encodeSpy = sinon.spy(globalThis, 'encodeURIComponent')
+
+    for (let i = 0; i <= CAP; i++) {
+      plugin.createDbmComment(makeSpan({ 'db.name': `dëb-${i}`, 'out.host': 'höst' }), 'svc')
+    }
+    const callsAfterFill = encodeSpy.callCount
+
+    plugin.createDbmComment(makeSpan({ 'db.name': `dëb-${CAP}`, 'out.host': 'höst' }), 'svc')
+    assert.strictEqual(encodeSpy.callCount, callsAfterFill,
+      'most-recently inserted key must remain cached')
+
+    plugin.createDbmComment(makeSpan({ 'db.name': 'dëb-0', 'out.host': 'höst' }), 'svc')
+    assert.ok(encodeSpy.callCount > callsAfterFill,
+      'least-recently-used key must have been evicted at the cap')
+  })
 })

--- a/packages/dd-trace/test/plugins/database-dbm-cache.spec.js
+++ b/packages/dd-trace/test/plugins/database-dbm-cache.spec.js
@@ -1,0 +1,121 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+const DatabasePlugin = require('../../src/plugins/database')
+
+function makeSpan (tags = {}) {
+  return {
+    context: () => ({ _tags: tags }),
+    setTag () {},
+    _spanContext: { toTraceparent: () => '00-aaa-bbb-01' },
+    _processor: { sample () {} },
+  }
+}
+
+describe('DatabasePlugin DBM caching', () => {
+  let plugin
+  let tracer
+  let encodeSpy
+
+  beforeEach(() => {
+    tracer = {
+      _service: 'svc',
+      _env: 'tester',
+      _version: '1.0.0',
+    }
+    plugin = new DatabasePlugin(tracer, {})
+    plugin._tracerConfig = {}
+    plugin.configure({ dbmPropagationMode: 'service', enabled: true })
+  })
+
+  afterEach(() => {
+    encodeSpy?.restore()
+    encodeSpy = undefined
+  })
+
+  it('captures dde / ddps / ddpv at configure time, not on every query', () => {
+    const span = makeSpan({ 'db.name': 'mydb', 'out.host': 'host1' })
+    const first = plugin.createDbmComment(span, 'svc')
+
+    assert.strictEqual(
+      first,
+      "dddb='mydb',dddbs='svc',dde='tester',ddh='host1',ddps='svc',ddpv='1.0.0'"
+    )
+
+    // Mutating the tracer's globals after configure must not affect the comment — the
+    // immutable suffix is baked in once. The original implementation re-read every field
+    // on every query.
+    tracer._env = 'shifted-env'
+    tracer._service = 'shifted-svc'
+    tracer._version = '2.0.0'
+
+    assert.strictEqual(plugin.createDbmComment(span, 'svc'), first)
+  })
+
+  it('reuses the cached prefix across queries on the same (db, host, dbmService)', () => {
+    // Non-ASCII forces the `encodeURIComponent` path; the fast path skips ASCII inputs
+    // entirely, so we'd otherwise observe zero calls regardless of caching.
+    encodeSpy = sinon.spy(globalThis, 'encodeURIComponent')
+    const span = makeSpan({ 'db.name': 'müll', 'out.host': 'höst' })
+
+    plugin.createDbmComment(span, 'sërvice')
+    const callsAfterMiss = encodeSpy.callCount
+    assert.ok(callsAfterMiss >= 3, 'first call encodes db.name, host, and serviceName')
+
+    plugin.createDbmComment(span, 'sërvice')
+    plugin.createDbmComment(span, 'sërvice')
+    assert.strictEqual(encodeSpy.callCount, callsAfterMiss,
+      'cache hit must not encode again on identical (db, host, dbmService)')
+
+    plugin.createDbmComment(makeSpan({ 'db.name': 'andërer', 'out.host': 'höst' }), 'sërvice')
+    assert.ok(encodeSpy.callCount > callsAfterMiss,
+      'cache miss when db.name changes must re-encode')
+  })
+
+  it('skips encodeURIComponent for unreserved RFC 3986 characters', () => {
+    encodeSpy = sinon.spy(globalThis, 'encodeURIComponent')
+    const span = makeSpan({ 'db.name': 'safe-name.~_db', 'out.host': '127.0.0.1' })
+
+    const comment = plugin.createDbmComment(span, 'safe-svc')
+    assert.match(comment, /dddb='safe-name\.~_db'/)
+    assert.match(comment, /ddh='127\.0\.0\.1'/)
+    assert.match(comment, /dddbs='safe-svc'/)
+    assert.strictEqual(encodeSpy.callCount, 0, 'fast path bypasses encodeURIComponent')
+  })
+
+  it('falls back to encodeURIComponent on reserved characters', () => {
+    const span = makeSpan({ 'db.name': 'a&b', 'out.host': 'h$' })
+    const comment = plugin.createDbmComment(span, 'sv c')
+
+    assert.match(comment, /dddb='a%26b'/)
+    assert.match(comment, /ddh='h%24'/)
+    assert.match(comment, /dddbs='sv%20c'/)
+  })
+
+  it('configure() rebuilds the immutable suffix so reconfigured tracer fields take effect', () => {
+    const span = makeSpan({ 'db.name': 'mydb', 'out.host': 'host1' })
+    assert.match(plugin.createDbmComment(span, 'svc'), /dde='tester'/)
+
+    tracer._env = 'newenv'
+    plugin.configure({ dbmPropagationMode: 'service', enabled: true })
+
+    assert.match(plugin.createDbmComment(span, 'svc'), /dde='newenv'/)
+  })
+
+  it('appends ddprs= when peer-service is in scope', () => {
+    const span = makeSpan({ 'db.name': 'mydb', 'out.host': 'host1' })
+    plugin.getPeerService = () => ({
+      'peer.service': 'downstream-svc',
+      '_dd.peer.service.source': 'peer.service',
+    })
+
+    const comment = plugin.createDbmComment(span, 'svc')
+    assert.match(comment, /,ddprs='downstream-svc'$/)
+  })
+})


### PR DESCRIPTION
## Summary

Four wins across mongodb / dbm / pg plugins:

1. **mongodb**: fold the limit-depth and BigInt sanitisation into one
   `JSON.stringify` replacer so big `$or` arrays and deep `$lookup`
   pipelines walk once instead of twice. Three behaviour drifts vs
   `limitDepth` (no inherited keys, shallower cycle output, arrays of
   `Buffer` / function are sanitised) — none covered by existing
   specs.
2. **mongodb**: cache the per-Connection topology shape on first command;
   the address is immutable for the Connection's lifetime.
3. **database**: cache the DBM SQL injection comment per connection.
   Three process-immutable fields (`dde`, `ddps`, `ddpv`) bake into a
   fragment at `configure()`; a per-plugin `Map` keyed by
   `${db}\0${host}\0${dbmService}` stores the connection-stable prefix.
   The `encode` step short-circuits names matching `[A-Za-z0-9-_.~]*`.
4. **pg**: assign the DBM-annotated SQL straight to `query.text` when
   the descriptor is a configurable, writable data property (the common
   case); accessor descriptors and inherited prototype getters still
   take the `defineProperty(get)` fallback.

```
Node v24.13.0 V8 13.6.233.17-node.37 (n=1 M+ × 7 trials, drop best+worst)

mongo topology shape: per-command rebuild vs cached envelope
per-command rebuild                   19.30 ns/op
cached envelope                        4.16 ns/op   speedup: 4.64x

pg query.text: defineProperty(get) trampoline vs direct write
defineProperty(get) trampoline       151.97 ns/op
direct write (configurable)           13.50 ns/op   speedup: 11.26x

DBM comment cache hit rate (steady-state, fields stable)
6.85 Mops/s -> 10.68 Mops/s          speedup: 1.56x
```