### PR TITLE
feat(http,http2): apply http.endpoint and queryStringObfuscation to client spans

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1992,7 +1992,8 @@ declare namespace tracer {
       middleware?: boolean;
 
       /**
-       * Whether (or how) to obfuscate querystring values in `http.url`.
+       * Whether (or how) to obfuscate querystring values in `http.url` on both
+       * inbound (server) and outbound (client) HTTP spans.
        *
        * - `true`: obfuscate all values
        * - `false`: disable obfuscation
@@ -2071,7 +2072,8 @@ declare namespace tracer {
        */
       validateStatus?: (code: number) => boolean;
       /**
-       * Whether (or how) to obfuscate querystring values in `http.url`.
+       * Whether (or how) to obfuscate querystring values in `http.url` on both
+       * inbound (server) and outbound (client) HTTP spans.
        *
        * - `true`: obfuscate all values
        * - `false`: disable obfuscation

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -2102,7 +2102,8 @@ declare namespace tracer {
       middleware?: boolean;
 
       /**
-       * Whether (or how) to obfuscate querystring values in `http.url`.
+       * Whether (or how) to obfuscate querystring values in `http.url` on both
+       * inbound (server) and outbound (client) HTTP spans.
        *
        * - `true`: obfuscate all values
        * - `false`: disable obfuscation
@@ -2181,7 +2182,8 @@ declare namespace tracer {
        */
       validateStatus?: (code: number) => boolean;
       /**
-       * Whether (or how) to obfuscate querystring values in `http.url`.
+       * Whether (or how) to obfuscate querystring values in `http.url` on both
+       * inbound (server) and outbound (client) HTTP spans.
        *
        * - `true`: obfuscate all values
        * - `false`: disable obfuscation

--- a/packages/datadog-plugin-http/src/client.js
+++ b/packages/datadog-plugin-http/src/client.js
@@ -9,9 +9,12 @@ const analyticsSampler = require('../../dd-trace/src/analytics_sampler')
 const formats = require('../../../ext/formats')
 const HTTP_HEADERS = formats.HTTP_HEADERS
 const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
+const { calculateHttpEndpoint, getQsObfuscator, obfuscateQs } = require('../../dd-trace/src/plugins/util/url')
 const log = require('../../dd-trace/src/log')
 const { CLIENT_PORT_KEY, COMPONENT, ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 
+const HTTP_URL = tags.HTTP_URL
+const HTTP_ENDPOINT = tags.HTTP_ENDPOINT
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
@@ -29,27 +32,34 @@ class HttpClientPlugin extends ClientPlugin {
     const hostname = options.hostname || options.host || 'localhost'
     const host = options.port ? `${hostname}:${options.port}` : hostname
     const pathname = options.path || options.pathname
-    const path = pathname ? pathname.split(/[?#]/)[0] : '/'
+    const [path, pathWithQuery] = splitPathAndQuery(pathname)
     const uri = `${protocol}//${host}${path}`
+    const httpUrl = path === pathWithQuery
+      ? uri
+      : obfuscateQs(this.config, `${protocol}//${host}${pathWithQuery}`)
 
     const allowed = this.config.filter(uri)
 
     const method = (options.method || 'GET').toUpperCase()
     const childOf = store && allowed ? store.span : null
+    const meta = {
+      [COMPONENT]: this.component,
+      'span.kind': 'client',
+      'resource.name': method,
+      'span.type': 'http',
+      'http.method': method,
+      [HTTP_URL]: httpUrl,
+      'out.host': hostname,
+    }
+    if (this.config.resourceRenamingEnabled) {
+      meta[HTTP_ENDPOINT] = calculateHttpEndpoint(path)
+    }
     // TODO delegate to super.startspan
     const span = this.startSpan(this.operationName(), {
       childOf,
       integrationName: this.component,
       service: this.serviceName({ pluginConfig: this.config, sessionDetails: extractSessionDetails(options) }),
-      meta: {
-        [COMPONENT]: this.component,
-        'span.kind': 'client',
-        'resource.name': method,
-        'span.type': 'http',
-        'http.method': method,
-        'http.url': uri,
-        'out.host': hostname,
-      },
+      meta,
       metrics: {
         [CLIENT_PORT_KEY]: Number.parseInt(options.port),
       },
@@ -169,6 +179,7 @@ function normalizeClientConfig (config) {
   const propagationFilter = getFilter({ blocklist: config.propagationBlocklist })
   const headers = getHeaders(config)
   const hooks = getHooks(config)
+  const queryStringObfuscation = getQsObfuscator(config)
 
   return {
     ...config,
@@ -177,7 +188,28 @@ function normalizeClientConfig (config) {
     propagationFilter,
     headers,
     hooks,
+    queryStringObfuscation,
   }
+}
+
+/**
+ * Split a raw HTTP request path into the path-only segment (for `http.endpoint`
+ * and filters) and the path-plus-query segment (for the `http.url` tag).
+ *
+ * Fragments are dropped from both because they never travel over the wire.
+ *
+ * @param {string | undefined} pathname
+ * @returns {[string, string]} `[path, pathWithQuery]`
+ */
+function splitPathAndQuery (pathname) {
+  if (!pathname) return ['/', '/']
+
+  const fragmentIndex = pathname.indexOf('#')
+  const pathWithQuery = fragmentIndex === -1 ? pathname : pathname.slice(0, fragmentIndex)
+  const queryIndex = pathWithQuery.indexOf('?')
+  const path = queryIndex === -1 ? pathWithQuery : pathWithQuery.slice(0, queryIndex)
+
+  return [path, pathWithQuery]
 }
 
 function is400ErrorCode (code) {

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -269,7 +269,7 @@ describe('Plugin', () => {
           })
         })
 
