### PR TITLE
test(ci-visibility): gather payloads until child exits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,6 +121,7 @@
 /integration-tests/vitest/ @DataDog/ci-app-libraries
 /integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
+/integration-tests/ci-visibility-intake.spec.js @DataDog/ci-app-libraries
 /integration-tests/CODEOWNERS @DataDog/ci-app-libraries
 /integration-tests/config-jest-multiproject.js @DataDog/ci-app-libraries
 /integration-tests/config-jest.js @DataDog/ci-app-libraries

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -369,19 +369,19 @@ class FakeCiVisIntake extends FakeAgent {
     return super.stop()
   }
 
-  // Gather payloads while childProcess runs; resolve as soon as onPayload accepts the
-  // buffer mid-stream, otherwise run onPayload once more after `gracePeriod` ms of
-  // post-exit drain. `hardTimeout` is a backstop for a genuinely hung child — bump it
-  // per-call only when a workload's child runtime is provably above the default.
+  // Gather payloads while childProcess runs, then run onPayload once on the
+  // accumulated buffer after the child emits `'exit'` plus `gracePeriod` ms of HTTP
+  // drain. `hardTimeout` is a backstop for a genuinely hung child — bump it per-call
+  // only when a workload's child runtime is provably above the default.
   /**
    * @param {import('child_process').ChildProcess | NodeJS.EventEmitter} childProcess
    *   Source of the `'exit'` event. `exitCode` / `signalCode` are read synchronously
    *   so a child that has already exited is handled correctly.
    * @param {(message: object) => boolean} [payloadMatch] Per-message filter; falsy
    *   accepts everything.
-   * @param {(payloads: object[]) => void} onPayload Assertion callback. Must be
-   *   idempotent over the same `payloads` reference — it is invoked once per match
-   *   and once more after the post-exit grace period.
+   * @param {(payloads: object[]) => void} onPayload Assertion callback, invoked once
+   *   on the post-exit buffer. Callers can read `childProcess.exitCode` immediately
+   *   after the returned promise resolves.
    * @param {{ gracePeriod?: number, hardTimeout?: number }} [options]
    */
   gatherPayloadsUntilChildExit (childProcess, payloadMatch, onPayload, options = {}) {
@@ -390,6 +390,7 @@ class FakeCiVisIntake extends FakeAgent {
 
     return new Promise((resolve, reject) => {
       let settled = false
+      let graceTimer = null
 
       const cleanup = () => {
         settled = true
@@ -399,30 +400,13 @@ class FakeCiVisIntake extends FakeAgent {
         clearTimeout(graceTimer)
       }
 
-      const finishGather = (final) => {
-        if (settled) return
-        try {
-          onPayload(payloads)
-          cleanup()
-          resolve()
-        } catch (error) {
-          if (!final) {
-            return
-          }
-          cleanup()
-          reject(error)
-        }
-      }
-
       const messageHandler = (message) => {
         if (settled) return
         if (!payloadMatch || payloadMatch(message)) {
           payloads.push(message)
-          finishGather(false)
         }
       }
 
-      let graceTimer = null
       const exitHandler = () => {
         if (settled) return
         graceTimer = setTimeout(() => {
@@ -435,7 +419,14 @@ class FakeCiVisIntake extends FakeAgent {
             ))
             return
           }
-          finishGather(true)
+          try {
+            onPayload(payloads)
+            cleanup()
+            resolve()
+          } catch (error) {
+            cleanup()
+            reject(error)
+          }
         }, gracePeriod)
       }
 

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -369,6 +369,95 @@ class FakeCiVisIntake extends FakeAgent {
     return super.stop()
   }
 
+  // Gather payloads while childProcess runs; resolve as soon as onPayload accepts the
+  // buffer mid-stream, otherwise run onPayload once more after `gracePeriod` ms of
+  // post-exit drain. `hardTimeout` is a backstop for a genuinely hung child — bump it
+  // per-call only when a workload's child runtime is provably above the default.
+  /**
+   * @param {import('child_process').ChildProcess | NodeJS.EventEmitter} childProcess
+   *   Source of the `'exit'` event. `exitCode` / `signalCode` are read synchronously
+   *   so a child that has already exited is handled correctly.
+   * @param {(message: object) => boolean} [payloadMatch] Per-message filter; falsy
+   *   accepts everything.
+   * @param {(payloads: object[]) => void} onPayload Assertion callback. Must be
+   *   idempotent over the same `payloads` reference — it is invoked once per match
+   *   and once more after the post-exit grace period.
+   * @param {{ gracePeriod?: number, hardTimeout?: number }} [options]
+   */
+  gatherPayloadsUntilChildExit (childProcess, payloadMatch, onPayload, options = {}) {
+    const { gracePeriod = 1000, hardTimeout = 30_000 } = options
+    const payloads = []
+
+    return new Promise((resolve, reject) => {
+      let settled = false
+
+      const cleanup = () => {
+        settled = true
+        this.off('message', messageHandler)
+        childProcess.off('exit', exitHandler)
+        clearTimeout(hardTimer)
+        clearTimeout(graceTimer)
+      }
+
+      const finishGather = (final) => {
+        if (settled) return
+        try {
+          onPayload(payloads)
+          cleanup()
+          resolve()
+        } catch (error) {
+          if (!final) {
+            return
+          }
+          cleanup()
+          reject(error)
+        }
+      }
+
+      const messageHandler = (message) => {
+        if (settled) return
+        if (!payloadMatch || payloadMatch(message)) {
+          payloads.push(message)
+          finishGather(false)
+        }
+      }
+
+      let graceTimer = null
+      const exitHandler = () => {
+        if (settled) return
+        graceTimer = setTimeout(() => {
+          if (settled) return
+          if (payloads.length === 0) {
+            cleanup()
+            reject(new Error(
+              'gatherPayloadsUntilChildExit: child exited with no matching payloads ' +
+              `(after ${gracePeriod}ms grace period)`
+            ))
+            return
+          }
+          finishGather(true)
+        }, gracePeriod)
+      }
+
+      const hardTimer = setTimeout(() => {
+        if (settled) return
+        cleanup()
+        reject(new Error(
+          `gatherPayloadsUntilChildExit: hard timeout of ${hardTimeout}ms expired (child still running)`
+        ))
+      }, hardTimeout)
+
+      this.on('message', messageHandler)
+
+      // Child may already have exited (very fast spawn-and-die).
+      if (childProcess.exitCode !== null || childProcess.signalCode != null) {
+        queueMicrotask(exitHandler)
+      } else {
+        childProcess.once('exit', exitHandler)
+      }
+    })
+  }
+
   // Similar to gatherPayloads but resolves if enough payloads have been gathered
   // to make the assertions pass. It times out after maxGatheringTime so it should
   // always be faster or as fast as gatherPayloads

--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -409,6 +409,12 @@ class FakeCiVisIntake extends FakeAgent {
 
       const exitHandler = () => {
         if (settled) return
+        // Hung-child backstop is moot once the child has exited; only the
+        // grace period applies from here. Without this, a child exiting
+        // close to `hardTimeout` races the grace timer and rejects with a
+        // wrong "child still running" message instead of running the
+        // assertion.
+        clearTimeout(hardTimer)
         graceTimer = setTimeout(() => {
           if (settled) return
           if (payloads.length === 0) {

--- a/integration-tests/ci-visibility-intake.spec.js
+++ b/integration-tests/ci-visibility-intake.spec.js
@@ -129,6 +129,25 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     await assert.rejects(promise, /hard timeout of 100ms/)
   })
 
+  it('does not surface a hard-timeout error when the child exits just before the backstop', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assert.strictEqual(payloads.length, 1)
+      },
+      { gracePeriod: 50, hardTimeout: 100 }
+    )
+
+    setTimeout(() => {
+      intake.emit('message', { url: '/api/v2/citestcycle', payload: {} })
+      child.simulateExit(0)
+    }, 80)
+
+    await promise
+  })
+
   it('treats a child that already exited as exit + grace', async () => {
     const child = fakeChildProcess()
     child.exitCode = 0

--- a/integration-tests/ci-visibility-intake.spec.js
+++ b/integration-tests/ci-visibility-intake.spec.js
@@ -25,29 +25,13 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
 
   afterEach(() => intake.stop())
 
-  it('resolves immediately when the caller assertion passes on an early payload', async () => {
+  it('runs the assertion once after child exit + grace and resolves on success', async () => {
     const child = fakeChildProcess()
     const promise = intake.gatherPayloadsUntilChildExit(
       child,
       ({ url }) => url === '/api/v2/citestcycle',
       (payloads) => {
-        assert.strictEqual(payloads.length, 1)
-      },
-      { gracePeriod: 50, hardTimeout: 5000 }
-    )
-
-    intake.emit('message', { url: '/api/v2/citestcycle', payload: {} })
-
-    await promise
-  })
-
-  it('resolves after child exit + grace when the assertion only passes once all events are in', async () => {
-    const child = fakeChildProcess()
-    const promise = intake.gatherPayloadsUntilChildExit(
-      child,
-      ({ url }) => url === '/api/v2/citestcycle',
-      (payloads) => {
-        assert.strictEqual(payloads.length, 3, 'expected exactly three payloads')
+        assert.strictEqual(payloads.length, 3)
       },
       { gracePeriod: 50, hardTimeout: 5000 }
     )
@@ -60,7 +44,29 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     await promise
   })
 
-  it('still picks up payloads that arrive during the grace period after child exit', async () => {
+  it('does not resolve before child exit, even when the buffer would satisfy the assertion', async () => {
+    const child = fakeChildProcess()
+    let assertionRuns = 0
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assertionRuns += 1
+        assert.strictEqual(payloads.length, 1)
+      },
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    assert.strictEqual(assertionRuns, 0, 'onPayload must not run before child exit')
+
+    child.simulateExit(0)
+    await promise
+    assert.strictEqual(assertionRuns, 1, 'onPayload runs exactly once on the post-exit buffer')
+  })
+
+  it('picks up payloads that arrive during the grace period after child exit', async () => {
     const child = fakeChildProcess()
     const promise = intake.gatherPayloadsUntilChildExit(
       child,
@@ -94,7 +100,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     await assert.rejects(promise, /child exited with no matching payloads/)
   })
 
-  it('rejects with the caller assertion error when payloads arrived but the assertion fails', async () => {
+  it('rejects with the caller assertion error when the post-exit buffer fails the assertion', async () => {
     const child = fakeChildProcess()
     const promise = intake.gatherPayloadsUntilChildExit(
       child,
@@ -111,7 +117,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     await assert.rejects(promise, /expected five payloads/)
   })
 
-  it('rejects with a hard-timeout error when the child neither exits nor satisfies the assertion', async () => {
+  it('rejects with a hard-timeout error when the child neither exits nor produces payloads', async () => {
     const child = fakeChildProcess()
     const promise = intake.gatherPayloadsUntilChildExit(
       child,
@@ -123,7 +129,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     await assert.rejects(promise, /hard timeout of 100ms/)
   })
 
-  it('treats a child that already exited as exit + grace, with no pre-subscribe payloads', async () => {
+  it('treats a child that already exited as exit + grace', async () => {
     const child = fakeChildProcess()
     child.exitCode = 0
 
@@ -132,7 +138,7 @@ describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
     const promise = intake.gatherPayloadsUntilChildExit(
       child,
       ({ url }) => url === '/api/v2/citestcycle',
-      () => assert.fail('onPayload must not run when no payloads matched'),
+      () => assert.fail('pre-subscribe payloads must not be captured'),
       { gracePeriod: 50, hardTimeout: 5000 }
     )
 

--- a/integration-tests/ci-visibility-intake.spec.js
+++ b/integration-tests/ci-visibility-intake.spec.js
@@ -1,0 +1,141 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+
+const { FakeCiVisIntake } = require('./ci-visibility-intake')
+
+function fakeChildProcess () {
+  const child = new EventEmitter()
+  child.exitCode = null
+  child.signalCode = null
+  child.simulateExit = (code = 0) => {
+    child.exitCode = code
+    child.emit('exit', code, null)
+  }
+  return child
+}
+
+describe('FakeCiVisIntake.gatherPayloadsUntilChildExit', () => {
+  let intake
+
+  beforeEach(async () => {
+    intake = await new FakeCiVisIntake().start()
+  })
+
+  afterEach(() => intake.stop())
+
+  it('resolves immediately when the caller assertion passes on an early payload', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assert.strictEqual(payloads.length, 1)
+      },
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: {} })
+
+    await promise
+  })
+
+  it('resolves after child exit + grace when the assertion only passes once all events are in', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assert.strictEqual(payloads.length, 3, 'expected exactly three payloads')
+      },
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 2 } })
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 3 } })
+    child.simulateExit(0)
+
+    await promise
+  })
+
+  it('still picks up payloads that arrive during the grace period after child exit', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assert.strictEqual(payloads.length, 2)
+      },
+      { gracePeriod: 100, hardTimeout: 5000 }
+    )
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
+    child.simulateExit(0)
+    setImmediate(() => {
+      intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 2 } })
+    })
+
+    await promise
+  })
+
+  it('rejects with a clear error when the child exits without any matching payloads', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      () => false,
+      () => assert.fail('onPayload must not run when no payloads matched'),
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+
+    child.simulateExit(1)
+
+    await assert.rejects(promise, /child exited with no matching payloads/)
+  })
+
+  it('rejects with the caller assertion error when payloads arrived but the assertion fails', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      (payloads) => {
+        assert.strictEqual(payloads.length, 5, 'expected five payloads')
+      },
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: { i: 1 } })
+    child.simulateExit(0)
+
+    await assert.rejects(promise, /expected five payloads/)
+  })
+
+  it('rejects with a hard-timeout error when the child neither exits nor satisfies the assertion', async () => {
+    const child = fakeChildProcess()
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      () => false,
+      () => {},
+      { gracePeriod: 50, hardTimeout: 100 }
+    )
+
+    await assert.rejects(promise, /hard timeout of 100ms/)
+  })
+
+  it('treats a child that already exited as exit + grace, with no pre-subscribe payloads', async () => {
+    const child = fakeChildProcess()
+    child.exitCode = 0
+
+    intake.emit('message', { url: '/api/v2/citestcycle', payload: {} })
+
+    const promise = intake.gatherPayloadsUntilChildExit(
+      child,
+      ({ url }) => url === '/api/v2/citestcycle',
+      () => assert.fail('onPayload must not run when no payloads matched'),
+      { gracePeriod: 50, hardTimeout: 5000 }
+    )
+
+    await assert.rejects(promise, /child exited with no matching payloads/)
+  })
+})

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -194,23 +194,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 2)
-
-            // new tests are detected but not retried
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 1)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.strictEqual(retriedTests.length, 0)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-          }, 25000)
-
         const specToRun = 'cypress/e2e/spec.cy.js'
         childProcess = exec(
           version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
@@ -225,10 +208,25 @@ moduleTypes.forEach(({
           }
         )
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          receiverPromise,
-        ])
+        await receiver.gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            assert.strictEqual(tests.length, 2)
+
+            // new tests are detected but not retried
+            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+            assert.strictEqual(newTests.length, 1)
+
+            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+            assert.strictEqual(retriedTests.length, 0)
+
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+          }
+        )
       })
     })
 
