### PR TITLE
[test optimization] Stabilize Cypress web app server lifecycle

### DIFF
--- a/integration-tests/ci-visibility/web-app-server.js
+++ b/integration-tests/ci-visibility/web-app-server.js
@@ -1,20 +1,44 @@
 'use strict'
 
-// File to spin an HTTP server that returns an HTML for playwright to visit
-const http = require('http')
+// File to spin an HTTP server that returns an HTML for browser tests to visit
+const http = require('node:http')
+
 const coverage = require('../ci-visibility/fixtures/istanbul-map-fixture.json')
 
-function createWebAppServer () {
-  const server = http.createServer((req, res) => {
-    // Close after each response so browser drivers don't reuse a socket the
-    // server has already FIN'd between requests (keep-alive race → `socket hang up`).
-    res.setHeader('Content-Type', 'text/html')
-    res.setHeader('Connection', 'close')
-    res.writeHead(200)
-    res.end(`
-      <!DOCTYPE html>
-      <html>
-        <title>Hello World</title>
+const DEFAULT_HOST = '127.0.0.1'
+const DEFAULT_BODY = '<div class="hello-world">Hello World</div>'
+
+/**
+ * @typedef {object} WebAppServerOptions
+ * @property {string} [body] - HTML body fragment rendered by the test app.
+ * @property {boolean} [includeCoverage=true] - Whether to expose the Istanbul fixture on window.__coverage__.
+ * @property {boolean} [includeRum=true] - Whether to expose the fake DD_RUM helper.
+ * @property {string} [title] - HTML title rendered by the test app.
+ */
+
+/**
+ * @typedef {object} StartedWebAppServer
+ * @property {string} baseUrl - Base URL for browser tests.
+ * @property {number} port - Port used by the server.
+ * @property {import('node:http').Server} server - Running HTTP server.
+ */
+
+/**
+ * Builds the static HTML returned by the browser test web app.
+ *
+ * @param {WebAppServerOptions} [options]
+ * @returns {string}
+ */
+function getWebAppHtml (options = {}) {
+  const {
+    body = DEFAULT_BODY,
+    includeCoverage = true,
+    includeRum = true,
+    title = 'Hello World',
+  } = options
+
+  const rumScript = includeRum
+    ? `
         <script>
           window.DD_RUM = {
             getInternalContext: () => {
@@ -24,15 +48,44 @@ function createWebAppServer () {
               return true
             }
           }
-        </script>
-        <body>
-          <div class="hello-world">Hello World</div>
-        </body>
+        </script>`
+    : ''
+
+  const coverageScript = includeCoverage
+    ? `
         <script>
           window.__coverage__ = ${JSON.stringify(coverage)}
-        </script>
+        </script>`
+    : ''
+
+  return `
+      <!DOCTYPE html>
+      <html>
+        <title>${title}</title>
+        ${rumScript}
+        <body>
+          ${body}
+        </body>
+        ${coverageScript}
       </html>
-    `)
+    `
+}
+
+/**
+ * Creates a stateless HTTP server for browser integration tests.
+ *
+ * @param {WebAppServerOptions} [options]
+ * @returns {import('node:http').Server}
+ */
+function createWebAppServer (options) {
+  const html = getWebAppHtml(options)
+  const server = http.createServer((req, res) => {
+    // Close after each response so browser drivers don't reuse a socket the
+    // server has already FIN'd between requests (keep-alive race → `socket hang up`).
+    res.setHeader('Content-Type', 'text/html')
+    res.setHeader('Connection', 'close')
+    res.writeHead(200)
+    res.end(html)
   })
 
   server.on('error', (error) => {
@@ -49,5 +102,58 @@ function createWebAppServer () {
   return server
 }
 
+/**
+ * Starts a web app server on a loopback-only ephemeral port.
+ *
+ * @param {WebAppServerOptions & { host?: string }} [options]
+ * @returns {Promise<StartedWebAppServer>}
+ */
+function startWebAppServer (options = {}) {
+  const { host = DEFAULT_HOST, ...serverOptions } = options
+  const server = createWebAppServer(serverOptions)
+
+  return new Promise((resolve, reject) => {
+    server.once('error', onError)
+    server.listen(0, host, () => {
+      server.removeListener('error', onError)
+
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Web app server did not bind to a TCP port'))
+        return
+      }
+
+      resolve({
+        baseUrl: `http://${host}:${address.port}`,
+        port: address.port,
+        server,
+      })
+    })
+
+    function onError (error) {
+      server.removeListener('error', onError)
+      reject(error)
+    }
+  })
+}
+
+/**
+ * Stops a web app server if it is running.
+ *
+ * @param {StartedWebAppServer|import('node:http').Server|undefined} webAppServer
+ * @returns {Promise<void>}
+ */
+function stopWebAppServer (webAppServer) {
+  const server = webAppServer?.server || webAppServer
+
+  if (!server?.listening) {
+    return Promise.resolve()
+  }
+
+  return new Promise(resolve => server.close(() => resolve()))
+}
+
 module.exports = createWebAppServer()
 module.exports.createWebAppServer = createWebAppServer
+module.exports.startWebAppServer = startWebAppServer
+module.exports.stopWebAppServer = stopWebAppServer

--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -15,7 +15,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const {
   TEST_STATUS,
   TEST_SOURCE_FILE,
@@ -95,7 +95,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -104,25 +104,23 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
     })
 
     context('flaky test retries', () => {
@@ -218,7 +216,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -273,7 +271,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               DD_CIVISIBILITY_FLAKY_RETRY_ENABLED: 'false',
               SPEC_PATTERN: specToRun,
             },
@@ -331,7 +329,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
               SPEC_PATTERN: specToRun,
             },
@@ -382,7 +380,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
               SPEC_PATTERN: specToRun,
             },
@@ -429,7 +427,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               CYPRESS_TEST_ISOLATION: 'false',
             },
@@ -490,7 +488,7 @@ moduleTypes.forEach(({
           cwd: `${cwd}/ci-visibility/subproject`,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
           },
         }
       )
@@ -555,7 +553,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...getCiVisEvpProxyConfig(receiver.port),
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: specToRun,
           },
         }

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -14,7 +14,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const {
   TEST_STATUS,
   TEST_IS_NEW,
@@ -94,7 +94,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -103,25 +103,23 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
     })
 
     context('early flake detection', () => {
@@ -183,7 +181,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -246,7 +244,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -304,7 +302,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false',
             },
@@ -358,7 +356,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/skipped-test.js',
             },
           }
