### PR TITLE
refactor(prefer-rest-params): convert instrumentations m-z

### DIFF
--- a/packages/datadog-instrumentations/src/mariadb.js
+++ b/packages/datadog-instrumentations/src/mariadb.js
@@ -12,13 +12,13 @@ const errorCh = channel('apm:mariadb:query:error')
 const skipCh = channel('apm:mariadb:pool:skip')
 
 function wrapCommandStart (start, ctx) {
-  return shimmer.wrapFunction(start, start => function () {
-    if (!startCh.hasSubscribers) return start.apply(this, arguments)
+  return shimmer.wrapFunction(start, start => function (...args) {
+    if (!startCh.hasSubscribers) return start.apply(this, args)
 
     const { reject, resolve } = this
     shimmer.wrap(this, 'resolve', function wrapResolve () {
-      return function () {
-        return finishCh.runStores(ctx, resolve, this, ...arguments)
+      return function (...args) {
+        return finishCh.runStores(ctx, resolve, this, ...args)
       }
     })
 
@@ -32,7 +32,7 @@ function wrapCommandStart (start, ctx) {
       }
     })
 
-    return startCh.runStores(ctx, start, this, ...arguments)
+    return startCh.runStores(ctx, start, this, ...args)
   })
 }
 
@@ -128,25 +128,25 @@ function wrapPoolBase (PoolBase) {
 // so instead we just skip instrumentation completely to avoid memory leaks
 // and/or orphan spans.
 function wrapPoolMethod (createConnection) {
-  return function () {
-    return skipCh.runStores({}, createConnection, this, ...arguments)
+  return function (...args) {
+    return skipCh.runStores({}, createConnection, this, ...args)
   }
 }
 
 function wrapPoolGetConnectionMethod (getConnection) {
-  return function wrappedGetConnection () {
-    const cb = arguments[arguments.length - 1]
-    if (typeof cb !== 'function') return getConnection.apply(this, arguments)
+  return function wrappedGetConnection (...args) {
+    const cb = args[args.length - 1]
+    if (typeof cb !== 'function') return getConnection.apply(this, args)
 
     const ctx = {}
 
-    arguments[arguments.length - 1] = function () {
-      return connectionFinishCh.runStores(ctx, cb, this, ...arguments)
+    args[args.length - 1] = function (...args) {
+      return connectionFinishCh.runStores(ctx, cb, this, ...args)
     }
 
     connectionStartCh.publish(ctx)
 
-    return getConnection.apply(this, arguments)
+    return getConnection.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/memcached.js
+++ b/packages/datadog-instrumentations/src/memcached.js
@@ -18,8 +18,8 @@ addHook({ name: 'memcached', versions: ['>=2.2'] }, Memcached => {
 
     const client = this
 
-    const wrappedQueryCompiler = function () {
-      const query = queryCompiler.apply(this, arguments)
+    const wrappedQueryCompiler = function (...args) {
+      const query = queryCompiler.apply(this, args)
 
       const ctx = { client, server, query }
       startCh.runStores(ctx, () => {

--- a/packages/datadog-instrumentations/src/microgateway-core.js
+++ b/packages/datadog-instrumentations/src/microgateway-core.js
@@ -14,8 +14,8 @@ const versions = ['>=2.1 <=3.0.0']
 const requestContexts = new WeakMap()
 
 function wrapConfigProxyFactory (configProxyFactory) {
-  return function () {
-    const configProxy = configProxyFactory.apply(this, arguments)
+  return function (...args) {
+    const configProxy = configProxyFactory.apply(this, args)
 
     return function (req, res, next) {
       const ctx = { req, res }

--- a/packages/datadog-instrumentations/src/mocha/common.js
+++ b/packages/datadog-instrumentations/src/mocha/common.js
@@ -20,9 +20,9 @@ addHook({
 
   patched.add(mochaEach)
 
-  return shimmer.wrapFunction(mochaEach, mochaEach => function () {
-    const [params] = arguments
-    const { it, ...rest } = mochaEach.apply(this, arguments)
+  return shimmer.wrapFunction(mochaEach, mochaEach => function (...args) {
+    const [params] = args
+    const { it, ...rest } = mochaEach.apply(this, args)
     return {
       it: function (title) {
         parameterizedTestCh.publish({ title, params })

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -370,17 +370,17 @@ addHook({
 }, (Mocha, frameworkVersion) => {
   warnDeprecatedMochaVersion(frameworkVersion)
 
-  shimmer.wrap(Mocha.prototype, 'run', run => function () {
+  shimmer.wrap(Mocha.prototype, 'run', run => function (...args) {
     // Workers do not need to request any data, just run the tests
     if (!testFinishCh.hasSubscribers || getEnvironmentVariable('MOCHA_WORKER_ID') || this.options.parallel) {
-      return run.apply(this, arguments)
+      return run.apply(this, args)
     }
 
     // `options.delay` does not work in parallel mode, so we can't delay the execution this way
     // This needs to be both here and in `runMocha` hook. Read the comment in `runMocha` hook for more info.
     this.options.delay = true
 
-    const runner = run.apply(this, arguments)
+    const runner = run.apply(this, args)
 
     // eslint-disable-next-line unicorn/no-array-for-each
     this.files.forEach((path) => {
@@ -427,11 +427,11 @@ addHook({
   file: 'lib/cli/run-helpers.js',
 }, (run) => {
   // `runMocha` is an async function
-  shimmer.wrap(run, 'runMocha', runMocha => function () {
+  shimmer.wrap(run, 'runMocha', runMocha => function (...args) {
     if (!testFinishCh.hasSubscribers) {
-      return runMocha.apply(this, arguments)
+      return runMocha.apply(this, args)
     }
-    const mocha = arguments[0]
+    const mocha = args[0]
 
     /**
      * This attaches `run` to the global context, which we'll call after
@@ -445,7 +445,7 @@ addHook({
       mocha.options.delay = true
     }
 
-    return runMocha.apply(this, arguments)
+    return runMocha.apply(this, args)
   })
   return run
 })
@@ -463,9 +463,9 @@ addHook({
 
   shimmer.wrap(Runner.prototype, 'runTests', runTests => getRunTestsWrapper(runTests, config))
 
-  shimmer.wrap(Runner.prototype, 'run', run => function () {
+  shimmer.wrap(Runner.prototype, 'run', run => function (...args) {
     if (!testFinishCh.hasSubscribers) {
-      return run.apply(this, arguments)
+      return run.apply(this, args)
     }
 
     const { suitesByTestFile, numSuitesByTestFile } = getSuitesByTestFile(this.suite)
@@ -553,7 +553,7 @@ addHook({
       }
     })
 
-    return run.apply(this, arguments)
+    return run.apply(this, args)
   })
 
   return Runner

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -102,9 +102,9 @@ function wrapOriginalEfdTest (test, slowTestRetries) {
 
     if (originalFn.length > 0) {
       const args = Array.prototype.slice.call(arguments)
-      args[0] = shimmer.wrapFunction(args[0], done => function () {
+      args[0] = shimmer.wrapFunction(args[0], done => function (...args) {
         recordDuration()
-        return done.apply(this, arguments)
+        return done.apply(this, args)
       })
       return originalFn.apply(this, args)
     }
@@ -142,13 +142,13 @@ function retryTest (test, numRetries, tags, slowTestRetries) {
       clonedTest._ddEfdRetryIndex = retryIndex + 1
       const originalFn = clonedTest.fn
       if (typeof originalFn === 'function') {
-        clonedTest.fn = shimmer.wrapFunction(originalFn, originalFn => function () {
+        clonedTest.fn = shimmer.wrapFunction(originalFn, originalFn => function (...args) {
           const efdRetryCount = efdRetryCountByTestFullName.get(getTestFullName(clonedTest))
           if (efdRetryCount !== undefined && clonedTest._ddEfdRetryIndex > efdRetryCount) {
             clonedTest._ddShouldSkipEfdRetry = true
             this.skip()
           }
-          return originalFn.apply(this, arguments)
+          return originalFn.apply(this, args)
         })
       }
     }
@@ -231,9 +231,9 @@ function getTestContext (test) {
 }
 
 function runnableWrapper (RunnablePackage, libraryConfig) {
-  shimmer.wrap(RunnablePackage.prototype, 'run', run => function () {
+  shimmer.wrap(RunnablePackage.prototype, 'run', run => function (...args) {
     if (!testFinishCh.hasSubscribers) {
-      return run.apply(this, arguments)
+      return run.apply(this, args)
     }
     if (libraryConfig?.isFlakyTestRetriesEnabled) {
       this.retries(libraryConfig?.flakyTestRetriesCount)
@@ -259,8 +259,8 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
 
       if (ctx) {
         // we bind the test fn to the correct context
-        const newFn = shimmer.wrapFunction(this.fn, originalFn => function () {
-          return testFnCh.runStores(ctx, () => originalFn.apply(this, arguments))
+        const newFn = shimmer.wrapFunction(this.fn, originalFn => function (...args) {
+          return testFnCh.runStores(ctx, () => originalFn.apply(this, args))
         })
 
         // we store the original function, not to lose it
@@ -271,7 +271,7 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
       }
     }
 
-    return run.apply(this, arguments)
+    return run.apply(this, args)
   })
   return RunnablePackage
 }

--- a/packages/datadog-instrumentations/src/mocha/worker.js
+++ b/packages/datadog-instrumentations/src/mocha/worker.js
@@ -27,7 +27,7 @@ addHook({
   versions: ['>=8.0.0'],
   file: 'lib/mocha.js',
 }, (Mocha) => {
-  shimmer.wrap(Mocha.prototype, 'run', run => function () {
+  shimmer.wrap(Mocha.prototype, 'run', run => function (...args) {
     if (this.options._ddIsKnownTestsEnabled) {
       config.isKnownTestsEnabled = true
       config.isEarlyFlakeDetectionEnabled = this.options._ddIsEfdEnabled
@@ -60,7 +60,7 @@ addHook({
       delete this.options._ddIsFlakyTestRetriesEnabled
       delete this.options._ddFlakyTestRetriesCount
     }
-    return run.apply(this, arguments)
+    return run.apply(this, args)
   })
 
   return Mocha
@@ -74,9 +74,9 @@ addHook({
 }, function (Runner) {
   shimmer.wrap(Runner.prototype, 'runTests', runTests => getRunTestsWrapper(runTests, config))
 
-  shimmer.wrap(Runner.prototype, 'run', run => function () {
+  shimmer.wrap(Runner.prototype, 'run', run => function (...args) {
     if (!workerFinishCh.hasSubscribers) {
-      return run.apply(this, arguments)
+      return run.apply(this, args)
     }
     // We flush when the worker ends with its test file (a mocha instance in a worker runs a single test file)
     this.once('end', () => {
@@ -95,7 +95,7 @@ addHook({
 
     this.on('pending', getOnPendingHandler())
 
-    return run.apply(this, arguments)
+    return run.apply(this, args)
   })
   return Runner
 })

--- a/packages/datadog-instrumentations/src/mongodb-core.js
+++ b/packages/datadog-instrumentations/src/mongodb-core.js
@@ -104,25 +104,25 @@ function wrapConnectionCommand (command, operation, name, instrumentFn = instrum
 }
 
 function wrapQuery (query, operation, name) {
-  return function () {
+  return function (...args) {
     if (!startCh.hasSubscribers) {
-      return query.apply(this, arguments)
+      return query.apply(this, args)
     }
     const pool = this.server.s.pool
     const ns = this.ns
     const ops = this.cmd
-    return instrument(operation, query, this, arguments, pool, ns, ops)
+    return instrument(operation, query, this, args, pool, ns, ops)
   }
 }
 
 function wrapCursor (cursor, operation, name) {
-  return function () {
+  return function (...args) {
     if (!startCh.hasSubscribers) {
-      return cursor.apply(this, arguments)
+      return cursor.apply(this, args)
     }
     const pool = this.server.s.pool
     const ns = this.ns
-    return instrument(operation, cursor, this, arguments, pool, ns, {}, { name })
+    return instrument(operation, cursor, this, args, pool, ns, {}, { name })
   }
 }
 

--- a/packages/datadog-instrumentations/src/mongodb.js
+++ b/packages/datadog-instrumentations/src/mongodb.js
@@ -35,22 +35,22 @@ addHook({ name: 'mongodb', versions: ['>=3.3 <5', '5', '>=6'] }, mongodb => {
     const useTwoArguments = collectionMethodsWithTwoFilters.includes(methodName)
 
     shimmer.wrap(mongodb.Collection.prototype, methodName, method => {
-      return function () {
+      return function (...args) {
         if (!startCh.hasSubscribers) {
-          return method.apply(this, arguments)
+          return method.apply(this, args)
         }
 
         const ctx = {
-          filters: [arguments[0]],
+          filters: [args[0]],
           methodName,
         }
 
         if (useTwoArguments) {
-          ctx.filters.push(arguments[1])
+          ctx.filters.push(args[1])
         }
 
         return startCh.runStores(ctx, () => {
-          return method.apply(this, arguments)
+          return method.apply(this, args)
         })
       }
     })

--- a/packages/datadog-instrumentations/src/mongoose.js
+++ b/packages/datadog-instrumentations/src/mongoose.js
@@ -66,14 +66,14 @@ addHook({
     if (!(methodName in Model)) continue
 
     shimmer.wrap(Model, methodName, method => {
-      return function wrappedModelMethod () {
+      return function wrappedModelMethod (...args) {
         if (!startCh.hasSubscribers) {
-          return method.apply(this, arguments)
+          return method.apply(this, args)
         }
 
-        const filters = [arguments[0]]
+        const filters = [args[0]]
         if (useTwoArguments) {
-          filters.push(arguments[1])
+          filters.push(args[1])
         }
 
         let callbackWrapped = false
@@ -84,10 +84,10 @@ addHook({
           if (typeof args[lastArgumentIndex] === 'function') {
             // is a callback, wrap it to execute finish()
             shimmer.wrap(args, lastArgumentIndex, originalCb => {
-              return function () {
+              return function (...args) {
                 finishCh.publish(ctx)
 
-                return originalCb.apply(this, arguments)
+                return originalCb.apply(this, args)
               }
             })
 
@@ -101,19 +101,19 @@ addHook({
         }
 
         return startCh.runStores(ctx, () => {
-          wrapCallbackIfExist(arguments, ctx)
+          wrapCallbackIfExist(args, ctx)
 
-          const res = method.apply(this, arguments)
+          const res = method.apply(this, args)
 
           // if it is not callback, wrap exec method and its then
           if (!callbackWrapped) {
             shimmer.wrap(res, 'exec', originalExec => {
-              return function wrappedExec () {
+              return function wrappedExec (...args) {
                 if (!callbackWrapped) {
-                  wrapCallbackIfExist(arguments, ctx)
+                  wrapCallbackIfExist(args, ctx)
                 }
 
-                const execResult = originalExec.apply(this, arguments)
+                const execResult = originalExec.apply(this, args)
 
                 if (callbackWrapped || typeof execResult?.then !== 'function') {
                   return execResult
@@ -121,27 +121,27 @@ addHook({
 
                 // wrap them method, wrap resolve and reject methods
                 shimmer.wrap(execResult, 'then', originalThen => {
-                  return function wrappedThen () {
-                    const resolve = arguments[0]
-                    const reject = arguments[1]
+                  return function wrappedThen (...args) {
+                    const resolve = args[0]
+                    const reject = args[1]
 
-                    arguments[0] = shimmer.wrapFunction(resolve, resolve => function wrappedResolve () {
+                    args[0] = shimmer.wrapFunction(resolve, resolve => function wrappedResolve (...args) {
                       finishCh.publish(ctx)
 
                       if (resolve) {
-                        return resolve.apply(this, arguments)
+                        return resolve.apply(this, args)
                       }
                     })
 
-                    arguments[1] = shimmer.wrapFunction(reject, reject => function wrappedReject () {
+                    args[1] = shimmer.wrapFunction(reject, reject => function wrappedReject (...args) {
                       finishCh.publish(ctx)
 
                       if (reject) {
-                        return reject.apply(this, arguments)
+                        return reject.apply(this, args)
                       }
                     })
 
-                    return originalThen.apply(this, arguments)
+                    return originalThen.apply(this, args)
                   }
                 })
 
@@ -165,8 +165,8 @@ addHook({
   versions: ['6', '>=7'],
   file: 'lib/helpers/query/sanitizeFilter.js',
 }, sanitizeFilter => {
-  return shimmer.wrapFunction(sanitizeFilter, sanitizeFilter => function wrappedSanitizeFilter () {
-    const sanitizedObject = sanitizeFilter.apply(this, arguments)
+  return shimmer.wrapFunction(sanitizeFilter, sanitizeFilter => function wrappedSanitizeFilter (...args) {
+    const sanitizedObject = sanitizeFilter.apply(this, args)
 
     if (sanitizeFilterFinishCh.hasSubscribers) {
       sanitizeFilterFinishCh.publish({

--- a/packages/datadog-instrumentations/src/mquery.js
+++ b/packages/datadog-instrumentations/src/mquery.js
@@ -42,22 +42,22 @@ addHook({
     if (!(methodName in Query.prototype)) continue
 
     shimmer.wrap(Query.prototype, methodName, method => {
-      return function () {
+      return function (...args) {
         if (prepareCh.hasSubscribers) {
-          const filters = getFilters(arguments, methodName)
+          const filters = getFilters(args, methodName)
           if (filters?.length) {
             prepareCh.publish({ filters })
           }
         }
 
-        return method.apply(this, arguments)
+        return method.apply(this, args)
       }
     })
   }
 
   shimmer.wrap(Query.prototype, 'exec', originalExec => {
-    return function wrappedExec () {
-      return tracingCh.tracePromise(originalExec, {}, this, arguments)
+    return function wrappedExec (...args) {
+      return tracingCh.tracePromise(originalExec, {}, this, args)
     }
   })
 

--- a/packages/datadog-instrumentations/src/multer.js
+++ b/packages/datadog-instrumentations/src/multer.js
@@ -6,7 +6,7 @@ const { channel, addHook, AsyncResource } = require('./helpers/instrument')
 const multerReadCh = channel('datadog:multer:read:finish')
 
 function publishRequestBodyAndNext (req, res, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, next => function (...args) {
     if (multerReadCh.hasSubscribers && req) {
       const abortController = new AbortController()
       const body = req.body
@@ -16,7 +16,7 @@ function publishRequestBodyAndNext (req, res, next) {
       if (abortController.signal.aborted) return
     }
 
-    return next.apply(this, arguments)
+    return next.apply(this, args)
   })
 }
 
@@ -25,8 +25,8 @@ addHook({
   file: 'lib/make-middleware.js',
   versions: ['^1.4.4-lts.1'],
 }, makeMiddleware => {
-  return shimmer.wrapFunction(makeMiddleware, makeMiddleware => function () {
-    const middleware = makeMiddleware.apply(this, arguments)
+  return shimmer.wrapFunction(makeMiddleware, makeMiddleware => function (...args) {
+    const middleware = makeMiddleware.apply(this, args)
 
     return shimmer.wrapFunction(middleware, middleware => function wrapMulterMiddleware (req, res, next) {
       const nextResource = new AsyncResource('bound-anonymous-fn')

--- a/packages/datadog-instrumentations/src/mysql.js
+++ b/packages/datadog-instrumentations/src/mysql.js
@@ -8,24 +8,24 @@ addHook({ name: 'mysql', file: 'lib/Connection.js', versions: ['>=2'] }, Connect
   const finishCh = channel('apm:mysql:query:finish')
   const errorCh = channel('apm:mysql:query:error')
 
-  shimmer.wrap(Connection.prototype, 'query', query => function () {
+  shimmer.wrap(Connection.prototype, 'query', query => function (...args) {
     if (!startCh.hasSubscribers) {
-      return query.apply(this, arguments)
+      return query.apply(this, args)
     }
 
-    const sql = arguments[0].sql || arguments[0]
+    const sql = args[0].sql || args[0]
     const conf = this.config
     const ctx = { sql, conf }
 
     return startCh.runStores(ctx, () => {
-      if (arguments[0].sql) {
-        arguments[0].sql = ctx.sql
+      if (args[0].sql) {
+        args[0].sql = ctx.sql
       } else {
-        arguments[0] = ctx.sql
+        args[0] = ctx.sql
       }
 
       try {
-        const res = query.apply(this, arguments)
+        const res = query.apply(this, args)
 
         if (res._callback) {
           const cb = res._callback
@@ -63,8 +63,8 @@ addHook({ name: 'mysql', file: 'lib/Pool.js', versions: ['>=2'] }, Pool => {
   const finishPoolQueryCh = channel('datadog:mysql:pool:query:finish')
 
   shimmer.wrap(Pool.prototype, 'getConnection', getConnection => function (cb) {
-    arguments[0] = function () {
-      return connectionFinishCh.runStores(ctx, cb, this, ...arguments)
+    arguments[0] = function (...args) {
+      return connectionFinishCh.runStores(ctx, cb, this, ...args)
     }
 
     const ctx = {}
@@ -74,24 +74,24 @@ addHook({ name: 'mysql', file: 'lib/Pool.js', versions: ['>=2'] }, Pool => {
     return getConnection.apply(this, arguments)
   })
 
-  shimmer.wrap(Pool.prototype, 'query', query => function () {
+  shimmer.wrap(Pool.prototype, 'query', query => function (...args) {
     if (!startPoolQueryCh.hasSubscribers) {
-      return query.apply(this, arguments)
+      return query.apply(this, args)
     }
 
-    const sql = arguments[0].sql || arguments[0]
+    const sql = args[0].sql || args[0]
     const ctx = { sql }
     const finish = () => finishPoolQueryCh.publish(ctx)
 
     return startPoolQueryCh.runStores(ctx, () => {
-      const cb = arguments[arguments.length - 1]
+      const cb = args[args.length - 1]
       if (typeof cb === 'function') {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function () {
-          return finishPoolQueryCh.runStores(ctx, cb, this, ...arguments)
+        args[args.length - 1] = shimmer.wrapFunction(cb, cb => function (...args) {
+          return finishPoolQueryCh.runStores(ctx, cb, this, ...args)
         })
       }
 
-      const retval = query.apply(this, arguments)
+      const retval = query.apply(this, args)
 
       if (retval && retval.then) {
         retval.then(finish).catch(finish)

--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -145,8 +145,8 @@ function wrapConnection (Connection, version) {
 
     if (cached === onResult) return
 
-    const wrapped = function () {
-      return commandFinishCh.runStores(ctx, onResult, this, ...arguments)
+    const wrapped = function (...args) {
+      return commandFinishCh.runStores(ctx, onResult, this, ...args)
     }
 
     wrappedOnResult.set(cmd, wrapped)
@@ -289,8 +289,8 @@ function wrapPoolCluster (PoolCluster) {
   const startOuterQueryCh = channel('datadog:mysql2:outerquery:start')
   const wrappedPoolNamespaces = new WeakSet()
 
-  shimmer.wrap(PoolCluster.prototype, 'of', of => function () {
-    const poolNamespace = of.apply(this, arguments)
+  shimmer.wrap(PoolCluster.prototype, 'of', of => function (...args) {
+    const poolNamespace = of.apply(this, args)
 
     if (startOuterQueryCh.hasSubscribers && !wrappedPoolNamespaces.has(poolNamespace)) {
       shimmer.wrap(poolNamespace, 'query', query => function (sql, values, cb) {

--- a/packages/datadog-instrumentations/src/net.js
+++ b/packages/datadog-instrumentations/src/net.js
@@ -21,16 +21,16 @@ addHook({ name: 'net' }, (net) => {
   // so that we don't miss the dns calls
   require('node:dns')
 
-  shimmer.wrap(net.Socket.prototype, 'connect', connect => function () {
+  shimmer.wrap(net.Socket.prototype, 'connect', connect => function (...args) {
     if (!startICPCh.hasSubscribers || !startTCPCh.hasSubscribers) {
-      return connect.apply(this, arguments)
+      return connect.apply(this, args)
     }
 
-    const options = getOptions(arguments)
-    const lastIndex = arguments.length - 1
-    const callback = arguments[lastIndex]
+    const options = getOptions(args)
+    const lastIndex = args.length - 1
+    const callback = args[lastIndex]
 
-    if (!options) return connect.apply(this, arguments)
+    if (!options) return connect.apply(this, args)
 
     const protocol = options.path ? 'ipc' : 'tcp'
     const startCh = protocol === 'ipc' ? startICPCh : startTCPCh
@@ -39,7 +39,7 @@ addHook({ name: 'net' }, (net) => {
     const ctx = { options }
 
     if (typeof callback === 'function') {
-      arguments[lastIndex] = function (...args) {
+      args[lastIndex] = function (...args) {
         return finishCh.runStores(ctx, callback, this, ...args)
       }
     }
@@ -67,7 +67,7 @@ addHook({ name: 'net' }, (net) => {
       })
 
       try {
-        return connect.apply(this, arguments)
+        return connect.apply(this, args)
       } catch (err) {
         errorCh.publish(err)
 

--- a/packages/datadog-instrumentations/src/nyc.js
+++ b/packages/datadog-instrumentations/src/nyc.js
@@ -17,7 +17,7 @@ addHook({
   setupSettingsCachePath()
 
   // `wrap` is an async function
-  shimmer.wrap(nycPackage.prototype, 'wrap', wrap => function () {
+  shimmer.wrap(nycPackage.prototype, 'wrap', wrap => function (...args) {
     // Only relevant if the config `all` is set to true (for untested code coverage)
     try {
       if (JSON.parse(getEnvironmentVariable('NYC_CONFIG')).all) {
@@ -27,16 +27,16 @@ addHook({
       // ignore errors
     }
 
-    return wrap.apply(this, arguments)
+    return wrap.apply(this, args)
   })
 
   // `report` is an async function, so we wait for it to complete before publishing
-  shimmer.wrap(nycPackage.prototype, 'report', report => function () {
+  shimmer.wrap(nycPackage.prototype, 'report', report => function (...args) {
     if (!codeCoverageReportCh.hasSubscribers) {
-      return report.apply(this, arguments)
+      return report.apply(this, args)
     }
     const nycInstance = this
-    const reportPromise = report.apply(this, arguments)
+    const reportPromise = report.apply(this, args)
 
     if (reportPromise && typeof reportPromise.then === 'function') {
       // Return a new promise that waits for both the report AND the coverage upload

--- a/packages/datadog-instrumentations/src/openai.js
+++ b/packages/datadog-instrumentations/src/openai.js
@@ -150,18 +150,18 @@ addHook({ name: 'openai', file: 'dist/api.js', versions: ['>=3.0.0 <4'] }, expor
   methodNames.shift() // remove leading 'constructor' method
 
   for (const methodName of methodNames) {
-    shimmer.wrap(exports.OpenAIApi.prototype, methodName, fn => function () {
+    shimmer.wrap(exports.OpenAIApi.prototype, methodName, fn => function (...args) {
       if (!ch.start.hasSubscribers) {
-        return fn.apply(this, arguments)
+        return fn.apply(this, args)
       }
 
       const ctx = {
         methodName,
-        args: arguments,
+        args,
         basePath: this.basePath,
       }
 
-      return ch.tracePromise(fn, ctx, this, ...arguments)
+      return ch.tracePromise(fn, ctx, this, ...args)
     })
   }
 
@@ -175,10 +175,10 @@ addHook({ name: 'openai', file: 'dist/api.js', versions: ['>=3.0.0 <4'] }, expor
  */
 function wrapStreamIterator (response, options, ctx) {
   return function (itr) {
-    return function () {
-      const iterator = itr.apply(this, arguments)
-      shimmer.wrap(iterator, 'next', next => function () {
-        return next.apply(this, arguments)
+    return function (...args) {
+      const iterator = itr.apply(this, args)
+      shimmer.wrap(iterator, 'next', next => function (...args) {
+        return next.apply(this, args)
           .then(res => {
             const { done, value: chunk } = res
             onStreamedChunkCh.publish({ ctx, chunk, done })
@@ -215,38 +215,38 @@ for (const extension of extensions) {
       const targetPrototype = exports[targetClass].prototype
 
       for (const methodName of methods) {
-        shimmer.wrap(targetPrototype, methodName, methodFn => function () {
+        shimmer.wrap(targetPrototype, methodName, methodFn => function (...args) {
           if (!ch.start.hasSubscribers) {
-            return methodFn.apply(this, arguments)
+            return methodFn.apply(this, args)
           }
 
           // The OpenAI library lets you set `stream: true` on the options arg to any method
           // However, we only want to handle streamed responses in specific cases
           // chat.completions and completions
-          const stream = streamedResponse && getOption(arguments, 'stream', false)
+          const stream = streamedResponse && getOption(args, 'stream', false)
 
           const client = this._client || this.client
 
           const ctx = {
             methodName: `${baseResource}.${methodName}`,
-            args: arguments,
+            args,
             basePath: client.baseURL,
           }
 
           return ch.start.runStores(ctx, () => {
-            const apiProm = methodFn.apply(this, arguments)
+            const apiProm = methodFn.apply(this, args)
 
             if (baseResource === 'chat.completions' && typeof apiProm._thenUnwrap === 'function') {
               // this should only ever be invoked from a client.beta.chat.completions.parse call
-              shimmer.wrap(apiProm, '_thenUnwrap', origApiPromThenUnwrap => function () {
+              shimmer.wrap(apiProm, '_thenUnwrap', origApiPromThenUnwrap => function (...args) {
                 // TODO(sam.brenner): I wonder if we can patch the APIPromise prototype instead, although
                 // we might not have access to everything we need...
 
                 // this is a new apipromise instance
-                const unwrappedPromise = origApiPromThenUnwrap.apply(this, arguments)
+                const unwrappedPromise = origApiPromThenUnwrap.apply(this, args)
 
-                shimmer.wrap(unwrappedPromise, 'parse', origApiPromParse => function () {
-                  const parsedPromise = origApiPromParse.apply(this, arguments)
+                shimmer.wrap(unwrappedPromise, 'parse', origApiPromParse => function (...args) {
+                  const parsedPromise = origApiPromParse.apply(this, args)
                     .then(body => Promise.all([this.responsePromise, body]))
 
                   return handleUnwrappedAPIPromise(parsedPromise, ctx, stream)
@@ -258,8 +258,8 @@ for (const extension of extensions) {
 
             // wrapping `parse` avoids problematic wrapping of `then` when trying to call
             // `withResponse` in userland code after. This way, we can return the whole `APIPromise`
-            shimmer.wrap(apiProm, 'parse', origApiPromParse => function () {
-              const parsedPromise = origApiPromParse.apply(this, arguments)
+            shimmer.wrap(apiProm, 'parse', origApiPromParse => function (...args) {
+              const parsedPromise = origApiPromParse.apply(this, args)
                 .then(body => Promise.all([this.responsePromise, body]))
 
               return handleUnwrappedAPIPromise(parsedPromise, ctx, stream)

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -137,21 +137,21 @@ addHook({ name: 'oracledb', versions: ['>=5'], file: 'lib/oracledb.js' }, oracle
     }
   })
   shimmer.wrap(oracledb.Pool.prototype, 'getConnection', getConnection => {
-    return function wrappedGetConnection () {
+    return function wrappedGetConnection (...args) {
       let callback
-      if (typeof arguments[arguments.length - 1] === 'function') {
-        callback = arguments[arguments.length - 1]
+      if (typeof args[args.length - 1] === 'function') {
+        callback = args[args.length - 1]
       }
       if (callback) {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
+        args[args.length - 1] = shimmer.wrapFunction(callback, callback => (err, connection) => {
           if (connection) {
             connectionAttributes.set(connection, poolAttributes.get(this))
           }
           callback(err, connection)
         })
-        getConnection.apply(this, arguments)
+        getConnection.apply(this, args)
       } else {
-        return getConnection.apply(this, arguments).then((connection) => {
+        return getConnection.apply(this, args).then((connection) => {
           connectionAttributes.set(connection, poolAttributes.get(this))
           return connection
         })

--- a/packages/datadog-instrumentations/src/passport-utils.js
+++ b/packages/datadog-instrumentations/src/passport-utils.js
@@ -40,15 +40,15 @@ function wrapVerify (verify) {
 }
 
 function wrapStrategy (Strategy) {
-  return function wrappedStrategy () {
+  return function wrappedStrategy (...args) {
     // verify function can be either the first or second argument
-    if (typeof arguments[0] === 'function') {
-      arguments[0] = wrapVerify(arguments[0])
+    if (typeof args[0] === 'function') {
+      args[0] = wrapVerify(args[0])
     } else {
-      arguments[1] = wrapVerify(arguments[1])
+      args[1] = wrapVerify(args[1])
     }
 
-    return Strategy.apply(this, arguments)
+    return Strategy.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -31,16 +31,16 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
 })
 
 function wrapQuery (query) {
-  return function () {
+  return function (...args) {
     if (!startCh.hasSubscribers) {
-      return query.apply(this, arguments)
+      return query.apply(this, args)
     }
 
     const processId = this.processID
 
-    const pgQuery = arguments[0] !== null && typeof arguments[0] === 'object'
-      ? arguments[0]
-      : { text: arguments[0] }
+    const pgQuery = args[0] !== null && typeof args[0] === 'object'
+      ? args[0]
+      : { text: args[0] }
 
     const textPropObj = pgQuery.cursor ?? pgQuery
     const textProp = Object.getOwnPropertyDescriptor(textPropObj, 'text')
@@ -80,7 +80,7 @@ function wrapQuery (query) {
 
         // Based on: https://github.com/brianc/node-postgres/blob/54eb0fa216aaccd727765641e7d1cf5da2bc483d/packages/pg/lib/client.js#L510
         const reusingQuery = typeof pgQuery.submit === 'function'
-        const callback = arguments[arguments.length - 1]
+        const callback = args[args.length - 1]
 
         finish(error)
 
@@ -109,9 +109,9 @@ function wrapQuery (query) {
         return Promise.reject(error)
       }
 
-      arguments[0] = pgQuery
+      args[0] = pgQuery
 
-      const retval = query.apply(this, arguments)
+      const retval = query.apply(this, args)
 
       const deperecated = Object.hasOwn(this, '_activeQuery')
       const queryQueue = deperecated ? this._queryQueue : this.queryQueue
@@ -153,18 +153,18 @@ const finish = (ctx) => {
   finishPoolQueryCh.publish(ctx)
 }
 function wrapPoolQuery (query) {
-  return function () {
+  return function (...args) {
     if (!startPoolQueryCh.hasSubscribers) {
-      return query.apply(this, arguments)
+      return query.apply(this, args)
     }
 
-    const pgQuery = arguments[0] !== null && typeof arguments[0] === 'object' ? arguments[0] : { text: arguments[0] }
+    const pgQuery = args[0] !== null && typeof args[0] === 'object' ? args[0] : { text: args[0] }
     const abortController = new AbortController()
 
     const ctx = { query: pgQuery, abortController }
 
     return startPoolQueryCh.runStores(ctx, () => {
-      const cb = arguments[arguments.length - 1]
+      const cb = args[args.length - 1]
 
       if (abortController.signal.aborted) {
         const error = abortController.signal.reason || new Error('Aborted')
@@ -179,13 +179,13 @@ function wrapPoolQuery (query) {
       }
 
       if (typeof cb === 'function') {
-        arguments[arguments.length - 1] = shimmer.wrapFunction(cb, cb => function () {
+        args[args.length - 1] = shimmer.wrapFunction(cb, cb => function (...args) {
           finish(ctx)
-          return cb.apply(this, arguments)
+          return cb.apply(this, args)
         })
       }
 
-      const retval = query.apply(this, arguments)
+      const retval = query.apply(this, args)
 
       if (retval?.then) {
         retval.then(() => {

--- a/packages/datadog-instrumentations/src/pino.js
+++ b/packages/datadog-instrumentations/src/pino.js
@@ -7,8 +7,8 @@ const {
 } = require('./helpers/instrument')
 
 function wrapPino (symbol, wrapper, pino) {
-  return function pinoWithTrace () {
-    const instance = pino.apply(this, arguments)
+  return function pinoWithTrace (...args) {
+    const instance = pino.apply(this, args)
 
     Object.defineProperty(instance, symbol, {
       configurable: true,
@@ -46,8 +46,8 @@ function wrapPrettifyObject (prettifyObject) {
 
 function wrapPrettyFactory (prettyFactory) {
   const ch = channel('apm:pino:log')
-  return function prettyFactoryWithTrace () {
-    const pretty = prettyFactory.apply(this, arguments)
+  return function prettyFactoryWithTrace (...args) {
+    const pretty = prettyFactory.apply(this, args)
     return function prettyWithTrace (obj) {
       const payload = { message: obj }
       ch.publish(payload)

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -575,9 +575,9 @@ function testEndHandler ({
 }
 
 function dispatcherRunWrapper (run) {
-  return function () {
+  return function (...args) {
     remainingTestsByFile = getTestsBySuiteFromTestsById(this._testById)
-    return run.apply(this, arguments)
+    return run.apply(this, args)
   }
 }
 
@@ -605,9 +605,9 @@ function dispatcherRunWrapperNew (run) {
 
 function dispatcherHook (dispatcherExport) {
   shimmer.wrap(dispatcherExport.Dispatcher.prototype, 'run', dispatcherRunWrapper)
-  shimmer.wrap(dispatcherExport.Dispatcher.prototype, '_createWorker', createWorker => function () {
+  shimmer.wrap(dispatcherExport.Dispatcher.prototype, '_createWorker', createWorker => function (...args) {
     const dispatcher = this
-    const worker = createWorker.apply(this, arguments)
+    const worker = createWorker.apply(this, args)
     const projects = getProjectsFromDispatcher(dispatcher)
     sessionProjects = projects
 
@@ -646,9 +646,9 @@ function dispatcherHook (dispatcherExport) {
 
 function dispatcherHookNew (dispatcherExport, runWrapper) {
   shimmer.wrap(dispatcherExport.Dispatcher.prototype, 'run', runWrapper)
-  shimmer.wrap(dispatcherExport.Dispatcher.prototype, '_createWorker', createWorker => function () {
+  shimmer.wrap(dispatcherExport.Dispatcher.prototype, '_createWorker', createWorker => function (...args) {
     const dispatcher = this
-    const worker = createWorker.apply(this, arguments)
+    const worker = createWorker.apply(this, args)
     const projects = getProjectsFromDispatcher(dispatcher)
     sessionProjects = projects
 
@@ -1423,7 +1423,7 @@ addHook({
 })
 
 function generateSummaryWrapper (generateSummary) {
-  return function () {
+  return function (...args) {
     for (const test of this.suite.allTests()) {
       // https://github.com/microsoft/playwright/blob/bf92ffecff6f30a292b53430dbaee0207e0c61ad/packages/playwright/src/reporters/base.ts#L279
       const didNotRun = test.outcome() === 'skipped' &&
@@ -1456,7 +1456,7 @@ function generateSummaryWrapper (generateSummary) {
         })
       }
     }
-    return generateSummary.apply(this, arguments)
+    return generateSummary.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/protobufjs.js
+++ b/packages/datadog-instrumentations/src/protobufjs.js
@@ -9,23 +9,23 @@ const deserializeChannel = dc.channel('apm:protobufjs:deserialize-end')
 
 function wrapSerialization (messageClass) {
   if (messageClass?.encode) {
-    shimmer.wrap(messageClass, 'encode', original => function () {
+    shimmer.wrap(messageClass, 'encode', original => function (...args) {
       if (!serializeChannel.hasSubscribers) {
-        return original.apply(this, arguments)
+        return original.apply(this, args)
       }
       serializeChannel.publish({ messageClass: this })
-      return original.apply(this, arguments)
+      return original.apply(this, args)
     })
   }
 }
 
 function wrapDeserialization (messageClass) {
   if (messageClass?.decode) {
-    shimmer.wrap(messageClass, 'decode', original => function () {
+    shimmer.wrap(messageClass, 'decode', original => function (...args) {
       if (!deserializeChannel.hasSubscribers) {
-        return original.apply(this, arguments)
+        return original.apply(this, args)
       }
-      const result = original.apply(this, arguments)
+      const result = original.apply(this, args)
       deserializeChannel.publish({ messageClass: result })
       return result
     })
@@ -34,8 +34,8 @@ function wrapDeserialization (messageClass) {
 
 function wrapSetup (messageClass) {
   if (messageClass?.setup) {
-    shimmer.wrap(messageClass, 'setup', original => function () {
-      const result = original.apply(this, arguments)
+    shimmer.wrap(messageClass, 'setup', original => function (...args) {
+      const result = original.apply(this, args)
 
       wrapSerialization(messageClass)
       wrapDeserialization(messageClass)
@@ -74,8 +74,8 @@ function wrapReflection (protobuf) {
   ]
 
   for (const method of reflectionMethods) {
-    shimmer.wrap(method.target, method.name, original => function () {
-      const result = original.apply(this, arguments)
+    shimmer.wrap(method.target, method.name, original => function (...args) {
+      const result = original.apply(this, args)
       if (result.nested) {
         for (const type in result.nested) {
           wrapSetup(result.nested[type])
@@ -97,8 +97,8 @@ addHook({
   name: 'protobufjs',
   versions: ['>=6.8.0'],
 }, protobuf => {
-  shimmer.wrap(protobuf.Root.prototype, 'load', original => function () {
-    const result = original.apply(this, arguments)
+  shimmer.wrap(protobuf.Root.prototype, 'load', original => function (...args) {
+    const result = original.apply(this, args)
     if (isPromise(result)) {
       return result.then(root => {
         wrapProtobufClasses(root)
@@ -110,14 +110,14 @@ addHook({
     return result
   })
 
-  shimmer.wrap(protobuf.Root.prototype, 'loadSync', original => function () {
-    const root = original.apply(this, arguments)
+  shimmer.wrap(protobuf.Root.prototype, 'loadSync', original => function (...args) {
+    const root = original.apply(this, args)
     wrapProtobufClasses(root)
     return root
   })
 
-  shimmer.wrap(protobuf, 'Type', Original => function () {
-    const typeInstance = new Original(...arguments)
+  shimmer.wrap(protobuf, 'Type', Original => function (...args) {
+    const typeInstance = new Original(...args)
     wrapSetup(typeInstance)
     return typeInstance
   })

--- a/packages/datadog-instrumentations/src/restify.js
+++ b/packages/datadog-instrumentations/src/restify.js
@@ -72,11 +72,11 @@ function wrapFn (fn) {
 }
 
 function wrapNext (req, next) {
-  return shimmer.wrapFunction(next, next => function () {
+  return shimmer.wrapFunction(next, next => function (...args) {
     nextChannel.publish({ req })
     finishChannel.publish({ req })
 
-    next.apply(this, arguments)
+    next.apply(this, args)
   })
 }
 

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -45,17 +45,17 @@ function createWrapRouterMethod (name, compile) {
   function wrapLayerHandle (layer, original) {
     original._name = original._name || layer.name
 
-    return shimmer.wrapFunction(original, original => function () {
-      if (!enterChannel.hasSubscribers) return original.apply(this, arguments)
+    return shimmer.wrapFunction(original, original => function (...args) {
+      if (!enterChannel.hasSubscribers) return original.apply(this, args)
 
       const matchers = getLayerMatchers(layer)
-      const lastIndex = arguments.length - 1
+      const lastIndex = args.length - 1
       const name = original._name || original.name
-      const req = arguments[arguments.length > 3 ? 1 : 0]
-      const next = arguments[lastIndex]
+      const req = args[args.length > 3 ? 1 : 0]
+      const next = args[lastIndex]
 
       if (typeof next === 'function') {
-        arguments[lastIndex] = wrapNext(req, next)
+        args[lastIndex] = wrapNext(req, next)
       }
 
       let route
@@ -77,7 +77,7 @@ function createWrapRouterMethod (name, compile) {
       enterChannel.publish({ name, req, route, layer })
 
       try {
-        return original.apply(this, arguments)
+        return original.apply(this, args)
       } catch (error) {
         errorChannel.publish({ req, error })
         nextChannel.publish({ req })
@@ -251,8 +251,8 @@ addHook({ name: 'router', versions: ['>=2'] }, Router => {
   const wrapRouterMethod = createWrapRouterMethod('router', getCompileToRegexp())
 
   const WrappedRouter = shimmer.wrapFunction(Router, function (originalRouter) {
-    return function wrappedMethod () {
-      const router = originalRouter.apply(this, arguments)
+    return function wrappedMethod (...args) {
+      const router = originalRouter.apply(this, args)
 
       shimmer.wrap(router, 'handle', function wrapHandle (originalHandle) {
         return function wrappedHandle (req, res, next) {
@@ -310,8 +310,8 @@ addHook({
 })
 
 function wrapParam (original) {
-  return function wrappedProcessParams () {
-    arguments[1] = shimmer.wrapFunction(arguments[1], (originalFn) => {
+  return function wrappedProcessParams (...args) {
+    args[1] = shimmer.wrapFunction(args[1], (originalFn) => {
       return function wrappedFn (req, res) {
         if (routerParamStartCh.hasSubscribers && Object.keys(req.params).length && !visitedParams.has(req.params)) {
           visitedParams.add(req.params)
@@ -332,7 +332,7 @@ function wrapParam (original) {
       }
     })
 
-    return original.apply(this, arguments)
+    return original.apply(this, args)
   }
 }
 

--- a/packages/datadog-instrumentations/src/stripe.js
+++ b/packages/datadog-instrumentations/src/stripe.js
@@ -8,8 +8,8 @@ const paymentIntentCreateFinishCh = channel('datadog:stripe:paymentIntent:create
 const constructEventFinishCh = channel('datadog:stripe:constructEvent:finish')
 
 function wrapSessionCreate (create) {
-  return function wrappedSessionCreate () {
-    const promise = create.apply(this, arguments)
+  return function wrappedSessionCreate (...args) {
+    const promise = create.apply(this, args)
 
     if (!checkoutSessionCreateFinishCh.hasSubscribers) return promise
 
@@ -21,8 +21,8 @@ function wrapSessionCreate (create) {
 }
 
 function wrapPaymentIntentCreate (create) {
-  return function wrappedPaymentIntentCreate () {
-    const promise = create.apply(this, arguments)
+  return function wrappedPaymentIntentCreate (...args) {
+    const promise = create.apply(this, args)
 
     if (!paymentIntentCreateFinishCh.hasSubscribers) return promise
 
@@ -34,8 +34,8 @@ function wrapPaymentIntentCreate (create) {
 }
 
 function wrapConstructEvent (constructEvent) {
-  return function wrappedConstructEvent () {
-    const result = constructEvent.apply(this, arguments)
+  return function wrappedConstructEvent (...args) {
+    const result = constructEvent.apply(this, args)
 
     // no need to check for hasSubscribers,
     // if it's false, the publish function will be noop
@@ -46,8 +46,8 @@ function wrapConstructEvent (constructEvent) {
 }
 
 function wrapConstructEventAsync (constructEventAsync) {
-  return function wrappedConstructEventAsync () {
-    const promise = constructEventAsync.apply(this, arguments)
+  return function wrappedConstructEventAsync (...args) {
+    const promise = constructEventAsync.apply(this, args)
 
     if (!constructEventFinishCh.hasSubscribers) return promise
 
@@ -77,8 +77,8 @@ function instrumentStripeInstance (stripe) {
 // returns nothing; without 'new' it delegates to 'new Stripe(...)' and returns
 // that result. We need to instrument whichever object actually got populated
 function wrapLegacyStripe (Stripe) {
-  return function wrappedStripe () {
-    const result = Stripe.apply(this, arguments)
+  return function wrappedStripe (...args) {
+    const result = Stripe.apply(this, args)
     const stripe = this instanceof Stripe ? this : result
     instrumentStripeInstance(stripe)
     return stripe
@@ -88,8 +88,8 @@ function wrapLegacyStripe (Stripe) {
 // stripe >=22: the constructor is a factory that always returns a fresh Stripe
 // instance regardless of 'new', so we just instrument and forward the result
 function wrapStripe (Stripe) {
-  return function wrappedStripe () {
-    const stripe = Stripe.apply(this, arguments)
+  return function wrappedStripe (...args) {
+    const stripe = Stripe.apply(this, args)
     instrumentStripeInstance(stripe)
     return stripe
   }

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -305,8 +305,8 @@ function recordFinalAttemptToFixExecution (task, status, providedContext) {
  * @returns {Function}
  */
 function wrapTestScopedFn (task, fn) {
-  return shimmer.wrapFunction(fn, fn => function () {
-    return testFnCh.runStores(taskToCtx.get(task), () => fn.apply(this, arguments))
+  return shimmer.wrapFunction(fn, fn => function (...args) {
+    return testFnCh.runStores(taskToCtx.get(task), () => fn.apply(this, args))
   })
 }
 
@@ -544,13 +544,13 @@ function getFinishWrapper (exitOrClose) {
 
 function getCliOrStartVitestWrapper (frameworkVersion) {
   return function (oldCliOrStartVitest) {
-    return function () {
+    return function (...args) {
       if (!testSessionStartCh.hasSubscribers || isSessionStarted) {
-        return oldCliOrStartVitest.apply(this, arguments)
+        return oldCliOrStartVitest.apply(this, args)
       }
       isSessionStarted = true
       testSessionStartCh.publish({ command: getTestCommand(), frameworkVersion })
-      return oldCliOrStartVitest.apply(this, arguments)
+      return oldCliOrStartVitest.apply(this, args)
     }
   }
 }
@@ -661,11 +661,11 @@ function getStartVitestWrapper (cliApiPackage, frameworkVersion) {
   const forksPoolWorker = getForksPoolWorkerExport(cliApiPackage)
   if (forksPoolWorker) {
     // function is async
-    shimmer.wrap(forksPoolWorker.value.prototype, 'start', start => function () {
+    shimmer.wrap(forksPoolWorker.value.prototype, 'start', start => function (...args) {
       vitestPool = 'child_process'
       this.env.DD_VITEST_WORKER = '1'
 
-      return start.apply(this, arguments)
+      return start.apply(this, args)
     })
     shimmer.wrap(forksPoolWorker.value.prototype, 'on', getWrappedOn)
   }
@@ -673,10 +673,10 @@ function getStartVitestWrapper (cliApiPackage, frameworkVersion) {
   const threadsPoolWorker = getThreadsPoolWorkerExport(cliApiPackage)
   if (threadsPoolWorker) {
     // function is async
-    shimmer.wrap(threadsPoolWorker.value.prototype, 'start', start => function () {
+    shimmer.wrap(threadsPoolWorker.value.prototype, 'start', start => function (...args) {
       vitestPool = 'worker_threads'
       this.env.DD_VITEST_WORKER = '1'
-      return start.apply(this, arguments)
+      return start.apply(this, args)
     })
     shimmer.wrap(threadsPoolWorker.value.prototype, 'on', getWrappedOn)
   }
@@ -1014,8 +1014,8 @@ function wrapVitestTestRunner (VitestTestRunner) {
           for (let i = 0; i < hookArray.length; i++) {
             const currentFn = hookArray[i]
             const originalFn = originalHookFns.get(currentFn) || currentFn
-            const wrappedFn = shimmer.wrapFunction(originalFn, fn => function () {
-              const result = testFnCh.runStores(taskToCtx.get(task), () => fn.apply(this, arguments))
+            const wrappedFn = shimmer.wrapFunction(originalFn, fn => function (...args) {
+              const result = testFnCh.runStores(taskToCtx.get(task), () => fn.apply(this, args))
 
               if (hookType === 'beforeEach') {
                 return wrapBeforeEachCleanupResult(task, result)

--- a/packages/datadog-instrumentations/src/winston.js
+++ b/packages/datadog-instrumentations/src/winston.js
@@ -33,8 +33,8 @@ addHook({ name: 'winston', file: 'lib/winston/logger.js', versions: ['>=3'] }, L
     }
   })
 
-  shimmer.wrap(Logger.prototype, 'configure', configure => function () {
-    const configureResponse = configure.apply(this, arguments)
+  shimmer.wrap(Logger.prototype, 'configure', configure => function (...args) {
+    const configureResponse = configure.apply(this, args)
     // After the original `configure`, because it resets transports
     if (addTransport.hasSubscribers) {
       addTransport.publish(this)
@@ -55,8 +55,8 @@ addHook({ name: 'winston', file: 'lib/winston/logger.js', versions: ['1', '2'] }
 })
 
 function wrapMethod (method, logCh) {
-  return function methodWithTrace () {
-    const result = method.apply(this, arguments)
+  return function methodWithTrace (...args) {
+    const result = method.apply(this, args)
 
     if (logCh.hasSubscribers) {
       for (const name in this.transports) {

--- a/packages/datadog-instrumentations/src/ws.js
+++ b/packages/datadog-instrumentations/src/ws.js
@@ -62,24 +62,24 @@ const setSocketCh = channel('tracing:ws:server:connect:setSocket')
 let kWebSocketSymbol
 
 function wrapHandleUpgrade (handleUpgrade) {
-  return function () {
-    const [req, socket, , cb] = arguments
+  return function (...args) {
+    const [req, socket, , cb] = args
     if (!serverCh.start.hasSubscribers || typeof cb !== 'function') {
-      return handleUpgrade.apply(this, arguments)
+      return handleUpgrade.apply(this, args)
     }
 
     const ctx = { req, socket }
 
-    arguments[3] = function () {
+    args[3] = function (...args) {
       return serverCh.asyncStart.runStores(ctx, () => {
         try {
-          return cb.apply(this, arguments)
+          return cb.apply(this, args)
         } finally {
           serverCh.asyncEnd.publish(ctx)
         }
-      }, this, ...arguments)
+      }, this, ...args)
     }
-    return serverCh.traceSync(handleUpgrade, ctx, this, ...arguments)
+    return serverCh.traceSync(handleUpgrade, ctx, this, ...args)
   }
 }
 


### PR DESCRIPTION
## Summary

Same shape change as #8353 applied to instrumentation files starting
`[m-z]*`.

Refs: https://github.com/DataDog/dd-trace-js/pull/8353