### PR TITLE
fix(mocha): report test_suite_end for files with no describe wrapper

### DIFF
--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed-failing.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed-failing.js
@@ -1,0 +1,9 @@
+'use strict'
+
+it('top-level failing test', () => {
+  throw new Error('intentional failure')
+})
+
+describe('a passing describe block', () => {
+  it('passing nested test', () => {})
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed.js
@@ -1,0 +1,7 @@
+'use strict'
+
+it('top-level passing test', () => {})
+
+describe('a describe block', () => {
+  it('nested passing test', () => {})
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed2.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-mixed2.js
@@ -1,0 +1,7 @@
+'use strict'
+
+it('top-level passing test 2', () => {})
+
+describe('a describe block 2', () => {
+  it('nested passing test 2', () => {})
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js
@@ -1,0 +1,12 @@
+'use strict'
+
+// Deliberately no describe() wrapper.
+// Tests are direct children of mocha's root suite.
+// This is the structure that exposes the suite-not-reported bug:
+// the 'suite' event handler in mocha/main.js only runs testSuiteStartCh
+// for non-root suites with suite.tests.length > 0. When there are no
+// non-root suites at all, no suite context is ever created and
+// no test_suite_end event is emitted.
+it('top-level passing test', () => {})
+
+it('top-level passing test two', () => {})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js
@@ -8,5 +8,4 @@
 // non-root suites at all, no suite context is ever created and
 // no test_suite_end event is emitted.
 it('top-level passing test', () => {})
-
 it('top-level passing test two', () => {})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-no-describe2.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-no-describe2.js
@@ -1,0 +1,4 @@
+'use strict'
+
+it('top-level passing test 2', () => {})
+it('top-level passing test two 2', () => {})

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1141,7 +1141,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         //
         // Meanwhile tests run and report normally as mocha.test spans.
 
-        it.only('reports a suite event for a single file with only top-level tests', async () => {
+        it('reports a suite event for a single file with only top-level tests', async () => {
           const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js'
           const eventsPromise = receiver
             .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -1163,7 +1163,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
 
-        it.only('reports suite events for two files with only top-level tests', async () => {
+        it('reports suite events for two files with only top-level tests', async () => {
           const suiteFiles = [
             'ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js',
             'ci-visibility/mocha-plugin-tests/top-level-it-no-describe2.js',
@@ -1193,7 +1193,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
 
-        it.only('reports a suite event for a file with mixed top-level and nested tests', async () => {
+        it('reports a suite event for a file with mixed top-level and nested tests', async () => {
           const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-mixed.js'
           const eventsPromise = receiver
             .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -1215,7 +1215,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
 
-        it.only('reports suite events for two files with mixed top-level and nested tests', async () => {
+        it('reports suite events for two files with mixed top-level and nested tests', async () => {
           const suiteFiles = [
             'ci-visibility/mocha-plugin-tests/top-level-it-mixed.js',
             'ci-visibility/mocha-plugin-tests/top-level-it-mixed2.js',

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1129,8 +1129,6 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         ])
       })
 
-      // ---- SUITE REPORTING BUG REPRODUCTION ----
-      // Delete this context block once the bug is understood or fixed.
       context('suite reporting - tests with no describe wrapper', () => {
         // When a test file uses only top-level it() calls (no describe() block),
         // mocha never emits a non-root 'suite' event for that file.
@@ -1142,36 +1140,111 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         // span is created by the plugin, and no test_suite_end event is emitted.
         //
         // Meanwhile tests run and report normally as mocha.test spans.
-        it.only('reports a test_suite_end event for a file whose tests have no describe wrapper', async () => {
+
+        it.only('reports a suite event for a single file with only top-level tests', async () => {
+          const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js'
           const eventsPromise = receiver
             .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
               const events = payloads.flatMap(({ payload }) => payload.events)
               const tests = events.filter(event => event.type === 'test').map(e => e.content)
               const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
 
-              // Test events are reported regardless of the bug — this passes
-              assert.strictEqual(tests.length, 2, 'Expected 2 test events')
-
-              // Suite event must be reported exactly once for the file.
-              // This assertion FAILS when the bug is present (suiteEvents.length === 0).
-              assert.strictEqual(suiteEvents.length, 1, 'Expected 1 test_suite_end event for the test file')
+              assert.strictEqual(tests.length, 2)
+              assert.strictEqual(suiteEvents.length, 1)
+              assertObjectContains(suiteEvents[0], { meta: { [TEST_SUITE]: suiteFile, [TEST_STATUS]: 'pass' } })
+              tests.forEach(test => assert.strictEqual(test.meta[TEST_SUITE], suiteFile))
             })
 
           childProcess = exec(
-            'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js',
-            {
-              cwd,
-              env: envVars,
-            }
+            `node node_modules/mocha/bin/mocha ./${suiteFile}`,
+            { cwd, env: envVars }
           )
 
-          await Promise.all([
-            eventsPromise,
-            once(childProcess, 'exit'),
-          ])
+          await Promise.all([eventsPromise, once(childProcess, 'exit')])
+        })
+
+        it.only('reports suite events for two files with only top-level tests', async () => {
+          const suiteFiles = [
+            'ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js',
+            'ci-visibility/mocha-plugin-tests/top-level-it-no-describe2.js',
+          ]
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(e => e.content)
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
+
+              assert.strictEqual(tests.length, 4)
+              assert.strictEqual(suiteEvents.length, 2)
+              suiteFiles.forEach(suiteFile => {
+                const suite = suiteEvents.find(e => e.meta[TEST_SUITE] === suiteFile)
+                assert.ok(suite, `Expected suite event for ${suiteFile}`)
+                assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+              })
+              tests.forEach(test => assert.ok(suiteFiles.includes(test.meta[TEST_SUITE])))
+            })
+
+          childProcess = exec(
+            'node node_modules/mocha/bin/mocha' +
+            ` ./${suiteFiles[0]} ./${suiteFiles[1]}`,
+            { cwd, env: envVars }
+          )
+
+          await Promise.all([eventsPromise, once(childProcess, 'exit')])
+        })
+
+        it.only('reports a suite event for a file with mixed top-level and nested tests', async () => {
+          const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-mixed.js'
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(e => e.content)
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
+
+              assert.strictEqual(tests.length, 2)
+              assert.strictEqual(suiteEvents.length, 1)
+              assertObjectContains(suiteEvents[0], { meta: { [TEST_SUITE]: suiteFile, [TEST_STATUS]: 'pass' } })
+              tests.forEach(test => assert.strictEqual(test.meta[TEST_SUITE], suiteFile))
+            })
+
+          childProcess = exec(
+            `node node_modules/mocha/bin/mocha ./${suiteFile}`,
+            { cwd, env: envVars }
+          )
+
+          await Promise.all([eventsPromise, once(childProcess, 'exit')])
+        })
+
+        it.only('reports suite events for two files with mixed top-level and nested tests', async () => {
+          const suiteFiles = [
+            'ci-visibility/mocha-plugin-tests/top-level-it-mixed.js',
+            'ci-visibility/mocha-plugin-tests/top-level-it-mixed2.js',
+          ]
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(e => e.content)
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
+
+              assert.strictEqual(tests.length, 4)
+              assert.strictEqual(suiteEvents.length, 2)
+              suiteFiles.forEach(suiteFile => {
+                const suite = suiteEvents.find(e => e.meta[TEST_SUITE] === suiteFile)
+                assert.ok(suite, `Expected suite event for ${suiteFile}`)
+                assert.strictEqual(suite.meta[TEST_STATUS], 'pass')
+              })
+              tests.forEach(test => assert.ok(suiteFiles.includes(test.meta[TEST_SUITE])))
+            })
+
+          childProcess = exec(
+            'node node_modules/mocha/bin/mocha' +
+            ` ./${suiteFiles[0]} ./${suiteFiles[1]}`,
+            { cwd, env: envVars }
+          )
+
+          await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
       })
-      // ---- END SUITE REPORTING BUG REPRODUCTION ----
     })
   })
 

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1244,6 +1244,25 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
 
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
+
+        it('reports fail status when a top-level test fails alongside passing nested tests', async () => {
+          const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-mixed-failing.js'
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
+
+              assert.strictEqual(suiteEvents.length, 1)
+              assertObjectContains(suiteEvents[0], { meta: { [TEST_SUITE]: suiteFile, [TEST_STATUS]: 'fail' } })
+            })
+
+          childProcess = exec(
+            `node node_modules/mocha/bin/mocha ./${suiteFile}`,
+            { cwd, env: envVars }
+          )
+
+          await Promise.all([eventsPromise, once(childProcess, 'exit')])
+        })
       })
     })
   })

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1128,6 +1128,50 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           once(childProcess, 'exit'),
         ])
       })
