### PR TITLE
ci: add dd-octo-sts policies for upcoming rate-limit work

### DIFF
--- a/.github/chainguard/all-green.sts.yaml
+++ b/.github/chainguard/all-green.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: 'repo:DataDog/dd-trace-js:(ref:refs/heads/master|pull_request)'
+
+claim_pattern:
+  event_name: (push|pull_request|schedule)
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/all-green\.yml@.*
+
+permissions:
+  actions: write
+  contents: read

--- a/.github/chainguard/codeql-analysis.sts.yaml
+++ b/.github/chainguard/codeql-analysis.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: 'repo:DataDog/dd-trace-js:(ref:refs/heads/(master|mq-working-branch-master-.*)|pull_request)'
+
+claim_pattern:
+  event_name: (push|pull_request)
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/codeql-analysis\.yml@.*
+
+permissions:
+  contents: read
+  actions: read
+  security_events: write

--- a/.github/chainguard/custom-node-version-dispatch.sts.yaml
+++ b/.github/chainguard/custom-node-version-dispatch.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-js:ref:refs/heads/master
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/master
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/custom-node-version-dispatch\.yml@refs/heads/master
+
+permissions:
+  actions: write

--- a/.github/chainguard/package-size-report.sts.yaml
+++ b/.github/chainguard/package-size-report.sts.yaml
@@ -1,0 +1,10 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: 'repo:DataDog/dd-trace-js:(ref:refs/heads/(master|mq-working-branch-master-.*)|pull_request)'
+
+claim_pattern:
+  event_name: (push|pull_request)
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/project\.yml@.*
+
+permissions:
+  pull_requests: write

--- a/.github/chainguard/stale.sts.yaml
+++ b/.github/chainguard/stale.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/dd-trace-js:ref:refs/heads/master
+
+claim_pattern:
+  event_name: schedule
+  ref: refs/heads/master
+  job_workflow_ref: DataDog/dd-trace-js/\.github/workflows/stale\.yml@refs/heads/master
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
## Summary

Prep PR for #8391. Lands the five new dd-octo-sts trust policies on master so the STS service can register them before the workflow changes that reference them try to mint tokens.

The policies are inert on their own — no workflow on master currently references any of these identities, so merging this PR has no behavioral effect. It only registers the trust relationships:

| Policy | For | Granted permissions |
|---|---|---|
| [`codeql-analysis.sts.yaml`](.github/chainguard/codeql-analysis.sts.yaml) | restored CodeQL workflow | `contents: read`, `actions: read`, `security_events: write` |
| [`all-green.sts.yaml`](.github/chainguard/all-green.sts.yaml) | All Green workflow-runs polling | `actions: write`, `contents: read` |
| [`package-size-report.sts.yaml`](.github/chainguard/package-size-report.sts.yaml) | `qard/heaviest-objects-in-the-universe` PR comment | `pull_requests: write` |
| [`custom-node-version-dispatch.sts.yaml`](.github/chainguard/custom-node-version-dispatch.sts.yaml) | nightly Node-version dispatcher | `actions: write` |
| [`stale.sts.yaml`](.github/chainguard/stale.sts.yaml) | stale-PR bot | `pull_requests: write` |

Each policy is scoped to the exact `job_workflow_ref` of its consumer, with the appropriate `event_name` claim pattern (push/pull_request/schedule/workflow_dispatch).

## Why split this from #8391

#8391 fails with `HTTP 404: no application matches the requested scope` when its CI tries to exchange OIDC for a `package-size-report` token, because the dd-octo-sts service resolves policy files from master only and the policies don't exist there yet. Landing this prep PR first unblocks #8391's CI.

## Test plan

- [ ] Confirm dd-octo-sts service picks up each new policy (check via `gh api ...` or the service's own UI/logs once merged)
- [ ] Re-run #8391's failing job after merge — the OIDC exchange should now succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)