### PR TITLE
refactor: dedupe identical function bodies

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -485,7 +485,7 @@ export default [
       'sonarjs/duplicates-in-character-class': 'off', // 86 errors
       'sonarjs/no-code-after-done': 'off', // 13 errors
       'sonarjs/no-element-overwrite': 'off', // 3 errors (false positives)
-      'sonarjs/no-identical-functions': 'off', // 25 errors
+      'sonarjs/no-identical-functions': 'error',
       'sonarjs/slow-regex': 'off', // 30 errors. Valuable ReDoS signal; needs audit.
       'sonarjs/stable-tests': 'off',
       'sonarjs/todo-tag': 'off', // 434 errors. We use TODO/FIXME as tracked markers by policy.

--- a/packages/datadog-instrumentations/test/http-client-options.spec.js
+++ b/packages/datadog-instrumentations/test/http-client-options.spec.js
@@ -156,6 +156,7 @@ describe('http client option ownership', () => {
 
   it('keeps tracing on http.request(undefined) without callback', () => {
     const events = []
+    // eslint-disable-next-line sonarjs/no-identical-functions -- per-test events buffer
     const onStart = (payload) => {
       if (payload?.args?.originalUrl === undefined) {
         events.push(payload)

--- a/packages/datadog-instrumentations/test/http.spec.js
+++ b/packages/datadog-instrumentations/test/http.spec.js
@@ -311,6 +311,7 @@ describe('client', () => {
           const chunks = []
           http.get(url, (res) => {
             res.setEncoding('utf8')
+            // eslint-disable-next-line sonarjs/no-identical-functions -- per-test chunks buffer
             const consume = () => {
               let chunk
               while ((chunk = res.read()) !== null) {

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -1,5 +1,10 @@
 'use strict'
 
+// Each `it` block declares its own inline http2 stream handler so the test
+// reads top-to-bottom. Hoisting them into shared helpers obscures what each
+// test exercises (status codes, header assertions, per-`done` flow).
+/* eslint-disable sonarjs/no-identical-functions */
+
 const assert = require('node:assert/strict')
 const fs = require('node:fs')
 const path = require('node:path')

--- a/packages/dd-trace/src/openfeature/noop.js
+++ b/packages/dd-trace/src/openfeature/noop.js
@@ -3,6 +3,18 @@
 const { NOOP_REASON } = require('./constants/constants')
 
 /**
+ * @template T
+ * @param {T} defaultValue
+ * @returns {Promise<{value: T, reason: string}>}
+ */
+function resolveDefault (defaultValue) {
+  return Promise.resolve({
+    value: defaultValue,
+    reason: NOOP_REASON,
+  })
+}
+
+/**
  * No-op implementation of OpenFeature provider that always returns default values.
  * Used when the OpenFeature provider is not initialized or disabled.
  * https://openfeature.dev/docs/reference/concepts/provider/
@@ -20,59 +32,51 @@ class NoopFlaggingProvider {
   }
 
   /**
-   * @param {string} flagKey - Flag key
-   * @param {boolean} defaultValue - Default value to return
-   * @param {object} context - Evaluation context
-   * @param {object} logger - Logger instance
-   * @returns {Promise<{value: boolean, reason: string}>} Resolution details
+   * @template T
+   * @param {string} flagKey
+   * @param {T} defaultValue
+   * @param {object} context
+   * @param {object} logger
+   * @returns {Promise<{value: T, reason: string}>}
    */
   resolveBooleanEvaluation (flagKey, defaultValue, context, logger) {
-    return Promise.resolve({
-      value: defaultValue,
-      reason: NOOP_REASON,
-    })
+    return resolveDefault(defaultValue)
   }
 
   /**
-   * @param {string} flagKey - Flag key
-   * @param {string} defaultValue - Default value to return
-   * @param {object} context - Evaluation context
-   * @param {object} logger - Logger instance
-   * @returns {Promise<{value: string, reason: string}>} Resolution details
+   * @template T
+   * @param {string} flagKey
+   * @param {T} defaultValue
+   * @param {object} context
+   * @param {object} logger
+   * @returns {Promise<{value: T, reason: string}>}
    */
   resolveStringEvaluation (flagKey, defaultValue, context, logger) {
-    return Promise.resolve({
-      value: defaultValue,
-      reason: NOOP_REASON,
-    })
+    return resolveDefault(defaultValue)
   }
 
   /**
-   * @param {string} flagKey - Flag key
-   * @param {number} defaultValue - Default value to return
-   * @param {object} context - Evaluation context
-   * @param {object} logger - Logger instance
-   * @returns {Promise<{value: number, reason: string}>} Resolution details
+   * @template T
+   * @param {string} flagKey
+   * @param {T} defaultValue
+   * @param {object} context
+   * @param {object} logger
+   * @returns {Promise<{value: T, reason: string}>}
    */
   resolveNumberEvaluation (flagKey, defaultValue, context, logger) {
-    return Promise.resolve({
-      value: defaultValue,
-      reason: NOOP_REASON,
-    })
+    return resolveDefault(defaultValue)
   }
 
   /**
-   * @param {string} flagKey - Flag key
-   * @param {object} defaultValue - Default value to return
-   * @param {object} context - Evaluation context
-   * @param {object} logger - Logger instance
-   * @returns {Promise<{value: object, reason: string}>} Resolution details
+   * @template T
+   * @param {string} flagKey
+   * @param {T} defaultValue
+   * @param {object} context
+   * @param {object} logger
+   * @returns {Promise<{value: T, reason: string}>}
    */
   resolveObjectEvaluation (flagKey, defaultValue, context, logger) {
-    return Promise.resolve({
-      value: defaultValue,
-      reason: NOOP_REASON,
-    })
+    return resolveDefault(defaultValue)
   }
 
   /**

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -174,7 +174,7 @@ class NetDecorator {
   }
 }
 
-class FilesystemDecorator {
+class KeyValueDecorator {
   constructor (stringTable) {
     this.stringTable = stringTable
   }
@@ -205,31 +205,11 @@ class ZlibDecorator {
   }
 }
 
-class CryptoDecorator {
-  constructor (stringTable) {
-    this.stringTable = stringTable
-  }
-
-  decorateSample (sampleInput, item) {
-    const labels = sampleInput.label
-    const stringTable = this.stringTable
-    for (const [key, value] of Object.entries(item.detail)) {
-      switch (typeof value) {
-        case 'string':
-          labels.push(labelFromStrStr(stringTable, key, value))
-          break
-        case 'number':
-          labels.push(new Label({ key: stringTable.dedup(key), num: value }))
-      }
-    }
-  }
-}
-
 // Keys correspond to PerformanceEntry.entryType, values are constructor
 // functions for type-specific decorators.
 const decoratorTypes = {
-  crypto: CryptoDecorator,
-  fs: FilesystemDecorator,
+  crypto: KeyValueDecorator,
+  fs: KeyValueDecorator,
   dns: DNSDecorator,
   gc: GCDecorator,
   net: NetDecorator,

--- a/packages/dd-trace/test/appsec/iast/utils.js
+++ b/packages/dd-trace/test/appsec/iast/utils.js
@@ -317,6 +317,50 @@ function prepareTestServerForIast (description, tests, iastConfig, pluginsToConf
   })
 }
 
+function createIastVulnerabilityHelpers (config, setApp) {
+  function testThatRequestHasVulnerability (fn, vulnerability, occurrencesAndLocation, cb, makeRequest) {
+    let testDescription
+    if (fn !== null && typeof fn === 'object') {
+      const obj = fn
+      fn = obj.fn
+      vulnerability = obj.vulnerability
+      occurrencesAndLocation = obj.occurrencesAndLocation || obj.occurrences
+      cb = obj.cb
+      makeRequest = obj.makeRequest
+      testDescription = obj.testDescription || testDescription
+    }
+
+    testDescription = testDescription || `should have ${vulnerability} vulnerability`
+
+    it(testDescription, function (done) {
+      this.timeout(5000)
+      setApp(fn)
+
+      checkVulnerabilityInRequest(vulnerability, occurrencesAndLocation, cb, makeRequest, config, done)
+    })
+  }
+
+  function testThatRequestHasNoVulnerability (fn, vulnerability, makeRequest) {
+    let testDescription
+    if (fn !== null && typeof fn === 'object') {
+      const obj = fn
+      fn = obj.fn
+      vulnerability = obj.vulnerability
+      makeRequest = obj.makeRequest
+      testDescription = obj.testDescription || testDescription
+    }
+
+    testDescription = testDescription || `should not have ${vulnerability} vulnerability`
+
+    it(testDescription, function (done) {
+      setApp(fn)
+      checkNoVulnerabilityInRequest(vulnerability, config, done, makeRequest)
+    })
+  }
+
+  return { testThatRequestHasVulnerability, testThatRequestHasNoVulnerability }
+}
+
 function prepareTestServerForIastInExpress (
   description,
   expressVersion,
@@ -382,47 +426,8 @@ function prepareTestServerForIastInExpress (
       return agent.close({ ritmReset: false })
     })
 
-    function testThatRequestHasVulnerability (fn, vulnerability, occurrencesAndLocation, cb, makeRequest) {
-      let testDescription
-      if (fn !== null && typeof fn === 'object') {
-        const obj = fn
-        fn = obj.fn
-        vulnerability = obj.vulnerability
-        occurrencesAndLocation = obj.occurrencesAndLocation || obj.occurrences
-        cb = obj.cb
-        makeRequest = obj.makeRequest
-        testDescription = obj.testDescription || testDescription
-      }
-
-      testDescription = testDescription || `should have ${vulnerability} vulnerability`
-
-      it(testDescription, function (done) {
-        this.timeout(5000)
-        app = fn
-
-        checkVulnerabilityInRequest(vulnerability, occurrencesAndLocation, cb, makeRequest, config, done)
-      })
-    }
-
-    function testThatRequestHasNoVulnerability (fn, vulnerability, makeRequest) {
-      let testDescription
-      if (fn !== null && typeof fn === 'object') {
-        const obj = fn
-        fn = obj.fn
-        vulnerability = obj.vulnerability
-        makeRequest = obj.makeRequest
-        testDescription = obj.testDescription || testDescription
-      }
-
-      testDescription = testDescription || `should not have ${vulnerability} vulnerability`
-
-      it(testDescription, function (done) {
-        app = fn
-        checkNoVulnerabilityInRequest(vulnerability, config, done, makeRequest)
-      })
-    }
-
-    tests(testThatRequestHasVulnerability, testThatRequestHasNoVulnerability, config)
+    const helpers = createIastVulnerabilityHelpers(config, (a) => { app = a })
+    tests(helpers.testThatRequestHasVulnerability, helpers.testThatRequestHasNoVulnerability, config)
   })
 }
 
@@ -490,47 +495,8 @@ function prepareTestServerForIastInFastify (description, fastifyVersion, tests, 
       return agent?.close({ ritmReset: false })
     })
 
-    function testThatRequestHasVulnerability (fn, vulnerability, occurrencesAndLocation, cb, makeRequest) {
-      let testDescription
-      if (fn !== null && typeof fn === 'object') {
-        const obj = fn
-        fn = obj.fn
-        vulnerability = obj.vulnerability
-        occurrencesAndLocation = obj.occurrencesAndLocation || obj.occurrences
-        cb = obj.cb
-        makeRequest = obj.makeRequest
-        testDescription = obj.testDescription || testDescription
-      }
-
-      testDescription = testDescription || `should have ${vulnerability} vulnerability`
-
-      it(testDescription, function (done) {
-        this.timeout(5000)
-        app = fn
-
-        checkVulnerabilityInRequest(vulnerability, occurrencesAndLocation, cb, makeRequest, config, done)
-      })
-    }
-
-    function testThatRequestHasNoVulnerability (fn, vulnerability, makeRequest) {
-      let testDescription
-      if (fn !== null && typeof fn === 'object') {
-        const obj = fn
-        fn = obj.fn
-        vulnerability = obj.vulnerability
-        makeRequest = obj.makeRequest
-        testDescription = obj.testDescription || testDescription
-      }
-
-      testDescription = testDescription || `should not have ${vulnerability} vulnerability`
-
-      it(testDescription, function (done) {
-        app = fn
-        checkNoVulnerabilityInRequest(vulnerability, config, done, makeRequest)
-      })
-    }
-
-    tests(testThatRequestHasVulnerability, testThatRequestHasNoVulnerability, config)
+    const helpers = createIastVulnerabilityHelpers(config, (a) => { app = a })
+    tests(helpers.testThatRequestHasVulnerability, helpers.testThatRequestHasNoVulnerability, config)
   })
 }
 


### PR DESCRIPTION
## Summary

Activates `sonarjs/no-identical-functions`. Test fixtures whose bodies
close over per-`it` state (http2 inline `app` handlers, per-test
event/chunk buffers) keep targeted `eslint-disable` lines — the
duplication is what makes each test self-contained — so the rule still
catches new duplicates outside that pattern.