### PR TITLE
ci(system-tests): use bun pm pack instead of npm pack

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -17,12 +17,15 @@ jobs:
   build-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout dd-trace-js
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          path: dd-trace-js
+          bun-version: 1.3.1
       - name: Pack dd-trace-js
-        run: mkdir -p ./binaries && echo /binaries/$(npm pack --silent --pack-destination ./binaries ./dd-trace-js) > ./binaries/nodejs-load-from-npm
+        run: |
+          mkdir -p ./binaries
+          FILENAME=$(bun pm pack --destination ./binaries --quiet)
+          echo "/binaries/$(basename "$FILENAME")" > ./binaries/nodejs-load-from-npm
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- Replaces `npm pack` with `bun pm pack --quiet` in the `build-artifacts` job, consistent with how packing is done in `integration-tests/helpers/index.js`
- Removes the `path: dd-trace-js` checkout subdirectory, which was only needed because the old command passed the directory as an argument to `npm pack`

## Test plan

- [ ] Verify the system-tests workflow passes with the new `build-artifacts` job

> Generated by [Claude Code](https://claude.com/claude-code)