### PR TITLE
test(ci-visibility): disable real net access in git_metadata

### DIFF
--- a/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
+++ b/packages/dd-trace/test/ci-visibility/exporters/git/git_metadata.spec.js
@@ -37,11 +37,16 @@ describe('git_metadata', () => {
   before(() => {
     fs.writeFileSync(temporaryPackFile, '')
     fs.writeFileSync(secondTemporaryPackFile, '')
+    // Any request that escapes a nock interceptor used to hang up to the per
+    // request 15 s timeout and blow the mocha wall on slow Windows CI; flip the
+    // failure into an immediate `NetConnectNotAllowedError` at the call site.
+    nock.disableNetConnect()
   })
 
   after(() => {
     fs.unlinkSync(temporaryPackFile)
     fs.unlinkSync(secondTemporaryPackFile)
+    nock.enableNetConnect()
   })
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

Unintercepted requests in `git_metadata.spec` used to hang two 15 s `request.timeout` windows back-to-back and blow the mocha 30 s wall on slow Windows CI with no diagnostic for which call wasn't mocked. `nock.disableNetConnect()` in the `before` hook flips that failure into an immediate `NetConnectNotAllowedError` naming the leaked URL.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/25365185786/job/74374126693