### PR TITLE
refactor(prefer-rest-params): convert instrumentations a-c

### DIFF
--- a/packages/datadog-instrumentations/src/aerospike.js
+++ b/packages/datadog-instrumentations/src/aerospike.js
@@ -12,8 +12,8 @@ const ch = tracingChannel('apm:aerospike:command')
 function wrapCreateCommand (createCommand) {
   if (typeof createCommand !== 'function') return createCommand
 
-  return function commandWithTrace () {
-    const CommandClass = createCommand.apply(this, arguments)
+  return function commandWithTrace (...args) {
+    const CommandClass = createCommand.apply(this, args)
 
     if (!CommandClass) return CommandClass
 

--- a/packages/datadog-instrumentations/src/ai.js
+++ b/packages/datadog-instrumentations/src/ai.js
@@ -119,17 +119,17 @@ function wrapTracer (tracer) {
   tracers.add(tracer)
 
   shimmer.wrap(tracer, 'startActiveSpan', function (startActiveSpan) {
-    return function () {
-      const name = arguments[0]
-      const options = arguments.length > 2 ? (arguments[1] ?? {}) : {} // startActiveSpan(name, fn)
-      const cb = arguments[arguments.length - 1]
+    return function (...args) {
+      const name = args[0]
+      const options = args.length > 2 ? (args[1] ?? {}) : {} // startActiveSpan(name, fn)
+      const cb = args[args.length - 1]
 
       const ctx = {
         name,
         attributes: options.attributes ?? {},
       }
 
-      arguments[arguments.length - 1] = shimmer.wrapFunction(cb, function (originalCb) {
+      args[args.length - 1] = shimmer.wrapFunction(cb, function (originalCb) {
         return function (span) {
           // the below is necessary in the case that the span is vercel ai's noopSpan.
           // while we don't want to patch the noopSpan more than once, we do want to treat each as a
@@ -138,9 +138,9 @@ function wrapTracer (tracer) {
           const freshSpan = Object.create(span) // TODO: does this cause memory leaks?
 
           shimmer.wrap(freshSpan, 'end', function (spanEnd) {
-            return function () {
+            return function (...args) {
               vercelAiTracingChannel.asyncEnd.publish(ctx)
-              return spanEnd.apply(this, arguments)
+              return spanEnd.apply(this, args)
             }
           })
 
@@ -164,7 +164,7 @@ function wrapTracer (tracer) {
       })
 
       return vercelAiTracingChannel.start.runStores(ctx, () => {
-        const result = startActiveSpan.apply(this, arguments)
+        const result = startActiveSpan.apply(this, args)
         vercelAiTracingChannel.end.publish(ctx)
         return result
       })

--- a/packages/datadog-instrumentations/src/anthropic.js
+++ b/packages/datadog-instrumentations/src/anthropic.js
@@ -8,10 +8,10 @@ const anthropicTracingChannel = tracingChannel('apm:anthropic:request')
 const onStreamedChunkCh = channel('apm:anthropic:request:chunk')
 
 function wrapStreamIterator (iterator, ctx) {
-  return function () {
-    const itr = iterator.apply(this, arguments)
-    shimmer.wrap(itr, 'next', next => function () {
-      return next.apply(this, arguments)
+  return function (...args) {
+    const itr = iterator.apply(this, args)
+    shimmer.wrap(itr, 'next', next => function (...args) {
+      return next.apply(this, args)
         .then(res => {
           const { done, value: chunk } = res
           onStreamedChunkCh.publish({ ctx, chunk, done })
@@ -33,12 +33,12 @@ function wrapStreamIterator (iterator, ctx) {
 }
 
 function wrapCreate (create) {
-  return function () {
+  return function (...args) {
     if (!anthropicTracingChannel.start.hasSubscribers) {
-      return create.apply(this, arguments)
+      return create.apply(this, args)
     }
 
-    const options = arguments[0]
+    const options = args[0]
     const stream = options.stream
 
     const ctx = { options, resource: 'create', baseUrl: this._client?.baseURL }
@@ -46,14 +46,14 @@ function wrapCreate (create) {
     return anthropicTracingChannel.start.runStores(ctx, () => {
       let apiPromise
       try {
-        apiPromise = create.apply(this, arguments)
+        apiPromise = create.apply(this, args)
       } catch (error) {
         finish(ctx, null, error)
         throw error
       }
 
-      shimmer.wrap(apiPromise, 'parse', parse => function () {
-        return parse.apply(this, arguments)
+      shimmer.wrap(apiPromise, 'parse', parse => function (...args) {
+        return parse.apply(this, args)
           .then(response => {
             if (stream) {
               shimmer.wrap(response, Symbol.asyncIterator, iterator => wrapStreamIterator(iterator, ctx))

--- a/packages/datadog-instrumentations/src/apollo-server-core.js
+++ b/packages/datadog-instrumentations/src/apollo-server-core.js
@@ -10,9 +10,9 @@ addHook({ name: 'apollo-server-core', file: 'dist/runHttpQuery.js', versions: ['
   const HttpQueryError = runHttpQueryModule.HttpQueryError
 
   shimmer.wrap(runHttpQueryModule, 'runHttpQuery', function wrapRunHttpQuery (originalRunHttpQuery) {
-    return function runHttpQuery () {
+    return function runHttpQuery (...args) {
       if (!requestChannel.start.hasSubscribers) {
-        return originalRunHttpQuery.apply(this, arguments)
+        return originalRunHttpQuery.apply(this, args)
       }
 
       const abortController = new AbortController()
@@ -22,7 +22,7 @@ addHook({ name: 'apollo-server-core', file: 'dist/runHttpQuery.js', versions: ['
         originalRunHttpQuery,
         { abortController, abortData },
         this,
-        ...arguments)
+        ...args)
 
       const abortPromise = new Promise((resolve, reject) => {
         abortController.signal.addEventListener('abort', (event) => {

--- a/packages/datadog-instrumentations/src/apollo-server.js
+++ b/packages/datadog-instrumentations/src/apollo-server.js
@@ -13,9 +13,9 @@ const requestChannel = dc.tracingChannel('datadog:apollo:request')
 let HeaderMap
 
 function wrapExecuteHTTPGraphQLRequest (originalExecuteHTTPGraphQLRequest) {
-  return function executeHTTPGraphQLRequest () {
+  return function executeHTTPGraphQLRequest (...args) {
     if (!HeaderMap || !requestChannel.start.hasSubscribers) {
-      return originalExecuteHTTPGraphQLRequest.apply(this, arguments)
+      return originalExecuteHTTPGraphQLRequest.apply(this, args)
     }
 
     const abortController = new AbortController()
@@ -25,7 +25,7 @@ function wrapExecuteHTTPGraphQLRequest (originalExecuteHTTPGraphQLRequest) {
       originalExecuteHTTPGraphQLRequest,
       { abortController, abortData },
       this,
-      ...arguments)
+      ...args)
 
     const abortPromise = new Promise((resolve, reject) => {
       abortController.signal.addEventListener('abort', (event) => {
@@ -89,10 +89,10 @@ function wrapEmit (emit) {
 }
 
 function wrapListen (originalListen) {
-  return function wrappedListen () {
+  return function wrappedListen (...args) {
     shimmer.wrap(this, 'emit', wrapEmit)
 
-    return originalListen.apply(this, arguments)
+    return originalListen.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/avsc.js
+++ b/packages/datadog-instrumentations/src/avsc.js
@@ -8,21 +8,21 @@ const serializeChannel = dc.channel('apm:avsc:serialize-start')
 const deserializeChannel = dc.channel('apm:avsc:deserialize-end')
 
 function wrapSerialization (Type) {
-  shimmer.wrap(Type.prototype, 'toBuffer', original => function () {
+  shimmer.wrap(Type.prototype, 'toBuffer', original => function (...args) {
     if (!serializeChannel.hasSubscribers) {
-      return original.apply(this, arguments)
+      return original.apply(this, args)
     }
     serializeChannel.publish({ messageClass: this })
-    return original.apply(this, arguments)
+    return original.apply(this, args)
   })
 }
 
 function wrapDeserialization (Type) {
-  shimmer.wrap(Type.prototype, 'fromBuffer', original => function () {
+  shimmer.wrap(Type.prototype, 'fromBuffer', original => function (...args) {
     if (!deserializeChannel.hasSubscribers) {
-      return original.apply(this, arguments)
+      return original.apply(this, args)
     }
-    const result = original.apply(this, arguments)
+    const result = original.apply(this, args)
     deserializeChannel.publish({ messageClass: result })
     return result
   })

--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -137,13 +137,13 @@ function wrapRequest (send) {
 }
 
 function wrapDeserialize (deserialize, headersCh, responseIndex = 0) {
-  return function () {
-    const response = arguments[responseIndex]
+  return function (...args) {
+    const response = args[responseIndex]
     if (headersCh.hasSubscribers) {
       headersCh.publish({ headers: response.headers })
     }
 
-    return deserialize.apply(this, arguments)
+    return deserialize.apply(this, args)
   }
 }
 
@@ -240,11 +240,11 @@ function handleCompletion (result, ctx, channels) {
   }
 
   shimmer.wrap(result.body, Symbol.asyncIterator, function (asyncIterator) {
-    return function () {
-      const iterator = asyncIterator.apply(this, arguments)
+    return function (...args) {
+      const iterator = asyncIterator.apply(this, args)
       shimmer.wrap(iterator, 'next', function (next) {
-        return function () {
-          return next.apply(this, arguments)
+        return function (...args) {
+          return next.apply(this, args)
             .then(result => {
               const { done, value: chunk } = result
               channels.streamedChunk.publish({ ctx, chunk, done })

--- a/packages/datadog-instrumentations/src/azure-durable-functions.js
+++ b/packages/datadog-instrumentations/src/azure-durable-functions.js
@@ -38,14 +38,14 @@ function entityWrapper (method) {
 }
 
 function entityHandler (handler, entityName) {
-  return function () {
-    if (!azureDurableFunctionsChannel.hasSubscribers) return handler.apply(this, arguments)
+  return function (...args) {
+    if (!azureDurableFunctionsChannel.hasSubscribers) return handler.apply(this, args)
 
-    const entityContext = arguments[0]
+    const entityContext = args[0]
     return azureDurableFunctionsChannel.traceSync(
       handler,
       { trigger: 'Entity', functionName: entityName, operationName: entityContext?.df?.operationName },
-      this, ...arguments)
+      this, ...args)
   }
 }
 
@@ -55,19 +55,19 @@ function activityHandler (method) {
       const isAsync =
         handler && handler.constructor && handler.constructor.name === 'AsyncFunction'
 
-      return function () {
-        if (!azureDurableFunctionsChannel.hasSubscribers) return handler.apply(this, arguments)
+      return function (...args) {
+        if (!azureDurableFunctionsChannel.hasSubscribers) return handler.apply(this, args)
 
         // use tracePromise if this is an async handler. otherwise, use traceSync
         return isAsync
           ? azureDurableFunctionsChannel.tracePromise(
             handler,
             { trigger: 'Activity', functionName: activityName },
-            this, ...arguments)
+            this, ...args)
           : azureDurableFunctionsChannel.traceSync(
             handler,
             { trigger: 'Activity', functionName: activityName },
-            this, ...arguments)
+            this, ...args)
       }
     })
     return method.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/bluebird.js
+++ b/packages/datadog-instrumentations/src/bluebird.js
@@ -6,8 +6,8 @@ const { wrapThen } = require('./helpers/promise')
 
 function createGetNewLibraryCopyWrap (originalLib) {
   return function wrapGetNewLibraryCopy (getNewLibraryCopy) {
-    return function getNewLibraryCopyWithTrace () {
-      const libraryCopy = getNewLibraryCopy.apply(this, arguments)
+    return function getNewLibraryCopyWithTrace (...args) {
+      const libraryCopy = getNewLibraryCopy.apply(this, args)
       shimmer.wrap(libraryCopy.prototype, '_then', wrapThen)
       shimmer.wrap(libraryCopy, 'getNewLibraryCopy', createGetNewLibraryCopyWrap(originalLib))
       return libraryCopy

--- a/packages/datadog-instrumentations/src/body-parser.js
+++ b/packages/datadog-instrumentations/src/body-parser.js
@@ -6,7 +6,7 @@ const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const bodyParserReadCh = channel('datadog:body-parser:read:finish')
 
 function publishRequestBodyAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, next => function (...args) {
     if (bodyParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const body = req.body
@@ -16,7 +16,7 @@ function publishRequestBodyAndNext (req, res, next) {
       if (abortController.signal.aborted) return
     }
 
-    return next.apply(this, arguments)
+    return next.apply(this, args)
   })
 }
 

--- a/packages/datadog-instrumentations/src/cassandra-driver.js
+++ b/packages/datadog-instrumentations/src/cassandra-driver.js
@@ -100,13 +100,13 @@ addHook({ name: 'cassandra-driver', versions: ['3 - 4.3'], patchDefault: false }
 })
 
 addHook({ name: 'cassandra-driver', versions: ['>=3.3'], file: 'lib/request-execution.js' }, RequestExecution => {
-  shimmer.wrap(RequestExecution.prototype, '_sendOnConnection', _sendOnConnection => function () {
+  shimmer.wrap(RequestExecution.prototype, '_sendOnConnection', _sendOnConnection => function (...args) {
     if (!startCh.hasSubscribers) {
-      return _sendOnConnection.apply(this, arguments)
+      return _sendOnConnection.apply(this, args)
     }
     startCtx = { hostname: this._connection.address, port: this._connection.port, ...startCtx }
     connectCh.publish(startCtx)
-    return _sendOnConnection.apply(this, arguments)
+    return _sendOnConnection.apply(this, args)
   })
   return RequestExecution
 })
@@ -122,9 +122,9 @@ addHook({ name: 'cassandra-driver', versions: ['3.3 - 4.3'], file: 'lib/request-
       return start.apply(this, arguments)
     }
 
-    arguments[0] = function () {
+    arguments[0] = function (...args) {
       startCtx = { hostname: execution._connection.address, port: execution._connection.port, ...startCtx }
-      return connectCh.runStores(startCtx, getHostCallback, this, ...arguments)
+      return connectCh.runStores(startCtx, getHostCallback, this, ...args)
     }
 
     return start.apply(this, arguments)
@@ -143,9 +143,9 @@ addHook({ name: 'cassandra-driver', versions: ['3 - 3.2'], file: 'lib/request-ha
       return send.apply(this, arguments)
     }
 
-    arguments[2] = function () {
+    arguments[2] = function (...args) {
       startCtx = { hostname: handler.connection.address, port: handler.connection.port, ...startCtx }
-      return connectCh.runStores(startCtx, callback, this, ...arguments)
+      return connectCh.runStores(startCtx, callback, this, ...args)
     }
 
     return send.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/child_process.js
+++ b/packages/datadog-instrumentations/src/child_process.js
@@ -82,12 +82,12 @@ function createContextFromChildProcessInfo (childProcessInfo) {
 
 function wrapChildProcessSyncMethod (returnError, shell = false) {
   return function wrapMethod (childProcessMethod) {
-    return function () {
-      if (!childProcessChannel.start.hasSubscribers || arguments.length === 0) {
-        return childProcessMethod.apply(this, arguments)
+    return function (...args) {
+      if (!childProcessChannel.start.hasSubscribers || args.length === 0) {
+        return childProcessMethod.apply(this, args)
       }
 
-      const callArgs = [...arguments]
+      const callArgs = [...args]
       const childProcessInfo = normalizeArgs(callArgs, shell)
       const context = createContextFromChildProcessInfo(childProcessInfo)
       context.callArgs = callArgs
@@ -118,12 +118,12 @@ function wrapChildProcessSyncMethod (returnError, shell = false) {
 }
 
 function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
-  return function () {
-    if (!childProcessChannel.start.hasSubscribers || arguments.length === 0) {
-      return customPromisifyMethod.apply(this, arguments)
+  return function (...args) {
+    if (!childProcessChannel.start.hasSubscribers || args.length === 0) {
+      return customPromisifyMethod.apply(this, args)
     }
 
-    const callArgs = [...arguments]
+    const callArgs = [...args]
     const childProcessInfo = normalizeArgs(callArgs, shell)
 
     const context = createContextFromChildProcessInfo(childProcessInfo)
@@ -170,12 +170,12 @@ function wrapChildProcessCustomPromisifyMethod (customPromisifyMethod, shell) {
 
 function wrapChildProcessAsyncMethod (ChildProcess, shell = false) {
   return function wrapMethod (childProcessMethod) {
-    function wrappedChildProcessMethod () {
-      if (!childProcessChannel.start.hasSubscribers || arguments.length === 0) {
-        return childProcessMethod.apply(this, arguments)
+    function wrappedChildProcessMethod (...args) {
+      if (!childProcessChannel.start.hasSubscribers || args.length === 0) {
+        return childProcessMethod.apply(this, args)
       }
 
-      const callArgs = [...arguments]
+      const callArgs = [...args]
       const childProcessInfo = normalizeArgs(callArgs, shell)
 
       const context = createContextFromChildProcessInfo(childProcessInfo)

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -47,8 +47,8 @@ function instrumentBaseModule (module) {
   // Helper function to wrap producer classes
   function wrapProducerClass (ProducerClass, className) {
     return shimmer.wrap(module, className, function wrapProducer (Original) {
-      return function wrappedProducer () {
-        const producer = new Original(...arguments)
+      return function wrappedProducer (...args) {
+        const producer = new Original(...args)
 
         // Hook the produce method
         if (typeof producer?.produce === 'function') {
@@ -94,9 +94,9 @@ function instrumentBaseModule (module) {
   // Helper function to wrap consumer classes
   function wrapConsumerClass (ConsumerClass, className) {
     return shimmer.wrap(module, className, function wrapConsumer (Original) {
-      return function wrappedConsumer () {
-        const consumer = new Original(...arguments)
-        const groupId = this.groupId || (arguments[0]?.['group.id'])
+      return function wrappedConsumer (...args) {
+        const consumer = new Original(...args)
+        const groupId = this.groupId || (args[0]?.['group.id'])
 
         // Wrap the consume method
         if (typeof consumer?.consume === 'function') {
@@ -196,11 +196,11 @@ function instrumentKafkaJS (kafkaJS) {
         // Wrap the producer method if it exists
         if (typeof kafka?.producer === 'function') {
           shimmer.wrap(kafka, 'producer', function wrapProducerMethod (producerMethod) {
-            return function wrappedProducerMethod () {
-              const producer = producerMethod.apply(this, arguments)
+            return function wrappedProducerMethod (...args) {
+              const producer = producerMethod.apply(this, args)
 
-              if (!brokers && arguments?.[0]?.['bootstrap.servers']) {
-                kafka._ddBrokers = arguments[0]['bootstrap.servers']
+              if (!brokers && args?.[0]?.['bootstrap.servers']) {
+                kafka._ddBrokers = args[0]['bootstrap.servers']
               }
 
               // Wrap the send method of the producer

--- a/packages/datadog-instrumentations/src/connect.js
+++ b/packages/datadog-instrumentations/src/connect.js
@@ -59,16 +59,16 @@ function wrapLayerHandle (layer) {
 
   const original = layer.handle
 
-  return shimmer.wrapFunction(original, original => function () {
-    if (!enterChannel.hasSubscribers) return original.apply(this, arguments)
+  return shimmer.wrapFunction(original, original => function (...args) {
+    if (!enterChannel.hasSubscribers) return original.apply(this, args)
 
-    const lastIndex = arguments.length - 1
+    const lastIndex = args.length - 1
     const name = original._name || original.name
-    const req = arguments[arguments.length > 3 ? 1 : 0]
-    const next = arguments[lastIndex]
+    const req = args[args.length > 3 ? 1 : 0]
+    const next = args[lastIndex]
 
     if (typeof next === 'function') {
-      arguments[lastIndex] = wrapNext(req, next)
+      args[lastIndex] = wrapNext(req, next)
     }
 
     const route = layer.route
@@ -76,7 +76,7 @@ function wrapLayerHandle (layer) {
     enterChannel.publish({ name, req, route })
 
     try {
-      return original.apply(this, arguments)
+      return original.apply(this, args)
     } catch (error) {
       errorChannel.publish({ req, error })
       nextChannel.publish({ req })

--- a/packages/datadog-instrumentations/src/cookie-parser.js
+++ b/packages/datadog-instrumentations/src/cookie-parser.js
@@ -6,7 +6,7 @@ const { channel, addHook } = require('./helpers/instrument')
 const cookieParserReadCh = channel('datadog:cookie-parser:read:finish')
 
 function publishRequestCookieAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function cookieParserWrapper () {
+  return shimmer.wrapFunction(next, next => function cookieParserWrapper (...args) {
     if (cookieParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
 
@@ -17,7 +17,7 @@ function publishRequestCookieAndNext (req, res, next) {
       if (abortController.signal.aborted) return
     }
 
-    return next.apply(this, arguments)
+    return next.apply(this, args)
   })
 }
 
@@ -25,8 +25,8 @@ addHook({
   name: 'cookie-parser',
   versions: ['>=1.0.0'],
 }, cookieParser => {
-  return shimmer.wrapFunction(cookieParser, cookieParser => function () {
-    const cookieMiddleware = cookieParser.apply(this, arguments)
+  return shimmer.wrapFunction(cookieParser, cookieParser => function (...args) {
+    const cookieMiddleware = cookieParser.apply(this, args)
 
     return shimmer.wrapFunction(cookieMiddleware, cookieMiddleware => function (req, res, next) {
       arguments[2] = publishRequestCookieAndNext(req, res, next)

--- a/packages/datadog-instrumentations/src/cookie.js
+++ b/packages/datadog-instrumentations/src/cookie.js
@@ -6,8 +6,8 @@ const { channel, addHook } = require('./helpers/instrument')
 const cookieParseCh = channel('datadog:cookie:parse:finish')
 
 function wrapParse (originalParse) {
-  return function () {
-    const cookies = originalParse.apply(this, arguments)
+  return function (...args) {
+    const cookies = originalParse.apply(this, args)
     if (cookieParseCh.hasSubscribers && cookies) {
       cookieParseCh.publish({ cookies })
     }

--- a/packages/datadog-instrumentations/src/couchbase.js
+++ b/packages/datadog-instrumentations/src/couchbase.js
@@ -77,25 +77,25 @@ function wrap (prefix, fn) {
   const finishCh = channel(prefix + ':finish')
   const errorCh = channel(prefix + ':error')
 
-  return function () {
+  return function (...args) {
     if (!startCh.hasSubscribers) {
-      return fn.apply(this, arguments)
+      return fn.apply(this, args)
     }
 
-    const callbackIndex = findCallbackIndex(arguments, 1)
+    const callbackIndex = findCallbackIndex(args, 1)
 
-    if (callbackIndex < 0) return fn.apply(this, arguments)
+    if (callbackIndex < 0) return fn.apply(this, args)
 
     const ctx = { bucket: { name: this.name || this._name }, seedNodes: this._dd_hosts }
     return startCh.runStores(ctx, () => {
-      const cb = arguments[callbackIndex]
+      const cb = args[callbackIndex]
 
-      arguments[callbackIndex] = shimmer.wrapFunction(cb, (cb) => {
-        return wrapCallbackFinish(cb, this, arguments, errorCh, finishCh, ctx, prefix)
+      args[callbackIndex] = shimmer.wrapFunction(cb, (cb) => {
+        return wrapCallbackFinish(cb, this, args, errorCh, finishCh, ctx, prefix)
       })
 
       try {
-        return fn.apply(this, arguments)
+        return fn.apply(this, args)
       } catch (error) {
         ctx.error = error
         void error.stack // trigger getting the stack at the original throwing point
@@ -173,12 +173,12 @@ function wrapCBandPromise (fn, name, startData, thisArg, args) {
 
 function wrapWithName (name) {
   return function (operation) {
-    return function () { // no arguments used by us
+    return function (...args) { // no arguments used by us
       return wrapCBandPromise(operation, name, {
         collection: { name: this._name || '_default' },
         bucket: { name: this._scope._bucket._name },
         seedNodes: this._dd_connStr,
-      }, this, arguments)
+      }, this, args)
     }
   }
 }
@@ -248,8 +248,8 @@ addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^2.6.12'] }, Cl
 
   shimmer.wrap(Cluster.prototype, 'query', query => wrapQuery(query))
   shimmer.wrap(Cluster.prototype, 'openBucket', openBucket => {
-    return function () {
-      const bucket = openBucket.apply(this, arguments)
+    return function (...args) {
+      const bucket = openBucket.apply(this, args)
       const hosts = this.dsnObj.hosts
       bucket._dd_hosts = hosts.map(hostAndPort => hostAndPort.join(':')).join(',')
       return bucket
@@ -261,8 +261,8 @@ addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^2.6.12'] }, Cl
 
 addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^3.0.7', '^3.1.3'] }, Bucket => {
   shimmer.wrap(Bucket.prototype, 'collection', getCollection => {
-    return function () {
-      const collection = getCollection.apply(this, arguments)
+    return function (...args) {
+      const collection = getCollection.apply(this, args)
       const connStr = this._cluster._connStr
       collection._dd_connStr = connStr
       return collection
@@ -294,8 +294,8 @@ addHook({ name: 'couchbase', file: 'dist/collection.js', versions: ['>=3.2.2'] }
 addHook({ name: 'couchbase', file: 'dist/bucket.js', versions: ['>=3.2.2'] }, bucket => {
   const Bucket = bucket.Bucket
   shimmer.wrap(Bucket.prototype, 'collection', getCollection => {
-    return function () {
-      const collection = getCollection.apply(this, arguments)
+    return function (...args) {
+      const collection = getCollection.apply(this, args)
       const connStr = this._cluster._connStr
       collection._dd_connStr = connStr
       return collection

--- a/packages/datadog-instrumentations/src/crypto.js
+++ b/packages/datadog-instrumentations/src/crypto.js
@@ -47,12 +47,12 @@ addHook({ name: 'crypto' }, crypto => {
 
 function wrapCryptoMethod (channel) {
   function wrapMethod (cryptoMethod) {
-    return function () {
-      if (channel.hasSubscribers && arguments.length > 0) {
-        const algorithm = arguments[0]
+    return function (...args) {
+      if (channel.hasSubscribers && args.length > 0) {
+        const algorithm = args[0]
         channel.publish({ algorithm })
       }
-      return cryptoMethod.apply(this, arguments)
+      return cryptoMethod.apply(this, args)
     }
   }
   return wrapMethod

--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -297,9 +297,9 @@ function wrapRun (pl, isLatestVersion, version) {
 
   patched.add(pl)
 
-  shimmer.wrap(pl.prototype, 'run', run => function () {
+  shimmer.wrap(pl.prototype, 'run', run => function (...args) {
     if (!testFinishCh.hasSubscribers) {
-      return run.apply(this, arguments)
+      return run.apply(this, args)
     }
 
     let numAttempt = 0
@@ -370,7 +370,7 @@ function wrapRun (pl, isLatestVersion, version) {
       const executionStart = performance.now()
 
       testFnCh.runStores(ctx, () => {
-        promise = run.apply(this, arguments)
+        promise = run.apply(this, args)
       })
       promise.finally(async () => {
         this.eventBroadcaster.removeListener('envelope', onEnvelope)
@@ -551,11 +551,11 @@ function wrapRun (pl, isLatestVersion, version) {
       })
     }
   })
-  shimmer.wrap(pl.prototype, 'runStep', runStep => function () {
+  shimmer.wrap(pl.prototype, 'runStep', runStep => function (...args) {
     if (!testFinishCh.hasSubscribers) {
-      return runStep.apply(this, arguments)
+      return runStep.apply(this, args)
     }
-    const testStep = arguments[0]
+    const testStep = args[0]
     let resource
 
     if (isLatestVersion) {
@@ -567,7 +567,7 @@ function wrapRun (pl, isLatestVersion, version) {
     const ctx = { resource }
     return testStepStartCh.runStores(ctx, () => {
       try {
-        const promise = runStep.apply(this, arguments)
+        const promise = runStep.apply(this, args)
 
         promise.then((result) => {
           const finalResult = satisfies(version, '>=12.0.0') ? result.result : result
@@ -1201,9 +1201,9 @@ addHook({
   versions: ['>=11.0.0'],
   file: 'lib/formatter/helpers/event_data_collector.js',
 }, (eventDataCollectorPackage) => {
-  shimmer.wrap(eventDataCollectorPackage.default.prototype, 'parseEnvelope', parseEnvelope => function () {
+  shimmer.wrap(eventDataCollectorPackage.default.prototype, 'parseEnvelope', parseEnvelope => function (...args) {
     eventDataCollector = this
-    return parseEnvelope.apply(this, arguments)
+    return parseEnvelope.apply(this, args)
   })
   return eventDataCollectorPackage
 })
@@ -1222,7 +1222,7 @@ addHook({
     parseWorkerMessage => getWrappedParseWorkerMessage(parseWorkerMessage, true)
   )
   // EFD in parallel mode only supported in >=11.0.0
-  shimmer.wrap(adapterPackage.ChildProcessAdapter.prototype, 'startWorker', startWorker => function () {
+  shimmer.wrap(adapterPackage.ChildProcessAdapter.prototype, 'startWorker', startWorker => function (...args) {
     if (isKnownTestsEnabled && isValidKnownTests(knownTests)) {
       this.options.worldParameters._ddIsKnownTestsEnabled = true
       this.options.worldParameters._ddIsEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
@@ -1252,7 +1252,7 @@ addHook({
       this.options.worldParameters._ddTestManagementAttemptToFixRetries = testManagementAttemptToFixRetries
     }
 
-    return startWorker.apply(this, arguments)
+    return startWorker.apply(this, args)
   })
   return adapterPackage
 })


### PR DESCRIPTION
## Summary

Same shape change as #8353 — `function () { … arguments … }` becomes
`function (...args)` — applied to instrumentation files starting
`[a-c]*`. Microbench in #8353 confirmed the two shapes are equivalent
on the shimmer hot path; this batch keeps each PR under the 400-line
review budget.

Refs: https://github.com/DataDog/dd-trace-js/pull/8353