+
+      // ---- SUITE REPORTING BUG REPRODUCTION ----
+      // Delete this context block once the bug is understood or fixed.
+      context('suite reporting - tests with no describe wrapper', () => {
+        // When a test file uses only top-level it() calls (no describe() block),
+        // mocha never emits a non-root 'suite' event for that file.
+        //
+        // The 'suite' handler in packages/datadog-instrumentations/src/mocha/main.js
+        // only fires testSuiteStartCh when it encounters a non-root suite with
+        // suite.tests.length > 0. With no non-root suites at all, the condition is
+        // never met: no suite context is stored in testFileToSuiteCtx, no suite
+        // span is created by the plugin, and no test_suite_end event is emitted.
+        //
+        // Meanwhile tests run and report normally as mocha.test spans.
+        it.only('reports a test_suite_end event for a file whose tests have no describe wrapper', async () => {
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(e => e.content)
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
+
+              // Test events are reported regardless of the bug — this passes
+              assert.strictEqual(tests.length, 2, 'Expected 2 test events')
+
+              // Suite event must be reported exactly once for the file.
+              // This assertion FAILS when the bug is present (suiteEvents.length === 0).
+              assert.strictEqual(suiteEvents.length, 1, 'Expected 1 test_suite_end event for the test file')
+            })
+
+          childProcess = exec(
+            'node node_modules/mocha/bin/mocha ./ci-visibility/mocha-plugin-tests/top-level-it-no-describe.js',
+            {
+              cwd,
+              env: envVars,
+            }
+          )
+
+          await Promise.all([
+            eventsPromise,
+            once(childProcess, 'exit'),
+          ])
+        })
+      })
+      // ---- END SUITE REPORTING BUG REPRODUCTION ----
     })
   })
 

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -489,6 +489,29 @@ addHook({
 
     this.on('suite', function (suite) {
       if (suite.root || !suite.tests.length) {
+        // This branch can be triggered when we have top level it(...) inside test files.
+        // In that case, they all (even if they are from different files) are going to be
+        // children of the root suite.
+        // Note: We could have suites that contain top level it(...) and also it(...) nested
+        // inside describe(...) ("mixed case"). Duplication is avoided by the context guard
+        // below. Since 'suite' fires for root first, in the mixed case the ctx is created
+        // here and the describe-based handler finds it already set.
+        if (suite.root && suite.tests.length > 0) {
+          const files = new Set(suite.tests.map(test => test.file).filter(Boolean))
+          for (const file of files) {
+            if (testFileToSuiteCtx.get(file)) continue
+            const isUnskippable = unskippableSuites.includes(file)
+            isForcedToRun = isUnskippable && suitesToSkip.includes(getTestSuitePath(file, process.cwd()))
+            const ctx = {
+              testSuiteAbsolutePath: file,
+              isUnskippable,
+              isForcedToRun,
+              itrCorrelationId,
+            }
+            testFileToSuiteCtx.set(file, ctx)
+            testSuiteStartCh.runStores(ctx, () => {})
+          }
+        }
         return
       }
       let ctx = testFileToSuiteCtx.get(suite.file)
@@ -508,6 +531,44 @@ addHook({
 
     this.on('suite end', function (suite) {
       if (suite.root) {
+        // Symmetric to the suite start fix
+        const fileToTests = new Map()
+        for (const test of suite.tests) {
+          if (!test.file) continue
+          if (!fileToTests.has(test.file)) fileToTests.set(test.file, [])
+          fileToTests.get(test.file).push(test)
+        }
+        for (const [file, tests] of fileToTests) {
+          // Mixed case: if a file appears in suitesByTestFile (pre-populated before the run),
+          // its numSuitesByTestFile counter hits zero when its last describe-based suite ends
+          // and the normal path below fires testSuiteFinishCh. Since root is last when
+          // 'suite end' fires, any such file has already been handled — skipping it here
+          // avoids duplication.
+          if (suitesByTestFile[file]) continue
+          let status = 'pass'
+          if (tests.every(test => test.isPending())) {
+            status = 'skip'
+          } else {
+            for (const test of tests) {
+              if (test.state === 'failed' || test.timedOut) {
+                status = 'fail'
+                break
+              }
+            }
+          }
+          if (global.__coverage__) {
+            const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
+            testSuiteCodeCoverageCh.publish({ coverageFiles, suiteFile: file })
+            mergeCoverage(global.__coverage__, originalCoverageMap)
+            resetCoverage(global.__coverage__)
+          }
+          const ctx = testFileToSuiteCtx.get(file)
+          if (ctx) {
+            testSuiteFinishCh.publish({ status, ...ctx.currentStore }, () => {})
+          } else {
+            log.warn('No ctx found for suite', file)
+          }
+        }
         return
       }
       const suitesInTestFile = suitesByTestFile[suite.file]

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -469,6 +469,10 @@ addHook({
     }
 
     const { suitesByTestFile, numSuitesByTestFile } = getSuitesByTestFile(this.suite)
+    // Root-level tests (direct children of root, no describe wrapper) keyed by file.
+    // Populated during the root 'suite' event so the normal finish path can include them
+    // in mixed-file status calculation.
+    const rootTestsByFile = new Map()
 
     this.once('start', getOnStartHandler(frameworkVersion))
 
@@ -499,6 +503,7 @@ addHook({
         if (suite.root && suite.tests.length > 0) {
           const files = new Set(suite.tests.map(test => test.file).filter(Boolean))
           for (const file of files) {
+            rootTestsByFile.set(file, suite.tests.filter(t => t.file === file))
             if (testFileToSuiteCtx.get(file)) continue
             const isUnskippable = unskippableSuites.includes(file)
             isForcedToRun = isUnskippable && suitesToSkip.includes(getTestSuitePath(file, process.cwd()))
@@ -578,8 +583,9 @@ addHook({
         return
       }
 
+      const rootTests = rootTestsByFile.get(suite.file) || []
       let status = 'pass'
-      if (suitesInTestFile.every(suite => suite.pending)) {
+      if (suitesInTestFile.every(suite => suite.pending) && rootTests.every(test => test.isPending())) {
         status = 'skip'
       } else {
         // has to check every test in the test file
@@ -591,6 +597,11 @@ addHook({
             }
           })
         })
+        for (const test of rootTests) {
+          if (test.state === 'failed' || test.timedOut) {
+            status = 'fail'
+          }
+        }
       }
 
       if (global.__coverage__) {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the Mocha CI Visibility instrumentation where test files containing only top-level `it()` calls (no `describe()` wrapper) never emit a `test_suite_end` event, causing those files to be silently absent from CI Visibility suite-level reporting.

### Motivation

#### The bug

In dd-trace's CI Visibility model, a *suite* maps to a *test file* (not to a `describe()` block, as it would in the mocha model). Every test file should produce exactly one `test_suite_end` event, regardless of its internal structure. When a file has only top-level `it()` calls, this invariant was broken.

The root cause is in the `'suite'` event handler in `packages/datadog-instrumentations/src/mocha/main.js`:

```js
this.on('suite', function (suite) {
  if (suite.root || !suite.tests.length) {
    return  // ← early exit, no suite context created
  }
  // ... create ctx and fire testSuiteStartCh
})
```

When a test file has no `describe()` blocks, Mocha never emits a non-root `'suite'` event for that file. Instead, the `it()` calls become direct children of the **root suite** (the single top-level container with `suite.root === true`). The handler above returns immediately for root, so:

1. `testFileToSuiteCtx` never gets an entry for the file.
2. `testSuiteStartCh` never fires, which implies no `mocha.test_suite` span is created by the plugin.
3. The symmetric `'suite end'` handler also returns early for root (`if (suite.root) return`), so `testSuiteFinishCh` is never published.

The result: individual `mocha.test` spans are reported normally (tests run fine), but they reference a `test.suite` (the file path) for which no `test_suite_end` event was ever emitted: orphaned test events in CI Visibility.

#### Why root fires first / last

This is a structural property of Mocha's `Runner.prototype.runSuite` (mocha `lib/runner.js`):

```js
Runner.prototype.runSuite = function (suite, fn) {
  this.emit(EVENT_SUITE_BEGIN, suite)   // ← fires on entry, before any children
  // ... recurse into child suites via next()
  function done() {
    self.emit(EVENT_SUITE_END, suite)   // ← fires on exit, after all children
  }
}
```

Root is entered before any child suite, so its `'suite'` event fires **first**. Root exits only after all descendants have fully completed, so its `'suite end'` fires **last**. These ordering guarantees are load-bearing for the fix.

#### The fix

The fix adds a branch inside the existing root guard in both the `'suite'` and `'suite end'` handlers.

**Start (`'suite'`):** When `suite.root && suite.tests.length > 0`, the root suite has direct test children from one or more files. We group `suite.tests` by `test.file` and fire `testSuiteStartCh` for each unique file not already in `testFileToSuiteCtx`. The existing context guard (`if (testFileToSuiteCtx.get(file)) continue`) handles the mixed case (that is: files that have both top-level `it()` calls and `describe()` blocks) without any additional logic: since root fires first, the `ctx` is created here, and the subsequent describe-based `'suite'` event finds it already set and skips.

**End (`'suite end'`):** When `suite.root`, we perform the same file grouping and fire `testSuiteFinishCh` for each file, computing status directly from `suite.tests` filtered by file. The mixed-case guard here uses `suitesByTestFile` (pre-populated before the run from all non-root suites): if a file appears there, its finish was already emitted by the normal path when `numSuitesByTestFile` hit zero. Skipping it avoids double-finishing.

#### Parallel mode

No changes needed. In parallel mode, suite lifecycle is driven by the `workerpool` hook (`WorkerHandler.exec`), which is called once per test file with the file path directly from `path[0]`. It never touches the `'suite'` event tree, so the bug does not exist there.

### Additional Notes

- Four new integration tests cover: single file (no describe), two files (no describe), single file (mixed), two files (mixed).
- Three new fixture files added under `integration-tests/ci-visibility/mocha-plugin-tests/`.
- The fix is entirely contained in the two existing event handlers — no changes to `getSuitesByTestFile`, the plugin, or any other layer.