-        it('should remove the query string from the URL', done => {
+        it('should keep non-secret query string parameters on the URL by default', done => {
           const app = express()
 
           app.get('/user', (req, res) => {
@@ -280,7 +280,7 @@ describe('Plugin', () => {
             agent.assertFirstTraceSpan({
               meta: {
                 'http.status_code': '200',
-                'http.url': `${protocol}://localhost:${port}/user`,
+                'http.url': `${protocol}://localhost:${port}/user?foo=bar`,
               },
             })
               .then(done)
@@ -879,7 +879,7 @@ describe('Plugin', () => {
             agent.assertFirstTraceSpan({
               meta: {
                 'http.status_code': '200',
-                'http.url': `${protocol}://localhost:${port}/user`,
+                'http.url': `${protocol}://localhost:${port}/user?foo=bar`,
               },
             })
               .then(done)
@@ -1499,6 +1499,116 @@ describe('Plugin', () => {
               const req = http.request(`${protocol}://localhost:${port}/health`, res => {
                 res.on('data', () => {})
               })
+              req.end()
+            })
+          })
+        })
+      })
+
+      describe('with queryStringObfuscation', () => {
+        describe('set to a regex pattern', () => {
+          beforeEach(() => {
+            return agent.load('http', { server: false, queryStringObfuscation: 'secret=.*?(&|$)' })
+              .then(() => {
+                http = require(pluginToBeLoaded)
+                express = require('express')
+              })
+          })
+
+          it('should obfuscate matching query string parameters on the client span', done => {
+            const app = express()
+            app.get('/user', (req, res) => res.status(200).send())
+
+            appListener = server(app, port => {
+              agent
+                .assertSomeTraces(traces => {
+                  const clientSpan = traces[0].find(span => span.meta['span.kind'] === 'client')
+                  assert.strictEqual(
+                    clientSpan.meta['http.url'],
+                    `${protocol}://localhost:${port}/user?<redacted>foo=bar`
+                  )
+                })
+                .then(done)
+                .catch(done)
+
+              const req = http.request(
+                `${protocol}://localhost:${port}/user?secret=password&foo=bar`,
+                res => {
+                  res.on('data', () => {})
+                }
+              )
+              req.end()
+            })
+          })
+        })
+
+        describe('set to true', () => {
+          beforeEach(() => {
+            return agent.load('http', { server: false, queryStringObfuscation: true })
+              .then(() => {
+                http = require(pluginToBeLoaded)
+                express = require('express')
+              })
+          })
+
+          it('should remove the entire query string from the client span', done => {
+            const app = express()
+            app.get('/user', (req, res) => res.status(200).send())
+
+            appListener = server(app, port => {
+              agent
+                .assertSomeTraces(traces => {
+                  const clientSpan = traces[0].find(span => span.meta['span.kind'] === 'client')
+                  assert.strictEqual(
+                    clientSpan.meta['http.url'],
+                    `${protocol}://localhost:${port}/user`
+                  )
+                })
+                .then(done)
+                .catch(done)
+
+              const req = http.request(
+                `${protocol}://localhost:${port}/user?secret=password&foo=bar`,
+                res => {
+                  res.on('data', () => {})
+                }
+              )
+              req.end()
+            })
+          })
+        })
+
+        describe('set to false', () => {
+          beforeEach(() => {
+            return agent.load('http', { server: false, queryStringObfuscation: false })
+              .then(() => {
+                http = require(pluginToBeLoaded)
+                express = require('express')
+              })
+          })
+
+          it('should not obfuscate the query string on the client span', done => {
+            const app = express()
+            app.get('/user', (req, res) => res.status(200).send())
+
+            appListener = server(app, port => {
+              agent
+                .assertSomeTraces(traces => {
+                  const clientSpan = traces[0].find(span => span.meta['span.kind'] === 'client')
+                  assert.strictEqual(
+                    clientSpan.meta['http.url'],
+                    `${protocol}://localhost:${port}/user?secret=password&foo=bar`
+                  )
+                })
+                .then(done)
+                .catch(done)
+
+              const req = http.request(
+                `${protocol}://localhost:${port}/user?secret=password&foo=bar`,
+                res => {
+                  res.on('data', () => {})
+                }
+              )
               req.end()
             })
           })

--- a/packages/datadog-plugin-http/test/http_endpoint.spec.js
+++ b/packages/datadog-plugin-http/test/http_endpoint.spec.js
@@ -3,7 +3,7 @@
 const assert = require('node:assert/strict')
 const axios = require('axios')
 
-const { describe, it, beforeEach, afterEach, before } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 
@@ -17,12 +17,6 @@ describe('Plugin', () => {
   ['http', 'node:http'].forEach(pluginToBeLoaded => {
     describe(`${pluginToBeLoaded}/server`, () => {
       describe('http.endpoint', () => {
-        before(() => {
-          // Needed when this spec file run together with other spec files, in which case the agent config is not
-          // re-loaded unless the existing agent is wiped first.
-          // And we need the agent config to be re-loaded in order to enable appsec.
-        })
-
         beforeEach(async () => {
           return agent.load('http', {}, { appsec: { enabled: true } })
             .then(() => {
@@ -105,6 +99,110 @@ describe('Plugin', () => {
             .catch(done)
 
           axios.get(`http://localhost:${port}/resources/abc-123`).catch(done)
+        })
+      })
+    })
+
+    describe(`${pluginToBeLoaded}/client`, () => {
+      describe('http.endpoint', () => {
+        beforeEach(async () => {
+          return agent.load('http', { server: false }, { appsec: { enabled: true } })
+            .then(() => {
+              http = require(pluginToBeLoaded)
+            })
+        })
+
+        afterEach(() => {
+          appListener && appListener.close()
+          return agent.close()
+        })
+
+        beforeEach(done => {
+          const server = new http.Server((req, res) => {
+            res.writeHead(200)
+            res.end()
+          })
+          appListener = server.listen(0, 'localhost', () => {
+            port = appListener.address().port
+            done()
+          })
+        })
+
+        it('should set http.endpoint with int', done => {
+          agent
+            .assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].meta['span.kind'], 'client')
+              assert.strictEqual(traces[0][0].meta['http.url'], `http://localhost:${port}/users/123`)
+              assert.strictEqual(traces[0][0].meta['http.endpoint'], '/users/{param:int}')
+            })
+            .then(done)
+            .catch(done)
+
+          axios.get(`http://localhost:${port}/users/123`).catch(done)
+        })
+
+        it('should normalize a mixed path into multiple param classes', done => {
+          agent
+            .assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].meta['span.kind'], 'client')
+              assert.strictEqual(
+                traces[0][0].meta['http.endpoint'],
+                '/v1/users/{param:int}/sessions/{param:hex}'
+              )
+            })
+            .then(done)
+            .catch(done)
+
+          axios.get(`http://localhost:${port}/v1/users/12345/sessions/a1b2c3d4e5f6`).catch(done)
+        })
+
+        it('should compute http.endpoint from the path only, ignoring the query string', done => {
+          agent
+            .assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].meta['span.kind'], 'client')
+              assert.strictEqual(traces[0][0].meta['http.endpoint'], '/users/{param:int}')
+            })
+            .then(done)
+            .catch(done)
+
+          axios.get(`http://localhost:${port}/users/123?cursor=abc&page=2`).catch(done)
+        })
+      })
+
+      describe('http.endpoint disabled', () => {
+        beforeEach(async () => {
+          return agent.load('http', { server: false })
+            .then(() => {
+              http = require(pluginToBeLoaded)
+            })
+        })
+
+        afterEach(() => {
+          appListener && appListener.close()
+          return agent.close()
+        })
+
+        beforeEach(done => {
+          const server = new http.Server((req, res) => {
+            res.writeHead(200)
+            res.end()
+          })
+          appListener = server.listen(0, 'localhost', () => {
+            port = appListener.address().port
+            done()
+          })
+        })
+
+        it('should not set http.endpoint when resourceRenamingEnabled is off', done => {
+          agent
+            .assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].meta['span.kind'], 'client')
+              assert.ok(!('http.endpoint' in traces[0][0].meta))
+            })
+            .then(done)
+            .catch(done)
+
+          axios.get(`http://localhost:${port}/users/123`).catch(done)
         })
       })
     })

