### PR TITLE
[test optimization] fix mocha EFD callback test arity

### DIFF
--- a/integration-tests/ci-visibility/test-early-flake-detection/mocha-callback-test.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/mocha-callback-test.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const http = require('node:http')
+
+describe('efd callback tests', () => {
+  it('closes server with done callback', function (done) {
+    const server = http.createServer((req, res) => {
+      res.end('ok')
+    })
+
+    server.listen(0, function () {
+      assert.strictEqual(server.listening, true)
+      server.close(done)
+    })
+  })
+})

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2287,6 +2287,70 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
     })
 
+    it('retries callback-style async tests', async () => {
+      receiver.setKnownTests({
+        mocha: {},
+      })
+      const NUM_RETRIES_EFD = 3
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': NUM_RETRIES_EFD,
+          },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
+      })
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const callbackTests = tests.filter(test =>
+            test.meta[TEST_SUITE] === 'ci-visibility/test-early-flake-detection/mocha-callback-test.js'
+          )
+
+          assert.strictEqual(callbackTests.length, NUM_RETRIES_EFD + 1)
+          callbackTests.forEach(test => {
+            assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+            assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+          })
+
+          const retriedTests = callbackTests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD)
+          retriedTests.forEach(test => {
+            assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+          })
+        })
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            SHOULD_CHECK_RESULTS: '1',
+            TESTS_TO_RUN: JSON.stringify([
+              './test-early-flake-detection/mocha-callback-test.js',
+            ]),
+          },
+        }
+      )
+
+      childProcess.stdout?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+      childProcess.stderr?.on('data', (chunk) => {
+        testOutput += chunk.toString()
+      })
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+      assert.strictEqual(exitCode, 0, testOutput)
+    })
+
     it('uses the retry count from the matching slow_test_retries bucket', async () => {
       receiver.setKnownTests({
         mocha: {},

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -94,7 +94,7 @@ function wrapOriginalEfdTest (test, slowTestRetries) {
   }
   test._ddEfdDurationWrapped = true
   const originalFn = test.fn
-  test.fn = function () {
+  test.fn = shimmer.wrapFunction(originalFn, originalFn => function () {
     const start = performance.now()
     const recordDuration = () => {
       setEfdRetryCountForTest(test, performance.now() - start, slowTestRetries)
@@ -102,11 +102,10 @@ function wrapOriginalEfdTest (test, slowTestRetries) {
 
     if (originalFn.length > 0) {
       const args = Array.prototype.slice.call(arguments)
-      const done = args[0]
-      args[0] = function () {
+      args[0] = shimmer.wrapFunction(args[0], done => function () {
         recordDuration()
         return done.apply(this, arguments)
-      }
+      })
       return originalFn.apply(this, args)
     }
 
@@ -127,7 +126,7 @@ function wrapOriginalEfdTest (test, slowTestRetries) {
       recordDuration()
       throw error
     }
-  }
+  })
 }
 
 function retryTest (test, numRetries, tags, slowTestRetries) {
@@ -143,14 +142,14 @@ function retryTest (test, numRetries, tags, slowTestRetries) {
       clonedTest._ddEfdRetryIndex = retryIndex + 1
       const originalFn = clonedTest.fn
       if (typeof originalFn === 'function') {
-        clonedTest.fn = function () {
+        clonedTest.fn = shimmer.wrapFunction(originalFn, originalFn => function () {
           const efdRetryCount = efdRetryCountByTestFullName.get(getTestFullName(clonedTest))
           if (efdRetryCount !== undefined && clonedTest._ddEfdRetryIndex > efdRetryCount) {
             clonedTest._ddShouldSkipEfdRetry = true
             this.skip()
           }
           return originalFn.apply(this, arguments)
-        }
+        })
       }
     }
     for (const tag of tags) {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Preserves Mocha callback-style test arity in EFD wrappers by using `shimmer.wrapFunction`, including cloned EFD retries.

Adds a regression test for a callback-style async Mocha test that completes through `done` from an HTTP server close callback.

### Motivation

https://github.com/DataDog/dd-trace-js/pull/8286 added a bug

EFD duration-bucket wrapping changed callback-style tests to zero-arity functions. Mocha then treated cloned retries as sync/promise tests and could call them without `done`, causing `done.apply(...)` to crash.

### Additional Notes
Validated with targeted Mocha EFD tests on latest and oldest supported Mocha, plus `node --check` on touched files.

Targeted ESLint could not run because this checkout is missing `eslint-plugin-sonarjs`.