### PR TITLE
chore: key the cache on DD_TRACE_GIT_METADATA_ENABLED

### DIFF
--- a/packages/dd-trace/src/git_metadata.js
+++ b/packages/dd-trace/src/git_metadata.js
@@ -12,19 +12,21 @@ const {
   resolveGitHeadSHA,
 } = require('./config/git_properties')
 
-/** @type {{ commitSHA: string | undefined, repositoryUrl: string | undefined } | undefined} */
-let cached
+/**
+ * @typedef {{ commitSHA: string | undefined, repositoryUrl: string | undefined }} GitMetadata
+ * @type {{ enabled?: GitMetadata, disabled?: GitMetadata }}
+ */
+const cache = {}
 
 /**
  * @param {import('./config/config-types').ConfigProperties} config
  */
 function getGitMetadata (config) {
-  if (cached) return cached
-
   if (!config.DD_TRACE_GIT_METADATA_ENABLED) {
-    cached = { commitSHA: undefined, repositoryUrl: undefined }
-    return cached
+    cache.disabled ??= { commitSHA: undefined, repositoryUrl: undefined }
+    return cache.disabled
   }
+  if (cache.enabled) return cache.enabled
 
   let repositoryUrl = removeUserSensitiveInfo(config.DD_GIT_REPOSITORY_URL ?? config.tags[GIT_REPOSITORY_URL])
   let commitSHA = config.DD_GIT_COMMIT_SHA ?? config.tags[GIT_COMMIT_SHA]
@@ -59,8 +61,8 @@ function getGitMetadata (config) {
 
   commitSHA ??= resolveGitHeadSHA(gitFolderPath)
 
-  cached = { commitSHA, repositoryUrl }
-  return cached
+  cache.enabled = { commitSHA, repositoryUrl }
+  return cache.enabled
 }
 
 module.exports = getGitMetadata

--- a/packages/dd-trace/test/git_metadata.spec.js
+++ b/packages/dd-trace/test/git_metadata.spec.js
@@ -183,6 +183,35 @@ describe('git metadata', () => {
     assert.strictEqual(getGitMetadata(config), getGitMetadata(config))
   })
 
+  // Regression: a single shared cache slot returned the disabled-branch
+  // empty result for any subsequent call once the first call had run with
+  // `DD_TRACE_GIT_METADATA_ENABLED=false`, even when the next caller passed
+  // a fresh `Config` with the flag flipped on and the env populated.
+  it('caches the disabled-branch result independently from the enabled-branch result', () => {
+    const getGitMetadata = proxyquire.noPreserveCache()('../src/git_metadata', {})
+
+    const disabledConfig = { DD_TRACE_GIT_METADATA_ENABLED: false, tags: {} }
+    const enabledConfig = {
+      DD_TRACE_GIT_METADATA_ENABLED: true,
+      DD_GIT_COMMIT_SHA: DUMMY_COMMIT_SHA,
+      DD_GIT_REPOSITORY_URL: DUMMY_REPOSITORY_URL,
+      tags: {},
+    }
+
+    assert.deepStrictEqual(getGitMetadata(disabledConfig), {
+      commitSHA: undefined,
+      repositoryUrl: undefined,
+    })
+    assert.deepStrictEqual(getGitMetadata(enabledConfig), {
+      commitSHA: DUMMY_COMMIT_SHA,
+      repositoryUrl: DUMMY_REPOSITORY_URL,
+    })
+    assert.deepStrictEqual(getGitMetadata({ DD_TRACE_GIT_METADATA_ENABLED: false, tags: {} }), {
+      commitSHA: undefined,
+      repositoryUrl: undefined,
+    })
+  })
+
   it('returns undefined when no git source is configured and cwd has no git', () => {
     const originalCwd = process.cwd()
     const tempDir = fs.mkdtempSync(path.join(TMP_DIR, 'dd-trace-no-git-'))


### PR DESCRIPTION
## Summary

A single `let cached` slot pinned the first call's result for the lifetime of the process. A fresh `Config` reaching `getGitMetadata` (different `DD_GIT_*` env, different `DD_GIT_PROPERTIES_FILE`, or a runtime flip of `DD_TRACE_GIT_METADATA_ENABLED`) received the previous instance's metadata and the new options went unread.

Replace the single slot with two named slots — `enabled` and `disabled` — keyed on `DD_TRACE_GIT_METADATA_ENABLED`, the only flag whose runtime value picks a different resolution path. Both slots stay O(1).

This is a future feature or fix: it allows the configuration to be changed with e.g., remote configuration.

## Test plan

- [ ] `yarn test` (`packages/dd-trace/test/git_metadata*.spec.js`) passes.