### PR TITLE
bench: fix benchmarks running unsupported versions

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -107,17 +107,17 @@ benchmark:
         GROUP: 5
       - MAJOR_VERSION: 24
         GROUP: 6
-      - MAJOR_VERSION: 26
+      - MAJOR_VERSION: 25
         GROUP: 1
-      - MAJOR_VERSION: 26
+      - MAJOR_VERSION: 25
         GROUP: 2
-      - MAJOR_VERSION: 26
+      - MAJOR_VERSION: 25
         GROUP: 3
-      - MAJOR_VERSION: 26
+      - MAJOR_VERSION: 25
         GROUP: 4
-      - MAJOR_VERSION: 26
+      - MAJOR_VERSION: 25
         GROUP: 5
-      - MAJOR_VERSION: 26
+      - MAJOR_VERSION: 25
         GROUP: 6
   variables:
     SPLITS: 6

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -107,18 +107,6 @@ benchmark:
         GROUP: 5
       - MAJOR_VERSION: 24
         GROUP: 6
-      - MAJOR_VERSION: 25
-        GROUP: 1
-      - MAJOR_VERSION: 25
-        GROUP: 2
-      - MAJOR_VERSION: 25
-        GROUP: 3
-      - MAJOR_VERSION: 25
-        GROUP: 4
-      - MAJOR_VERSION: 25
-        GROUP: 5
-      - MAJOR_VERSION: 25
-        GROUP: 6
   variables:
     SPLITS: 6
 

--- a/benchmark/sirun/appsec-iast/insecure-bank.js
+++ b/benchmark/sirun/appsec-iast/insecure-bank.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const http = require('http')
-const app = require('/opt/insecure-bank-js/app') // eslint-disable-line import/no-absolute-path
 
 const { port } = require('./common')
+const loadInsecureBank = require('../load-insecure-bank')
 
+const app = loadInsecureBank()
 app.set('port', port)
 const server = http.createServer(app)
 

--- a/benchmark/sirun/appsec-iast/insecure-bank.js
+++ b/benchmark/sirun/appsec-iast/insecure-bank.js
@@ -2,8 +2,8 @@
 
 const http = require('http')
 
-const { port } = require('./common')
 const loadInsecureBank = require('../load-insecure-bank')
+const { port } = require('./common')
 
 const app = loadInsecureBank()
 app.set('port', port)

--- a/benchmark/sirun/appsec/insecure-bank.js
+++ b/benchmark/sirun/appsec/insecure-bank.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const http = require('http')
-const app = require('/opt/insecure-bank-js/app') // eslint-disable-line import/no-absolute-path
 
 const { port } = require('./common')
+const loadInsecureBank = require('../load-insecure-bank')
 
+const app = loadInsecureBank()
 app.set('port', port)
 const server = http.createServer(app)
 

--- a/benchmark/sirun/appsec/insecure-bank.js
+++ b/benchmark/sirun/appsec/insecure-bank.js
@@ -2,8 +2,8 @@
 
 const http = require('http')
 
-const { port } = require('./common')
 const loadInsecureBank = require('../load-insecure-bank')
+const { port } = require('./common')
 
 const app = loadInsecureBank()
 app.set('port', port)

--- a/benchmark/sirun/load-insecure-bank.js
+++ b/benchmark/sirun/load-insecure-bank.js
@@ -6,12 +6,14 @@ const url = require('url')
  * @returns {import('http').RequestListener}
  */
 function loadInsecureBank () {
+  // eslint-disable-next-line n/no-deprecated-api
   const parse = url.parse
   /**
    * @param {string} value
    * @param {boolean} [parseQueryString]
    * @param {boolean} [slashesDenoteHost]
    */
+  // eslint-disable-next-line n/no-deprecated-api
   url.parse = function parseSqliteMemory (value, parseQueryString, slashesDenoteHost) {
     if (value === 'sqlite::memory:') {
       return {
@@ -28,6 +30,7 @@ function loadInsecureBank () {
   try {
     return require('/opt/insecure-bank-js/app') // eslint-disable-line import/no-absolute-path
   } finally {
+    // eslint-disable-next-line n/no-deprecated-api
     url.parse = parse
   }
 }

--- a/benchmark/sirun/load-insecure-bank.js
+++ b/benchmark/sirun/load-insecure-bank.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const url = require('url')
+
+/**
+ * @returns {import('http').RequestListener}
+ */
+function loadInsecureBank () {
+  const parse = url.parse
+  /**
+   * @param {string} value
+   * @param {boolean} [parseQueryString]
+   * @param {boolean} [slashesDenoteHost]
+   */
+  url.parse = function parseSqliteMemory (value, parseQueryString, slashesDenoteHost) {
+    if (value === 'sqlite::memory:') {
+      return {
+        protocol: 'sqlite:',
+        hostname: '',
+        pathname: '/:memory:',
+        query: {},
+      }
+    }
+
+    return parse(value, parseQueryString, slashesDenoteHost)
+  }
+
+  try {
+    return require('/opt/insecure-bank-js/app') // eslint-disable-line import/no-absolute-path
+  } finally {
+    url.parse = parse
+  }
+}
+
+module.exports = loadInsecureBank


### PR DESCRIPTION
The merge order hide the fact that the benchmarks were failing on Node.js 26. This just removes them.