--- a/packages/datadog-plugin-http2/src/client.js
+++ b/packages/datadog-plugin-http2/src/client.js
@@ -9,9 +9,12 @@ const tags = require('../../../ext/tags')
 const kinds = require('../../../ext/kinds')
 const formats = require('../../../ext/formats')
 const { COMPONENT, CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
+const { calculateHttpEndpoint, getQsObfuscator, obfuscateQs } = require('../../dd-trace/src/plugins/util/url')
 const urlFilter = require('../../dd-trace/src/plugins/util/urlfilter')
 
 const HTTP_HEADERS = formats.HTTP_HEADERS
+const HTTP_URL = tags.HTTP_URL
+const HTTP_ENDPOINT = tags.HTTP_ENDPOINT
 const HTTP_STATUS_CODE = tags.HTTP_STATUS_CODE
 const HTTP_REQUEST_HEADERS = tags.HTTP_REQUEST_HEADERS
 const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
@@ -30,27 +33,35 @@ class Http2ClientPlugin extends ClientPlugin {
   bindStart (message) {
     const { authority, options, headers = {} } = message
     const sessionDetails = extractSessionDetails(authority, options)
-    const path = headers[HTTP2_HEADER_PATH] || '/'
-    const pathname = path.split(/[?#]/)[0]
+    const rawPath = headers[HTTP2_HEADER_PATH] || '/'
+    const [pathname, pathWithQuery] = splitPathAndQuery(rawPath)
     const method = headers[HTTP2_HEADER_METHOD] || HTTP2_METHOD_GET
-    const uri = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}${pathname}`
+    const origin = `${sessionDetails.protocol}//${sessionDetails.host}:${sessionDetails.port}`
+    const uri = `${origin}${pathname}`
+    const httpUrl = pathname === pathWithQuery
+      ? uri
+      : obfuscateQs(this.config, `${origin}${pathWithQuery}`)
     const allowed = this.config.filter(uri)
 
     const store = storage('legacy').getStore()
     const childOf = store && allowed ? store.span : null
+    const meta = {
+      [COMPONENT]: this.constructor.id,
+      [SPAN_KIND]: CLIENT,
+      'resource.name': method,
+      'span.type': 'http',
+      'http.method': method,
+      [HTTP_URL]: httpUrl,
+      'out.host': sessionDetails.host,
+    }
+    if (this.config.resourceRenamingEnabled) {
+      meta[HTTP_ENDPOINT] = calculateHttpEndpoint(pathname)
+    }
     const span = this.startSpan(this.operationName(), {
       childOf,
       integrationName: this.constructor.id,
       service: this.serviceName({ pluginConfig: this.config, sessionDetails }),
-      meta: {
-        [COMPONENT]: this.constructor.id,
-        [SPAN_KIND]: CLIENT,
-        'resource.name': method,
-        'span.type': 'http',
-        'http.method': method,
-        'http.url': uri,
-        'out.host': sessionDetails.host,
-      },
+      meta,
       metrics: {
         [CLIENT_PORT_KEY]: Number.parseInt(sessionDetails.port),
       },
@@ -63,7 +74,7 @@ class Http2ClientPlugin extends ClientPlugin {
 
     addHeaderTags(span, headers, HTTP_REQUEST_HEADERS, this.config)
 
-    if (!hasAmazonSignature(headers, path)) {
+    if (!hasAmazonSignature(headers, rawPath)) {
       this.tracer.inject(span, HTTP_HEADERS, headers)
     }
 
@@ -179,13 +190,32 @@ function normalizeConfig (config) {
   const validateStatus = getStatusValidator(config)
   const filter = getFilter(config)
   const headers = getHeaders(config)
+  const queryStringObfuscation = getQsObfuscator(config)
 
   return {
     ...config,
     validateStatus,
     filter,
     headers,
+    queryStringObfuscation,
   }
+}
+
+/**
+ * Split a raw HTTP/2 `:path` header into the path-only segment (for
+ * `http.endpoint` and filters) and the path-plus-query segment (for the
+ * `http.url` tag). Fragments are dropped from both.
+ *
+ * @param {string} rawPath
+ * @returns {[string, string]} `[path, pathWithQuery]`
+ */
+function splitPathAndQuery (rawPath) {
+  const fragmentIndex = rawPath.indexOf('#')
+  const pathWithQuery = fragmentIndex === -1 ? rawPath : rawPath.slice(0, fragmentIndex)
+  const queryIndex = pathWithQuery.indexOf('?')
+  const path = queryIndex === -1 ? pathWithQuery : pathWithQuery.slice(0, queryIndex)
+
+  return [path, pathWithQuery]
 }
 
 function getFilter (config) {

--- a/packages/datadog-plugin-http2/test/client.spec.js
+++ b/packages/datadog-plugin-http2/test/client.spec.js
@@ -199,7 +199,7 @@ describe('Plugin', () => {
           })
         })
 
-        it('should remove the query string from the URL', done => {
+        it('should keep non-secret query string parameters on the URL by default', done => {
           const app = (stream, headers) => {
             stream.respond({
               ':status': 200,
@@ -210,7 +210,10 @@ describe('Plugin', () => {
           appListener = server(app, port => {
             agent
               .assertSomeTraces(traces => {
-                assert.strictEqual(traces[0][0].meta['http.url'], `${protocol}://localhost:${port}/user`)
+                assert.strictEqual(
+                  traces[0][0].meta['http.url'],
+                  `${protocol}://localhost:${port}/user?foo=bar`
+                )
               })
               .then(done)
               .catch(done)
@@ -994,6 +997,148 @@ describe('Plugin', () => {
             client.request({ ':path': '/health' })
               .on('error', done)
               .end()
+          })
+        })
+      })
+
+      describe('http.endpoint', () => {
+        beforeEach(() => {
+          return agent.load('http2', { server: false }, { appsec: { enabled: true } })
+            .then(() => {
+              http2 = require(loadPlugin)
+            })
+        })
+
+        it('should set http.endpoint with int', done => {
+          const app = (stream) => {
+            stream.respond({ ':status': 200 })
+            stream.end()
+          }
+
+          appListener = server(app, port => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(traces[0][0].meta['span.kind'], 'client')
+                assert.strictEqual(traces[0][0].meta['http.endpoint'], '/users/{param:int}')
+              })
+              .then(done)
+              .catch(done)
+
+            const client = http2.connect(`${protocol}://localhost:${port}`).on('error', done)
+            client.request({ ':path': '/users/123' }).on('error', done).end()
+          })
+        })
+
+        it('should compute http.endpoint from the path only, ignoring the query string', done => {
+          const app = (stream) => {
+            stream.respond({ ':status': 200 })
+            stream.end()
+          }
+
+          appListener = server(app, port => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(traces[0][0].meta['span.kind'], 'client')
+                assert.strictEqual(traces[0][0].meta['http.endpoint'], '/users/{param:int}')
+              })
+              .then(done)
+              .catch(done)
+
+            const client = http2.connect(`${protocol}://localhost:${port}`).on('error', done)
+            client.request({ ':path': '/users/123?cursor=abc' }).on('error', done).end()
+          })
+        })
+      })
+
+      describe('with queryStringObfuscation set to a regex pattern', () => {
+        beforeEach(() => {
+          return agent.load('http2', { server: false, queryStringObfuscation: 'secret=.*?(&|$)' })
+            .then(() => {
+              http2 = require(loadPlugin)
+            })
+        })
+
+        it('should obfuscate matching query string parameters', done => {
+          const app = (stream) => {
+            stream.respond({ ':status': 200 })
+            stream.end()
+          }
+
+          appListener = server(app, port => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(
+                  traces[0][0].meta['http.url'],
+                  `${protocol}://localhost:${port}/user?<redacted>foo=bar`
+                )
+              })
+              .then(done)
+              .catch(done)
+
+            const client = http2.connect(`${protocol}://localhost:${port}`).on('error', done)
+            client.request({ ':path': '/user?secret=password&foo=bar' }).on('error', done).end()
+          })
+        })
+      })
+
+      describe('with queryStringObfuscation set to true', () => {
+        beforeEach(() => {
+          return agent.load('http2', { server: false, queryStringObfuscation: true })
+            .then(() => {
+              http2 = require(loadPlugin)
+            })
+        })
+
+        it('should remove the entire query string', done => {
+          const app = (stream) => {
+            stream.respond({ ':status': 200 })
+            stream.end()
+          }
+
+          appListener = server(app, port => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(
+                  traces[0][0].meta['http.url'],
+                  `${protocol}://localhost:${port}/user`
+                )
+              })
+              .then(done)
+              .catch(done)
+
+            const client = http2.connect(`${protocol}://localhost:${port}`).on('error', done)
+            client.request({ ':path': '/user?secret=password&foo=bar' }).on('error', done).end()
+          })
+        })
+      })
+
+      describe('with queryStringObfuscation set to false', () => {
+        beforeEach(() => {
+          return agent.load('http2', { server: false, queryStringObfuscation: false })
+            .then(() => {
+              http2 = require(loadPlugin)
+            })
+        })
+
+        it('should not obfuscate the query string', done => {
+          const app = (stream) => {
+            stream.respond({ ':status': 200 })
+            stream.end()
+          }
+
+          appListener = server(app, port => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(
+                  traces[0][0].meta['http.url'],
+                  `${protocol}://localhost:${port}/user?secret=password&foo=bar`
+                )
+              })
+              .then(done)
+              .catch(done)
+
+            const client = http2.connect(`${protocol}://localhost:${port}`).on('error', done)
+            client.request({ ':path': '/user?secret=password&foo=bar' }).on('error', done).end()
           })
         })
       })

