### PR TITLE
refactor: drop bare `Function` from JSDoc types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -279,7 +279,7 @@ export default [
       // no-defaults: This should be activated, since the defaults will not be picked up in a description.
       'jsdoc/no-defaults': 'off',
       'jsdoc/no-undefined-types': 'off',
-      'jsdoc/reject-function-type': 'off',
+      'jsdoc/reject-function-type': 'error',
       'jsdoc/require-jsdoc': 'off',
       'jsdoc/require-param-description': 'off', // Having a description is not crucial for now.
       'jsdoc/require-param': 'off',

--- a/integration-tests/debugger/snapshot-time-budget.spec.js
+++ b/integration-tests/debugger/snapshot-time-budget.spec.js
@@ -199,7 +199,7 @@ describe('Dynamic Instrumentation', function () {
  * @param {number} [config.maxPausedTime] - Optional maximum pause time in ms (skips timing assertion if not provided)
  * @param {number} config.breakpointIndex - Index of the breakpoint to test
  * @param {number} config.maxReferenceDepth - Maximum reference depth for snapshot
- * @param {Function} [assertFn] - Optional assertion function for the snapshot locals
+ * @param {(...args: unknown[]) => unknown} [assertFn] - Optional assertion function for the snapshot locals
  */
 function test ({ t, maxPausedTime, breakpointIndex, maxReferenceDepth }, assertFn) {
   const breakpoint = t.breakpoints[breakpointIndex]

--- a/integration-tests/debugger/utils.js
+++ b/integration-tests/debugger/utils.js
@@ -271,7 +271,7 @@ function getBreakpointInfo ({ deployedFile, sourceFile = deployedFile, stackInde
  * Test helper for basic input messages with remote config and tracing.
  *
  * @param {DebuggerTestEnvironment} t - The test environment.
- * @param {Function} done - The mocha done callback.
+ * @param {(...args: unknown[]) => unknown} done - The mocha done callback.
  */
 function testBasicInput (t, done) {
   t.triggerBreakpoint()
@@ -284,7 +284,7 @@ function testBasicInput (t, done) {
  *
  * @param {DebuggerTestEnvironment} t - The test environment.
  * @param {import('../../packages/dd-trace/test/debugger/devtools_client/utils').ProbeConfig} probe - The probe config.
- * @param {Function} done - The mocha done callback.
+ * @param {(...args: unknown[]) => unknown} done - The mocha done callback.
  */
 function testBasicInputWithoutRC (t, probe, done) {
   t.triggerBreakpoint()
@@ -295,7 +295,7 @@ function testBasicInputWithoutRC (t, probe, done) {
  * Setup assertion listeners for basic input tests with tracing integration.
  *
  * @param {DebuggerTestEnvironment} t - The test environment.
- * @param {Function} done - The mocha done callback.
+ * @param {(...args: unknown[]) => unknown} done - The mocha done callback.
  * @param {import('../../packages/dd-trace/test/debugger/devtools_client/utils').ProbeConfig} [probe] - Optional probe
  *   config to use instead of t.rcConfig.config.
  */

--- a/integration-tests/helpers/fake-agent.js
+++ b/integration-tests/helpers/fake-agent.js
@@ -215,8 +215,8 @@ module.exports = class FakeAgent extends EventEmitter {
    * Assert that a telemetry message is received.
    *
    * @param {object} options
-   * @param {Function} [options.fn] - Function called with each matching telemetry message. If it throws,
-   *     the error is collected and the listener stays alive for the next message. Defaults to a no-op.
+   * @param {(...args: unknown[]) => unknown} [options.fn] - Called with each matching message. If it throws, the
+   *     error is collected and the listener stays alive for the next message. Defaults to a no-op.
    * @param {string} options.requestType - The telemetry request type to match.
    * @param {number} [options.timeout=30_000] - Timeout in milliseconds before the promise rejects.
    * @param {number} [options.expectedMessageCount=1] - Number of matching messages to wait for.

--- a/packages/datadog-code-origin/index.js
+++ b/packages/datadog-code-origin/index.js
@@ -3,6 +3,10 @@
 const { getEnvironmentVariable } = require('../dd-trace/src/config/helper')
 const { parseUserLandFrames } = require('../dd-trace/src/plugins/util/stacktrace')
 
+/**
+ * @typedef {(...args: unknown[]) => unknown} Callable
+ */
+
 const ENTRY_SPAN_STACK_FRAMES_LIMIT = 1
 const EXIT_SPAN_STACK_FRAMES_LIMIT =
   Number(getEnvironmentVariable('_DD_CODE_ORIGIN_FOR_SPANS_EXIT_SPAN_MAX_USER_FRAMES')) || 8
@@ -13,7 +17,7 @@ module.exports = {
 }
 
 /**
- * @param {Function} [topOfStackFunc] - A function present in the current stack, above which no stack frames should be
+ * @param {Callable} [topOfStackFunc] - A function present in the current stack, above which no stack frames should be
  *   collected.
  * @returns {Record<string, string>}
  */
@@ -22,7 +26,7 @@ function entryTags (topOfStackFunc) {
 }
 
 /**
- * @param {Function} [topOfStackFunc] - A function present in the current stack, above which no stack frames should be
+ * @param {Callable} [topOfStackFunc] - A function present in the current stack, above which no stack frames should be
  *   collected.
  * @returns {Record<string, string>}
  */
@@ -33,7 +37,7 @@ function exitTags (topOfStackFunc) {
 /**
  * @param {'entry'|'exit'} type - The type of code origin.
  * @param {number} limit - The maximum number of stack frames to include in the tags.
- * @param {Function} [topOfStackFunc] - A function present in the current stack, above which no stack frames should be
+ * @param {Callable} [topOfStackFunc] - A function present in the current stack, above which no stack frames should be
  *   collected.
  * @returns {Record<string, string>}
  */

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -65,11 +65,11 @@ function getChannelBag (suffix) {
   return bag
 }
 
-/** @type {WeakMap<Function, string>} */
+/** @type {WeakMap<(...args: unknown[]) => unknown, string>} */
 const clientNameCache = new WeakMap()
 
 /**
- * @param {Function} clientCtor
+ * @param {(...args: unknown[]) => unknown} clientCtor
  * @returns {string}
  */
 function getClientName (clientCtor) {
@@ -81,11 +81,11 @@ function getClientName (clientCtor) {
   return name
 }
 
-/** @type {WeakMap<Function, string>} */
+/** @type {WeakMap<(...args: unknown[]) => unknown, string>} */
 const operationCache = new WeakMap()
 
 /**
- * @param {Function} commandCtor
+ * @param {(...args: unknown[]) => unknown} commandCtor
  * @returns {string}
  */
 function getOperationName (commandCtor) {

--- a/packages/datadog-instrumentations/src/cypress-config.js
+++ b/packages/datadog-instrumentations/src/cypress-config.js
@@ -109,10 +109,10 @@ function injectSupportFile (config) {
  * the `ci:cypress:setup-node-events` diagnostic channel, avoiding direct
  * tracer references in the instrumentation layer.
  *
- * @param {Function} on Cypress event registration function
+ * @param {(...args: unknown[]) => unknown} on Cypress event registration function
  * @param {object} config Cypress resolved config object
- * @param {Function[]} userAfterSpecHandlers user's after:spec handlers collected from wrappedOn
- * @param {Function[]} userAfterRunHandlers user's after:run handlers collected from wrappedOn
+ * @param {(...args: unknown[]) => unknown[]} userAfterSpecHandlers user's after:spec handlers collected from wrappedOn
+ * @param {(...args: unknown[]) => unknown[]} userAfterRunHandlers user's after:run handlers collected from wrappedOn
  * @returns {object} the config object (possibly modified)
  */
 function registerDdTraceHooks (on, config, userAfterSpecHandlers, userAfterRunHandlers) {
@@ -169,8 +169,8 @@ function registerDdTraceHooks (on, config, userAfterSpecHandlers, userAfterRunHa
 }
 
 /**
- * @param {Function|undefined} originalSetupNodeEvents
- * @returns {Function}
+ * @param {(...args: unknown[]) => unknown|undefined} originalSetupNodeEvents
+ * @returns {(...args: unknown[]) => unknown}
  */
 function wrapSetupNodeEvents (originalSetupNodeEvents) {
   return function ddSetupNodeEvents (on, config) {
@@ -370,7 +370,7 @@ function configureTsNodeForTypeScript6 (projectRoot, configFilePath) {
  * via the defineConfig shimmer.
  *
  * @param {object|undefined} options
- * @returns {{ options: object|undefined, cleanup: Function }}
+ * @returns {{ options: object|undefined, cleanup: (...args: unknown[]) => unknown }}
  */
 function wrapCliConfigFileOptions (options) {
   const noop = { options, cleanup: () => {} }

--- a/packages/datadog-instrumentations/src/helpers/callback-instrumentor.js
+++ b/packages/datadog-instrumentations/src/helpers/callback-instrumentor.js
@@ -23,7 +23,7 @@ const { channel } = require('./instrument')
  *   non-error argument before publishing `:finish`. Plugins that tag spans from the call's
  *   return value (e.g. the DNS lookup plugin) rely on this.
  * @returns {(buildContext: (thisArg: unknown, args: IArguments) => object | undefined) =>
- *   (fn: Function) => Function}
+ *   (fn: (...args: unknown[]) => unknown) => (...args: unknown[]) => unknown}
  */
 function createCallbackInstrumentor (prefix, { captureResult = false } = {}) {
   const startCh = channel(prefix + ':start')

--- a/packages/datadog-instrumentations/src/helpers/hook.js
+++ b/packages/datadog-instrumentations/src/helpers/hook.js
@@ -26,13 +26,13 @@ function getVersion (moduleBaseDir) {
  * @overload
  * @param {string[]} modules list of modules to hook into
  * @param {object} hookOptions hook options
- * @param {Function} onrequire callback to be executed upon encountering module
+ * @param {(...args: unknown[]) => unknown} onrequire callback to be executed upon encountering module
  */
 /**
  * @overload
  * @param {string[]} modules list of modules to hook into
  * @param {object} hookOptions hook options
- * @param {Function} onrequire callback to be executed upon encountering module
+ * @param {(...args: unknown[]) => unknown} onrequire callback to be executed upon encountering module
  */
 function Hook (modules, hookOptions, onrequire) {
   // TODO: Rewrite this to use class syntax. The same should be done for ritm.

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -1825,8 +1825,8 @@ function removeDatadogTestEnvironmentOptions (testEnvironmentOptions) {
  * Wrap `createScriptTransformer` to temporarily hide Datadog-specific
  * `testEnvironmentOptions` keys while Jest builds its transform config.
  *
- * @param {Function} createScriptTransformer
- * @returns {Function}
+ * @param {(...args: unknown[]) => unknown} createScriptTransformer
+ * @returns {(...args: unknown[]) => unknown}
  */
 function wrapCreateScriptTransformer (createScriptTransformer) {
   return function (config) {

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -6,7 +6,7 @@ const shimmer = require('../../datadog-shimmer')
 const satisfies = require('../../../vendor/dist/semifies')
 const { channel, addHook } = require('./helpers/instrument')
 
-/** @type {WeakMap<object, Function>} */
+/** @type {WeakMap<object, (...args: unknown[]) => unknown>} */
 const wrappedOnResult = new WeakMap()
 
 /**
@@ -18,9 +18,9 @@ function resolveSqlString (sql) {
 }
 
 /**
- * @param {Function} Connection
+ * @param {(...args: unknown[]) => unknown} Connection
  * @param {string} version
- * @returns {Function}
+ * @returns {(...args: unknown[]) => unknown}
  */
 function wrapConnection (Connection, version) {
   const startCh = channel('apm:mysql2:query:start')
@@ -35,7 +35,7 @@ function wrapConnection (Connection, version) {
   shimmer.wrap(Connection.prototype, 'addCommand', addCommand => function (cmd) {
     if (!startCh.hasSubscribers) return addCommand.apply(this, arguments)
 
-    const command = /** @type {{ execute?: Function, constructor?: { name?: string } }} */ (cmd)
+    const command = /** @type {{ execute?: (...args: unknown[]) => unknown, constructor?: { name?: string } }} */ (cmd)
     if (typeof command.execute !== 'function') return addCommand.apply(this, arguments)
 
     const name = command.constructor?.name
@@ -155,10 +155,10 @@ function wrapConnection (Connection, version) {
 
   /**
    * @param {object} cmd
-   * @param {Function} execute
+   * @param {(...args: unknown[]) => unknown} execute
    * @param {object} ctx
    * @param {object} config
-   * @returns {Function}
+   * @returns {(...args: unknown[]) => unknown}
    */
   function wrapExecute (cmd, execute, ctx, config) {
     return shimmer.wrapFunction(execute, execute => function executeWithTrace (packet, connection) {
@@ -184,7 +184,7 @@ function wrapConnection (Connection, version) {
             finishCh.runStores(ctx, onResult, this, ...arguments)
           })
         } else {
-          const command = /** @type {{ once?: Function }} */ (this)
+          const command = /** @type {{ once?: (...args: unknown[]) => unknown }} */ (this)
           if (typeof command.once === 'function') {
             command.once(errorMonitor, error => {
               ctx.error = error
@@ -207,9 +207,9 @@ function wrapConnection (Connection, version) {
   }
 }
 /**
- * @param {Function} Pool
+ * @param {(...args: unknown[]) => unknown} Pool
  * @param {string} version
- * @returns {Function}
+ * @returns {(...args: unknown[]) => unknown}
  */
 function wrapPool (Pool, version) {
   const startOuterQueryCh = channel('datadog:mysql2:outerquery:start')
@@ -269,7 +269,7 @@ function wrapPool (Pool, version) {
 
       if (typeof cb === 'function') {
         process.nextTick(() => {
-          /** @type {Function} */ (cb)(abortController.signal.reason)
+          /** @type {(...args: unknown[]) => unknown} */ (cb)(abortController.signal.reason)
         })
       }
       return
@@ -282,8 +282,8 @@ function wrapPool (Pool, version) {
 }
 
 /**
- * @param {Function} PoolCluster
- * @returns {Function}
+ * @param {(...args: unknown[]) => unknown} PoolCluster
+ * @returns {(...args: unknown[]) => unknown}
  */
 function wrapPoolCluster (PoolCluster) {
   const startOuterQueryCh = channel('datadog:mysql2:outerquery:start')
@@ -341,7 +341,7 @@ function wrapPoolCluster (PoolCluster) {
 
           if (typeof cb === 'function') {
             process.nextTick(() => {
-              /** @type {Function} */ (cb)(abortController.signal.reason)
+              /** @type {(...args: unknown[]) => unknown} */ (cb)(abortController.signal.reason)
             })
           }
 

--- a/packages/datadog-instrumentations/src/prisma.js
+++ b/packages/datadog-instrumentations/src/prisma.js
@@ -141,7 +141,8 @@ function resolveClientDbConfig (clientConfig, datasourceName, runtimeDbConfig) {
  */
 const prismaHook = (runtime, versions, isIitm) => {
   /**
-   * @typedef {{ getPrismaClient?: (config: PrismaRuntimeConfig, ...args: unknown[]) => Function }} PrismaRuntime
+   * @typedef {(...args: unknown[]) => unknown} Callable
+   * @typedef {{ getPrismaClient?: (config: PrismaRuntimeConfig, ...args: unknown[]) => Callable }} PrismaRuntime
    */
   const prismaRuntime = /** @type {PrismaRuntime} */ (runtime)
   const originalGetPrismaClient = prismaRuntime.getPrismaClient

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -171,7 +171,7 @@ function isReporterPackageNewest (vitestPackage) {
  * Minified export keys change across versions, so we search by function/class name.
  * @param {object} pkg - The module exports object
  * @param {string} name - The `.name` value to look for
- * @returns {{ key: string, value: Function } | undefined}
+ * @returns {{ key: string, value: (...args: unknown[]) => unknown } | undefined}
  */
 function findExportByName (pkg, name) {
   for (const [key, value] of Object.entries(pkg)) {
@@ -283,8 +283,8 @@ function recordFinalAttemptToFixExecution (task, status, providedContext) {
 /**
  * Wraps a function so it runs inside the current test span context.
  * @param {object} task
- * @param {Function} fn
- * @returns {Function}
+ * @param {(...args: unknown[]) => unknown} fn
+ * @returns {(...args: unknown[]) => unknown}
  */
 function wrapTestScopedFn (task, fn) {
   return shimmer.wrapFunction(fn, fn => function () {

--- a/packages/datadog-instrumentations/src/ws.js
+++ b/packages/datadog-instrumentations/src/ws.js
@@ -119,11 +119,11 @@ function createWrapEmit (emit) {
 }
 
 /**
- * @param {Function} setSocket
+ * @param {(...args: unknown[]) => unknown} setSocket
  * @returns {(...args: unknown[]) => unknown}
  */
 /**
- * @param {Function} on
+ * @param {(...args: unknown[]) => unknown} on
  * @returns {(...args: unknown[]) => unknown}
  */
 function wrapReceiverOn (on) {
@@ -188,7 +188,7 @@ addHook({
  * finished connection span is retained for the entire lifetime of the WebSocket
  * (via ACF -> handle -> WeakMap).
  *
- * @param {Function} setSocket
+ * @param {(...args: unknown[]) => unknown} setSocket
  * @returns {(...args: unknown[]) => unknown}
  */
 function wrapSetSocket (setSocket) {

--- a/packages/datadog-instrumentations/test/aws-sdk.spec.js
+++ b/packages/datadog-instrumentations/test/aws-sdk.spec.js
@@ -16,7 +16,7 @@ const SMITHY_HOOK = globalThis[Symbol.for('_ddtrace_instrumentations')]['@smithy
  * @param {string} serviceId Suffix the wrapper feeds into the channel-name
  *   lookup; pick a unique one per test to keep diagnostic-channel state
  *   isolated.
- * @returns {Function}
+ * @returns {(...args: unknown[]) => unknown}
  */
 function makeFakeClientClass (serviceId) {
   class FakeClient {

--- a/packages/datadog-plugin-nyc/src/index.js
+++ b/packages/datadog-plugin-nyc/src/index.js
@@ -66,7 +66,7 @@ class NycPlugin extends CiPlugin {
   /**
    * Handles the coverage report by discovering and uploading it if enabled.
    * @param {string} rootDir - The root directory where coverage reports are located.
-   * @param {Function} [onDone] - Callback to signal completion.
+   * @param {(...args: unknown[]) => unknown} [onDone] - Callback to signal completion.
    */
   handleCoverageReport (rootDir, onDone) {
     const done = onDone || (() => {})

--- a/packages/datadog-plugin-prisma/src/datadog-tracing-helper.js
+++ b/packages/datadog-plugin-prisma/src/datadog-tracing-helper.js
@@ -87,7 +87,7 @@ class DatadogTracingHelper {
 
   /**
    * @param {object} options
-   * @param {Function} callback
+   * @param {(...args: unknown[]) => unknown} callback
    * @returns {unknown}
    */
   runInChildSpan (options, callback) {

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -436,7 +436,7 @@ class VitestPlugin extends CiPlugin {
   /**
    * Handles the coverage report by discovering and uploading it if enabled.
    * @param {string} rootDir - The root directory where coverage reports are located.
-   * @param {Function} [onDone] - Callback to signal completion.
+   * @param {(...args: unknown[]) => unknown} [onDone] - Callback to signal completion.
    */
   handleCoverageReport (rootDir, onDone) {
     if (!this.libraryConfig?.isCoverageReportUploadEnabled) {

--- a/packages/datadog-shimmer/src/shimmer.js
+++ b/packages/datadog-shimmer/src/shimmer.js
@@ -1,6 +1,10 @@
 'use strict'
 
 /**
+ * @typedef {(...args: unknown[]) => unknown} Callable
+ */
+
+/**
  * @type {Set<string | symbol>}
  */
 const skipMethods = new Set([
@@ -16,8 +20,8 @@ const nonConfigurableModuleExports = new WeakMap()
 /**
  * Copies properties from the original function to the wrapped function.
  *
- * @param {Function} original - The original function.
- * @param {Function} wrapped - The wrapped function.
+ * @param {Callable} original - The original function.
+ * @param {Callable} wrapped - The wrapped function.
  */
 function copyProperties (original, wrapped) {
   if (original.constructor !== wrapped.constructor) {
@@ -68,9 +72,9 @@ function copyObjectProperties (original, wrapped, skipKey) {
 /**
  * Wraps a function with a wrapper function.
  *
- * @param {Function} original - The original function to wrap.
- * @param {(original: Function) => Function} wrapper - The wrapper function.
- * @returns {Function} The wrapped function.
+ * @param {Callable} original - The original function to wrap.
+ * @param {(original: Callable) => Callable} wrapper - The wrapper function.
+ * @returns {Callable} The wrapped function.
  */
 function wrapFunction (original, wrapper) {
   if (typeof original !== 'function') return original
@@ -85,16 +89,16 @@ function wrapFunction (original, wrapper) {
 /**
  * Wraps a method of an object with a wrapper function.
  *
- * @param {Record<string | symbol, unknown> | Function | undefined} target - The target
+ * @param {Record<string | symbol, unknown> | Callable | undefined} target - The target
  * object.
  * @param {string | symbol} name - The property key of the method to wrap.
- * @param {(original: Function) => (...args: unknown[]) => unknown} wrapper - The wrapper function.
+ * @param {(original: Callable) => (...args: unknown[]) => unknown} wrapper - The wrapper function.
  * @param {{ replaceGetter?: boolean }} [options] - If `replaceGetter` is set to
  * true, the getter is accessed and the getter is replaced with one that just
  * returns the earlier retrieved value. Use with care! This may only be done in
  * case the getter absolutely has no side effect and no setter is defined for the
  * property.
- * @returns {Record<string | symbol, unknown> | Function | undefined} The target object with
+ * @returns {Record<string | symbol, unknown> | Callable | undefined} The target object with
  * the wrapped method.
  */
 function wrap (target, name, wrapper, options) {
@@ -207,11 +211,11 @@ function wrap (target, name, wrapper, options) {
  * Wraps multiple methods and or multiple objects with a wrapper function.
  * May also receive a single method or object or a single method name.
  *
- * @param {Array<Record<string | symbol, unknown> | Function> |
+ * @param {Array<Record<string | symbol, unknown> | Callable> |
  *         Record<string | symbol, unknown> |
- *         Function} targets - The target objects.
+ *         Callable} targets - The target objects.
  * @param {Array<string | symbol> | string | symbol} names - The property keys of the methods to wrap.
- * @param {(original: Function) => (...args: unknown[]) => unknown} wrapper - The wrapper function.
+ * @param {(original: Callable) => (...args: unknown[]) => unknown} wrapper - The wrapper function.
  */
 function massWrap (targets, names, wrapper) {
   targets = toArray(targets)
@@ -238,7 +242,7 @@ function toArray (maybeArray) {
 /**
  * Asserts that a method is a function.
  *
- * @param {Record<string | symbol, unknown> | Function} target - The target object.
+ * @param {Record<string | symbol, unknown> | Callable} target - The target object.
  * @param {string | symbol} name - The property key of the method.
  * @param {unknown} method - The method to assert.
  * @throws {Error} If the method is not a function.
@@ -263,7 +267,7 @@ function assertMethod (target, name, method) {
 /**
  * Asserts that a target is not a class constructor.
  *
- * @param {Function} target - The target function.
+ * @param {Callable} target - The target function.
  * @throws {Error} If the target is a class constructor.
  */
 function assertNotClass (target) {

--- a/packages/dd-trace/src/agent/info.js
+++ b/packages/dd-trace/src/agent/info.js
@@ -16,7 +16,7 @@ module.exports = {
 /**
  * Fetches agent information from the /info endpoint
  * @param {URL} url - The agent URL
- * @param {Function} callback - Callback function with signature (err, agentInfo)
+ * @param {(...args: unknown[]) => unknown} callback - Callback function with signature (err, agentInfo)
  */
 function fetchAgentInfo (url, callback) {
   const urlKey = url.href

--- a/packages/dd-trace/src/aiguard/index.js
+++ b/packages/dd-trace/src/aiguard/index.js
@@ -43,7 +43,11 @@ function disable () {
 /**
  * Handles channel messages with pre-converted messages.
  *
- * @param {{messages: Array<object>, resolve: Function, reject: Function}} ctx
+ * @param {{
+ *   messages: Array<object>,
+ *   resolve: (...args: unknown[]) => unknown,
+ *   reject: (...args: unknown[]) => unknown,
+ * }} ctx
  */
 function onEvaluate (ctx) {
   if (!ctx.messages?.length) {

--- a/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
+++ b/packages/dd-trace/src/ci-visibility/early-flake-detection/get-known-tests.js
@@ -114,7 +114,7 @@ function getKnownTests ({
  * @param {string} params.runtimeVersion
  * @param {object} [params.custom]
  * @param {string | null} params.cacheKey
- * @param {Function} done
+ * @param {(...args: unknown[]) => unknown} done
  */
 function fetchFromApi ({
   url,

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -399,7 +399,7 @@ class CiVisibilityExporter extends BufferingExporter {
    * @param {string} options.filePath - Path to the coverage report file
    * @param {string} options.format - Format of the coverage report
    * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
-   * @param {Function} callback - Callback function (err)
+   * @param {(...args: unknown[]) => unknown} callback - Callback function (err)
    */
   uploadCoverageReport ({ filePath, format, testEnvironmentMetadata }, callback) {
     if (!this._codeCoverageReportUrl) {

--- a/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
+++ b/packages/dd-trace/src/ci-visibility/intelligent-test-runner/get-skippable-suites.js
@@ -82,7 +82,7 @@ function getSkippableSuites ({
  * @param {object} [params.custom]
  * @param {string} [params.testLevel]
  * @param {string | null} params.cacheKey
- * @param {Function} done
+ * @param {(...args: unknown[]) => unknown} done
  */
 function fetchFromApi ({
   url,

--- a/packages/dd-trace/src/ci-visibility/requests/fs-cache.js
+++ b/packages/dd-trace/src/ci-visibility/requests/fs-cache.js
@@ -145,7 +145,7 @@ function touchLock (cacheKey) {
  * Returns a function that stops the heartbeat and releases the lock.
  *
  * @param {string} cacheKey
- * @returns {Function}
+ * @returns {(...args: unknown[]) => unknown}
  */
 function startLockHeartbeat (cacheKey) {
   const interval = setInterval(() => touchLock(cacheKey), CACHE_LOCK_HEARTBEAT_MS)
@@ -175,8 +175,8 @@ function isLockStale (cacheKey) {
  * Polls until the cache file appears or the timeout is reached.
  *
  * @param {string} cacheKey
- * @param {Function} fetchFn - function(done) that fetches from the API
- * @param {Function} done - callback(err, ...results)
+ * @param {(...args: unknown[]) => unknown} fetchFn - function(done) that fetches from the API
+ * @param {(...args: unknown[]) => unknown} done - callback(err, ...results)
  */
 function waitForCache (cacheKey, fetchFn, done) {
   const poll = () => {
@@ -215,9 +215,9 @@ function waitForCache (cacheKey, fetchFn, done) {
  * When enabled, checks cache → acquires lock → fetches → writes cache → releases lock.
  *
  * @param {string} cacheKey - Unique cache key for this request
- * @param {Function} fetchFn - function(cacheKey, done) that performs the API request.
+ * @param {(...args: unknown[]) => unknown} fetchFn - function(cacheKey, done) that performs the API request.
  *   Must call writeToCache(cacheKey, data) on success before calling done(null, data).
- * @param {Function} done - callback(err, ...results)
+ * @param {(...args: unknown[]) => unknown} done - callback(err, ...results)
  */
 function withCache (cacheKey, fetchFn, done) {
   if (!isCacheEnabled()) {

--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -43,7 +43,7 @@ function parseUrl (urlObjOrString) {
  *
  * @param {string} data - Request body (e.g. JSON string)
  * @param {object} options - { url, path?, method?, headers?, timeout? } (may be mutated)
- * @param {Function} callback - (err, res, statusCode) => void
+ * @param {(...args: unknown[]) => unknown} callback - (err, res, statusCode) => void
  */
 function request (data, options, callback) {
   const headers = options.headers ? { ...options.headers } : {}

--- a/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-coverage-report.js
@@ -28,7 +28,7 @@ const UPLOAD_TIMEOUT_MS = 30_000
  * @param {URL} options.url - The base URL for the coverage report upload
  * @param {boolean} [options.isEvpProxy] - Whether to use EVP proxy for the upload
  * @param {string} [options.evpProxyPrefix] - The EVP proxy prefix (e.g., '/evp_proxy/v4')
- * @param {Function} callback - Callback function (err)
+ * @param {(...args: unknown[]) => unknown} callback - Callback function (err)
  */
 function uploadCoverageReport (
   { filePath, format, testEnvironmentMetadata, url, isEvpProxy, evpProxyPrefix },

--- a/packages/dd-trace/src/ci-visibility/test-management/get-test-management-tests.js
+++ b/packages/dd-trace/src/ci-visibility/test-management/get-test-management-tests.js
@@ -88,7 +88,7 @@ function getTestManagementTests ({
  * @param {string} [params.commitHeadMessage]
  * @param {string} [params.branch]
  * @param {string | null} params.cacheKey
- * @param {Function} done
+ * @param {(...args: unknown[]) => unknown} done
  */
 function fetchFromApi ({
   url,

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -256,8 +256,9 @@ session.on('Debugger.paused', async ({ params }) => {
           message: error.message,
         }))
       }
+      const processLocals = /** @type {(...args: unknown[]) => unknown} */ (processLocalState)
       snapshot.captures = {
-        lines: { [probe.location.lines[0]]: { locals: /** @type {Function} */ (processLocalState)() } },
+        lines: { [probe.location.lines[0]]: { locals: processLocals() } },
       }
     } else if (probe.compiledCaptureExpressions !== undefined) {
       const expressionResult = /** @type {Map} */ (captureExpressionResults).get(probe.id)

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -115,7 +115,7 @@ class AgentlessExporter {
 
   /**
    * Flushes any pending traces immediately. Clears the batch timer.
-   * @param {Function} [done] - Callback when flush is complete
+   * @param {(...args: unknown[]) => unknown} [done] - Callback when flush is complete
    */
   flush (done = () => {}) {
     clearTimeout(this.#timer)

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -54,7 +54,7 @@ class AgentlessWriter extends BaseWriter {
 
   /**
    * Flushes accumulated traces to the intake as a single request.
-   * @param {Function} [done] - Callback when send completes
+   * @param {(...args: unknown[]) => unknown} [done] - Callback when send completes
    */
   flush (done = () => {}) {
     if (!request.writable) {
@@ -89,7 +89,7 @@ class AgentlessWriter extends BaseWriter {
    * Sends the encoded payload to the intake endpoint.
    * @param {Buffer} data - The encoded JSON payload
    * @param {number} count - Number of traces in the payload
-   * @param {Function} done - Callback when complete
+   * @param {(...args: unknown[]) => unknown} done - Callback when complete
    */
   _sendPayload (data, count, done) {
     if (!data || data.length === 0) {

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -62,7 +62,7 @@ function crashFlush () {
 /**
  * Patches your AWS Lambda handler function to add some tracing support.
  *
- * @param {Function} lambdaHandler a Lambda handler function.
+ * @param {(...args: unknown[]) => unknown} lambdaHandler a Lambda handler function.
  */
 exports.datadog = function datadog (lambdaHandler) {
   return (...args) => {

--- a/packages/dd-trace/src/lambda/runtime/patch.js
+++ b/packages/dd-trace/src/lambda/runtime/patch.js
@@ -27,7 +27,7 @@ const patchDatadogLambdaModule = (datadogLambdaModule) => {
  * Datadog instrumentation by getting the Lambda handler from its
  * arguments.
  *
- * @param {Function} datadogHandler the Datadog Lambda handler to destructure.
+ * @param {(...args: unknown[]) => unknown} datadogHandler the Datadog Lambda handler to destructure.
  * @returns the datadogHandler with its arguments patched.
  */
 function patchDatadogLambdaHandler (datadogHandler) {
@@ -51,7 +51,7 @@ const patchLambdaModule = (handlerPath) => (lambdaModule) => {
 /**
  * Patches a Lambda handler in order to do Datadog instrumentation.
  *
- * @param {Function} lambdaHandler the Lambda handler to be patched.
+ * @param {(...args: unknown[]) => unknown} lambdaHandler the Lambda handler to be patched.
  * @returns a function which patches the given Lambda handler.
  */
 function patchLambdaHandler (lambdaHandler) {

--- a/packages/dd-trace/src/openfeature/remote_config.js
+++ b/packages/dd-trace/src/openfeature/remote_config.js
@@ -7,7 +7,7 @@ const RemoteConfigCapabilities = require('../remote_config/capabilities')
  *
  * @param {object} rc - RemoteConfig instance
  * @param {object} config - Tracer config
- * @param {Function} getOpenfeatureProxy - Function that returns the OpenFeature proxy from tracer
+ * @param {(...args: unknown[]) => unknown} getOpenfeatureProxy - Returns the OpenFeature proxy from tracer
  */
 function enable (rc, config, getOpenfeatureProxy) {
   // Always enable capability for feature flag configuration

--- a/packages/dd-trace/src/openfeature/writers/util.js
+++ b/packages/dd-trace/src/openfeature/writers/util.js
@@ -8,7 +8,7 @@ const { getAgentUrl } = require('../../agent/url')
 /**
  * Determines if the agent supports EVP proxy and sets the writer enabled state accordingly
  * @param {import('../../config')} config - Tracer configuration object
- * @param {Function} setWriterEnabledValue - Callback to set the writer enabled state
+ * @param {(...args: unknown[]) => unknown} setWriterEnabledValue - Callback to set the writer enabled state
  */
 function setAgentStrategy (config, setWriterEnabledValue) {
   fetchAgentInfo(getAgentUrl(config), (err, agentInfo) => {

--- a/packages/dd-trace/src/opentelemetry/logs/otlp_http_log_exporter.js
+++ b/packages/dd-trace/src/opentelemetry/logs/otlp_http_log_exporter.js
@@ -37,7 +37,7 @@ class OtlpHttpLogExporter extends OtlpHttpExporterBase {
    * Exports log records via OTLP over HTTP.
    *
    * @param {LogRecord[]} logRecords - Array of enriched log records to export
-   * @param {Function} resultCallback - Callback function for export result
+   * @param {(...args: unknown[]) => unknown} resultCallback - Callback function for export result
    *
    * @returns {void}
    */

--- a/packages/dd-trace/src/opentelemetry/metrics/instruments.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/instruments.js
@@ -131,7 +131,7 @@ class ObservableInstrument extends Instrument {
   /**
    * Adds a callback to invoke during metric collection.
    *
-   * @param {Function} callback - Receives an ObservableResult to record observations
+   * @param {(...args: unknown[]) => unknown} callback - Receives an ObservableResult to record observations
    */
   addCallback (callback) {
     if (typeof callback !== 'function') return
@@ -142,7 +142,7 @@ class ObservableInstrument extends Instrument {
   /**
    * Removes a callback.
    *
-   * @param {Function} callback - The callback to remove
+   * @param {(...args: unknown[]) => unknown} callback - The callback to remove
    */
   removeCallback (callback) {
     const index = this.#callbacks.indexOf(callback)

--- a/packages/dd-trace/src/opentelemetry/metrics/meter.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/meter.js
@@ -53,7 +53,7 @@ class Meter {
    *
    * @param {string} name - Instrument name (will be normalized to lowercase)
    * @param {string} type - Instrument type (e.g., 'counter', 'histogram', 'gauge')
-   * @param {Function} InstrumentClass - Constructor for the instrument type
+   * @param {(...args: unknown[]) => unknown} InstrumentClass - Constructor for the instrument type
    * @param {MetricOptions} [options] - Instrument options (description, unit, etc.)
    * @returns {Instrument} The instrument instance (new or cached)
    */
@@ -150,7 +150,7 @@ class Meter {
   /**
    * Adds a batch observable callback (not implemented).
    *
-   * @param {Function} callback - Batch observable callback
+   * @param {(...args: unknown[]) => unknown} callback - Batch observable callback
    * @param {Array} observables - Array of observable instruments
    */
   addBatchObservableCallback (callback, observables) {
@@ -160,7 +160,7 @@ class Meter {
   /**
    * Removes a batch observable callback (not implemented).
    *
-   * @param {Function} callback - Batch observable callback
+   * @param {(...args: unknown[]) => unknown} callback - Batch observable callback
    * @param {Array} observables - Array of observable instruments
    */
   removeBatchObservableCallback (callback, observables) {

--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -184,7 +184,7 @@ class PeriodicMetricReader {
   /**
    * Collects measurements and exports metrics.
    *
-   * @param {Function} [callback] - Called after export completes
+   * @param {(...args: unknown[]) => unknown} [callback] - Called after export completes
    */
   #collectAndExport (callback = () => {}) {
     // Atomically drain measurements for export. New measurements can be recorded
@@ -425,7 +425,7 @@ class MetricAggregator {
    * @param {AggregatedMetric} metric - The metric to find or create a data point for
    * @param {Attributes} attributes - The attributes of the metric
    * @param {string} attrKey - The attribute key
-   * @param {Function} createInitialDataPoint - Function to create an initial data point
+   * @param {(...args: unknown[]) => unknown} createInitialDataPoint - Function to create an initial data point
    * @returns {NumberDataPoint|HistogramDataPoint} - The data point
    */
   #findOrCreateDataPoint (metric, attributes, attrKey, createInitialDataPoint) {

--- a/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
+++ b/packages/dd-trace/src/opentelemetry/otlp/otlp_http_exporter_base.js
@@ -69,7 +69,7 @@ class OtlpHttpExporterBase {
   /**
    * Sends the payload via HTTP request.
    * @param {Buffer|string} payload - The payload to send
-   * @param {Function} resultCallback - Callback for the result
+   * @param {(...args: unknown[]) => unknown} resultCallback - Callback for the result
    * @protected
    */
   sendPayload (payload, resultCallback) {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -712,7 +712,7 @@ module.exports = class CiPlugin extends Plugin {
    * Uploads coverage reports if enabled. This is the common logic used by plugins.
    * @param {object} options - Upload options
    * @param {string} options.rootDir - The root directory where coverage reports are located
-   * @param {Function} [options.onDone] - Callback to signal completion
+   * @param {(...args: unknown[]) => unknown} [options.onDone] - Callback to signal completion
    */
   uploadCoverageReports ({ rootDir, onDone }) {
     const done = onDone || (() => {})

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -110,7 +110,7 @@ class TracingPlugin extends Plugin {
 
   /**
    * @param {string} eventName
-   * @param {Function} handler
+   * @param {(...args: unknown[]) => unknown} handler
    */
   addTraceSub (eventName, handler) {
     const prefix = this.constructor.prefix || `apm:${this.component}:${this.operation}`
@@ -119,7 +119,7 @@ class TracingPlugin extends Plugin {
 
   /**
    * @param {string} eventName
-   * @param {Function} transform
+   * @param {(...args: unknown[]) => unknown} transform
    */
   addTraceBind (eventName, transform) {
     const prefix = this.constructor.prefix || `apm:${this.component}:${this.operation}`

--- a/packages/dd-trace/src/remote_config/index.js
+++ b/packages/dd-trace/src/remote_config/index.js
@@ -123,7 +123,7 @@ class RemoteConfig {
    * It **implies subscription** (equivalent to calling `subscribeProducts(product)`).
    *
    * @param {string} product
-   * @param {Function} handler
+   * @param {(...args: unknown[]) => unknown} handler
    */
   setProductHandler (product, handler) {
     this.#handlers.set(product, handler)
@@ -201,7 +201,7 @@ class RemoteConfig {
   /**
    * Remove a previously-registered batch handler.
    *
-   * @param {Function} handler
+   * @param {(...args: unknown[]) => unknown} handler
    */
   removeBatchHandler (handler) {
     this.#batchHandlers.delete(handler)

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -44,12 +44,12 @@ function normalizeModuleName (name) {
  * @overload
  * @param {string[]} modules list of modules to hook into
  * @param {object} options hook options
- * @param {Function} onrequire callback to be executed upon encountering module
+ * @param {(...args: unknown[]) => unknown} onrequire callback to be executed upon encountering module
  */
 /**
  * @overload
  * @param {string[]} modules list of modules to hook into
- * @param {Function} onrequire callback to be executed upon encountering module
+ * @param {(...args: unknown[]) => unknown} onrequire callback to be executed upon encountering module
  */
 function Hook (modules, options, onrequire) {
   if (!(this instanceof Hook)) return new Hook(modules, options, onrequire)

--- a/packages/dd-trace/src/telemetry/telemetry.js
+++ b/packages/dd-trace/src/telemetry/telemetry.js
@@ -18,7 +18,8 @@ const sessionPropagation = require('./session-propagation')
  * @typedef {Record<string, unknown>} TelemetryPayloadObject
  */
 /**
- * @typedef {string | number | boolean | null | URL | Record<string, unknown> | unknown[] | Function} ConfigValue
+ * @typedef {string | number | boolean | null | URL | Record<string, unknown> | unknown[]
+ *   | ((...args: unknown[]) => unknown)} ConfigValue
  */
 /**
  * @typedef {{ [K in keyof processTags]: typeof processTags.tagsObject[K] }} ProcessTags

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -15,7 +15,7 @@ describe('breakpoints', function () {
   /**
    * @type {{
    *   post: sinon.SinonStub;
-   *   on: Function;
+   *   on: (...args: unknown[]) => unknown;
    *   '@noCallThru': boolean;
    * }}
    */

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -26,7 +26,7 @@ const event = {
 describe('onPause', function () {
   /**
    * @typedef {{
-   *   on: sinon.SinonSpy & { args: Array<[string, Function]> },
+   *   on: sinon.SinonSpy & { args: Array<[string, (...args: unknown[]) => unknown]> },
    *   post: sinon.SinonSpy,
    *   emit: sinon.SinonSpy,
    *   '@noCallThru'?: boolean
@@ -36,7 +36,7 @@ describe('onPause', function () {
   let session
   /** @type {sinon.SinonSpy} */
   let send
-  /** @type {Function} */
+  /** @type {(...args: unknown[]) => unknown} */
   let onPaused
   /** @type {sinon.SinonSpy} */
   let ackReceived

--- a/packages/dd-trace/test/debugger/devtools_client/state.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/state.spec.js
@@ -244,8 +244,8 @@ describe('getStackFromCallFrames', function () {
    *
    * @param {object} options - Configuration options
    * @param {Array<object>} options.scripts - Scripts to register
-   * @param {Function} options.getOriginalPosition - Source map resolution function
-   * @param {Function} [options.loadSourceMapSync] - Source map loader function
+   * @param {(...args: unknown[]) => unknown} options.getOriginalPosition - Source map resolution function
+   * @param {(...args: unknown[]) => unknown} [options.loadSourceMapSync] - Source map loader function
    * @returns {object} - The state module
    */
   function createState ({ scripts, getOriginalPosition, loadSourceMapSync = () => ({ sources: [] }) }) {

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -448,7 +448,7 @@ module.exports = {
 
   /**
    * Register handler to be executed on each agent call, multiple times
-   * @param {Function} handler
+   * @param {(...args: unknown[]) => unknown} handler
    */
   subscribe (handler) {
     traceHandlers.add({ handler })
@@ -456,7 +456,7 @@ module.exports = {
 
   /**
    * Remove a handler
-   * @param {Function} handler
+   * @param {(...args: unknown[]) => unknown} handler
    */
   unsubscribe (handler) {
     for (const traceHandler of traceHandlers) {


### PR DESCRIPTION
## Summary

Activates `jsdoc/reject-function-type`. `Function` is replaced with
`(...args: unknown[]) => unknown` (or a `Callable` typedef where the
type appears repeatedly). Files with multiple long type expressions
get a per-file `Callable` typedef so the JSDoc lines stay under the
120-char cap.