### PR TITLE
fix(ci): approve pnpm package-manager builds

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -32,7 +32,14 @@ jobs:
           - name: npm
             install: npm install
           - name: pnpm
-            install: pnpm add
+            install: >-
+              pnpm
+              --allow-build=@datadog/native-appsec
+              --allow-build=@datadog/native-iast-taint-tracking
+              --allow-build=@datadog/native-metrics
+              --allow-build=@datadog/pprof
+              --allow-build=dd-trace
+              add
           - name: yarn
             install: yarn add
           - name: yarn-berry


### PR DESCRIPTION
### What does this PR do?
Updates the Platform package-manager smoke test so the pnpm matrix entry explicitly allows lifecycle scripts for `dd-trace` and its native optional dependencies when installing the packed tarball.

### Motivation
pnpm 11 enables strict dependency build approval by default. The job installs the latest pnpm globally, so `pnpm add /tmp/dd-trace.tgz` now fails with `ERR_PNPM_IGNORED_BUILDS` unless these known build scripts are approved.

### Additional Notes
Validated locally with:

- `npm run verify:workflow-job-names`
- `git diff --check`
- pnpm `11.0.8` smoke tests confirming repeated `--allow-build` flags run lifecycle scripts successfully.
