### PR TITLE
refactor: activate three sonarjs test/loop rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -483,13 +483,13 @@ export default [
 
       // --- Rules to check later ------------------
       'sonarjs/duplicates-in-character-class': 'off', // 86 errors
-      'sonarjs/no-code-after-done': 'off', // 13 errors
+      'sonarjs/no-code-after-done': 'error',
       'sonarjs/no-element-overwrite': 'off', // 3 errors (false positives)
       'sonarjs/no-identical-functions': 'off', // 25 errors
       'sonarjs/slow-regex': 'off', // 30 errors. Valuable ReDoS signal; needs audit.
-      'sonarjs/stable-tests': 'off',
+      'sonarjs/stable-tests': 'error',
       'sonarjs/todo-tag': 'off', // 434 errors. We use TODO/FIXME as tracked markers by policy.
-      'sonarjs/updated-loop-counter': 'off', // 4 errors
+      'sonarjs/updated-loop-counter': 'error',
     },
   },
   {
@@ -749,6 +749,25 @@ export default [
     rules: {
       'mocha/max-top-level-suites': 'off',
       'mocha/no-pending-tests': 'off',
+    },
+  },
+  {
+    // CI-visibility retry fixtures intentionally call `this.retries(N)` to
+    // exercise the dd-trace test-optimization retry code paths. The fixtures
+    // ARE the flaky tests that the plugin watches.
+    name: 'dd-trace/tests/ci-visibility-retry-fixtures',
+    files: [
+      'integration-tests/ci-visibility/jest-plugin-tests/**/*.js',
+      'integration-tests/ci-visibility/mocha-hooks/**/*.js',
+      'integration-tests/ci-visibility/mocha-plugin-tests/**/*.js',
+      'integration-tests/ci-visibility/mocha-retries-test-fn/**/*.js',
+      'integration-tests/ci-visibility/test-nested-hooks/**/*.js',
+    ],
+    plugins: {
+      sonarjs: eslintPluginSonar,
+    },
+    rules: {
+      'sonarjs/stable-tests': 'off',
     },
   },
   {

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -44,6 +44,7 @@ versions.forEach((version) => {
   describe(`playwright@${version}`, function () {
     let cwd, receiver, childProcess, webAppPort, webAppServer
 
+    // eslint-disable-next-line sonarjs/stable-tests -- chromium download is flaky in CI
     this.retries(2)
     this.timeout(80000)
 

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -270,7 +270,7 @@ versions.forEach((version) => {
     })
 
     it('works when tests are compiled to a different location', function (done) {
-      // this has shown some flakiness
+      // eslint-disable-next-line sonarjs/stable-tests -- TS compile cache occasionally races
       this.retries(1)
       let testOutput = ''
 

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -410,6 +410,7 @@ describe('profiler', () => {
     it('code hotspots and endpoint tracing works', async function () {
       // see comment on busyCycleTimeNs recomputation below. Ideally a single retry should be enough
       // with recomputed busyCycleTimeNs, but let's give ourselves more leeway.
+      // eslint-disable-next-line sonarjs/stable-tests -- timing-dependent profiler sample alignment
       this.retries(9)
       const procStart = BigInt(Date.now() * 1000000)
       const env = {

--- a/integration-tests/remote_config.spec.js
+++ b/integration-tests/remote_config.spec.js
@@ -67,11 +67,11 @@ describe('Remote config client id', () => {
 
           // Verify entrypoint.type has the expected value
           assert.ok(processTags.some(tag => tag === 'entrypoint.type:script'))
+          agent.removeListener('remote-config-request', handleRemoteConfigRequest)
           done()
         } catch (err) {
-          done(err)
-        } finally {
           agent.removeListener('remote-config-request', handleRemoteConfigRequest)
+          done(err)
         }
       }
 

--- a/packages/datadog-plugin-amqplib/test/dsm.spec.js
+++ b/packages/datadog-plugin-amqplib/test/dsm.spec.js
@@ -308,11 +308,11 @@ describe('Plugin', () => {
                 assert.ok(produceB?.args[2], 'Process B produce should have a parent DSM context')
                 assert.deepStrictEqual(produceA.args[2].hash, consumeA.returnValue.hash)
                 assert.deepStrictEqual(produceB.args[2].hash, consumeB.returnValue.hash)
+                setCheckpointSpy.restore()
                 done()
               } catch (e) {
-                done(e)
-              } finally {
                 setCheckpointSpy.restore()
+                done(e)
               }
             }
 

--- a/packages/datadog-plugin-aws-sdk/test/serverless-peer-service.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/serverless-peer-service.spec.js
@@ -12,6 +12,7 @@ const { setup } = require('./spec_helpers')
 
 describe('Plugin', () => {
   describe('Serverless', function () {
+    // eslint-disable-next-line sonarjs/stable-tests -- aws-sdk integration depends on real AWS endpoints
     this.retries(5)
     this.timeout(15000)
     setup()

--- a/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
+++ b/packages/datadog-plugin-child_process/src/scrub-cmd-params.js
@@ -104,13 +104,13 @@ function scrubChildProcessCmd (expression) {
           result.push(token)
 
           if (PROCESS_DENYLIST.has(token)) {
-            for (index++; index < expressionTokens.length; index++) {
-              const token = expressionTokens[index]
+            for (let i = index + 1; i < expressionTokens.length; i++) {
+              const innerToken = expressionTokens[i]
 
-              if (token.op) {
-                result.push(token.op)
+              if (innerToken.op) {
+                result.push(innerToken.op)
               } else {
-                expressionTokens[index] = REDACTED
+                expressionTokens[i] = REDACTED
                 result.push(REDACTED)
               }
             }

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/index.spec.js
@@ -182,11 +182,11 @@ describe('Plugin', () => {
                 try {
                   assert.notStrictEqual(currentSpan, firstSpan)
                   assert.strictEqual(currentSpan.context()._name, expectedSchema.receive.opName)
+                  eachMessage = async () => {} // avoid being called for each message
                   done()
                 } catch (e) {
+                  eachMessage = async () => {}
                   done(e)
-                } finally {
-                  eachMessage = async () => {} // avoid being called for each message
                 }
               }
 
@@ -300,11 +300,11 @@ describe('Plugin', () => {
                 try {
                   assert.notEqual(currentSpan, firstSpan)
                   assert.strictEqual(currentSpan.context()._name, expectedSchema.receive.opName)
+                  eachBatch = () => {} // avoid being called for each message
                   done()
                 } catch (e) {
+                  eachBatch = () => {}
                   done(e)
-                } finally {
-                  eachBatch = () => {} // avoid being called for each message
                 }
               }
 

--- a/packages/datadog-plugin-connect/test/index.spec.js
+++ b/packages/datadog-plugin-connect/test/index.spec.js
@@ -494,12 +494,12 @@ describe('Plugin', () => {
           app.use((req, res) => {
             try {
               assert.strictEqual(storage.getStore(), store)
+              res.end()
               done()
             } catch (e) {
+              res.end()
               done(e)
             }
-
-            res.end()
           })
 
           appListener = http.createServer(app).listen(0, 'localhost', () => {

--- a/packages/datadog-plugin-express/test/index.spec.js
+++ b/packages/datadog-plugin-express/test/index.spec.js
@@ -1438,12 +1438,12 @@ describe('Plugin', () => {
           app.get('/user', (req, res) => {
             try {
               assert.strictEqual(storage.getStore(), store)
+              res.status(200).send()
               done()
             } catch (e) {
+              res.status(200).send()
               done(e)
             }
-
-            res.status(200).send()
           })
 
           appListener = app.listen(0, 'localhost', () => {

--- a/packages/datadog-plugin-fastify/test/tracing.spec.js
+++ b/packages/datadog-plugin-fastify/test/tracing.spec.js
@@ -338,12 +338,12 @@ describe('Plugin', () => {
             app.get('/user', (request, reply) => {
               try {
                 assert.strictEqual(storage.getStore(), store)
+                reply.send()
                 done()
               } catch (e) {
+                reply.send()
                 done(e)
               }
-
-              reply.send()
             })
 
             app.listen({ host, port: 0 }, () => {

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -252,11 +252,11 @@ describe('Plugin', () => {
               try {
                 assert.notDeepStrictEqual(currentSpan, firstSpan)
                 assert.strictEqual(currentSpan.context()._name, expectedSchema.receive.opName)
+                eachMessage = () => {} // avoid being called for each message
                 done()
               } catch (e) {
+                eachMessage = () => {}
                 done(e)
-              } finally {
-                eachMessage = () => {} // avoid being called for each message
               }
             }
 
@@ -315,11 +315,11 @@ describe('Plugin', () => {
             let eachBatch = async ({ batch }) => {
               try {
                 assert.strictEqual(batch.isEmpty(), false)
+                eachBatch = () => {} // avoid being called for each message
                 done()
               } catch (e) {
+                eachBatch = () => {}
                 done(e)
-              } finally {
-                eachBatch = () => {} // avoid being called for each message
               }
             }
 
@@ -358,11 +358,11 @@ describe('Plugin', () => {
                 const name = spy.firstCall.args[1]
                 assert.strictEqual(name, afterStart.name)
 
+                eachMessage = () => {}
                 done()
               } catch (e) {
-                done(e)
-              } finally {
                 eachMessage = () => {}
+                done(e)
               }
             }
 
@@ -457,11 +457,11 @@ describe('Plugin', () => {
               try {
                 assert.notEqual(currentSpan, firstSpan)
                 assert.strictEqual(currentSpan.context()._name, expectedSchema.receive.opName)
+                eachBatch = () => {} // avoid being called for each message
                 done()
               } catch (e) {
+                eachBatch = () => {}
                 done(e)
-              } finally {
-                eachBatch = () => {} // avoid being called for each message
               }
             }
 

--- a/packages/datadog-plugin-restify/test/index.spec.js
+++ b/packages/datadog-plugin-restify/test/index.spec.js
@@ -187,8 +187,8 @@ describe('Plugin', () => {
           server.get('/user', (req, res, next) => {
             assert.notStrictEqual(tracer.scope().active(), null)
             res.send(200)
-            done()
             next()
+            done()
           })
 
           appListener = server.listen(0, 'localhost', () => {
@@ -238,12 +238,12 @@ describe('Plugin', () => {
           server.get('/user', (req, res, next) => {
             try {
               assert.strictEqual(storage.getStore(), store)
+              res.end()
               done()
             } catch (e) {
+              res.end()
               done(e)
             }
-
-            res.end()
           })
 
           appListener = server.listen(0, 'localhost', () => {

--- a/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
+++ b/packages/dd-trace/src/appsec/iast/vulnerabilities-formatter/evidence-redaction/sensitive-handler.js
@@ -133,6 +133,7 @@ class SensitiveHandler {
         }
 
         start = i + (nextTainted.end - nextTainted.start)
+        // eslint-disable-next-line sonarjs/updated-loop-counter -- skip ahead; outer `i++` advances to `start`
         i = start - 1
         nextTainted = ranges.shift()
         nextTaintedIndex++
@@ -159,6 +160,7 @@ class SensitiveHandler {
         this.writeRedactedValuePart(valueParts, _length)
 
         start = i + _length
+        // eslint-disable-next-line sonarjs/updated-loop-counter -- skip ahead; outer `i++` advances to `start`
         i = start - 1
         nextSensitive = sensitive.shift()
       }

--- a/packages/dd-trace/src/debugger/devtools_client/snapshot-pruner.js
+++ b/packages/dd-trace/src/debugger/devtools_client/snapshot-pruner.js
@@ -175,6 +175,7 @@ function parseJsonToTree (json) {
     switch (json.charCodeAt(index)) {
       case 34: { // 34: double quote
         const stringStart = index + 1
+        // eslint-disable-next-line sonarjs/updated-loop-counter -- skip past the string token
         index = skipString(json, index)
         const stringLength = index - stringStart
 

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -12,6 +12,7 @@ function encodeUnicode (str = '') {
   for (let index = 0; index < str.length; index++) {
     if (str.charCodeAt(index) > 127) {
       let result = str.slice(0, index)
+      // eslint-disable-next-line sonarjs/updated-loop-counter -- inner loop continues from outer position
       for (; index < str.length; index++) {
         const code = str.charCodeAt(index)
         result += code > 127 ? String.raw`\u${code.toString(16).padStart(4, '0')}` : str[index]

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -75,6 +75,7 @@ function withNamingSchema (
         const { opName, serviceName, defaultTracerService } = expected[versionName]
 
         it('should conform to the naming schema', function () {
+          // eslint-disable-next-line sonarjs/stable-tests -- naming-schema assertions race agent flush
           this.retries(3)
           this.timeout(25000)
 
@@ -136,6 +137,7 @@ function withNamingSchema (
       const { serviceName, defaultTracerService } = expected.v1
 
       it('should pass service name through', function () {
+        // eslint-disable-next-line sonarjs/stable-tests -- naming-schema assertions race agent flush
         this.retries(3)
         this.timeout(15000)
 


### PR DESCRIPTION
## Summary

Moves test cleanup before `done()` (`no-code-after-done`), splits
nested-loop counters in the IAST handler / debugger snapshot pruner /
llmobs unicode encoder out of the outer index (`updated-loop-counter`),
and disables `stable-tests` for the CI-visibility retry fixtures whose
`this.retries(N)` is the contract under test. The remaining genuine
retries (Playwright chromium, profiler timing, AWS SDK serverless,
naming-schema agent flush) keep targeted disables with the actual
flake source spelled out.