### PR TITLE
fix(http): retire req.emit lifetime wrap in favor of diagnostics_channel

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -1,7 +1,5 @@
 'use strict'
 
-/* eslint-disable no-fallthrough */
-
 const url = require('url')
 const { errorMonitor } = require('events')
 const { channel, addHook } = require('../helpers/instrument')
@@ -16,8 +14,47 @@ const asyncStartChannel = channel('apm:http:client:request:asyncStart')
 const errorChannel = channel('apm:http:client:request:error')
 const responseFinishChannel = channel('apm:http:client:response:finish')
 
+// Subscribe at module load. Node 18+ publishes this for every client response
+// *before* invoking the user's `'response'` listeners, and unlike a
+// `req.once('response')` listener the subscription does not bump
+// `req.listenerCount('response')` — so Node's `_dump()` fallback that drains
+// an unread response stays intact.
+const nativeClientResponseFinishChannel = channel('http.client.response.finish')
+
+const requestContexts = new WeakMap()
+
+nativeClientResponseFinishChannel.subscribe(onNativeClientResponseFinish)
+
 addHook({ name: 'http' }, hookFn)
 addHook({ name: 'https' }, hookFn)
+
+/**
+ * @param {{ finished?: boolean }} ctx Instrumentation context. Mutated with `finished`.
+ */
+function finishRequest (ctx) {
+  if (!ctx.finished) {
+    ctx.finished = true
+    finishChannel.publish(ctx)
+  }
+}
+
+/**
+ * @param {{ request: import('http').ClientRequest, response: import('http').IncomingMessage }} payload
+ */
+function onNativeClientResponseFinish ({ request, response }) {
+  const ctx = requestContexts.get(request)
+  if (ctx === undefined) return
+
+  ctx.res = response
+  const onResponseSettled = () => finishRequest(ctx)
+  response.once('end', onResponseSettled)
+  response.once(errorMonitor, onResponseSettled)
+
+  const instrumentation = setupResponseInstrumentation(ctx, response)
+  if (instrumentation) {
+    queueMicrotask(instrumentation.finalizeIfNeeded)
+  }
+}
 
 function hookFn (http) {
   patch(http, 'request')
@@ -185,7 +222,6 @@ function patch (http, methodName) {
       const ctx = { args, http, abortController }
 
       return startChannel.runStores(ctx, () => {
-        let finished = false
         let callback = args.callback
 
         if (callback) {
@@ -198,64 +234,45 @@ function patch (http, methodName) {
 
         const options = args.options
 
-        const finish = () => {
-          if (!finished) {
-            finished = true
-            finishChannel.publish(ctx)
-          }
-        }
-
         try {
           const req = request.call(this, options, callback)
-          const emit = req.emit
           const setTimeout = req.setTimeout
 
           ctx.req = req
+          requestContexts.set(req, ctx)
 
           // tracked to accurately discern custom request socket timeout
-          let customRequestTimeout = false
+          ctx.customRequestTimeout = false
           req.setTimeout = function (...args) {
-            customRequestTimeout = true
+            ctx.customRequestTimeout = true
             return setTimeout.apply(this, args)
           }
 
-          req.emit = function (eventName, arg) {
-            switch (eventName) {
-              case 'response': {
-                const res = arg
-                ctx.res = res
-                res.once('end', finish)
-                res.once(errorMonitor, finish)
+          // Per-event listeners — not a lifetime `req.emit` reassignment — so
+          // the dd-trace frame stays off the stack the user's listeners see.
+          // See https://github.com/DataDog/dd-trace-js/issues/1564.
+          req.once('connect', (res) => {
+            ctx.res = res
+            finishRequest(ctx)
+          })
 
-                const instrumentation = setupResponseInstrumentation(ctx, res)
+          req.once('upgrade', (res) => {
+            ctx.res = res
+            finishRequest(ctx)
+          })
 
-                if (!instrumentation) {
-                  break
-                }
+          req.on(errorMonitor, (error) => {
+            ctx.error = error
+            errorChannel.publish(ctx)
+            finishRequest(ctx)
+          })
 
-                const result = emit.apply(this, arguments)
+          req.once('timeout', () => {
+            errorChannel.publish(ctx)
+            finishRequest(ctx)
+          })
 
-                instrumentation.finalizeIfNeeded()
-
-                return result
-              }
-              case 'connect':
-              case 'upgrade':
-                ctx.res = arg
-                finish()
-                break
-              case 'error':
-              case 'timeout':
-                ctx.error = arg
-                ctx.customRequestTimeout = customRequestTimeout
-                errorChannel.publish(ctx)
-              case 'abort': // deprecated and replaced by `close` in node 17
-              case 'close':
-                finish()
-            }
-
-            return emit.apply(this, arguments)
-          }
+          req.once('close', () => finishRequest(ctx))
 
           if (abortController.signal.aborted) {
             req.destroy(abortController.signal.reason || new Error('Aborted'))
@@ -268,7 +285,7 @@ function patch (http, methodName) {
           // if the initial request failed, ctx.req will be unset, we must close the span here
           // fix for: https://github.com/DataDog/dd-trace-js/issues/5016
           if (!ctx.req) {
-            finish()
+            finishRequest(ctx)
           }
           throw e
         } finally {

--- a/packages/datadog-instrumentations/test/http.spec.js
+++ b/packages/datadog-instrumentations/test/http.spec.js
@@ -43,6 +43,15 @@ describe('client', () => {
     errorChannel.unsubscribe(errorChannelCb)
   })
 
+  it('ignores http.client.response.finish for requests not started by the wrap', () => {
+    // Requests created outside `instrumentRequest` (e.g. before the wrap is
+    // attached, or via unrelated `http.ClientRequest` constructors) still cause
+    // Node to publish on this channel; the handler has to no-op on those.
+    const fakeRequest = new (require('events').EventEmitter)()
+    const fakeResponse = new (require('events').EventEmitter)()
+    dc.channel('http.client.response.finish').publish({ request: fakeRequest, response: fakeResponse })
+  })
+
   /*
    * Necessary because the tracer makes extra requests to the agent
    * and the same stub could be called multiple times

--- a/packages/datadog-plugin-http/test/client.spec.js
+++ b/packages/datadog-plugin-http/test/client.spec.js
@@ -983,6 +983,31 @@ describe('Plugin', () => {
         })
       })
 
+      describe('stack noise', () => {
+        beforeEach(() => {
+          return agent.load('http', { server: false })
+            .then(() => {
+              http = require(pluginToBeLoaded)
+            })
+        })
+
+        it('keeps datadog-instrumentations frames off the req error-listener stack on connection failure', done => {
+          const req = http.request(`${protocol}://localhost:7357/user`)
+
+          req.on('error', () => {
+            const handlerStack = new Error('frame check').stack
+            assert.doesNotMatch(
+              handlerStack,
+              /datadog-instrumentations\/src\/http\/client\.js/,
+              'dd-trace http client frame in user error-listener stack'
+            )
+            done()
+          })
+
+          req.end()
+        })
+      })
+
       describe('with late plugin initialization and an external subscriber', () => {
         let ch
         let sub


### PR DESCRIPTION
## Summary

`packages/datadog-instrumentations/src/http/client.js` rewrote `req.emit` for the lifetime of every outgoing `http.ClientRequest`. That made the wrap a permanent frame on the call stack inside every event the user observed — most visibly inside `'error'` listeners, where the stack a customer's handler prints / sends to an error reporter starts inside dd-trace instead of at their own callback.

The fix swaps the lifetime wrap for per-event listeners plus a single subscription to Node's native `http.client.response.finish` channel. The `apm:http:client:request:*` channels keep firing with identical payloads, so the plugin and AppSec / IAST subscribers do not change.

1. `req.once('connect' | 'upgrade' | 'timeout' | 'close', …)` and `req.on(errorMonitor, …)` carry the span-lifecycle events. `errorMonitor` keeps the `'error'` observation passive — it does not absorb the user's error.
2. The `'response'` path subscribes to `http.client.response.finish` rather than `req.once('response', …)`. Subscribing preserves Node's `_dump()` fallback that drains an unread response stream, so the apm span still finishes when the user does not consume the body.
3. A `WeakMap<ClientRequest, ctx>` links the channel handler back to the per-request context without mutating user-owned objects.

The synchronous AppSec SSRF abort path (`if (abortController.signal.aborted) req.destroy(...)` right after `request.call(...)` returns) and the `req.setTimeout` narrow wrap that drives `customRequestTimeout` are unchanged.

## Test plan

- [ ] Regression test (`describe('stack noise')` in `packages/datadog-plugin-http/test/client.spec.js`) fails on master and passes on this branch for each of `http`, `https`, `node:http`, `node:https`.
- [ ] `packages/datadog-plugin-http/test/client.spec.js` — full file, 202 cases.
- [ ] `packages/datadog-instrumentations/test/http.spec.js` + `http-client-options.spec.js`.
- [ ] `packages/dd-trace/test/appsec/rasp/ssrf.spec.js`, `ssrf.express.plugin.spec.js`, and `packages/dd-trace/test/appsec/iast/analyzers/ssrf-analyzer.spec.js` to confirm the AppSec / IAST subscriber contract is preserved (including the synchronous WAF-abort path).
- [ ] `nyc` on `packages/datadog-instrumentations/src/http/client.js` — every changed line and branch covered (statements 98.21 %, branches 89.89 %, functions 100 %, lines 98.14 %); the three uncovered lines (`Buffer.from(chunk)` for non-Buffer non-string chunks, the legacy `url.parse` fallback, `options.auth`) all predate this PR.

Fixes: https://github.com/DataDog/dd-trace-js/issues/1564