### PR TITLE
refactor(prefer-rest-params): convert instrumentations d-l

### DIFF
--- a/packages/datadog-instrumentations/src/elasticsearch.js
+++ b/packages/datadog-instrumentations/src/elasticsearch.js
@@ -37,8 +37,8 @@ addHook({ name: 'elasticsearch', file: 'src/lib/connection_pool.js', versions: [
 function createWrapGetConnection (name) {
   const connectCh = channel(`apm:${name}:query:connect`)
   return function wrapRequest (request) {
-    return function () {
-      const connection = request.apply(this, arguments)
+    return function (...args) {
+      const connection = request.apply(this, args)
       if (connectCh.hasSubscribers && connection && connection.url) {
         connectCh.publish(connection.url)
       }
@@ -50,17 +50,17 @@ function createWrapGetConnection (name) {
 function createWrapSelect () {
   const connectCh = channel('apm:elasticsearch:query:connect')
   return function wrapRequest (request) {
-    return function () {
-      if (arguments.length === 1) {
-        const cb = arguments[0]
-        arguments[0] = shimmer.wrapFunction(cb, cb => function (err, connection) {
+    return function (...args) {
+      if (args.length === 1) {
+        const cb = args[0]
+        args[0] = shimmer.wrapFunction(cb, cb => function (err, connection) {
           if (connectCh.hasSubscribers && connection && connection.host) {
             connectCh.publish({ hostname: connection.host.host, port: connection.host.port })
           }
           cb(err, connection)
         })
       }
-      return request.apply(this, arguments)
+      return request.apply(this, args)
     }
   }
 }

--- a/packages/datadog-instrumentations/src/express-mongo-sanitize.js
+++ b/packages/datadog-instrumentations/src/express-mongo-sanitize.js
@@ -12,8 +12,8 @@ const sanitizeMiddlewareFinished = channel('datadog:express-mongo-sanitize:filte
 const propertiesToSanitize = ['body', 'params', 'headers', 'query']
 
 addHook({ name: 'express-mongo-sanitize', versions: ['>=1.0.0'] }, expressMongoSanitize => {
-  shimmer.wrap(expressMongoSanitize, 'sanitize', sanitize => function () {
-    const sanitizedObject = sanitize.apply(this, arguments)
+  shimmer.wrap(expressMongoSanitize, 'sanitize', sanitize => function (...args) {
+    const sanitizedObject = sanitize.apply(this, args)
 
     if (sanitizeMethodFinished.hasSubscribers) {
       sanitizeMethodFinished.publish({ sanitizedObject })
@@ -22,21 +22,21 @@ addHook({ name: 'express-mongo-sanitize', versions: ['>=1.0.0'] }, expressMongoS
     return sanitizedObject
   })
 
-  return shimmer.wrapFunction(expressMongoSanitize, expressMongoSanitize => function () {
-    const middleware = expressMongoSanitize.apply(this, arguments)
+  return shimmer.wrapFunction(expressMongoSanitize, expressMongoSanitize => function (...args) {
+    const middleware = expressMongoSanitize.apply(this, args)
 
     return shimmer.wrapFunction(middleware, middleware => function (req, res, next) {
       if (!sanitizeMiddlewareFinished.hasSubscribers) {
         return middleware.apply(this, arguments)
       }
 
-      const wrappedNext = shimmer.wrapFunction(next, next => function () {
+      const wrappedNext = shimmer.wrapFunction(next, next => function (...args) {
         sanitizeMiddlewareFinished.publish({
           sanitizedProperties: propertiesToSanitize,
           req,
         })
 
-        return next.apply(this, arguments)
+        return next.apply(this, args)
       })
 
       return middleware.call(this, req, res, wrappedNext)

--- a/packages/datadog-instrumentations/src/express-session.js
+++ b/packages/datadog-instrumentations/src/express-session.js
@@ -8,7 +8,7 @@ const sessionMiddlewareFinishCh = channel('datadog:express-session:middleware:fi
 function wrapSessionMiddleware (sessionMiddleware) {
   return function wrappedSessionMiddleware (req, res, next) {
     shimmer.wrap(arguments, 2, function wrapNext (next) {
-      return function wrappedNext () {
+      return function wrappedNext (...args) {
         if (sessionMiddlewareFinishCh.hasSubscribers) {
           const abortController = new AbortController()
 
@@ -17,7 +17,7 @@ function wrapSessionMiddleware (sessionMiddleware) {
           if (abortController.signal.aborted) return
         }
 
-        return next.apply(this, arguments)
+        return next.apply(this, args)
       }
     })
 
@@ -26,8 +26,8 @@ function wrapSessionMiddleware (sessionMiddleware) {
 }
 
 function wrapSession (session) {
-  return function wrappedSession () {
-    const sessionMiddleware = session.apply(this, arguments)
+  return function wrappedSession (...args) {
+    const sessionMiddleware = session.apply(this, args)
 
     return shimmer.wrapFunction(sessionMiddleware, wrapSessionMiddleware)
   }

--- a/packages/datadog-instrumentations/src/express.js
+++ b/packages/datadog-instrumentations/src/express.js
@@ -54,12 +54,12 @@ function wrapResponseRender (render) {
 
     const abortController = new AbortController()
     return responseRenderChannel.traceSync(
-      function () {
+      function (...args) {
         if (abortController.signal.aborted) {
           throw abortController.signal.reason || new Error('Aborted')
         }
 
-        return render.apply(this, arguments)
+        return render.apply(this, args)
       },
       {
         req: this.req,
@@ -172,7 +172,7 @@ addHook({ name: 'express', versions: ['4'], file: 'lib/express.js' }, express =>
 const queryParserReadCh = channel('datadog:query:read:finish')
 
 function publishQueryParsedAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, next => function (...args) {
     if (queryParserReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const query = req.query
@@ -182,7 +182,7 @@ function publishQueryParsedAndNext (req, res, next) {
       if (abortController.signal.aborted) return
     }
 
-    return next.apply(this, arguments)
+    return next.apply(this, args)
   })
 }
 
@@ -191,8 +191,8 @@ addHook({
   versions: ['4'],
   file: 'lib/middleware/query.js',
 }, query => {
-  return shimmer.wrapFunction(query, query => function () {
-    const queryMiddleware = query.apply(this, arguments)
+  return shimmer.wrapFunction(query, query => function (...args) {
+    const queryMiddleware = query.apply(this, args)
 
     return shimmer.wrapFunction(queryMiddleware, queryMiddleware => function (req, res, next) {
       arguments[2] = publishQueryParsedAndNext(req, res, next)
@@ -204,9 +204,9 @@ addHook({
 const processParamsStartCh = channel('datadog:express:process_params:start')
 function wrapProcessParamsMethod (requestPositionInArguments) {
   return function wrapProcessParams (original) {
-    return function wrappedProcessParams () {
+    return function wrappedProcessParams (...args) {
       if (processParamsStartCh.hasSubscribers) {
-        const req = arguments[requestPositionInArguments]
+        const req = args[requestPositionInArguments]
         const abortController = new AbortController()
 
         processParamsStartCh.publish({
@@ -219,7 +219,7 @@ function wrapProcessParamsMethod (requestPositionInArguments) {
         if (abortController.signal.aborted) return
       }
 
-      return original.apply(this, arguments)
+      return original.apply(this, args)
     }
   }
 }

--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -25,8 +25,8 @@ const bodyPublished = new WeakSet()
 function wrapFastify (fastify, hasParsingEvents) {
   if (typeof fastify !== 'function') return fastify
 
-  return function fastifyWithTrace () {
-    const app = fastify.apply(this, arguments)
+  return function fastifyWithTrace (...args) {
+    const app = fastify.apply(this, args)
 
     if (!app || typeof app.addHook !== 'function') return app
 

--- a/packages/datadog-instrumentations/src/fs.js
+++ b/packages/datadog-instrumentations/src/fs.js
@@ -165,13 +165,13 @@ function initDirAsyncIteratorProperties (iterator) {
 
 function createWrapDirAsyncIterator () {
   return function wrapDirAsyncIterator (asyncIterator) {
-    return function wrappedAsyncIterator () {
+    return function wrappedAsyncIterator (...args) {
       if (!kDirReadPromisified || !kDirClosePromisified) {
         initDirAsyncIteratorProperties(this)
       }
       wrap(this, kDirReadPromisified, createWrapFunction('dir.', 'read'))
       wrap(this, kDirClosePromisified, createWrapFunction('dir.', 'close'))
-      return asyncIterator.apply(this, arguments)
+      return asyncIterator.apply(this, args)
     }
   }
 }
@@ -231,12 +231,12 @@ function createWatchWrapFunction (override = '') {
     const name = override || original.name
     const method = name
     const operation = name
-    return function () {
-      if (!startChannel.hasSubscribers) return original.apply(this, arguments)
-      const ctx = getMessage(method, watchMethods[operation], arguments, this)
+    return function (...args) {
+      if (!startChannel.hasSubscribers) return original.apply(this, args)
+      const ctx = getMessage(method, watchMethods[operation], args, this)
       return startChannel.runStores(ctx, () => {
         try {
-          const result = original.apply(this, arguments)
+          const result = original.apply(this, args)
           finishChannel.runStores(ctx, () => {})
           return result
         } catch (error) {
@@ -256,14 +256,14 @@ function createWrapFunction (prefix = '', override = '') {
     const method = `${prefix}${name}`
     const operation = name.match(/^(.+?)(Sync)?(\.native)?$/)[1]
 
-    return function () {
-      if (!startChannel.hasSubscribers) return original.apply(this, arguments)
+    return function (...args) {
+      if (!startChannel.hasSubscribers) return original.apply(this, args)
 
-      const lastIndex = arguments.length - 1
-      const cb = typeof arguments[lastIndex] === 'function' && arguments[lastIndex]
+      const lastIndex = args.length - 1
+      const cb = typeof args[lastIndex] === 'function' && args[lastIndex]
       const params = getMethodParamsRelationByPrefix(prefix)[operation]
       const abortController = new AbortController()
-      const ctx = { ...getMessage(method, params, arguments, this), abortController }
+      const ctx = { ...getMessage(method, params, args, this), abortController }
 
       const finish = function (error, cb = () => {}) {
         if (error !== null && typeof error === 'object') { // fs.exists receives a boolean
@@ -274,7 +274,7 @@ function createWrapFunction (prefix = '', override = '') {
       }
 
       if (cb) {
-        arguments[lastIndex] = shimmer.wrapFunction(cb, cb => function (e) {
+        args[lastIndex] = shimmer.wrapFunction(cb, cb => function (e) {
           return finish(e, () => cb.apply(this, arguments))
         })
       }
@@ -290,13 +290,13 @@ function createWrapFunction (prefix = '', override = '') {
             finish(error)
             throw error
           } else if (cb) {
-            arguments[lastIndex](error)
+            args[lastIndex](error)
             return
           }
         }
 
         try {
-          const result = original.apply(this, arguments)
+          const result = original.apply(this, args)
           if (cb) return result
           if (result && typeof result.then === 'function') {
             // TODO method open returning promise and filehandle prototype not initialized, initialize it

--- a/packages/datadog-instrumentations/src/google-cloud-pubsub.js
+++ b/packages/datadog-instrumentations/src/google-cloud-pubsub.js
@@ -167,17 +167,17 @@ addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'], file: 'build/src/su
    * Flow: message.ack() -> store context -> acknowledge() API -> retrieve context
    */
   if (Message?.prototype?.ack) {
-    shimmer.wrap(Message.prototype, 'ack', originalAck => function () {
+    shimmer.wrap(Message.prototype, 'ack', originalAck => function (...args) {
       if (this.ackId) {
         const ctx = {
           message: this,
           ackId: this.ackId,
         }
 
-        return messageAckStoreCh.runStores(ctx, originalAck, this, ...arguments)
+        return messageAckStoreCh.runStores(ctx, originalAck, this, ...args)
       }
 
-      return originalAck.apply(this, arguments)
+      return originalAck.apply(this, args)
     })
   }
 
@@ -212,7 +212,7 @@ addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'], file: 'build/src/le
     return receiveFinishCh.runStores(ctx || { message }, remove, this, ...arguments)
   })
 
-  shimmer.wrap(LeaseManager.prototype, 'clear', clear => function () {
+  shimmer.wrap(LeaseManager.prototype, 'clear', clear => function (...args) {
     if (this._messages) {
       for (const message of this._messages.values()) {
         const ctx = messageContexts.get(message)
@@ -222,7 +222,7 @@ addHook({ name: '@google-cloud/pubsub', versions: ['>=1.2'], file: 'build/src/le
         }
       }
     }
-    return clear.apply(this, arguments)
+    return clear.apply(this, args)
   })
 })
 

--- a/packages/datadog-instrumentations/src/google-genai.js
+++ b/packages/datadog-instrumentations/src/google-genai.js
@@ -46,10 +46,10 @@ function wrapGenerateContent (method) {
 }
 
 function wrapStreamIterator (iterator, ctx) {
-  return function () {
-    const itr = iterator.apply(this, arguments)
-    shimmer.wrap(itr, 'next', next => function () {
-      return next.apply(this, arguments)
+  return function (...args) {
+    const itr = iterator.apply(this, args)
+    shimmer.wrap(itr, 'next', next => function (...args) {
+      return next.apply(this, args)
         .then(res => {
           const { done, value: chunk } = res
           onStreamedChunkCh.publish({ ctx, chunk, done })

--- a/packages/datadog-instrumentations/src/grpc/server.js
+++ b/packages/datadog-instrumentations/src/grpc/server.js
@@ -49,9 +49,9 @@ function wrapHandler (func, name) {
         }
 
         shimmer.wrap(call, 'emit', emit => {
-          return function () {
+          return function (...args) {
             return emitChannel.runStores(ctx, () => {
-              return emit.apply(this, arguments)
+              return emit.apply(this, args)
             })
           }
         })

--- a/packages/datadog-instrumentations/src/hapi.js
+++ b/packages/datadog-instrumentations/src/hapi.js
@@ -28,12 +28,12 @@ function wrapServer (server) {
 }
 
 function wrapStart (start) {
-  return shimmer.wrapFunction(start, start => function () {
+  return shimmer.wrapFunction(start, start => function (...args) {
     if (this && typeof this.ext === 'function') {
       this.ext('onPreResponse', onPreResponse)
     }
 
-    return start.apply(this, arguments)
+    return start.apply(this, args)
   })
 }
 

--- a/packages/datadog-instrumentations/src/helpers/callback-instrumentor.js
+++ b/packages/datadog-instrumentations/src/helpers/callback-instrumentor.js
@@ -32,20 +32,20 @@ function createCallbackInstrumentor (prefix, { captureResult = false } = {}) {
 
   return function instrument (buildContext) {
     return function wrap (fn) {
-      return function () {
-        const lastIndex = arguments.length - 1
-        const cb = arguments[lastIndex]
+      return function (...args) {
+        const lastIndex = args.length - 1
+        const cb = args[lastIndex]
         if (!startCh.hasSubscribers || typeof cb !== 'function') {
-          return fn.apply(this, arguments)
+          return fn.apply(this, args)
         }
 
-        const ctx = buildContext(this, arguments)
+        const ctx = buildContext(this, args)
         if (ctx === undefined) {
-          return fn.apply(this, arguments)
+          return fn.apply(this, args)
         }
 
         return startCh.runStores(ctx, () => {
-          arguments[lastIndex] = shimmer.wrapFunction(cb, cb => function (error, ...rest) {
+          args[lastIndex] = shimmer.wrapFunction(cb, cb => function (error, ...rest) {
             if (error) {
               ctx.error = error
               errorCh.publish(ctx)
@@ -57,7 +57,7 @@ function createCallbackInstrumentor (prefix, { captureResult = false } = {}) {
           })
 
           try {
-            return fn.apply(this, arguments)
+            return fn.apply(this, args)
           } catch (error) {
             void error.stack // trigger getting the stack at the original throwing point
             ctx.error = error

--- a/packages/datadog-instrumentations/src/helpers/promise.js
+++ b/packages/datadog-instrumentations/src/helpers/promise.js
@@ -21,9 +21,9 @@ exports.wrapThen = function wrapThen (origThen) {
 function wrapCallback (ar, callback) {
   if (typeof callback !== 'function') return callback
 
-  return function () {
+  return function (...args) {
     return ar.runInAsyncScope(() => {
-      return callback.apply(this, arguments)
+      return callback.apply(this, args)
     })
   }
 }

--- a/packages/datadog-instrumentations/src/hono.js
+++ b/packages/datadog-instrumentations/src/hono.js
@@ -56,10 +56,10 @@ function wrapNext (req, route, next) {
   return shimmer.wrapFunction(
     next,
     (next) =>
-      function () {
+      function (...args) {
         nextChannel.publish({ req, route })
 
-        return next.apply(this, arguments)
+        return next.apply(this, args)
       }
   )
 }

--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -107,8 +107,8 @@ function setupResponseInstrumentation (ctx, res) {
       // For 'readable' events, wrap the read() method
       if (eventName === 'readable' && !originalRead && !dataListenerAdded && typeof res.read === 'function') {
         originalRead = res.read
-        res.read = function () {
-          const chunk = originalRead.apply(this, arguments)
+        res.read = function (...args) {
+          const chunk = originalRead.apply(this, args)
           if (!dataListenerAdded) {
             dataReadStarted = true
             collectChunk(chunk)
@@ -189,9 +189,9 @@ function patch (http, methodName) {
         let callback = args.callback
 
         if (callback) {
-          callback = shimmer.wrapFunction(args.callback, cb => function () {
+          callback = shimmer.wrapFunction(args.callback, cb => function (...args) {
             return asyncStartChannel.runStores(ctx, () => {
-              return cb.apply(this, arguments)
+              return cb.apply(this, args)
             })
           })
         }
@@ -214,9 +214,9 @@ function patch (http, methodName) {
 
           // tracked to accurately discern custom request socket timeout
           let customRequestTimeout = false
-          req.setTimeout = function () {
+          req.setTimeout = function (...args) {
             customRequestTimeout = true
-            return setTimeout.apply(this, arguments)
+            return setTimeout.apply(this, args)
           }
 
           req.emit = function (eventName, arg) {

--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -126,9 +126,9 @@ function wrapWriteHead (writeHead) {
 }
 
 function wrapWrite (write) {
-  return function wrappedWrite () {
+  return function wrappedWrite (...args) {
     if (!startWriteHeadCh.hasSubscribers) {
-      return write.apply(this, arguments)
+      return write.apply(this, args)
     }
 
     const abortController = new AbortController()
@@ -147,7 +147,7 @@ function wrapWrite (write) {
       return true
     }
 
-    return write.apply(this, arguments)
+    return write.apply(this, args)
   }
 }
 
@@ -177,9 +177,9 @@ function wrapSetHeader (setHeader) {
 }
 
 function wrapAppendOrRemoveHeader (originalMethod) {
-  return function wrappedAppendOrRemoveHeader () {
+  return function wrappedAppendOrRemoveHeader (...args) {
     if (!startSetHeaderCh.hasSubscribers) {
-      return originalMethod.apply(this, arguments)
+      return originalMethod.apply(this, args)
     }
 
     const abortController = new AbortController()
@@ -189,14 +189,14 @@ function wrapAppendOrRemoveHeader (originalMethod) {
       return this
     }
 
-    return originalMethod.apply(this, arguments)
+    return originalMethod.apply(this, args)
   }
 }
 
 function wrapEnd (end) {
-  return function wrappedEnd () {
+  return function wrappedEnd (...args) {
     if (!startWriteHeadCh.hasSubscribers) {
-      return end.apply(this, arguments)
+      return end.apply(this, args)
     }
 
     const abortController = new AbortController()
@@ -215,6 +215,6 @@ function wrapEnd (end) {
       return this
     }
 
-    return end.apply(this, arguments)
+    return end.apply(this, args)
   }
 }

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -521,13 +521,13 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       const setNameToParams = (name, params) => { this.nameToParams[name] = [...params] }
 
       if (event.name === 'setup' && this.global.test) {
-        shimmer.wrap(this.global.test, 'each', each => function () {
-          const testParameters = getFormattedJestTestParameters(arguments)
-          const eachBind = each.apply(this, arguments)
-          return function () {
-            const [testName] = arguments
+        shimmer.wrap(this.global.test, 'each', each => function (...args) {
+          const testParameters = getFormattedJestTestParameters(args)
+          const eachBind = each.apply(this, args)
+          return function (...args) {
+            const [testName] = args
             setNameToParams(testName, testParameters)
-            return eachBind.apply(this, arguments)
+            return eachBind.apply(this, args)
           }
         })
       }
@@ -624,16 +624,16 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
             } else {
               originalHookFns.set(hook, hookFn)
             }
-            const newHookFn = shimmer.wrapFunction(hookFn, hookFn => function () {
-              return testFnCh.runStores(ctx, () => hookFn.apply(this, arguments))
+            const newHookFn = shimmer.wrapFunction(hookFn, hookFn => function (...args) {
+              return testFnCh.runStores(ctx, () => hookFn.apply(this, args))
             })
             hook.fn = newHookFn
           }
           const originalFn = event.test.fn
           originalTestFns.set(event.test, originalFn)
 
-          const newFn = shimmer.wrapFunction(event.test.fn, testFn => function () {
-            return testFnCh.runStores(ctx, () => testFn.apply(this, arguments))
+          const newFn = shimmer.wrapFunction(event.test.fn, testFn => function (...args) {
+            return testFnCh.runStores(ctx, () => testFn.apply(this, args))
           })
 
           event.test.fn = newFn
@@ -648,8 +648,8 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         } else {
           originalHookFns.set(event.hook, hookFn)
         }
-        event.hook.fn = shimmer.wrapFunction(hookFn, hookFn => function () {
-          return testSuiteHookFnCh.runStores(ctx, () => hookFn.apply(this, arguments))
+        event.hook.fn = shimmer.wrapFunction(hookFn, hookFn => function (...args) {
+          return testSuiteHookFnCh.runStores(ctx, () => hookFn.apply(this, args))
         })
       }
 
@@ -1544,14 +1544,14 @@ function coverageReporterWrapper (coverageReporter) {
    * in which case we'll leave it.
    */
   // `_addUntestedFiles` is an async function
-  shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => function () {
+  shimmer.wrap(CoverageReporter.prototype, '_addUntestedFiles', addUntestedFiles => function (...args) {
     if (DD_TEST_TIA_KEEP_COV_CONFIG) {
-      return addUntestedFiles.apply(this, arguments)
+      return addUntestedFiles.apply(this, args)
     }
     if (isCodeCoverageEnabledBecauseOfUs) {
       return Promise.resolve()
     }
-    return addUntestedFiles.apply(this, arguments)
+    return addUntestedFiles.apply(this, args)
   })
 
   return coverageReporter
@@ -1594,8 +1594,8 @@ addHook({
   name: '@jest/test-sequencer',
   versions: ['>=28'],
 }, (sequencerPackage, frameworkVersion) => {
-  shimmer.wrap(sequencerPackage.default.prototype, 'shard', shard => function () {
-    const shardedTests = shard.apply(this, arguments)
+  shimmer.wrap(sequencerPackage.default.prototype, 'shard', shard => function (...args) {
+    const shardedTests = shard.apply(this, args)
 
     if (!shardedTests.length || !isSuitesSkippingEnabled || !skippableSuites.length) {
       return shardedTests
@@ -1642,10 +1642,10 @@ addHook({
 
 function jestAdapterWrapper (jestAdapter, jestVersion) {
   const adapter = jestAdapter.default ?? jestAdapter
-  const newAdapter = shimmer.wrapFunction(adapter, adapter => function () {
-    const environment = arguments[2]
+  const newAdapter = shimmer.wrapFunction(adapter, adapter => function (...args) {
+    const environment = args[2]
     if (!environment || !environment.testEnvironmentOptions) {
-      return adapter.apply(this, arguments)
+      return adapter.apply(this, args)
     }
     testSuiteStartCh.publish({
       testSuite: environment.testSuite,
@@ -1655,7 +1655,7 @@ function jestAdapterWrapper (jestAdapter, jestVersion) {
       frameworkVersion: jestVersion,
       testSuiteAbsolutePath: environment.testSuiteAbsolutePath,
     })
-    return adapter.apply(this, arguments).then(suiteResults => {
+    return adapter.apply(this, args).then(suiteResults => {
       const { numFailingTests, skipped, failureMessage: errorMessage } = suiteResults
       let status = 'pass'
       if (skipped) {
@@ -1773,8 +1773,8 @@ function jestConfigAsyncWrapper (jestConfig) {
 }
 
 function jestConfigSyncWrapper (jestConfig) {
-  return shimmer.wrap(jestConfig, 'readConfigs', readConfigs => function () {
-    const readConfigsResult = readConfigs.apply(this, arguments)
+  return shimmer.wrap(jestConfig, 'readConfigs', readConfigs => function (...args) {
+    const readConfigsResult = readConfigs.apply(this, args)
     configureTestEnvironment(readConfigsResult)
     return readConfigsResult
   })
@@ -1983,10 +1983,10 @@ addHook({
 })
 
 function onMessageWrapper (onMessage) {
-  return function () {
-    const response = arguments[0]
+  return function (...args) {
+    const response = args[0]
     if (!Array.isArray(response)) {
-      return onMessage.apply(this, arguments)
+      return onMessage.apply(this, args)
     }
 
     const [code, data] = response
@@ -2013,7 +2013,7 @@ function onMessageWrapper (onMessage) {
       }
       return
     }
-    return onMessage.apply(this, arguments)
+    return onMessage.apply(this, args)
   }
 }
 
@@ -2077,8 +2077,8 @@ function wrapWorker (worker) {
 }
 
 function enqueueWrapper (enqueue) {
-  return function () {
-    shimmer.wrap(arguments[0], 'onStart', onStart => function (worker) {
+  return function (...args) {
+    shimmer.wrap(args[0], 'onStart', onStart => function (worker) {
       if (worker) {
         const currentChannel = worker._child || worker._worker
         const previousChannel = wrappedWorkerChannels.get(worker)
@@ -2095,7 +2095,7 @@ function enqueueWrapper (enqueue) {
       }
       return onStart.apply(this, arguments)
     })
-    return enqueue.apply(this, arguments)
+    return enqueue.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -34,16 +34,16 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     }
   }
 
-  shimmer.wrap(Kafka.prototype, 'producer', createProducer => function () {
-    const producer = createProducer.apply(this, arguments)
+  shimmer.wrap(Kafka.prototype, 'producer', createProducer => function (...args) {
+    const producer = createProducer.apply(this, args)
     const send = producer.send
     const bootstrapServers = this._brokers
 
     const kafkaClusterIdPromise = getKafkaClusterId(this)
 
-    producer.send = function () {
+    producer.send = function (...args) {
       const wrappedSend = (clusterId) => {
-        const { topic, messages = [] } = arguments[0]
+        const { topic, messages = [] } = args[0]
 
         const ctx = {
           bootstrapServers,
@@ -61,7 +61,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
 
         return producerStartCh.runStores(ctx, () => {
           try {
-            const result = send.apply(this, arguments)
+            const result = send.apply(this, args)
             result.then(
               (res) => {
                 ctx.result = res
@@ -110,9 +110,9 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     return producer
   })
 
-  shimmer.wrap(Kafka.prototype, 'consumer', createConsumer => function () {
+  shimmer.wrap(Kafka.prototype, 'consumer', createConsumer => function (...args) {
     if (!consumerStartCh.hasSubscribers) {
-      return createConsumer.apply(this, arguments)
+      return createConsumer.apply(this, args)
     }
 
     const kafkaClusterIdPromise = getKafkaClusterId(this)
@@ -129,7 +129,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
       return { topic, partition, messages, groupId, clusterId }
     }
 
-    const consumer = createConsumer.apply(this, arguments)
+    const consumer = createConsumer.apply(this, args)
 
     consumer.on(consumer.events.COMMIT_OFFSETS, (event) => {
       const { payload: { groupId: commitGroupId, topics } } = event
@@ -149,7 +149,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
     })
 
     const run = consumer.run
-    const groupId = arguments[0].groupId
+    const groupId = args[0].groupId
 
     consumer.run = function ({ eachMessage, eachBatch, ...runArgs }) {
       const wrapConsume = (clusterId) => {

--- a/packages/datadog-instrumentations/src/knex.js
+++ b/packages/datadog-instrumentations/src/knex.js
@@ -32,41 +32,41 @@ addHook({
   versions: ['>=2'],
   file: 'lib/knex-builder/Knex.js',
 }, Knex => {
-  shimmer.wrap(Knex.Client.prototype, 'raw', raw => function () {
+  shimmer.wrap(Knex.Client.prototype, 'raw', raw => function (...args) {
     if (!startRawQueryCh.hasSubscribers) {
-      return raw.apply(this, arguments)
+      return raw.apply(this, args)
     }
 
-    const sql = arguments[0]
+    const sql = args[0]
 
     // Skip query done by Knex to get the value used for undefined
     if (sql === 'DEFAULT') {
-      return raw.apply(this, arguments)
+      return raw.apply(this, args)
     }
 
     const context = { sql, dialect: this.dialect }
     return startRawQueryCh.runStores(context, () => {
-      const rawResult = raw.apply(this, arguments)
-      shimmer.wrap(rawResult, 'then', originalThen => function () {
+      const rawResult = raw.apply(this, args)
+      shimmer.wrap(rawResult, 'then', originalThen => function (...args) {
         return rawQuerySubscribes.runStores(context, () => {
-          arguments[0] = wrapCallbackWithFinish(arguments[0], finish, context)
-          if (arguments[1]) arguments[1] = wrapCallbackWithFinish(arguments[1], finish, context)
+          args[0] = wrapCallbackWithFinish(args[0], finish, context)
+          if (args[1]) args[1] = wrapCallbackWithFinish(args[1], finish, context)
 
-          const originalThenResult = originalThen.apply(this, arguments)
+          const originalThenResult = originalThen.apply(this, args)
 
-          shimmer.wrap(originalThenResult, 'catch', originalCatch => function () {
-            arguments[0] = wrapCallbackWithFinish(arguments[0], finish, context)
-            return originalCatch.apply(this, arguments)
+          shimmer.wrap(originalThenResult, 'catch', originalCatch => function (...args) {
+            args[0] = wrapCallbackWithFinish(args[0], finish, context)
+            return originalCatch.apply(this, args)
           })
 
           return originalThenResult
         })
       })
 
-      shimmer.wrap(rawResult, 'asCallback', originalAsCallback => function () {
+      shimmer.wrap(rawResult, 'asCallback', originalAsCallback => function (...args) {
         return rawQuerySubscribes.runStores(context, () => {
-          arguments[0] = wrapCallbackWithFinish(arguments[0], finish, context)
-          return originalAsCallback.apply(this, arguments)
+          args[0] = wrapCallbackWithFinish(args[0], finish, context)
+          return originalAsCallback.apply(this, args)
         })
       })
 
@@ -80,7 +80,7 @@ addHook({
 function wrapCallbackWithFinish (callback, finish, context) {
   if (typeof callback !== 'function') return callback
 
-  return shimmer.wrapFunction(callback, callback => function () {
-    finish(context, () => callback.apply(this, arguments))
+  return shimmer.wrapFunction(callback, callback => function (...args) {
+    finish(context, () => callback.apply(this, args))
   })
 }

--- a/packages/datadog-instrumentations/src/koa.js
+++ b/packages/datadog-instrumentations/src/koa.js
@@ -14,8 +14,8 @@ const routeChannel = channel('apm:koa:request:route')
 const originals = new WeakMap()
 
 function wrapCallback (callback) {
-  return function callbackWithTrace () {
-    const handleRequest = callback.apply(this, arguments)
+  return function callbackWithTrace (...args) {
+    const handleRequest = callback.apply(this, args)
 
     if (typeof handleRequest !== 'function') return handleRequest
 
@@ -28,8 +28,8 @@ function wrapCallback (callback) {
 }
 
 function wrapUse (use) {
-  return function useWithTrace () {
-    const result = use.apply(this, arguments)
+  return function useWithTrace (...args) {
+    const result = use.apply(this, args)
 
     if (Array.isArray(this.middleware)) {
       const fn = this.middleware.pop()
@@ -54,8 +54,8 @@ function wrapRegister (register) {
 }
 
 function wrapRouterUse (use) {
-  return function useWithTrace () {
-    const router = use.apply(this, arguments)
+  return function useWithTrace (...args) {
+    const router = use.apply(this, args)
 
     for (const layer of router.stack) {
       wrapStack(layer)
@@ -144,10 +144,10 @@ function fulfill (ctx, error) {
 }
 
 function wrapNext (req, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, next => function (...args) {
     nextChannel.publish({ req })
 
-    return next.apply(this, arguments)
+    return next.apply(this, args)
   })
 }
 

--- a/packages/datadog-instrumentations/src/ldapjs.js
+++ b/packages/datadog-instrumentations/src/ldapjs.js
@@ -71,12 +71,12 @@ addHook({ name: 'ldapjs', versions: ['>=2'] }, ldapjs => {
     return search.apply(this, arguments)
   })
 
-  shimmer.wrap(ldapjs.Client.prototype, '_send', _send => function () {
-    const callbackIndex = getCallbackArgIndex(arguments)
+  shimmer.wrap(ldapjs.Client.prototype, '_send', _send => function (...args) {
+    const callbackIndex = getCallbackArgIndex(args)
     if (callbackIndex > -1) {
-      const callback = arguments[callbackIndex]
+      const callback = args[callbackIndex]
       // eslint-disable-next-line n/handle-callback-err
-      arguments[callbackIndex] = shimmer.wrapFunction(callback, callback => function (err, corkedEmitter) {
+      args[callbackIndex] = shimmer.wrapFunction(callback, callback => function (err, corkedEmitter) {
         if (corkedEmitter !== null && typeof corkedEmitter === 'object' && typeof corkedEmitter.on === 'function') {
           wrapEmitter(corkedEmitter)
         }
@@ -84,7 +84,7 @@ addHook({ name: 'ldapjs', versions: ['>=2'] }, ldapjs => {
       })
     }
 
-    return _send.apply(this, arguments)
+    return _send.apply(this, args)
   })
 
   shimmer.wrap(ldapjs.Client.prototype, 'bind', bind => function (dn, password, controls, callback) {

--- a/packages/datadog-instrumentations/src/light-my-request.js
+++ b/packages/datadog-instrumentations/src/light-my-request.js
@@ -69,8 +69,8 @@ function wrapDispatchFunc (dispatchFunc) {
     // Also wrap end() as fallback
     const originalEnd = res.end
     if (originalEnd) {
-      res.end = function wrappedEnd () {
-        const result = originalEnd.apply(this, arguments)
+      res.end = function wrappedEnd (...args) {
+        const result = originalEnd.apply(this, args)
         // Trigger finish if events don't fire
         setImmediate(onFinish)
         return result

--- a/packages/datadog-instrumentations/src/limitd-client.js
+++ b/packages/datadog-instrumentations/src/limitd-client.js
@@ -4,10 +4,10 @@ const shimmer = require('../../datadog-shimmer')
 const { addHook, AsyncResource } = require('./helpers/instrument')
 
 function wrapRequest (original) {
-  return function () {
-    const id = arguments.length - 1
-    arguments[id] = AsyncResource.bind(arguments[id])
-    return original.apply(this, arguments)
+  return function (...args) {
+    const id = args.length - 1
+    args[id] = AsyncResource.bind(args[id])
+    return original.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -12,13 +12,13 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
     lodash,
     instrumentedLodashFn,
     lodashFn => {
-      return function () {
+      return function (...args) {
         if (!lodashOperationCh.hasSubscribers) {
-          return lodashFn.apply(this, arguments)
+          return lodashFn.apply(this, args)
         }
 
-        const result = lodashFn.apply(this, arguments)
-        const message = { operation: lodashFn.name, arguments, result }
+        const result = lodashFn.apply(this, args)
+        const message = { operation: lodashFn.name, args, result }
         lodashOperationCh.publish(message)
 
         return message.result

--- a/packages/datadog-instrumentations/src/lodash.js
+++ b/packages/datadog-instrumentations/src/lodash.js
@@ -18,7 +18,7 @@ addHook({ name: 'lodash', versions: ['>=4'] }, lodash => {
         }
 
         const result = lodashFn.apply(this, args)
-        const message = { operation: lodashFn.name, args, result }
+        const message = { operation: lodashFn.name, arguments: args, result }
         lodashOperationCh.publish(message)
 
         return message.result


### PR DESCRIPTION
## Summary

Same shape change as #8353 applied to instrumentation files starting
`[d-l]*`.

Refs: https://github.com/DataDog/dd-trace-js/pull/8353