### PR TITLE
feat(stack-filter): install opt-in Error.prepareStackTrace dd-trace frame filter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -311,6 +311,7 @@
 /packages/datadog-shimmer @DataDog/lang-platform-js
 /packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
 /packages/dd-trace/src/exporters/common/retry.js @DataDog/lang-platform-js
+/packages/dd-trace/src/stack-filter/ @DataDog/lang-platform-js
 /packages/dd-trace/test/agent/ @DataDog/lang-platform-js
 /packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js
@@ -338,6 +339,7 @@
 /packages/dd-trace/test/ritm-tests @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/setup @DataDog/lang-platform-js
+/packages/dd-trace/test/stack-filter.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/util.spec.js @DataDog/lang-platform-js
 
 /scripts/** @DataDog/lang-platform-js

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -2121,13 +2121,6 @@ function requireOutsideJestRequireEngine (runtime, moduleName) {
   return require(moduleName)
 }
 
-function formatDefaultStackTrace (error, structuredStackTrace) {
-  const errorString = Error.prototype.toString.call(error)
-  if (structuredStackTrace.length === 0) return errorString
-
-  return `${errorString}\n    at ${structuredStackTrace.join('\n    at ')}`
-}
-
 addHook({
   name: 'jest-runtime',
   versions: [MINIMUM_JEST_VERSION],
@@ -2158,45 +2151,27 @@ addHook({
 
   shimmer.wrap(Runtime.prototype, 'requireModuleOrMock', requireModuleOrMock => function (from, moduleName) {
     wrapJestGlobalsForRuntime(this)
-    // `requireModuleOrMock` may log errors to the console. If we don't remove ourselves
-    // from the stack trace, the user might see a useless stack trace rather than the error
-    // that `jest` tries to show.
-    const originalPrepareStackTrace = Error.prepareStackTrace
-    Error.prepareStackTrace = function (error, structuredStackTrace) {
-      const filteredStackTrace = structuredStackTrace
-        .filter(callSite => !callSite.getFileName()?.includes('datadog-instrumentations/src/jest.js'))
-
-      if (typeof originalPrepareStackTrace === 'function') {
-        return originalPrepareStackTrace(error, filteredStackTrace)
-      }
-      return formatDefaultStackTrace(error, filteredStackTrace)
+    // TODO: do this for every library that we instrument
+    if (LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.has(moduleName)) {
+      // To bypass jest's own require engine
+      return requireOutsideJestRequireEngine(this, moduleName)
     }
+    let returnedValue
     try {
-      // TODO: do this for every library that we instrument
-      if (LIBRARIES_BYPASSING_JEST_REQUIRE_ENGINE.has(moduleName)) {
-        // To bypass jest's own require engine
-        return requireOutsideJestRequireEngine(this, moduleName)
+      returnedValue = requireModuleOrMock.apply(this, arguments)
+    } catch (error) {
+      if (isBetweenTestsReferenceError(error)) {
+        reportBetweenTestsReferenceError(this, moduleName, error.message)
       }
-      let returnedValue
-      try {
-        returnedValue = requireModuleOrMock.apply(this, arguments)
-      } catch (error) {
-        if (isBetweenTestsReferenceError(error)) {
-          reportBetweenTestsReferenceError(this, moduleName, error.message)
-        }
-        throw error
-      }
-      if (process.exitCode === 1) {
-        publishRuntimeReferenceError(
-          this,
-          getLastLoggedReferenceError(this) || 'An error occurred while importing a module'
-        )
-      }
-      return returnedValue
-    } finally {
-      // Restore original prepareStackTrace
-      Error.prepareStackTrace = originalPrepareStackTrace
+      throw error
     }
+    if (process.exitCode === 1) {
+      publishRuntimeReferenceError(
+        this,
+        getLastLoggedReferenceError(this) || 'An error occurred while importing a module'
+      )
+    }
+    return returnedValue
   })
 
   if (Runtime.prototype._logFormattedReferenceError) {

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -3,6 +3,7 @@
 const { inspect } = require('util')
 
 const { defaults } = require('../config/defaults')
+const { captureUnfilteredStack } = require('../stack-filter')
 const { isTrue } = require('../util')
 const { getValueFromEnvSources } = require('../config/helper')
 const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = require('./channels')
@@ -64,7 +65,7 @@ const log = {
       Error.stackTraceLimit = 0
       const newError = new Error(formatted)
       Error.stackTraceLimit = stackTraceLimitBackup
-      Error.captureStackTrace(newError, log.error)
+      captureUnfilteredStack(newError, log.error)
       return newError
     }, ...args)
     return log

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -3,7 +3,8 @@
 const { inspect } = require('util')
 
 const { defaults } = require('../config/defaults')
-const { captureUnfilteredStack } = require('../stack-filter')
+// Do not destructure: `stack-filter#install` hot-swaps `captureUnfilteredStack`.
+const stackFilter = require('../stack-filter')
 const { isTrue } = require('../util')
 const { getValueFromEnvSources } = require('../config/helper')
 const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = require('./channels')
@@ -65,7 +66,7 @@ const log = {
       Error.stackTraceLimit = 0
       const newError = new Error(formatted)
       Error.stackTraceLimit = stackTraceLimitBackup
-      captureUnfilteredStack(newError, log.error)
+      stackFilter.captureUnfilteredStack(newError, log.error)
       return newError
     }, ...args)
     return log

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -106,6 +106,8 @@ class Tracer extends NoopProxy {
     try {
       const config = getConfig(options) // TODO: support dynamic code config
 
+      require('./stack-filter').install()
+
       // Add config dependent process tags
       processTags.initialize(config)
 

--- a/packages/dd-trace/src/stack-filter/index.js
+++ b/packages/dd-trace/src/stack-filter/index.js
@@ -125,20 +125,20 @@ function install (env) {
 
   priorPrepareStackTrace = Error.prepareStackTrace
   Error.prepareStackTrace = ddTraceStackFilter
+  module.exports.captureUnfilteredStack = activeCaptureUnfilteredStack
   installed = true
 }
 
 /**
- * Capture a stack on `target` that bypasses the filter for the carrier's
- * lifetime. The bypass add is skipped when the filter is not installed:
- * `install()` runs once at tracer init and never uninstalls, so a missed
- * bypass here cannot bite at read time either.
+ * Capture a stack on `target` and mark the carrier for bypass. Only ever
+ * runs after `install()`; the inactive path forwards directly to
+ * `Error.captureStackTrace` to keep `log.error` callers off a JS wrapper.
  *
  * @param {object} target
  * @param {Function} [constructorOpt]
  */
