### PR TITLE
test(pg): pin prepared-statement reuse under DBM full mode

### DIFF
--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -784,6 +784,17 @@ describe('Plugin', () => {
           )
         })
 
+        it('reuses prepared statements across calls without "must be unique" error', async () => {
+          const buildQuery = () => ({
+            name: 'pgRepeatedSelect',
+            text: 'SELECT $1::text as message',
+          })
+
+          await client.query(buildQuery(), ['first'])
+          await client.query(buildQuery(), ['second'])
+          await client.query(buildQuery(), ['third'])
+        })
+
         it('should not fail when using query object with getters', done => {
           const query = {
             name: 'pgSelectQuery',


### PR DESCRIPTION
## Summary

Adds a regression test that exercises a named pg query reused across calls under `dbmPropagationMode: 'full'`. Without the `disableFullMode = !!query.name` guard in the pg plugin, the per-trace `traceparent` in the DBM comment makes `query.text` differ on every call and pg's `parsedStatements` cache rejects the second submission with `Prepared statements must be unique - '<name>' was used for a different statement` — the exact failure mode reported in issue #3793.

Verified locally:

- master + new test → green on `pg@8.0.3` and `pg@8.17.1` (the floor and head of the supported `>=8.0.3` range).
- master with the named-query guard forced off → both versions fail with the byte-identical error from the issue.

Refs: https://github.com/DataDog/dd-trace-js/issues/3793