### PR TITLE
test(cypress): stub the test page via cy.intercept

### DIFF
--- a/integration-tests/ci-visibility/subproject/cypress/e2e/spec.cy.js
+++ b/integration-tests/ci-visibility/subproject/cypress/e2e/spec.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('context', () => {
   it('passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/ci-visibility/subproject/cypress/support/e2e.js
+++ b/integration-tests/ci-visibility/subproject/cypress/support/e2e.js
@@ -1,3 +1,29 @@
-'use strict'
+/* eslint-disable */
+const coverage = require('../../../fixtures/istanbul-map-fixture.json')
+
+const TEST_PAGE_URL = 'http://test-page.dd-trace.invalid/'
+
+const TEST_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <head><title>Hello World</title></head>
+  <body>
+    <div class="hello-world">Hello World</div>
+  </body>
+  <script>
+    window.__coverage__ = ${JSON.stringify(coverage)}
+  </script>
+</html>`
+
+// Stub the page response inside the Cypress proxy so the navigation never
+// leaves Cypress' Node process. Mirrors the main sandbox `cy.visitTestPage()`
+// without dragging in its `cypress-fail-fast` branch, which the subproject
+// does not install.
+Cypress.Commands.add('visitTestPage', () => {
+  cy.intercept('GET', `${TEST_PAGE_URL}**`, {
+    headers: { 'Content-Type': 'text/html' },
+    body: TEST_PAGE_HTML,
+  })
+  return cy.visit(TEST_PAGE_URL)
+})
 
 require('dd-trace/ci/cypress/support')

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -13,7 +13,6 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
   TEST_STATUS,
   TEST_CODE_COVERAGE_ENABLED,
@@ -98,7 +97,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -111,48 +110,17 @@ moduleTypes.forEach(({
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
-    // Cypress child processes can sometimes hang or take longer to
-    // terminate. This can cause `FakeCiVisIntake#stop` to be delayed
-    // because there are pending connections.
     afterEach(async () => {
       if (childProcess && childProcess.pid) {
         try {
           childProcess.kill('SIGKILL')
-        } catch (error) {
-          // Process might already be dead - this is fine, ignore error
+        } catch {
+          // Process is already dead, no FD to clean up.
         }
-
-        // Don't wait for exit - Cypress processes can hang indefinitely in uninterruptible I/O
-        // The OS will clean up zombies, and fresh server per test prevents port conflicts
       }
 
-      // Close web server before stopping receiver
-      if (webAppServer) {
-        await /** @type {Promise<void>} */ (new Promise((resolve) => {
-          webAppServer.close((err) => {
-            if (err) {
-              // eslint-disable-next-line no-console
-              console.error('Web server close error:', err)
-            }
-            resolve()
-          })
-        }))
-      }
-
-      // Add timeout to prevent hanging
       const stopPromise = receiver.stop()
       const timeoutPromise = new Promise((resolve, reject) =>
         setTimeout(() => reject(new Error('Receiver stop timeout')), RECEIVER_STOP_TIMEOUT)
@@ -164,9 +132,6 @@ moduleTypes.forEach(({
         // eslint-disable-next-line no-console
         console.warn('Receiver stop timed out:', error.message)
       }
-
-      // Small delay to allow OS to release ports
-      await new Promise(resolve => setTimeout(resolve, 100))
     })
 
     context('intelligent test runner', () => {
@@ -186,7 +151,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -231,7 +195,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -300,7 +263,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/{other,spec}.cy.js',
             },
           }
@@ -355,7 +317,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/other.cy.js',
             },
           }
@@ -430,7 +391,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/{other,spec}.cy.js',
             },
           }
@@ -499,7 +459,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/{other,spec}.cy.js',
             },
           }
@@ -553,7 +512,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -590,7 +548,6 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -643,7 +600,6 @@ moduleTypes.forEach(({
             cwd: `${cwd}/ci-visibility/subproject`,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
             },
           }
         )
