### PR TITLE
perf(shimmer): drop assertNotClass toString call

### DIFF
--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -267,7 +267,13 @@ function assertMethod (target, name, method) {
  * @throws {Error} If the target is a class constructor.
  */
 function assertNotClass (target) {
-  if (Function.prototype.toString.call(target).startsWith('class')) {
+  // Class constructors have a non-writable `prototype` property; functions have a
+  // writable one and arrows / async / method-shorthand have none at all. The
+  // `'prototype' in target` gate skips the descriptor lookup for the no-prototype
+  // shapes; the `in` operator is cheaper than reading `target.prototype` since
+  // it returns a boolean instead of materialising the prototype reference.
+  if ('prototype' in target &&
+      Object.getOwnPropertyDescriptor(target, 'prototype').writable === false) {
     throw new TypeError('Target is a native class constructor and cannot be wrapped.')
   }
 }

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -2,6 +2,8 @@
 
 const assert = require('node:assert/strict')
 
+const sinon = require('sinon')
+
 const shimmer = require('../src/shimmer')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
 
@@ -432,6 +434,27 @@ describe('shimmer', () => {
       Counter.toString = 'invalid'
 
       assert.throws(() => shimmer.wrapFunction(Counter, Counter => function () {}), /Target is a native class constructor and cannot be wrapped\./)
+    })
+
+    it('should detect class constructors without materializing the source', () => {
+      const spy = sinon.spy(Function.prototype, 'toString')
+      try {
+        const count = inc => inc
+        shimmer.wrapFunction(count, count => () => {})
+
+        function legacyCtor (start) { this.value = start }
+        shimmer.wrapFunction(legacyCtor, ctor => function () { ctor.apply(this, arguments) })
+
+        class Counter {}
+        assert.throws(
+          () => shimmer.wrapFunction(Counter, Counter => function () {}),
+          /Target is a native class constructor and cannot be wrapped\./
+        )
+
+        assert.strictEqual(spy.callCount, 0)
+      } finally {
+        spy.restore()
+      }
     })
 
     it('should preserve property descriptors from the original', () => {


### PR DESCRIPTION
## Summary

`Function.prototype.toString.call(target).startsWith('class')`
materializes the target's full source on every wrap, and `wrapFunction`
runs on multiple instrumentation hot paths.

Class constructors have a non-writable `prototype` descriptor; arrows /
async / method-shorthand have no own `prototype`. The `'prototype' in
target` gate skips the descriptor lookup for the no-prototype shapes;
the `in` operator returns a boolean without materialising the prototype
reference, so it's cheaper than reading `target.prototype`. The check
preserves the existing test that pins behaviour when user code overrides
`target.toString`.

```
Node v24.13.0 V8 13.6.233.17-node.37 (n=1 M+ × 7 trials, drop best+worst)

shimmer.assertNotClass: realistic 5-target mix (regular fn / arrow / async / method-shorthand / class)
toString().startsWith (original)              28.15 ns/op
descriptor lookup unconditional               12.99 ns/op
'prototype' in target gate + descriptor       10.29 ns/op   speedup: 2.74x vs original
```

Alternatives considered:

- `target.prototype` as the gate (instead of `'prototype' in target`) was 13.41 ns — slower, because for regular function and class it materializes the prototype object reference.
- Caching the result via a `WeakMap` would be ~5.3 ns on cache hits, but `assertNotClass` runs once per `shimmer.wrap` (mostly module-load), so cache hits are rare. Not worth the side-table.
- A `Symbol`-keyed property cache on the target itself would be faster, but would mutate caller-owned functions — violates `bridgear-coding-style` "External-object state".