### PR TITLE
perf(http): drop per-emit array literal in wrapResponseEmit

### DIFF
--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -43,7 +43,7 @@ function wrapResponseEmit (emit) {
       return emit.apply(this, arguments)
     }
 
-    if (['finish', 'close'].includes(eventName) && !requestFinishedSet.has(this)) {
+    if ((eventName === 'finish' || eventName === 'close') && !requestFinishedSet.has(this)) {
       finishServerCh.publish({ req: this.req })
       requestFinishedSet.add(this)
     }


### PR DESCRIPTION
## Summary

`['finish', 'close'].includes(eventName)` allocated the array on every
server response emit. Two `===` comparisons read the same.