### PR TITLE
feat(kafkajs): instrument producer.sendBatch

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -300,6 +300,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-kafkajs:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: kafkajs
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-knex:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/kafkajs.js
+++ b/packages/datadog-instrumentations/src/kafkajs.js
@@ -62,6 +62,7 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
   shimmer.wrap(Kafka.prototype, 'producer', createProducer => function () {
     const producer = createProducer.apply(this, arguments)
     const originalSend = producer.send
+    const originalSendBatch = producer.sendBatch
     const bootstrapServers = this._brokers
     const cluster = clientToCluster.get(producer)
 
@@ -75,33 +76,44 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
       }
     }
 
-    producer.send = function (...args) {
-      if (!producerStartCh.hasSubscribers) {
-        return originalSend.apply(this, args)
-      }
-
-      // Fast path: kafkajs has fetched metadata, so versions and clusterId
-      // are already on the broker pool.
+    /**
+     * Resolve the negotiated clusterId once and hand it to `call`. Fast path reads
+     * `cluster.brokerPool.metadata` synchronously when kafkajs already fetched it.
+     * Slow path primes `refreshMetadataIfNecessary`, which `sharedPromiseTo`
+     * deduplicates with kafkajs's own internal fetch so total latency is unchanged.
+     *
+     * @param {(clusterId: string | undefined) => Promise<unknown>} call
+     */
+    const withClusterId = (call) => {
       const metadata = cluster?.brokerPool?.metadata
       if (metadata) {
         refreshHeaderSupport()
-        return runSend.call(this, args, metadata.clusterId)
+        return call(metadata.clusterId)
       }
-
-      // Slow path, taken at most once per producer connect cycle. Prime the
-      // metadata fetch kafkajs's send would do internally a few stack frames
-      // later. `sharedPromiseTo` collapses our call and kafkajs's call into a
-      // single round trip, so total latency is unchanged.
       if (typeof cluster?.refreshMetadataIfNecessary !== 'function') {
-        return runSend.call(this, args)
+        return call()
       }
       return cluster.refreshMetadataIfNecessary().then(
         () => {
           refreshHeaderSupport()
-          return runSend.call(this, args, cluster.brokerPool?.metadata?.clusterId)
+          return call(cluster.brokerPool?.metadata?.clusterId)
         },
-        () => runSend.call(this, args)
+        () => call()
       )
+    }
+
+    producer.send = function (...args) {
+      if (!producerStartCh.hasSubscribers) {
+        return originalSend.apply(this, args)
+      }
+      return withClusterId((clusterId) => runSend.call(this, args, clusterId))
+    }
+
+    producer.sendBatch = function (...args) {
+      if (!producerStartCh.hasSubscribers) {
+        return originalSendBatch.apply(this, args)
+      }
+      return withClusterId((clusterId) => runSendBatch.call(this, args, clusterId))
     }
 
     function runSend (args, clusterId) {
@@ -164,6 +176,98 @@ addHook({ name: 'kafkajs', file: 'src/index.js', versions: ['>=1.4'] }, (BaseKaf
           throw error
         }
       })
+    }
+
+    function runSendBatch (args, clusterId) {
+      const arg0 = args[0]
+      const inputTopicMessages = Array.isArray(arg0?.topicMessages) ? arg0.topicMessages : []
+      if (inputTopicMessages.length === 0) {
+        return originalSendBatch.apply(this, args)
+      }
+
+      // One ctx per topicMessages entry — kafkajs implements `send` as a single-entry
+      // `sendBatch` (`producer/messageProducer.js`), so one span per entry is the same
+      // unit `send` already produces. Cloning only happens for valid arrays so kafkajs
+      // still sees and rejects a caller's malformed `messages` field.
+      const outputEntries = new Array(inputTopicMessages.length)
+      const ctxList = []
+      let cloned = false
+      for (let i = 0; i < inputTopicMessages.length; i++) {
+        const entry = inputTopicMessages[i]
+        const topic = entry?.topic
+        const rawMessages = entry?.messages
+        let entryMessages = rawMessages
+        if (Array.isArray(rawMessages) && rawMessages.length > 0) {
+          entryMessages = cloneMessages(rawMessages, !disableHeaderInjection)
+          outputEntries[i] = { ...entry, messages: entryMessages }
+          cloned = true
+        } else {
+          outputEntries[i] = entry
+        }
+        ctxList.push({
+          bootstrapServers,
+          clusterId,
+          disableHeaderInjection,
+          messages: Array.isArray(entryMessages) ? entryMessages : [],
+          topic,
+        })
+      }
+      if (cloned) {
+        args[0] = { ...arg0, topicMessages: outputEntries }
+      }
+
+      for (const ctx of ctxList) {
+        producerStartCh.runStores(ctx, noop)
+      }
+
+      let result
+      try {
+        result = originalSendBatch.apply(this, args)
+      } catch (error) {
+        failProduceBatch(ctxList, error)
+        throw error
+      }
+
+      result.then(
+        (res) => {
+          for (const ctx of ctxList) {
+            ctx.result = res
+            producerFinishCh.publish(ctx)
+          }
+          // kafkajs returns a single aggregated response covering every topic;
+          // commit fires once so the plugin's `setOffset` loop runs once per
+          // entry of the response, not once per span.
+          producerCommitCh.publish(ctxList[0])
+        },
+        (error) => failProduceBatch(ctxList, error)
+      )
+
+      return result
+    }
+
+    /**
+     * Tag every open ctx with the shared error, then publish error + finish so the
+     * plugin closes each span. The mixed-version safety net (broker advertised
+     * Produce v3+ but the leader rejected the headers) fires at most once per
+     * failed batch and short-circuits subsequent sends to the disabled path.
+     *
+     * @param {Array<object>} ctxList
+     * @param {Error} error
+     */
+    function failProduceBatch (ctxList, error) {
+      if (error?.name === 'KafkaJSProtocolError' && error.type === 'UNKNOWN') {
+        disableHeaderInjection = true
+        refreshHeaderSupport = noop
+        log.error(
+          // eslint-disable-next-line @stylistic/max-len
+          'Kafka Broker responded with UNKNOWN_SERVER_ERROR (-1). Please look at broker logs for more information. Tracer message header injection for Kafka is disabled.'
+        )
+      }
+      for (const ctx of ctxList) {
+        ctx.error = error
+        producerErrorCh.publish(ctx)
+        producerFinishCh.publish(ctx)
+      }
     }
 
     return producer

