### PR TITLE
ci: restore CodeQL config for default setup

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - 'benchmark'
+  - 'integration-tests'
+  - 'node-upstream-tests'
+  - 'packages/**/test'
+  - 'scripts'
+  - 'vendor/dist'


### PR DESCRIPTION
## Summary

- Restores the CodeQL configuration that was removed in #8380. GitHub's CodeQL **default setup** also consumes a config file (to honor `paths-ignore` etc.), so removing it left the default setup running without our scoping.
- Places the file at the standard location and name: `.github/codeql/codeql-config.yml` (hyphenated, under `codeql/`). The previous path was `.github/codeql_config.yml` — non-standard underscore and no subdirectory.
- Content is identical to the previously removed file (same `paths-ignore` list).

## Notes

After merge, the repository's CodeQL default setup needs to be pointed at the new path (`.github/codeql/codeql-config.yml`) in repo settings → Code security → Code scanning → CodeQL → Edit configuration.

## Test plan

- [ ] Confirm CodeQL default setup picks up the config on the next scheduled / push-triggered scan
- [ ] Verify analysis honors `paths-ignore` (no findings reported under `benchmark/`, `integration-tests/`, `node-upstream-tests/`, `packages/**/test`, `scripts/`, `vendor/dist`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)