@@ -236,19 +234,6 @@ moduleTypes.forEach(({
     if (version === 'latest') {
       it('does not crash for multi origin tests', async () => {
         const envVars = getCiVisEvpProxyConfig(receiver.port)
-
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-              .filter(event => event.type !== 'span')
-            assert.strictEqual(events.length, 4)
-
-            const test = events.find(event => event.type === 'test').content
-            assert.strictEqual(test.resource, 'cypress/e2e/multi-origin.js.tests multiple origins')
-            assert.strictEqual(test.meta[TEST_STATUS], 'pass')
-            // cypress@latest esm + multi-origin browser context switching adds cold-start overhead
-            // the suite-level `warmCypressBinary` (commonJS path) doesn't reach.
-          }, 50_000)
 
         secondWebAppServer = http.createServer((req, res) => {
           res.setHeader('Content-Type', 'text/html')
@@ -282,26 +267,30 @@ moduleTypes.forEach(({
         )
 
         await Promise.all([
-          once(childProcess, 'exit'),
           once(childProcess.stdout, 'end'),
           once(childProcess.stderr, 'end'),
-          receiverPromise,
+          // cypress@latest esm + multi-origin browser context switching adds cold-start overhead
+          // that the suite-level `warmCypressBinary` (commonJS path) doesn't reach, so this one
+          // child run takes measurably longer than the rest of the suite and earns its own backstop.
+          receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+                .filter(event => event.type !== 'span')
+              assert.strictEqual(events.length, 4)
+
+              const test = events.find(event => event.type === 'test').content
+              assert.strictEqual(test.resource, 'cypress/e2e/multi-origin.js.tests multiple origins')
+              assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+            },
+            { hardTimeout: 50_000 }
+          ),
         ])
       })
     }
 
     it('sets _dd.test.is_user_provided_service to true if DD_SERVICE is used', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const testEvents = events.filter(event => event.type === 'test')
-
-          testEvents.forEach(({ content: { meta } }) => {
-            assert.strictEqual(meta[DD_TEST_IS_USER_PROVIDED_SERVICE], 'true')
-          })
-        }, 25000)
-
       const envVars = getCiVisEvpProxyConfig(receiver.port)
 
       childProcess = exec(
@@ -317,10 +306,19 @@ moduleTypes.forEach(({
         }
       )
 
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
+      await receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.endsWith('/api/v2/citestcycle'),
+        payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testEvents = events.filter(event => event.type === 'test')
+
+          testEvents.forEach(({ content: { meta } }) => {
+            assert.strictEqual(meta[DD_TEST_IS_USER_PROVIDED_SERVICE], 'true')
+          })
+        }
+      )
     })
 
     context('test management', () => {
@@ -343,15 +341,15 @@ moduleTypes.forEach(({
           })
         })
 
-        const getTestAssertions = ({
+        const awaitTestAssertions = ({
           isAttemptToFix,
           shouldAlwaysPass,
           shouldFailSometimes,
           isQuarantined,
           isDisabled,
-        }) =>
+        }, child) =>
           receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            .gatherPayloadsUntilChildExit(child, ({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
               const events = payloads.flatMap(({ payload }) => payload.events)
               const tests = events.filter(event => event.type === 'test').map(event => event.content)
               const testSession = events.find(event => event.type === 'test_session_end').content
@@ -420,7 +418,7 @@ moduleTypes.forEach(({
                   }
                 }
               }
-            }, 25000)
+            })
 
         /**
          * @param {{
@@ -440,13 +438,6 @@ moduleTypes.forEach(({
           isDisabled,
           extraEnvVars = {},
         } = {}) => {
-          const testAssertionsPromise = getTestAssertions({
-            isAttemptToFix,
-            shouldAlwaysPass,
-            shouldFailSometimes,
-            isQuarantined,
-            isDisabled,
-          })
           let stdout = ''
 
           const envVars = getCiVisEvpProxyConfig(receiver.port)
@@ -477,10 +468,13 @@ moduleTypes.forEach(({
             process.stderr.write(data)
           })
 
-          const [[exitCode]] = await Promise.all([
-            once(childProcess, 'exit'),
-            testAssertionsPromise,
-          ])
+          await awaitTestAssertions({
+            isAttemptToFix,
+            shouldAlwaysPass,
+            shouldFailSometimes,
+            isQuarantined,
+            isDisabled,
+          }, childProcess)
 
           if (isAttemptToFix) {
             assert.match(stdout, /Datadog Test Optimization: attempting to fix .*attempt to fix is attempt to fix/)
@@ -515,9 +509,9 @@ moduleTypes.forEach(({
           }
 
           if (shouldAlwaysPass) {
-            assert.strictEqual(exitCode, 0)
+            assert.strictEqual(childProcess.exitCode, 0)
           } else {
-            assert.strictEqual(exitCode, 1)
+            assert.strictEqual(childProcess.exitCode, 1)
           }
         }
 
@@ -557,22 +551,6 @@ moduleTypes.forEach(({
             },
           })
 
-          const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const tests = events.filter(event => event.type === 'test').map(event => event.content)
-              const attemptToFixTests = tests
-                .filter(test => test.meta[TEST_NAME] === 'attempt to fix after hook passes before after hook fails')
-                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
-
-              assert.strictEqual(attemptToFixTests.length, 4)
-
-              const lastAttempt = attemptToFixTests[attemptToFixTests.length - 1]
-              assert.strictEqual(lastAttempt.meta[TEST_STATUS], 'fail')
-              assert.match(lastAttempt.meta[ERROR_MESSAGE], /error in after hook/)
-              assert.strictEqual(lastAttempt.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
-            }, 25000)
-
           const envVars = getCiVisEvpProxyConfig(receiver.port)
           const specToRun = 'cypress/e2e/attempt-to-fix-after-hook.js'
 
@@ -588,12 +566,26 @@ moduleTypes.forEach(({
             }
           )
 
-          const [[exitCode]] = await Promise.all([
-            once(childProcess, 'exit'),
-            receiverPromise,
-          ])
+          await receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const attemptToFixTests = tests
+                .filter(test => test.meta[TEST_NAME] === 'attempt to fix after hook passes before after hook fails')
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
 
-          assert.strictEqual(exitCode, 1)
+              assert.strictEqual(attemptToFixTests.length, 4)
+
+              const lastAttempt = attemptToFixTests[attemptToFixTests.length - 1]
+              assert.strictEqual(lastAttempt.meta[TEST_STATUS], 'fail')
+              assert.match(lastAttempt.meta[ERROR_MESSAGE], /error in after hook/)
+              assert.strictEqual(lastAttempt.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+            }
+          )
+
+          assert.strictEqual(childProcess.exitCode, 1)
         })
 
         it('does not attempt to fix tests if test management is not enabled', async () => {
@@ -626,22 +618,6 @@ moduleTypes.forEach(({
             known_tests_enabled: true,
           })
 
-          const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const tests = events.filter(event => event.type === 'test').map(event => event.content)
-              const atfTests = tests.filter(
-                t => t.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true'
-              )
-              assert.ok(atfTests.length > 0)
-              for (const test of atfTests) {
-                assert.ok(
-                  !(TEST_IS_NEW in test.meta),
-                  'ATF test that is in known tests should not be tagged as new'
-                )
-              }
-            }, 25000)
-
           const envVars = getCiVisEvpProxyConfig(receiver.port)
           const specToRun = 'cypress/e2e/attempt-to-fix.js'
 
@@ -658,10 +634,24 @@ moduleTypes.forEach(({
             }
           )
 
-          await Promise.all([
-            once(childProcess, 'exit'),
-            eventsPromise,
-          ])
+          await receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const atfTests = tests.filter(
+                t => t.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true'
+              )
+              assert.ok(atfTests.length > 0)
+              for (const test of atfTests) {
+                assert.ok(
+                  !(TEST_IS_NEW in test.meta),
+                  'ATF test that is in known tests should not be tagged as new'
+                )
+              }
+            }
+          )
         })
 
         it('ignores quarantine when attempting to fix a test', async () => {
@@ -728,9 +718,9 @@ moduleTypes.forEach(({
           })
         })
 
-        const getTestAssertions = (isDisabling) =>
+        const awaitTestAssertions = (isDisabling, child) =>
           receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            .gatherPayloadsUntilChildExit(child, ({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
               const events = payloads.flatMap(({ payload }) => payload.events)
               const failedTest = events.find(event => event.type === 'test').content
               const testSession = events.find(event => event.type === 'test_session_end').content
@@ -750,11 +740,9 @@ moduleTypes.forEach(({
                 assert.strictEqual(failedTest.meta[TEST_STATUS], 'fail')
                 assert.ok(!(TEST_MANAGEMENT_IS_DISABLED in failedTest.meta))
               }
-            }, 25000)
+            })
 
         const runDisableTest = async (isDisabling, extraEnvVars = {}) => {
-          const testAssertionsPromise = getTestAssertions(isDisabling)
-
           const envVars = getCiVisEvpProxyConfig(receiver.port)
 
           const specToRun = 'cypress/e2e/disable.js'
@@ -772,15 +760,12 @@ moduleTypes.forEach(({
             }
           )
 
-          const [[exitCode]] = await Promise.all([
-            once(childProcess, 'exit'),
-            testAssertionsPromise,
-          ])
+          await awaitTestAssertions(isDisabling, childProcess)
 
           if (isDisabling) {
-            assert.strictEqual(exitCode, 0)
+            assert.strictEqual(childProcess.exitCode, 0)
           } else {
-            assert.strictEqual(exitCode, 1)
+            assert.strictEqual(childProcess.exitCode, 1)
           }
         }
 
@@ -822,9 +807,9 @@ moduleTypes.forEach(({
           })
         })
 
-        const getTestAssertions = (isQuarantining) =>
+        const awaitTestAssertions = (isQuarantining, child) =>
           receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+            .gatherPayloadsUntilChildExit(child, ({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
               const events = payloads.flatMap(({ payload }) => payload.events)
               const failedTest = events.find(event => event.type === 'test').content
               const testSession = events.find(event => event.type === 'test_session_end').content
@@ -850,11 +835,9 @@ moduleTypes.forEach(({
                 assert.strictEqual(failedTest.meta[TEST_STATUS], 'fail')
                 assert.ok(!(TEST_MANAGEMENT_IS_QUARANTINED in failedTest.meta))
               }
-            }, 25000)
+            })
 
         const runQuarantineTest = async (isQuarantining, extraEnvVars = {}) => {
-          const testAssertionsPromise = getTestAssertions(isQuarantining)
-
           const envVars = getCiVisEvpProxyConfig(receiver.port)
 
           const specToRun = 'cypress/e2e/quarantine.js'
@@ -872,15 +855,12 @@ moduleTypes.forEach(({
             }
           )
 
-          const [[exitCode]] = await Promise.all([
-            once(childProcess, 'exit'),
-            testAssertionsPromise,
-          ])
+          await awaitTestAssertions(isQuarantining, childProcess)
 
           if (isQuarantining) {
-            assert.strictEqual(exitCode, 0)
+            assert.strictEqual(childProcess.exitCode, 0)
           } else {
-            assert.strictEqual(exitCode, 1)
+            assert.strictEqual(childProcess.exitCode, 1)
           }
         }
 
@@ -910,18 +890,6 @@ moduleTypes.forEach(({
         })
         receiver.setTestManagementTestsResponseCode(404)
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testSessionEnd = events.find(event => event.type === 'test_session_end')
-            assert.ok(testSessionEnd, 'expected test_session_end event in payloads')
-            const testSession = testSessionEnd.content
-            assert.ok(!(TEST_MANAGEMENT_ENABLED in testSession.meta))
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            // it is not retried
-            assert.strictEqual(tests.length, 1)
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/attempt-to-fix.js'
@@ -939,10 +907,20 @@ moduleTypes.forEach(({
           }
         )
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          eventsPromise,
-        ])
+        await receiver.gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSessionEnd = events.find(event => event.type === 'test_session_end')
+            assert.ok(testSessionEnd, 'expected test_session_end event in payloads')
+            const testSession = testSessionEnd.content
+            assert.ok(!(TEST_MANAGEMENT_ENABLED in testSession.meta))
+            const tests = events.filter(event => event.type === 'test').map(event => event.content)
+            // it is not retried
+            assert.strictEqual(tests.length, 1)
+          }
+        )
       })
 
       over12It('does not retry attempt to fix tests when testIsolation is false', async () => {
@@ -966,8 +944,28 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+        const envVars = getCiVisEvpProxyConfig(receiver.port)
+
+        const specToRun = 'cypress/e2e/attempt-to-fix.js'
+
+        childProcess = exec(
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+          {
+            cwd,
+            env: {
+              ...envVars,
+              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              SPEC_PATTERN: specToRun,
+              CYPRESS_SHOULD_ALWAYS_PASS: '1',
+              CYPRESS_TEST_ISOLATION: 'false',
+            },
+          }
+        )
+
+        await receiver.gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          payloads => {
             const events = payloads.flatMap(({ payload }) => payload.events)
             const tests = events.filter(event => event.type === 'test').map(event => event.content)
             const testSession = events.find(event => event.type === 'test_session_end').content
@@ -989,30 +987,8 @@ moduleTypes.forEach(({
               assert.ok(!(TEST_IS_RETRY in test.meta))
               assert.ok(!(TEST_RETRY_REASON in test.meta))
             })
-          }, 25000)
-
-        const envVars = getCiVisEvpProxyConfig(receiver.port)
-
-        const specToRun = 'cypress/e2e/attempt-to-fix.js'
-
-        childProcess = exec(
-          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
-          {
-            cwd,
-            env: {
-              ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-              SPEC_PATTERN: specToRun,
-              CYPRESS_SHOULD_ALWAYS_PASS: '1',
-              CYPRESS_TEST_ISOLATION: 'false',
-            },
           }
         )
-
-        await Promise.all([
-          once(childProcess, 'exit'),
-          receiverPromise,
-        ])
       })
 
       it('retries attempt to fix tests in the correct order (right after original test)', async () => {
@@ -1041,44 +1017,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // 1 test with attempt to fix (1 original + 3 retries) + 2 tests without = 6 tests total
-            assert.equal(tests.length, 6)
-
-            // Extract test execution order with full details
-            const testExecutionOrder = tests.map(test => ({
-              name: test.meta[TEST_NAME],
-              isRetry: test.meta[TEST_IS_RETRY] === 'true',
-              isAttemptToFix: test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true',
-            }))
-
-            // Expected order:
-            // 1. "first test" (original, no retries)
-            // 2. "second test" (original)
-            // 3. "second test" (retry 1)
-            // 4. "second test" (retry 2)
-            // 5. "second test" (retry 3)
-            // 6. "third test" (original, no retries)
-
-            assertObjectContains(testExecutionOrder, [
-              { name: 'attempt to fix order first test', isRetry: false, isAttemptToFix: false },
-              { name: 'attempt to fix order second test', isRetry: false, isAttemptToFix: true },
-              { name: 'attempt to fix order second test', isRetry: true, isAttemptToFix: true },
-              { name: 'attempt to fix order second test', isRetry: true, isAttemptToFix: true },
-              { name: 'attempt to fix order second test', isRetry: true, isAttemptToFix: true },
-              { name: 'attempt to fix order third test', isRetry: false, isAttemptToFix: false },
-            ])
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assertObjectContains(testSession.meta, {
-              [TEST_MANAGEMENT_ENABLED]: 'true',
-            })
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/attempt-to-fix-order.js'
@@ -1103,10 +1041,48 @@ moduleTypes.forEach(({
         })
 
         await Promise.all([
-          once(childProcess, 'exit'),
           once(childProcess.stdout, 'end'),
           once(childProcess.stderr, 'end'),
-          receiverPromise,
+          receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // 1 test with attempt to fix (1 original + 3 retries) + 2 tests without = 6 tests total
+              assert.equal(tests.length, 6)
+
+              // Extract test execution order with full details
+              const testExecutionOrder = tests.map(test => ({
+                name: test.meta[TEST_NAME],
+                isRetry: test.meta[TEST_IS_RETRY] === 'true',
+                isAttemptToFix: test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX] === 'true',
+              }))
+
+              // Expected order:
+              // 1. "first test" (original, no retries)
+              // 2. "second test" (original)
+              // 3. "second test" (retry 1)
+              // 4. "second test" (retry 2)
+              // 5. "second test" (retry 3)
+              // 6. "third test" (original, no retries)
+
+              assertObjectContains(testExecutionOrder, [
+                { name: 'attempt to fix order first test', isRetry: false, isAttemptToFix: false },
+                { name: 'attempt to fix order second test', isRetry: false, isAttemptToFix: true },
+                { name: 'attempt to fix order second test', isRetry: true, isAttemptToFix: true },
+                { name: 'attempt to fix order second test', isRetry: true, isAttemptToFix: true },
+                { name: 'attempt to fix order second test', isRetry: true, isAttemptToFix: true },
+                { name: 'attempt to fix order third test', isRetry: false, isAttemptToFix: false },
+              ])
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assertObjectContains(testSession.meta, {
+                [TEST_MANAGEMENT_ENABLED]: 'true',
+              })
+            }
+          ),
         ])
 
         assert.match(testOutput, /Retrying "attempt to fix order second test" because it is an attempt to fix/)


### PR DESCRIPTION
## Summary

`gatherPayloadsMaxTimeout` in the CI visibility integration test
harness runs on a wall clock independent of the child process it
watches. On the slowest CI matrices the fixed budget can expire
before Cypress / Jest / Playwright finishes; the gather returns an
empty buffer and the caller's `events.find(...).content` lookup
surfaces as a misleading `TypeError` from inside a `setTimeout`
frame, hiding the real cause.

`gatherPayloadsUntilChildExit` ties the gather to child-process
lifecycle: it waits for `'exit'`, drains in-flight HTTP for a short
grace period, then runs the caller's assertion on the actual buffer.
The hard timeout becomes a backstop for a hung child (default
`30_000ms`), not patience for a slow one; one explicit per-call
override (the cypress multi-origin test) covers a workload whose
esm cold-start exceeds the default.

This canary migrates `cypress/cypress-test-management.spec.js`, the
spec where the original failure was observed. Other specs sharing
the pattern stay on `gatherPayloadsMaxTimeout` for now.

## Test plan

- [ ] `./node_modules/.bin/mocha --timeout 10000 integration-tests/ci-visibility-intake.spec.js` — 7 unit tests for the helper pass locally
- [ ] CI runs `cypress/cypress-test-management.spec.js` across all matrices and stays green on `cypress 14.5.4 / node-oldest / esm`

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/25442963293/job/74639050412