### PR TITLE
fix(fetch): rename globalThis.fetch wrapper from "value" to "fetch"

### DIFF
--- a/packages/datadog-instrumentations/src/fetch.js
+++ b/packages/datadog-instrumentations/src/fetch.js
@@ -5,10 +5,10 @@ const { IS_SERVERLESS } = require('../../dd-trace/src/serverless')
 if (globalThis.fetch) {
   const globalFetch = globalThis.fetch
 
-  let fetch = (input, init) => {
+  let wrappedFetch = (input, init) => {
     wrapRealFetch()
 
-    return fetch(input, init)
+    return wrappedFetch(input, init)
   }
 
   function wrapRealFetch () {
@@ -20,14 +20,14 @@ if (globalThis.fetch) {
       channel('dd-trace:instrumentation:load').publish({ name: 'global:fetch' })
     })
 
-    fetch = wrapFetch(globalFetch)
+    wrappedFetch = wrapFetch(globalFetch)
   }
 
   if (!IS_SERVERLESS) {
     wrapRealFetch()
   }
 
-  globalThis.fetch = function value (input, init) {
-    return fetch(input, init)
+  globalThis.fetch = function fetch (input, init) {
+    return wrappedFetch(input, init)
   }
 }

--- a/packages/datadog-instrumentations/test/fetch.spec.js
+++ b/packages/datadog-instrumentations/test/fetch.spec.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { before, describe, it } = require('mocha')
+
+describe('packages/datadog-instrumentations/src/fetch.js', () => {
+  describe('globalThis.fetch identity', () => {
+    let nameBefore
+
+    before(() => {
+      nameBefore = globalThis.fetch.name
+      require('../src/fetch')
+    })
+
+    it('preserves the fetch function name after dd-trace loads', () => {
+      assert.equal(nameBefore, 'fetch')
+      assert.equal(globalThis.fetch.name, 'fetch')
+    })
+
+    it('forwards calls to the wrapped fetch without recursion', () => {
+      return assert.rejects(globalThis.fetch('not-a-real-protocol://x'), TypeError)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`globalThis.fetch`'s wrapper carries the name `value`, so every stack frame that flows through fetch surfaces as `at value` instead of `at fetch`. Rename the wrapper -- and the inner `let fetch` slot it forwards to, since the named function expression's name shadows the outer binding and would self-recurse otherwise -- so frames blend with bundled-undici fetch.

## Test plan

- New `packages/datadog-instrumentations/test/fetch.spec.js` pins `globalThis.fetch.name === 'fetch'` after the instrumentation loads and that the wrapper forwards calls without self-recursion:

  ```
  ./node_modules/.bin/mocha packages/datadog-instrumentations/test/fetch.spec.js
  ```

- `nyc` on the file reports 87.5% line / statement coverage. The uncovered region is the pre-existing serverless-only stub path (lines 9-11); the rename on those lines is identity-preserving.

Refs: https://github.com/nodejs/undici/pull/2701