### PR TITLE
[test optimization] Bump cucumber latest version

### DIFF
--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -27,7 +27,7 @@
     "durable-functions": "3.3.0",
     "@azure/service-bus": "7.9.5",
     "@confluentinc/kafka-javascript": "1.8.0",
-    "@cucumber/cucumber": "12.5.0",
+    "@cucumber/cucumber": "12.8.2",
     "@datadog/openfeature-node-server": "0.3.1",
     "@elastic/elasticsearch": "9.3.2",
     "@elastic/transport": "9.3.3",

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -52,7 +52,7 @@
     "dependency": "@cucumber/cucumber",
     "integration": "cucumber",
     "minimum_tracer_supported": "7.0.0",
-    "max_tracer_supported": "12.5.0",
+    "max_tracer_supported": "12.8.2",
     "auto-instrumented": "True"
   },
   {

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -6,7 +6,7 @@ dependency,integration,minimum_tracer_supported,max_tracer_supported,auto-instru
 @azure/functions,azure-functions,4.0.0,4.11.0,True
 @azure/service-bus,azure-service-bus,7.9.2,7.9.5,True
 @confluentinc/kafka-javascript,confluentinc-kafka-javascript,1.0.0,1.8.0,True
-@cucumber/cucumber,cucumber,7.0.0,12.5.0,True
+@cucumber/cucumber,cucumber,7.0.0,12.8.2,True
 @elastic/elasticsearch,elasticsearch,5.6.16,9.3.2,True
 @elastic/transport,elasticsearch,8.0.0,9.3.3,True
 @google-cloud/pubsub,google-cloud-pubsub,1.2.0,5.2.2,True


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Bumps the `@cucumber/cucumber` plugin-version pin from `12.5.0` to `12.8.2`.

### Motivation
`@cucumber/cucumber@latest` currently resolves to `12.8.2`, while the Test Optimization plugin-version matrix was still pinned to `12.5.0`.

### Additional Notes
Validation:
- `npm view @cucumber/cucumber dist-tags version --json`

CI monitoring requested before local investigation of any Test Optimization Cucumber failures.