### PR TITLE
fix(log): buffer startup logs until config resolves

### DIFF
--- a/packages/dd-trace/src/config/config-types.d.ts
+++ b/packages/dd-trace/src/config/config-types.d.ts
@@ -8,7 +8,6 @@ export interface ConfigProperties extends GeneratedConfig {
     responsesEnabled: boolean
     rules: PayloadTaggingRules
   }
-  debug: boolean
   instrumentationSource: 'manual' | 'ssi'
   isCiVisibility: boolean
   isServiceNameInferred: boolean
@@ -26,7 +25,6 @@ export interface ConfigProperties extends GeneratedConfig {
   stableConfig: {
     fleetEntries: Record<string, string>
     localEntries: Record<string, string>
-    warnings: string[] | undefined
   }
   tracePropagationStyle: GeneratedConfig['tracePropagationStyle']
 }

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -21,7 +21,9 @@
  */
 
 const { deprecate } = require('util')
+
 const { DD_MAJOR } = require('../../../../version')
+const log = require('../log')
 const applyMajorOverrides = require('./major-overrides')
 const {
   supportedConfigurations,
@@ -92,7 +94,6 @@ for (const deprecation of Object.keys(deprecations)) {
 
 let localStableConfig
 let fleetStableConfig
-let stableConfigWarnings
 let stableConfigLoaded = false
 
 function loadStableConfig () {
@@ -109,7 +110,6 @@ function loadStableConfig () {
   const instance = new StableConfig()
   localStableConfig = instance.localEntries
   fleetStableConfig = instance.fleetEntries
-  stableConfigWarnings = instance.warnings
 }
 
 function getValueFromSource (name, source) {
@@ -150,10 +150,9 @@ function validateAccess (name) {
 
 module.exports = {
   /**
-   * Expose raw stable config maps and warnings for consumers that need
-   * per-source access (e.g. telemetry in Config).
+   * Expose raw stable config maps for consumers that need per-source access.
    *
-   * @returns {{ localStableConfig: object, fleetStableConfig: object, stableConfigWarnings: string[] }}
+   * @returns {{ localStableConfig: object, fleetStableConfig: object }}
    */
   getStableConfigSources () {
     if (!stableConfigLoaded) {
@@ -162,7 +161,6 @@ module.exports = {
     return {
       localStableConfig,
       fleetStableConfig,
-      stableConfigWarnings,
     }
   },
   /**
@@ -188,12 +186,11 @@ module.exports = {
               break
             }
           }
-        // TODO(BridgeAR) Implement logging. It would have to use a timeout to
-        // lazily log the message after all loading being done otherwise.
-        //   debug(
-        //     `Missing configuration ${env} in supported-configurations file. The environment variable is ignored.`
-        //   )
-        // This could be moved inside the main config logic.
+        } else {
+          log.warn(
+            'Missing configuration %s in supported-configurations.json. The environment variable is ignored.',
+            key,
+          )
         }
         deprecationMethods[key]?.()
       } else if (!internalOnly) {

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -22,6 +22,7 @@ const { ORIGIN_KEY, DATADOG_MINI_AGENT_PATH } = require('../constants')
 const { appendRules } = require('../payload-tagging/config')
 const ConfigBase = require('./config-base')
 const {
+  getConfiguredEnvName,
   getEnvironmentVariable,
   getEnvironmentVariables,
   getStableConfigSources,
@@ -174,22 +175,6 @@ class Config extends ConfigBase {
     this.stableConfig = {
       fleetEntries: configEnvSources.fleetStableConfig ?? {},
       localEntries: configEnvSources.localStableConfig ?? {},
-      warnings: configEnvSources.stableConfigWarnings,
-    }
-
-    // Configure the logger first so it can be used to warn about other configs
-    // TODO: Implement auto buffering of inside of log module before first
-    // configure call. That way the logger is always available and the
-    // application doesn't need to configure it first and the configuration
-    // happens inside of config instead of inside of log module. If the logger
-    // is not deactivated, the buffered logs would be discarded. That way stable
-    // config warnings can also be logged directly and do not need special
-    // handling.
-    this.debug = log.configure(options)
-
-    // Process stable config warnings, if any
-    for (const warning of this.stableConfig?.warnings ?? []) {
-      log.warn(warning)
     }
 
     this.#applyDefaults()
@@ -617,6 +602,15 @@ class Config extends ConfigBase {
 
     // Single tags update is tracked as a calculated value.
     setAndTrack(this, 'tags', this.tags)
+
+    if (!trackedConfigOrigins.has('DD_TRACE_DEBUG') &&
+        this.logLevel === 'debug' &&
+        // eslint-disable-next-line eslint-rules/eslint-env-aliases
+        getConfiguredEnvName('DD_TRACE_LOG_LEVEL') === 'OTEL_LOG_LEVEL') {
+      setAndTrack(this, 'DD_TRACE_DEBUG', true)
+    }
+
+    log.configure(this)
 
     telemetry.updateConfig([...configWithOrigin.values()], this)
   }

--- a/packages/dd-trace/src/config/stable.js
+++ b/packages/dd-trace/src/config/stable.js
@@ -2,11 +2,11 @@
 
 const os = require('os')
 const fs = require('fs')
+const log = require('../log')
 const { getEnvironmentVariable } = require('./helper')
 
 class StableConfig {
   constructor () {
-    this.warnings = [] // Logger hasn't been initialized yet, so we can't use log.warn
     this.localEntries = {}
     this.fleetEntries = {}
     this.wasm_loaded = false
@@ -27,13 +27,13 @@ class StableConfig {
       libdatadog = require('@datadog/libdatadog')
       this.wasm_loaded = true
     } catch {
-      this.warnings.push('Can\'t load libdatadog library')
+      log.warn('Can\'t load libdatadog library')
       return
     }
 
     const libconfig = libdatadog.maybeLoad('library_config')
     if (libconfig === undefined) {
-      this.warnings.push('Can\'t load library_config library')
+      log.warn('Can\'t load library_config library')
       return
     }
 
@@ -50,17 +50,17 @@ class StableConfig {
           this.fleetEntries[entry.name] = entry.value
         }
       }
-    } catch (e) {
-      this.warnings.push(`Error parsing configuration from file: ${e.message}`)
+    } catch (error) {
+      log.warn('Error parsing configuration from file: %s', error.message)
     }
   }
 
   #readConfigFromPath (path) {
     try {
       return fs.readFileSync(path, 'utf8')
-    } catch (err) {
-      if (err.code !== 'ENOENT') {
-        this.warnings.push(`Error reading config file at ${path}. ${err.code}: ${err.message}`)
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        log.warn('Error reading config file at %s. %s: %s', path, error.code, error.message)
       }
       return '' // Always return a string for configurator.get_configuration()
     }

--- a/packages/dd-trace/src/debugger/config.js
+++ b/packages/dd-trace/src/debugger/config.js
@@ -6,7 +6,7 @@ module.exports = function getDebuggerConfig (config, inputPath) {
   const { commitSHA, repositoryUrl } = getGitMetadata(config)
   return {
     commitSHA,
-    debug: config.debug,
+    debug: config.DD_TRACE_DEBUG,
     dynamicInstrumentation: config.dynamicInstrumentation,
     env: config.env,
     hostname: config.hostname,

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -2,117 +2,224 @@
 
 const { inspect } = require('util')
 
-const { defaults } = require('../config/defaults')
-const { isTrue } = require('../util')
-const { getValueFromEnvSources } = require('../config/helper')
 const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = require('./channels')
 const logWriter = require('./writer')
 const { Log, LogConfig, NoTransmitError } = require('./log')
 
-const config = {
-  enabled: defaults.DD_TRACE_DEBUG,
-  logger: undefined,
-  logLevel: defaults.logLevel,
-}
+/**
+ * @typedef {import('../config/config-types').ConfigProperties} ConfigProperties
+ * @typedef {Partial<Pick<ConfigProperties, 'DD_TRACE_DEBUG' | 'logger' | 'logLevel'>>} LoggerConfig
+ * @typedef {import('diagnostics_channel').Channel} Channel
+ * @typedef {((formatted: string) => string | Error) | null} LogFormatter
+ * @typedef {[Channel, LogFormatter, unknown[]]} BufferedLog
+ */
 
-// In most places where we know we want to mute a log we use log.error() directly
 const NO_TRANSMIT = new LogConfig(false)
+
+/** @type {BufferedLog[]} */
+let buffer = []
 
 const log = {
   LogConfig,
   NO_TRANSMIT,
   NoTransmitError,
+  trace: bufferTrace,
+  debug: bufferDebug,
+  info: bufferInfo,
+  warn: bufferWarn,
+  error: bufferError,
+  errorWithoutTelemetry: bufferErrorWithoutTelemetry,
 
-  trace (...args) {
-    if (traceChannel.hasSubscribers) {
-      const logRecord = {}
-
-      Error.captureStackTrace(logRecord, log.trace)
-
-      const stack = logRecord.stack.split('\n')
-      const fn = stack[1].replace(/^\s+at ([^\s]+) .+/, '$1')
-      const options = { depth: 2, breakLength: Infinity, compact: true, maxArrayLength: Infinity }
-      const params = args.map(a => inspect(a, options)).join(', ')
-
-      stack[0] = `Trace: ${fn}(${params})`
-
-      publishFormatted(traceChannel, null, stack.join('\n'))
-    }
-    // TODO: Why do we allow chaining here? This is likely not used anywhere.
-    // If it is used, that seems like a mistake.
-    return log
-  },
-
-  debug (...args) {
-    publishFormatted(debugChannel, null, ...args)
-    return log
-  },
-
-  info (...args) {
-    publishFormatted(infoChannel, null, ...args)
-    return log
-  },
-
-  warn (...args) {
-    publishFormatted(warnChannel, null, ...args)
-    return log
-  },
-
-  error (...args) {
-    publishFormatted(errorChannel, formatted => {
-      const stackTraceLimitBackup = Error.stackTraceLimit
-      Error.stackTraceLimit = 0
-      const newError = new Error(formatted)
-      Error.stackTraceLimit = stackTraceLimitBackup
-      Error.captureStackTrace(newError, log.error)
-      return newError
-    }, ...args)
-    return log
-  },
-
-  errorWithoutTelemetry (...args) {
-    args.push(NO_TRANSMIT)
-    publishFormatted(errorChannel, null, ...args)
-    return log
-  },
-
+  /**
+   * @param {LoggerConfig} options
+   */
   configure (options) {
-    config.logger = options.logger
-    config.logLevel = options.logLevel ??
-        getValueFromEnvSources('DD_TRACE_LOG_LEVEL') ??
-        config.logLevel
-    config.enabled = isTrue(
-      getValueFromEnvSources('DD_TRACE_DEBUG') ??
-      // TODO: Handle this by adding a log buffer so that configure may be called with the actual configurations.
-      // eslint-disable-next-line eslint-rules/eslint-process-env
-      (process.env.OTEL_LOG_LEVEL === 'debug' || config.enabled)
-    )
-    logWriter.configure(config.enabled, config.logLevel, options.logger)
+    const enabled = options.DD_TRACE_DEBUG === true
+    logWriter.configure(enabled, options.logLevel, options.logger)
+    setLogMethods(enabled)
 
-    return config.enabled
+    const buffered = buffer
+    buffer = []
+
+    if (enabled) {
+      for (const [channel, formatter, args] of buffered) {
+        publishFormatted(channel, formatter, ...args)
+      }
+    }
+
+    return enabled
   },
 }
 
-function publishFormatted (ch, formatter, ...args) {
-  if (ch.hasSubscribers) {
+/**
+ * @param {...unknown} args
+ */
+function bufferTrace (...args) {
+  const formatted = formatTrace(args)
+  bufferLog(traceChannel, null, [formatted])
+}
+
+/**
+ * @param {...unknown} args
+ */
+function bufferDebug (...args) {
+  bufferLog(debugChannel, null, args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function bufferInfo (...args) {
+  bufferLog(infoChannel, null, args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function bufferWarn (...args) {
+  bufferLog(warnChannel, null, args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function bufferError (...args) {
+  bufferLog(errorChannel, formatError, args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function bufferErrorWithoutTelemetry (...args) {
+  args.push(NO_TRANSMIT)
+  bufferLog(errorChannel, null, args)
+}
+
+/**
+ * @param {Channel} channel
+ * @param {LogFormatter} formatter
+ * @param {unknown[]} args
+ */
+function bufferLog (channel, formatter, args) {
+  buffer.push([channel, formatter, args])
+}
+
+/**
+ * @param {...unknown} args
+ */
+function writeTrace (...args) {
+  if (traceChannel.hasSubscribers) {
+    const formatted = formatTrace(args)
+    publishFormatted(traceChannel, null, formatted)
+  }
+}
+
+/**
+ * @param {...unknown} args
+ */
+function writeDebug (...args) {
+  publishFormatted(debugChannel, null, ...args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function writeInfo (...args) {
+  publishFormatted(infoChannel, null, ...args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function writeWarn (...args) {
+  publishFormatted(warnChannel, null, ...args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function writeError (...args) {
+  publishFormatted(errorChannel, formatError, ...args)
+}
+
+/**
+ * @param {...unknown} args
+ */
+function writeErrorWithoutTelemetry (...args) {
+  args.push(NO_TRANSMIT)
+  publishFormatted(errorChannel, null, ...args)
+}
+
+function noopLog () {}
+
+/**
+ * @param {boolean} enabled
+ */
+function setLogMethods (enabled) {
+  log.trace = enabled ? writeTrace : noopLog
+  log.debug = enabled ? writeDebug : noopLog
+  log.info = enabled ? writeInfo : noopLog
+  log.warn = enabled ? writeWarn : noopLog
+  log.error = enabled ? writeError : noopLog
+  log.errorWithoutTelemetry = enabled ? writeErrorWithoutTelemetry : noopLog
+}
+
+/**
+ * @param {unknown[]} args
+ */
+function formatTrace (args) {
+  const logRecord = { stack: '' }
+
+  Error.captureStackTrace(logRecord, log.trace)
+
+  const stack = logRecord.stack.split('\n')
+  const fn = stack[1].replace(/^\s+at ([^\s]+) .+/, '$1')
+  const options = { depth: 2, breakLength: Infinity, compact: true, maxArrayLength: Infinity }
+  const params = args.map(a => inspect(a, options)).join(', ')
+
+  stack[0] = `Trace: ${fn}(${params})`
+
+  return stack.join('\n')
+}
+
+/**
+ * @param {string} formatted
+ */
+function formatError (formatted) {
+  const stackTraceLimitBackup = Error.stackTraceLimit
+  Error.stackTraceLimit = 0
+  const newError = new Error(formatted)
+  Error.stackTraceLimit = stackTraceLimitBackup
+  Error.captureStackTrace(newError, log.error)
+  return newError
+}
+
+/**
+ * @param {Channel} channel
+ * @param {LogFormatter} formatter
+ * @param {...unknown} args
+ */
+function publishFormatted (channel, formatter, ...args) {
+  if (channel.hasSubscribers) {
     const log = Log.parse(...args)
     const { formatted, cause } = getErrorLog(log)
 
-    // calling twice ch.publish() because Error cause is only available in Node.js v16.9.0
+    // calling twice channel.publish() because Error cause is only available in Node.js v16.9.0
     // TODO: replace it with Error(message, { cause }) when cause has broad support
-    if (formatted) ch.publish(formatter?.(formatted) || formatted)
-    if (cause) ch.publish(cause)
+    if (formatted) channel.publish(formatter?.(formatted) || formatted)
+    if (cause) channel.publish(cause)
   }
 }
 
-function getErrorLog (err) {
-  if (typeof err?.delegate === 'function') {
-    const result = err.delegate()
+/**
+ * @param {Log} errorLog
+ */
+function getErrorLog (errorLog) {
+  if (typeof errorLog?.delegate === 'function') {
+    const result = errorLog.delegate()
     return Array.isArray(result) ? Log.parse(...result) : Log.parse(result)
   }
-  return err
+  return errorLog
 }
-
-log.configure({})
 
 module.exports = log

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -26,7 +26,7 @@ class DatadogTracer {
     this._version = config.version
     this._env = config.env
     this._logInjection = config.logInjection
-    this._debug = config.debug
+    this._debug = config.DD_TRACE_DEBUG
     this._prioritySampler = prioritySampler ?? new PrioritySampler(config.env, config.sampler)
 
     // OTEL_TRACES_EXPORTER=otlp should not replace the Test Optimization

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -98,7 +98,7 @@ function configInfo () {
     enabled: config.enabled,
     service: config.service,
     agent_url: url,
-    debug: !!config.debug,
+    debug: !!config.DD_TRACE_DEBUG,
     sample_rate: config.sampler.sampleRate,
     sampling_rules: samplingRules,
     tags: config.tags,

--- a/packages/dd-trace/test/config/helper.spec.js
+++ b/packages/dd-trace/test/config/helper.spec.js
@@ -29,7 +29,6 @@ describe('config-helper stable config sources', () => {
         DD_SERVICE: 'fleet-service',
         DD_ENV: 'fleet-env',
       }
-      this.warnings = []
     })
 
     const { getStableConfigSources } = proxyquire('../../src/config/helper', {
@@ -51,7 +50,6 @@ describe('config-helper stable config sources', () => {
       DD_SERVICE: 'fleet-service',
       DD_ENV: 'fleet-env',
     })
-    assert.deepStrictEqual(sources.stableConfigWarnings, [])
   })
 
   it('does not load stable config in serverless environment', () => {
@@ -82,6 +80,7 @@ describe('config-helper stable config sources', () => {
 describe('config-helper env resolution', () => {
   let getValueFromEnvSources
   let getConfiguredEnvName
+  let getEnvironmentVariables
   let getEnvironmentVariable
   let resetModule
   let originalEnv
@@ -91,6 +90,7 @@ describe('config-helper env resolution', () => {
     const mod = proxyquire('../../src/config/helper', overrides)
     getValueFromEnvSources = mod.getValueFromEnvSources
     getConfiguredEnvName = mod.getConfiguredEnvName
+    getEnvironmentVariables = mod.getEnvironmentVariables
     getEnvironmentVariable = mod.getEnvironmentVariable
     resetModule = () => {}
   }
@@ -185,6 +185,28 @@ describe('config-helper env resolution', () => {
     assert.strictEqual(value, 'production')
   })
 
+  it('logs unsupported DD_ environment variables while collecting envs', () => {
+    const log = {
+      warn: sinon.spy(),
+    }
+    loadModule({
+      '../log': log,
+      '../serverless': {
+        IS_SERVERLESS: true,
+      },
+    })
+    process.env.DD_UNSUPPORTED_CONFIG = 'value'
+
+    const envs = getEnvironmentVariables()
+
+    assert.ok(!('DD_UNSUPPORTED_CONFIG' in envs))
+    sinon.assert.calledOnceWithExactly(
+      log.warn,
+      'Missing configuration %s in supported-configurations.json. The environment variable is ignored.',
+      'DD_UNSUPPORTED_CONFIG',
+    )
+  })
+
   describe('with stable config and env vars', () => {
     beforeEach(() => {
       // Re-load module with stable config enabled (non-serverless)
@@ -197,7 +219,6 @@ describe('config-helper env resolution', () => {
         this.fleetEntries = {
           DD_SERVICE: 'fleet-service',
         }
-        this.warnings = []
       })
 
       const mod = proxyquire('../../src/config/helper', {
@@ -226,7 +247,6 @@ describe('config-helper env resolution', () => {
           DD_TRACE_SAMPLE_RATE: '0.9',
           DD_SERVICE: 'fleet',
         }
-        this.warnings = []
       })
 
       const mod = proxyquire('../../src/config/helper', {
@@ -252,7 +272,6 @@ describe('config-helper env resolution', () => {
         this.fleetEntries = {
           DD_SERVICE: undefined,
         }
-        this.warnings = []
       })
 
       const mod = proxyquire('../../src/config/helper', {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -29,6 +29,10 @@ describe('Config', () => {
   let fs
   let existsSyncParam
   let existsSyncReturn
+  let logInfo
+  let logWarn
+  let logError
+  let logConfigure
   let updateConfig
   const isWindows = process.platform === 'win32'
 
@@ -59,9 +63,10 @@ describe('Config', () => {
     } = overrides
 
     log = proxyquire('../../src/log', {})
-    sinon.spy(log, 'info')
-    sinon.spy(log, 'warn')
-    sinon.spy(log, 'error')
+    logInfo = sinon.spy(log, 'info')
+    logWarn = sinon.spy(log, 'warn')
+    logError = sinon.spy(log, 'error')
+    logConfigure = sinon.spy(log, 'configure')
     const parsers = proxyquire.noPreserveCache()('../../src/config/parsers', {})
     const supportedConfigurations = proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
     const configDefaults = proxyquire.noPreserveCache()('../../src/config/defaults', {
@@ -70,8 +75,13 @@ describe('Config', () => {
       './parsers': parsers,
       '../../../../version': { DD_MAJOR: ddMajor },
     })
+    const stableConfig = proxyquire.noPreserveCache()('../../src/config/stable', {
+      '../log': log,
+    })
     const configHelper = proxyquire.noPreserveCache()('../../src/config/helper', {
+      '../log': log,
       './supported-configurations.json': supportedConfigurations,
+      './stable': stableConfig,
     })
     const serverless = proxyquire.noPreserveCache()('../../src/serverless', {})
     return proxyquire.noPreserveCache()('../../src/config', {
@@ -81,6 +91,7 @@ describe('Config', () => {
       '../serverless': serverless,
       'node:fs': fs,
       './helper': configHelper,
+      './stable': stableConfig,
       '../pkg': pkg,
       '../../../../version': { DD_MAJOR: ddMajor },
     })(options)
@@ -238,7 +249,6 @@ describe('Config', () => {
   describe('property surface', () => {
     // Mirror of the runtime-only fields in `ConfigProperties` (config-types.d.ts).
     const INTERNAL_RUNTIME_PROPERTIES = [
-      'debug',
       'isServiceNameInferred',
       'sampler',
       'stableConfig',
@@ -267,10 +277,50 @@ describe('Config', () => {
     const config = getConfig()
 
     assertObjectContains(config, {
-      debug: true,
+      DD_TRACE_DEBUG: true,
       logger: undefined,
       logLevel: 'error',
     })
+  })
+
+  it('should configure the logger with the resolved config', () => {
+    process.env.DD_TRACE_DEBUG = 'true'
+    process.env.DD_TRACE_LOG_LEVEL = 'warn'
+    const logger = {
+      debug: sinon.spy(),
+      error: sinon.spy(),
+    }
+
+    const config = getConfig({ logger, logLevel: 'error' })
+
+    sinon.assert.calledOnce(logConfigure)
+    assert.strictEqual(logConfigure.firstCall.args[0], config)
+    assertObjectContains(logConfigure.firstCall.args[0], {
+      DD_TRACE_DEBUG: true,
+      logger,
+      logLevel: 'error',
+    })
+  })
+
+  it('should keep DD_TRACE_DEBUG precedence when OTEL_LOG_LEVEL is debug', () => {
+    process.env.DD_TRACE_DEBUG = 'false'
+    process.env.OTEL_LOG_LEVEL = 'debug'
+
+    const config = getConfig()
+
+    assert.strictEqual(config.DD_TRACE_DEBUG, false)
+    sinon.assert.calledOnce(logConfigure)
+    assert.strictEqual(logConfigure.firstCall.args[0].DD_TRACE_DEBUG, false)
+  })
+
+  it('should enable debug when OTEL_LOG_LEVEL is the configured log level source', () => {
+    process.env.OTEL_LOG_LEVEL = 'debug'
+
+    const config = getConfig()
+
+    assert.strictEqual(config.DD_TRACE_DEBUG, true)
+    sinon.assert.calledOnce(logConfigure)
+    assert.strictEqual(logConfigure.firstCall.args[0].DD_TRACE_DEBUG, true)
   })
 
   it('should accept a circular logger instance without overflowing the stack (issue #8122)', () => {
@@ -323,7 +373,7 @@ describe('Config', () => {
     const config = getConfig()
 
     assertObjectContains(config, {
-      debug: false,
+      DD_TRACE_DEBUG: false,
       service: 'service',
       logLevel: 'error',
       sampleRate: 0.5,
@@ -358,7 +408,7 @@ describe('Config', () => {
     const config = getConfig()
 
     assertObjectContains(config, {
-      debug: true,
+      DD_TRACE_DEBUG: true,
       service: 'otel_service',
       logLevel: 'debug',
       sampleRate: 0.1,
@@ -549,12 +599,12 @@ describe('Config', () => {
       ['always_off', 'parentbased_always_off'],
       ['traceidratio', 'parentbased_traceidratio'],
     ]) {
-      log.info.resetHistory()
+      logInfo.resetHistory()
       process.env.OTEL_TRACES_SAMPLER = sampler
       process.env.OTEL_TRACES_SAMPLER_ARG = '0.5'
       getConfig()
       sinon.assert.calledWith(
-        log.info,
+        logInfo,
         'OTEL_TRACES_SAMPLER=%s does not respect upstream sampling decisions; using parent-based equivalent %s instead',
         sampler,
         parentBased
@@ -564,11 +614,11 @@ describe('Config', () => {
 
   it('should not log a sampler upgrade for parentbased samplers', () => {
     for (const sampler of ['parentbased_always_on', 'parentbased_always_off', 'parentbased_traceidratio']) {
-      log.info.resetHistory()
+      logInfo.resetHistory()
       process.env.OTEL_TRACES_SAMPLER = sampler
       process.env.OTEL_TRACES_SAMPLER_ARG = '0.5'
       getConfig()
-      const upgradeCall = log.info.getCalls().find(
+      const upgradeCall = logInfo.getCalls().find(
         (call) => call.args[0]?.includes?.('does not respect upstream sampling decisions')
       )
       assert.strictEqual(upgradeCall, undefined)
@@ -627,7 +677,7 @@ describe('Config', () => {
   it('should not warn when OTEL_EXPORTER_OTLP_TRACES_PROTOCOL is http/json', () => {
     process.env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = 'http/json'
     getConfig()
-    const warnCall = log.warn.getCalls().find(
+    const warnCall = logWarn.getCalls().find(
       (call) => call.args[0]?.includes?.('OTEL_EXPORTER_OTLP_TRACES_PROTOCOL')
     )
     assert.strictEqual(warnCall, undefined)
@@ -694,7 +744,6 @@ describe('Config', () => {
         },
       },
       DD_CRASHTRACKING_ENABLED: true,
-      debug: false,
       dogstatsd: {
         hostname: '127.0.0.1',
         port: 8125,
@@ -951,7 +1000,7 @@ describe('Config', () => {
     const config = getConfig({
       logger: {},
     })
-    sinon.assert.notCalled(log.warn)
+    sinon.assert.notCalled(logWarn)
     assert.strictEqual(config.spanAttributeSchema, 'v0')
   })
 
@@ -1170,7 +1219,6 @@ describe('Config', () => {
         },
       },
       DD_CRASHTRACKING_ENABLED: false,
-      debug: true,
       dogstatsd: {
         hostname: 'dsd-agent',
         port: 5218,
@@ -1783,22 +1831,22 @@ describe('Config', () => {
     if (DD_MAJOR < 6) {
       assert.deepStrictEqual(config.tracePropagationStyle.extract, ['datadog', 'b3', 'b3 single header'])
       assert.deepStrictEqual(config.tracePropagationStyle.inject, ['datadog', 'b3', 'b3 single header'])
-      sinon.assert.calledOnce(log.warn)
+      sinon.assert.calledOnce(logWarn)
     } else {
       // In v6 `experimental.b3` is no longer parsed, so the calculated push doesn't fire and the
       // propagation styles stay at the explicit input (`tracePropagationStyle: { inject: ['datadog'], ... }`).
       assert.deepStrictEqual(config.tracePropagationStyle.extract, ['datadog'])
       assert.deepStrictEqual(config.tracePropagationStyle.inject, ['datadog'])
-      sinon.assert.calledThrice(log.warn)
+      sinon.assert.calledTwice(logWarn)
       sinon.assert.calledWithExactly(
-        log.warn,
+        logWarn,
         'Unknown option %s with value %o',
         'iast.securityControlsConfiguration',
         'SANITIZER:CODE_INJECTION:sanitizer.js:method',
       )
-      sinon.assert.calledWithExactly(log.warn, 'Unknown option %s with value %o', 'experimental.b3', true)
+      sinon.assert.calledWithExactly(logWarn, 'Unknown option %s with value %o', 'experimental.b3', true)
     }
-    sinon.assert.calledWithExactly(log.warn, 'Unknown option %s with value %o', 'enabled', false)
+    sinon.assert.calledWithExactly(logWarn, 'Unknown option %s with value %o', 'enabled', false)
 
     sinon.assert.calledOnce(updateConfig)
 
@@ -1968,7 +2016,7 @@ describe('Config', () => {
     const config = getConfig()
 
     sinon.assert.calledWithExactly(
-      log.warn,
+      logWarn,
       "Invalid value: 'foo' for DD_TRACE_SPAN_ATTRIBUTE_SCHEMA (source: env_var), picked default",
     )
     assert.strictEqual(config.spanAttributeSchema, 'v0')
@@ -2920,16 +2968,16 @@ describe('Config', () => {
       it(`v5 keeps experimental.iast (${name})`, () => {
         const config = getConfig({ experimental: { iast } }, { ddMajor: 5 })
         assert.strictEqual(config.iast[v5Field], v5Value)
-        sinon.assert.notCalled(log.warn)
+        sinon.assert.notCalled(logWarn)
       })
 
       it(`v6 rejects experimental.iast (${name}) as Unknown option`, () => {
         const config = getConfig({ experimental: { iast } }, { ddMajor: 6 })
         assert.strictEqual(config.iast.enabled, false)
         assert.strictEqual(config.iast.requestSampling, 30)
-        sinon.assert.calledOnce(log.warn)
+        sinon.assert.calledOnce(logWarn)
         sinon.assert.calledWithExactly(
-          log.warn,
+          logWarn,
           'Unknown option %s with value %o',
           'experimental.iast',
           iast,
@@ -2968,7 +3016,7 @@ describe('Config', () => {
 
       assert.strictEqual(config.sampler?.spanSamplingRules, undefined)
       sinon.assert.calledWithMatch(
-        log.warn,
+        logWarn,
         'Error reading span sampling rules file %s; %o',
         '{"sample_rate":',
         sinon.match.instanceOf(SyntaxError)
@@ -2989,7 +3037,7 @@ describe('Config', () => {
       },
     })
 
-    sinon.assert.callCount(log.error, 3)
+    sinon.assert.callCount(logError, 3)
     const assertMissingAppsecTemplateError = (message, optionName, fileName) => {
       const escapedFileName = fileName.replaceAll('.', '\\.')
       const escapedOptionName = optionName.replaceAll('.', '\\.')
@@ -3011,17 +3059,17 @@ describe('Config', () => {
     }
 
     assertMissingAppsecTemplateError(
-      log.error.firstCall.args[0],
+      logError.firstCall.args[0],
       'appsec.blockedTemplateHtml',
       'DOES_NOT_EXIST.html'
     )
     assertMissingAppsecTemplateError(
-      log.error.secondCall.args[0],
+      logError.secondCall.args[0],
       'appsec.blockedTemplateJson',
       'DOES_NOT_EXIST.json'
     )
     assertMissingAppsecTemplateError(
-      log.error.thirdCall.args[0],
+      logError.thirdCall.args[0],
       'appsec.blockedTemplateGraphql',
       'DOES_NOT_EXIST.json'
     )
@@ -3700,9 +3748,6 @@ apm_configuration_default:
   DD_RUNTIME_METRICS_ENABLED: 'true'
   DD_FOOBAR_ENABLED: baz
 `)
-      const stableConfig = new StableConfig()
-      assert.strictEqual(stableConfig.warnings.length, 0)
-
       const config = getConfig()
       assert.strictEqual(config.runtimeMetrics.enabled, true)
     })
@@ -3714,8 +3759,75 @@ apm_configuration_default:
     apm_configuration_default:
 DD_RUNTIME_METRICS_ENABLED true
 `)
+      getConfig()
+      sinon.assert.calledWithMatch(logWarn, 'Error parsing configuration from file: %s')
+    })
+
+    it('should log a warning if the libdatadog library is unavailable', () => {
+      fs.writeFileSync(
+        localConfigPath,
+        `
+apm_configuration_default:
+  DD_RUNTIME_METRICS_ENABLED: 'true'
+`)
+      const log = {
+        warn: sinon.spy(),
+      }
+      const StableConfig = proxyquire.noPreserveCache()('../../src/config/stable', {
+        '../log': log,
+        '@datadog/libdatadog': null,
+      })
+
       const stableConfig = new StableConfig()
-      assert.strictEqual(stableConfig.warnings.length, 1)
+
+      assert.strictEqual(stableConfig.wasm_loaded, false)
+      sinon.assert.calledOnceWithExactly(log.warn, 'Can\'t load libdatadog library')
+    })
+
+    it('should log a warning if the library_config module is unavailable', () => {
+      fs.writeFileSync(
+        localConfigPath,
+        `
+apm_configuration_default:
+  DD_RUNTIME_METRICS_ENABLED: 'true'
+`)
+      const log = {
+        warn: sinon.spy(),
+      }
+      const StableConfig = proxyquire.noPreserveCache()('../../src/config/stable', {
+        '../log': log,
+        '@datadog/libdatadog': {
+          maybeLoad: sinon.stub().withArgs('library_config').returns(undefined),
+        },
+      })
+
+      const stableConfig = new StableConfig()
+
+      assert.strictEqual(stableConfig.wasm_loaded, true)
+      sinon.assert.calledOnceWithExactly(log.warn, 'Can\'t load library_config library')
+    })
+
+    it('should log a warning if stable config files cannot be read', () => {
+      const log = {
+        warn: sinon.spy(),
+      }
+      const StableConfig = proxyquire.noPreserveCache()('../../src/config/stable', {
+        '../log': log,
+        fs: {
+          readFileSync: sinon.stub().throws(Object.assign(new Error('Access denied'), { code: 'EACCES' })),
+        },
+      })
+
+      const stableConfig = new StableConfig()
+
+      assert.strictEqual(stableConfig.wasm_loaded, false)
+      sinon.assert.calledWithExactly(
+        log.warn,
+        'Error reading config file at %s. %s: %s',
+        localConfigPath,
+        'EACCES',
+        'Access denied',
+      )
     })
 
     it('should only load the WASM module if the stable config files exist', () => {
@@ -3745,7 +3857,6 @@ apm_configuration_default:
       assert.deepStrictEqual(stableConfig.stableConfig, {
         fleetEntries: {},
         localEntries: {},
-        warnings: undefined,
       })
     })
 
@@ -4071,8 +4182,8 @@ rules:
 
       getConfig(undefined, { ddMajor: 5 })
 
-      assert.strictEqual(log.warn.called, true)
-      const warningMessage = log.warn.args[0][0]
+      assert.strictEqual(logWarn.called, true)
+      const warningMessage = logWarn.args[0][0]
       assert.match(warningMessage, /NX_TASK_TARGET_PROJECT is set but no service name was configured/)
       assert.match(warningMessage, /In v6, NX_TASK_TARGET_PROJECT will be used as the default service name/)
       assert.match(warningMessage, /Set DD_ENABLE_NX_SERVICE_NAME=true to opt-in/)
@@ -4087,7 +4198,7 @@ rules:
       const config = getConfig(undefined, { ddMajor: 6 })
 
       assert.strictEqual(config.service, 'my-nx-project')
-      assert.strictEqual(log.warn.called, false)
+      assert.strictEqual(logWarn.called, false)
     })
 
     it('should not warn when DD_ENABLE_NX_SERVICE_NAME is explicitly set', () => {
@@ -4098,7 +4209,7 @@ rules:
 
       getConfig()
 
-      assert.strictEqual(log.warn.called, false)
+      assert.strictEqual(logWarn.called, false)
     })
 
     it('should not warn when a service name is explicitly configured', () => {
@@ -4108,7 +4219,7 @@ rules:
 
       getConfig()
 
-      assert.strictEqual(log.warn.called, false)
+      assert.strictEqual(logWarn.called, false)
     })
   })
 

--- a/packages/dd-trace/test/debugger/index.spec.js
+++ b/packages/dd-trace/test/debugger/index.spec.js
@@ -60,7 +60,7 @@ describe('debugger/index', () => {
     })
 
     config = {
-      debug: false,
+      DD_TRACE_DEBUG: false,
       dynamicInstrumentation: {
         enabled: true,
       },

--- a/packages/dd-trace/test/log.spec.js
+++ b/packages/dd-trace/test/log.spec.js
@@ -15,37 +15,14 @@ describe('log', () => {
   describe('config', () => {
     let env
 
-    /**
-     * @param {{
-     *   fleetEntries?: Record<string, string|undefined>,
-     *   localEntries?: Record<string, string|undefined>,
-     *   isServerless?: boolean
-     * }} [options]
-     */
-    const reloadLog = (options = {}) => {
-      const { fleetEntries, localEntries, isServerless = true } = options
+    const reloadLog = () => {
       const logWriter = {
         configure: sinon.spy(),
       }
-      const configHelper = isServerless
-        ? proxyquire.noPreserveCache()('../src/config/helper', {
-          '../serverless': { IS_SERVERLESS: true },
-        })
-        : proxyquire.noPreserveCache()('../src/config/helper', {
-          '../serverless': { IS_SERVERLESS: false },
-          './stable': function StableConfigStub () {
-            this.localEntries = localEntries
-            this.fleetEntries = fleetEntries
-            this.warnings = []
-          },
-        })
 
       const log = proxyquire.noPreserveCache()('../src/log', {
-        '../config/helper': configHelper,
         './writer': logWriter,
       })
-
-      logWriter.configure.resetHistory()
 
       return { log, logWriter }
     }
@@ -64,11 +41,27 @@ describe('log', () => {
       assert.strictEqual(typeof log.configure, 'function')
     })
 
-    it('should configure with default config if no environment variables are set', () => {
+    it('should configure without debug enabled by default', () => {
       const { log, logWriter } = reloadLog()
 
       assert.strictEqual(log.configure({}), false)
-      sinon.assert.calledOnceWithExactly(logWriter.configure, false, 'debug', undefined)
+      sinon.assert.calledOnceWithExactly(logWriter.configure, false, undefined, undefined)
+    })
+
+    it('should configure from DD_TRACE_DEBUG when that source is configured', () => {
+      process.env.DD_TRACE_DEBUG = 'false'
+      const { log, logWriter } = reloadLog()
+
+      assert.strictEqual(log.configure({ DD_TRACE_DEBUG: true }), true)
+      sinon.assert.calledOnceWithExactly(logWriter.configure, true, undefined, undefined)
+    })
+
+    it('should configure from DD_TRACE_DEBUG when disabled', () => {
+      process.env.DD_TRACE_DEBUG = 'false'
+      const { log, logWriter } = reloadLog()
+
+      assert.strictEqual(log.configure({ DD_TRACE_DEBUG: false }), false)
+      sinon.assert.calledOnceWithExactly(logWriter.configure, false, undefined, undefined)
     })
 
     it('should pass the logger option to the writer', () => {
@@ -78,135 +71,85 @@ describe('log', () => {
         error: () => {},
       }
 
-      log.configure({ logger })
+      log.configure({ DD_TRACE_DEBUG: true, logLevel: 'debug', logger })
 
-      sinon.assert.calledOnceWithExactly(logWriter.configure, false, 'debug', logger)
+      sinon.assert.calledOnceWithExactly(logWriter.configure, true, 'debug', logger)
     })
 
-    it('should initialize from environment variables with DD env vars taking precedence OTEL env vars', () => {
-      process.env.DD_TRACE_LOG_LEVEL = 'error'
-      process.env.DD_TRACE_DEBUG = 'false'
-      process.env.OTEL_LOG_LEVEL = 'debug'
+    it('should pass the final log level to the writer', () => {
       const { log, logWriter } = reloadLog()
 
-      assert.strictEqual(log.configure({}), false)
-      sinon.assert.calledOnceWithExactly(logWriter.configure, false, 'error', undefined)
+      assert.strictEqual(log.configure({ DD_TRACE_DEBUG: true, logLevel: 'error' }), true)
+      sinon.assert.calledOnceWithExactly(logWriter.configure, true, 'error', undefined)
     })
 
-    it('should initialize with OTEL environment variables when DD env vars are not set', () => {
-      process.env.OTEL_LOG_LEVEL = 'debug'
-      const { log, logWriter } = reloadLog()
+    it('should replay buffered logs when configured', () => {
+      const log = proxyquire.noPreserveCache()('../src/log', {})
+      const logger = {
+        debug: sinon.spy(),
+        info: sinon.spy(),
+        warn: sinon.spy(),
+        error: sinon.spy(),
+      }
 
-      assert.strictEqual(log.configure({}), true)
-      sinon.assert.calledOnceWithExactly(logWriter.configure, true, 'debug', undefined)
+      log.debug('early debug')
+      log.info('early info')
+      log.warn('early %s', 'warning')
+      log.error('early error')
+      log.errorWithoutTelemetry('early error without telemetry')
+      log.configure({ DD_TRACE_DEBUG: true, logLevel: 'debug', logger })
+
+      sinon.assert.calledOnceWithExactly(logger.debug, 'early debug')
+      sinon.assert.calledOnceWithExactly(logger.info, 'early info')
+      sinon.assert.calledOnceWithExactly(logger.warn, 'early warning')
+      sinon.assert.calledTwice(logger.error)
+      assert.strictEqual(logger.error.firstCall.args[0].message, 'early error')
+      assert.strictEqual(logger.error.secondCall.args[0], 'early error without telemetry')
     })
 
-    it('should initialize from environment variables', () => {
-      process.env.DD_TRACE_DEBUG = 'true'
-      const { log, logWriter } = reloadLog()
+    it('should drop buffered logs when disabled', () => {
+      const log = proxyquire.noPreserveCache()('../src/log', {})
+      const logger = {
+        debug: sinon.spy(),
+        warn: sinon.spy(),
+        error: sinon.spy(),
+      }
 
-      assert.strictEqual(log.configure({}), true)
-      sinon.assert.calledOnceWithExactly(logWriter.configure, true, 'debug', undefined)
+      log.warn('early %s', 'warning')
+      log.configure({ DD_TRACE_DEBUG: false, logLevel: 'debug', logger })
+
+      sinon.assert.notCalled(logger.warn)
     })
 
-    it('should read case-insensitive booleans from environment variables', () => {
-      process.env.DD_TRACE_DEBUG = 'TRUE'
-      const { log, logWriter } = reloadLog()
+    it('should preserve buffered trace call sites', function foo () {
+      const log = proxyquire.noPreserveCache()('../src/log', {})
+      const logger = {
+        debug: sinon.spy(),
+        error: sinon.spy(),
+      }
 
-      assert.strictEqual(log.configure({}), true)
-      sinon.assert.calledOnceWithExactly(logWriter.configure, true, 'debug', undefined)
+      log.trace('early trace')
+      log.configure({ DD_TRACE_DEBUG: true, logLevel: 'trace', logger })
+
+      sinon.assert.calledOnce(logger.debug)
+      assert.match(logger.debug.firstCall.args[0], /^Trace: Context.foo\('early trace'\)/)
     })
 
-    describe('configure', () => {
-      it('prefers fleetStableConfigValue over env and local', () => {
-        process.env.DD_TRACE_DEBUG = 'false'
+    it('should replace write methods with noops when disabled after being enabled', () => {
+      const log = proxyquire.noPreserveCache()('../src/log', {})
+      const logger = {
+        debug: sinon.spy(),
+        error: sinon.spy(),
+      }
 
-        let loaded = reloadLog({
-          fleetEntries: { DD_TRACE_DEBUG: 'true' },
-          isServerless: false,
-          localEntries: { DD_TRACE_DEBUG: 'false' },
-        })
-        assert.strictEqual(loaded.log.configure({}), true)
+      log.configure({ DD_TRACE_DEBUG: true, logLevel: 'debug', logger })
+      log.debug('before disable')
+      log.configure({ DD_TRACE_DEBUG: false, logLevel: 'debug', logger })
+      log.debug('after disable')
+      log.error('after disable')
 
-        process.env.DD_TRACE_DEBUG = 'true'
-
-        loaded = reloadLog({
-          fleetEntries: { DD_TRACE_DEBUG: 'false' },
-          isServerless: false,
-          localEntries: { DD_TRACE_DEBUG: 'true' },
-        })
-        assert.strictEqual(loaded.log.configure({}), false)
-      })
-
-      it('uses DD_TRACE_DEBUG when fleetStableConfigValue is not set', () => {
-        process.env.DD_TRACE_DEBUG = 'true'
-        let loaded = reloadLog({
-          isServerless: false,
-          localEntries: { DD_TRACE_DEBUG: 'false' },
-        })
-        assert.strictEqual(loaded.log.configure({}), true)
-
-        process.env.DD_TRACE_DEBUG = 'false'
-        loaded = reloadLog({
-          isServerless: false,
-          localEntries: { DD_TRACE_DEBUG: 'true' },
-        })
-        assert.strictEqual(loaded.log.configure({}), false)
-      })
-
-      it('uses OTEL_LOG_LEVEL=debug when DD vars are not set', () => {
-        process.env.OTEL_LOG_LEVEL = 'debug'
-        let loaded = reloadLog({
-          isServerless: false,
-          localEntries: { OTEL_LOG_LEVEL: 'info' },
-        })
-        assert.strictEqual(loaded.log.configure({}), true)
-
-        process.env.OTEL_LOG_LEVEL = 'info'
-        loaded = reloadLog({
-          isServerless: false,
-          localEntries: { OTEL_LOG_LEVEL: 'debug' },
-        })
-        assert.strictEqual(loaded.log.configure({}), false)
-      })
-
-      it('falls back to localStableConfigValue', () => {
-        let loaded = reloadLog({
-          isServerless: false,
-          localEntries: { DD_TRACE_DEBUG: 'false' },
-        })
-        assert.strictEqual(loaded.log.configure({}), false)
-
-        loaded = reloadLog({
-          isServerless: false,
-          localEntries: { DD_TRACE_DEBUG: 'true' },
-        })
-        assert.strictEqual(loaded.log.configure({}), true)
-      })
-
-      it('falls back to internal config.enabled when nothing else provided', () => {
-        const { log, logWriter } = reloadLog({
-          fleetEntries: {},
-          isServerless: false,
-          localEntries: {},
-        })
-
-        process.env.OTEL_LOG_LEVEL = 'debug'
-        assert.strictEqual(log.configure({}), true)
-
-        process.env = {}
-        assert.strictEqual(log.configure({}), true)
-        sinon.assert.calledWithExactly(logWriter.configure.secondCall, true, 'debug', undefined)
-      })
-
-      it('falls back to the previous log level when no override is provided', () => {
-        const { log, logWriter } = reloadLog()
-
-        log.configure({ logLevel: 'error' })
-        log.configure({})
-
-        sinon.assert.calledWithExactly(logWriter.configure.secondCall, false, 'error', undefined)
-      })
+      sinon.assert.calledOnceWithExactly(logger.debug, 'before disable')
+      sinon.assert.notCalled(logger.error)
     })
   })
 
@@ -216,13 +159,9 @@ describe('log', () => {
     let logger
     let error
 
-    function loadConfiguredLog (options = {}, envEntries = {}) {
-      process.env = {
-        DD_TRACE_DEBUG: 'true',
-        ...envEntries,
-      }
+    function loadConfiguredLog (options = {}) {
       log = proxyquire.noPreserveCache()('../src/log', {})
-      log.configure(options)
+      log.configure({ DD_TRACE_DEBUG: true, logLevel: 'debug', ...options })
       return log
     }
 
@@ -252,12 +191,15 @@ describe('log', () => {
       console.debug.restore()
     })
 
-    it('should support chaining', () => {
+    it('should not return itself from logger methods', () => {
       loadConfiguredLog({ logger })
 
-      log
-        .error('error')
-        .debug('debug')
+      assert.strictEqual(log.trace('trace'), undefined)
+      assert.strictEqual(log.debug('debug'), undefined)
+      assert.strictEqual(log.info('info'), undefined)
+      assert.strictEqual(log.warn('warn'), undefined)
+      assert.strictEqual(log.error('error'), undefined)
+      assert.strictEqual(log.errorWithoutTelemetry('error without telemetry'), undefined)
     })
 
     it('should call the logger in a noop context', () => {
@@ -412,7 +354,7 @@ describe('log', () => {
 
     describe('configure', () => {
       it('should disable the logger when DD_TRACE_DEBUG is false', () => {
-        loadConfiguredLog({}, { DD_TRACE_DEBUG: 'false' })
+        loadConfiguredLog({ DD_TRACE_DEBUG: false })
         log.debug('debug')
         log.error(error)
 
@@ -420,8 +362,8 @@ describe('log', () => {
         sinon.assert.notCalled(console.error)
       })
 
-      it('should enable the logger when OTEL_LOG_LEVEL is debug', () => {
-        loadConfiguredLog({}, { OTEL_LOG_LEVEL: 'debug' })
+      it('should enable the logger when DD_TRACE_DEBUG is true', () => {
+        loadConfiguredLog({ DD_TRACE_DEBUG: true })
         log.debug('debug')
         log.error(error)
 

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -79,7 +79,7 @@ describe('Tracer', () => {
       sampleRate: 0.5,
       logger: 'logger',
       tags: {},
-      debug: true,
+      DD_TRACE_DEBUG: true,
       experimental: {},
     }
 

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -18,7 +18,7 @@ const configWithStartupLogs = {
   service: 'test',
   hostname: 'example.com',
   port: 4321,
-  debug: true,
+  DD_TRACE_DEBUG: true,
   sampler: {
     sampleRate: 1,
   },


### PR DESCRIPTION
Config can emit warnings before final logger configuration now, so stable config and unsupported-env warnings do not need early setup or side channels.

Keeping logger enablement on `DD_TRACE_DEBUG` also avoids tracking a synthetic `debug` config field.