### PR TITLE
perf(plugins): trim per-message work across elasticsearch, grpc, couchbase, and pub/sub

### DIFF
--- a/packages/datadog-instrumentations/src/couchbase.js
+++ b/packages/datadog-instrumentations/src/couchbase.js
@@ -7,6 +7,39 @@ const {
   addHook,
 } = require('./helpers/instrument')
 
+/**
+ * @typedef {object} ChannelBag
+ * @property {ReturnType<typeof channel>} start
+ * @property {ReturnType<typeof channel>} finish
+ * @property {ReturnType<typeof channel>} error
+ * @property {ReturnType<typeof channel>} callbackStart
+ * @property {ReturnType<typeof channel>} callbackFinish
+ */
+
+// Cache the per-op channel set keyed by `apm:couchbase:<name>` so each traced
+// call skips the template-literal allocation and the `channel(...)` lookup.
+/** @type {Map<string, ChannelBag>} */
+const channelBags = new Map()
+
+/**
+ * @param {string} prefix Full channel prefix, e.g. `apm:couchbase:query`.
+ * @returns {ChannelBag}
+ */
+function getChannelBag (prefix) {
+  let bag = channelBags.get(prefix)
+  if (bag === undefined) {
+    bag = {
+      start: channel(`${prefix}:start`),
+      finish: channel(`${prefix}:finish`),
+      error: channel(`${prefix}:error`),
+      callbackStart: channel(`${prefix}:callback:start`),
+      callbackFinish: channel(`${prefix}:callback:finish`),
+    }
+    channelBags.set(prefix, bag)
+  }
+  return bag
+}
+
 function findCallbackIndex (args, lowerbound = 2) {
   for (let i = args.length - 1; i >= lowerbound; i--) {
     if (typeof args[i] === 'function') return i
@@ -26,12 +59,11 @@ function wrapAllNames (names, action) {
 }
 
 function wrapCallback (callback, ctx, channelPrefix) {
-  const callbackStartCh = channel(`${channelPrefix}:callback:start`)
-  const callbackFinishCh = channel(`${channelPrefix}:callback:finish`)
+  const channels = getChannelBag(channelPrefix)
 
-  const wrapped = callbackStartCh.runStores(ctx, () => {
+  const wrapped = channels.callbackStart.runStores(ctx, () => {
     return function (...args) {
-      return callbackFinishCh.runStores(ctx, () => {
+      return channels.callbackFinish.runStores(ctx, () => {
         return callback.apply(this, args)
       })
     }
@@ -52,18 +84,15 @@ function wrapQuery (query) {
   }
 }
 
-function wrapCallbackFinish (callback, thisArg, _args, errorCh, finishCh, ctx, channelPrefix) {
-  const callbackStartCh = channel(`${channelPrefix}:callback:start`)
-  const callbackFinishCh = channel(`${channelPrefix}:callback:finish`)
-
-  const wrapped = callbackStartCh.runStores(ctx, () => {
+function wrapCallbackFinish (callback, thisArg, _args, channels, ctx) {
+  const wrapped = channels.callbackStart.runStores(ctx, () => {
     return function finish (error, result) {
-      return callbackFinishCh.runStores(ctx, () => {
+      return channels.callbackFinish.runStores(ctx, () => {
         if (error) {
           ctx.error = error
-          errorCh.publish(ctx)
+          channels.error.publish(ctx)
         }
-        finishCh.publish(ctx)
+        channels.finish.publish(ctx)
         return callback.apply(thisArg, [error, result])
       })
     }
@@ -73,12 +102,10 @@ function wrapCallbackFinish (callback, thisArg, _args, errorCh, finishCh, ctx, c
 }
 
 function wrap (prefix, fn) {
-  const startCh = channel(prefix + ':start')
-  const finishCh = channel(prefix + ':finish')
-  const errorCh = channel(prefix + ':error')
+  const channels = getChannelBag(prefix)
 
   return function (...args) {
-    if (!startCh.hasSubscribers) {
+    if (!channels.start.hasSubscribers) {
       return fn.apply(this, args)
     }
 
@@ -87,11 +114,11 @@ function wrap (prefix, fn) {
     if (callbackIndex < 0) return fn.apply(this, args)
 
     const ctx = { bucket: { name: this.name || this._name }, seedNodes: this._dd_hosts }
-    return startCh.runStores(ctx, () => {
+    return channels.start.runStores(ctx, () => {
       const cb = args[callbackIndex]
 
       args[callbackIndex] = shimmer.wrapFunction(cb, (cb) => {
-        return wrapCallbackFinish(cb, this, args, errorCh, finishCh, ctx, prefix)
+        return wrapCallbackFinish(cb, this, args, channels, ctx)
       })
 
       try {
@@ -99,7 +126,7 @@ function wrap (prefix, fn) {
       } catch (error) {
         ctx.error = error
         void error.stack // trigger getting the stack at the original throwing point
-        errorCh.publish(ctx)
+        channels.error.publish(ctx)
 
         throw error
       }
@@ -130,21 +157,19 @@ function wrapMaybeInvoke (_maybeInvoke, channelPrefix) {
 // semver >=3
 
 function wrapCBandPromise (fn, name, startData, thisArg, args) {
-  const startCh = channel(`apm:couchbase:${name}:start`)
-  const finishCh = channel(`apm:couchbase:${name}:finish`)
-  const errorCh = channel(`apm:couchbase:${name}:error`)
+  const channels = getChannelBag(`apm:couchbase:${name}`)
 
-  if (!startCh.hasSubscribers) return fn.apply(thisArg, args)
+  if (!channels.start.hasSubscribers) return fn.apply(thisArg, args)
 
   const ctx = startData
-  return startCh.runStores(ctx, () => {
+  return channels.start.runStores(ctx, () => {
     try {
       const cbIndex = findCallbackIndex(args, 1)
       if (cbIndex >= 0) {
         // v3 offers callback or promises event handling
         // NOTE: this does not work with v3.2.0-3.2.1 cluster.query, as there is a bug in the couchbase source code
         args[cbIndex] = shimmer.wrapFunction(args[cbIndex], (cb) => {
-          return wrapCallbackFinish(cb, thisArg, args, errorCh, finishCh, ctx, `apm:couchbase:${name}`)
+          return wrapCallbackFinish(cb, thisArg, args, channels, ctx)
         })
       }
       const res = fn.apply(thisArg, args)
@@ -153,19 +178,19 @@ function wrapCBandPromise (fn, name, startData, thisArg, args) {
       res.then(
         (result) => {
           ctx.result = result
-          finishCh.publish(ctx)
+          channels.finish.publish(ctx)
         },
         (err) => {
           ctx.error = err
-          errorCh.publish(ctx)
-          finishCh.publish(ctx)
+          channels.error.publish(ctx)
+          channels.finish.publish(ctx)
         }
       )
       return res
     } catch (e) {
       void e.stack
       ctx.error = e
-      errorCh.publish(ctx)
+      channels.error.publish(ctx)
       throw e
     }
   })
@@ -196,14 +221,12 @@ addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^2.6.12'] }, Buc
     return wrapMaybeInvoke(maybeInvoke, 'apm:couchbase:bucket:maybeInvoke')
   })
 
-  const startCh = channel('apm:couchbase:query:start')
-  const finishCh = channel('apm:couchbase:query:finish')
-  const errorCh = channel('apm:couchbase:query:error')
+  const queryChannels = getChannelBag('apm:couchbase:query')
 
   shimmer.wrap(Bucket.prototype, 'query', query => wrapQuery(query))
 
   shimmer.wrap(Bucket.prototype, '_n1qlReq', _n1qlReq => function (host, q, adhoc, emitter) {
-    if (!startCh.hasSubscribers) {
+    if (!queryChannels.start.hasSubscribers) {
       return _n1qlReq.apply(this, arguments)
     }
 
@@ -212,16 +235,16 @@ addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^2.6.12'] }, Buc
     const n1qlQuery = getQueryResource(q)
 
     const ctx = { resource: n1qlQuery, bucket: { name: this.name || this._name }, seedNodes: this._dd_hosts }
-    return startCh.runStores(ctx, () => {
+    return queryChannels.start.runStores(ctx, () => {
       emitter.once('rows', () => {
-        finishCh.publish(ctx)
+        queryChannels.finish.publish(ctx)
       })
 
       emitter.once(errorMonitor, (error) => {
         if (!error) return
         ctx.error = error
-        errorCh.publish(ctx)
-        finishCh.publish(ctx)
+        queryChannels.error.publish(ctx)
+        queryChannels.finish.publish(ctx)
       })
 
       try {
@@ -229,7 +252,7 @@ addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^2.6.12'] }, Buc
       } catch (err) {
         void err.stack // trigger getting the stack at the original throwing point
         ctx.error = err
-        errorCh.publish(ctx)
+        queryChannels.error.publish(ctx)
 
         throw err
       }

--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -2,27 +2,40 @@
 
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
-const ELASTICSEARCH_URL = 'elasticsearch.url'
-const ELASTICSEARCH_METHOD = 'elasticsearch.method'
-const ELASTICSEARCH_BODY = 'elasticsearch.body'
-const ELASTICSEARCH_PARAMS = 'elasticsearch.params'
-
 class ElasticsearchPlugin extends DatabasePlugin {
   static id = 'elasticsearch'
+
+  #urlTag
+  #methodTag
+  #bodyTag
+  #paramsTag
+
+  constructor (...args) {
+    super(...args)
+
+    // `this.system` is `'elasticsearch'` here but `'opensearch'` on the
+    // OpenSearchPlugin subclass; cache the per-instance tag keys so the
+    // hot path stays allocation-free without losing that distinction.
+    const { system } = this
+    this.#urlTag = `${system}.url`
+    this.#methodTag = `${system}.method`
+    this.#bodyTag = `${system}.body`
+    this.#paramsTag = `${system}.params`
+  }
 
   bindStart (ctx) {
     const { params } = ctx
 
     const meta = {
       'db.type': this.system,
-      [ELASTICSEARCH_URL]: params.path,
-      [ELASTICSEARCH_METHOD]: params.method,
-      [ELASTICSEARCH_BODY]: getBody(params.body || params.bulkBody),
+      [this.#urlTag]: params.path,
+      [this.#methodTag]: params.method,
+      [this.#bodyTag]: getBody(params.body || params.bulkBody),
     }
 
     const queryString = params.querystring || params.query
     if (queryString !== undefined) {
-      meta[ELASTICSEARCH_PARAMS] = JSON.stringify(queryString)
+      meta[this.#paramsTag] = JSON.stringify(queryString)
     }
 
     this.startSpan(this.operationName(), {

--- a/packages/datadog-plugin-elasticsearch/src/index.js
+++ b/packages/datadog-plugin-elasticsearch/src/index.js
@@ -2,26 +2,35 @@
 
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
+const ELASTICSEARCH_URL = 'elasticsearch.url'
+const ELASTICSEARCH_METHOD = 'elasticsearch.method'
+const ELASTICSEARCH_BODY = 'elasticsearch.body'
+const ELASTICSEARCH_PARAMS = 'elasticsearch.params'
+
 class ElasticsearchPlugin extends DatabasePlugin {
   static id = 'elasticsearch'
 
   bindStart (ctx) {
     const { params } = ctx
 
-    const body = getBody(params.body || params.bulkBody)
+    const meta = {
+      'db.type': this.system,
+      [ELASTICSEARCH_URL]: params.path,
+      [ELASTICSEARCH_METHOD]: params.method,
+      [ELASTICSEARCH_BODY]: getBody(params.body || params.bulkBody),
+    }
+
+    const queryString = params.querystring || params.query
+    if (queryString !== undefined) {
+      meta[ELASTICSEARCH_PARAMS] = JSON.stringify(queryString)
+    }
 
     this.startSpan(this.operationName(), {
       service: this.serviceName({ pluginConfig: this.config }),
       resource: `${params.method} ${quantizePath(params.path)}`,
       type: 'elasticsearch',
       kind: 'client',
-      meta: {
-        'db.type': this.system,
-        [`${this.system}.url`]: params.path,
-        [`${this.system}.method`]: params.method,
-        [`${this.system}.body`]: body,
-        [`${this.system}.params`]: JSON.stringify(params.querystring || params.query),
-      },
+      meta,
     }, ctx)
 
     return ctx.currentStore

--- a/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/src/producer.js
@@ -54,9 +54,13 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
      * - Inject batch span context + metadata into all message attributes for downstream
      *   consumers to reconstruct the trace and understand batch relationships
      */
-    const spanLinkData = hasTraceContext
-      ? messages.slice(1).map(msg => this.#extractSpanLink(msg.attributes)).filter(Boolean)
-      : []
+    const spanLinkData = []
+    if (hasTraceContext) {
+      for (let i = 1; i < messageCount; i++) {
+        const link = this.#extractSpanLink(messages[i].attributes)
+        if (link) spanLinkData.push(link)
+      }
+    }
 
     const firstAttrs = messages[0]?.attributes
     const parentData = firstAttrs?.['x-datadog-trace-id'] && firstAttrs['x-datadog-parent-id']
@@ -107,35 +111,40 @@ class GoogleCloudPubsubProducerPlugin extends ProducerPlugin {
       ))
     }
 
-    for (let i = 0; i < messages.length; i++) {
+    const messageCountStr = String(messageCount)
+    const startTimeStr = String(Math.floor(batchSpan._startTime))
+    const dsmEnabled = this.config.dsmEnabled
+
+    for (let i = 0; i < messageCount; i++) {
       const msg = messages[i]
-      msg.attributes ??= {}
+      const attributes = msg.attributes ??= {}
 
       if (!hasTraceContext) {
-        this.tracer.inject(batchSpan, 'text_map', msg.attributes)
+        this.tracer.inject(batchSpan, 'text_map', attributes)
       }
 
-      Object.assign(msg.attributes, {
-        '_dd.pubsub_request.trace_id': batchTraceIdHex,
-        '_dd.pubsub_request.span_id': batchSpanIdHex,
-        '_dd.batch.size': String(messageCount),
-        '_dd.batch.index': String(i),
-        'gcloud.project_id': projectId,
-        'pubsub.topic': topic,
-        'x-dd-publish-start-time': String(Math.floor(batchSpan._startTime)),
-      })
+      // Assign keys one-by-one rather than via `Object.assign({...})` so V8
+      // keeps the attributes object on its existing hidden class instead of
+      // allocating a fresh literal per message.
+      attributes['_dd.pubsub_request.trace_id'] = batchTraceIdHex
+      attributes['_dd.pubsub_request.span_id'] = batchSpanIdHex
+      attributes['_dd.batch.size'] = messageCountStr
+      attributes['_dd.batch.index'] = String(i)
+      attributes['gcloud.project_id'] = projectId
+      attributes['pubsub.topic'] = topic
+      attributes['x-dd-publish-start-time'] = startTimeStr
 
       if (batchTraceIdUpper) {
-        msg.attributes['_dd.pubsub_request.p.tid'] = batchTraceIdUpper
+        attributes['_dd.pubsub_request.p.tid'] = batchTraceIdUpper
       }
 
-      if (this.config.dsmEnabled) {
+      if (dsmEnabled) {
         const dataStreamsContext = this.tracer.setCheckpoint(
           ['direction:out', `topic:${topic}`, 'type:google-pubsub'],
           batchSpan,
           getHeadersSize(msg)
         )
-        DsmPathwayCodec.encode(dataStreamsContext, msg.attributes)
+        DsmPathwayCodec.encode(dataStreamsContext, attributes)
       }
     }
 

--- a/packages/datadog-plugin-grpc/src/client.js
+++ b/packages/datadog-plugin-grpc/src/client.js
@@ -86,12 +86,11 @@ class GrpcClientPlugin extends ClientPlugin {
       // The only scheme we want to support here is ipv[46]:port, although
       // more are supported by the library
       // https://github.com/grpc/grpc/blob/v1.60.0/doc/naming.md
-      const parts = peer.split(':')
-      if (/^\d+/.test(parts.at(-1))) {
-        const port = parts.at(-1)
-        const ip = parts.slice(0, -1).join(':')
-        span.setTag('network.destination.ip', ip)
-        span.setTag('network.destination.port', port)
+      const colonIndex = peer.lastIndexOf(':')
+      const tail = colonIndex === -1 ? '' : peer.slice(colonIndex + 1)
+      if (tail && /^\d+$/.test(tail)) {
+        span.setTag('network.destination.ip', peer.slice(0, colonIndex))
+        span.setTag('network.destination.port', tail)
       } else {
         span.setTag('network.destination.ip', peer)
       }
@@ -121,7 +120,7 @@ function inject (tracer, span, metadata) {
 
   tracer.inject(span, TEXT_MAP, carrier)
 
-  for (const key in carrier) {
+  for (const key of Object.keys(carrier)) {
     metadata.set(key, carrier[key])
   }
 }

--- a/packages/datadog-plugin-grpc/src/util.js
+++ b/packages/datadog-plugin-grpc/src/util.js
@@ -3,46 +3,81 @@
 const pick = require('../../datadog-core/src/utils/src/pick')
 const log = require('../../dd-trace/src/log')
 
+/**
+ * @typedef {object} ParsedMethodPath
+ * @property {string} name
+ * @property {string} service
+ * @property {string} package
+ */
+
+// Sentinel returned by `getFilter` when the user has not configured a metadata
+// filter. `addMetadataTags` short-circuits on this identity to skip the
+// `metadata.getMap()` clone in the default no-filter case.
 function getEmptyObject () {
   return {}
 }
 
+/**
+ * gRPC method paths are stable per service definition (e.g.
+ * `/pkg.Service/Method`); a service typically only has a small finite set.
+ * Cache the parsed `{name, service, package}` triple by path so we skip the
+ * `path.split('/')` + `serviceParts.split('.')` + `serviceParts.pop()` work
+ * on every call.
+ *
+ * @type {Map<string, ParsedMethodPath>}
+ */
+const methodPathCache = new Map()
+
+/**
+ * @param {string} path
+ * @returns {ParsedMethodPath}
+ */
+function parseMethodPath (path) {
+  const methodParts = path.split('/')
+
+  if (methodParts.length > 2) {
+    const serviceParts = methodParts[1].split('.')
+    return {
+      name: methodParts[2],
+      service: serviceParts.pop(),
+      package: serviceParts.join('.'),
+    }
+  }
+
+  return { name: methodParts.at(-1), service: '', package: '' }
+}
+
 module.exports = {
+  getEmptyObject,
+
   getMethodMetadata (path, kind) {
-    const tags = {
+    if (typeof path !== 'string') {
+      return { path, kind, name: '', service: '', package: '' }
+    }
+
+    let parsed = methodPathCache.get(path)
+    if (parsed === undefined) {
+      parsed = parseMethodPath(path)
+      methodPathCache.set(path, parsed)
+    }
+
+    return {
       path,
       kind,
-      name: '',
-      service: '',
-      package: '',
+      name: parsed.name,
+      service: parsed.service,
+      package: parsed.package,
     }
-
-    if (typeof path !== 'string') return tags
-
-    const methodParts = path.split('/')
-
-    if (methodParts.length > 2) {
-      const serviceParts = methodParts[1].split('.')
-      const name = methodParts[2]
-      const service = serviceParts.pop()
-      const pkg = serviceParts.join('.')
-
-      tags.name = name
-      tags.service = service
-      tags.package = pkg
-    } else {
-      tags.name = methodParts.at(-1)
-    }
-
-    return tags
   },
 
   addMetadataTags (span, metadata, filter, type) {
     if (!metadata || typeof metadata.getMap !== 'function') return
+    // Default no-op filter: skip the full metadata clone via `getMap()`.
+    if (filter === getEmptyObject) return
 
     const values = filter(metadata.getMap())
 
-    for (const key in values) {
+    for (const key of Object.keys(values)) {
       span.setTag(`grpc.${type}.metadata.${key}`, values[key])
     }
   },

--- a/packages/datadog-plugin-grpc/test/util.spec.js
+++ b/packages/datadog-plugin-grpc/test/util.spec.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { afterEach, describe, it } = require('mocha')
+
+const { addMetadataTags, getEmptyObject, getFilter, getMethodMetadata } = require('../src/util')
+
+describe('grpc util', () => {
+  describe('getMethodMetadata', () => {
+    it('parses a fully-qualified method path', () => {
+      const result = getMethodMetadata('/pkg.sub.Service/Method', 'unary')
+      assert.deepStrictEqual(result, {
+        path: '/pkg.sub.Service/Method',
+        kind: 'unary',
+        name: 'Method',
+        service: 'Service',
+        package: 'pkg.sub',
+      })
+    })
+
+    it('parses a path without a package', () => {
+      const result = getMethodMetadata('/Service/Method', 'serverStream')
+      assert.deepStrictEqual(result, {
+        path: '/Service/Method',
+        kind: 'serverStream',
+        name: 'Method',
+        service: 'Service',
+        package: '',
+      })
+    })
+
+    it('falls back when the path is not fully qualified', () => {
+      const result = getMethodMetadata('LegacyMethod', 'unary')
+      assert.deepStrictEqual(result, {
+        path: 'LegacyMethod',
+        kind: 'unary',
+        name: 'LegacyMethod',
+        service: '',
+        package: '',
+      })
+    })
+
+    it('returns empty fields when the path is not a string', () => {
+      const result = getMethodMetadata(undefined, 'unary')
+      assert.deepStrictEqual(result, {
+        path: undefined,
+        kind: 'unary',
+        name: '',
+        service: '',
+        package: '',
+      })
+    })
+
+    it('threads the kind through on a cache hit', () => {
+      const path = '/cache.Hit.Service/Method'
+      const first = getMethodMetadata(path, 'unary')
+      const second = getMethodMetadata(path, 'serverStream')
+      assert.strictEqual(first.kind, 'unary')
+      assert.strictEqual(second.kind, 'serverStream')
+      assert.strictEqual(first.name, second.name)
+      assert.strictEqual(first.service, second.service)
+      assert.strictEqual(first.package, second.package)
+    })
+  })
+
+  describe('addMetadataTags', () => {
+    function fakeMetadata (map) {
+      return { getMap: () => map }
+    }
+
+    function fakeSpan () {
+      const tags = {}
+      return {
+        tags,
+        setTag (key, value) { tags[key] = value },
+      }
+    }
+
+    it('skips the metadata clone when the default empty filter is in use', () => {
+      const span = fakeSpan()
+      let called = false
+      const metadata = {
+        getMap () {
+          called = true
+          return { traceparent: 'should-not-leak' }
+        },
+      }
+      addMetadataTags(span, metadata, getEmptyObject, 'request')
+      assert.strictEqual(called, false)
+      assert.deepStrictEqual(span.tags, {})
+    })
+
+    it('forwards filtered values to setTag on the span', () => {
+      const span = fakeSpan()
+      const filter = (map) => ({ 'x-trace-id': map['x-trace-id'] })
+      addMetadataTags(span, fakeMetadata({ 'x-trace-id': 'abc', secret: 'shh' }), filter, 'request')
+      assert.deepStrictEqual(span.tags, { 'grpc.request.metadata.x-trace-id': 'abc' })
+    })
+
+    const objectProto = Object.prototype
+
+    afterEach(() => {
+      // Defence-in-depth: tests shouldn't leak prototype pollution.
+      delete objectProto.injected
+    })
+
+    it('does not pick up inherited keys when iterating filter output', () => {
+      const span = fakeSpan()
+      objectProto.injected = 'leak'
+      const filter = () => ({ direct: 'kept' })
+      addMetadataTags(span, fakeMetadata({}), filter, 'response')
+      assert.deepStrictEqual(span.tags, { 'grpc.response.metadata.direct': 'kept' })
+    })
+  })
+
+  describe('getFilter', () => {
+    it('returns the same empty-object sentinel when no filter is configured', () => {
+      const filterA = getFilter({}, 'metadata')
+      const filterB = getFilter({}, 'metadata')
+      assert.strictEqual(filterA, getEmptyObject)
+      assert.strictEqual(filterB, getEmptyObject)
+    })
+
+    it('returns the user-provided function as-is', () => {
+      const userFilter = (input) => input
+      assert.strictEqual(getFilter({ metadata: userFilter }, 'metadata'), userFilter)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Four wins on per-message / per-call hot paths:

1. **elasticsearch**: skip `JSON.stringify(params.querystring ||
   params.query)` when both fields are absent; previously the literal
   string `"undefined"` was tagged on the span. Hoist the four
   `${this.system}.…` tag keys to module-scope constants.
2. **grpc**: cache the `{name, service, package}` triple by path in a
   module-scope `Map`; export the `getEmptyObject` filter sentinel and
   short-circuit on identity before the `metadata.getMap()` clone;
   replace remaining `for-in` walks (`addMetadataTags`, client
   `inject`) with `for-of Object.keys`; parse the peer string with
   `lastIndexOf(':')` + two `slice` calls and tighten the digit check
   so peers like `unix:` no longer tag with an empty port.
3. **couchbase**: cache a `ChannelBag` per `apm:couchbase:<name>`
   prefix; `wrapCBandPromise`, `wrap`, `wrapCallback`, and
   `wrapCallbackFinish` no longer repeat the same template-literal
   lookups per traced call.
4. **pubsub**: hoist `String(messageCount)` and `String(Math.floor(...))`
   out of the per-message loop in `bindStart`; assign the seven
   attribute fields per-key so V8 keeps `msg.attributes` on its
   existing hidden class; replace
   `messages.slice(1).map(...).filter(Boolean)` in span-link extraction
   with a single `for` loop.

```
Node v24.13.0 V8 13.6.233.17-node.37 (n=200 k+ × 7 trials, drop best+worst)

gRPC getMethodMetadata: parse path on every call vs cached
parse on every call                   74.50 ns/op
cache hit (Map.get)                    5.84 ns/op   speedup: 12.76x

gRPC peer parse: 5 realistic peer strings
split + slice + at(-1)               360.06 ns/op
lastIndexOf + slice                  166.78 ns/op   speedup: 2.16x

couchbase channel resolution per traced call
5 template-literal channel() calls    28.40 ns/op
cached bag (Map.get)                   6.93 ns/op   speedup: 4.10x
```