@@ -412,7 +410,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -467,7 +465,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -525,7 +523,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false',
             },
@@ -584,7 +582,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -650,7 +648,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               CYPRESS_TEST_ISOLATION: 'false',
             },
@@ -747,7 +745,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }

--- a/integration-tests/cypress/cypress-final-status.spec.js
+++ b/integration-tests/cypress/cypress-final-status.spec.js
@@ -12,7 +12,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const {
   TEST_STATUS,
   TEST_IS_NEW,
@@ -89,7 +89,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -98,25 +98,23 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
     })
 
     // These tests require Cypress >=10 features (defineConfig, setupNodeEvents)
@@ -184,7 +182,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -278,7 +276,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
               },
             }
@@ -362,7 +360,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -448,7 +446,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -497,7 +495,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '0',
               SPEC_PATTERN: specToRun,
             },
@@ -557,7 +555,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -628,7 +626,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -681,7 +679,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }
@@ -742,7 +740,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }

--- a/integration-tests/cypress/cypress-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-impacted-tests.spec.js
@@ -16,7 +16,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const {
   TEST_SOURCE_FILE,
   TEST_IS_NEW,
@@ -103,7 +103,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -112,25 +112,23 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
     })
 
     context('libraries capabilities', () => {
@@ -166,7 +164,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               DD_TEST_SESSION_NAME: 'my-test-session-name',
               SPEC_PATTERN: specToRun,
             },
@@ -306,7 +304,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               GITHUB_BASE_REF: '',
               ...extraEnvVars,
@@ -422,7 +420,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               GITHUB_BASE_REF: '',
               CYPRESS_TEST_ISOLATION: 'false',
@@ -512,7 +510,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               GITHUB_BASE_REF: '',
             },

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -14,7 +14,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const {
   TEST_STATUS,
   TEST_CODE_COVERAGE_ENABLED,
@@ -98,7 +98,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -107,25 +107,23 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
     })
 
     context('intelligent test runner', () => {
@@ -145,7 +143,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -190,7 +188,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -259,7 +257,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/{other,spec}.cy.js',
             },
           }
@@ -314,7 +312,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/other.cy.js',
             },
           }
@@ -389,7 +387,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/{other,spec}.cy.js',
             },
           }
@@ -458,7 +456,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/{other,spec}.cy.js',
             },
           }
@@ -512,7 +510,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -549,7 +547,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
             },
           }
@@ -602,7 +600,7 @@ moduleTypes.forEach(({
             cwd: `${cwd}/ci-visibility/subproject`,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
             },
           }
         )
