### PR TITLE
fix: tolerate non-string span event names and whitespace-suffixed step functions JSON

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/stepfunctions.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/stepfunctions.js
@@ -41,10 +41,14 @@ class Stepfunctions extends BaseAwsSdkPlugin {
     if ((operation !== 'startExecution' && operation !== 'startSyncExecution') || !request.params?.input) return
 
     const input = request.params.input
-    // Cheap object-shape gate: only inject into JSON object payloads,
-    // matching the prior `typeof inputObj === 'object'` check without the
-    // round-trip parse.
-    if (typeof input !== 'string' || input.length < 2 || input[input.length - 1] !== '}') return
+    if (typeof input !== 'string' || input.length < 2) return
+
+    // Skip non-object payloads up front to avoid a `JSON.parse` round-trip.
+    // `trimEnd` is the identity on payloads with no trailing whitespace;
+    // for the rare whitespace-suffixed object the slow path inside
+    // `injectFieldIntoJsonObject` handles the parse + restringify.
+    const trimmed = input.trimEnd()
+    if (trimmed.length < 2 || trimmed.charCodeAt(trimmed.length - 1) !== 0x7D) return
 
     const injected = {}
     this.tracer.inject(span, 'text_map', injected)

--- a/packages/datadog-plugin-aws-sdk/test/stepfunctions-request-inject.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/stepfunctions-request-inject.spec.js
@@ -23,7 +23,7 @@ function buildPlugin (inject = (span, format, info) => { info['x-datadog-trace-i
 
 describe('Stepfunctions plugin requestInject', () => {
   for (const operation of ['startExecution', 'startSyncExecution']) {
-    describe(`${operation}`, () => {
+    describe(operation, () => {
       it('injects context into a JSON object payload with no whitespace', () => {
         const plugin = buildPlugin()
         const request = { operation, params: { input: '{"a":1}' } }
@@ -92,11 +92,11 @@ describe('Stepfunctions plugin requestInject', () => {
 
       it('skips injection when the trimmed payload is shorter than 2 bytes', () => {
         const plugin = buildPlugin()
-        const request = { operation, params: { input: '{ ' } }
+        const request = { operation, params: { input: '} ' } }
 
         plugin.requestInject(null, request)
 
-        assert.strictEqual(request.params.input, '{ ')
+        assert.strictEqual(request.params.input, '} ')
       })
     })
   }

--- a/packages/datadog-plugin-aws-sdk/test/stepfunctions-request-inject.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/stepfunctions-request-inject.spec.js
@@ -1,0 +1,121 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const Stepfunctions = require('../src/services/stepfunctions')
+
+/**
+ * `Object.create(Stepfunctions.prototype)` skips the heavy plugin /
+ * diagnostic-channel wiring in `BaseAwsSdkPlugin`'s constructor. The method
+ * under test only reads `this.tracer.inject`, so a hand-rolled stub is
+ * enough to exercise the `requestInject` shape gate.
+ *
+ * @param {(span: unknown, format: string, info: object) => void} [inject]
+ * @returns {Stepfunctions}
+ */
+function buildPlugin (inject = (span, format, info) => { info['x-datadog-trace-id'] = '123' }) {
+  const plugin = Object.create(Stepfunctions.prototype)
+  plugin._tracer = { inject }
+  return plugin
+}
+
+describe('Stepfunctions plugin requestInject', () => {
+  for (const operation of ['startExecution', 'startSyncExecution']) {
+    describe(`${operation}`, () => {
+      it('injects context into a JSON object payload with no whitespace', () => {
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: '{"a":1}' } }
+
+        plugin.requestInject(null, request)
+
+        assert.deepStrictEqual(JSON.parse(request.params.input), {
+          a: 1,
+          _datadog: { 'x-datadog-trace-id': '123' },
+        })
+      })
+
+      it('injects context when the JSON payload has trailing whitespace', () => {
+        // Regression: the cheap shape gate used to require the literal
+        // last byte to be `}`, dropping context propagation for any payload
+        // serialized with trailing whitespace (e.g. `\n` from a formatter
+        // or a custom serializer).
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: '{"a":1}\n' } }
+
+        plugin.requestInject(null, request)
+
+        assert.deepStrictEqual(JSON.parse(request.params.input), {
+          a: 1,
+          _datadog: { 'x-datadog-trace-id': '123' },
+        })
+      })
+
+      it('injects context for an empty JSON object', () => {
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: '{}' } }
+
+        plugin.requestInject(null, request)
+
+        assert.deepStrictEqual(JSON.parse(request.params.input), {
+          _datadog: { 'x-datadog-trace-id': '123' },
+        })
+      })
+
+      it('skips injection for a JSON array payload', () => {
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: '[1,2,3]' } }
+
+        plugin.requestInject(null, request)
+
+        assert.strictEqual(request.params.input, '[1,2,3]')
+      })
+
+      it('skips injection for a JSON string primitive payload', () => {
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: '"hello"' } }
+
+        plugin.requestInject(null, request)
+
+        assert.strictEqual(request.params.input, '"hello"')
+      })
+
+      it('skips injection for a non-string input', () => {
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: 42 } }
+
+        plugin.requestInject(null, request)
+
+        assert.strictEqual(request.params.input, 42)
+      })
+
+      it('skips injection when the trimmed payload is shorter than 2 bytes', () => {
+        const plugin = buildPlugin()
+        const request = { operation, params: { input: '{ ' } }
+
+        plugin.requestInject(null, request)
+
+        assert.strictEqual(request.params.input, '{ ')
+      })
+    })
+  }
+
+  it('skips other operations entirely', () => {
+    const plugin = buildPlugin()
+    const request = { operation: 'describeExecution', params: { input: '{"a":1}' } }
+
+    plugin.requestInject(null, request)
+
+    assert.strictEqual(request.params.input, '{"a":1}')
+  })
+
+  it('skips injection when params or input is missing', () => {
+    const plugin = buildPlugin()
+    const request = { operation: 'startExecution', params: {} }
+
+    plugin.requestInject(null, request)
+
+    assert.deepStrictEqual(request.params, {})
+  })
+})

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -771,7 +771,10 @@ class AgentEncoder {
 
     let arrayCount = 0
     for (const event of spanEvents) {
-      if (event === null || typeof event !== 'object') continue
+      // `addEvent` and the OTel bridge do not type-check `name`, and a
+      // non-string would throw downstream in `Buffer.byteLength`. Drop the
+      // bad event silently so the rest of the trace still encodes.
+      if (event === null || typeof event !== 'object' || typeof event.name !== 'string') continue
 
       const eventHeaderOffset = bytes.length
       bytes.reserve(1)

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -713,5 +713,36 @@ describe('encode', () => {
       assert.match(logger.debug.getCall(1).args[0], /unsupported_key2/)
       assert.match(logger.debug.getCall(2).args[0], /unsupported_key3/)
     })
+
+    it('should skip events whose name is not a string without throwing', () => {
+      // `addEvent` and the OTel bridge do not type-check `name`. The native
+      // path used to hand `name` straight to `_encodeString`, which throws
+      // for `Symbol` / `null` / non-coercible values via `Buffer.byteLength`
+      // and would have aborted the entire trace. Bad entries are dropped
+      // silently; the rest of the trace must still encode.
+      const topLevelEvents = [
+        { name: null, time_unix_nano: 1000000, attributes: { ok: true } },
+        { name: 42, time_unix_nano: 2000000 },
+        { name: Symbol('event'), time_unix_nano: 3000000 },
+        { name: undefined, time_unix_nano: 4000000 },
+        { name: 'kept', time_unix_nano: 5000000, attributes: { mood: 'happy' } },
+      ]
+
+      data[0].span_events = topLevelEvents
+
+      encoder.encode(data)
+
+      const buffer = encoder.makePayload()
+      const decoded = msgpack.decode(buffer, { useBigInt64: true })
+      const trace = decoded[0]
+
+      assert.deepStrictEqual(trace[0].span_events, [
+        {
+          name: 'kept',
+          time_unix_nano: 5000000,
+          attributes: { mood: { type: 0, string_value: 'happy' } },
+        },
+      ])
+    })
   })
 })


### PR DESCRIPTION
## Summary

Two regressions flagged in the v5.102.0 release-proposal review:

1. **Native span events** (#8233) crash the entire trace export when `event.name` is `null` / `Symbol(...)` because `Buffer.byteLength` throws. `Span.addEvent` and the OTel bridge accept any value.
2. **Step functions input** (#8231) silently loses distributed-tracing propagation when the JSON payload has trailing whitespace (`'{"a":1}\n'`).

Refs: https://github.com/DataDog/dd-trace-js/pull/8339