### PR TITLE
refactor(prefer-rest-params): convert non-instrumentation wrappers

### DIFF
--- a/benchmark/sirun/shimmer-runtime/index.js
+++ b/benchmark/sirun/shimmer-runtime/index.js
@@ -46,8 +46,8 @@ if (ENABLED !== 'true') {
 } else {
   if (WRAP_FUNCTION === 'true') {
     const wrapped = shimmer.wrapFunction(testedFn, (original) => {
-      return function () {
-        return original.apply(this, arguments)
+      return function (...args) {
+        return original.apply(this, args)
       }
     })
     for (let i = 0; i < ITERATIONS; i++) {
@@ -58,8 +58,8 @@ if (ENABLED !== 'true') {
       testedFn,
     }
     shimmer.wrap(obj, 'testedFn', (original) => {
-      return function () {
-        return original.apply(this, arguments)
+      return function (...args) {
+        return original.apply(this, args)
       }
     })
     const wrapped = obj.testedFn

--- a/benchmark/sirun/shimmer-startup/index.js
+++ b/benchmark/sirun/shimmer-startup/index.js
@@ -43,8 +43,8 @@ if (ENABLED === 'true') {
   if (WRAP_FUNCTION === 'true') {
     for (let i = 0; i < ITERATIONS; i++) {
       shimmer.wrapFunction(testedFn, (original) => {
-        return function () {
-          return original.apply(this, arguments)
+        return function (...args) {
+          return original.apply(this, args)
         }
       })
     }
@@ -54,8 +54,8 @@ if (ENABLED === 'true') {
     }
     for (let i = 0; i < ITERATIONS; i++) {
       shimmer.wrap(obj, 'testedFn', (original) => {
-        return function () {
-          return original.apply(this, arguments)
+        return function (...args) {
+          return original.apply(this, args)
         }
       })
     }

--- a/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
@@ -40,20 +40,20 @@ describe('Sfn', () => {
         const client = new lib.SFNClient(params)
         return {
           client,
-          createStateMachine: function () {
-            const req = new lib.CreateStateMachineCommand(...arguments)
+          createStateMachine: function (...args) {
+            const req = new lib.CreateStateMachineCommand(...args)
             return client.send(req)
           },
-          deleteStateMachine: function () {
-            const req = new lib.DeleteStateMachineCommand(...arguments)
+          deleteStateMachine: function (...args) {
+            const req = new lib.DeleteStateMachineCommand(...args)
             return client.send(req)
           },
-          startExecution: function () {
-            const req = new lib.StartExecutionCommand(...arguments)
+          startExecution: function (...args) {
+            const req = new lib.StartExecutionCommand(...args)
             return client.send(req)
           },
-          describeExecution: function () {
-            const req = new lib.DescribeExecutionCommand(...arguments)
+          describeExecution: function (...args) {
+            const req = new lib.DescribeExecutionCommand(...args)
             return client.send(req)
           },
         }
@@ -62,12 +62,12 @@ describe('Sfn', () => {
         const client = new StepFunctions(params)
         return {
           client,
-          createStateMachine: function () { return client.createStateMachine(...arguments).promise() },
-          deleteStateMachine: function () {
-            return client.deleteStateMachine(...arguments).promise()
+          createStateMachine: function (...args) { return client.createStateMachine(...args).promise() },
+          deleteStateMachine: function (...args) {
+            return client.deleteStateMachine(...args).promise()
           },
-          startExecution: function () { return client.startExecution(...arguments).promise() },
-          describeExecution: function () { return client.describeExecution(...arguments).promise() },
+          startExecution: function (...args) { return client.startExecution(...args).promise() },
+          describeExecution: function (...args) { return client.describeExecution(...args).promise() },
         }
       }
     }

--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -99,14 +99,14 @@ describe('Plugin', () => {
 
             // Server-side safeguard: if something tries to send a response, record it.
             const writeHead = res.writeHead
-            res.writeHead = function () {
+            res.writeHead = function (...args) {
               responseSent = true
-              return writeHead.apply(this, arguments)
+              return writeHead.apply(this, args)
             }
             const end = res.end
-            res.end = function () {
+            res.end = function (...args) {
               responseSent = true
-              return end.apply(this, arguments)
+              return end.apply(this, args)
             }
 
             allowHandler.then(() => {

--- a/packages/datadog-plugin-rhea/test/index.spec.js
+++ b/packages/datadog-plugin-rhea/test/index.spec.js
@@ -455,9 +455,9 @@ describe('Plugin', () => {
                 const Session = require(`../../../versions/rhea@${version}/node_modules/rhea/lib/session.js`)
                 const onTransfer = Session.prototype.on_transfer
                 const error = new Error('this is an error')
-                Session.prototype.on_transfer = function onTransferWrapped () {
+                Session.prototype.on_transfer = function onTransferWrapped (...args) {
                   try {
-                    return onTransfer.apply(this, arguments)
+                    return onTransfer.apply(this, args)
                   } catch (e) {
                     // this is just to prevent mocha from crashing
                   }

--- a/packages/datadog-shimmer/test/shimmer.spec.js
+++ b/packages/datadog-shimmer/test/shimmer.spec.js
@@ -163,8 +163,8 @@ describe('shimmer', () => {
       }
       const obj = { Counter }
 
-      shimmer.wrap(obj, 'Counter', Counter => function () {
-        Counter.apply(this, arguments)
+      shimmer.wrap(obj, 'Counter', Counter => function (...args) {
+        Counter.apply(this, args)
         this.value++
       })
 
@@ -443,7 +443,7 @@ describe('shimmer', () => {
         shimmer.wrapFunction(count, count => () => {})
 
         function legacyCtor (start) { this.value = start }
-        shimmer.wrapFunction(legacyCtor, ctor => function () { ctor.apply(this, arguments) })
+        shimmer.wrapFunction(legacyCtor, ctor => function (...args) { ctor.apply(this, args) })
 
         class Counter {}
         assert.throws(

--- a/packages/dd-trace/src/appsec/iast/security-controls/index.js
+++ b/packages/dd-trace/src/appsec/iast/security-controls/index.js
@@ -111,8 +111,8 @@ function resolve (path, obj, separator = '.') {
 }
 
 function wrapSanitizer (target, secureMarks) {
-  return shimmer.wrapFunction(target, orig => function () {
-    const result = orig.apply(this, arguments)
+  return shimmer.wrapFunction(target, orig => function (...args) {
+    const result = orig.apply(this, args)
 
     try {
       return addSecureMarks(result, secureMarks)

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/plugins/kafka.js
@@ -14,8 +14,8 @@ class KafkaConsumerIastPlugin extends SourceIastPlugin {
   }
 
   getToStringWrap (toString, iastContext, type) {
-    return function () {
-      const res = toString.apply(this, arguments)
+    return function (...args) {
+      const res = toString.apply(this, args)
       return newTaintedString(iastContext, res, undefined, type)
     }
   }

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/rewriter.js
@@ -123,8 +123,8 @@ function getCompileMethodFn (compileMethod) {
     return compileMethod.apply(this, [content, filename])
   }
 
-  const shim = function () {
-    return delegate.apply(this, arguments)
+  const shim = function (...args) {
+    return delegate.apply(this, args)
   }
 
   unwrapCompile = function () {

--- a/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
+++ b/packages/dd-trace/src/appsec/iast/taint-tracking/taint-tracking-impl.js
@@ -66,8 +66,8 @@ function getFilteredCsiFn (cb, filter, getContext) {
   }
 }
 
-function notString () {
-  return Array.prototype.some.call(arguments, (p) => typeof p !== 'string')
+function notString (...args) {
+  return Array.prototype.some.call(args, (p) => typeof p !== 'string')
 }
 
 function isValidCsiMethod (fn, protos) {

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -146,11 +146,11 @@ class LLMObs extends NoopLLMObs {
 
     const llmobs = this
 
-    function wrapped () {
+    function wrapped (...args) {
       telemetry.incrementLLMObsSpanStartCount({ autoinstrumented: false, kind })
 
       const span = llmobs._tracer.scope().active()
-      const fnArgs = arguments
+      const fnArgs = args
 
       const lastArgId = fnArgs.length - 1
       const cb = fnArgs[lastArgId]
@@ -158,12 +158,12 @@ class LLMObs extends NoopLLMObs {
 
       if (hasCallback) {
         const scopeBoundCb = llmobs.#bind(cb)
-        fnArgs[lastArgId] = function () {
+        fnArgs[lastArgId] = function (...args) {
           // it is standard practice to follow the callback signature (err, result)
           // however, we try to parse the arguments to determine if the first argument is an error
           // if it is not, and is not undefined, we will use that for the output value
-          const maybeError = arguments[0]
-          const maybeResult = arguments[1]
+          const maybeError = args[0]
+          const maybeResult = args[1]
 
           llmobs.#autoAnnotate(
             span,
@@ -172,7 +172,7 @@ class LLMObs extends NoopLLMObs {
             isError(maybeError) || maybeError == null ? maybeResult : maybeError
           )
 
-          return scopeBoundCb.apply(this, arguments)
+          return scopeBoundCb.apply(this, args)
         }
       }
 
@@ -573,9 +573,9 @@ class LLMObs extends NoopLLMObs {
     const llmobs = this
     const activeSpan = llmobs._active()
 
-    return function () {
+    return function (...args) {
       return llmobs.#activate(activeSpan, null, () => {
-        return fn.apply(this, arguments)
+        return fn.apply(this, args)
       })
     }
   }

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -307,10 +307,10 @@ const web = {
     return contexts.get(req)
   },
   wrapRes (context, req, res, end) {
-    return function () {
+    return function (...args) {
       web.finishAll(context)
 
-      return end.apply(res, arguments)
+      return end.apply(res, args)
     }
   },
   wrapEnd (context) {
@@ -328,8 +328,8 @@ const web = {
         return ends.get(this)
       },
       set (value) {
-        ends.set(this, function () {
-          return storage('legacy').run(context.store, value, ...arguments)
+        ends.set(this, function (...args) {
+          return storage('legacy').run(context.store, value, ...args)
         })
       },
     })

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -37,9 +37,9 @@ class Scope {
     const scope = this
     const spanOrActive = this._spanOrActive(span)
 
-    return function () {
+    return function (...args) {
       return scope.activate(spanOrActive, () => {
-        return fn.apply(this, arguments)
+        return fn.apply(this, args)
       })
     }
   }

--- a/packages/dd-trace/src/tracer.js
+++ b/packages/dd-trace/src/tracer.js
@@ -100,27 +100,27 @@ class DatadogTracer extends Tracer {
   wrap (name, options, fn) {
     const tracer = this
 
-    return function () {
+    return function (...args) {
       let optionsObj = options
       if (typeof optionsObj === 'function' && typeof fn === 'function') {
-        optionsObj = optionsObj.apply(this, arguments)
+        optionsObj = optionsObj.apply(this, args)
       }
 
-      const lastArgId = arguments.length - 1
-      const cb = arguments[lastArgId]
+      const lastArgId = args.length - 1
+      const cb = args[lastArgId]
 
       if (typeof cb === 'function') {
         const scopeBoundCb = tracer.scope().bind(cb)
         return tracer.trace(name, optionsObj, (span, done) => {
-          arguments[lastArgId] = function (err) {
+          args[lastArgId] = function (err) {
             done(err)
             return scopeBoundCb.apply(this, arguments)
           }
 
-          return fn.apply(this, arguments)
+          return fn.apply(this, args)
         })
       }
-      return tracer.trace(name, optionsObj, () => fn.apply(this, arguments))
+      return tracer.trace(name, optionsObj, () => fn.apply(this, args))
     }
   }
 

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/rewriter.spec.js
@@ -63,8 +63,8 @@ describe('IAST Rewriter', () => {
       workerThreads = require('worker_threads')
 
       MessageChannel = workerThreads.MessageChannel
-      workerThreads.MessageChannel = function () {
-        const res = new MessageChannel(...arguments)
+      workerThreads.MessageChannel = function (...args) {
+        const res = new MessageChannel(...args)
         port1On = sinon.spy(res.port1, 'on')
         port1Unref = sinon.spy(res.port1, 'unref')
 

--- a/packages/dd-trace/test/telemetry/dependencies.spec.js
+++ b/packages/dd-trace/test/telemetry/dependencies.spec.js
@@ -334,8 +334,8 @@ describe('dependencies', () => {
       let atLeastOneTimeout = false
       global.setImmediate = function (callback) {
         atLeastOneTimeout = true
-        const timeout = originalSetImmediate(function () {
-          const cbResult = callback.apply(this, arguments)
+        const timeout = originalSetImmediate(function (...args) {
+          const cbResult = callback.apply(this, args)
           timeouts.splice(timeouts.indexOf(timeout), 1)
           return cbResult
         })


### PR DESCRIPTION
## Summary

Replaces `function () { … arguments … }` with `function (...args)` in
benchmarks, tests, plugins, and `dd-trace/src` modules outside the
instrumentation hot path.

## Why

Microbench on the canonical shimmer forwarding shape
(`fn.apply(this, arguments)` vs `fn.apply(this, args)`) on Node 24.13.0
/ V8 13.6 over 7 trials of 5 M iterations each (drop best+worst):
`arguments` 5.87 ns/call, `...args` 5.95 ns/call — 0.08 ns delta is
inside the 0.2-0.7 ns trial-to-trial noise, so the modern syntax does
not cost meaningful perf in modern V8 even on the instrumentation hot
path.

The instrumentation files (`packages/datadog-instrumentations/src/*`)
ship in follow-up PRs to keep each diff under the 400-line review
budget. The eslint rule stays off until all 928 hits are migrated;
final activation lands when the last file is done.