### PR TITLE
[test optimization] Mitigate `vitest` flakiness 

### DIFF
--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -887,12 +887,12 @@ versions.forEach((version) => {
         })
       })
 
-      it('uses the retry count from the matching slow_test_retries bucket', (done) => {
+      it('uses the retry count from the matching slow_test_retries bucket', async () => {
         receiver.setSettings({
           early_flake_detection: {
             enabled: true,
             slow_test_retries: {
-              '5s': 2,
+              '5s': 1,
               '10s': 0,
             },
             faulty_session_threshold: 100,
@@ -912,10 +912,10 @@ versions.forEach((version) => {
             const instantTests = tests.filter(test =>
               test.meta[TEST_NAME] === 'early flake detection can retry tests that always pass'
             )
-            assert.strictEqual(instantTests.length, 3)
+            assert.strictEqual(instantTests.length, 2)
             assert.strictEqual(
               instantTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd).length,
-              2
+              1
             )
 
             const slowTests = tests.filter(test =>
@@ -925,10 +925,10 @@ versions.forEach((version) => {
             assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
             assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
             assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
-          }, 70_000)
+          }, 55_000)
 
         childProcess = exec(
-          './node_modules/.bin/vitest run',
+          './node_modules/.bin/vitest run -t "can retry tests that always pass|slightly slow duration bucket test"',
           {
             cwd,
             env: {
@@ -940,12 +940,8 @@ versions.forEach((version) => {
           }
         )
 
-        childProcess.on('exit', (exitCode) => {
-          eventsPromise.then(() => {
-            assert.strictEqual(exitCode, 0)
-            done()
-          }).catch(done)
-        })
+        const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        assert.strictEqual(exitCode, 0)
       })
 
       it('fails if all the attempts fail', (done) => {


### PR DESCRIPTION

### What does this PR do?

Make the test faster by making `vitest` run fewer tests. Also, reduce the timeout of the `gatherPayloadsMaxTimeout` call to be smaller than the test's timeout (60s) otherwise the only error we end up seeing is a timeout. 

### Motivation
Newly added tests are flaking https://github.com/DataDog/dd-trace-js/actions/runs/25655606103 after merging https://github.com/DataDog/dd-trace-js/pull/8288

