### PR TITLE
fix(kafka): stop mutating caller-owned message.headers

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -1112,6 +1112,28 @@ function assertUUID (actual, msg = 'not a valid UUID') {
   assert.match(actual, /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/, msg)
 }
 
+/**
+ * Recursively `Object.freeze` an object plus everything reachable from it. Use
+ * in tests when an instrumentation contract says "we won't mutate this": any
+ * accidental write to the value or its nested structures throws synchronously
+ * under strict mode, so the test fails at the offending assignment instead of
+ * far downstream via deep-equality.
+ *
+ * @template T
+ * @param {T} value
+ * @returns {T}
+ */
+function deepFreeze (value) {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) {
+    return value
+  }
+  Object.freeze(value)
+  for (const key of Reflect.ownKeys(value)) {
+    deepFreeze(value[key])
+  }
+  return value
+}
+
 module.exports = {
   ANY_NUMBER,
   ANY_STRING,
@@ -1120,6 +1142,7 @@ module.exports = {
   hookFile,
   assertObjectContains,
   assertUUID,
+  deepFreeze,
   stopProc,
   spawnProc,
   spawnProcAndExpectExit,

--- a/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
+++ b/packages/datadog-instrumentations/src/confluentinc-kafka-javascript.js
@@ -7,6 +7,7 @@ const {
   addHook,
   channel,
 } = require('./helpers/instrument')
+const { cloneMessages } = require('./helpers/kafka')
 
 // Create channels for Confluent Kafka JavaScript
 const channels = {
@@ -211,46 +212,62 @@ function instrumentKafkaJS (kafkaJS) {
                       return send.apply(this, arguments)
                     }
 
+                    const disableHeaderInjection = disabledHeaderWeakSet.has(producer)
+
+                    // Hand the underlying client a shallow clone so neither
+                    // injection nor the client's auto-fields (it sets
+                    // `headers: null` on messages without headers) ever
+                    // touch caller-owned objects. With injection disabled the
+                    // clone must not seed `headers: {}` either: brokers that
+                    // reject any header field cannot recover otherwise.
+                    let outgoingPayload = payload
+                    if (payload && Array.isArray(payload.messages)) {
+                      outgoingPayload = {
+                        ...payload,
+                        messages: cloneMessages(payload.messages, !disableHeaderInjection),
+                      }
+                    }
+
                     const ctx = {
-                      topic: payload?.topic,
-                      messages: payload?.messages || [],
+                      topic: outgoingPayload?.topic,
+                      messages: outgoingPayload?.messages || [],
                       bootstrapServers: kafka._ddBrokers,
-                      disableHeaderInjection: disabledHeaderWeakSet.has(producer),
+                      disableHeaderInjection,
                     }
 
                     return channels.producerStart.runStores(ctx, () => {
                       try {
-                        const result = send.apply(this, arguments)
+                        const result = send.call(this, outgoingPayload)
 
                         result.then((res) => {
                           ctx.result = res
                           channels.producerCommit.publish(ctx)
                           channels.producerFinish.publish(ctx)
-                        }, (err) => {
-                          if (err) {
-                            // Fixes bug where we would inject message headers for kafka brokers
-                            // that don't support headers (version <0.11). On the error, we disable
-                            // header injection. Tnfortunately the error name / type is not more specific.
-                            // This approach is implemented by other tracers as well.
-                            if (err.name === 'KafkaJSError' && err.type === 'ERR_UNKNOWN') {
+                        }, (error) => {
+                          if (error) {
+                            // KafkaJS-compat reports `ERR_UNKNOWN` for brokers
+                            // <0.11 that cannot parse headers. Stop injecting
+                            // for this producer; subsequent sends to the same
+                            // broker succeed.
+                            if (error.name === 'KafkaJSError' && error.type === 'ERR_UNKNOWN') {
                               disabledHeaderWeakSet.add(producer)
                               log.error(
                                 // eslint-disable-next-line @stylistic/max-len
                                 'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
                               )
                             }
-                            ctx.error = err
+                            ctx.error = error
                             channels.producerError.publish(ctx)
                           }
                           channels.producerFinish.publish(ctx)
                         })
 
                         return result
-                      } catch (e) {
-                        ctx.error = e
+                      } catch (error) {
+                        ctx.error = error
                         channels.producerError.publish(ctx)
                         channels.producerFinish.publish(ctx)
-                        throw e
+                        throw error
                       }
                     })
                   }

--- a/packages/datadog-instrumentations/src/helpers/kafka.js
+++ b/packages/datadog-instrumentations/src/helpers/kafka.js
@@ -1,0 +1,31 @@
+'use strict'
+
+/**
+ * Shallow-clone each message and its headers so the boundary, kafkajs, and
+ * the user never share the same nested objects. With `ensureHeaders` true
+ * (header injection enabled) messages without `headers` get an empty object
+ * the producer plugin can inject into; with it false (broker rejected
+ * headers) the absence of `headers` is preserved so brokers that fail on any
+ * header field can recover.
+ *
+ * @param {Array<unknown>} messages
+ * @param {boolean} ensureHeaders
+ */
+function cloneMessages (messages, ensureHeaders) {
+  const result = new Array(messages.length)
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i]
+    if (message === null || typeof message !== 'object') {
+      result[i] = message
+    } else if (message.headers) {
+      result[i] = { ...message, headers: { ...message.headers } }
+    } else {
+      result[i] = ensureHeaders ? { ...message, headers: {} } : { ...message }
+    }
+  }
+  return result
+}
+
+module.exports = {
+  cloneMessages,
+}

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -7,6 +7,7 @@ const {
   channel,
   addHook,
 } = require('./helpers/instrument')
+const { cloneMessages } = require('./helpers/kafka')
 
 const producerStartCh = channel('apm:kafkajs:produce:start')
 const producerCommitCh = channel('apm:kafkajs:produce:commit')
@@ -43,20 +44,27 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
 
     producer.send = function (...args) {
       const wrappedSend = (clusterId) => {
-        const { topic, messages = [] } = args[0]
+        const arg0 = args[0]
+        const topic = arg0?.topic
+        const inputMessages = Array.isArray(arg0?.messages) ? arg0.messages : []
+        const disableHeaderInjection = disabledHeaderWeakSet.has(producer)
+
+        // Hand kafkajs and the plugin a shallow clone so injection writes to
+        // tracer-owned objects instead of the caller's. With injection
+        // disabled the clone must not seed `headers: {}` either: brokers that
+        // reject any header field cannot recover otherwise.
+        let messages = inputMessages
+        if (inputMessages.length > 0) {
+          messages = cloneMessages(inputMessages, !disableHeaderInjection)
+          args[0] = { ...arg0, messages }
+        }
 
         const ctx = {
           bootstrapServers,
           clusterId,
-          disableHeaderInjection: disabledHeaderWeakSet.has(producer),
+          disableHeaderInjection,
           messages,
           topic,
-        }
-
-        for (const message of messages) {
-          if (message !== null && typeof message === 'object' && !ctx.disableHeaderInjection) {
-            message.headers = message.headers || {}
-          }
         }
 
         return producerStartCh.runStores(ctx, () => {

--- a/packages/datadog-instrumentations/test/helpers/kafka.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/kafka.spec.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it } = require('mocha')
+
+const { cloneMessages } = require('../../src/helpers/kafka')
+
+describe('helpers/kafka', () => {
+  describe('cloneMessages', () => {
+    it('returns a fresh array; the input is not the output', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const output = cloneMessages(input, false)
+      assert.notStrictEqual(output, input)
+      assert.notStrictEqual(output[0], input[0])
+    })
+
+    it('keeps the headers field absent when ensureHeaders is false and input has none', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const [cloned] = cloneMessages(input, false)
+      assert.strictEqual(Object.hasOwn(cloned, 'headers'), false)
+      assert.strictEqual(input[0].headers, undefined)
+    })
+
+    it('seeds an empty headers object when ensureHeaders is true and input has none', () => {
+      const input = [{ key: 'k', value: 'v' }]
+      const [cloned] = cloneMessages(input, true)
+      assert.deepStrictEqual(cloned.headers, {})
+      assert.strictEqual(input[0].headers, undefined)
+    })
+
+    it('shallow-clones existing headers so caller mutations stay isolated', () => {
+      const headers = { foo: 'bar' }
+      const [withHeaders] = cloneMessages([{ key: 'k', value: 'v', headers }], false)
+      const [withInjection] = cloneMessages([{ key: 'k', value: 'v', headers }], true)
+      assert.notStrictEqual(withHeaders.headers, headers)
+      assert.notStrictEqual(withInjection.headers, headers)
+      assert.deepStrictEqual(withHeaders.headers, headers)
+      assert.deepStrictEqual(withInjection.headers, headers)
+    })
+
+    it('passes non-object entries through unchanged regardless of ensureHeaders', () => {
+      const sentinel = Symbol('not-a-message')
+      const input = [null, sentinel, 0, '']
+      assert.deepStrictEqual(cloneMessages(input, false), [null, sentinel, 0, ''])
+      assert.deepStrictEqual(cloneMessages(input, true), [null, sentinel, 0, ''])
+    })
+  })
+})

--- a/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
+++ b/packages/datadog-plugin-confluentinc-kafka-javascript/test/dsm.spec.js
@@ -288,24 +288,65 @@ describe('Plugin', () => {
           })
 
           it('should hit an error for the first send and not inject headers in later sends', async () => {
-            const testMessages = [{ key: 'key1', value: 'test1' }]
-            const testMessages2 = [{ key: 'key2', value: 'test2' }]
+            const dc = require('dc-polyfill')
+            const { deepFreeze } = require('../../../integration-tests/helpers')
+
+            const startCh = dc.channel('apm:confluentinc-kafka-javascript:produce:start')
+
+            // Snapshot headers at publish time. The underlying client
+            // converts each cloned message's `headers` to an array-of-pairs
+            // form before shipping, so the live reference would show that
+            // post-conversion shape; we want the bindStart-time injection
+            // result instead.
+            const headerSnapshots = []
+            const headerPresence = []
+            const captureStart = (ctx) => {
+              headerSnapshots.push(ctx.messages.map((m) => (
+                m && typeof m === 'object' && m.headers ? { ...m.headers } : undefined
+              )))
+              headerPresence.push(ctx.messages.map((m) => (
+                m && typeof m === 'object' ? Object.hasOwn(m, 'headers') : null
+              )))
+            }
+            startCh.subscribe(captureStart)
+
+            // Deep-freeze the user's input on both sends; any boundary or
+            // library write to the array, its messages, or their headers
+            // throws synchronously.
+            const testMessages = deepFreeze([{ key: 'key1', value: 'test1' }])
+            const testMessages2 = deepFreeze([{ key: 'key2', value: 'test2' }])
 
             try {
-              await producer.send({ topic: testTopic, messages: testMessages })
-              assert.fail('First producer.send() should have thrown an error')
-            } catch (e) {
-              assert.strictEqual(e, error)
+              await assert.rejects(
+                producer.send({ topic: testTopic, messages: testMessages }),
+                error
+              )
+
+              const firstHeaders = headerSnapshots.find(
+                (snapshot) => snapshot[0] && Object.hasOwn(snapshot[0], 'x-datadog-trace-id')
+              )
+              assert.ok(firstHeaders, 'expected a captured batch with x-datadog-trace-id')
+
+              const sendsBefore = headerSnapshots.length
+              produceStub.restore()
+
+              const result = await producer.send({ topic: testTopic, messages: testMessages2 })
+
+              // After the broker reports ERR_UNKNOWN the producer skips
+              // injection. The boundary still clones, so the underlying
+              // client's `headers: null` post-publish mutation lands on the
+              // clone, not on the user's frozen array. The clone must not
+              // seed `headers: {}` either: brokers that reject any header
+              // field cannot recover otherwise.
+              const injectedAfterError = headerSnapshots
+                .slice(sendsBefore)
+                .filter((snap) => snap[0] && Object.hasOwn(snap[0], 'x-datadog-trace-id'))
+              assert.strictEqual(injectedAfterError.length, 0)
+              assert.deepStrictEqual(headerPresence[sendsBefore], [false])
+              assert.notStrictEqual(result, undefined)
+            } finally {
+              startCh.unsubscribe(captureStart)
             }
-            // Verify headers were injected in the first attempt
-            assert.ok(Object.hasOwn(testMessages[0].headers[0], 'x-datadog-trace-id'))
-
-            // restore the stub to allow the next send to succeed
-            produceStub.restore()
-
-            const result = await producer.send({ topic: testTopic, messages: testMessages2 })
-            assert.strictEqual(testMessages2[0].headers, null)
-            assert.notStrictEqual(result, undefined)
           })
         })
       })

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -12,7 +12,7 @@ const { withNamingSchema, withPeerService, withVersions } = require('../../dd-tr
 const agent = require('../../dd-trace/test/plugins/agent')
 const { expectSomeSpan, withDefaults } = require('../../dd-trace/test/plugins/helpers')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
-const { assertObjectContains } = require('../../../integration-tests/helpers')
+const { assertObjectContains, deepFreeze } = require('../../../integration-tests/helpers')
 
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
@@ -37,7 +37,6 @@ describe('Plugin', () => {
 
       describe('without configuration', () => {
         const messages = [{ key: 'key1', value: 'test2' }]
-        const messages2 = [{ key: 'key2', value: 'test3' }]
 
         beforeEach(async () => {
           tracer = require('../../dd-trace')
@@ -97,6 +96,17 @@ describe('Plugin', () => {
             '127.0.0.1:9092',
             'messaging.kafka.bootstrap.servers'
           )
+
+          it('should not mutate user-supplied message objects', async () => {
+            // Deep-freezing the input means any accidental write to a
+            // message, its headers, or the array itself throws synchronously.
+            const userMessages = deepFreeze([
+              { key: 'key', value: 'value', headers: { foo: 'bar' } },
+              { key: 'key2', value: 'value2' },
+            ])
+
+            await sendMessages(kafka, testTopic, userMessages)
+          })
 
           it('should be instrumented w/ error', async () => {
             const producer = kafka.producer()
@@ -190,16 +200,38 @@ describe('Plugin', () => {
             })
 
             it('should hit an error for the first send and not inject headers in later sends', async () => {
-              await assert.rejects(producer.send({ topic: testTopic, messages }), error)
+              const startCh = dc.channel('apm:kafkajs:produce:start')
+              const sentMessageBatches = []
+              const captureStart = (ctx) => sentMessageBatches.push(ctx.messages)
+              startCh.subscribe(captureStart)
 
-              assert.ok(Object.hasOwn(messages[0].headers, 'x-datadog-trace-id'))
+              // Freeze both batches: any boundary or plugin write to the
+              // user's array, its messages, or their headers throws here.
+              const firstBatch = deepFreeze([{ key: 'key1', value: 'test2' }])
+              const secondBatch = deepFreeze([{ key: 'key2', value: 'test3' }])
 
-              // restore the stub to allow the next send to succeed
-              sendRequestStub.restore()
+              try {
+                await assert.rejects(producer.send({ topic: testTopic, messages: firstBatch }), error)
 
-              const result2 = await producer.send({ topic: testTopic, messages: messages2 })
-              assert.strictEqual(messages2[0].headers, undefined)
-              assert.strictEqual(result2[0].errorCode, 0)
+                // The first send injects trace headers into the cloned
+                // batch that kafkajs serializes.
+                assert.ok(Object.hasOwn(sentMessageBatches[0][0].headers, 'x-datadog-trace-id'))
+
+                sendRequestStub.restore()
+
+                const result2 = await producer.send({ topic: testTopic, messages: secondBatch })
+
+                // After UNKNOWN the boundary clones with `cloneMessages`
+                // (frozen input stays untouched) and the clone has no
+                // `headers` field at all — brokers that reject any header
+                // field can recover.
+                const [clonedAfterDisable] = sentMessageBatches[1]
+                assert.notStrictEqual(clonedAfterDisable, secondBatch[0])
+                assert.strictEqual(Object.hasOwn(clonedAfterDisable, 'headers'), false)
+                assert.strictEqual(result2[0].errorCode, 0)
+              } finally {
+                startCh.unsubscribe(captureStart)
+              }
             })
           })
 


### PR DESCRIPTION
## Summary

Both kafkajs's producer wrap and the `@confluentinc/kafka-javascript` KafkaJS-compat producer wrap mutated the caller's `message.headers` in place. Either path leaves the caller holding the side effects of someone else's instrumentation.

1. The kafkajs boundary seeded `headers: {}` on every message before the plugin injected trace context.
2. The confluent KafkaJS-compat path handed `payload.messages` straight to the underlying client, which then wrote `headers: null` on messages without headers.

The boundary now hands kafkajs and the underlying confluent client a shallow clone of the messages array via a single `cloneMessages(messages, ensureHeaders)` helper. With injection enabled the helper seeds `headers: {}` on the clone for the plugin to inject into; with injection disabled (after the broker reported `KafkaJSProtocolError UNKNOWN` / `KafkaJSError ERR_UNKNOWN`) the helper preserves the absence of `headers` so brokers that reject any header field can recover.

## Test plan

- [ ] `./node_modules/.bin/mocha packages/datadog-instrumentations/test/helpers/kafka.spec.js` — unit tests for `cloneMessages`.
- [ ] `PLUGINS=kafkajs SPEC=index npm run test:plugins` — exercises the deep-frozen-input regression test and the `KafkaJSProtocolError UNKNOWN` recovery path that pins the no-`headers: {}` seeding invariant.
- [ ] `PLUGINS=confluentinc-kafka-javascript SPEC=dsm npm run test:plugins` — pins the same invariant for the KafkaJS-compat path.

Refs: https://github.com/DataDog/dd-trace-js/issues/5270
Refs: https://github.com/DataDog/dd-trace-js/pull/8253