--- a/packages/datadog-instrumentations/test/kafkajs.spec.js
+++ b/packages/datadog-instrumentations/test/kafkajs.spec.js
@@ -356,61 +356,6 @@ describe('packages/datadog-instrumentations/src/kafkajs.js', () => {
       }
     })
 
-    it('forwards to originalSendBatch without publishing when topicMessages is empty', async () => {
-      let sendBatchCalls = 0
-      const start = captureChannel(startCh)
-
-      const { producer } = stageProducer({
-        cluster: readyCluster(),
-        originalSendBatch: () => { sendBatchCalls++; return Promise.resolve(undefined) },
-      })
-
-      try {
-        await producer.sendBatch({ topicMessages: [] })
-
-        assert.equal(sendBatchCalls, 1)
-        assert.equal(start.events.length, 0)
-      } finally {
-        start.unsubscribe()
-      }
-    })
-
-    it('forwards the negotiated clusterId on every entry after refreshMetadataIfNecessary resolves', async () => {
-      const cluster = {
-        brokerPool: { versions: { 0: { maxVersion: 9 } } },
-        refreshMetadataIfNecessary: () => {
-          cluster.brokerPool.metadata = { clusterId: 'cluster-resolved' }
-          return Promise.resolve()
-        },
-      }
-
-      let sendBatchCalls = 0
-      const start = captureChannel(startCh)
-
-      const { producer } = stageProducer({
-        cluster,
-        originalSendBatch: () => { sendBatchCalls++; return Promise.resolve(undefined) },
-      })
-
-      try {
-        await producer.sendBatch({
-          topicMessages: [
-            { topic: 'a', messages: [{ key: 'k', value: 'v' }] },
-            { topic: 'b', messages: [{ key: 'k2', value: 'v2' }] },
-          ],
-        })
-
-        assert.equal(sendBatchCalls, 1)
-        assert.equal(start.events.length, 2)
-        assert.equal(start.events[0].topic, 'a')
-        assert.equal(start.events[0].clusterId, 'cluster-resolved')
-        assert.equal(start.events[1].topic, 'b')
-        assert.equal(start.events[1].clusterId, 'cluster-resolved')
-      } finally {
-        start.unsubscribe()
-      }
-    })
-
     it('publishes one start+finish ctx per entry and commits once on the first ctx', async () => {
       const start = captureChannel(startCh)
       const commit = captureChannel(commitCh)

--- a/packages/datadog-instrumentations/test/kafkajs.spec.js
+++ b/packages/datadog-instrumentations/test/kafkajs.spec.js
@@ -1,0 +1,287 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const dc = require('dc-polyfill')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+require('../src/kafkajs')
+
+const HOOKS = globalThis[Symbol.for('_ddtrace_instrumentations')].kafkajs
+const PRODUCER_HOOK = HOOKS.find((entry) => entry.file === 'src/producer/index.js').hook
+const INDEX_HOOK = HOOKS.find((entry) => entry.file === 'src/index.js').hook
+
+/**
+ * @param {object} options
+ * @param {object} [options.cluster] Read for `brokerPool` and
+ *   `refreshMetadataIfNecessary`; `undefined` skips clientToCluster registration.
+ * @param {Function} options.originalSend Returns a thenable; the boundary
+ *   forwards send calls to this after cloning the messages.
+ */
+function stageProducer ({ cluster, originalSend }) {
+  const baseCreateProducer = (params) => ({ send: originalSend, _params: params })
+  const wrappedCreateProducer = PRODUCER_HOOK(baseCreateProducer)
+
+  class FakeBaseKafka {
+    constructor (options) { this._options = options }
+
+    producer (params) {
+      return wrappedCreateProducer({ cluster, ...params })
+    }
+
+    // `shimmer.wrap` asserts the method exists on the prototype; the consumer
+    // surface stays inert because the tests below only exercise producers.
+    consumer () {}
+  }
+
+  const WrappedKafka = INDEX_HOOK(FakeBaseKafka)
+  const kafka = new WrappedKafka({ brokers: ['127.0.0.1:9092'] })
+  return { kafka, producer: kafka.producer() }
+}
+
+describe('packages/datadog-instrumentations/src/kafkajs.js', () => {
+  const startCh = dc.channel('apm:kafkajs:produce:start')
+  const startNoop = () => {}
+
+  beforeEach(() => {
+    startCh.subscribe(startNoop)
+  })
+
+  afterEach(() => {
+    startCh.unsubscribe(startNoop)
+  })
+
+  describe('producer.send slow path (no metadata yet)', () => {
+    it('runs send after refreshMetadataIfNecessary resolves and forwards the negotiated clusterId', async () => {
+      let sendCalls = 0
+      // Metadata absent on first call so the boundary takes the slow path,
+      // then populated by the time the resolve callback reads it.
+      const cluster = {
+        brokerPool: { versions: { 0: { maxVersion: 9 } } },
+        refreshMetadataIfNecessary: () => {
+          cluster.brokerPool.metadata = { clusterId: 'cluster-resolved' }
+          return Promise.resolve()
+        },
+      }
+
+      const seenCtx = []
+      const captureStart = (ctx) => seenCtx.push(ctx)
+      startCh.subscribe(captureStart)
+
+      const { producer } = stageProducer({
+        cluster,
+        originalSend: () => { sendCalls++; return Promise.resolve(undefined) },
+      })
+
+      try {
+        await producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+
+        assert.equal(sendCalls, 1)
+        assert.equal(seenCtx.length, 1)
+        assert.equal(seenCtx[0].clusterId, 'cluster-resolved')
+        assert.equal(seenCtx[0].disableHeaderInjection, false)
+      } finally {
+        startCh.unsubscribe(captureStart)
+      }
+    })
+
+    it('still runs send when refreshMetadataIfNecessary rejects (no clusterId)', async () => {
+      let sendCalls = 0
+      const cluster = {
+        brokerPool: { versions: { 0: { maxVersion: 9 } } },
+        refreshMetadataIfNecessary: () => Promise.reject(new Error('boom')),
+      }
+
+      const seenCtx = []
+      const captureStart = (ctx) => seenCtx.push(ctx)
+      startCh.subscribe(captureStart)
+
+      const { producer } = stageProducer({
+        cluster,
+        originalSend: () => { sendCalls++; return Promise.resolve(undefined) },
+      })
+
+      try {
+        await producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+
+        assert.equal(sendCalls, 1)
+        assert.equal(seenCtx.length, 1)
+        assert.equal(seenCtx[0].clusterId, undefined)
+      } finally {
+        startCh.unsubscribe(captureStart)
+      }
+    })
+
+    it('skips refreshMetadataIfNecessary when the cluster does not expose it', async () => {
+      let sendCalls = 0
+      const cluster = { brokerPool: { versions: { 0: { maxVersion: 9 } } } }
+
+      const { producer } = stageProducer({
+        cluster,
+        originalSend: () => { sendCalls++; return Promise.resolve(undefined) },
+      })
+
+      const result = producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+
+      assert.equal(typeof result.then, 'function')
+      await result
+      assert.equal(sendCalls, 1)
+    })
+  })
+
+  describe('proactive header-support refresh', () => {
+    it('disables injection on first send when the broker negotiated Produce <v3', async () => {
+      const cluster = {
+        brokerPool: {
+          metadata: { clusterId: 'old-broker' },
+          versions: { 0: { maxVersion: 2 } },
+        },
+      }
+
+      const seenCtx = []
+      const captureStart = (ctx) => seenCtx.push(ctx)
+      startCh.subscribe(captureStart)
+
+      const { producer } = stageProducer({
+        cluster,
+        originalSend: () => Promise.resolve(undefined),
+      })
+
+      try {
+        await producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+
+        assert.equal(seenCtx[0].disableHeaderInjection, true)
+      } finally {
+        startCh.unsubscribe(captureStart)
+      }
+    })
+
+    it('stops re-running the header-support check after the first disable', async () => {
+      let versionLookups = 0
+      const cluster = {
+        brokerPool: {
+          metadata: { clusterId: 'old-broker' },
+          versions: new Proxy({ 0: { maxVersion: 2 } }, {
+            get (target, key) {
+              if (key === '0') versionLookups++
+              return target[key]
+            },
+          }),
+        },
+      }
+
+      const { producer } = stageProducer({
+        cluster,
+        originalSend: () => Promise.resolve(undefined),
+      })
+
+      await producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+      await producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+      await producer.send({ topic: 'topic', messages: [{ key: 'k', value: 'v' }] })
+
+      assert.equal(versionLookups, 1)
+    })
+  })
+
+  describe('reactive header-support disable', () => {
+    it('disables injection on the next send after KafkaJSProtocolError UNKNOWN', async () => {
+      let sendCalls = 0
+      const cluster = {
+        brokerPool: {
+          metadata: { clusterId: 'mixed-version-cluster' },
+          versions: { 0: { maxVersion: 9 } },
+        },
+      }
+
+      const seenCtx = []
+      const captureStart = (ctx) => seenCtx.push(ctx)
+      startCh.subscribe(captureStart)
+
+      const error = Object.assign(new Error('UNKNOWN_SERVER_ERROR'), {
+        name: 'KafkaJSProtocolError',
+        type: 'UNKNOWN',
+      })
+
+      const originalSend = () => {
+        sendCalls++
+        return sendCalls === 1 ? Promise.reject(error) : Promise.resolve(undefined)
+      }
+
+      const { producer } = stageProducer({ cluster, originalSend })
+
+      try {
+        await assert.rejects(
+          producer.send({ topic: 't', messages: [{ key: 'k', value: 'v' }] }),
+          error
+        )
+        await producer.send({ topic: 't', messages: [{ key: 'k', value: 'v' }] })
+
+        assert.equal(seenCtx.length, 2)
+        assert.equal(seenCtx[0].disableHeaderInjection, false)
+        assert.equal(seenCtx[1].disableHeaderInjection, true)
+      } finally {
+        startCh.unsubscribe(captureStart)
+      }
+    })
+
+    it('leaves injection enabled on unrelated protocol errors', async () => {
+      const cluster = {
+        brokerPool: {
+          metadata: { clusterId: 'healthy-cluster' },
+          versions: { 0: { maxVersion: 9 } },
+        },
+      }
+
+      const seenCtx = []
+      const captureStart = (ctx) => seenCtx.push(ctx)
+      startCh.subscribe(captureStart)
+
+      const error = Object.assign(new Error('other'), {
+        name: 'KafkaJSProtocolError',
+        type: 'TOPIC_AUTHORIZATION_FAILED',
+      })
+
+      let sendCalls = 0
+      const originalSend = () => {
+        sendCalls++
+        return sendCalls === 1 ? Promise.reject(error) : Promise.resolve(undefined)
+      }
+
+      const { producer } = stageProducer({ cluster, originalSend })
+
+      try {
+        await assert.rejects(
+          producer.send({ topic: 't', messages: [{ key: 'k', value: 'v' }] }),
+          error
+        )
+        await producer.send({ topic: 't', messages: [{ key: 'k', value: 'v' }] })
+
+        assert.equal(seenCtx.length, 2)
+        assert.equal(seenCtx[0].disableHeaderInjection, false)
+        assert.equal(seenCtx[1].disableHeaderInjection, false)
+      } finally {
+        startCh.unsubscribe(captureStart)
+      }
+    })
+  })
+
+  describe('producer.send fast skip', () => {
+    it('bypasses the boundary entirely when no subscriber is attached to the produce channel', async () => {
+      startCh.unsubscribe(startNoop)
+      try {
+        let sendCalls = 0
+        const { producer } = stageProducer({
+          cluster: { brokerPool: { metadata: { clusterId: 'irrelevant' } } },
+          originalSend: () => { sendCalls++; return Promise.resolve('passthrough') },
+        })
+
+        const result = await producer.send({ topic: 't', messages: [{ key: 'k', value: 'v' }] })
+
+        assert.equal(sendCalls, 1)
+        assert.equal(result, 'passthrough')
+      } finally {
+        startCh.subscribe(startNoop)
+      }
+    })
+  })
+})

--- a/packages/datadog-instrumentations/test/kafkajs.spec.js
+++ b/packages/datadog-instrumentations/test/kafkajs.spec.js
@@ -15,11 +15,18 @@ const INDEX_HOOK = HOOKS.find((entry) => entry.file === 'src/index.js').hook
  * @param {object} options
  * @param {object} [options.cluster] Read for `brokerPool` and
  *   `refreshMetadataIfNecessary`; `undefined` skips clientToCluster registration.
- * @param {Function} options.originalSend Returns a thenable; the boundary
+ * @param {Function} [options.originalSend] Returns a thenable; the boundary
  *   forwards send calls to this after cloning the messages.
+ * @param {Function} [options.originalSendBatch] Returns a thenable or throws
+ *   synchronously; the boundary forwards sendBatch calls to this after cloning
+ *   each entry's messages.
  */
-function stageProducer ({ cluster, originalSend }) {
-  const baseCreateProducer = (params) => ({ send: originalSend, _params: params })
+function stageProducer ({ cluster, originalSend, originalSendBatch }) {
+  const baseCreateProducer = (params) => ({
+    send: originalSend,
+    sendBatch: originalSendBatch,
+    _params: params,
+  })
   const wrappedCreateProducer = PRODUCER_HOOK(baseCreateProducer)
 
   class FakeBaseKafka {
@@ -281,6 +288,308 @@ describe('packages/datadog-instrumentations/src/kafkajs.js', () => {
         assert.equal(result, 'passthrough')
       } finally {
         startCh.subscribe(startNoop)
+      }
+    })
+  })
+
+  describe('producer.sendBatch', () => {
+    const commitCh = dc.channel('apm:kafkajs:produce:commit')
+    const errorCh = dc.channel('apm:kafkajs:produce:error')
+    const finishCh = dc.channel('apm:kafkajs:produce:finish')
+
+    /**
+     * @param {import('dc-polyfill').Channel} channel
+     */
+    function captureChannel (channel) {
+      const events = []
+      const handler = (ctx) => events.push(ctx)
+      channel.subscribe(handler)
+      return { events, unsubscribe: () => channel.unsubscribe(handler) }
+    }
+
+    function readyCluster () {
+      return {
+        brokerPool: {
+          metadata: { clusterId: 'cluster-x' },
+          versions: { 0: { maxVersion: 9 } },
+        },
+      }
+    }
+
+    it('bypasses the boundary entirely when no subscriber is attached to the produce channel', async () => {
+      startCh.unsubscribe(startNoop)
+      try {
+        let sendBatchCalls = 0
+        const { producer } = stageProducer({
+          cluster: readyCluster(),
+          originalSendBatch: () => { sendBatchCalls++; return Promise.resolve('passthrough') },
+        })
+
+        const result = await producer.sendBatch({
+          topicMessages: [{ topic: 't', messages: [{ key: 'k', value: 'v' }] }],
+        })
+
+        assert.equal(sendBatchCalls, 1)
+        assert.equal(result, 'passthrough')
+      } finally {
+        startCh.subscribe(startNoop)
+      }
+    })
+
+    it('forwards to originalSendBatch without publishing when topicMessages is missing', async () => {
+      let sendBatchCalls = 0
+      const start = captureChannel(startCh)
+
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: () => { sendBatchCalls++; return Promise.resolve('passthrough') },
+      })
+
+      try {
+        const result = await producer.sendBatch({})
+
+        assert.equal(sendBatchCalls, 1)
+        assert.equal(result, 'passthrough')
+        assert.equal(start.events.length, 0)
+      } finally {
+        start.unsubscribe()
+      }
+    })
+
+    it('forwards to originalSendBatch without publishing when topicMessages is empty', async () => {
+      let sendBatchCalls = 0
+      const start = captureChannel(startCh)
+
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: () => { sendBatchCalls++; return Promise.resolve(undefined) },
+      })
+
+      try {
+        await producer.sendBatch({ topicMessages: [] })
+
+        assert.equal(sendBatchCalls, 1)
+        assert.equal(start.events.length, 0)
+      } finally {
+        start.unsubscribe()
+      }
+    })
+
+    it('forwards the negotiated clusterId on every entry after refreshMetadataIfNecessary resolves', async () => {
+      const cluster = {
+        brokerPool: { versions: { 0: { maxVersion: 9 } } },
+        refreshMetadataIfNecessary: () => {
+          cluster.brokerPool.metadata = { clusterId: 'cluster-resolved' }
+          return Promise.resolve()
+        },
+      }
+
+      let sendBatchCalls = 0
+      const start = captureChannel(startCh)
+
+      const { producer } = stageProducer({
+        cluster,
+        originalSendBatch: () => { sendBatchCalls++; return Promise.resolve(undefined) },
+      })
+
+      try {
+        await producer.sendBatch({
+          topicMessages: [
+            { topic: 'a', messages: [{ key: 'k', value: 'v' }] },
+            { topic: 'b', messages: [{ key: 'k2', value: 'v2' }] },
+          ],
+        })
+
+        assert.equal(sendBatchCalls, 1)
+        assert.equal(start.events.length, 2)
+        assert.equal(start.events[0].topic, 'a')
+        assert.equal(start.events[0].clusterId, 'cluster-resolved')
+        assert.equal(start.events[1].topic, 'b')
+        assert.equal(start.events[1].clusterId, 'cluster-resolved')
+      } finally {
+        start.unsubscribe()
+      }
+    })
+
+    it('publishes one start+finish ctx per entry and commits once on the first ctx', async () => {
+      const start = captureChannel(startCh)
+      const commit = captureChannel(commitCh)
+      const finish = captureChannel(finishCh)
+
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: () => Promise.resolve('batch-result'),
+      })
+
+      try {
+        await producer.sendBatch({
+          topicMessages: [
+            { topic: 'a', messages: [{ key: 'k', value: 'v' }] },
+            { topic: 'b', messages: [{ key: 'k2', value: 'v2' }] },
+          ],
+        })
+
+        assert.equal(start.events.length, 2)
+        assert.equal(finish.events.length, 2)
+        assert.equal(commit.events.length, 1)
+        assert.equal(commit.events[0], start.events[0])
+        assert.equal(finish.events[0].result, 'batch-result')
+        assert.equal(finish.events[1].result, 'batch-result')
+      } finally {
+        start.unsubscribe()
+        commit.unsubscribe()
+        finish.unsubscribe()
+      }
+    })
+
+    it('passes a per-entry ctx with empty messages through when one entry has a non-array messages field', async () => {
+      const start = captureChannel(startCh)
+      let forwardedArg0
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: (arg0) => {
+          forwardedArg0 = arg0
+          return Promise.resolve(undefined)
+        },
+      })
+
+      const userTopicMessages = [
+        { topic: 'a', messages: [{ key: 'k', value: 'v' }] },
+        { topic: 'b', messages: 'not-an-array' },
+      ]
+
+      try {
+        await producer.sendBatch({ topicMessages: userTopicMessages })
+
+        assert.equal(start.events.length, 2)
+        assert.equal(start.events[1].topic, 'b')
+        assert.deepEqual(start.events[1].messages, [])
+        // Invalid entry forwarded verbatim so kafkajs surfaces its own validation error.
+        assert.equal(forwardedArg0.topicMessages[1], userTopicMessages[1])
+      } finally {
+        start.unsubscribe()
+      }
+    })
+
+    it('leaves args[0] untouched when no entry has a non-empty messages array', async () => {
+      const start = captureChannel(startCh)
+      let forwardedArg0
+      const userArg0 = {
+        topicMessages: [
+          { topic: 'a', messages: 'not-an-array' },
+          { topic: 'b', messages: [] },
+        ],
+      }
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: (arg0) => {
+          forwardedArg0 = arg0
+          return Promise.resolve(undefined)
+        },
+      })
+
+      try {
+        await producer.sendBatch(userArg0)
+
+        assert.equal(start.events.length, 2)
+        assert.equal(forwardedArg0, userArg0)
+        assert.deepEqual(start.events[0].messages, [])
+        assert.deepEqual(start.events[1].messages, [])
+      } finally {
+        start.unsubscribe()
+      }
+    })
+
+    it('tags every per-topic ctx with the sync error and rethrows', () => {
+      const error = new Error('boom-sync')
+      const start = captureChannel(startCh)
+      const errorEvents = captureChannel(errorCh)
+      const finish = captureChannel(finishCh)
+
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: () => { throw error },
+      })
+
+      try {
+        assert.throws(() => producer.sendBatch({
+          topicMessages: [
+            { topic: 'a', messages: [{ key: 'k', value: 'v' }] },
+            { topic: 'b', messages: [{ key: 'k2', value: 'v2' }] },
+          ],
+        }), error)
+
+        assert.equal(start.events.length, 2)
+        assert.equal(errorEvents.events.length, 2)
+        assert.equal(finish.events.length, 2)
+        assert.equal(errorEvents.events[0].error, error)
+        assert.equal(errorEvents.events[1].error, error)
+      } finally {
+        start.unsubscribe()
+        errorEvents.unsubscribe()
+        finish.unsubscribe()
+      }
+    })
+
+    it('tags every per-topic ctx with the async rejection error', async () => {
+      const error = new Error('boom-async')
+      const start = captureChannel(startCh)
+      const errorEvents = captureChannel(errorCh)
+      const finish = captureChannel(finishCh)
+
+      const { producer } = stageProducer({
+        cluster: readyCluster(),
+        originalSendBatch: () => Promise.reject(error),
+      })
+
+      try {
+        await assert.rejects(producer.sendBatch({
+          topicMessages: [
+            { topic: 'a', messages: [{ key: 'k', value: 'v' }] },
+            { topic: 'b', messages: [{ key: 'k2', value: 'v2' }] },
+          ],
+        }), error)
+
+        assert.equal(start.events.length, 2)
+        assert.equal(errorEvents.events.length, 2)
+        assert.equal(finish.events.length, 2)
+        assert.equal(errorEvents.events[1].error, error)
+      } finally {
+        start.unsubscribe()
+        errorEvents.unsubscribe()
+        finish.unsubscribe()
+      }
+    })
+
+    it('disables header injection on the next sendBatch after KafkaJSProtocolError UNKNOWN', async () => {
+      const start = captureChannel(startCh)
+
+      const error = Object.assign(new Error('UNKNOWN_SERVER_ERROR'), {
+        name: 'KafkaJSProtocolError',
+        type: 'UNKNOWN',
+      })
+
+      let sendBatchCalls = 0
+      const originalSendBatch = () => {
+        sendBatchCalls++
+        return sendBatchCalls === 1 ? Promise.reject(error) : Promise.resolve(undefined)
+      }
+
+      const { producer } = stageProducer({ cluster: readyCluster(), originalSendBatch })
+
+      try {
+        await assert.rejects(producer.sendBatch({
+          topicMessages: [{ topic: 't', messages: [{ key: 'k', value: 'v' }] }],
+        }), error)
+        await producer.sendBatch({
+          topicMessages: [{ topic: 't', messages: [{ key: 'k', value: 'v' }] }],
+        })
+
+        assert.equal(start.events.length, 2)
+        assert.equal(start.events[0].disableHeaderInjection, false)
+        assert.equal(start.events[1].disableHeaderInjection, true)
+      } finally {
+        start.unsubscribe()
       }
     })
   })

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -101,6 +101,9 @@ class KafkajsProducerPlugin extends ProducerPlugin {
       // response, only the starting offset.
       const offsets = []
       for (const entry of result) {
+        // sendBatch hands the same multi-topic response to every per-topic
+        // ctx; the span only owns its own topic's entries.
+        if (entry.topicName !== ctx.topic) continue
         const offsetAsLong = entry.offset ?? entry.baseOffset
         if (entry.partition === undefined || offsetAsLong === undefined) continue
         // Kafka offsets are 64-bit; coercing to Number loses precision past

--- a/packages/datadog-plugin-kafkajs/test/commit.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/commit.spec.js
@@ -28,6 +28,7 @@ describe('kafkajs producer finish', () => {
     try {
       plugin.finish({
         currentStore: { span },
+        topic: 't',
         messages: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
         result: [
           { topicName: 't', partition: 2, baseOffset: '20' },
@@ -55,6 +56,7 @@ describe('kafkajs producer finish', () => {
     try {
       plugin.finish({
         currentStore: { span },
+        topic: 't',
         messages: [{ value: 'one' }],
         result: [{ topicName: 't', partition: 0, baseOffset: hugeOffset }],
       })
@@ -71,6 +73,7 @@ describe('kafkajs producer finish', () => {
     try {
       plugin.finish({
         currentStore: { span },
+        topic: 't',
         messages: [{ value: 'one' }],
         result: [{ topicName: 't', partition: 0, baseOffset: 0 }],
       })
@@ -79,6 +82,32 @@ describe('kafkajs producer finish', () => {
     }
     assert.equal(tags['kafka.messages.offsets'], JSON.stringify([{ partition: 0, start_offset: '0' }]))
     assert.equal(tags['kafka.message.offset'], '0')
+  })
+
+  it('keeps offsets isolated to ctx.topic in multi-topic sendBatch responses', () => {
+    const { plugin, span, tags, restore } = makeFinishHarness()
+    try {
+      plugin.finish({
+        currentStore: { span },
+        topic: 'a',
+        messages: [{ value: 'one' }, { value: 'two' }],
+        result: [
+          { topicName: 'a', partition: 0, baseOffset: '5' },
+          { topicName: 'b', partition: 0, baseOffset: '99' },
+          { topicName: 'a', partition: 1, baseOffset: '7' },
+        ],
+      })
+    } finally {
+      restore()
+    }
+    // Topic 'b' must not bleed into topic 'a''s span: the user query
+    // 'show me the offsets we wrote to topic a' has to match the broker.
+    assert.equal(tags['kafka.messages.offsets'], JSON.stringify([
+      { partition: 0, start_offset: '5' },
+      { partition: 1, start_offset: '7' },
+    ]))
+    assert.equal(tags['kafka.partition'], undefined)
+    assert.equal(tags['kafka.message.offset'], undefined)
   })
 })
 

--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -109,6 +109,25 @@ describe('Plugin', () => {
             assert.strictEqual(setDataStreamsContextSpy.args[0][0].hash, expectedProducerHash)
           })
 
+          it('Should set one checkpoint per topic on sendBatch', async () => {
+            const expectedAHash = getDsmPathwayHash(topicAOut, true, ENTRY_PARENT_HASH)
+            const expectedBHash = getDsmPathwayHash(topicBOut, true, ENTRY_PARENT_HASH)
+
+            const producer = kafka.producer()
+            await producer.connect()
+            await producer.sendBatch({
+              topicMessages: [
+                { topic: topicAOut, messages: [{ key: 'a', value: 'va' }] },
+                { topic: topicBOut, messages: [{ key: 'b', value: 'vb' }] },
+              ],
+            })
+            await producer.disconnect()
+
+            const hashes = setDataStreamsContextSpy.getCalls().map(call => call.args[0].hash)
+            assert.ok(hashes.includes(expectedAHash), `missing DSM checkpoint for ${topicAOut}`)
+            assert.ok(hashes.includes(expectedBHash), `missing DSM checkpoint for ${topicBOut}`)
+          })
+
           it('Should set a checkpoint on consume (eachMessage)', async () => {
             const runArgs = []
             await consumer.run({
@@ -324,6 +343,23 @@ describe('Plugin', () => {
             const runArg = setOffsetSpy.lastCall.args[0]
             assert.strictEqual(runArg.topic, testTopic)
             assert.strictEqual(runArg.kafka_cluster_id, testKafkaClusterId)
+          })
+
+          it('Should add one backlog per response item on sendBatch (no N x M duplication)', async () => {
+            const producer = kafka.producer()
+            await producer.connect()
+            await producer.sendBatch({
+              topicMessages: [
+                { topic: topicAOut, messages: [{ key: 'a', value: 'va' }] },
+                { topic: topicBOut, messages: [{ key: 'b', value: 'vb' }] },
+              ],
+            })
+            await producer.disconnect()
+
+            const produceCalls = setOffsetSpy.getCalls()
+              .filter(call => call.args[0]?.type === 'kafka_produce')
+            const topics = produceCalls.map(call => call.args[0].topic).sort()
+            assert.deepStrictEqual(topics, [topicAOut, topicBOut].sort())
           })
         })
       })

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -329,6 +329,210 @@ describe('Plugin', () => {
           )
         })
 
+        describe('producer (sendBatch)', () => {
+          let topicA
+          let topicB
+
+          beforeEach(async () => {
+            topicA = `${testTopic}-batch-a`
+            topicB = `${testTopic}-batch-b`
+            const batchAdmin = kafka.admin()
+            await createTopicWithRetry(batchAdmin, {
+              waitForLeaders: true,
+              topics: [topicA, topicB].map(topic => ({
+                topic,
+                numPartitions: 1,
+                replicationFactor: 1,
+              })),
+            })
+            await batchAdmin.disconnect()
+          })
+
+          it('should emit one kafka.produce span per topicMessages entry', async () => {
+            // Per-topic offset isolation: the broker returns one aggregated
+            // response covering every topic in the batch; each span must tag
+            // only its own topic's (partition, offset) entries.
+            const topicAOffsets = JSON.stringify([{ partition: 0, start_offset: '0' }])
+            const topicBOffsets = JSON.stringify([{ partition: 0, start_offset: '0' }])
+
+            const topicASpanPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0].find(s =>
+                s.name === expectedSchema.send.opName && s.resource === topicA)
+              assert.ok(span, `no kafka.produce span for ${topicA}`)
+              assertObjectContains(span, {
+                service: expectedSchema.send.serviceName,
+                meta: {
+                  'span.kind': 'producer',
+                  component: 'kafkajs',
+                  'messaging.destination.name': topicA,
+                  'messaging.kafka.bootstrap.servers': '127.0.0.1:9092',
+                  'kafka.cluster_id': testKafkaClusterId,
+                  'kafka.messages.offsets': topicAOffsets,
+                },
+                metrics: { 'kafka.batch_size': 1 },
+                error: 0,
+              })
+            })
+
+            const topicBSpanPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0].find(s =>
+                s.name === expectedSchema.send.opName && s.resource === topicB)
+              assert.ok(span, `no kafka.produce span for ${topicB}`)
+              assertObjectContains(span, {
+                resource: topicB,
+                meta: { 'kafka.messages.offsets': topicBOffsets },
+                metrics: { 'kafka.batch_size': 2 },
+                error: 0,
+              })
+            })
+
+            await sendBatch(kafka, [
+              { topic: topicA, messages: [{ key: 'a', value: 'msg-a' }] },
+              { topic: topicB, messages: [{ key: 'b1', value: 'msg-b1' }, { key: 'b2', value: 'msg-b2' }] },
+            ])
+
+            return Promise.all([topicASpanPromise, topicBSpanPromise])
+          })
+
+          it('should emit one span for a single-topic sendBatch (mirrors send)', async () => {
+            const expectedSpanPromise = agent.assertSomeTraces(traces => {
+              const spans = traces[0].filter(s => s.name === expectedSchema.send.opName)
+              assert.strictEqual(spans.length, 1)
+              assertObjectContains(spans[0], {
+                service: expectedSchema.send.serviceName,
+                resource: topicA,
+                meta: {
+                  'span.kind': 'producer',
+                  component: 'kafkajs',
+                  'messaging.destination.name': topicA,
+                  'messaging.kafka.bootstrap.servers': '127.0.0.1:9092',
+                  'kafka.cluster_id': testKafkaClusterId,
+                },
+                metrics: { 'kafka.batch_size': 1 },
+                error: 0,
+              })
+            })
+
+            await sendBatch(kafka, [{ topic: topicA, messages: [{ key: 'k', value: 'v' }] }])
+
+            return expectedSpanPromise
+          })
+
+          it('should inject a distinct trace context into each topic\'s cloned messages', async () => {
+            const startCh = dc.channel('apm:kafkajs:produce:start')
+            const sentBatches = []
+            const captureStart = (ctx) => sentBatches.push({ topic: ctx.topic, messages: ctx.messages })
+            startCh.subscribe(captureStart)
+
+            try {
+              // Deep-freeze the user input so any boundary or plugin write to it throws.
+              const userTopicMessages = deepFreeze([
+                { topic: topicA, messages: [{ key: 'a', value: 'msg-a' }] },
+                { topic: topicB, messages: [{ key: 'b', value: 'msg-b' }] },
+              ])
+
+              await sendBatch(kafka, userTopicMessages)
+
+              assert.strictEqual(sentBatches.length, 2)
+              const aBatch = sentBatches.find(b => b.topic === topicA)
+              const bBatch = sentBatches.find(b => b.topic === topicB)
+              const aTraceId = aBatch.messages[0].headers['x-datadog-trace-id'].toString()
+              const bTraceId = bBatch.messages[0].headers['x-datadog-trace-id'].toString()
+              assert.ok(aTraceId)
+              assert.ok(bTraceId)
+              assert.notStrictEqual(aTraceId, bTraceId)
+            } finally {
+              startCh.unsubscribe(captureStart)
+            }
+          })
+
+          it('should tag error on every per-topic span when sendBatch rejects', async () => {
+            const errorSpanPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0].find(s =>
+                s.name === expectedSchema.send.opName && s.resource === topicA)
+              assert.ok(span, `no kafka.produce span for ${topicA}`)
+              assert.strictEqual(span.error, 1)
+              assert.ok(span.meta[ERROR_MESSAGE])
+            })
+
+            const producer = kafka.producer()
+            await producer.connect()
+            await assert.rejects(producer.sendBatch({
+              topicMessages: [
+                { topic: topicA, messages: 'not-an-array' },
+              ],
+            }))
+            await producer.disconnect()
+
+            return errorSpanPromise
+          })
+
+          describe('when broker rejects headers with UNKNOWN_SERVER_ERROR', function () {
+            // kafkajs 1.4.0 is very slow when encountering errors
+            this.timeout(30000)
+
+            let produceStub
+            let producer
+            const error = Object.assign(
+              new Error('Simulated KafkaJSProtocolError UNKNOWN from Broker.produce stub'),
+              { name: 'KafkaJSProtocolError', type: 'UNKNOWN' }
+            )
+
+            beforeEach(async () => {
+              const otherKafka = new Kafka({
+                clientId: `kafkajs-test-${version}`,
+                brokers: ['127.0.0.1:9092'],
+                retry: { retries: 0 },
+              })
+              produceStub = sinon.stub(Broker.prototype, 'produce').rejects(error)
+              producer = otherKafka.producer({ transactionTimeout: 10 })
+              await producer.connect()
+            })
+
+            afterEach(() => {
+              produceStub.restore()
+            })
+
+            it('disables header injection for later sendBatch calls', async () => {
+              const startCh = dc.channel('apm:kafkajs:produce:start')
+              const sentBatches = []
+              const captureStart = (ctx) => sentBatches.push({ topic: ctx.topic, messages: ctx.messages })
+              startCh.subscribe(captureStart)
+
+              const firstBatch = deepFreeze([{ key: 'k1', value: 'v1' }])
+              const secondBatch = deepFreeze([{ key: 'k2', value: 'v2' }])
+
+              try {
+                await assert.rejects(producer.sendBatch({
+                  topicMessages: [{ topic: topicA, messages: firstBatch }],
+                }), error)
+
+                // The first send injects trace headers into the cloned batch.
+                assert.ok(
+                  Object.hasOwn(sentBatches[0].messages[0].headers, 'x-datadog-trace-id'),
+                  `Available keys: ${inspect(Object.keys(sentBatches[0].messages[0].headers))}`
+                )
+
+                produceStub.restore()
+
+                const result2 = await producer.sendBatch({
+                  topicMessages: [{ topic: topicA, messages: secondBatch }],
+                })
+
+                // After UNKNOWN, header injection is disabled: cloned messages
+                // have no `headers` field at all, the user's frozen input is
+                // untouched, and brokers that reject any header field recover.
+                const [clonedAfterDisable] = sentBatches[1].messages
+                assert.notStrictEqual(clonedAfterDisable, secondBatch[0])
+                assert.strictEqual(Object.hasOwn(clonedAfterDisable, 'headers'), false)
+                assert.strictEqual(result2[0].errorCode, 0)
+              } finally {
+                startCh.unsubscribe(captureStart)
+              }
+            })
+          })
+        })
+
         describe('consumer (eachMessage)', () => {
           let consumer
 
@@ -662,4 +866,12 @@ async function sendMessages (kafka, topic, messages) {
     messages,
   })
   await producer.disconnect()
+}
+
+async function sendBatch (kafka, topicMessages) {
+  const producer = kafka.producer()
+  await producer.connect()
+  const result = await producer.sendBatch({ topicMessages })
+  await producer.disconnect()
+  return result
 }


### PR DESCRIPTION
## Summary

The kafkajs `producer.sendBatch` API was uninstrumented — calls produced no spans, propagated no trace context, and emitted no DSM checkpoints. This adds tracing, header injection, and DSM checkpoints, modeled as one `kafka.produce` span per `topicMessages[]` entry (mirrors what `producer.send` already emits for the single-topic case and how kafkajs decomposes `send` into `sendBatch` internally).

Fixes: https://github.com/DataDog/dd-trace-js/issues/1711