@@ -642,7 +640,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             CYPRESS_ENABLE_INCOMPATIBLE_PLUGIN: '1',
             SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
           },

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -18,7 +18,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const coverageFixture = require('../ci-visibility/fixtures/istanbul-map-fixture.json')
 const {
   TEST_STATUS,
@@ -150,7 +150,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -159,25 +159,23 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
     })
 
     it('instruments tests with the APM protocol (old agents)', async () => {
@@ -257,7 +255,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: specToRun,
           },
         }
@@ -283,7 +281,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...restEnvVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
             },
           }
         )
@@ -342,7 +340,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -415,7 +413,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-*.js',
           },
         }
@@ -455,7 +453,7 @@ moduleTypes.forEach(({
           env: {
             ...envVars,
             NODE_OPTIONS: '-r dd-trace/ci/init',
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -502,7 +500,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -548,7 +546,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
             },
           }
@@ -595,7 +593,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
             },
           }
@@ -647,7 +645,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
               },
             }
@@ -698,7 +696,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -818,7 +816,7 @@ moduleTypes.forEach(({
             cwd: subprojectDir,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
             },
           }
         )
@@ -875,7 +873,7 @@ moduleTypes.forEach(({
             // a separate OTEL collector. The Test Optimization exporter
             // must win inside isCiVisibility mode.
             OTEL_TRACES_EXPORTER: 'otlp',
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -928,7 +926,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         })
@@ -1018,7 +1016,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -1060,7 +1058,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             CYPRESS_ENABLE_AFTER_RUN_CUSTOM: '1',
             CYPRESS_ENABLE_AFTER_SPEC_CUSTOM: '1',
             CYPRESS_ENABLE_MANUAL_PLUGIN: '1',
@@ -1114,7 +1112,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         }
@@ -1168,7 +1166,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             CYPRESS_ENABLE_AFTER_RUN_CUSTOM: '1',
             CYPRESS_ENABLE_AFTER_SPEC_CUSTOM: '1',
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
@@ -1244,7 +1242,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/dist/spec-source-line.cy.js',
           },
         })
@@ -1357,7 +1355,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/dist/spec-source-line-fallback.cy.js',
           },
         })
@@ -1405,7 +1403,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/dist/spec-source-line-no-match.cy.js',
           },
         })
@@ -1448,7 +1446,7 @@ moduleTypes.forEach(({
         cwd,
         env: {
           ...envVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+          CYPRESS_BASE_URL: webAppBaseUrl,
           SPEC_PATTERN: 'cypress/e2e/spec-source-line-invocation.cy.js',
         },
       })
@@ -1522,7 +1520,7 @@ moduleTypes.forEach(({
         cwd,
         env: {
           ...envVars,
-          CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+          CYPRESS_BASE_URL: webAppBaseUrl,
           SPEC_PATTERN: 'cypress/e2e/spec-source-line.cy.ts',
         },
       })
@@ -1570,7 +1568,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
               },
             }
@@ -1611,7 +1609,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
               },
             }
@@ -1653,7 +1651,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
               },
             }
@@ -1701,7 +1699,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
               },
             }
@@ -1731,7 +1729,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             DD_SITE: '= invalid = url',
             SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
           },
@@ -1920,7 +1918,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2',
             DD_TEST_SESSION_NAME: 'my-test-session',
             DD_SERVICE: undefined,
@@ -1964,7 +1962,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
           },
         }

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -3,7 +3,6 @@
 const assert = require('node:assert/strict')
 const { exec } = require('node:child_process')
 const { once } = require('node:events')
