### PR TITLE
chore(benchmark): drop Node 18 from sirun matrix and add Node 26

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -71,18 +71,6 @@ benchmark:
   # one, change the other — otherwise variants get silently skipped.
   parallel:
     matrix:
-      - MAJOR_VERSION: 18
-        GROUP: 1
-      - MAJOR_VERSION: 18
-        GROUP: 2
-      - MAJOR_VERSION: 18
-        GROUP: 3
-      - MAJOR_VERSION: 18
-        GROUP: 4
-      - MAJOR_VERSION: 18
-        GROUP: 5
-      - MAJOR_VERSION: 18
-        GROUP: 6
       - MAJOR_VERSION: 20
         GROUP: 1
       - MAJOR_VERSION: 20
@@ -118,6 +106,18 @@ benchmark:
       - MAJOR_VERSION: 24
         GROUP: 5
       - MAJOR_VERSION: 24
+        GROUP: 6
+      - MAJOR_VERSION: 26
+        GROUP: 1
+      - MAJOR_VERSION: 26
+        GROUP: 2
+      - MAJOR_VERSION: 26
+        GROUP: 3
+      - MAJOR_VERSION: 26
+        GROUP: 4
+      - MAJOR_VERSION: 26
+        GROUP: 5
+      - MAJOR_VERSION: 26
         GROUP: 6
   variables:
     SPLITS: 6

--- a/benchmark/sirun/startup/README.md
+++ b/benchmark/sirun/startup/README.md
@@ -35,18 +35,18 @@ git add package.json package-lock.json
 
 Do not commit `node_modules/`; `runall.sh` re-installs via `npm ci`.
 
-The bench runs across every Node major dd-trace supports (18+), so every
-pinned version must:
+The bench runs across the Node majors listed in
+`.gitlab/benchmarks.yml` (currently 20–26), so every pinned version
+must:
 
-1. Have an `engines.node` range that includes Node 18, including all
-   transitive dependencies after `npm install` resolves.
+1. Have an `engines.node` range that includes the matrix floor,
+   including all transitive dependencies after `npm install` resolves.
 2. Be loadable through CJS `require()`. ESM-only releases (recent `got`,
    `uuid`) break the fixture's `require(name)` walk; pin a CJS-era
    version (e.g. `got@11`, `uuid@9`) instead.
 
-Some top-level packages still satisfy (1) and (2) themselves but pull in
-transitive deps that bumped to Node 20+ (e.g. `fastify@5` resolves
-`find-my-way@>=9.3` which requires Node 20). When that happens, add an
-`overrides` entry pinning the offending transitive dep to the last
-release that supports Node 18; do not downgrade the top-level package
-unless it has no other Node-18-compatible release.
+Some top-level packages still satisfy (1) and (2) themselves but pull
+in transitive deps that bumped past the matrix floor. When that
+happens, add an `overrides` entry pinning the offending transitive dep
+to the last release that supports the floor; do not downgrade the
+top-level package unless it has no other compatible release.

--- a/benchmark/sirun/startup/everything-fixture/package-lock.json
+++ b/benchmark/sirun/startup/everything-fixture/package-lock.json
@@ -1097,6 +1097,18 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -2850,10 +2862,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2862,7 +2874,26 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2901,39 +2932,6 @@
         "toad-cache": "^3.7.0"
       }
     },
-    "node_modules/fastify/node_modules/find-my-way": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.2.0.tgz",
-      "integrity": "sha512-d3uCir8Hmg7W1Ywp8nKf2lJJYU9Nwinvo+1D39Dn09nz65UKXIxUh7j7K8zeWhxqe1WrkS7FJyON/Q/3lPoc6w==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-querystring": "^1.0.0",
-        "safe-regex2": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/fastify/node_modules/safe-regex2": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-4.0.1.tgz",
-      "integrity": "sha512-goqsB+bSlOmVX+CiFX2PFc1OV88j5jvBqIM+DgqrucHnUguAUNtiNOs+aTadq2NqsLQ+TQ3UEVG3gtSFcdlkCg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.5.0"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2968,6 +2966,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/fn.name": {
@@ -4338,6 +4350,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4495,15 +4522,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
-    },
-    "node_modules/pino/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
     },
     "node_modules/postgres-array": {
       "version": "2.0.0",
@@ -4878,6 +4896,28 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -4910,9 +4950,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5170,6 +5210,24 @@
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
     },
+    "node_modules/thread-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.1.0.tgz",
+      "integrity": "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
     "node_modules/tildify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
@@ -5374,6 +5432,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/benchmark/sirun/startup/everything-fixture/package.json
+++ b/benchmark/sirun/startup/everything-fixture/package.json
@@ -35,7 +35,6 @@
     "ws": "8.20.0"
   },
   "overrides": {
-    "find-my-way": "9.2.0",
-    "thread-stream": "3.1.0"
+    "fast-xml-parser": "5.7.2"
   }
 }


### PR DESCRIPTION
Node.js 18 hit EOL in April 2025. The sirun benchmark matrix replaces its six `MAJOR_VERSION=18` groups in `.gitlab/benchmarks.yml` with six `MAJOR_VERSION=26` groups; bench coverage is now {20, 22, 24, 26}. This is bench-only; dd-trace's own `engines.node` is unchanged.

The `find-my-way` and `thread-stream` overrides in the startup fixture were Node-18-only accommodations and are no longer load-bearing; both resolve naturally on the new matrix floor (`find-my-way@9.6.0`, `thread-stream@4.1.0`, each declaring `engines.node >=20`). The `fast-xml-parser` override replaces them to keep the fixture installable against current security advisories.