### PR TITLE
fix(test-optimization): support concurrent Vitest tests

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/concurrent-early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/concurrent-early-flake-detection.mjs
@@ -1,0 +1,24 @@
+import { describe, test, expect } from 'vitest'
+
+let eventuallyPassAttempts = 0
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('concurrent early flake detection', () => {
+  test.concurrent('can retry concurrent tests that eventually pass', async () => {
+    await wait(20)
+    expect(1 + 2).to.equal(eventuallyPassAttempts++ === 0 ? 4 : 3)
+  })
+
+  test.concurrent('can retry concurrent tests that always pass', async () => {
+    await wait(10)
+    expect(1 + 2).to.equal(3)
+  })
+
+  test('can retry non-concurrent tests in a mixed suite', async () => {
+    await wait(5)
+    expect(1 + 2).to.equal(3)
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/concurrent-flaky-test-retries.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/concurrent-flaky-test-retries.mjs
@@ -1,0 +1,30 @@
+import { describe, test, expect } from 'vitest'
+
+let eventuallyPassAttempts = 0
+let nonConcurrentEventuallyPassAttempts = 0
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('concurrent flaky test retries', () => {
+  test.concurrent('can retry concurrent tests that eventually pass', async () => {
+    await wait(20)
+    expect(++eventuallyPassAttempts).to.equal(2)
+  })
+
+  test.concurrent('can retry concurrent tests that never pass', async () => {
+    await wait(10)
+    expect(1 + 2).to.equal(4)
+  })
+
+  test.concurrent('does not retry concurrent tests if unnecessary', async () => {
+    await wait(5)
+    expect(1 + 2).to.equal(3)
+  })
+
+  test('can retry non-concurrent tests in a mixed suite', async () => {
+    await wait(1)
+    expect(++nonConcurrentEventuallyPassAttempts).to.equal(2)
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/concurrent-ftr-disabled.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/concurrent-ftr-disabled.mjs
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest'
+import { sum } from './bad-sum'
+
+let attempt = 0
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('dynamic instrumentation with concurrent tests', () => {
+  test('serial retry does not use Failed Test Replay', () => {
+    if (attempt++ === 0) {
+      expect(sum(11, 2)).to.equal(13)
+    } else {
+      expect(sum(1, 2)).to.equal(3)
+    }
+  })
+
+  test.concurrent('concurrent test disables Failed Test Replay for the file', async () => {
+    await wait(1)
+    expect(sum(1, 2)).to.equal(3)
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/concurrent-impacted-test.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/concurrent-impacted-test.mjs
@@ -1,0 +1,15 @@
+import { describe, test, expect } from 'vitest'
+
+describe('concurrent impacted test', () => {
+  test.concurrent('can mark first concurrent impacted test', () => {
+    expect(1 + 2).to.equal(3)
+  })
+
+  test.concurrent('can mark second concurrent impacted test', () => {
+    expect(2 + 2).to.equal(4)
+  })
+
+  test('can mark a non-concurrent impacted test in the same suite', () => {
+    expect(3 + 2).to.equal(5)
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/http-integration.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/http-integration.mjs
@@ -15,6 +15,10 @@ function httpRequest (path) {
   })
 }
 
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 describe('vitest-test-integration-http', () => {
   test('can do integration http', async () => {
     const testSpan = tracer.scope().active()
@@ -38,6 +42,84 @@ describe('vitest-test-hook-http', () => {
 
   test('hook http is linked to test span', () => {
     expect(true).toBe(true)
+  })
+})
+
+describe('vitest-test-concurrent-hook-http', () => {
+  beforeEach(async () => {
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  afterEach(async () => {
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test.concurrent('first concurrent hook http is linked to first test span', async () => {
+    await wait(30)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test.concurrent('second concurrent hook http is linked to second test span', async () => {
+    await wait(10)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+})
+
+describe.concurrent('vitest-describe-concurrent-hook-http', () => {
+  beforeEach(async () => {
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  afterEach(async () => {
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test('first inherited concurrent hook http is linked to first test span', async () => {
+    await wait(30)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test('second inherited concurrent hook http is linked to second test span', async () => {
+    await wait(10)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+})
+
+describe('vitest-mixed-concurrent-hook-http', () => {
+  beforeEach(async () => {
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  afterEach(async () => {
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test('serial hook http is linked to serial test span', async () => {
+    await wait(5)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test.concurrent('first mixed concurrent hook http is linked to first test span', async () => {
+    await wait(30)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
+  })
+
+  test.concurrent('second mixed concurrent hook http is linked to second test span', async () => {
+    await wait(10)
+    const statusCode = await httpRequest('/info')
+    expect(statusCode).toBe(200)
   })
 })
 

--- a/integration-tests/ci-visibility/vitest-tests/test-management-concurrent.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/test-management-concurrent.mjs
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'vitest'
+
+function wait (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('concurrent test management', () => {
+  test.concurrent('can attempt to fix a concurrent test', async () => {
+    await wait(20)
+    // eslint-disable-next-line no-console
+    console.log('I am running concurrent attempt to fix')
+    expect(1 + 2).to.equal(4)
+  })
+
+  test.concurrent('can disable a concurrent test', async () => {
+    await wait(15)
+    // eslint-disable-next-line no-console
+    console.log('I am running concurrent disabled')
+    expect(1 + 2).to.equal(4)
+  })
+
+  test.concurrent('can quarantine a concurrent test', async () => {
+    await wait(10)
+    // eslint-disable-next-line no-console
+    console.log('I am running concurrent quarantined')
+    expect(1 + 2).to.equal(4)
+  })
+
+  test.concurrent('can pass normally in a concurrent management suite', async () => {
+    await wait(5)
+    expect(1 + 2).to.equal(3)
+  })
+
+  test('can attempt to fix a non-concurrent test in a mixed management suite', async () => {
+    await wait(4)
+    // eslint-disable-next-line no-console
+    console.log('I am running non-concurrent attempt to fix')
+    expect(1 + 2).to.equal(4)
+  })
+
+  test('can disable a non-concurrent test in a mixed management suite', async () => {
+    await wait(3)
+    // eslint-disable-next-line no-console
+    console.log('I am running non-concurrent disabled')
+    expect(1 + 2).to.equal(4)
+  })
+
+  test('can pass normally beside concurrent management tests', async () => {
+    await wait(2)
+    expect(1 + 2).to.equal(3)
+  })
+})

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -150,7 +150,32 @@ versions.forEach((version) => {
             })
           })`
         )
-        execSync('git add ci-visibility/vitest-tests/impacted-test.mjs', { cwd, stdio: 'ignore' })
+        fs.writeFileSync(
+          path.join(cwd, 'ci-visibility/vitest-tests/concurrent-impacted-test.mjs'),
+          `import { describe, test, expect } from 'vitest'
+          function wait (ms) {
+            return new Promise(resolve => setTimeout(resolve, ms))
+          }
+          describe('concurrent impacted test', () => {
+            test.concurrent('can mark first concurrent impacted test', async () => {
+              await wait(20)
+              expect(1 + 2).to.equal(3)
+            })
+            test.concurrent('can mark second concurrent impacted test', async () => {
+              await wait(10)
+              expect(2 + 2).to.equal(4)
+            })
+            test('can mark a non-concurrent impacted test in the same suite', async () => {
+              await wait(5)
+              expect(3 + 2).to.equal(5)
+            })
+          })`
+        )
+        execSync(
+          'git add ci-visibility/vitest-tests/impacted-test.mjs ' +
+            'ci-visibility/vitest-tests/concurrent-impacted-test.mjs',
+          { cwd, stdio: 'ignore' }
+        )
         execSync('git commit -m "modify impacted-test.mjs"', { cwd, stdio: 'ignore' })
       })
 
@@ -261,6 +286,52 @@ versions.forEach((version) => {
           runImpactedTest(done, { isModified: true })
         })
 
+        it('supports test.concurrent with impacted tests', async () => {
+          receiver.setSettings({ impacted_tests_enabled: true })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const concurrentImpactedTests = tests.filter(
+                test => test.meta[TEST_SOURCE_FILE] === 'ci-visibility/vitest-tests/concurrent-impacted-test.mjs'
+              )
+
+              assert.strictEqual(concurrentImpactedTests.length, 3)
+              assertObjectContains(concurrentImpactedTests.map(test => test.meta[TEST_NAME]), [
+                'concurrent impacted test can mark first concurrent impacted test',
+                'concurrent impacted test can mark second concurrent impacted test',
+                'concurrent impacted test can mark a non-concurrent impacted test in the same suite',
+              ])
+
+              for (const test of concurrentImpactedTests) {
+                assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+                assert.strictEqual(test.meta[TEST_IS_MODIFIED], 'true')
+                assert.ok(!(TEST_IS_NEW in test.meta))
+                assert.ok(!(TEST_IS_RETRY in test.meta))
+              }
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/vitest run',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                TEST_DIR: 'ci-visibility/vitest-tests/concurrent-impacted-test.mjs',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init --no-warnings',
+                GITHUB_BASE_REF: '',
+              },
+            }
+          )
+
+          const [[exitCode]] = await Promise.all([
+            once(childProcess, 'exit'),
+            eventsPromise,
+          ])
+          assert.strictEqual(exitCode, 0)
+        })
+
         it('should not be detected as impacted if disabled', (done) => {
           receiver.setSettings({ impacted_tests_enabled: false })
 
@@ -295,6 +366,168 @@ versions.forEach((version) => {
           })
           runImpactedTest(done, { isModified: true, isEfd: true, isNew: true })
         })
+      })
+    })
+
+    context('test.concurrent advanced features', () => {
+      it('supports test.concurrent with auto test retries', async () => {
+        receiver.setSettings({
+          itr_enabled: false,
+          code_coverage: false,
+          tests_skipping: false,
+          flaky_test_retries_enabled: true,
+          early_flake_detection: { enabled: false },
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+            const eventuallyPassingTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent flaky test retries can retry concurrent tests that eventually pass'
+            )
+            assert.strictEqual(eventuallyPassingTests.length, 2)
+            assert.strictEqual(eventuallyPassingTests.filter(test => test.meta[TEST_STATUS] === 'fail').length, 1)
+            assert.strictEqual(eventuallyPassingTests.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
+            assert.strictEqual(
+              eventuallyPassingTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
+                .length,
+              1
+            )
+
+            const neverPassingTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent flaky test retries can retry concurrent tests that never pass'
+            )
+            assert.strictEqual(neverPassingTests.length, 3)
+            assert.strictEqual(neverPassingTests.filter(test => test.meta[TEST_STATUS] === 'fail').length, 3)
+            assert.strictEqual(
+              neverPassingTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length,
+              2
+            )
+
+            const notRetriedTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent flaky test retries does not retry concurrent tests if unnecessary'
+            )
+            assert.strictEqual(notRetriedTests.length, 1)
+            assert.strictEqual(notRetriedTests[0].meta[TEST_STATUS], 'pass')
+            assert.ok(!(TEST_IS_RETRY in notRetriedTests[0].meta))
+            assert.ok(!(TEST_RETRY_REASON in notRetriedTests[0].meta))
+
+            const mixedNonConcurrentTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent flaky test retries can retry non-concurrent tests in a mixed suite'
+            )
+            assert.strictEqual(mixedNonConcurrentTests.length, 2)
+            assert.strictEqual(mixedNonConcurrentTests.filter(test => test.meta[TEST_STATUS] === 'fail').length, 1)
+            assert.strictEqual(mixedNonConcurrentTests.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
+            assert.strictEqual(
+              mixedNonConcurrentTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr)
+                .length,
+              1
+            )
+          })
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/concurrent-flaky-test-retries.mjs',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '2',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 1)
+      })
+
+      it('supports test.concurrent with early flake detection', async () => {
+        receiver.setKnownTests({ vitest: {} })
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            const testSession = events.find(event => event.type === 'test_session_end').content
+
+            assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+            assert.strictEqual(tests.length, (NUM_RETRIES_EFD + 1) * 3)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD * 3)
+            for (const test of tests) {
+              assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
+            }
+            for (const test of retriedTests) {
+              assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+            }
+
+            const eventuallyPassingTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent early flake detection can retry concurrent tests that eventually pass'
+            )
+            assert.strictEqual(eventuallyPassingTests.length, NUM_RETRIES_EFD + 1)
+            assert.strictEqual(eventuallyPassingTests.filter(test => test.meta[TEST_STATUS] === 'fail').length, 1)
+            assert.strictEqual(
+              eventuallyPassingTests.filter(test => test.meta[TEST_STATUS] === 'pass').length,
+              NUM_RETRIES_EFD
+            )
+
+            const alwaysPassingTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent early flake detection can retry concurrent tests that always pass'
+            )
+            assert.strictEqual(alwaysPassingTests.length, NUM_RETRIES_EFD + 1)
+            assert.strictEqual(alwaysPassingTests.filter(test => test.meta[TEST_STATUS] === 'pass').length,
+              NUM_RETRIES_EFD + 1)
+
+            const mixedNonConcurrentTests = tests.filter(
+              test => test.meta[TEST_NAME] ===
+                'concurrent early flake detection can retry non-concurrent tests in a mixed suite'
+            )
+            assert.strictEqual(mixedNonConcurrentTests.length, NUM_RETRIES_EFD + 1)
+            assert.strictEqual(mixedNonConcurrentTests.filter(test => test.meta[TEST_STATUS] === 'pass').length,
+              NUM_RETRIES_EFD + 1)
+          })
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/concurrent-early-flake-detection.mjs',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 0)
       })
     })
 

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -904,6 +904,32 @@ versions.forEach((version) => {
           )
           assert.strictEqual(cleanupHookHttpSpans.length, 2,
             'should have 2 http spans from beforeEach and its returned cleanup as children of test span')
+
+          const concurrentHookTestNames = [
+            'vitest-test-concurrent-hook-http first concurrent hook http is linked to first test span',
+            'vitest-test-concurrent-hook-http second concurrent hook http is linked to second test span',
+            'vitest-describe-concurrent-hook-http first inherited concurrent hook http is linked to first test span',
+            'vitest-describe-concurrent-hook-http second inherited concurrent hook http is linked to second test span',
+            'vitest-mixed-concurrent-hook-http serial hook http is linked to serial test span',
+            'vitest-mixed-concurrent-hook-http first mixed concurrent hook http is linked to first test span',
+            'vitest-mixed-concurrent-hook-http second mixed concurrent hook http is linked to second test span',
+          ]
+          for (const testName of concurrentHookTestNames) {
+            const concurrentHookTestSpan = tests.find(test => test.meta[TEST_NAME] === testName)
+            assert.ok(concurrentHookTestSpan, `should have concurrent hook test span for ${testName}`)
+            assert.strictEqual(concurrentHookTestSpan.meta[TEST_STATUS], 'pass')
+
+            const concurrentHookHttpSpans = spans.filter(span =>
+              span.name === 'http.request' &&
+              span.trace_id.toString() === concurrentHookTestSpan.trace_id.toString() &&
+              span.parent_id.toString() === concurrentHookTestSpan.span_id.toString()
+            )
+            assert.strictEqual(
+              concurrentHookHttpSpans.length,
+              3,
+              `should have beforeEach, test body, and afterEach HTTP spans as children of ${testName}`
+            )
+          }
         }, 25000)
 
       childProcess = exec(
@@ -2510,6 +2536,59 @@ versions.forEach((version) => {
               done()
             }).catch(done)
           })
+        })
+
+        it('does not run Failed Test Replay for files with concurrent tests', async () => {
+          receiver.setSettings({
+            flaky_test_retries_enabled: true,
+            di_enabled: true,
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+
+              assert.strictEqual(retriedTests.length, 1)
+              const [retriedTest] = retriedTests
+              assert.strictEqual(
+                retriedTest.meta[TEST_NAME],
+                'dynamic instrumentation with concurrent tests serial retry does not use Failed Test Replay'
+              )
+
+              const hasDebugTags = Object.keys(retriedTest.meta)
+                .some(property =>
+                  property.startsWith(DI_DEBUG_ERROR_PREFIX) || property === DI_ERROR_DEBUG_INFO_CAPTURED
+                )
+              assert.strictEqual(hasDebugTags, false)
+            })
+
+          const logsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/logs'), (payloads) => {
+              if (payloads.length > 0) {
+                throw new Error('Unexpected logs')
+              }
+            }, 5000)
+
+          childProcess = exec(
+            './node_modules/.bin/vitest run --retry=1',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                TEST_DIR: 'ci-visibility/vitest-tests/concurrent-ftr-disabled.mjs',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              },
+            }
+          )
+
+          const [[exitCode]] = await Promise.all([
+            once(childProcess, 'exit'),
+            eventsPromise,
+            logsPromise,
+          ])
+          assert.strictEqual(exitCode, 0)
         })
 
         it('does not crash if the retry does not hit the breakpoint', (done) => {

--- a/integration-tests/vitest/vitest.test-management.spec.js
+++ b/integration-tests/vitest/vitest.test-management.spec.js
@@ -33,6 +33,38 @@ const { NODE_MAJOR } = require('../../version')
 // vitest@4.x requires Node.js >= 20
 const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 
+function assertAttemptToFixFailures (tests, testName) {
+  const attemptedToFixTests = tests
+    .filter(test => test.meta[TEST_NAME] === testName)
+    .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+  assert.strictEqual(attemptedToFixTests.length, 4)
+  attemptedToFixTests.forEach((test, index) => {
+    const isFirstAttempt = index === 0
+    const isLastAttempt = index === attemptedToFixTests.length - 1
+
+    assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+    assert.strictEqual(test.meta[TEST_STATUS], 'fail')
+    if (isFirstAttempt) {
+      assert.ok(!(TEST_IS_RETRY in test.meta))
+      assert.ok(!(TEST_RETRY_REASON in test.meta))
+      assert.ok(!(TEST_FINAL_STATUS in test.meta))
+    } else {
+      assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+      assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atf)
+    }
+
+    if (isLastAttempt) {
+      assert.strictEqual(test.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+      assert.strictEqual(test.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+      assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'fail')
+    } else {
+      assert.ok(!(TEST_HAS_FAILED_ALL_RETRIES in test.meta))
+      assert.ok(!(TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED in test.meta))
+    }
+  })
+}
+
 versions.forEach((version) => {
   describe(`vitest@${version}`, () => {
     let cwd, receiver, childProcess
@@ -161,6 +193,136 @@ versions.forEach((version) => {
 
     if (version === 'latest') {
       context('test management', () => {
+        it('supports test.concurrent with test management features', async () => {
+          const attemptToFixTestName = 'concurrent test management can attempt to fix a concurrent test'
+          const disabledTestName = 'concurrent test management can disable a concurrent test'
+          const quarantinedTestName = 'concurrent test management can quarantine a concurrent test'
+          const passingTestName = 'concurrent test management can pass normally in a concurrent management suite'
+          const nonConcurrentAttemptToFixTestName =
+            'concurrent test management can attempt to fix a non-concurrent test in a mixed management suite'
+          const nonConcurrentDisabledTestName =
+            'concurrent test management can disable a non-concurrent test in a mixed management suite'
+          const nonConcurrentPassingTestName =
+            'concurrent test management can pass normally beside concurrent management tests'
+
+          receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
+          receiver.setTestManagementTests({
+            vitest: {
+              suites: {
+                'ci-visibility/vitest-tests/test-management-concurrent.mjs': {
+                  tests: {
+                    [attemptToFixTestName]: {
+                      properties: {
+                        attempt_to_fix: true,
+                      },
+                    },
+                    [disabledTestName]: {
+                      properties: {
+                        disabled: true,
+                      },
+                    },
+                    [quarantinedTestName]: {
+                      properties: {
+                        quarantined: true,
+                      },
+                    },
+                    [nonConcurrentAttemptToFixTestName]: {
+                      properties: {
+                        attempt_to_fix: true,
+                      },
+                    },
+                    [nonConcurrentDisabledTestName]: {
+                      properties: {
+                        disabled: true,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const testSession = events.find(event => event.type === 'test_session_end').content
+
+              assert.strictEqual(testSession.meta[TEST_MANAGEMENT_ENABLED], 'true')
+
+              assertAttemptToFixFailures(tests, attemptToFixTestName)
+              assertAttemptToFixFailures(tests, nonConcurrentAttemptToFixTestName)
+
+              const disabledTest = tests.find(test => test.meta[TEST_NAME] === disabledTestName)
+              assert.ok(disabledTest, 'Expected to find disabled concurrent test')
+              assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+              assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
+
+              const nonConcurrentDisabledTest = tests.find(
+                test => test.meta[TEST_NAME] === nonConcurrentDisabledTestName
+              )
+              assert.ok(nonConcurrentDisabledTest, 'Expected to find disabled non-concurrent test')
+              assert.strictEqual(nonConcurrentDisabledTest.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(nonConcurrentDisabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+              assert.strictEqual(nonConcurrentDisabledTest.meta[TEST_FINAL_STATUS], 'skip')
+
+              const quarantinedTest = tests.find(test => test.meta[TEST_NAME] === quarantinedTestName)
+              assert.ok(quarantinedTest, 'Expected to find quarantined concurrent test')
+              assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+              assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
+
+              const passingTest = tests.find(test => test.meta[TEST_NAME] === passingTestName)
+              assert.ok(passingTest, 'Expected to find passing concurrent test')
+              assert.strictEqual(passingTest.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(passingTest.meta[TEST_FINAL_STATUS], 'pass')
+              assert.ok(!(TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX in passingTest.meta))
+              assert.ok(!(TEST_MANAGEMENT_IS_DISABLED in passingTest.meta))
+              assert.ok(!(TEST_MANAGEMENT_IS_QUARANTINED in passingTest.meta))
+
+              const nonConcurrentPassingTest = tests.find(test => test.meta[TEST_NAME] === nonConcurrentPassingTestName)
+              assert.ok(nonConcurrentPassingTest, 'Expected to find passing non-concurrent test')
+              assert.strictEqual(nonConcurrentPassingTest.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(nonConcurrentPassingTest.meta[TEST_FINAL_STATUS], 'pass')
+              assert.ok(!(TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX in nonConcurrentPassingTest.meta))
+              assert.ok(!(TEST_MANAGEMENT_IS_DISABLED in nonConcurrentPassingTest.meta))
+              assert.ok(!(TEST_MANAGEMENT_IS_QUARANTINED in nonConcurrentPassingTest.meta))
+            })
+
+          let stdout = ''
+          childProcess = exec(
+            './node_modules/.bin/vitest run',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                TEST_DIR: 'ci-visibility/vitest-tests/test-management-concurrent.mjs',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init --no-warnings',
+              },
+            }
+          )
+
+          childProcess.stdout?.on('data', (data) => {
+            stdout += data
+          })
+          childProcess.stderr?.on('data', (data) => {
+            stdout += data
+          })
+
+          const [[exitCode]] = await Promise.all([
+            once(childProcess, 'exit'),
+            eventsPromise,
+          ])
+
+          assert.match(stdout, /I am running concurrent attempt to fix/)
+          assert.match(stdout, /I am running non-concurrent attempt to fix/)
+          assert.doesNotMatch(stdout, /I am running concurrent disabled/)
+          assert.doesNotMatch(stdout, /I am running non-concurrent disabled/)
+          assert.match(stdout, /I am running concurrent quarantined/)
+          assert.strictEqual(exitCode, 1)
+        })
+
         context('attempt to fix', () => {
           beforeEach(() => {
             receiver.setTestManagementTests({

--- a/packages/datadog-instrumentations/src/vitest-worker.js
+++ b/packages/datadog-instrumentations/src/vitest-worker.js
@@ -39,21 +39,22 @@ const taskToTestProperties = new WeakMap()
 const taskToStatuses = new WeakMap()
 const taskToReportedErrorCount = new WeakMap()
 const attemptToFixTaskToStatuses = new WeakMap()
+const fileToHasConcurrentTests = new WeakMap()
 const originalHookFns = new WeakMap()
 const newTasks = new WeakSet()
 const dynamicNameTasks = new WeakSet()
 const disabledTasks = new WeakSet()
 const quarantinedTasks = new WeakSet()
 const attemptToFixTasks = new WeakSet()
+const attemptToFixRetryTasks = new WeakSet()
 const modifiedTasks = new WeakSet()
+const efdRetryTasks = new WeakSet()
 const efdDeterminedRetries = new WeakMap()
 const efdSlowAbortedTasks = new WeakSet()
 const efdExecutionStartByTask = new WeakMap()
 const efdSkippedRetryResults = new WeakMap()
 const attemptToFixExecutions = new Map()
 const loggedAttemptToFixTests = new Set()
-let isRetryReasonEfd = false
-let isRetryReasonAttemptToFix = false
 const switchedStatuses = new WeakSet()
 let vitestGetFn = null
 let vitestSetFn = null
@@ -138,6 +139,70 @@ function wrapBeforeEachCleanupResult (task, result) {
   return result
 }
 
+/**
+ * Returns whether a Vitest task tree includes any concurrent task.
+ *
+ * @param {Array<{ type?: string, concurrent?: boolean, tasks?: object[] }>|undefined} tasks
+ * @returns {boolean}
+ */
+function hasConcurrentTask (tasks) {
+  if (!tasks) return false
+
+  for (const task of tasks) {
+    if (task.concurrent === true) return true
+    if (hasConcurrentTask(task.tasks)) return true
+  }
+
+  return false
+}
+
+/**
+ * Returns whether a Vitest file includes any concurrent test.
+ *
+ * @param {{ tasks?: object[] }} file
+ * @returns {boolean}
+ */
+function hasConcurrentTests (file) {
+  const cached = fileToHasConcurrentTests.get(file)
+  if (cached !== undefined) return cached
+
+  const hasConcurrent = hasConcurrentTask(file.tasks)
+  fileToHasConcurrentTests.set(file, hasConcurrent)
+  return hasConcurrent
+}
+
+/**
+ * Gets the task associated with a Vitest hook invocation.
+ *
+ * @param {unknown[]} args
+ * @param {object} fallbackTask
+ * @returns {object}
+ */
+function getTaskFromHookArgs (args, fallbackTask) {
+  return args[0]?.task || fallbackTask
+}
+
+/**
+ * Wraps a Vitest hook so it runs inside the span context for the current test.
+ *
+ * @param {'beforeEach'|'afterEach'} hookType
+ * @param {Function} fn
+ * @param {object} fallbackTask
+ * @returns {Function}
+ */
+function wrapSuiteHookFn (hookType, fn, fallbackTask) {
+  return shimmer.wrapFunction(fn, fn => function (...args) {
+    const task = getTaskFromHookArgs(args, fallbackTask)
+    const result = testFnCh.runStores(taskToCtx.get(task), () => fn.apply(this, args))
+
+    if (hookType === 'beforeEach') {
+      return wrapBeforeEachCleanupResult(task, result)
+    }
+
+    return result
+  })
+}
+
 function wrapVitestTestRunner (VitestTestRunner) {
   // `onBeforeRunTask` is run before any repetition or attempt is run
   // `onBeforeRunTask` is an async function
@@ -163,7 +228,9 @@ function wrapVitestTestRunner (VitestTestRunner) {
         isQuarantined,
       } = testProperties
       if (isAttemptToFix) {
-        isRetryReasonAttemptToFix = task.repeats !== testManagementAttemptToFixRetries
+        if (task.repeats !== testManagementAttemptToFixRetries) {
+          attemptToFixRetryTasks.add(task)
+        }
         disableFrameworkRetries(task)
         task.repeats = testManagementAttemptToFixRetries
         attemptToFixTasks.add(task)
@@ -183,7 +250,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
 
     if (isImpactedTestsEnabled && testProperties.isModified) {
       if (isEarlyFlakeDetectionEnabled) {
-        isRetryReasonEfd = true
+        efdRetryTasks.add(task)
         disableFrameworkRetries(task)
         task.repeats = numRepeats
       }
@@ -193,7 +260,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
 
     if (isKnownTestsEnabled && testProperties.isNew && !attemptToFixTasks.has(task)) {
       if (isEarlyFlakeDetectionEnabled && !modifiedTasks.has(task)) {
-        isRetryReasonEfd = true
+        efdRetryTasks.add(task)
         disableFrameworkRetries(task)
         task.repeats = numRepeats
       }
@@ -267,6 +334,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
     }
 
     const { retry: numAttempt, repeats: numRepetition } = retryInfo
+    const isFailedTestReplayAllowed = !hasConcurrentTests(task.file)
     const isEfdManagedTask = isEarlyFlakeDetectionEnabled && taskToStatuses.has(task) && !attemptToFixTasks.has(task)
 
     if (isEfdManagedTask && numRepetition > 0 && !efdDeterminedRetries.has(task)) {
@@ -303,13 +371,13 @@ function wrapVitestTestRunner (VitestTestRunner) {
 
     // We finish the previous test here because we know it has failed already
     if (numAttempt > 0) {
-      const shouldWaitForHitProbe = isDiEnabled && numAttempt > 1
+      const shouldWaitForHitProbe = isDiEnabled && isFailedTestReplayAllowed && numAttempt > 1
       if (shouldWaitForHitProbe) {
         await waitForHitProbe()
       }
 
       const promises = {}
-      const shouldSetProbe = isDiEnabled && numAttempt === 1
+      const shouldSetProbe = isDiEnabled && isFailedTestReplayAllowed && numAttempt === 1
       const ctx = taskToCtx.get(task)
       const testError = getCurrentAttemptTestError(task, task.result?.errors)
       if (ctx) {
@@ -377,18 +445,18 @@ function wrapVitestTestRunner (VitestTestRunner) {
 
     const isRetryReasonAtr = numAttempt > 0 &&
       isFlakyTestRetriesEnabledForTask(providedContext, task) &&
-      !isRetryReasonAttemptToFix &&
-      !isRetryReasonEfd
+      !attemptToFixRetryTasks.has(task) &&
+      !efdRetryTasks.has(task)
 
     const ctx = {
       testName,
       testSuiteAbsolutePath: task.file.filepath,
       isRetry: numAttempt > 0 || numRepetition > 0,
-      isRetryReasonEfd,
-      isRetryReasonAttemptToFix: isRetryReasonAttemptToFix && numRepetition > 0,
+      isRetryReasonEfd: efdRetryTasks.has(task),
+      isRetryReasonAttemptToFix: attemptToFixRetryTasks.has(task) && numRepetition > 0,
       isNew,
       hasDynamicName: dynamicNameTasks.has(task),
-      mightHitProbe: isDiEnabled && numAttempt > 0,
+      mightHitProbe: isDiEnabled && isFailedTestReplayAllowed && numAttempt > 0,
       isAttemptToFix: attemptToFixTasks.has(task),
       isDisabled: disabledTasks.has(task),
       isQuarantined: quarantinedTasks.has(task),
@@ -429,17 +497,9 @@ function wrapVitestTestRunner (VitestTestRunner) {
           if (!hookArray) continue
           for (let i = 0; i < hookArray.length; i++) {
             const currentFn = hookArray[i]
-            const originalFn = originalHookFns.get(currentFn) || currentFn
-            const wrappedFn = shimmer.wrapFunction(originalFn, fn => function (...args) {
-              const result = testFnCh.runStores(taskToCtx.get(task), () => fn.apply(this, args))
-
-              if (hookType === 'beforeEach') {
-                return wrapBeforeEachCleanupResult(task, result)
-              }
-
-              return result
-            })
-            originalHookFns.set(wrappedFn, originalFn)
+            if (originalHookFns.has(currentFn)) continue
+            const wrappedFn = wrapSuiteHookFn(hookType, currentFn, task)
+            originalHookFns.set(wrappedFn, currentFn)
             hookArray[i] = wrappedFn
           }
         }
@@ -468,6 +528,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
       const ctx = taskToCtx.get(task)
 
       const { isDiEnabled } = getProvidedContext()
+      const isFailedTestReplayAllowed = !hasConcurrentTests(task.file)
 
       if (efdSkippedRetryResults.has(task)) {
         task.result = efdSkippedRetryResults.get(task)
@@ -475,7 +536,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
         return result
       }
 
-      if (isDiEnabled && retryInfo.retry > 1) {
+      if (isDiEnabled && isFailedTestReplayAllowed && retryInfo.retry > 1) {
         await waitForHitProbe()
       }
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds support for Vitest `test.concurrent` in Test Optimization when retries, early flake detection, impacted tests, test management, and hook context propagation are enabled.

### Motivation
<!-- What inspired you to submit this pull request? -->

Vitest can interleave concurrent tasks in the same worker. The worker instrumentation had task state that was effectively process-global for retry reasons, and shared suite hooks were repeatedly wrapped with a task-specific closure. That could attribute retry metadata or hook-created spans to the wrong test when concurrent tests ran together.

This keeps the existing Test Optimization session definition: one test session and module for the Vitest invocation, with each concurrent test reported as its own test span under that session.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Ports the original PR onto the current split Vitest instrumentation (`vitest-main.js`, `vitest-worker.js`, `vitest-util.js`).
- Stores retry-reason state per Vitest task instead of in process-global booleans.
- Wraps suite hooks once and resolves the active task from Vitest hook arguments.
- Disables Failed Test Replay for every test in a Vitest file that contains any concurrent task, because probe ownership is still plugin-global.
