### PR TITLE
perf(couchbase): cache the per-operation channel bag

### DIFF
--- a/packages/datadog-instrumentations/src/couchbase.js
+++ b/packages/datadog-instrumentations/src/couchbase.js
@@ -1,10 +1,26 @@
 'use strict'
 
+const { tracingChannel } = require('dc-polyfill')
+
 const shimmer = require('../../datadog-shimmer')
 const {
-  channel,
   addHook,
 } = require('./helpers/instrument')
+
+// One TracingChannel per traced operation, looked up at module init so the
+// hot path only does property reads on a stable handle.
+const queryCh = tracingChannel('apm:couchbase:query')
+const upsertCh = tracingChannel('apm:couchbase:upsert')
+const insertCh = tracingChannel('apm:couchbase:insert')
+const replaceCh = tracingChannel('apm:couchbase:replace')
+
+/** @type {Map<string, ReturnType<typeof tracingChannel>>} */
+const opChannelByName = new Map([
+  ['query', queryCh],
+  ['upsert', upsertCh],
+  ['insert', insertCh],
+  ['replace', replaceCh],
+])
 
 function findCallbackIndex (args, lowerbound = 2) {
   for (let i = args.length - 1; i >= lowerbound; i--) {
@@ -18,90 +34,75 @@ function getQueryResource (q) {
   return q && (typeof q === 'string' ? q : q.statement)
 }
 
-function wrapAllNames (names, action) {
-  for (const name of names) {
-    action(name)
+// Hand-rolled instead of `tracingChannel.tracePromise`: synchronous
+// `res.then(...)` dodges the `Promise.resolve(thenable)` microtask race on
+// SDK v3.2.x / v4.0-v4.4 (lazy listener attachment), and external `.on()`
+// is forbidden on v4.5.0+ (JSCBC-1301 depromisify). See commit body.
+/**
+ * @param {import('node:diagnostics_channel').TracingChannel} ch
+ *   Pinned per-op channel.
+ * @param {(...callArgs: unknown[]) => unknown} fn The SDK method being traced.
+ * @param {object} ctx Mutated to record `result` / `error`.
+ * @param {object} thisArg
+ * @param {unknown[]} args Forwarded to `fn` verbatim.
+ */
+function traceV3 (ch, fn, ctx, thisArg, args) {
+  if (!ch.start.hasSubscribers) return fn.apply(thisArg, args)
+  const cbIndex = findCallbackIndex(args, 1)
+  if (cbIndex >= 0) {
+    return ch.traceCallback(fn, cbIndex, ctx, thisArg, ...args)
   }
-}
-
-function wrapCallbackFinish (callback, thisArg, _args, errorCh, finishCh, ctx, channelPrefix) {
-  const callbackStartCh = channel(`${channelPrefix}:callback:start`)
-  const callbackFinishCh = channel(`${channelPrefix}:callback:finish`)
-
-  const wrapped = callbackStartCh.runStores(ctx, () => {
-    return function finish (error, result) {
-      return callbackFinishCh.runStores(ctx, () => {
-        if (error) {
-          ctx.error = error
-          errorCh.publish(ctx)
-        }
-        finishCh.publish(ctx)
-        return callback.apply(thisArg, [error, result])
-      })
-    }
-  })
-  Object.defineProperty(wrapped, '_dd_wrapped', { value: true })
-  return wrapped
-}
-
-function wrapCBandPromise (fn, name, startData, thisArg, args) {
-  const startCh = channel(`apm:couchbase:${name}:start`)
-  const finishCh = channel(`apm:couchbase:${name}:finish`)
-  const errorCh = channel(`apm:couchbase:${name}:error`)
-
-  if (!startCh.hasSubscribers) return fn.apply(thisArg, args)
-
-  const ctx = startData
-  return startCh.runStores(ctx, () => {
+  return ch.start.runStores(ctx, () => {
     try {
-      const cbIndex = findCallbackIndex(args, 1)
-      if (cbIndex >= 0) {
-        // v3 offers callback or promises event handling
-        // NOTE: this does not work with v3.2.0-3.2.1 cluster.query, as there is a bug in the couchbase source code
-        args[cbIndex] = shimmer.wrapFunction(args[cbIndex], (cb) => {
-          return wrapCallbackFinish(cb, thisArg, args, errorCh, finishCh, ctx, `apm:couchbase:${name}`)
-        })
-      }
       const res = fn.apply(thisArg, args)
-
-      // semver >=3 will always return promise by default
       res.then(
         (result) => {
           ctx.result = result
-          finishCh.publish(ctx)
+          ch.asyncStart.publish(ctx)
+          ch.asyncEnd.publish(ctx)
         },
-        (err) => {
-          ctx.error = err
-          errorCh.publish(ctx)
-          finishCh.publish(ctx)
+        (error) => {
+          ctx.error = error
+          ch.error.publish(ctx)
+          ch.asyncStart.publish(ctx)
+          ch.asyncEnd.publish(ctx)
         }
       )
       return res
-    } catch (e) {
-      void e.stack
-      ctx.error = e
-      errorCh.publish(ctx)
-      throw e
+    } catch (error) {
+      ctx.error = error
+      ch.error.publish(ctx)
+      throw error
+    } finally {
+      ch.end.publish(ctx)
     }
   })
 }
 
-function wrapWithName (name) {
+/**
+ * @param {string} name Operation name (`upsert`, `insert`, `replace`).
+ */
+function wrapV3WithName (name) {
+  const ch = opChannelByName.get(name)
   return function (operation) {
-    return function (...args) { // no arguments used by us
-      return wrapCBandPromise(operation, name, {
+    return function (...args) {
+      const ctx = {
         collection: { name: this._name || '_default' },
         bucket: { name: this._scope._bucket._name },
         seedNodes: this._dd_connStr,
-      }, this, args)
+      }
+      return traceV3(ch, operation, ctx, this, args)
     }
   }
 }
 
+/**
+ * @param {(...args: unknown[]) => unknown} query Original `Cluster.prototype.query`.
+ */
 function wrapV3Query (query) {
-  return function (q) {
-    const resource = getQueryResource(q)
-    return wrapCBandPromise(query, 'query', { resource, seedNodes: this._connStr }, this, arguments)
+  return function (...args) {
+    const ctx = { resource: getQueryResource(args[0]), seedNodes: this._connStr }
+    return traceV3(queryCh, query, ctx, this, args)
   }
 }
 
@@ -119,9 +120,9 @@ addHook({ name: 'couchbase', file: 'lib/bucket.js', versions: ['^3.0.7', '^3.1.3
 })
 
 addHook({ name: 'couchbase', file: 'lib/collection.js', versions: ['^3.0.7', '^3.1.3'] }, Collection => {
-  wrapAllNames(['upsert', 'insert', 'replace'], name => {
-    shimmer.wrap(Collection.prototype, name, wrapWithName(name))
-  })
+  for (const name of ['upsert', 'insert', 'replace']) {
+    shimmer.wrap(Collection.prototype, name, wrapV3WithName(name))
+  }
 })
 
 addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^3.0.7', '^3.1.3'] }, Cluster => {
@@ -134,9 +135,9 @@ addHook({ name: 'couchbase', file: 'lib/cluster.js', versions: ['^3.0.7', '^3.1.
 addHook({ name: 'couchbase', file: 'dist/collection.js', versions: ['>=3.2.2'] }, collection => {
   const Collection = collection.Collection
 
-  wrapAllNames(['upsert', 'insert', 'replace'], name => {
-    shimmer.wrap(Collection.prototype, name, wrapWithName(name))
-  })
+  for (const name of ['upsert', 'insert', 'replace']) {
+    shimmer.wrap(Collection.prototype, name, wrapV3WithName(name))
+  }
 })
 
 addHook({ name: 'couchbase', file: 'dist/bucket.js', versions: ['>=3.2.2'] }, bucket => {

--- a/packages/datadog-instrumentations/test/couchbase.spec.js
+++ b/packages/datadog-instrumentations/test/couchbase.spec.js
@@ -1,0 +1,353 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const EventEmitter = require('node:events')
+
+const { tracingChannel } = require('dc-polyfill')
+const { afterEach, before, describe, it } = require('mocha')
+
+require('../src/couchbase')
+
+const COUCHBASE_HOOKS = globalThis[Symbol.for('_ddtrace_instrumentations')].couchbase
+
+const queryChannel = tracingChannel('apm:couchbase:query')
+const upsertChannel = tracingChannel('apm:couchbase:upsert')
+
+// Mirror of the SDK's `StreamablePromise` in v3.2.x / v4.0-v4.4: lazy
+// internal Promise that only constructs on first `.then`. No depromisify
+// override on `.on` — that surfaced later (v4.5.0+, JSCBC-1301). The
+// orchestrator wrap relies on calling `.then(...)` synchronously to
+// trigger the lazy listener attachment before libcouchbase emits.
+class FakeStreamablePromise extends EventEmitter {
+  #promise = null
+  #promiseifyFn
+
+  constructor (promiseifyFn) {
+    super()
+    this.#promiseifyFn = promiseifyFn
+  }
+
+  get promise () {
+    this.#promise ??= new Promise((resolve, reject) => this.#promiseifyFn(this, resolve, reject))
+    return this.#promise
+  }
+
+  then (onfulfilled, onrejected) { return this.promise.then(onfulfilled, onrejected) }
+  catch (onrejected) { return this.promise.catch(onrejected) }
+  finally (onfinally) { return this.promise.finally(onfinally) }
+}
+
+// Mirror of the SDK's `StreamablePromise` in v4.5.0+. Eager listener
+// attachment via a proxy `emitter` that bypasses the `.on` override,
+// plus the JSCBC-1301 depromisify behaviour: external `.on()` /
+// `.addListener()` calls remove the SDK's internal listeners and null
+// `_promise`. Subsequent `.then` / `.catch` / `.finally` then throw
+// `Cannot await a promise that is already registered for events`. This
+// is the v4.5.0+ contract: API must be either awaited or used with
+// events, never both. The orchestrator wrap therefore must NEVER call
+// `.on()` on the SDK's return value.
+class FakeStreamablePromiseV45 extends EventEmitter {
+  #promise = null
+  #promiseOns = []
+  #depromisified = false
+
+  constructor (promiseifyFn) {
+    super()
+    const eeOn = EventEmitter.prototype.on
+    this.#promise = new Promise((resolve, reject) => {
+      const proxy = {
+        on: (eventName, listener) => {
+          this.#promiseOns.push([eventName, listener])
+          eeOn.call(this, eventName, listener)
+        },
+      }
+      promiseifyFn(proxy, resolve, reject)
+    })
+  }
+
+  #depromisify () {
+    for (const [eventName, listener] of this.#promiseOns) this.off(eventName, listener)
+    this.#promiseOns = []
+    this.#promise = null
+    this.#depromisified = true
+  }
+
+  get promise () {
+    if (this.#depromisified) {
+      throw new Error('Cannot await a promise that is already registered for events')
+    }
+    return this.#promise
+  }
+
+  on (eventName, listener) {
+    this.#depromisify()
+    return super.on(eventName, listener)
+  }
+
+  addListener (eventName, listener) {
+    this.#depromisify()
+    return super.addListener(eventName, listener)
+  }
+
+  then (onfulfilled, onrejected) { return this.promise.then(onfulfilled, onrejected) }
+  catch (onrejected) { return this.promise.catch(onrejected) }
+  finally (onfinally) { return this.promise.finally(onfinally) }
+}
+
+function rowsPromiseifyFn (rowsToResultFn) {
+  return (emitter, resolve, reject) => {
+    let err
+    const rows = []
+    let meta
+    emitter.on('row', r => rows.push(r))
+    emitter.on('meta', m => { meta = m })
+    emitter.on('error', e => { err = e })
+    emitter.on('end', () => {
+      if (err) return reject(err)
+      resolve(rowsToResultFn(rows, meta))
+    })
+  }
+}
+
+class FakeStreamableRowPromise extends FakeStreamablePromise {
+  constructor (rowsToResultFn) { super(rowsPromiseifyFn(rowsToResultFn)) }
+}
+
+class FakeStreamableRowPromiseV45 extends FakeStreamablePromiseV45 {
+  constructor (rowsToResultFn) { super(rowsPromiseifyFn(rowsToResultFn)) }
+}
+
+/**
+ * @param {string} file File suffix to match against the registered addHook entries.
+ * @returns {(mod: unknown) => unknown}
+ */
+function findHook (file) {
+  for (const entry of COUCHBASE_HOOKS) {
+    if (entry.file === file) return entry.hook
+  }
+  throw new Error(`couchbase hook for ${file} not registered`)
+}
+
+const wrapClusterQuery = findHook('dist/cluster.js')
+const wrapBucket = findHook('dist/bucket.js')
+const wrapCollection = findHook('dist/collection.js')
+
+function makeFakeSdk ({ emit }) {
+  class FakeCluster {
+    constructor () {
+      this._connStr = 'couchbase://localhost'
+    }
+
+    query (statement) {
+      const emitter = new FakeStreamableRowPromise(rows => ({ rows }))
+      emit(emitter)
+      return emitter
+    }
+  }
+
+  class FakeCollection {
+    constructor (bucket, name) {
+      this._scope = { _bucket: { _name: bucket._name } }
+      this._name = name
+    }
+
+    upsert (key, value, ...rest) { return this.#kv(emit, rest) }
+    insert (key, value, ...rest) { return this.#kv(emit, rest) }
+    replace (key, value, ...rest) { return this.#kv(emit, rest) }
+
+    // Mirrors the real SDK's `PromiseHelper.wrapAsync(...)` (cluster.ts /
+    // collection.ts on every traced op): when a callback is provided, it
+    // synchronously calls `.then(...)` on the StreamablePromise to forward
+    // resolve / reject to the callback. That `.then` is what triggers the
+    // lazy listener attachment in `StreamablePromise.get promise` for v3.2.x
+    // and v4.0-v4.4, so an `'error'` listener exists by the time
+    // libcouchbase fires.
+    #kv (emit, rest) {
+      const callback = typeof rest.at(-1) === 'function' ? rest.at(-1) : undefined
+      const emitter = new FakeStreamableRowPromise(rows => ({ rows }))
+      emit(emitter)
+      if (callback) {
+        emitter.then(
+          (result) => callback(undefined, result),
+          (error) => callback(error, undefined)
+        )
+        setImmediate(() => emitter.emit('end'))
+      }
+      return emitter
+    }
+  }
+
+  FakeCollection.DEFAULT_NAME = '_default'
+
+  class FakeBucket {
+    constructor (cluster, name) {
+      this._cluster = cluster
+      this._name = name
+    }
+
+    collection (name) { return new FakeCollection(this, name) }
+  }
+
+  wrapClusterQuery({ Cluster: FakeCluster })
+  wrapBucket({ Bucket: FakeBucket })
+  wrapCollection({ Collection: FakeCollection })
+
+  const cluster = new FakeCluster()
+  const bucket = new FakeBucket(cluster, 'datadog-test')
+  const collection = bucket.collection('_default')
+  return { cluster, bucket, collection }
+}
+
+describe('couchbase instrumentation: v3.2.x StreamableRowPromise', () => {
+  /** @type {Array<() => void>} */
+  const cleanups = []
+
+  before(() => {
+    assert.equal(Array.isArray(COUCHBASE_HOOKS), true, 'couchbase hooks must register on require')
+  })
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()()
+  })
+
+  function subscribe (ch, names = ['start', 'asyncStart', 'asyncEnd', 'error', 'end']) {
+    const events = []
+    const handlers = {}
+    for (const name of names) {
+      handlers[name] = ctx => events.push({ name, ctx })
+    }
+    ch.subscribe(handlers)
+    cleanups.push(() => ch.unsubscribe(handlers))
+    return events
+  }
+
+  it('does not crash when libcouchbase emits "error" on the StreamableRowPromise asynchronously', async () => {
+    const events = subscribe(queryChannel)
+    let pendingEmitter
+    const { cluster } = makeFakeSdk({ emit: e => { pendingEmitter = e } })
+
+    const promise = cluster.query('SELECT 1+1')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    pendingEmitter.emit('error', new Error('libcouchbase: request canceled'))
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    assert.equal(events.some(e => e.name === 'start'), true, 'start event must fire')
+    assert.equal(typeof promise.on, 'function', 'wrap returns the original EventEmitter surface')
+  })
+
+  it('does not crash when the SDK emits "error" before any caller awaits the promise', async () => {
+    subscribe(queryChannel)
+    let pendingEmitter
+    const { cluster } = makeFakeSdk({ emit: e => { pendingEmitter = e } })
+
+    cluster.query('SELECT 1+1')
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    pendingEmitter.emit('error', new Error('libcouchbase: request canceled'))
+
+    await new Promise(resolve => setImmediate(resolve))
+  })
+
+  it('drives asyncStart/asyncEnd/error sub-channels for the promise path', async () => {
+    const events = subscribe(queryChannel)
+    let pendingEmitter
+    const { cluster } = makeFakeSdk({ emit: e => { pendingEmitter = e } })
+
+    const promise = cluster.query('SELECT 1+1').catch(() => {})
+
+    pendingEmitter.emit('error', new Error('libcouchbase: query failed'))
+    pendingEmitter.emit('end')
+
+    await promise
+
+    const eventNames = events.map(e => e.name)
+    assert.deepEqual(eventNames, ['start', 'end', 'error', 'asyncStart', 'asyncEnd'])
+    const errorEvent = events.find(e => e.name === 'error')
+    assert.equal(errorEvent.ctx.error.message, 'libcouchbase: query failed')
+  })
+
+  it('drives asyncStart/asyncEnd on a successful resolution', async () => {
+    const events = subscribe(queryChannel)
+    let pendingEmitter
+    const { cluster } = makeFakeSdk({ emit: e => { pendingEmitter = e } })
+
+    const rows = [{ a: 1 }, { a: 2 }]
+    const promise = cluster.query('SELECT *')
+
+    for (const row of rows) pendingEmitter.emit('row', row)
+    pendingEmitter.emit('end')
+
+    const result = await promise
+
+    assert.deepEqual(result, { rows })
+    const eventNames = events.map(e => e.name)
+    assert.deepEqual(eventNames, ['start', 'end', 'asyncStart', 'asyncEnd'])
+  })
+
+  it('publishes :error and rethrows when the wrapped operation throws synchronously', () => {
+    const events = subscribe(queryChannel)
+
+    class ThrowingCluster {
+      constructor () { this._connStr = 'couchbase://localhost' }
+      query () { throw new Error('libcouchbase: invalid argument') }
+    }
+
+    wrapClusterQuery({ Cluster: ThrowingCluster })
+    const cluster = new ThrowingCluster()
+
+    assert.throws(() => cluster.query('SELECT bad'), /invalid argument/)
+
+    const eventNames = events.map(e => e.name)
+    assert.deepEqual(eventNames, ['start', 'error', 'end'])
+    const errorEvent = events.find(e => e.name === 'error')
+    assert.equal(errorEvent.ctx.error.message, 'libcouchbase: invalid argument')
+  })
+
+  it('does not call .on() on the SDK return value (v4.5.0+ depromisify regression guard)', async () => {
+    subscribe(queryChannel)
+    let pendingEmitter
+
+    class V45Cluster {
+      constructor () { this._connStr = 'couchbase://localhost' }
+
+      query (statement) {
+        const emitter = new FakeStreamableRowPromiseV45(rows => ({ rows }))
+        pendingEmitter = emitter
+        return emitter
+      }
+    }
+
+    wrapClusterQuery({ Cluster: V45Cluster })
+    const cluster = new V45Cluster()
+
+    const result = cluster.query('SELECT 1')
+
+    setImmediate(() => pendingEmitter.emit('end'))
+
+    // If the wrap calls `.on()` on the return value, JSCBC-1301
+    // depromisifies and `await result` throws. The contract has been part
+    // of the SDK since v4.5.0.
+    await result
+  })
+
+  it('drives the callback path through traceCallback without losing the EE surface', async () => {
+    const events = subscribe(upsertChannel)
+    let pendingEmitter
+    const { collection } = makeFakeSdk({ emit: e => { pendingEmitter = e } })
+
+    const result = collection.upsert('k', 'v', () => {})
+
+    assert.equal(typeof result.on, 'function', 'callback path must keep the EventEmitter surface')
+
+    pendingEmitter.emit('error', new Error('libcouchbase: timeout'))
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const startEvent = events.find(e => e.name === 'start')
+    assert.notEqual(startEvent, undefined, 'start must fire under the callback path')
+  })
+})

--- a/packages/datadog-plugin-couchbase/src/index.js
+++ b/packages/datadog-plugin-couchbase/src/index.js
@@ -1,18 +1,49 @@
 'use strict'
 
 const StoragePlugin = require('../../dd-trace/src/plugins/storage')
-const { storage } = require('../../datadog-core')
 
 class CouchBasePlugin extends StoragePlugin {
   static id = 'couchbase'
   static peerServicePrecursors = ['db.couchbase.seed.nodes']
 
-  addBinds (func, start) {
-    this.addBind(`apm:couchbase:${func}:start`, start)
-    this.addSub(`apm:couchbase:${func}:error`, ({ error }) => this.addError(error))
-    this.addSub(`apm:couchbase:${func}:finish`, ctx => this.finish(ctx))
-    this.addBind(`apm:couchbase:${func}:callback:start`, callbackStart)
-    this.addBind(`apm:couchbase:${func}:callback:finish`, callbackFinish)
+  constructor (...args) {
+    super(...args)
+
+    this.#addOpSubs('query', (ctx) => {
+      const { resource, bucket, seedNodes } = ctx
+      this.startSpan(
+        'query',
+        {
+          'span.type': 'sql',
+          'resource.name': resource,
+          'span.kind': this.constructor.kind,
+        },
+        { bucket, seedNodes },
+        ctx
+      )
+      return ctx.currentStore
+    })
+
+    for (const op of ['upsert', 'insert', 'replace']) {
+      this.#addOpSubs(op, (ctx) => {
+        const { bucket, collection, seedNodes } = ctx
+        this.startSpan(op, {}, { bucket, collection, seedNodes }, ctx)
+        return ctx.currentStore
+      })
+    }
+  }
+
+  /**
+   * @param {string} op Operation name (`query`, `upsert`, ...).
+   * @param {(ctx: object) => object} bindStart Operation-specific span starter.
+   */
+  #addOpSubs (op, bindStart) {
+    const prefix = `tracing:apm:couchbase:${op}`
+    this.addBind(`${prefix}:start`, bindStart)
+    this.addBind(`${prefix}:asyncStart`, bindAsyncStart)
+    this.addSub(`${prefix}:asyncEnd`, finishSpan)
+    this.addSub(`${prefix}:end`, finishSpanIfSync)
+    this.addSub(`${prefix}:error`, setSpanError)
   }
 
   startSpan (operation, customTags, { bucket, collection, seedNodes }, ctx) {
@@ -27,8 +58,8 @@ class CouchBasePlugin extends StoragePlugin {
     if (bucket) tags['couchbase.bucket.name'] = bucket.name
     if (collection) tags['couchbase.collection.name'] = collection.name
 
-    for (const tag in customTags) {
-      tags[tag] = customTags[tag]
+    for (const key of Object.keys(customTags)) {
+      tags[key] = customTags[key]
     }
 
     return super.startSpan(
@@ -40,48 +71,30 @@ class CouchBasePlugin extends StoragePlugin {
       ctx
     )
   }
-
-  constructor (...args) {
-    super(...args)
-
-    this.addBinds('query', (ctx) => {
-      const { resource, bucket, seedNodes } = ctx
-
-      this.startSpan(
-        'query',
-        {
-          'span.type': 'sql',
-          'resource.name': resource,
-          'span.kind': this.constructor.kind,
-        },
-        { bucket, seedNodes },
-        ctx
-      )
-
-      return ctx.currentStore
-    })
-    this._addCommandSubs('upsert')
-    this._addCommandSubs('insert')
-    this._addCommandSubs('replace')
-  }
-
-  _addCommandSubs (name) {
-    this.addBinds(name, (ctx) => {
-      const { bucket, collection, seedNodes } = ctx
-
-      this.startSpan(name, {}, { bucket, collection, seedNodes }, ctx)
-      return ctx.currentStore
-    })
-  }
 }
 
-function callbackStart (ctx) {
-  ctx.parentStore = storage('legacy').getStore()
+function bindAsyncStart (ctx) {
   return ctx.parentStore
 }
 
-function callbackFinish (ctx) {
-  return ctx.parentStore
+function finishSpan (ctx) {
+  ctx.currentStore?.span?.finish()
+}
+
+// `end` fires synchronously after the wrapped function returns. For async
+// resolutions ctx.result and ctx.error are still unset at that point and the
+// span is closed later via asyncEnd. For a sync throw or sync-resolved
+// callback, this is the only finalization signal.
+function finishSpanIfSync (ctx) {
+  if ((ctx.error !== undefined || ctx.result !== undefined) && ctx.currentStore?.span) {
+    ctx.currentStore.span.finish()
+  }
+}
+
+function setSpanError (ctx) {
+  if (ctx.error && ctx.currentStore?.span) {
+    ctx.currentStore.span.setTag('error', ctx.error)
+  }
 }
 
 module.exports = CouchBasePlugin


### PR DESCRIPTION
`wrapCBandPromise` and `wrapCallbackFinish` each resolved three to
five `channel()` handles by template literal on every traced call.
Pin one stdlib `tracingChannel('apm:couchbase:<op>')` per operation
at module init and route the callback path through `traceCallback`
and the promise path through a hand-rolled equivalent of
`tracePromise`. couchbase was reinventing what `tracingChannel(name)`
already does, and the `tracing:apm:couchbase:<op>:*` family aligns
with what aerospike and other plugins already publish.

The hand-roll on the promise path navigates two SDK quirks:

1. **Lazy listener attachment** in v3.2.x and v4.0-v4.4.
   `StreamablePromise` only attaches its `'row'` / `'error'` /
   `'end'` listeners when `.get promise` runs on the first
   `.then(...)`. Native `tracePromise` wraps the thenable with
   `Promise.resolve(thenable)`, deferring the inner `.then` call by
   a microtask; if libcouchbase emits `'error'` synchronously
   before that microtask drains, no listener is attached and Node
   crashes the process. Calling `res.then(...)` synchronously here
   triggers the lazy getter on the same tick as `fn.apply`. The
   first force-push without this surfaced as the
   `Emitted 'error' event on StreamableRowPromise instance`
   crash on `couchbase ^3.0.7 (3.2.7)` and `>=4.0.0 <4.2.0`.

2. **Mode-exclusive API in v4.5.0+** (JSCBC-1301: "API must either
   be awaited or have events registered immediately").
   `StreamablePromise.on()` / `.addListener()` call
   `_depromisify()`, which removes the SDK's internal listeners
   *and* nulls `_promise`. The next `await` then throws
   `Cannot await a promise that is already registered for events`.
   So this wrap must NEVER call `.on()` on the SDK's return value;
   the synchronous `.then(...)` is the only safe attachment point.
   An earlier defensive `silenceEmitterErrors(res)` call (no-op
   `'error'` listener) tripped exactly this on Node 18 + couchbase
   `>=4.2.0` after the second force-push and is now removed: the
   SDK's internal `'error'` listener (eager via the constructor's
   proxy emitter on v4.5.0+, lazy via our synchronous `.then` on
   v3.2.x / v4.0-v4.4) is sufficient.

Bench (Node 24.15 / V8 13.6, 50k iters x 7 trials, drop best+worst,
master baseline -> this commit):

  cold callback  (0 subs):     61.18 ->  11.99 ns/op  ( -49.20 ns/op,  -80%)
  cold promise   (0 subs):     80.01 ->  30.36 ns/op  ( -49.66 ns/op,  -62%)
  warm callback  (1 sub):    1238.20 -> 168.40 ns/op  (-1069.80 ns/op, -86%)
  warm promise   (1 sub):     256.93 -> 101.97 ns/op  ( -154.96 ns/op, -60%)

The warm-callback gain comes from `traceCallback` not needing
`shimmer.wrapFunction` per call; the cold gains come from doing one
stable property access instead of resolving five suffix-keyed
diagnostic channels per traced call.

The plugin (`packages/datadog-plugin-couchbase/src/index.js`) is
adjusted in lockstep to subscribe to `:start` (bind) /
`:asyncStart` (bind) / `:asyncEnd` / `:end` / `:error` per op.

A new instrumentation-level unit test
(`packages/datadog-instrumentations/test/couchbase.spec.js`) pins
seven permutations covering both SDK shapes: synchronous EE
'error' before await, lazy emit after await, asyncStart / asyncEnd
/ error sub-channel firing on rejection and on success, sync-throw
publishes `:error` and rethrows, the callback path keeps the
EventEmitter surface, and a v4.5.0+-shaped `FakeStreamableRowPromiseV45`
guards against re-introduction of any `.on()` call on the SDK's
return value (the depromisify regression). Tests pass on both
Node 24.15.0 and Node 20.20.2 (the CI Node version where the first
`tracePromise` shape and the second `silenceEmitterErrors` shape
both crashed). The plugin integration tests in
`packages/datadog-plugin-couchbase/test/index.spec.js` continue to
pin the callback, promise, and error-callback permutations on the
live couchbase service in Linux CI.
