### PR TITLE
[test optimization] report ITR line coverage totals in mocha

### DIFF
--- a/integration-tests/ci-visibility/tia-code-coverage-mocha.spec.js
+++ b/integration-tests/ci-visibility/tia-code-coverage-mocha.spec.js
@@ -1,0 +1,386 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { exec } = require('node:child_process')
+const { once } = require('node:events')
+const path = require('node:path')
+
+const {
+  sandboxCwd,
+  useSandbox,
+  getCiVisAgentlessConfig,
+} = require('../helpers')
+const { FakeCiVisIntake } = require('../ci-visibility-intake')
+const {
+  TEST_CODE_COVERAGE_LINES_PCT,
+  TEST_ITR_TESTS_SKIPPED,
+  TEST_SKIPPED_BY_ITR,
+  TEST_STATUS,
+  getLineCoverageBitmap,
+} = require('../../packages/dd-trace/src/plugins/util/test')
+
+const FIXTURE_ROOT = 'ci-visibility/tia-code-coverage'
+const SUBDIRECTORY_FIXTURE_ROOT = 'tia-code-coverage'
+const SKIPPED_SUITE = `${FIXTURE_ROOT}/test-skipped.js`
+const SUBDIRECTORY_SKIPPED_SUITE = `${SUBDIRECTORY_FIXTURE_ROOT}/test-skipped.js`
+const SKIPPED_SOURCE = `${FIXTURE_ROOT}/src/skipped-dependency.js`
+const LINE_PCT_RE = /Lines\s*:\s*(\d+(?:\.\d+)?)%/
+const TESTS_TO_RUN = JSON.stringify([
+  './tia-code-coverage/test-run.js',
+  './tia-code-coverage/test-skipped.js',
+])
+const MOCHA_COMMAND = './node_modules/nyc/bin/nyc.js --all ' +
+  `--include '${FIXTURE_ROOT}/src/**' -r=text-summary node ./ci-visibility/run-mocha.js`
+const MINIMUM_SUPPORTED_MOCHA_VERSION = '8.0.0'
+
+const MOCHA_VERSION_CONFIGS = [
+  {
+    version: 'latest',
+    dependencies: ['mocha', 'nyc'],
+  },
+  {
+    version: MINIMUM_SUPPORTED_MOCHA_VERSION,
+    dependencies: [`mocha@${MINIMUM_SUPPORTED_MOCHA_VERSION}`, 'nyc'],
+  },
+]
+
+function getLinesBitmapBase64 (startLine, endLine) {
+  const lineCoverage = {}
+  for (let line = startLine; line <= endLine; line++) {
+    lineCoverage[line] = 1
+  }
+  return getLineCoverageBitmap(lineCoverage, true).toString('base64')
+}
+
+function getCoverageEvents (payloads) {
+  return payloads
+    .flatMap(({ payload }) => payload)
+    .flatMap(({ content }) => content.coverages)
+}
+
+function getLinePctFromOutput (output) {
+  const match = output.match(LINE_PCT_RE)
+  assert.ok(match, `coverage output did not include a lines percentage:\n${output}`)
+  return Number(match[1])
+}
+
+function getSubdirectoryMochaCommand (cwd) {
+  const nycBin = path.join(cwd, 'node_modules/nyc/bin/nyc.js')
+
+  return `${nycBin} --all --include '${FIXTURE_ROOT}/src/**' -r=text-summary ` +
+    'node -e "process.chdir(\'ci-visibility\'); require(process.cwd() + \'/run-mocha.js\')"'
+}
+
+function describeMochaVersion (mochaVersion, dependencies) {
+  describe(`TIA code coverage mocha@${mochaVersion}`, function () {
+    let cwd
+    let childProcess
+
+    this.timeout(180_000)
+
+    useSandbox(dependencies, true)
+
+    before(() => {
+      cwd = sandboxCwd()
+    })
+
+    afterEach(() => {
+      if (childProcess?.exitCode === null) {
+        childProcess.kill()
+      }
+    })
+
+    async function runMocha ({
+      suitesToSkip = [],
+      skippableCoverage = {},
+      settings = {
+        itr_enabled: true,
+        code_coverage: true,
+        coverage_report_upload_enabled: true,
+        tests_skipping: true,
+      },
+      expectSuiteCoverage = true,
+      expectSessionCoverage = true,
+      expectCoveragePayloads = true,
+      command = MOCHA_COMMAND,
+      runCwd = cwd,
+      testsToRun = TESTS_TO_RUN,
+    } = {}) {
+      const receiver = await new FakeCiVisIntake().start()
+      receiver.setSettings(settings)
+      receiver.setSuitesToSkip(suitesToSkip)
+      receiver.setSkippableCoverage(skippableCoverage)
+
+      let eventsResult
+      let coverageResult
+      let output = ''
+      const coveragePayloads = []
+      const coverageRequestListener = (message) => {
+        if (message.url.endsWith('/api/v2/citestcov')) {
+          coveragePayloads.push(message)
+        }
+      }
+      receiver.on('message', coverageRequestListener)
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSessionEvent = events.find(event => event.type === 'test_session_end')
+          assert.ok(testSessionEvent, `test session event should be reported:\n${output}`)
+          const testSession = testSessionEvent.content
+          const skippedSuites = events
+            .filter(event => event.type === 'test_suite_end')
+            .map(event => event.content)
+            .filter(suite => suite.meta[TEST_SKIPPED_BY_ITR] === 'true')
+
+          eventsResult = {
+            codeCoverageLinesPct: testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT],
+            isTiaSkipped: testSession.meta[TEST_ITR_TESTS_SKIPPED],
+            skippedSuites,
+          }
+        })
+
+      const coveragePromise = expectCoveragePayloads
+        ? receiver.gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcov'), (payloads) => {
+          const coverages = getCoverageEvents(payloads)
+          const suiteCoverage = coverages.find(coverage => coverage.test_suite_id)
+          const sessionCoverage = coverages.find(coverage => !coverage.test_suite_id)
+          const coveredFile = coverages
+            .flatMap(coverage => coverage.files)
+            .find(file => file.bitmap)
+
+          if (expectSuiteCoverage) {
+            assert.ok(suiteCoverage, `suite code coverage should be reported:\n${output}`)
+          } else {
+            assert.strictEqual(suiteCoverage, undefined, `suite code coverage should not be reported:\n${output}`)
+          }
+          if (expectSessionCoverage) {
+            assert.ok(sessionCoverage, `session executable-line coverage should be reported:\n${output}`)
+          } else {
+            assert.strictEqual(
+              sessionCoverage,
+              undefined,
+            `session executable-line coverage should not be reported:\n${output}`
+            )
+          }
+          assert.ok(coveredFile?.bitmap, `covered files should report line coverage bitmaps:\n${output}`)
+
+          coverageResult = coverages
+        })
+        : Promise.resolve()
+
+      childProcess = exec(
+        command,
+        {
+          cwd: runCwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: testsToRun,
+          },
+        }
+      )
+      childProcess.stdout?.on('data', chunk => {
+        output += chunk.toString()
+      })
+      childProcess.stderr?.on('data', chunk => {
+        output += chunk.toString()
+      })
+
+      try {
+        const stdoutEndPromise = childProcess.stdout ? once(childProcess.stdout, 'end') : Promise.resolve()
+        const stderrEndPromise = childProcess.stderr ? once(childProcess.stderr, 'end') : Promise.resolve()
+        const [, , [exitCode]] = await Promise.all([
+          eventsPromise,
+          coveragePromise,
+          once(childProcess, 'exit'),
+          stdoutEndPromise,
+          stderrEndPromise,
+        ])
+        assert.strictEqual(exitCode, 0)
+        if (!expectCoveragePayloads) {
+          await new Promise(resolve => setTimeout(resolve, 500))
+          assert.strictEqual(coveragePayloads.length, 0, `code coverage payloads should not be reported:\n${output}`)
+        }
+
+        return {
+          ...eventsResult,
+          coverages: coverageResult,
+          output,
+          stdoutCodeCoverageLinesPct: getLinePctFromOutput(output),
+        }
+      } finally {
+        receiver.off('message', coverageRequestListener)
+        await receiver.stop()
+      }
+    }
+
+    // Mocha customers are already running nyc when TIA coverage is available. If a suite is skipped without backend
+    // coverage, nyc's local total drops and Datadog withholds lines_pct; with meta.coverage backfill, both totals
+    // match.
+    it('keeps total code coverage stable with skipped coverage', async () => {
+      const baseline = await runMocha()
+
+      assert.strictEqual(baseline.isTiaSkipped, 'false')
+      assert.strictEqual(baseline.codeCoverageLinesPct, baseline.stdoutCodeCoverageLinesPct)
+      assert.ok(baseline.codeCoverageLinesPct > 0, `baseline coverage was ${baseline.codeCoverageLinesPct}`)
+      assert.ok(baseline.codeCoverageLinesPct < 100, `baseline coverage was ${baseline.codeCoverageLinesPct}`)
+      assert.ok(baseline.coverages.length > 0, 'baseline should report coverage payloads')
+
+      const skippedWithoutCoverage = await runMocha({
+        suitesToSkip: [{
+          type: 'suite',
+          attributes: {
+            suite: SKIPPED_SUITE,
+          },
+        }],
+      })
+
+      assert.strictEqual(skippedWithoutCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithoutCoverage.skippedSuites.length, 1)
+      assert.strictEqual(skippedWithoutCoverage.skippedSuites[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(skippedWithoutCoverage.codeCoverageLinesPct, undefined)
+      assert.ok(
+        skippedWithoutCoverage.stdoutCodeCoverageLinesPct < baseline.stdoutCodeCoverageLinesPct,
+      `expected ${skippedWithoutCoverage.stdoutCodeCoverageLinesPct} to be lower ` +
+      `than ${baseline.stdoutCodeCoverageLinesPct}`
+      )
+
+      const skippedWithCoverage = await runMocha({
+        suitesToSkip: [{
+          type: 'suite',
+          attributes: {
+            suite: SKIPPED_SUITE,
+          },
+        }],
+        skippableCoverage: {
+          [SKIPPED_SOURCE]: getLinesBitmapBase64(1, 20),
+        },
+      })
+
+      assert.strictEqual(skippedWithCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithCoverage.skippedSuites.length, 1)
+      assert.strictEqual(skippedWithCoverage.skippedSuites[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(skippedWithCoverage.stdoutCodeCoverageLinesPct, baseline.stdoutCodeCoverageLinesPct)
+      assert.strictEqual(skippedWithCoverage.codeCoverageLinesPct, baseline.codeCoverageLinesPct)
+    })
+
+    it('backfills repository-relative skipped coverage when mocha runs from a subdirectory', async () => {
+      const runFromSubdirectory = {
+        command: getSubdirectoryMochaCommand(cwd),
+      }
+      const baseline = await runMocha(runFromSubdirectory)
+
+      const skippedWithCoverage = await runMocha({
+        ...runFromSubdirectory,
+        suitesToSkip: [{
+          type: 'suite',
+          attributes: {
+            suite: SUBDIRECTORY_SKIPPED_SUITE,
+          },
+        }],
+        skippableCoverage: {
+          [SKIPPED_SOURCE]: getLinesBitmapBase64(1, 20),
+        },
+      })
+      const sessionCoverage = skippedWithCoverage.coverages.find(coverage => !coverage.test_suite_id)
+
+      assert.strictEqual(skippedWithCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithCoverage.skippedSuites.length, 1)
+      assert.strictEqual(skippedWithCoverage.stdoutCodeCoverageLinesPct, baseline.stdoutCodeCoverageLinesPct)
+      assert.strictEqual(skippedWithCoverage.codeCoverageLinesPct, baseline.codeCoverageLinesPct)
+      assert.ok(sessionCoverage.files.some(file => file.filename === SKIPPED_SOURCE))
+    })
+
+    // TIA suite-level CITESTCOV collection is independent from Datadog Code Coverage. With report upload disabled we
+    // still upload suite coverage for future TIA decisions, but we do not backfill, upload session executable coverage,
+    // or tag Datadog lines_pct.
+    it('only uploads suite coverage when TIA is enabled but coverage report upload is disabled', async () => {
+      const result = await runMocha({
+        suitesToSkip: [{
+          type: 'suite',
+          attributes: {
+            suite: SKIPPED_SUITE,
+          },
+        }],
+        settings: {
+          itr_enabled: true,
+          code_coverage: true,
+          coverage_report_upload_enabled: false,
+          tests_skipping: true,
+        },
+        expectSessionCoverage: false,
+      })
+
+      assert.strictEqual(result.isTiaSkipped, 'true')
+      assert.strictEqual(result.skippedSuites.length, 1)
+      assert.strictEqual(result.skippedSuites[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(result.codeCoverageLinesPct, undefined)
+      assert.ok(result.stdoutCodeCoverageLinesPct > 0)
+    })
+
+    // The backend code_coverage flag keeps its original meaning: it controls suite/test CITESTCOV collection for TIA.
+    // With both code_coverage and coverage report upload disabled, TIA can still skip, but no coverage payload is sent.
+    it('does not upload citestcov payloads when TIA code coverage is disabled', async () => {
+      const result = await runMocha({
+        suitesToSkip: [{
+          type: 'suite',
+          attributes: {
+            suite: SKIPPED_SUITE,
+          },
+        }],
+        settings: {
+          itr_enabled: true,
+          code_coverage: false,
+          coverage_report_upload_enabled: false,
+          tests_skipping: true,
+        },
+        expectCoveragePayloads: false,
+      })
+
+      assert.strictEqual(result.isTiaSkipped, 'true')
+      assert.strictEqual(result.skippedSuites.length, 1)
+      assert.strictEqual(result.skippedSuites[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(result.codeCoverageLinesPct, undefined)
+      assert.ok(result.stdoutCodeCoverageLinesPct > 0)
+    })
+
+    // coverage_report_upload_enabled is the backfill gate. Even when TIA suite coverage upload is disabled through
+    // code_coverage=false, Datadog Code Coverage still gets the session executable-lines payload and backfilled total.
+    it('backfills and reports session coverage when coverage report upload is enabled', async () => {
+      const settings = {
+        itr_enabled: true,
+        code_coverage: false,
+        coverage_report_upload_enabled: true,
+        tests_skipping: true,
+      }
+      const baseline = await runMocha({
+        settings,
+        expectSuiteCoverage: false,
+      })
+
+      const skippedWithCoverage = await runMocha({
+        suitesToSkip: [{
+          type: 'suite',
+          attributes: {
+            suite: SKIPPED_SUITE,
+          },
+        }],
+        skippableCoverage: {
+          [SKIPPED_SOURCE]: getLinesBitmapBase64(1, 20),
+        },
+        settings,
+        expectSuiteCoverage: false,
+      })
+
+      assert.strictEqual(skippedWithCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithCoverage.skippedSuites.length, 1)
+      assert.strictEqual(skippedWithCoverage.skippedSuites[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(skippedWithCoverage.stdoutCodeCoverageLinesPct, baseline.stdoutCodeCoverageLinesPct)
+      assert.strictEqual(skippedWithCoverage.codeCoverageLinesPct, baseline.codeCoverageLinesPct)
+    })
+  })
+}
+
+for (const { version, dependencies } of MOCHA_VERSION_CONFIGS) {
+  describeMochaVersion(version, dependencies)
+}

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -76,6 +76,7 @@ const {
   DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS,
   DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS,
   TEST_FINAL_STATUS,
+  getLineCoverageBitmap,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const {
@@ -92,6 +93,14 @@ function assertItrSkippingEnabledTags (events, expected) {
   assert.strictEqual(testSuite.meta[TEST_ITR_SKIPPING_ENABLED], expected)
   const test = events.find(event => event.type === 'test').content
   assert.strictEqual(test.meta[TEST_ITR_SKIPPING_ENABLED], expected)
+}
+
+function getLinesBitmapBase64 (startLine, endLine) {
+  const lineCoverage = {}
+  for (let line = startLine; line <= endLine; line++) {
+    lineCoverage[line] = 1
+  }
+  return getLineCoverageBitmap(lineCoverage, true).toString('base64')
 }
 
 const runTestsCommand = 'node ./ci-visibility/run-mocha.js'
@@ -1918,7 +1927,14 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
     })
 
-    it('can report code coverage', (done) => {
+    it('can report code coverage', async () => {
+      receiver.setSettings({
+        itr_enabled: true,
+        code_coverage: true,
+        coverage_report_upload_enabled: true,
+        tests_skipping: true,
+      })
+
       let testOutput = ''
       const libraryConfigRequestPromise = receiver.payloadReceived(
         ({ url }) => url === '/api/v2/libraries/tests/services/setting'
@@ -1926,7 +1942,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       const codeCovRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcov')
       const eventsRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcycle')
 
-      Promise.all([
+      const requestsPromise = Promise.all([
         libraryConfigRequestPromise,
         codeCovRequestPromise,
         eventsRequestPromise,
@@ -1973,7 +1989,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           (acc, type) => type === 'test_suite_end' ? acc + 1 : acc, 0
         )
         assert.strictEqual(numSuites, 2)
-      }).catch(done)
+      })
 
       childProcess = exec(
         runTestsWithCoverageCommand,
@@ -1985,11 +2001,15 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       childProcess.stdout?.on('data', (chunk) => {
         testOutput += chunk.toString()
       })
-      childProcess.on('exit', () => {
-        // coverage report
-        assert.match(testOutput, /Lines {7}/)
-        done()
-      })
+      const stdoutEndPromise = childProcess.stdout ? once(childProcess.stdout, 'end') : Promise.resolve()
+      const [, [exitCode]] = await Promise.all([
+        requestsPromise,
+        once(childProcess, 'exit'),
+        stdoutEndPromise,
+      ])
+      assert.strictEqual(exitCode, 0)
+      // coverage report
+      assert.match(testOutput, /Lines {7}/)
     })
 
     it('does not report code coverage if disabled by the API', (done) => {
@@ -2029,19 +2049,22 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       )
     })
 
-    it('can skip suites received by the intelligent test runner API and still reports code coverage', (done) => {
+    it('can skip suites received by the intelligent test runner API and still reports code coverage', async () => {
       receiver.setSuitesToSkip([{
         type: 'suite',
         attributes: {
           suite: 'ci-visibility/test/ci-visibility-test.js',
         },
       }])
+      receiver.setSkippableCoverage({
+        'ci-visibility/test/ci-visibility-test.js': getLinesBitmapBase64(1, 20),
+      })
 
       const skippableRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/ci/tests/skippable')
       const coverageRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcov')
       const eventsRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcycle')
 
-      Promise.all([
+      const requestsPromise = Promise.all([
         skippableRequestPromise,
         coverageRequestPromise,
         eventsRequestPromise,
@@ -2081,8 +2104,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_TYPE], 'suite')
         assert.strictEqual(testModule.metrics[TEST_ITR_SKIPPING_COUNT], 1)
         assertItrSkippingEnabledTags(eventsRequest.payload.events, 'true')
-        done()
-      }).catch(done)
+      })
 
       childProcess = exec(
         runTestsWithCoverageCommand,
@@ -2091,9 +2113,19 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           env: getCiVisAgentlessConfig(receiver.port),
         }
       )
+      const [, [exitCode]] = await Promise.all([
+        requestsPromise,
+        once(childProcess, 'exit'),
+      ])
+      assert.strictEqual(exitCode, 0)
     })
 
-    it('marks the test session as skipped if every suite is skipped', (done) => {
+    it('marks the test session as skipped if every suite is skipped', async () => {
+      receiver.setSettings({
+        itr_enabled: true,
+        code_coverage: false,
+        tests_skipping: true,
+      })
       receiver.setSuitesToSkip(
         [
           {
@@ -2124,11 +2156,11 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           env: getCiVisAgentlessConfig(receiver.port),
         }
       )
-      childProcess.on('exit', () => {
-        eventsPromise.then(() => {
-          done()
-        }).catch(done)
-      })
+      const [, [exitCode]] = await Promise.all([
+        eventsPromise,
+        once(childProcess, 'exit'),
+      ])
+      assert.strictEqual(exitCode, 0)
     })
 
     it('does not skip tests if git metadata upload fails', (done) => {
@@ -2214,7 +2246,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       )
     })
 
-    it('does not skip suites if suite is marked as unskippable', (done) => {
+    it('does not skip suites if suite is marked as unskippable', async () => {
+      const coveredSkippedLines = getLinesBitmapBase64(1, 20)
       receiver.setSuitesToSkip([
         {
           type: 'suite',
@@ -2229,6 +2262,10 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           },
         },
       ])
+      receiver.setSkippableCoverage({
+        'ci-visibility/unskippable-test/test-to-skip.js': coveredSkippedLines,
+        'ci-visibility/unskippable-test/test-unskippable.js': coveredSkippedLines,
+      })
 
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -2282,14 +2319,14 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         }
       )
 
-      childProcess.on('exit', () => {
-        eventsPromise.then(() => {
-          done()
-        }).catch(done)
-      })
+      const [, [exitCode]] = await Promise.all([
+        eventsPromise,
+        once(childProcess, 'exit'),
+      ])
+      assert.strictEqual(exitCode, 0)
     })
 
-    it('only sets forced to run if suite was going to be skipped by ITR', (done) => {
+    it('only sets forced to run if suite was going to be skipped by ITR', async () => {
       receiver.setSuitesToSkip([
         {
           type: 'suite',
@@ -2298,6 +2335,9 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           },
         },
       ])
+      receiver.setSkippableCoverage({
+        'ci-visibility/unskippable-test/test-to-skip.js': getLinesBitmapBase64(1, 20),
+      })
 
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
@@ -2351,11 +2391,11 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         }
       )
 
-      childProcess.on('exit', () => {
-        eventsPromise.then(() => {
-          done()
-        }).catch(done)
-      })
+      const [, [exitCode]] = await Promise.all([
+        eventsPromise,
+        once(childProcess, 'exit'),
+      ])
+      assert.strictEqual(exitCode, 0)
     })
 
     it('sets _dd.ci.itr.tests_skipped to false if the received suite is not skipped', (done) => {
@@ -2463,6 +2503,9 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           suite: 'ci-visibility/test/ci-visibility-test.js',
         },
       }])
+      receiver.setSkippableCoverage({
+        'ci-visibility/test/ci-visibility-test.js': getLinesBitmapBase64(1, 20),
+      })
 
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -6,16 +6,21 @@ const { DD_MAJOR } = require('../../../../version')
 const { addHook, channel } = require('../helpers/instrument')
 const shimmer = require('../../../datadog-shimmer')
 const { isMarkedAsUnskippable } = require('../../../datadog-plugin-jest/src/util')
+const { writeCoverageBackfillToCache } = require('../../../dd-trace/src/ci-visibility/test-optimization-cache')
 const log = require('../../../dd-trace/src/log')
 const { getEnvironmentVariable } = require('../../../dd-trace/src/config/helper')
 const {
   getTestSuitePath,
   MOCHA_WORKER_TRACE_PAYLOAD_CODE,
   fromCoverageMapToCoverage,
-  getCoveredFilenamesFromCoverage,
+  getCoveredFilesFromCoverage,
+  getExecutableFilesFromCoverage,
+  applySkippedCoverageToCoverage,
   mergeCoverage,
   resetCoverage,
   getIsFaultyEarlyFlakeDetection,
+  getRelativeCoverageFiles,
+  getTestCoverageLinesPercentage,
   collectTestOptimizationSummariesFromTraces,
   logTestOptimizationSummary,
   getTestOptimizationRequestResults,
@@ -53,6 +58,8 @@ const unskippableSuites = []
 let suitesToSkip = []
 let isSuitesSkipped = false
 let skippedSuites = []
+let skippableSuitesCoverage = {}
+let skippedSuitesCoverage = {}
 let itrCorrelationId = ''
 let isForcedToRun = false
 const config = {}
@@ -133,10 +140,33 @@ function haveRootTestsFinished (rootTests) {
   return true
 }
 
+function getSuitePath (suite) {
+  return getTestSuitePath(suite.file, process.cwd())
+}
+
+function getSuitesToSkip (originalSuites) {
+  return getSuitesToSkipFromPaths(originalSuites.map(getSuitePath))
+}
+
+function getSuitesToSkipFromPaths (localSuites) {
+  const localSuitesSet = new Set(localSuites)
+  const suitesToSkipForRun = []
+
+  for (const suite of suitesToSkip) {
+    if (localSuitesSet.has(suite)) {
+      suitesToSkipForRun.push(suite)
+    }
+  }
+
+  return suitesToSkipForRun
+}
+
 function getFilteredSuites (originalSuites) {
+  const suitesToSkipForRun = getSuitesToSkip(originalSuites)
+
   return originalSuites.reduce((acc, suite) => {
-    const testPath = getTestSuitePath(suite.file, process.cwd())
-    const shouldSkip = suitesToSkip.includes(testPath)
+    const testPath = getSuitePath(suite)
+    const shouldSkip = suitesToSkipForRun.includes(testPath)
     const isUnskippable = unskippableSuites.includes(suite.file)
     if (shouldSkip && !isUnskippable) {
       acc.skippedSuites.add(testPath)
@@ -144,7 +174,50 @@ function getFilteredSuites (originalSuites) {
       acc.suitesToRun.push(suite)
     }
     return acc
-  }, { suitesToRun: [], skippedSuites: new Set() })
+  }, { suitesToRun: [], skippedSuites: new Set(), suitesToSkipForRun })
+}
+
+function hasSkippableSuitesCoverage () {
+  return skippableSuitesCoverage &&
+    typeof skippableSuitesCoverage === 'object' &&
+    Object.keys(skippableSuitesCoverage).length > 0
+}
+
+function isTiaCoverageBackfillEnabled () {
+  return config.isItrEnabled && config.isCoverageReportUploadEnabled
+}
+
+function getCoverageRootDir () {
+  return config.repositoryRoot || process.cwd()
+}
+
+function shouldReportCodeCoverageLinesPct (hasBackfilledCoverage) {
+  return !isSuitesSkipped || hasBackfilledCoverage
+}
+
+function getSkippedSuitesCoverageForRun () {
+  return isSuitesSkipped && isTiaCoverageBackfillEnabled() && hasSkippableSuitesCoverage()
+    ? skippableSuitesCoverage
+    : {}
+}
+
+function applySkippedCoverageToMochaCoverageMap () {
+  if (!isTiaCoverageBackfillEnabled()) return false
+  return applySkippedCoverageToCoverage(originalCoverageMap, skippedSuitesCoverage, getCoverageRootDir())
+}
+
+function getMochaTestSessionCoverageFiles () {
+  return getRelativeCoverageFiles(getExecutableFilesFromCoverage(originalCoverageMap), getCoverageRootDir())
+}
+
+function resetSuiteSkippingRunState () {
+  isSuitesSkipped = false
+  skippedSuites = []
+  skippableSuitesCoverage = {}
+  skippedSuitesCoverage = {}
+  untestedCoverage = undefined
+  config.repositoryRoot = undefined
+  writeCoverageBackfillToCache({})
 }
 
 function getOnStartHandler (frameworkVersion) {
@@ -218,12 +291,24 @@ function getOnEndHandler (isParallel) {
     testFileToSuiteCtx.clear()
 
     let testCodeCoverageLinesTotal
-    if (global.__coverage__) {
+    let testSessionCoverageFiles
+    if (global.__coverage__ || untestedCoverage) {
       try {
+        let hasBackfilledCoverage = false
         if (untestedCoverage) {
           originalCoverageMap.merge(fromCoverageMapToCoverage(untestedCoverage))
         }
-        testCodeCoverageLinesTotal = originalCoverageMap.getCoverageSummary().lines.pct
+        hasBackfilledCoverage = applySkippedCoverageToMochaCoverageMap()
+        if (shouldReportCodeCoverageLinesPct(hasBackfilledCoverage)) {
+          testCodeCoverageLinesTotal = getTestCoverageLinesPercentage(
+            originalCoverageMap,
+            undefined,
+            getCoverageRootDir()
+          )
+        }
+        if (isTiaCoverageBackfillEnabled()) {
+          testSessionCoverageFiles = getMochaTestSessionCoverageFiles()
+        }
       } catch {
         // ignore errors
       }
@@ -235,6 +320,7 @@ function getOnEndHandler (isParallel) {
       status,
       isSuitesSkipped,
       testCodeCoverageLinesTotal,
+      testSessionCoverageFiles,
       numSkippedSuites: skippedSuites.length,
       hasForcedToRunSuites: isForcedToRun,
       hasUnskippableSuites: !!unskippableSuites.length,
@@ -276,23 +362,39 @@ function applyTestManagementTestsResponse ({ err, testManagementTests: receivedT
   }
 }
 
-function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFinishRequest) {
+function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFinishRequest, localSuites) {
   const ctx = {
     isParallel,
     frameworkVersion,
   }
   let skippableSuitesResponse
+  resetSuiteSkippingRunState()
 
-  const onReceivedSkippableSuites = ({ err, skippableSuites, itrCorrelationId: responseItrCorrelationId }) => {
+  const onReceivedSkippableSuites = ({
+    err,
+    skippableSuites,
+    itrCorrelationId: responseItrCorrelationId,
+    skippableSuitesCoverage: responseSkippableSuitesCoverage,
+  }) => {
     if (err) {
       suitesToSkip = []
+      skippableSuitesCoverage = {}
     } else {
       suitesToSkip = skippableSuites
       itrCorrelationId = responseItrCorrelationId
+      skippableSuitesCoverage = responseSkippableSuitesCoverage || {}
     }
+    if (localSuites) {
+      suitesToSkip = getSuitesToSkipFromPaths(localSuites)
+      mochaGlobalRunCh.runStores(ctx, () => {
+        onFinishRequest()
+      })
+      return
+    }
+
     // We remove the suites that we skip through ITR
     const filteredSuites = getFilteredSuites(runner.suite.suites)
-    const { suitesToRun } = filteredSuites
+    const { suitesToRun, suitesToSkipForRun } = filteredSuites
 
     isSuitesSkipped = suitesToRun.length !== runner.suite.suites.length
 
@@ -301,6 +403,9 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     runner.suite.suites = suitesToRun
 
     skippedSuites = [...filteredSuites.skippedSuites]
+    suitesToSkip = suitesToSkipForRun
+    skippedSuitesCoverage = getSkippedSuitesCoverageForRun()
+    writeCoverageBackfillToCache(skippedSuitesCoverage, getCoverageRootDir())
 
     mochaGlobalRunCh.runStores(ctx, () => {
       onFinishRequest()
@@ -346,12 +451,13 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     }
   }
 
-  const onReceivedConfiguration = ({ err, libraryConfig }) => {
+  const onReceivedConfiguration = ({ err, libraryConfig, repositoryRoot }) => {
     if (err || !skippableSuitesCh.hasSubscribers || !knownTestsCh.hasSubscribers) {
       return mochaGlobalRunCh.runStores(ctx, () => {
         onFinishRequest()
       })
     }
+    config.repositoryRoot = repositoryRoot
     config.isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
     config.earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
     config.earlyFlakeDetectionSlowTestRetries = libraryConfig.earlyFlakeDetectionSlowTestRetries ?? {}
@@ -360,7 +466,10 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     config.isTestManagementTestsEnabled = libraryConfig.isTestManagementEnabled
     config.testManagementAttemptToFixRetries = libraryConfig.testManagementAttemptToFixRetries
     config.isImpactedTestsEnabled = libraryConfig.isImpactedTestsEnabled
-    config.isSuitesSkippingEnabled = libraryConfig.isSuitesSkippingEnabled
+    config.isItrEnabled = libraryConfig.isItrEnabled
+    config.isCodeCoverageEnabled = libraryConfig.isCodeCoverageEnabled
+    config.isCoverageReportUploadEnabled = libraryConfig.isCoverageReportUploadEnabled
+    config.isSuitesSkippingEnabled = config.isItrEnabled && libraryConfig.isSuitesSkippingEnabled
     config.isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
     config.flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
 
@@ -588,7 +697,7 @@ addHook({
       const status = getRootSuiteStatus(rootTests)
 
       if (global.__coverage__) {
-        const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
+        const coverageFiles = getCoveredFilesFromCoverage(global.__coverage__)
         testSuiteCodeCoverageCh.publish({ coverageFiles, suiteFile: file })
         mergeCoverage(global.__coverage__, originalCoverageMap)
         resetCoverage(global.__coverage__)
@@ -786,7 +895,7 @@ addHook({
       }
 
       if (global.__coverage__) {
-        const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
+        const coverageFiles = getCoveredFilesFromCoverage(global.__coverage__)
 
         testSuiteCodeCoverageCh.publish({
           coverageFiles,
@@ -908,11 +1017,11 @@ addHook({
       }
     }
 
+    const localSuites = files.map(file => getTestSuitePath(file, process.cwd()))
     getExecutionConfiguration(this, true, frameworkVersion, () => {
       if (config.isKnownTestsEnabled) {
-        const testSuites = files.map(file => getTestSuitePath(file, process.cwd()))
         const isFaulty = getIsFaultyEarlyFlakeDetection(
-          testSuites,
+          localSuites,
           config.knownTests?.mocha || {},
           config.earlyFlakeDetectionFaultyThreshold
         )
@@ -937,11 +1046,13 @@ addHook({
         }
         isSuitesSkipped = skippedFiles.length > 0
         skippedSuites = skippedFiles
+        skippedSuitesCoverage = getSkippedSuitesCoverageForRun()
+        writeCoverageBackfillToCache(skippedSuitesCoverage, getCoverageRootDir())
         run.apply(this, [cb, { files: filteredFiles }])
       } else {
         run.apply(this, arguments)
       }
-    })
+    }, localSuites)
 
     return this
   })

--- a/packages/datadog-instrumentations/src/nyc.js
+++ b/packages/datadog-instrumentations/src/nyc.js
@@ -2,7 +2,12 @@
 
 const shimmer = require('../../datadog-shimmer')
 const { getEnvironmentVariable } = require('../../dd-trace/src/config/helper')
-const { setupSettingsCachePath } = require('../../dd-trace/src/ci-visibility/test-optimization-cache')
+const {
+  readCoverageBackfillFromCache,
+  readCoverageBackfillRootDirFromCache,
+  setupSettingsCachePath,
+} = require('../../dd-trace/src/ci-visibility/test-optimization-cache')
+const { applySkippedCoverageToCoverage } = require('../../dd-trace/src/plugins/util/test')
 const { addHook, channel } = require('./helpers/instrument')
 
 const codeCoverageWrapCh = channel('ci:nyc:wrap')
@@ -15,6 +20,38 @@ addHook({
   // Set up the cache file path early (when nyc is required) so it's available
   // when dd-trace fetches library configuration
   setupSettingsCachePath()
+
+  if (nycPackage.prototype.getCoverageMapFromAllCoverageFiles) {
+    // Mocha receives skipped-suite coverage in the test process, but nyc merges reports later in the nyc process.
+    // Reuse the settings cache path as the process handoff so nyc can backfill skipped files before reporting.
+    shimmer.wrap(
+      nycPackage.prototype,
+      'getCoverageMapFromAllCoverageFiles',
+      getCoverageMapFromAllCoverageFiles => function (...args) {
+        const coverageMap = getCoverageMapFromAllCoverageFiles.apply(this, args)
+        const applyCoverageBackfill = (resolvedCoverageMap) => {
+          try {
+            if (!resolvedCoverageMap) {
+              return resolvedCoverageMap
+            }
+            applySkippedCoverageToCoverage(
+              resolvedCoverageMap,
+              readCoverageBackfillFromCache(),
+              readCoverageBackfillRootDirFromCache() || this.cwd
+            )
+          } catch {
+            // Do not break nyc's report generation if the cached backfill is stale or malformed.
+          }
+          return resolvedCoverageMap
+        }
+
+        if (coverageMap && typeof coverageMap.then === 'function') {
+          return coverageMap.then(applyCoverageBackfill)
+        }
+        return applyCoverageBackfill(coverageMap)
+      }
+    )
+  }
 
   // `wrap` is an async function
   shimmer.wrap(nycPackage.prototype, 'wrap', wrap => function (...args) {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -11,6 +11,7 @@ const {
   TEST_PARAMETERS,
   finishAllTraceSpans,
   getTestSuitePath,
+  getRelativeCoverageFiles,
   getTestParametersString,
   getTestSuiteCommonTags,
   addIntelligentTestRunnerSpanTags,
@@ -73,8 +74,10 @@ class MochaPlugin extends CiPlugin {
         this.telemetry.count(TELEMETRY_CODE_COVERAGE_EMPTY)
       }
 
-      const relativeCoverageFiles = [...coverageFiles, suiteFile]
-        .map(filename => getTestSuitePath(filename, this.repositoryRoot || this.sourceRoot))
+      const relativeCoverageFiles = [
+        ...getRelativeCoverageFiles(coverageFiles, this.repositoryRoot || this.sourceRoot),
+        getTestSuitePath(suiteFile, this.repositoryRoot || this.sourceRoot),
+      ]
 
       const { _traceId, _spanId } = testSuiteSpan.context()
 
@@ -352,6 +355,7 @@ class MochaPlugin extends CiPlugin {
       status,
       isSuitesSkipped,
       testCodeCoverageLinesTotal,
+      testSessionCoverageFiles,
       numSkippedSuites,
       hasForcedToRunSuites,
       hasUnskippableSuites,
@@ -362,7 +366,11 @@ class MochaPlugin extends CiPlugin {
       isParallel,
     }) => {
       if (this.testSessionSpan) {
-        const { isSuitesSkippingEnabled, isCodeCoverageEnabled } = this.libraryConfig || {}
+        const {
+          isSuitesSkippingEnabled,
+          isCodeCoverageEnabled,
+          isCoverageReportUploadEnabled,
+        } = this.libraryConfig || {}
         this.testSessionSpan.setTag(TEST_STATUS, status)
         this.testModuleSpan.setTag(TEST_STATUS, status)
 
@@ -393,6 +401,13 @@ class MochaPlugin extends CiPlugin {
             hasUnskippableSuites,
           }
         )
+
+        if (testSessionCoverageFiles?.length && isCoverageReportUploadEnabled) {
+          this.tracer._exporter.exportCoverage({
+            sessionId: this.testSessionSpan.context()._traceId,
+            files: testSessionCoverageFiles,
+          })
+        }
 
         if (isEarlyFlakeDetectionEnabled) {
           this.testSessionSpan.setTag(TEST_EARLY_FLAKE_ENABLED, 'true')

--- a/packages/dd-trace/src/ci-visibility/test-optimization-cache.js
+++ b/packages/dd-trace/src/ci-visibility/test-optimization-cache.js
@@ -1,12 +1,15 @@
 'use strict'
 
-const { writeFileSync } = require('node:fs')
+const { existsSync, readFileSync, writeFileSync } = require('node:fs')
 const { tmpdir } = require('node:os')
 const { randomUUID } = require('node:crypto')
 const path = require('node:path')
 
 const { getValueFromEnvSources } = require('../config/helper')
 const log = require('../log')
+
+const COVERAGE_BACKFILL_KEY = '_ddCoverageBackfill'
+const COVERAGE_BACKFILL_ROOT_DIR_KEY = '_ddCoverageBackfillRootDir'
 
 /**
  * Gets the test optimization settings cache file path from the env var.
@@ -36,26 +39,87 @@ function setupSettingsCachePath () {
 }
 
 /**
- * Writes the settings to the cache file specified by DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE.
- * Does nothing if the env var is not set.
- * @param {object} settings - The settings object to cache.
+ * Reads the shared test optimization cache file.
+ * @returns {object} Cached settings and metadata.
  */
-function writeSettingsToCache (settings) {
+function readCacheFile () {
+  const settingsCachePath = getSettingsCachePath()
+  if (!settingsCachePath || !existsSync(settingsCachePath)) {
+    return {}
+  }
+
+  try {
+    return JSON.parse(readFileSync(settingsCachePath, 'utf8'))
+  } catch (err) {
+    log.debug('Failed to read settings cache: %s', err.message)
+    return {}
+  }
+}
+
+/**
+ * Writes the shared test optimization cache file.
+ * @param {object} cache - Cached settings and metadata.
+ */
+function writeCacheFile (cache) {
   const settingsCachePath = getSettingsCachePath()
   if (!settingsCachePath) {
     return
   }
 
   try {
-    writeFileSync(settingsCachePath, JSON.stringify(settings), 'utf8')
+    writeFileSync(settingsCachePath, JSON.stringify(cache), 'utf8')
     log.debug('Settings written to %s', settingsCachePath)
   } catch (err) {
     log.error('Failed to write settings to cache file', err)
   }
 }
 
+/**
+ * Writes the settings to the cache file specified by DD_EXPERIMENTAL_TEST_OPT_SETTINGS_CACHE.
+ * Does nothing if the env var is not set.
+ * @param {object} settings - The settings object to cache.
+ */
+function writeSettingsToCache (settings) {
+  writeCacheFile({
+    ...readCacheFile(),
+    ...settings,
+  })
+}
+
+/**
+ * Writes TIA coverage backfill to the shared nyc settings cache.
+ * @param {object} coverage - Repository-relative coverage bitmaps by filename.
+ * @param {string} [rootDir] - Root directory that coverage filenames are relative to.
+ */
+function writeCoverageBackfillToCache (coverage, rootDir) {
+  writeCacheFile({
+    ...readCacheFile(),
+    [COVERAGE_BACKFILL_KEY]: coverage,
+    [COVERAGE_BACKFILL_ROOT_DIR_KEY]: rootDir,
+  })
+}
+
+/**
+ * Reads TIA coverage backfill from the shared nyc settings cache.
+ * @returns {object|undefined} Repository-relative coverage bitmaps by filename.
+ */
+function readCoverageBackfillFromCache () {
+  return readCacheFile()[COVERAGE_BACKFILL_KEY]
+}
+
+/**
+ * Reads TIA coverage backfill root directory from the shared nyc settings cache.
+ * @returns {string|undefined} Root directory that cached coverage filenames are relative to.
+ */
+function readCoverageBackfillRootDirFromCache () {
+  return readCacheFile()[COVERAGE_BACKFILL_ROOT_DIR_KEY]
+}
+
 module.exports = {
   getSettingsCachePath,
+  readCoverageBackfillFromCache,
+  readCoverageBackfillRootDirFromCache,
   setupSettingsCachePath,
+  writeCoverageBackfillToCache,
   writeSettingsToCache,
 }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -174,7 +174,7 @@ module.exports = class CiPlugin extends Plugin {
           },
         }
         this.tracer._exporter.addMetadataTags(metadataTags)
-        onDone({ err, libraryConfig, requestErrorTags })
+        onDone({ err, libraryConfig, repositoryRoot: this.repositoryRoot, requestErrorTags })
       })
     })
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -420,6 +420,7 @@ module.exports = {
   getCoveredFilenamesFromCoverage,
   getCoveredFilesFromCoverage,
   getExecutableFilesFromCoverage,
+  getRelativeCoverageFiles,
   getLineCoverageBitmap,
   applySkippedCoverageToCoverage,
   getTestCoverageLinesPercentage,
@@ -1073,6 +1074,13 @@ function getExecutableFilesFromCoverage (coverage) {
   }
 
   return coverageFiles
+}
+
+function getRelativeCoverageFiles (coverageFiles, rootDir) {
+  return coverageFiles.map(({ filename, bitmap }) => ({
+    filename: getTestSuitePath(filename, rootDir),
+    bitmap,
+  }))
 }
 
 function getLineCoverageBitmap (lineCoverage, onlyCoveredLines = false) {


### PR DESCRIPTION
### What does this PR do?
Adds TIA total code coverage backfill support for Mocha.

When Mocha suite skipping skips test files, dd-trace now stores backend `meta.coverage` from the skippable response and lets `nyc` merge that coverage before report generation. This keeps `nyc` stdout coverage and Datadog session `test.code_coverage.lines_pct` aligned with the no-skip baseline.

The product behavior is:
- suite-level `citestcov` remains gated by backend `code_coverage`
- skipped-suite backfill, session executable-line coverage, and report-upload behavior are gated by `coverage_report_upload_enabled`
- Mocha `test.code_coverage.lines_pct` is reported when no suites were skipped, or when skipped-suite coverage was
  actually backfilled

### Motivation
Mocha requires `nyc` for TIA coverage, so skipped-suite coverage has to be merged through the `nyc` report generation path. This gives Mocha stable total coverage without making suite skipping depend on receiving backend coverage.

### Additional Notes
The Mocha coverage tests live in `integration-tests/ci-visibility/tia-code-coverage-mocha.spec.js`.

The settings cache change is needed because Mocha receives skipped-suite coverage in the instrumented test process, but `nyc` merges coverage and generates the final report from its own process. The existing test-optimization cache file is now also used as the cross-process handoff for skipped-suite coverage backfill.