--- a/packages/dd-trace/src/plugins/util/url.js
+++ b/packages/dd-trace/src/plugins/util/url.js
@@ -2,6 +2,8 @@
 
 const { URL } = require('url')
 
+const log = require('../../log')
+
 const HTTP2_HEADER_AUTHORITY = ':authority'
 const HTTP2_HEADER_SCHEME = ':scheme'
 const HTTP2_HEADER_PATH = ':path'
@@ -38,7 +40,7 @@ function getProtocol (req) {
 /**
  * Obfuscate query string
  *
- * @param {object} config
+ * @param {{ queryStringObfuscation: boolean | RegExp }} config
  * @param {string} url
  * @returns {string} obfuscated URL
  */
@@ -58,6 +60,38 @@ function obfuscateQs (config, url) {
   qs = qs.replace(queryStringObfuscation, '<redacted>')
 
   return `${path}?${qs}`
+}
+
+/**
+ * Normalize a user-supplied `queryStringObfuscation` value into the shape
+ * {@link obfuscateQs} expects (`false`, `true`, or a compiled `RegExp`).
+ *
+ * @param {{ queryStringObfuscation?: boolean | string }} config
+ * @returns {boolean | RegExp}
+ */
+function getQsObfuscator (config) {
+  const obfuscator = config.queryStringObfuscation
+
+  if (typeof obfuscator === 'boolean') {
+    return obfuscator
+  }
+
+  if (typeof obfuscator === 'string') {
+    if (obfuscator === '') return false
+    if (obfuscator === '.*') return true
+
+    try {
+      return new RegExp(obfuscator, 'gi')
+    } catch (error) {
+      log.error('Error compiling query string obfuscation regex', error)
+    }
+  }
+
+  if (Object.hasOwn(config, 'queryStringObfuscation')) {
+    log.error('Expected `queryStringObfuscation` to be a regex string or boolean.')
+  }
+
+  return true
 }
 
 /**
@@ -139,6 +173,7 @@ function filterSensitiveInfoFromRepository (repositoryUrl) {
 module.exports = {
   extractURL,
   obfuscateQs,
+  getQsObfuscator,
   calculateHttpEndpoint,
   filterSensitiveInfoFromRepository,
   extractPathFromUrl, // test only

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -12,7 +12,7 @@ const TracingPlugin = require('../tracing')
 const { storage } = require('../../../../datadog-core')
 const urlFilter = require('./urlfilter')
 const { createInferredProxySpan, finishInferredProxySpan } = require('./inferred_proxy')
-const { extractURL, obfuscateQs, calculateHttpEndpoint } = require('./url')
+const { extractURL, obfuscateQs, getQsObfuscator, calculateHttpEndpoint } = require('./url')
 
 let extractIp
 
@@ -526,32 +526,6 @@ function getMiddlewareSetting (config) {
     return config.middleware
   } else if (config && config.hasOwnProperty('middleware')) {
     log.error('Expected `middleware` to be a boolean.')
-  }
-
-  return true
-}
-
-function getQsObfuscator (config) {
-  const obfuscator = config.queryStringObfuscation
-
-  if (typeof obfuscator === 'boolean') {
-    return obfuscator
-  }
-
-  if (typeof obfuscator === 'string') {
-    if (obfuscator === '') return false // disable obfuscator
-
-    if (obfuscator === '.*') return true // optimize full redact
-
-    try {
-      return new RegExp(obfuscator, 'gi')
-    } catch (err) {
-      log.error('Web plugin error getting qs obfuscator', err)
-    }
-  }
-
-  if (config.hasOwnProperty('queryStringObfuscation')) {
-    log.error('Expected `queryStringObfuscation` to be a regex string or boolean.')
   }
 
   return true

--- a/packages/dd-trace/test/plugins/util/url.spec.js
+++ b/packages/dd-trace/test/plugins/util/url.spec.js
@@ -138,6 +138,36 @@ describe('plugins/util/url', () => {
     })
   })
 
+  describe('getQsObfuscator', () => {
+    it('should pass booleans through unchanged', () => {
+      assert.strictEqual(url.getQsObfuscator({ queryStringObfuscation: true }), true)
+      assert.strictEqual(url.getQsObfuscator({ queryStringObfuscation: false }), false)
+    })
+
+    it('should map an empty string to false (disabled)', () => {
+      assert.strictEqual(url.getQsObfuscator({ queryStringObfuscation: '' }), false)
+    })
+
+    it('should map ".*" to true (strip everything)', () => {
+      assert.strictEqual(url.getQsObfuscator({ queryStringObfuscation: '.*' }), true)
+    })
+
+    it('should compile a valid regex string into a global, case-insensitive RegExp', () => {
+      const result = url.getQsObfuscator({ queryStringObfuscation: 'secret=.*?(&|$)' })
+      assert.ok(result instanceof RegExp)
+      assert.strictEqual(result.source, 'secret=.*?(&|$)')
+      assert.strictEqual(result.flags, 'gi')
+    })
+
+    it('should fall back to true on an invalid regex string', () => {
+      assert.strictEqual(url.getQsObfuscator({ queryStringObfuscation: '(?' }), true)
+    })
+
+    it('should default to true when the option is absent', () => {
+      assert.strictEqual(url.getQsObfuscator({}), true)
+    })
+  })
+
   describe('extractPathFromUrl', () => {
     it('should return / for empty or missing url', () => {
       assert.strictEqual(url.extractPathFromUrl(''), '/')


### PR DESCRIPTION
## Summary

The server side already tags both `http.endpoint` and `http.url`-with-`queryStringObfuscation` for inbound HTTP / HTTP/2 spans. The client side did neither. This brings the client to parity, closes the open half of [#2022](https://github.com/DataDog/dd-trace-js/issues/2022), and gives outbound `http.url` a low-cardinality companion before it starts carrying the query string.

1. `http.endpoint` lands on outbound HTTP and HTTP/2 client spans when `resourceRenamingEnabled` is on. Computed from the request path with the same `calculateHttpEndpoint` the server uses. Clients have no `http.route` companion to aggregate on; this gives them the same low-cardinality bucket key.
2. `queryStringObfuscation` now applies to outbound `http.url`. The client used to strip the query string unconditionally; the same tri-state (`false` / `true` / regex) and the default secrets regex now behave consistently on both sides.

## Why

The default secrets-redacting regex still applies, so credentials in client URLs are redacted by construction. The cardinality risk that comes with putting the query string on `http.url` is absorbed by Phase 1's `http.endpoint`, which is computed from the path only — `calculateHttpEndpoint` runs through `extractPathFromUrl`, whose `PATH_REGEX` strips everything after the first `?` before normalization. So `http.endpoint` has bounded cardinality regardless of QS content.

To restore the previous strip-all client behaviour, set `queryStringObfuscation: true`.

The `getQsObfuscator` normaliser moves from `packages/dd-trace/src/plugins/util/web.js` to `packages/dd-trace/src/plugins/util/url.js` so server and client share one implementation. No behaviour change in the server path.

## Test plan

- [x] `packages/dd-trace/test/plugins/util/url.spec.js` — direct unit tests for `getQsObfuscator` (booleans, empty string, `.*`, valid regex, invalid regex fallback, missing option default)
- [x] `packages/dd-trace/test/plugins/util/web.spec.js` — existing `getQsObfuscator` coverage via `web.normalizeConfig`, still green
- [x] `packages/datadog-plugin-http/test/http_endpoint.spec.js` — added `http/client` and `node:http/client` blocks for int / mixed / QS-stripped-from-endpoint cases, plus a `resourceRenamingEnabled: false` negative
- [x] `packages/datadog-plugin-http/test/client.spec.js` — added `with queryStringObfuscation` (regex / true / false), updated `should remove the query string from the URL` to assert the new default
- [x] `packages/datadog-plugin-http2/test/client.spec.js` — added `http.endpoint` and `queryStringObfuscation` blocks, mirroring the http set
- [x] `npm run lint` — clean
- [x] Coverage: `url.js` 100% statements / lines / functions; client plugins 100% functions, ~97% lines (uncovered lines are pre-existing error-log paths and a `extractSessionDetails(string)` path my change doesn't touch)

Fixes: https://github.com/DataDog/dd-trace-js/issues/2022