### PR TITLE
test(setup): isolate getInstrumentation from production addHook

### DIFF
--- a/packages/dd-trace/test/setup/helpers/load-inst.js
+++ b/packages/dd-trace/test/setup/helpers/load-inst.js
@@ -2,21 +2,43 @@
 
 const fs = require('fs')
 const path = require('path')
-const proxyquire = require('proxyquire')
+
+const INSTRUMENT_HELPER_PATH = path.join(
+  __dirname, '../../../../datadog-instrumentations/src/helpers/instrument'
+)
 
 function loadInstFile (file, instrumentations) {
-  const instrument = {
-    addHook (instrumentation) {
-      instrumentations.push(instrumentation)
-    },
-  }
-
   const instPath = path.join(__dirname, `../../../../datadog-instrumentations/src/${file}`)
 
-  proxyquire.noPreserveCache()(instPath, {
-    './helpers/instrument': instrument,
-    '../helpers/instrument': instrument,
-  })
+  // Patch `addHook` for the duration of this load and filter to the SUT's own
+  // call sites; addHook calls from transitively-loaded siblings (e.g.
+  // `router.js` from `express.js`) are dropped — each caller has its own
+  // `getInstrumentation(name)` that captures them.
+  const realInstrument = require(INSTRUMENT_HELPER_PATH)
+  const originalAddHook = realInstrument.addHook
+  realInstrument.addHook = (instrumentation) => {
+    const callerFrame = new Error().stack?.split('\n', 4)[2] ?? ''
+    if (callerFrame.includes(instPath)) {
+      instrumentations.push(instrumentation)
+    }
+  }
+
+  // Snapshot `require.cache` and drop everything this load adds, so production's
+  // `helpers/register.js` re-evaluation finds an empty cache and re-runs the
+  // integration's top-level `addHook` calls.
+  const cacheBefore = new Set(Object.keys(require.cache))
+
+  try {
+    delete require.cache[instPath]
+    require(instPath)
+  } finally {
+    realInstrument.addHook = originalAddHook
+    for (const id of Object.keys(require.cache)) {
+      if (!cacheBefore.has(id)) {
+        delete require.cache[id]
+      }
+    }
+  }
 }
 
 function loadOneInst (name) {


### PR DESCRIPTION
## Summary

The previous \`proxyquire\`-based loader injected a fake \`./helpers/instrument\` module so the SUT's \`addHook\` calls landed in the test-local list, but every integration sibling the SUT required transitively (\`router.js\` from \`express.js\`, \`fs.js\` from \`pg.js\`, …) shared that fake \`addHook\` for the duration of the load. The list the caller got back was polluted with sibling entries.

The new shape patches the real \`addHook\` for the load duration and filters by stack frame — only \`addHook\` calls whose immediate caller comes from the SUT's own file land in the list. Sibling registrations stay in production's \`instrumentations\` table where their own \`getInstrumentation\` call site picks them up. The load also snapshots \`require.cache\` and drops everything it added on the way out so \`helpers/register.js\` re-evaluates each integration cleanly the first time the host library is \`require\`'d.

## Test plan

- [ ] \`yarn test:plugins\` passes (the helper is consumed via \`withVersions\` from \`packages/dd-trace/test/setup/mocha.js\`).