### PR TITLE
ci: remove node_modules cache from install action

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,28 +1,11 @@
 name: Install dependencies
 description: Install dependencies
-inputs:
-  cache:
-    description: "Whether to enable caching of node_modules."
-    required: false
-    default: 'false'
 runs:
   using: composite
   steps:
-    - id: yarn-cache
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        key: yarn-cache-${{ github.workflow }}-${{ github.job }}-${{ hashFiles('yarn.lock') }}-v2
-        path: node_modules.tar
-      if: inputs.cache == 'true'
-    - run: tar -xf node_modules.tar
-      shell: bash
-      if: inputs.cache == 'true' && steps.yarn-cache.outputs.cache-hit == 'true'
       # Retry in case of server error from registry.
       # Wait 60 seconds to give the registry server time to heal.
     - run: bun install --linker=hoisted --trust || sleep 60 && bun install --linker=hoisted --trust
       shell: bash
       env:
         _DD_IGNORE_ENGINES: 'true'
-    - run: tar -cf node_modules.tar node_modules
-      shell: bash
-      if: inputs.cache == 'true' && steps.yarn-cache.outputs.cache-hit != 'true'

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
       # Retry in case of server error from registry.
       # Wait 60 seconds to give the registry server time to heal.
-    - run: bun install --linker=hoisted --trust || sleep 60 && bun install --linker=hoisted --trust
+    - run: bun install --linker=hoisted --trust --network-concurrency 8 || (sleep 60 && bun install --linker=hoisted --trust --network-concurrency 8)
       shell: bash
       env:
         _DD_IGNORE_ENGINES: 'true'

--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -76,8 +76,6 @@ jobs:
         with:
           version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
-        with:
-          cache: "true"
       - run: yarn test:aiguard:ci
       - uses: ./.github/actions/node-crash-report
         if: failure()

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -80,8 +80,6 @@ jobs:
         with:
           version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
-        with:
-          cache: "true"
       - run: yarn test:trace:core:ci
       - uses: ./.github/actions/node-crash-report
         if: failure()

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -83,8 +83,6 @@ jobs:
         with:
           version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
-        with:
-          cache: "true"
       - run: yarn test:appsec:ci
       - uses: ./.github/actions/node-crash-report
         if: failure()

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -103,8 +103,6 @@ jobs:
         with:
           version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
-        with:
-          cache: "true"
       - run: yarn test:integration:openfeature:coverage
       - uses: ./.github/actions/node-crash-report
         if: failure()

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -88,8 +88,6 @@ jobs:
         with:
           version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
-        with:
-          cache: "true"
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler:coverage
       - uses: ./.github/actions/node-crash-report


### PR DESCRIPTION
## Summary

- Removes the `cache` input and tar-based `node_modules` caching from `.github/actions/install`
- Removes `cache: "true"` from all 5 callers (apm-capabilities, appsec, profiling, aiguard, openfeature workflows)

Bun is faster on Windows than yarn/npm, so caching is less needed. Caching also seems to be causing crashes on Windows 2025/2026, so removing it might also be safer.

## Test plan

- [ ] Verify CI passes on affected workflows (apm-capabilities, appsec, profiling, aiguard, openfeature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)