### PR TITLE
update llmobs encode unicode mixed benchmarks with less iterations

### DIFF
--- a/benchmark/sirun/llmobs/meta.json
+++ b/benchmark/sirun/llmobs/meta.json
@@ -3,10 +3,19 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 30,
+  "iterations": 5,
   "instructions": true,
   "variants": {
-    "encode-unicode-ascii": { "env": { "VARIANT": "encode-unicode-ascii" } },
-    "encode-unicode-mixed": { "baseline": "encode-unicode-ascii", "env": { "VARIANT": "encode-unicode-mixed" } }
+    "encode-unicode-ascii": {
+      "env": {
+        "VARIANT": "encode-unicode-ascii"
+      }
+    },
+    "encode-unicode-mixed": {
+      "baseline": "encode-unicode-ascii",
+      "env": {
+        "VARIANT": "encode-unicode-mixed"
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update LLMObs encode unicode mixed benchmarks with less iterations.

### Motivation
<!-- What inspired you to submit this pull request? -->

This is slowing down significantly our benchmarks. We run on metal machines specifically to remove all noise, so 5 iterations ought to be enough.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


