### PR TITLE
fix(http2): restore req.emit after the response handshake

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -607,6 +607,7 @@ export default [
       'integration-tests/**/*.js',
       'integration-tests/**/*.mjs',
       'packages/datadog-instrumentations/test/helpers/check-require-cache/**/*.js',
+      'packages/datadog-plugin-http2/test/stack-attribution/**/*.js',
       'packages/datadog-plugin-net/test/epipe-crash/**/*.js',
       'packages/datadog-plugin-openai/test/no-init.js',
       'packages/dd-trace/test/custom-metrics-app.js',

--- a/packages/datadog-instrumentations/src/http2/client.js
+++ b/packages/datadog-instrumentations/src/http2/client.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { errorMonitor } = require('node:events')
+
 const shimmer = require('../../../datadog-shimmer')
 const { addHook, channel } = require('../helpers/instrument')
 
@@ -13,6 +15,19 @@ const errorChannel = channel('apm:http2:client:request:error')
 function createWrapEmit (ctx) {
   return function wrapEmit (emit) {
     return function (event, arg1) {
+      switch (event) {
+        case 'response':
+          this.emit = emit
+          setupTerminalListeners(this, ctx)
+          break
+        case 'error':
+        case 'close':
+          this.emit = emit
+          break
+        default:
+          return emit.apply(this, arguments)
+      }
+
       ctx.eventName = event
       ctx.eventData = arg1
 
@@ -25,6 +40,21 @@ function createWrapEmit (ctx) {
       })
     }
   }
+}
+
+function setupTerminalListeners (req, ctx) {
+  req.once('close', () => {
+    ctx.eventName = 'close'
+    ctx.eventData = undefined
+    asyncStartChannel.runStores(ctx, () => {})
+    asyncEndChannel.publish(ctx)
+  })
+  req.once(errorMonitor, (error) => {
+    ctx.eventName = 'error'
+    ctx.eventData = error
+    asyncStartChannel.runStores(ctx, () => {})
+    asyncEndChannel.publish(ctx)
+  })
 }
 
 function createWrapRequest (authority, options) {

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -555,6 +555,37 @@ describe('Plugin', () => {
           req.end()
         })
 
+        it('should tag the span when the stream errors after the response', done => {
+          let error
+          const app = (stream) => {
+            stream.on('error', () => {})
+            stream.respond({ ':status': 200 })
+          }
+
+          appListener = server(app, port => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(traces[0][0].error, 1)
+                assert.strictEqual(traces[0][0].meta[ERROR_TYPE], error.name)
+                assert.strictEqual(traces[0][0].meta[ERROR_MESSAGE], error.message)
+              })
+              .then(done)
+              .catch(done)
+
+            const client = http2
+              .connect(`${protocol}://localhost:${port}`)
+              .on('error', () => {})
+
+            const req = client.request({ ':path': '/' })
+              .on('response', () => {
+                req.destroy(new Error('post-response failure'))
+              })
+              .on('error', (err) => { error = err })
+
+            req.end()
+          })
+        })
+
         it('should not record HTTP 5XX responses as errors by default', done => {
           const app = (stream, headers) => {
             stream.respond({

--- a/packages/datadog-plugin-http2/test/stack-attribution.spec.js
+++ b/packages/datadog-plugin-http2/test/stack-attribution.spec.js
@@ -1,0 +1,53 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { fork } = require('node:child_process')
+const path = require('node:path')
+
+const { describe, it } = require('mocha')
+
+/**
+ * @param {string} fixtureName
+ * @returns {Promise<{ code: number | null, stderr: string }>}
+ */
+function runFixture (fixtureName) {
+  return new Promise((resolve) => {
+    const child = fork(
+      path.join(__dirname, 'stack-attribution', fixtureName),
+      {
+        stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
+        env: {
+          ...process.env,
+          DD_TRACE_AGENT_PORT: '0',
+        },
+      }
+    )
+
+    let stderr = ''
+    child.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    child.on('exit', (code) => {
+      resolve({ code, stderr })
+    })
+  })
+}
+
+describe('http2 client instrumentation stack attribution', () => {
+  it('keeps dd-trace out of crash stacks emitted after \'response\' has fired', async () => {
+    const { code, stderr } = await runFixture('with-tracer.js')
+
+    assert.notStrictEqual(code, 0, 'process should crash with no error listener')
+    assert.match(stderr, /crash from data listener/)
+    assert.doesNotMatch(stderr, /datadog-instrumentations\/src\/http2\/client\.js/)
+  }).timeout(10_000)
+
+  it('matches the baseline crash without the tracer', async () => {
+    const { code, stderr } = await runFixture('without-tracer.js')
+
+    assert.notStrictEqual(code, 0, 'process should crash with no error listener')
+    assert.match(stderr, /crash from data listener/)
+    assert.doesNotMatch(stderr, /datadog-instrumentations/)
+  }).timeout(10_000)
+})

--- a/packages/datadog-plugin-http2/test/stack-attribution/with-tracer.js
+++ b/packages/datadog-plugin-http2/test/stack-attribution/with-tracer.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const tracer = require('../../../dd-trace')
+tracer.init({
+  plugins: false,
+})
+tracer.use('http2')
+
+// eslint-disable-next-line import/order
+const http2 = require('node:http2')
+
+const server = http2.createServer()
+server.on('stream', (stream) => {
+  stream.respond({ ':status': 200 })
+  stream.end('payload')
+})
+
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port
+  const client = http2.connect(`http://127.0.0.1:${port}`)
+  const req = client.request({ ':path': '/' })
+
+  req.on('response', () => {
+    req.on('data', () => {
+      throw new Error('crash from data listener')
+    })
+  })
+
+  setTimeout(() => {
+    server.close()
+    client.close()
+    process.exit(0)
+  }, 3000)
+})

--- a/packages/datadog-plugin-http2/test/stack-attribution/without-tracer.js
+++ b/packages/datadog-plugin-http2/test/stack-attribution/without-tracer.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const http2 = require('node:http2')
+
+const server = http2.createServer()
+server.on('stream', (stream) => {
+  stream.respond({ ':status': 200 })
+  stream.end('payload')
+})
+
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port
+  const client = http2.connect(`http://127.0.0.1:${port}`)
+  const req = client.request({ ':path': '/' })
+
+  req.on('response', () => {
+    req.on('data', () => {
+      throw new Error('crash from data listener')
+    })
+  })
+
+  setTimeout(() => {
+    server.close()
+    client.close()
+    process.exit(0)
+  }, 3000)
+})


### PR DESCRIPTION
## Summary

Mirrors PR #8275 (`net.Socket.emit`) for http2 client streams. The
wrap on `req.emit` only needs to live until `'response'` (or a
pre-response `'error'` / `'close'`) is observed; after that, the
original emit is reinstated and a `'close'` / `errorMonitor` pair
takes over publishing the terminal channel events. http2 has no
native `diagnostics_channel` coverage, so restore-after-fire is the
applicable mechanic.

The crash that originally tripped this -- a throw from a `'data'` /
`'end'` listener with no `'error'` recovery -- is unchanged. The
process still terminates; `datadog-instrumentations/src/http2/client.js`
just stops showing up on the stack so the integration no longer looks
like the cause.

## Test plan

- New black-box regression: `packages/datadog-plugin-http2/test/stack-attribution.spec.js`
  forks a fixture that throws from a `'data'` listener and asserts
  the stack contains the user crash but no
  `datadog-instrumentations/src/http2/client.js` frame. A sibling
  test runs the same scenario without the tracer to pin the baseline
  crash shape.
- Extra plugin assertion in `client.spec.js`: post-response stream
  destroy now tags the span with the error type / message; this
  covers the new `errorMonitor` terminal listener.
- nyc on `packages/datadog-instrumentations/src/http2/client.js`:
  every changed line and branch is hit by `client.spec.js` plus the
  new spec. Remaining gaps (`createWrapRequest` catch,
  `connectChannel` publish, `http2.default` aliasing) are pre-
  existing and out of scope.

## Open questions

- `packages/datadog-instrumentations/src/http2/server.js` wraps
  `res.emit` for the full response lifetime and has the same stack-
  attribution problem. Worth a follow-up that mirrors this change.

Refs: https://github.com/DataDog/dd-trace-js/pull/8275