### PR TITLE
perf(benchmark): tune sirun inner loops per variant to keep stddev low

### DIFF
--- a/benchmark/sirun/encoding/index.js
+++ b/benchmark/sirun/encoding/index.js
@@ -5,7 +5,14 @@ const assert = require('node:assert/strict')
 const {
   ENCODER_VERSION,
   WITH_SPAN_EVENTS = 'none',
+  // Per-variant inner-loop count keeps each variant in the ~1-3 s/iter
+  // sweet spot. Driven from meta.json so all variant tuning lives next to
+  // the rest of the variant config; the legacy and native paths run several
+  // multiples slower per encode and need fewer iterations to stay in budget.
+  INNER_ITERATIONS = '5000',
 } = process.env
+
+const innerIterations = Number(INNER_ITERATIONS)
 
 const { AgentEncoder } = require(`../../../packages/dd-trace/src/encode/${ENCODER_VERSION}`)
 const id = require('../../../packages/dd-trace/src/id')
@@ -74,11 +81,11 @@ assert.ok(encoder._traceBytes.length > 0)
 encoder._reset()
 
 if (WITH_SPAN_EVENTS === 'none') {
-  for (let iteration = 0; iteration < 5000; iteration++) {
+  for (let iteration = 0; iteration < innerIterations; iteration++) {
     encoder.encode(trace)
   }
 } else {
-  for (let iteration = 0; iteration < 5000; iteration++) {
+  for (let iteration = 0; iteration < innerIterations; iteration++) {
     attachFreshEvents()
     encoder.encode(trace)
   }

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -4,7 +4,7 @@
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
   "instructions": true,
-  "iterations": 10,
+  "iterations": 22,
   "variants": {
     "0.4": {
       "env": {
@@ -23,7 +23,8 @@
       "env": {
         "ENCODER_VERSION": "0.4",
         "WITH_SPAN_EVENTS": "native",
-        "DD_TRACE_NATIVE_SPAN_EVENTS": "true"
+        "DD_TRACE_NATIVE_SPAN_EVENTS": "true",
+        "INNER_ITERATIONS": "1000"
       }
     },
     "0.4-events-legacy": {
@@ -31,7 +32,8 @@
       "env": {
         "ENCODER_VERSION": "0.4",
         "WITH_SPAN_EVENTS": "legacy",
-        "DD_TRACE_NATIVE_SPAN_EVENTS": "false"
+        "DD_TRACE_NATIVE_SPAN_EVENTS": "false",
+        "INNER_ITERATIONS": "3000"
       }
     },
     "0.5-events-legacy": {

--- a/benchmark/sirun/llmobs/index.js
+++ b/benchmark/sirun/llmobs/index.js
@@ -23,7 +23,11 @@ const {
   VARIANT,
 } = process.env
 
-const ITERATIONS = 30_000
+// Per-variant inner-loop count keeps each variant in the ~1-3 s/iter sweet
+// spot. The mixed path is ~7x slower per event because of the `code > 127`
+// branch in the unicode replacer; keeping it at the ascii inner count would
+// push the variant over the per-variant runtime budget without adding signal.
+const ITERATIONS = VARIANT === 'encode-unicode-mixed' ? 4_000 : 30_000
 
 const writer = new LLMObsSpanWriter({
   apiKey: 'placeholder-api-key',

--- a/benchmark/sirun/llmobs/meta.json
+++ b/benchmark/sirun/llmobs/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 5,
+  "iterations": 30,
   "instructions": true,
   "variants": {
     "encode-unicode-ascii": {

--- a/benchmark/sirun/plugin-aws-sdk/index.js
+++ b/benchmark/sirun/plugin-aws-sdk/index.js
@@ -8,7 +8,10 @@ const Lambda = require('../../../packages/datadog-plugin-aws-sdk/src/services/la
 
 const { VARIANT } = process.env
 
-const ITERATIONS = 2_000_000
+// Sized so the slowest variant (`eventbridge-inject-detail`, ~1.8 µs per
+// inject on Linux CI) lands in the ~1-3 s/iter sweet spot at the meta-level
+// `iterations: 30` outer count.
+const ITERATIONS = 1_000_000
 
 // Plugin reads `this.tracer` via a getter that forwards to `this._tracer`; wire the
 // stub through the underscore field so the public access path stays intact.

--- a/benchmark/sirun/plugin-aws-sdk/meta.json
+++ b/benchmark/sirun/plugin-aws-sdk/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 30,
   "instructions": true,
   "variants": {
     "extract-response-body": {

--- a/benchmark/sirun/plugin-dns/meta.json
+++ b/benchmark/sirun/plugin-dns/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 40,
+  "iterations": 30,
   "instructions": true,
   "variants": {
     "control": {

--- a/benchmark/sirun/propagation/index.js
+++ b/benchmark/sirun/propagation/index.js
@@ -8,7 +8,11 @@ const TextMapPropagator = require('../../../packages/dd-trace/src/opentracing/pr
 
 const { VARIANT } = process.env
 
-const ITERATIONS = 300_000
+// `extract-inject` does both an extract and an inject per inner iteration, so
+// it runs ~2x the work of the single-operation variants. Drop its inner count
+// to keep per-iteration wall-clock in the ~1-3 s sweet spot the rest of the
+// suite targets.
+const ITERATIONS = VARIANT === 'extract-inject' ? 100_000 : 300_000
 
 // Duck-typed config keeps the bench out of the full `Config` singleton (telemetry
 // registration, env reads). The propagator only reads the fields below.

--- a/benchmark/sirun/propagation/meta.json
+++ b/benchmark/sirun/propagation/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 30,
   "instructions": true,
   "variants": {
     "extract": {


### PR DESCRIPTION
## Summary

Five sirun benches sit comfortably inside the per-variant runtime
budget only when their slow variant has a smaller inner loop than the
fast ones. Cutting the outer `iterations` count alone drops sample
size below the ~30-sample target the suite was designed around, where
wall.time stddev climbs into the double-digits and the regression
signal stops being readable.

Each touched variant now runs in the ~1-3 s/iter sweet spot at the
restored ~30-iteration outer count:

1. `llmobs/encode-unicode-mixed`: mixed-unicode encoding is ~9x
   slower per event than ascii.
2. `encoding/0.4-events-native` and `0.4-events-legacy`: span-events
   encoding is several multiples slower than the no-events path. A
   new `INNER_ITERATIONS` env var keeps variant tuning in `meta.json`.
3. `propagation/extract-inject`: extract + inject per inner step is
   ~2x the work of the other variants.
4. `plugin-aws-sdk`: shared inner sized for the slowest variant
   (`eventbridge-inject-detail`).

`plugin-dns` only needs the outer-count cut; per-iter was already in
the band.

## Test plan

CI (Microbenchmarks job) is the test plan: each touched variant
should report `wall.time.stddev_pct` near the suite's ~3% target on
Linux CI, and total per-variant runtime should stay inside the budget.