### PR TITLE
perf(appsec): trim per-request allocations in waf and reporter

### DIFF
--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -5,6 +5,7 @@ const web = require('../plugins/util/web')
 const { extractIp } = require('../plugins/util/ip_extractor')
 const { HTTP_CLIENT_IP } = require('../../../../ext/tags')
 const { IS_SERVERLESS } = require('../serverless')
+const { isEmpty } = require('../util')
 const RuleManager = require('./rule_manager')
 const appsecRemoteConfig = require('./remote_config')
 const {
@@ -128,7 +129,7 @@ function onRequestBodyParsed ({ req, res, body, abortController }) {
   }
 
   if (typeof body === 'object') {
-    if (isEmptyObject(body)) return
+    if (isEmpty(body)) return
     analyzedBodies.add(body)
   }
 
@@ -149,7 +150,7 @@ function onRequestCookieParser ({ req, res, abortController, cookies }) {
   const rootSpan = web.root(req)
   if (!rootSpan) return
 
-  if (isEmptyObject(cookies)) return
+  if (isEmpty(cookies)) return
   analyzedCookies.add(cookies)
 
   const results = waf.run({
@@ -180,12 +181,9 @@ function incomingHttpStartTranslator ({ req, res, abortController }) {
     }
   }
 
-  const requestHeaders = { ...req.headers }
-  delete requestHeaders.cookie
-
   const persistent = {
     [addresses.HTTP_INCOMING_URL]: req.url,
-    [addresses.HTTP_INCOMING_HEADERS]: requestHeaders,
+    [addresses.HTTP_INCOMING_HEADERS]: copyHeadersOmitting(req.headers, 'cookie'),
     [addresses.HTTP_INCOMING_METHOD]: req.method,
   }
 
@@ -204,7 +202,7 @@ function incomingHttpEndTranslator ({ req, res }) {
   // we need to keep this to support other body parsers
   if (req.body !== undefined && req.body !== null) {
     if (typeof req.body === 'object') {
-      if (!isEmptyObject(req.body) && !analyzedBodies.has(req.body)) {
+      if (!isEmpty(req.body) && !analyzedBodies.has(req.body)) {
         persistent[addresses.HTTP_INCOMING_BODY] = req.body
       }
     } else {
@@ -216,7 +214,7 @@ function incomingHttpEndTranslator ({ req, res }) {
   if (
     req.cookies !== null &&
     typeof req.cookies === 'object' &&
-    !isEmptyObject(req.cookies) &&
+    !isEmpty(req.cookies) &&
     !analyzedCookies.has(req.cookies)
   ) {
     persistent[addresses.HTTP_INCOMING_COOKIES] = req.cookies
@@ -227,7 +225,7 @@ function incomingHttpEndTranslator ({ req, res }) {
   if (
     query !== null &&
     typeof query === 'object' &&
-    !isEmptyObject(query)
+    !isEmpty(query)
   ) {
     persistent[addresses.HTTP_INCOMING_QUERY] = query
   }
@@ -239,7 +237,7 @@ function incomingHttpEndTranslator ({ req, res }) {
     persistent[addresses.WAF_CONTEXT_PROCESSOR] = { 'extract-schema': true }
   }
 
-  if (!isEmptyObject(persistent)) {
+  if (!isEmpty(persistent)) {
     waf.run({ persistent }, req)
   }
 
@@ -313,7 +311,7 @@ function onRequestQueryParsed ({ req, res, query, abortController }) {
   const rootSpan = web.root(req)
   if (!rootSpan) return
 
-  if (isEmptyObject(query)) return
+  if (isEmpty(query)) return
 
   const results = waf.run({
     persistent: {
@@ -328,7 +326,7 @@ function onRequestProcessParams ({ req, res, abortController, params }) {
   const rootSpan = web.root(req)
   if (!rootSpan) return
 
-  if (!params || typeof params !== 'object' || isEmptyObject(params)) return
+  if (!params || typeof params !== 'object' || isEmpty(params)) return
 
   const results = waf.run({
     persistent: {
@@ -352,7 +350,7 @@ function onResponseBody ({ req, res, body }) {
 }
 
 function onResponseWriteHead ({ req, res, abortController, statusCode, responseHeaders }) {
-  if (!isEmptyObject(responseHeaders)) {
+  if (!isEmpty(responseHeaders)) {
     storedResponseHeaders.set(req, responseHeaders)
   }
 
@@ -375,13 +373,10 @@ function onResponseWriteHead ({ req, res, abortController, statusCode, responseH
   const rootSpan = web.root(req)
   if (!rootSpan) return
 
-  responseHeaders = { ...responseHeaders }
-  delete responseHeaders['set-cookie']
-
   const results = waf.run({
     persistent: {
       [addresses.HTTP_INCOMING_RESPONSE_CODE]: String(statusCode),
-      [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: responseHeaders,
+      [addresses.HTTP_INCOMING_RESPONSE_HEADERS]: copyHeadersOmitting(responseHeaders, 'set-cookie'),
     },
   }, req)
 
@@ -540,14 +535,16 @@ function disable () {
   if (stripeConstructEvent.hasSubscribers) stripeConstructEvent.unsubscribe(onStripeConstructEvent)
 }
 
-// this is faster than Object.keys().length === 0
-function isEmptyObject (obj) {
-  // eslint-disable-next-line no-unreachable-loop
-  for (const _ in obj) {
-    return false
+/**
+ * @param {Record<string, unknown>} src
+ * @param {string} omit
+ */
+function copyHeadersOmitting (src, omit) {
+  const filtered = {}
+  for (const key of Object.keys(src)) {
+    if (key !== omit) filtered[key] = src[key]
   }
-
-  return true
+  return filtered
 }
 
 module.exports = {

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -509,7 +509,9 @@ function finishRequest (req, res, storedResponseHeaders, requestBody) {
   if (!rootSpan) return
 
   if (metricsQueue.size) {
-    rootSpan.addTags(Object.fromEntries(metricsQueue))
+    for (const [key, value] of metricsQueue) {
+      rootSpan.setTag(key, value)
+    }
 
     keepTrace(rootSpan, ASM)
 

--- a/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
+++ b/packages/dd-trace/src/appsec/waf/waf_context_wrapper.js
@@ -20,6 +20,20 @@ class WAFContextWrapper {
     this.knownAddresses = knownAddresses
     this.addressesToSkip = new Set()
     this.cachedUserIdResults = new Map()
+    // Reused across run() calls; Reporter.reportMetrics consumes it synchronously.
+    this.metrics = {
+      rulesVersion,
+      wafVersion,
+      wafTimeout: false,
+      duration: 0,
+      durationExt: 0,
+      blockTriggered: false,
+      ruleTriggered: false,
+      errorCode: null,
+      maxTruncatedString: null,
+      maxTruncatedContainerSize: null,
+      maxTruncatedContainerDepth: null,
+    }
   }
 
   run ({ persistent, ephemeral }, raspRule, req) {
@@ -44,7 +58,8 @@ class WAFContextWrapper {
 
     const payload = {}
     let payloadHasData = false
-    const newAddressesToSkip = new Set(this.addressesToSkip)
+    // Cloned lazily; only the preventDuplicateAddresses branch below adds to it.
+    let newAddressesToSkip
 
     if (persistent !== null && typeof persistent === 'object') {
       const persistentInputs = {}
@@ -55,6 +70,7 @@ class WAFContextWrapper {
           hasPersistentInputs = true
           persistentInputs[key] = persistent[key]
           if (preventDuplicateAddresses.has(key)) {
+            newAddressesToSkip ??= new Set(this.addressesToSkip)
             newAddressesToSkip.add(key)
           }
         }
@@ -85,19 +101,16 @@ class WAFContextWrapper {
 
     if (!payloadHasData) return
 
-    const metrics = {
-      rulesVersion: this.rulesVersion,
-      wafVersion: this.wafVersion,
-      wafTimeout: false,
-      duration: 0,
-      durationExt: 0,
-      blockTriggered: false,
-      ruleTriggered: false,
-      errorCode: null,
-      maxTruncatedString: null,
-      maxTruncatedContainerSize: null,
-      maxTruncatedContainerDepth: null,
-    }
+    const metrics = this.metrics
+    metrics.wafTimeout = false
+    metrics.duration = 0
+    metrics.durationExt = 0
+    metrics.blockTriggered = false
+    metrics.ruleTriggered = false
+    metrics.errorCode = null
+    metrics.maxTruncatedString = null
+    metrics.maxTruncatedContainerSize = null
+    metrics.maxTruncatedContainerDepth = null
 
     try {
       const start = process.hrtime.bigint()
@@ -123,7 +136,9 @@ class WAFContextWrapper {
         if (maxTruncatedContainerDepth) metrics.maxTruncatedContainerDepth = maxTruncatedContainerDepth
       }
 
-      this.addressesToSkip = newAddressesToSkip
+      if (newAddressesToSkip !== undefined) {
+        this.addressesToSkip = newAddressesToSkip
+      }
 
       const ruleTriggered = !!result.events?.length
 

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -881,7 +881,8 @@ describe('reporter', () => {
       Reporter.finishRequest(req, wafContext, {})
 
       sinon.assert.calledOnceWithExactly(web.root, req)
-      sinon.assert.calledWithExactly(span.addTags, { a: 1, b: 2 })
+      sinon.assert.calledWith(span.setTag.firstCall, 'a', 1)
+      sinon.assert.calledWith(span.setTag.secondCall, 'b', 2)
       assert.strictEqual(Reporter.metricsQueue.size, 0)
     })
 


### PR DESCRIPTION
## Summary

Three wins on the AppSec hot path:

1. **waf**: defer the `new Set(this.addressesToSkip)` clone into the
   single branch that adds to it (`preventDuplicateAddresses`);
   preallocate the 10-key `metrics` literal on the wrapper and reset
   its mutable fields per run.
2. **reporter**: replace the local `isEmptyObject` with the shared
   `isEmpty` helper; replace the `{ ...req.headers }; delete .cookie`
   pattern (two key walks + hidden-class transition) with a
   single-pass `copyHeadersOmitting`.
3. **reporter**: iterate `metricsQueue` directly with `setTag` per
   entry, dropping the throwaway `Object.fromEntries(...)` per
   `finishRequest`.

```
Node v24.13.0 V8 13.6.233.17-node.37 (n=1 M+ × 7 trials, drop best+worst)

WAF run() allocations per call
Set clone + 10-key metrics alloc      17.44 ns/op
lazy clone + reused metrics            4.47 ns/op   speedup: 3.90x

AppSec one-walk header copy (8-key realistic header bag)
{ ...headers }; delete .cookie       193.32 ns/op
single-pass copyHeadersOmitting       88.59 ns/op   speedup: 2.18x

AppSec metricsQueue per finishRequest
Object.fromEntries(map) + addTags    213.08 ns/op
setTag per Map entry                  37.87 ns/op   speedup: 5.63x
```

The originally-stacked IAST CSI specialisation commit (\`makeCsi0/2/Var\`) was dropped after benchmarking on Node 24.13 / V8 13.6: with a real native fn that V8 cannot inline through, the explicit-arity split shows no measurable improvement over the original variadic shape — every comparison was within noise except slice 2-arg active where the variadic is actually 2.4× faster (the inner / outer try/catch split adds a function call boundary that costs more than V8 saves by inlining the inner). The IAST work would need a re-think before it earns its place.