### PR TITLE
ci(actions): use setup-bun with no-cache to avoid rate limits

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -55,6 +55,3 @@ runs:
       if: steps.node-version-cache.outputs.cache-hit != 'true'
       shell: bash
       run: node -v | tr -d 'v' > /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
-    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      with:
-        bun-version: 1.3.1

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -55,3 +55,7 @@ runs:
       if: steps.node-version-cache.outputs.cache-hit != 'true'
       shell: bash
       run: node -v | tr -d 'v' > /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: 1.3.1
+        no-cache: true


### PR DESCRIPTION
## Summary

Restores the `oven-sh/setup-bun` action with the `no-cache: true` option to avoid hitting the GitHub Cache API rate limit, while keeping bun installed via the dedicated action rather than npm.

## Test plan

- Verify that workflows using this action continue to work correctly
- Confirm that bun is properly installed via setup-bun
- Confirm that the GitHub Cache API rate limit is no longer hit

:robot_face: Generated with Claude Code