@@ -683,7 +639,6 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
             CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN: '1',
             SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
           },

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -804,9 +804,12 @@ moduleTypes.forEach(({
         '',
       ].join('\n'))
       fs.mkdirSync(path.join(subprojectDir, 'cypress', 'support'), { recursive: true })
-      fs.copyFileSync(
-        path.join(cwd, 'cypress', 'support', 'e2e.js'),
-        path.join(subprojectDir, 'cypress', 'support', 'e2e.js')
+      // The sandbox's `cypress/support/e2e.js` resolves a sibling fixture via a
+      // relative path that webpack only follows from the sandbox root. Copying
+      // the file into this subproject breaks that bundle and silences the spec.
+      fs.writeFileSync(
+        path.join(subprojectDir, 'cypress', 'support', 'e2e.js'),
+        "require('dd-trace/ci/cypress/support')\n"
       )
       // Minimal passing spec so the test is self-contained and doesn't
       // depend on the rest of the sandbox's e2e tree.

--- a/integration-tests/cypress/e2e/attempt-to-fix-after-hook.js
+++ b/integration-tests/cypress/e2e/attempt-to-fix-after-hook.js
@@ -6,7 +6,7 @@ describe('attempt to fix after hook', () => {
   })
 
   it('passes before after hook fails', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/attempt-to-fix-order.js
+++ b/integration-tests/cypress/e2e/attempt-to-fix-order.js
@@ -2,19 +2,19 @@
 
 describe('attempt to fix order', () => {
   it('first test', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
 
   it('second test', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
 
   it('third test', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/attempt-to-fix.js
+++ b/integration-tests/cypress/e2e/attempt-to-fix.js
@@ -13,7 +13,7 @@ function getTextToAssert () {
 
 describe('attempt to fix', () => {
   it('is attempt to fix', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', getTextToAssert())
   })

--- a/integration-tests/cypress/e2e/basic-fail.js
+++ b/integration-tests/cypress/e2e/basic-fail.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('basic fail suite', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visitTestPage()
     cy.task('dd:addTags', { addTagsBeforeEach: 'customBeforeEach' })
   })
 

--- a/integration-tests/cypress/e2e/basic-pass.js
+++ b/integration-tests/cypress/e2e/basic-pass.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('basic pass suite', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visitTestPage()
     cy.task('dd:addTags', { addTagsBeforeEach: 'customBeforeEach' })
   })
 

--- a/integration-tests/cypress/e2e/disable.js
+++ b/integration-tests/cypress/e2e/disable.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('disable', () => {
   it('is disabled', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello Warld')
   })

--- a/integration-tests/cypress/e2e/flaky-test-retries.js
+++ b/integration-tests/cypress/e2e/flaky-test-retries.js
@@ -2,17 +2,17 @@
 describe('flaky test retry', () => {
   let numAttempt = 0
   it('eventually passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', numAttempt++ === 2 ? 'Hello World' : 'Hello Warld')
   })
   it('never passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello Warld')
   })
   it('always passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/flaky-with-hooks.cy.js
+++ b/integration-tests/cypress/e2e/flaky-with-hooks.cy.js
@@ -2,7 +2,7 @@
 let numAttempt = 0
 describe('flaky with hooks', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visitTestPage()
   })
   afterEach(() => {
     // cleanup

--- a/integration-tests/cypress/e2e/hook-describe-error.cy.js
+++ b/integration-tests/cypress/e2e/hook-describe-error.cy.js
@@ -4,12 +4,12 @@ describe('after', () => {
     throw new Error('error in after hook')
   })
   it('passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
   it('will be marked as failed', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
@@ -20,7 +20,7 @@ describe('before', () => {
     throw new Error('error in before hook')
   })
   it('will be skipped', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/hook-test-error.cy.js
+++ b/integration-tests/cypress/e2e/hook-test-error.cy.js
@@ -7,17 +7,17 @@ describe('hook-test-error tests', () => {
     }
   })
   it('passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
   it('will fail because afterEach fails', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
   it('does not run because earlier afterEach fails', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/impacted-test-order.js
+++ b/integration-tests/cypress/e2e/impacted-test-order.js
@@ -2,13 +2,13 @@
 
 describe('impacted test order', () => {
   it('first test', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
 
   it('second test', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/impacted-test.js
+++ b/integration-tests/cypress/e2e/impacted-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('impacted test', () => {
   it('is impacted test', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/other.cy.js
+++ b/integration-tests/cypress/e2e/other.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('context', () => {
   it('passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/quarantine.js
+++ b/integration-tests/cypress/e2e/quarantine.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('quarantine', () => {
   it('is quarantined', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello Warld')
   })

--- a/integration-tests/cypress/e2e/skipped-test.js
+++ b/integration-tests/cypress/e2e/skipped-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('skipped', () => {
   it.skip('skipped', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/spec-source-line-fallback.cy.ts
+++ b/integration-tests/cypress/e2e/spec-source-line-fallback.cy.ts
@@ -6,7 +6,7 @@ interface TypeOnly {
 describe('spec source line fallback branch', () => {
   it('fallback branch literal title', () => {
     Cypress.mocha.getRunner().currentRunnable.invocationDetails.line = 9999
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/spec-source-line-invocation.cy.js
+++ b/integration-tests/cypress/e2e/spec-source-line-invocation.cy.js
@@ -7,7 +7,7 @@
 
 describe('spec source line invocation details js', () => {
   it('uses invocation details line as source line', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/spec-source-line-no-match.cy.ts
+++ b/integration-tests/cypress/e2e/spec-source-line-no-match.cy.ts
@@ -8,7 +8,7 @@ const NO_MATCH_TITLE = ['no', 'match', 'title'].join(' ')
 describe('spec source line no match', () => {
   it(NO_MATCH_TITLE, () => {
     Cypress.mocha.getRunner().currentRunnable.invocationDetails.line = 9999
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/spec-source-line.cy.ts
+++ b/integration-tests/cypress/e2e/spec-source-line.cy.ts
@@ -9,12 +9,12 @@ interface TypeScriptOnlyInterface {
 const SOME_VARIABLE = 'interpolated'
 describe('spec source line', () => {
   it('reports correct line number', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
   specify(`template ${SOME_VARIABLE} string test name`, () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })

--- a/integration-tests/cypress/e2e/spec.cy.js
+++ b/integration-tests/cypress/e2e/spec.cy.js
@@ -4,7 +4,7 @@
  */
 describe('context', () => {
   it('passes', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello World')
   })
@@ -12,7 +12,7 @@ describe('context', () => {
 
 describe('other context', () => {
   it('fails', () => {
-    cy.visit('/')
+    cy.visitTestPage()
       .get('.hello-world')
       .should('have.text', 'Hello Warld')
   })

--- a/integration-tests/cypress/e2e/test-management-with-hooks.cy.js
+++ b/integration-tests/cypress/e2e/test-management-with-hooks.cy.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 describe('quarantined with hooks', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visitTestPage()
   })
   afterEach(() => {
     // cleanup
@@ -16,7 +16,7 @@ describe('quarantined with hooks', () => {
 
 describe('quarantined with failing afterEach', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visitTestPage()
   })
   afterEach(() => {
     throw new Error('error in afterEach hook')
@@ -28,7 +28,7 @@ describe('quarantined with failing afterEach', () => {
 
 describe('disabled with hooks', () => {
   beforeEach(() => {
-    cy.visit('/')
+    cy.visitTestPage()
   })
   afterEach(() => {
     // cleanup

--- a/integration-tests/cypress/support/e2e.js
+++ b/integration-tests/cypress/support/e2e.js
@@ -1,4 +1,34 @@
-// eslint-disable-next-line
+/* eslint-disable */
+const coverage = require('../../ci-visibility/fixtures/istanbul-map-fixture.json')
+
+const TEST_PAGE_URL = 'http://test-page.dd-trace.invalid/'
+
+const TEST_PAGE_HTML = `<!DOCTYPE html>
+<html>
+  <head><title>Hello World</title></head>
+  <body>
+    <div class="hello-world">Hello World</div>
+  </body>
+  <script>
+    window.DD_RUM = {
+      getInternalContext: () => true,
+      stopSession: () => true,
+    }
+    window.__coverage__ = ${JSON.stringify(coverage)}
+  </script>
+</html>`
+
+// Stub the page response inside the Cypress proxy so the navigation never
+// leaves Cypress' Node process. Removes the localhost HTTP round trip whose
+// `cy.visit()` flake is documented at https://github.com/cypress-io/cypress/issues/27119.
+Cypress.Commands.add('visitTestPage', () => {
+  cy.intercept('GET', `${TEST_PAGE_URL}**`, {
+    headers: { 'Content-Type': 'text/html' },
+    body: TEST_PAGE_HTML,
+  })
+  return cy.visit(TEST_PAGE_URL)
+})
+
 if (Cypress.env('ENABLE_INCOMPATIBLE_PLUGIN')) {
   require('cypress-fail-fast')
 }


### PR DESCRIPTION
Cypress' proxy occasionally drops the first `cy.visit('/')` against the localhost test server with `socket hang up` from
`node:_http_client.socketOnEnd`. Upstream classifies the flake as not-planned (cypress-io/cypress#27119), and the boundary lives inside Cypress' http.Agent. There is no signal we can read to avoid the bad path.

The integration tests do not need a real HTTP server. `cy.intercept` inside the Cypress proxy stubs the navigation directly, so the proxy never goes upstream. `cy.visitTestPage` in `cypress/support/e2e.js` registers the intercept and returns the visit chainable so existing `.get('.hello-world').should(...)` chains keep working.

`createWebAppServer`, `CYPRESS_BASE_URL`, and the 100 ms "release ports" sleep go with the localhost server in `cypress-itr.spec.js`. The `multi-origin.js` fixture stays on `cy.visit('/')` because `cy.origin` requires real cross-origin URLs; the inline servers in `cypress-test-management.spec.js` still cover that case.

Refs: https://github.com/cypress-io/cypress/issues/27119
Refs: https://github.com/DataDog/dd-trace-js/actions/runs/25435197717/job/74611204649