-const http = require('node:http')
 
 const semver = require('semver')
 const {
@@ -15,7 +14,7 @@ const {
   warmCypressBinary,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
-const { createWebAppServer } = require('../ci-visibility/web-app-server')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
 const {
   TEST_STATUS,
@@ -99,7 +98,7 @@ moduleTypes.forEach(({
     }
 
     this.timeout(80_000)
-    let cwd, receiver, childProcess, webAppPort, webAppServer, secondWebAppServer
+    let cwd, receiver, childProcess, webAppBaseUrl, webAppServer, secondWebAppBaseUrl, secondWebAppServer
 
     // cypress-fail-fast is required as an incompatible plugin.
     // typescript is required to compile .cy.ts spec files in the pre-compiled JS tests.
@@ -108,32 +107,35 @@ moduleTypes.forEach(({
     before(async function () {
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
+
+      if (version === 'latest') {
+        const secondWebApp = await startWebAppServer({
+          body: '<div class="hella-world">Hella World</div>',
+          includeCoverage: false,
+          includeRum: false,
+          title: 'Hella World',
+        })
+        secondWebAppBaseUrl = secondWebApp.baseUrl
+        secondWebAppServer = secondWebApp.server
+      }
     })
 
     after(async () => {
-      // Cleanup second web app server if it exists
-      if (secondWebAppServer) {
-        await new Promise(resolve => secondWebAppServer.close(resolve))
-      }
+      await stopWebAppServer(secondWebAppServer)
+      await stopWebAppServer(webAppServer)
     })
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()
-
-      // Create a fresh web server for each test to avoid state issues
-      webAppServer = createWebAppServer()
-      await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
-        webAppServer.once('error', reject)
-        webAppServer.listen(0, 'localhost', () => {
-          webAppPort = webAppServer.address().port
-          webAppServer.removeListener('error', reject)
-          resolve()
-        })
-      }))
     })
 
     afterEach(async () => {
-      await stopCiVisTestEnv({ childProcess, webAppServer, receiver })
+      await stopCiVisTestEnv({ childProcess, receiver })
+      childProcess = undefined
     })
 
     context('known tests without early flake detection', () => {
@@ -160,7 +162,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               DD_CIVISIBILITY_EARLY_FLAKE_DETECTION_ENABLED: 'false',
             },
@@ -194,21 +196,6 @@ moduleTypes.forEach(({
       it('does not crash for multi origin tests', async () => {
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        secondWebAppServer = http.createServer((req, res) => {
-          res.setHeader('Content-Type', 'text/html')
-          res.writeHead(200)
-          res.end(`
-            <!DOCTYPE html>
-            <html>
-              <div class="hella-world">Hella World</div>
-            </html>
-          `)
-        })
-
-        const secondWebAppPort = await new Promise(resolve => {
-          secondWebAppServer.listen(0, 'localhost', () => resolve(secondWebAppServer.address().port))
-        })
-
         const specToRun = 'cypress/e2e/multi-origin.js'
 
         childProcess = exec(
@@ -217,8 +204,8 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
-              CYPRESS_BASE_URL_SECOND: `http://localhost:${secondWebAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
+              CYPRESS_BASE_URL_SECOND: secondWebAppBaseUrl,
               SPEC_PATTERN: specToRun,
               DD_TRACE_DEBUG: 'true',
             },
@@ -258,7 +245,7 @@ moduleTypes.forEach(({
           cwd,
           env: {
             ...envVars,
-            CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+            CYPRESS_BASE_URL: webAppBaseUrl,
             DD_SERVICE: 'my-service',
             SPEC_PATTERN: 'cypress/e2e/spec.cy.js',
           },
@@ -409,7 +396,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
                 ...extraEnvVars,
                 ...(shouldAlwaysPass ? { CYPRESS_SHOULD_ALWAYS_PASS: '1' } : {}),
@@ -519,7 +506,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
               },
             }
@@ -586,7 +573,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
                 CYPRESS_SHOULD_ALWAYS_PASS: '1',
               },
@@ -712,7 +699,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
                 ...extraEnvVars,
               },
@@ -807,7 +794,7 @@ moduleTypes.forEach(({
               cwd,
               env: {
                 ...envVars,
-                CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+                CYPRESS_BASE_URL: webAppBaseUrl,
                 SPEC_PATTERN: specToRun,
                 ...extraEnvVars,
               },
@@ -859,7 +846,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               DD_TRACE_DEBUG: '1',
             },
@@ -913,7 +900,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
               CYPRESS_SHOULD_ALWAYS_PASS: '1',
               CYPRESS_TEST_ISOLATION: 'false',
@@ -986,7 +973,7 @@ moduleTypes.forEach(({
             cwd,
             env: {
               ...envVars,
-              CYPRESS_BASE_URL: `http://localhost:${webAppPort}`,
+              CYPRESS_BASE_URL: webAppBaseUrl,
               SPEC_PATTERN: specToRun,
             },
           }


### PR DESCRIPTION
## What changed

- Added suite-scoped Cypress web app start/stop helpers backed by loopback-only ephemeral ports.
- Updated Cypress integration suites to reuse the static target web app across tests while keeping the Cypress child process and fake CI intake isolated per test.
- Moved the multi-origin second app onto the same shared helper with a dedicated app variant.

## Why

The Cypress integration harness was binding and closing the target web app for every outer test. That repeated lifecycle adds timing-sensitive socket and teardown churn around Cypress process shutdown. Keeping the stateless static app alive for the suite removes that source of flakiness while preserving per-test telemetry isolation.

