### PR TITLE
fix(config): disable OTLP only when protocolVersion is explicitly set

### DIFF
--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -357,7 +357,7 @@ class Config extends ConfigBase {
       setAndTrack(this, 'DD_METRICS_OTEL_ENABLED', false)
     }
 
-    if (this.OTEL_TRACES_EXPORTER === 'otlp' && this.protocolVersion && this.protocolVersion !== '0.4') {
+    if (this.OTEL_TRACES_EXPORTER === 'otlp' && trackedConfigOrigins.has('protocolVersion')) {
       log.warn('DD_TRACE_AGENT_PROTOCOL_VERSION is set, disabling OTLP traces export')
       setAndTrack(this, 'OTEL_TRACES_EXPORTER', 'none')
     }

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -536,7 +536,7 @@ describe('Config', () => {
     assert.strictEqual(config.OTEL_TRACES_EXPORTER, 'none')
   })
 
-  it('should disable OTLP traces export when DD_TRACE_AGENT_PROTOCOL_VERSION is set, even when its value matches the default', () => {
+  it('should disable OTLP traces export when DD_TRACE_AGENT_PROTOCOL_VERSION is set', () => {
     process.env.OTEL_TRACES_EXPORTER = 'otlp'
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.4'
     const config = getConfig()

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -536,6 +536,13 @@ describe('Config', () => {
     assert.strictEqual(config.OTEL_TRACES_EXPORTER, 'none')
   })
 
+  it('should not disable OTLP traces export when DD_TRACE_AGENT_PROTOCOL_VERSION is unset', () => {
+    process.env.OTEL_TRACES_EXPORTER = 'otlp'
+    delete process.env.DD_TRACE_AGENT_PROTOCOL_VERSION
+    const config = getConfig()
+    assert.strictEqual(config.OTEL_TRACES_EXPORTER, 'otlp')
+  })
+
   it('should disable OTLP traces export when DD_TRACE_AGENT_PROTOCOL_VERSION is set', () => {
     process.env.OTEL_TRACES_EXPORTER = 'otlp'
     process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.4'

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -536,6 +536,13 @@ describe('Config', () => {
     assert.strictEqual(config.OTEL_TRACES_EXPORTER, 'none')
   })
 
+  it('should disable OTLP traces export when DD_TRACE_AGENT_PROTOCOL_VERSION is set, even when its value matches the default', () => {
+    process.env.OTEL_TRACES_EXPORTER = 'otlp'
+    process.env.DD_TRACE_AGENT_PROTOCOL_VERSION = '0.4'
+    const config = getConfig()
+    assert.strictEqual(config.OTEL_TRACES_EXPORTER, 'none')
+  })
+
   it('should fall back to http/json when OTEL_EXPORTER_OTLP_TRACES_PROTOCOL is unsupported', () => {
     process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = 'grpc'
     const config = getConfig()


### PR DESCRIPTION
## Summary

The OTLP-disable rule fires on `protocolVersion !== '0.4'`, which proxies "user typed something" as a value comparison because '0.4' is both the default and the universally-deployed value. That proxy breaks the moment the default changes: any user enabling OTLP would have it silently disabled even though they never touched the protocol version.

Observable behavior change: explicitly setting `DD_TRACE_AGENT_PROTOCOL_VERSION=0.4` while OTLP is enabled now disables OTLP. Previously the value-equal-to-default special case slipped through.

Refs: https://github.com/DataDog/dd-trace-js/pull/8324