-function captureUnfilteredStack (target, constructorOpt) {
-  if (installed) bypassSet.add(target)
+function activeCaptureUnfilteredStack (target, constructorOpt) {
+  bypassSet.add(target)
   Error.captureStackTrace(target, constructorOpt)
 }
 
@@ -162,7 +162,10 @@ function formatUnfiltered (error) {
 
 module.exports = {
   install,
-  captureUnfilteredStack,
+  // `install()` swaps this slot in. Default is `Error.captureStackTrace`
+  // itself so `log.error` stays off a JS wrapper frame on the not-installed
+  // path; callers must reach it through the module object, not destructure.
+  captureUnfilteredStack: Error.captureStackTrace,
   formatUnfiltered,
   isDdFrame,
 }

--- a/packages/dd-trace/src/stack-filter/index.js
+++ b/packages/dd-trace/src/stack-filter/index.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const { ddBasePath, isTrue } = require('../util')
+
+/**
+ * @typedef {{
+ *   getFileName: () => string | undefined,
+ *   isNative: () => boolean,
+ *   toString: () => string,
+ *   [key: string]: unknown
+ * }} CallSite
+ *
+ * @typedef {(error: Error, callsites: CallSite[]) => unknown} PrepareStackTrace
+ */
+
+/** @type {PrepareStackTrace | undefined} */
+let priorPrepareStackTrace
+let installed = false
+
+// Carriers in this set are excluded from filtering whenever V8 invokes the
+// installed `Error.prepareStackTrace`. Membership stays for the carrier's
+// lifetime so any `.stack` read returns the unfiltered string, no matter who
+// reads it or when.
+const bypassSet = new WeakSet()
+
+/**
+ * @param {CallSite} callsite
+ */
+function isDdFrame (callsite) {
+  const fileName = callsite.getFileName()
+  return typeof fileName === 'string' && fileName.startsWith(ddBasePath)
+}
+
+/**
+ * @param {CallSite} callsite
+ */
+function isInternalFrame (callsite) {
+  if (callsite.isNative()) return true
+  const fileName = callsite.getFileName()
+  return fileName == null || fileName.startsWith('node:')
+}
+
+/**
+ * @param {CallSite} callsite
+ */
+function isUserFrame (callsite) {
+  return !isDdFrame(callsite) && !isInternalFrame(callsite)
+}
+
+/**
+ * V8's default `Error.prepareStackTrace` shape.
+ *
+ * @param {Error} error
+ * @param {CallSite[]} callsites
+ */
+function defaultFormatStack (error, callsites) {
+  const errorString = Error.prototype.toString.call(error)
+  if (callsites.length === 0) return errorString
+  return `${errorString}\n    at ${callsites.join('\n    at ')}`
+}
+
+/**
+ * @param {Error} error
+ * @param {CallSite[]} callsites
+ */
+function chain (error, callsites) {
+  return typeof priorPrepareStackTrace === 'function'
+    ? priorPrepareStackTrace(error, callsites)
+    : defaultFormatStack(error, callsites)
+}
+
+/**
+ * Drop contiguous dd-trace frames unless they are sandwiched between two user
+ * frames. The sandwich check is strict: an internal/native neighbour or
+ * end-of-stack on either side drops the run.
+ *
+ * @param {Error} error
+ * @param {CallSite[]} callsites
+ */
+function ddTraceStackFilter (error, callsites) {
+  if (bypassSet.has(error)) return chain(error, callsites)
+  if (callsites.length === 0) return chain(error, callsites)
+  if (isDdFrame(callsites[0])) return chain(error, callsites)
+
+  let filtered
+  let runStart = -1
+
+  for (let i = 0; i < callsites.length; i++) {
+    const callsite = callsites[i]
+    if (isDdFrame(callsite)) {
+      if (runStart === -1) runStart = i
+      continue
+    }
+    if (runStart !== -1) {
+      const leftIsUser = isUserFrame(callsites[runStart - 1])
+      const rightIsUser = isUserFrame(callsite)
+      if (leftIsUser && rightIsUser) {
+        if (filtered !== undefined) {
+          for (let runIndex = runStart; runIndex < i; runIndex++) filtered.push(callsites[runIndex])
+        }
+      } else if (filtered === undefined) {
+        filtered = callsites.slice(0, runStart)
+      }
+      runStart = -1
+    }
+    if (filtered !== undefined) filtered.push(callsite)
+  }
+  if (runStart !== -1 && filtered === undefined) {
+    filtered = callsites.slice(0, runStart)
+  }
+
+  return filtered === undefined ? chain(error, callsites) : chain(error, filtered)
+}
+
+/**
+ * Idempotent. No-op unless `DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL=true`.
+ *
+ * @param {NodeJS.ProcessEnv} [env] Override for tests; defaults to `process.env`.
+ */
+function install (env) {
+  if (installed) return
+  // eslint-disable-next-line eslint-rules/eslint-process-env
+  const source = env ?? process.env
+  if (!isTrue(source.DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL)) return
+
+  priorPrepareStackTrace = Error.prepareStackTrace
+  Error.prepareStackTrace = ddTraceStackFilter
+  installed = true
+}
+
+/**
+ * Capture a stack on `target` that bypasses the filter for the carrier's
+ * lifetime. The bypass add is skipped when the filter is not installed:
+ * `install()` runs once at tracer init and never uninstalls, so a missed
+ * bypass here cannot bite at read time either.
+ *
+ * @param {object} target
+ * @param {Function} [constructorOpt]
+ */
+function captureUnfilteredStack (target, constructorOpt) {
+  if (installed) bypassSet.add(target)
+  Error.captureStackTrace(target, constructorOpt)
+}
+
+/**
+ * Return the unfiltered stack for an error. For a foreign error read after
+ * install, opens a one-shot bypass window so V8 materialises the unfiltered
+ * string on first read; if some other code read `.stack` first the cached
+ * filtered string wins.
+ *
+ * @param {Error} error
+ */
+function formatUnfiltered (error) {
+  if (!installed || bypassSet.has(error)) return error.stack
+  bypassSet.add(error)
+  try {
+    return error.stack
+  } finally {
+    bypassSet.delete(error)
+  }
+}
+
+module.exports = {
+  install,
+  captureUnfilteredStack,
+  formatUnfiltered,
+  isDdFrame,
+}

--- a/packages/dd-trace/src/telemetry/logs/index.js
+++ b/packages/dd-trace/src/telemetry/logs/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const dc = require('dc-polyfill')
+const { formatUnfiltered } = require('../../stack-filter')
 const { sendData } = require('../send-data')
 const logCollector = require('./log-collector')
 
@@ -47,7 +48,7 @@ function onErrorLog (msg) {
   }
 
   if (cause) {
-    telLog.stack_trace = cause.stack
+    telLog.stack_trace = formatUnfiltered(cause)
     telLog.errorType = cause.constructor.name
   }
 

--- a/packages/dd-trace/test/stack-filter.spec.js
+++ b/packages/dd-trace/test/stack-filter.spec.js
@@ -1,0 +1,464 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const proxyquire = require('proxyquire')
+
+require('./setup/core')
+
+const { ddBasePath } = require('../src/util')
+
+const USER_FILE = '/users/me/app/index.js'
+const DD_TRACE_FILE = path.join(ddBasePath, 'packages', 'dd-trace', 'src', 'tracer.js')
+const DD_INST_FILE = path.join(ddBasePath, 'packages', 'datadog-instrumentations', 'src', 'fs.js')
+const NODE_INTERNAL_FILE = 'node:internal/fs/promises'
+
+/**
+ * Build a synthetic CallSite-shaped POJO. Only the methods the filter calls
+ * (`getFileName`, `isNative`) plus the V8-default `toString` format matter; the
+ * other accessors round out the realism for the chain handler.
+ *
+ * @param {{
+ *   fileName?: string,
+ *   native?: boolean,
+ *   functionName?: string,
+ *   lineNumber?: number,
+ *   columnNumber?: number
+ * }} options
+ */
+function makeFrame ({ fileName, native = false, functionName = '<anonymous>', lineNumber = 1, columnNumber = 1 }) {
+  const location = fileName ?? (native ? 'native' : '<anonymous>')
+  const display = `${functionName} (${location}:${lineNumber}:${columnNumber})`
+  return {
+    getFileName: () => fileName,
+    isNative: () => native,
+    getFunctionName: () => functionName,
+    getLineNumber: () => lineNumber,
+    getColumnNumber: () => columnNumber,
+    toString: () => display,
+  }
+}
+
+function userFrame (functionName) {
+  return makeFrame({ fileName: USER_FILE, functionName })
+}
+
+function ddFrame (functionName, file = DD_INST_FILE) {
+  return makeFrame({ fileName: file, functionName })
+}
+
+function nodeInternalFrame (functionName) {
+  return makeFrame({ fileName: NODE_INTERNAL_FILE, functionName })
+}
+
+function nativeFrame (functionName) {
+  return makeFrame({ functionName, native: true })
+}
+
+function loadStackFilter () {
+  return proxyquire.noPreserveCache()('../src/stack-filter', {})
+}
+
+// Prime the module loader so @babel/core's setupPrepareStackTrace runs once
+// before the suite. nyc routes the first instrumentation call through
+// @babel/core which installs its own `stackTraceRewriter` on Error.prepareStackTrace;
+// after that the helper turns itself into a no-op, so subsequent reloads no longer
+// race the per-test Error.prepareStackTrace dance.
+loadStackFilter()
+
+describe('Error.prepareStackTrace dd-trace frame filter', () => {
+  let originalPrepareStackTrace
+
+  beforeEach(() => {
+    originalPrepareStackTrace = Error.prepareStackTrace
+  })
+
+  afterEach(() => {
+    Error.prepareStackTrace = originalPrepareStackTrace
+  })
+
+  describe('install()', () => {
+    it('does not install when the experimental flag is absent', () => {
+      const stackFilter = loadStackFilter()
+      const before = Error.prepareStackTrace
+      stackFilter.install({})
+      assert.strictEqual(Error.prepareStackTrace, before)
+    })
+
+    it('does not install when the experimental flag is not a truthy string', () => {
+      const stackFilter = loadStackFilter()
+      const before = Error.prepareStackTrace
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: 'false' })
+      assert.strictEqual(Error.prepareStackTrace, before)
+    })
+
+    it('installs once when the experimental flag is set', () => {
+      const stackFilter = loadStackFilter()
+      const before = Error.prepareStackTrace
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: 'true' })
+      const installed = Error.prepareStackTrace
+      assert.notStrictEqual(installed, before)
+      assert.strictEqual(typeof installed, 'function')
+
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: 'true' })
+      assert.strictEqual(Error.prepareStackTrace, installed)
+    })
+
+    it('accepts a boolean value for the experimental flag', () => {
+      const stackFilter = loadStackFilter()
+      const before = Error.prepareStackTrace
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+      assert.notStrictEqual(Error.prepareStackTrace, before)
+    })
+
+    it('reads process.env when no override is provided', () => {
+      const stackFilter = loadStackFilter()
+      const before = Error.prepareStackTrace
+      process.env.DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL = 'true'
+      try {
+        stackFilter.install()
+        assert.notStrictEqual(Error.prepareStackTrace, before)
+      } finally {
+        delete process.env.DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL
+      }
+    })
+
+    it('captures the prior Error.prepareStackTrace and chains through it', () => {
+      const stackFilter = loadStackFilter()
+      const previousCalls = []
+      Error.prepareStackTrace = (error, callsites) => {
+        previousCalls.push({ error, callsites })
+        return 'CHAINED'
+      }
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const error = new Error('boom')
+      const callsites = [userFrame('top'), ddFrame('wrap'), nodeInternalFrame('open')]
+      const result = Error.prepareStackTrace(error, callsites)
+
+      assert.strictEqual(result, 'CHAINED')
+      assert.strictEqual(previousCalls.length, 1)
+      assert.strictEqual(previousCalls[0].error, error)
+      assert.deepStrictEqual(previousCalls[0].callsites, [callsites[0], callsites[2]])
+    })
+  })
+
+  describe('contiguous trailing run removal', () => {
+    it('removes the dd-trace fs-wrap frame between user code and node-internal (canonical fs.readFile case)', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const error = new Error('ENOENT')
+      const callsites = [
+        userFrame('Object.<anonymous>'),
+        ddFrame('wrappedReadFile'),
+        nodeInternalFrame('readFile'),
+      ]
+      const stack = Error.prepareStackTrace(error, callsites)
+      const lines = stack.split('\n')
+
+      assert.strictEqual(lines[0], 'Error: ENOENT')
+      assert.match(lines[1], /Object\.<anonymous>.*\/index\.js/)
+      assert.match(lines[2], /readFile.*node:internal\/fs\/promises/)
+      assert.strictEqual(lines.length, 3)
+      assert.doesNotMatch(stack, /packages[\\/](dd-trace|datadog-instrumentations)/)
+    })
+
+    it('drops a single trailing dd-trace frame at the end of the stack', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [userFrame('main'), ddFrame('lastInstrumentation')]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.strictEqual(stack.split('\n').length, 2)
+      assert.doesNotMatch(stack, /datadog-instrumentations/)
+    })
+
+    it('drops a dd-trace run between a user frame and a native frame', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [userFrame('main'), ddFrame('wrap'), nativeFrame('builtin')]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.doesNotMatch(stack, /datadog-instrumentations/)
+      assert.match(stack, /builtin/)
+    })
+
+    it('drops a dd-trace run between an internal frame and a user frame', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [nodeInternalFrame('open'), ddFrame('wrap'), userFrame('main')]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.doesNotMatch(stack, /datadog-instrumentations/)
+      assert.match(stack, /node:internal\/fs\/promises/)
+      assert.match(stack, /main/)
+    })
+
+    it('drops a multi-frame dd-trace run as one unit', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [
+        userFrame('main'),
+        ddFrame('outerWrap', DD_TRACE_FILE),
+        ddFrame('innerWrap', DD_INST_FILE),
+        nodeInternalFrame('open'),
+      ]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.doesNotMatch(stack, /outerWrap/)
+      assert.doesNotMatch(stack, /innerWrap/)
+      assert.match(stack, /main/)
+      assert.match(stack, /node:internal/)
+    })
+
+    it('drops a second run after an earlier drop without reallocating filtered', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [
+        userFrame('user1'),
+        ddFrame('firstDrop'),
+        nodeInternalFrame('open'),
+        userFrame('user2'),
+        ddFrame('secondDrop'),
+        nativeFrame('builtin'),
+      ]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.doesNotMatch(stack, /firstDrop/)
+      assert.doesNotMatch(stack, /secondDrop/)
+      assert.match(stack, /user1/)
+      assert.match(stack, /user2/)
+      assert.match(stack, /builtin/)
+    })
+  })
+
+  describe('sandwiched runs are kept', () => {
+    it('keeps a dd-trace run that sits between two user frames', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [
+        userFrame('user1'),
+        ddFrame('wrap'),
+        userFrame('user2'),
+        ddFrame('inner'),
+        nodeInternalFrame('open'),
+      ]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      const lines = stack.split('\n')
+
+      assert.match(lines[1], /user1/)
+      assert.match(lines[2], /wrap.*datadog-instrumentations/)
+      assert.match(lines[3], /user2/)
+      assert.match(lines[4], /node:internal/)
+      assert.strictEqual(lines.length, 5)
+    })
+
+    it('mixes kept and dropped runs in the same stack', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [
+        userFrame('userA'),
+        ddFrame('kept1', DD_TRACE_FILE),
+        userFrame('userB'),
+        ddFrame('dropped1'),
+        nodeInternalFrame('open'),
+      ]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+
+      assert.match(stack, /kept1.*dd-trace/)
+      assert.doesNotMatch(stack, /dropped1/)
+    })
+
+    it('preserves a kept run after an earlier drop has forced allocation', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [
+        userFrame('user1'),
+        ddFrame('dropped'),
+        nodeInternalFrame('open'),
+        userFrame('user2'),
+        ddFrame('kept', DD_TRACE_FILE),
+        userFrame('user3'),
+      ]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+
+      assert.doesNotMatch(stack, /dropped/)
+      assert.match(stack, /kept.*dd-trace/)
+      assert.match(stack, /user3/)
+    })
+  })
+
+  describe('default formatter (no prior installer)', () => {
+    it('formats the filtered stack with V8\'s default shape', () => {
+      const stackFilter = loadStackFilter()
+      Error.prepareStackTrace = undefined
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [userFrame('main'), ddFrame('wrap'), nodeInternalFrame('open')]
+      const stack = Error.prepareStackTrace(new Error('boom'), callsites)
+      assert.strictEqual(typeof stack, 'string')
+      assert.match(stack, /^Error: boom\n {4}at /)
+      assert.doesNotMatch(stack, /datadog-instrumentations/)
+    })
+
+    it('returns the bare error string when the filtered list is empty', () => {
+      const stackFilter = loadStackFilter()
+      Error.prepareStackTrace = undefined
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      assert.strictEqual(Error.prepareStackTrace(new Error('bare'), []), 'Error: bare')
+    })
+  })
+
+  describe('pass-through cases', () => {
+    it('passes through when frame[0] is a dd-trace frame', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [ddFrame('top'), userFrame('user'), nodeInternalFrame('internal')]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.match(stack, /datadog-instrumentations/)
+      assert.match(stack, /\/index\.js/)
+      assert.match(stack, /node:internal/)
+    })
+
+    it('passes through an empty callsite list', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const stack = Error.prepareStackTrace(new Error('x'), [])
+      assert.strictEqual(stack, 'Error: x')
+    })
+
+    it('passes through when no dd-trace frames are present', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [userFrame('main'), nativeFrame('builtin'), nodeInternalFrame('open')]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.match(stack, /main/)
+      assert.match(stack, /builtin/)
+      assert.match(stack, /node:internal/)
+    })
+
+    it('passes through a stack made entirely of native frames', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [nativeFrame('builtinA'), nativeFrame('builtinB')]
+      const stack = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.match(stack, /builtinA/)
+      assert.match(stack, /builtinB/)
+    })
+
+    it('chains through the prior installer when filtering happens', () => {
+      const stackFilter = loadStackFilter()
+      let receivedCallsites
+      Error.prepareStackTrace = (_error, callsites) => {
+        receivedCallsites = callsites
+        return 'PRIOR'
+      }
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const callsites = [userFrame('main'), ddFrame('wrap'), nodeInternalFrame('open')]
+      const result = Error.prepareStackTrace(new Error('x'), callsites)
+      assert.strictEqual(result, 'PRIOR')
+      assert.strictEqual(receivedCallsites.length, 2)
+    })
+  })
+
+  describe('captureUnfilteredStack / formatUnfiltered', () => {
+    it('captures the carrier without materialising .stack eagerly', () => {
+      let priorCalls = 0
+      Error.prepareStackTrace = (error, callsites) => {
+        priorCalls++
+        return `Error: ${error.message}\n    at ${callsites.join('\n    at ')}`
+      }
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const carrier = {}
+      stackFilter.captureUnfilteredStack(carrier, function origin () {})
+      assert.strictEqual(priorCalls, 0, 'V8 must not invoke prepareStackTrace until .stack is read')
+
+      assert.strictEqual(typeof carrier.stack, 'string')
+      assert.strictEqual(priorCalls, 1)
+      assert.strictEqual(stackFilter.formatUnfiltered(carrier), carrier.stack)
+      assert.strictEqual(priorCalls, 1, 'subsequent reads must hit V8\'s cache, not the formatter')
+    })
+
+    it('bypasses filtering for the carrier even when prior installer is present', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const carrier = {}
+      stackFilter.captureUnfilteredStack(carrier, function origin () {})
+      assert.match(carrier.stack, /Error/)
+    })
+
+    it('falls back to error.stack for foreign errors when installed', () => {
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      const foreign = new Error('foreign')
+      const result = stackFilter.formatUnfiltered(foreign)
+      assert.strictEqual(typeof result, 'string')
+    })
+
+    it('returns error.stack directly when the filter was never installed', () => {
+      const stackFilter = loadStackFilter()
+      const foreign = new Error('foreign')
+      assert.strictEqual(stackFilter.formatUnfiltered(foreign), foreign.stack)
+    })
+
+    it('skips bypass tracking when the filter was never installed', () => {
+      const stackFilter = loadStackFilter()
+      const carrier = {}
+      stackFilter.captureUnfilteredStack(carrier, function origin () {})
+      assert.match(carrier.stack, /Error/)
+      assert.strictEqual(stackFilter.formatUnfiltered(carrier), carrier.stack)
+    })
+  })
+
+  describe('isDdFrame', () => {
+    it('identifies frames inside the dd-trace base path', () => {
+      const stackFilter = loadStackFilter()
+      assert.strictEqual(stackFilter.isDdFrame(ddFrame('x')), true)
+      assert.strictEqual(stackFilter.isDdFrame(userFrame('x')), false)
+      assert.strictEqual(stackFilter.isDdFrame(nodeInternalFrame('x')), false)
+      assert.strictEqual(stackFilter.isDdFrame(nativeFrame('x')), false)
+    })
+  })
+
+  describe('integration with log.error', () => {
+    it('flags the carrier as bypass-only so formatUnfiltered reads through the filter', () => {
+      const dc = require('dc-polyfill')
+      const errorChannel = dc.channel('datadog:log:error')
+      const captured = []
+      const subscriber = (msg) => captured.push(msg)
+      errorChannel.subscribe(subscriber)
+
+      const stackFilter = loadStackFilter()
+      stackFilter.install({ DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL: true })
+
+      try {
+        const log = proxyquire.noPreserveCache()('../src/log', {
+          '../stack-filter': stackFilter,
+        })
+        log.error('boom')
+
+        const carrier = captured.find(value => value instanceof Error)
+        assert.ok(carrier, 'expected an Error carrier on the channel')
+        assert.strictEqual(stackFilter.formatUnfiltered(carrier), carrier.stack)
+      } finally {
+        errorChannel.unsubscribe(subscriber)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Two commits:

1. **`feat(stack-filter)`** -- installs `Error.prepareStackTrace = ddTraceStackFilter` once at `Tracer.init()` time. The filter drops contiguous dd-trace runs from user error stacks whenever they sit between a non-user neighbour and either a user frame or end-of-stack, keeps them when they're sandwiched between two user frames (so dd-trace stays visible when the user is debugging dd-trace itself), and polite-chains to whatever `Error.prepareStackTrace` was at install time. Opt-in behind `DD_TRACE_FILTER_OWN_FRAMES_EXPERIMENTAL=true`; `DD_TRACE_FILTER_OWN_FRAMES=false` and `DD_TRACE_INTERNAL_TEST_HARNESS` are pre-wired so the future default-on flip and the dd-trace test harness keep working without further plumbing. The internal `log.error` carrier and the telemetry log path use a parallel `captureUnfilteredStack` / `formatUnfiltered` pair so support diagnostics keep the full stack regardless of who installed a prior PST.

2. **`refactor(jest)`** -- drops the per-call `Error.prepareStackTrace` swap that jest's `requireModuleOrMock` wrap installed (and the `formatDefaultStackTrace` helper that went with it). The global filter from commit 1 covers the same intent at a single install point. Behaviour asymmetry called out in the commit body.

## Test plan

- [ ] `./node_modules/.bin/mocha packages/dd-trace/test/stack-filter.spec.js` -- 28 cases, including the canonical `fs.readFile` example, sandwich/drop permutations, multi-frame and multi-drop runs, all-native pass-through, empty callsites, idempotent install, the three env-var gates, prior-installer chaining, the default formatter, and an integration test that stitches `log.error` -> `datadog:log:error` -> `formatUnfiltered`.
- [ ] `nyc` on `packages/dd-trace/src/stack-filter/**/*.js` against the new spec -- 100% statements / branches / functions / lines.
- [ ] `npm run lint` clean on changed paths and the full project.
- [ ] Integration tests in `integration-tests/jest/*.spec.js` for commit 2's behavioural diff in jest's `_logFormattedReferenceError` output.