### PR TITLE
test(aws-sdk): skip aws-sdk@2.1693.0+ on Node.js 18

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
@@ -3,6 +3,7 @@
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const { NODE_MAJOR } = require('../../../version')
 
+const AWS_SDK_V2_RANGE = NODE_MAJOR === 18 ? '<2.1693.0' : '*'
 const AWS_SDK_V3_RANGE = NODE_MAJOR === 18 ? '3.0.0' : '>3.0.0'
 
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
@@ -26,7 +27,7 @@ function withAwsSdkV2Versions (range, cb) {
     range = undefined
   }
 
-  withVersions('aws-sdk', ['aws-sdk'], range, cb)
+  withVersions('aws-sdk', ['aws-sdk'], getAwsSdkV2Range(range), cb)
 }
 
 /**
@@ -56,6 +57,14 @@ function withAwsSdkVersions (range, cb) {
 
   withAwsSdkV2Versions(range, cb)
   withAwsSdkV3Versions(range, cb)
+}
+
+/**
+ * @param {string|undefined} range
+ * @returns {string}
+ */
+function getAwsSdkV2Range (range) {
+  return range === undefined ? AWS_SDK_V2_RANGE : `${range} ${AWS_SDK_V2_RANGE}`
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Adds `AWS_SDK_V2_RANGE` to the aws-sdk plugin's `spec_helpers` and applies it inside `withAwsSdkV2Versions`, mirroring the existing `AWS_SDK_V3_RANGE` Node-18 cap. On Node.js 18 the v2 range resolves to `<2.1693.0`, excluding the broken latest release; on other Node versions it's `*` so nothing is filtered.

### Motivation

`aws-sdk@2.1693.0` is no longer compatible with Node.js 18, which was failing the `oldest` Node leg of the `aws-sdk` CI matrix. The repo already has the same Node-major-conditional pattern for the v3 SDK (`AWS_SDK_V3_RANGE`); this PR adds the v2 counterpart.

### Additional Notes

The change is centralized in the helper, so every `withAwsSdkVersions` / `withAwsSdkV2Versions` call site picks it up automatically — no per-test-file edits needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)