### PR TITLE
feat(cypress): report ITR line coverage payloads for cypress

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -345,6 +345,7 @@ jobs:
         spec:
           - cypress-reporting
           - cypress-itr
+          - cypress-tia-code-coverage
           - cypress-efd
           - cypress-atr
           - cypress-test-management

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -2107,6 +2107,13 @@ moduleTypes.forEach(({
     })
 
     it('can report code coverage if it is available', async () => {
+      receiver.setSettings({
+        itr_enabled: true,
+        code_coverage: true,
+        coverage_report_upload_enabled: true,
+        tests_skipping: false,
+      })
+
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       childProcess = exec(
@@ -2125,23 +2132,31 @@ moduleTypes.forEach(({
         childProcess,
         ({ url }) => url === '/api/v2/citestcov',
         payloads => {
-          const [{ payload: coveragePayloads }] = payloads
+          const coverages = payloads
+            .flatMap(({ payload }) => payload)
+            .flatMap(coverage => coverage.content.coverages)
+          const testCoverages = coverages.filter(coverage => coverage.test_suite_id)
+          const sessionCoverage = coverages.find(coverage => !coverage.test_suite_id)
 
-          const coverages = coveragePayloads.map(coverage => coverage.content)
-            .flatMap(content => content.coverages)
-
-          coverages.forEach(coverage => {
+          testCoverages.forEach(coverage => {
             assert.ok(Object.hasOwn(coverage, 'test_session_id'), `Available keys: ${inspect(Object.keys(coverage))}`)
             assert.ok(Object.hasOwn(coverage, 'test_suite_id'), `Available keys: ${inspect(Object.keys(coverage))}`)
             assert.ok(Object.hasOwn(coverage, 'span_id'), `Available keys: ${inspect(Object.keys(coverage))}`)
             assert.ok(Object.hasOwn(coverage, 'files'), `Available keys: ${inspect(Object.keys(coverage))}`)
           })
+          assert.ok(sessionCoverage, 'session executable-line coverage should be reported')
+          assert.ok(
+            sessionCoverage.files.every(file => file.bitmap),
+            'session executable-line coverage should include line coverage bitmaps'
+          )
 
-          const fileNames = coverages
+          const fileNames = testCoverages
             .flatMap(coverageAttachment => coverageAttachment.files)
             .map(file => file.filename)
+          const sessionFileNames = sessionCoverage.files.map(file => file.filename)
 
           assertObjectContains(fileNames, Object.keys(coverageFixture))
+          assertObjectContains(sessionFileNames, Object.keys(coverageFixture))
         }, { hardTimeout: 25000 })
 
       await Promise.all([

--- a/integration-tests/cypress/cypress-tia-code-coverage.spec.js
+++ b/integration-tests/cypress/cypress-tia-code-coverage.spec.js
@@ -1,0 +1,374 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { exec } = require('node:child_process')
+
+const {
+  sandboxCwd,
+  useSandbox,
+  getCiVisAgentlessConfig,
+  stopCiVisTestEnv,
+  warmCypressBinary,
+} = require('../helpers')
+const { FakeCiVisIntake } = require('../ci-visibility-intake')
+const { startWebAppServer, stopWebAppServer } = require('../ci-visibility/web-app-server')
+const {
+  TEST_CODE_COVERAGE_LINES_PCT,
+  TEST_ITR_SKIPPING_COUNT,
+  TEST_ITR_TESTS_SKIPPED,
+  TEST_SKIPPED_BY_ITR,
+  TEST_STATUS,
+  getLineCoverageBitmap,
+} = require('../../packages/dd-trace/src/plugins/util/test')
+const { DD_MAJOR, NODE_MAJOR } = require('../../version')
+
+const requestedVersion = process.env.CYPRESS_VERSION
+const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
+const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
+const hookFile = 'dd-trace/loader-hook.mjs'
+const CYPRESS_RUN_HARD_TIMEOUT = 70_000
+const SPEC_PATTERN = 'cypress/e2e/{other,spec}.cy.js'
+const SKIPPED_TEST = {
+  type: 'test',
+  attributes: {
+    name: 'context passes',
+    suite: 'cypress/e2e/other.cy.js',
+  },
+}
+const SKIPPED_SOURCE = 'src/utils.tsx'
+const SKIPPED_SOURCE_COVERED_LINES = [1, 3, 4, 7]
+
+function gatherCypressPayloads (receiver, childProcess, endpoint, onPayload) {
+  return receiver.gatherPayloadsUntilChildExit(
+    childProcess,
+    ({ url }) => url.endsWith(endpoint),
+    onPayload,
+    { hardTimeout: CYPRESS_RUN_HARD_TIMEOUT }
+  )
+}
+
+function getLinesBitmapBase64 (lines) {
+  const lineCoverage = {}
+  for (const line of lines) {
+    lineCoverage[line] = 1
+  }
+  return getLineCoverageBitmap(lineCoverage, true).toString('base64')
+}
+
+function getCoverageEvents (payloads) {
+  return payloads
+    .flatMap(({ payload }) => payload)
+    .flatMap(({ content }) => content.coverages)
+}
+
+function shouldTestsRun (type) {
+  if (DD_MAJOR === 5) {
+    if (NODE_MAJOR <= 16) {
+      return version === '6.7.0' && type === 'commonJS'
+    }
+    if (NODE_MAJOR > 16) {
+      if (NODE_MAJOR <= 18) {
+        return version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
+    }
+  }
+  if (DD_MAJOR === 6) {
+    if (NODE_MAJOR <= 16) {
+      return false
+    }
+    if (NODE_MAJOR > 16) {
+      if (NODE_MAJOR <= 18) {
+        return version === '12.0.0' || version === '14.5.4'
+      }
+      return version === '12.0.0' || version === '14.5.4' || version === 'latest'
+    }
+  }
+  return false
+}
+
+const moduleTypes = [
+  {
+    type: 'commonJS',
+    testCommand: function commandWithSuffic (version) {
+      const commandSuffix = version === '6.7.0' ? '--config-file cypress-config.json --spec "cypress/e2e/*.cy.js"' : ''
+      return `./node_modules/.bin/cypress run ${commandSuffix}`
+    },
+  },
+  {
+    type: 'esm',
+    testCommand: `node --loader=${hookFile} ./cypress-esm-config.mjs`,
+  },
+].filter(moduleType => !process.env.CYPRESS_MODULE_TYPE || process.env.CYPRESS_MODULE_TYPE === moduleType.type)
+
+moduleTypes.forEach(({
+  type,
+  testCommand,
+}) => {
+  if (typeof testCommand === 'function') {
+    testCommand = testCommand(version)
+  }
+
+  describe(`TIA code coverage cypress@${version} ${type}`, function () {
+    if (!shouldTestsRun(type)) {
+      // eslint-disable-next-line no-console
+      console.log(`Skipping tests for cypress@${version} ${type} for dd-trace@${DD_MAJOR} node@${NODE_MAJOR}`)
+      return
+    }
+
+    this.timeout(180_000)
+
+    let cwd, childProcess, webAppBaseUrl, webAppServer
+
+    useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
+
+    before(async function () {
+      cwd = sandboxCwd()
+      await warmCypressBinary(cwd)
+
+      const webApp = await startWebAppServer()
+      webAppBaseUrl = webApp.baseUrl
+      webAppServer = webApp.server
+    })
+
+    afterEach(() => {
+      if (childProcess?.exitCode === null) {
+        childProcess.kill()
+      }
+      childProcess = undefined
+    })
+
+    after(async () => {
+      await stopWebAppServer(webAppServer)
+    })
+
+    async function runCypress ({
+      testsToSkip = [],
+      skippableCoverage = {},
+      settings = {
+        itr_enabled: true,
+        code_coverage: true,
+        coverage_report_upload_enabled: true,
+        tests_skipping: true,
+      },
+      expectTestCoverage = true,
+      expectSessionCoverage = true,
+      expectCoveragePayloads = true,
+      specPattern = SPEC_PATTERN,
+      assertEvents,
+    } = {}) {
+      const receiver = await new FakeCiVisIntake().start()
+      receiver.setSettings(settings)
+      receiver.setSuitesToSkip(testsToSkip)
+      receiver.setSkippableCoverage(skippableCoverage)
+
+      let eventsResult
+      let coverageResult
+      const coveragePayloads = []
+      const coverageRequestListener = (message) => {
+        if (message.url.endsWith('/api/v2/citestcov')) {
+          coveragePayloads.push(message)
+        }
+      }
+      receiver.on('message', coverageRequestListener)
+
+      childProcess = exec(
+        testCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            CYPRESS_BASE_URL: webAppBaseUrl,
+            SPEC_PATTERN: specPattern,
+          },
+        }
+      )
+
+      childProcess.stdout?.pipe(process.stdout)
+      childProcess.stderr?.pipe(process.stderr)
+
+      const eventsPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+        const testSession = events.find(event => event.type === 'test_session_end').content
+        const skippedTests = events
+          .filter(event => event.type === 'test')
+          .map(event => event.content)
+          .filter(test => test.meta[TEST_SKIPPED_BY_ITR] === 'true')
+
+        eventsResult = {
+          codeCoverageLinesPct: testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT],
+          isTiaSkipped: testSession.meta[TEST_ITR_TESTS_SKIPPED],
+          skippedTests,
+          tests: events.filter(event => event.type === 'test').map(event => event.content),
+        }
+        assertEvents?.(events)
+      })
+
+      const coveragePromise = expectCoveragePayloads
+        ? gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcov', payloads => {
+          const coverages = getCoverageEvents(payloads)
+          const testCoverage = coverages.find(coverage => coverage.test_suite_id)
+          const sessionCoverage = coverages.find(coverage => !coverage.test_suite_id)
+          const coveredFile = coverages
+            .flatMap(coverage => coverage.files)
+            .find(file => file.bitmap)
+
+          if (expectTestCoverage) {
+            assert.ok(testCoverage, 'test code coverage should be reported')
+          } else {
+            assert.strictEqual(testCoverage, undefined, 'test code coverage should not be reported')
+          }
+          if (expectSessionCoverage) {
+            assert.ok(sessionCoverage, 'session executable-line coverage should be reported')
+          } else {
+            assert.strictEqual(sessionCoverage, undefined, 'session executable-line coverage should not be reported')
+          }
+          assert.ok(coveredFile?.bitmap, 'covered files should report line coverage bitmaps')
+
+          coverageResult = coverages
+        })
+        : Promise.resolve()
+
+      try {
+        await Promise.all([
+          eventsPromise,
+          coveragePromise,
+        ])
+        if (!expectCoveragePayloads) {
+          await new Promise(resolve => setTimeout(resolve, 500))
+          assert.strictEqual(coveragePayloads.length, 0, 'code coverage payloads should not be reported')
+        }
+
+        return {
+          ...eventsResult,
+          coverages: coverageResult,
+        }
+      } finally {
+        receiver.off('message', coverageRequestListener)
+        await stopCiVisTestEnv({ childProcess, receiver })
+        childProcess = undefined
+      }
+    }
+
+    it('keeps total code coverage stable with skipped coverage', async () => {
+      const baseline = await runCypress()
+
+      assert.strictEqual(baseline.isTiaSkipped, 'false')
+      assert.ok(baseline.codeCoverageLinesPct > 0)
+      assert.ok(baseline.codeCoverageLinesPct < 100)
+      assert.ok(baseline.coverages.length > 0, 'baseline should report coverage payloads')
+
+      const skippedWithoutCoverage = await runCypress({
+        testsToSkip: [SKIPPED_TEST],
+      })
+
+      assert.strictEqual(skippedWithoutCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithoutCoverage.skippedTests.length, 1)
+      assert.strictEqual(skippedWithoutCoverage.skippedTests[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(skippedWithoutCoverage.codeCoverageLinesPct, undefined)
+
+      const skippedWithCoverage = await runCypress({
+        testsToSkip: [SKIPPED_TEST],
+        skippableCoverage: {
+          [SKIPPED_SOURCE]: getLinesBitmapBase64(SKIPPED_SOURCE_COVERED_LINES),
+        },
+      })
+
+      assert.strictEqual(skippedWithCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithCoverage.skippedTests.length, 1)
+      assert.strictEqual(skippedWithCoverage.skippedTests[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(skippedWithCoverage.codeCoverageLinesPct, baseline.codeCoverageLinesPct)
+    })
+
+    it('does not skip tests with missing line coverage when coverage report upload is enabled', async () => {
+      const result = await runCypress({
+        testsToSkip: [{
+          type: 'test',
+          attributes: {
+            ...SKIPPED_TEST.attributes,
+            _is_missing_line_code_coverage: true,
+          },
+        }],
+        specPattern: 'cypress/e2e/other.cy.js',
+        assertEvents: (events) => {
+          const test = events.find(event =>
+            event.content.resource === 'cypress/e2e/other.cy.js.context passes'
+          ).content
+          assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+          assert.notStrictEqual(test.meta[TEST_SKIPPED_BY_ITR], 'true')
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 0)
+        },
+      })
+
+      assert.strictEqual(result.isTiaSkipped, 'false')
+    })
+
+    it('only uploads test coverage when TIA is enabled but coverage report upload is disabled', async () => {
+      const result = await runCypress({
+        testsToSkip: [SKIPPED_TEST],
+        settings: {
+          itr_enabled: true,
+          code_coverage: true,
+          coverage_report_upload_enabled: false,
+          tests_skipping: true,
+        },
+        expectSessionCoverage: false,
+      })
+
+      assert.strictEqual(result.isTiaSkipped, 'true')
+      assert.strictEqual(result.skippedTests.length, 1)
+      assert.strictEqual(result.skippedTests[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(result.codeCoverageLinesPct, undefined)
+    })
+
+    it('does not upload citestcov payloads when TIA code coverage is disabled', async () => {
+      const result = await runCypress({
+        testsToSkip: [SKIPPED_TEST],
+        settings: {
+          itr_enabled: true,
+          code_coverage: false,
+          coverage_report_upload_enabled: false,
+          tests_skipping: true,
+        },
+        expectCoveragePayloads: false,
+      })
+
+      assert.strictEqual(result.isTiaSkipped, 'true')
+      assert.strictEqual(result.skippedTests.length, 1)
+      assert.strictEqual(result.skippedTests[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(result.codeCoverageLinesPct, undefined)
+    })
+
+    it('backfills and reports session coverage when coverage report upload is enabled', async () => {
+      const settings = {
+        itr_enabled: true,
+        code_coverage: false,
+        coverage_report_upload_enabled: true,
+        tests_skipping: true,
+      }
+      const baseline = await runCypress({
+        settings,
+        expectTestCoverage: false,
+      })
+
+      const skippedWithCoverage = await runCypress({
+        testsToSkip: [SKIPPED_TEST],
+        skippableCoverage: {
+          [SKIPPED_SOURCE]: getLinesBitmapBase64(SKIPPED_SOURCE_COVERED_LINES),
+        },
+        settings,
+        expectTestCoverage: false,
+      })
+      const sessionCoverage = skippedWithCoverage.coverages.find(coverage => !coverage.test_suite_id)
+      const skippedCoverageFile = sessionCoverage.files.find(file => file.filename === SKIPPED_SOURCE)
+
+      assert.strictEqual(skippedWithCoverage.isTiaSkipped, 'true')
+      assert.strictEqual(skippedWithCoverage.skippedTests.length, 1)
+      assert.strictEqual(skippedWithCoverage.skippedTests[0].meta[TEST_STATUS], 'skip')
+      assert.strictEqual(skippedWithCoverage.codeCoverageLinesPct, baseline.codeCoverageLinesPct)
+      assert.ok(skippedCoverageFile?.bitmap, 'session coverage should include line coverage bitmaps')
+    })
+  })
+})

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -4,6 +4,7 @@
 const { performance } = require('perf_hooks')
 const dateNow = Date.now
 
+const { createCoverageMap } = require('../../../vendor/dist/istanbul-lib-coverage')
 const satisfies = require('../../../vendor/dist/semifies')
 const {
   TEST_STATUS,
@@ -25,7 +26,12 @@ const {
   TEST_MODULE,
   TEST_SOURCE_START,
   finishAllTraceSpans,
-  getCoveredFilenamesFromCoverage,
+  getCoveredFilesFromCoverage,
+  getExecutableFilesFromCoverage,
+  getRelativeCoverageFiles,
+  getTestCoverageLinesPercentage,
+  applySkippedCoverageToCoverage,
+  mergeCoverage,
   getTestSuitePath,
   addIntelligentTestRunnerSpanTags,
   TEST_SKIPPED_BY_ITR,
@@ -201,13 +207,17 @@ function getSkippableTests (tracer, testConfiguration) {
     if (!tracer._tracer._exporter?.getSkippableSuites) {
       return resolve({ err: new Error('Test Optimization was not initialized correctly') })
     }
-    tracer._tracer._exporter.getSkippableSuites(testConfiguration, (err, skippableTests, correlationId) => {
-      resolve({
-        err,
-        skippableTests,
-        correlationId,
-      })
-    })
+    tracer._tracer._exporter.getSkippableSuites(
+      testConfiguration,
+      (err, skippableTests, correlationId, skippableTestsCoverage) => {
+        resolve({
+          err,
+          skippableTests,
+          correlationId,
+          skippableTestsCoverage,
+        })
+      }
+    )
   })
 }
 
@@ -361,9 +371,11 @@ class CypressPlugin {
   finishedTestsByFile = {}
   testStatuses = {}
   hasLibraryConfiguration = false
+  isItrEnabled = false
   isTestsSkipped = false
   isSuitesSkippingEnabled = false
   isCodeCoverageEnabled = false
+  isCoverageReportUploadEnabled = false
   isFlakyTestRetriesEnabled = false
   flakyTestRetriesCount = 0
   isEarlyFlakeDetectionEnabled = false
@@ -376,6 +388,8 @@ class CypressPlugin {
   earlyFlakeDetectionFaultyThreshold = 0
   testsToSkip = []
   skippedTests = []
+  skippableTestsCoverage = {}
+  testSessionCoverageMap = createCoverageMap()
   hasForcedToRunSuites = false
   hasUnskippableSuites = false
   unskippableSuites = []
@@ -440,9 +454,11 @@ class CypressPlugin {
     this.finishedTestsByFile = {}
     this.testStatuses = {}
     this.hasLibraryConfiguration = false
+    this.isItrEnabled = false
     this.isTestsSkipped = false
     this.isSuitesSkippingEnabled = false
     this.isCodeCoverageEnabled = false
+    this.isCoverageReportUploadEnabled = false
     this.isFlakyTestRetriesEnabled = false
     this.flakyTestRetriesCount = 0
     this.isEarlyFlakeDetectionEnabled = false
@@ -455,6 +471,8 @@ class CypressPlugin {
     this.earlyFlakeDetectionFaultyThreshold = 0
     this.testsToSkip = []
     this.skippedTests = []
+    this.skippableTestsCoverage = {}
+    this.testSessionCoverageMap = createCoverageMap()
     this.hasForcedToRunSuites = false
     this.hasUnskippableSuites = false
     this.unskippableSuites = []
@@ -494,6 +512,117 @@ class CypressPlugin {
     return this._timeOrigin + performance.now() - this._perfOrigin
   }
 
+  /**
+   * Returns the directory used to normalize coverage file names.
+   *
+   * @returns {string}
+   */
+  getCoverageRootDir () {
+    return this.repositoryRoot || this.rootDir || process.cwd()
+  }
+
+  /**
+   * Returns whether the backend supplied skipped-test coverage data.
+   *
+   * @returns {boolean}
+   */
+  hasSkippableTestsCoverage () {
+    return !!(this.skippableTestsCoverage &&
+      typeof this.skippableTestsCoverage === 'object' &&
+      Object.keys(this.skippableTestsCoverage).length > 0)
+  }
+
+  /**
+   * Returns whether skipped test coverage should be backfilled into the session coverage map.
+   *
+   * @returns {boolean}
+   */
+  shouldBackfillSkippedCoverage () {
+    return this.isItrEnabled &&
+      this.isCoverageReportUploadEnabled &&
+      this.isTestsSkipped &&
+      this.hasSkippableTestsCoverage()
+  }
+
+  /**
+   * Adds a test's Istanbul coverage to the aggregated session coverage map.
+   *
+   * @param {object} coverage
+   * @returns {void}
+   */
+  addTestSessionCoverage (coverage) {
+    mergeCoverage(coverage, this.testSessionCoverageMap)
+  }
+
+  /**
+   * Applies backend skipped-test coverage to the aggregated session coverage map.
+   *
+   * @returns {boolean}
+   */
+  applySkippedCoverageToTestSessionCoverage () {
+    if (!this.shouldBackfillSkippedCoverage()) {
+      return false
+    }
+
+    return applySkippedCoverageToCoverage(
+      this.testSessionCoverageMap,
+      this.skippableTestsCoverage,
+      this.getCoverageRootDir()
+    )
+  }
+
+  /**
+   * Calculates the total session code coverage percentage when product rules allow reporting it.
+   *
+   * @param {boolean} hasBackfilledCoverage
+   * @returns {number | undefined}
+   */
+  getTestCodeCoverageLinesTotal (hasBackfilledCoverage) {
+    if (!this.testSessionCoverageMap.files().length || (this.isTestsSkipped && !hasBackfilledCoverage)) {
+      return
+    }
+
+    return getTestCoverageLinesPercentage(this.testSessionCoverageMap, undefined, this.getCoverageRootDir())
+  }
+
+  /**
+   * Returns repository-relative executable-line coverage files for the test session.
+   *
+   * @returns {Array<{ filename: string, bitmap: Buffer }>}
+   */
+  getTestSessionCoverageFiles () {
+    return getRelativeCoverageFiles(
+      getExecutableFilesFromCoverage(this.testSessionCoverageMap),
+      this.getCoverageRootDir()
+    )
+  }
+
+  /**
+   * Uploads executable-line coverage for the test session when backend configuration enables it.
+   *
+   * @returns {void}
+   */
+  reportTestSessionCoverage () {
+    const exporter = this.tracer._tracer._exporter
+    if (
+      !this.testSessionSpan ||
+      !this.isCoverageReportUploadEnabled ||
+      !exporter?.exportCoverage
+    ) {
+      return
+    }
+
+    const files = this.getTestSessionCoverageFiles()
+    if (!files.length) {
+      return
+    }
+
+    exporter.exportCoverage({
+      sessionId: this.testSessionSpan.context()._traceId,
+      files,
+    })
+  }
+
   // Init function returns a promise that resolves with the Cypress configuration
   // Depending on the received configuration, the Cypress configuration can be modified:
   // for example, to enable retries for failed tests.
@@ -529,8 +658,10 @@ class CypressPlugin {
           this.hasLibraryConfiguration = true
           const {
             libraryConfig: {
+              isItrEnabled,
               isSuitesSkippingEnabled,
               isCodeCoverageEnabled,
+              isCoverageReportUploadEnabled,
               isEarlyFlakeDetectionEnabled,
               earlyFlakeDetectionNumRetries,
               earlyFlakeDetectionSlowTestRetries,
@@ -543,8 +674,10 @@ class CypressPlugin {
               isImpactedTestsEnabled,
             },
           } = libraryConfigurationResponse
+          this.isItrEnabled = isItrEnabled
           this.isSuitesSkippingEnabled = isSuitesSkippingEnabled
           this.isCodeCoverageEnabled = isCodeCoverageEnabled
+          this.isCoverageReportUploadEnabled = isCoverageReportUploadEnabled
           this.isEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
           this.earlyFlakeDetectionNumRetries = earlyFlakeDetectionNumRetries
           this.earlyFlakeDetectionSlowTestRetries = earlyFlakeDetectionSlowTestRetries ?? {}
@@ -797,7 +930,10 @@ class CypressPlugin {
       isSuitesSkippingEnabled: this.isSuitesSkippingEnabled,
       getKnownTests: () => getKnownTests(this.tracer, this.testConfiguration),
       getTestManagementTests: () => getTestManagementTests(this.tracer, this.testConfiguration),
-      getSkippableSuites: () => getSkippableTests(this.tracer, this.testConfiguration),
+      getSkippableSuites: () => getSkippableTests(this.tracer, {
+        ...this.testConfiguration,
+        isCoverageReportUploadEnabled: this.isCoverageReportUploadEnabled,
+      }),
     })
 
     if (this.isKnownTestsEnabled) {
@@ -834,13 +970,17 @@ class CypressPlugin {
 
     if (this.isSuitesSkippingEnabled) {
       const skippableTestsResponse =
-        skippableTestsRequestResponse || await getSkippableTests(this.tracer, this.testConfiguration)
+        skippableTestsRequestResponse || await getSkippableTests(this.tracer, {
+          ...this.testConfiguration,
+          isCoverageReportUploadEnabled: this.isCoverageReportUploadEnabled,
+        })
       if (skippableTestsResponse.err) {
         log.error('Cypress skippable tests response error', skippableTestsResponse.err)
         this._pendingRequestErrorTags.push({ tag: DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS, value: 'true' })
       } else {
-        const { skippableTests, correlationId } = skippableTestsResponse
+        const { skippableTests, correlationId, skippableTestsCoverage } = skippableTestsResponse
         this.testsToSkip = skippableTests || []
+        this.skippableTestsCoverage = skippableTestsCoverage || {}
         this.itrCorrelationId = correlationId
         incrementCountMetric(TELEMETRY_ITR_SKIPPED, { testLevel: 'test' }, this.testsToSkip.length)
       }
@@ -962,6 +1102,9 @@ class CypressPlugin {
     }
     if (this.testSessionSpan && this.testModuleSpan) {
       const testStatus = getSessionStatus(suiteStats)
+      const hasBackfilledCoverage = this.applySkippedCoverageToTestSessionCoverage()
+      const testCodeCoverageLinesTotal = this.getTestCodeCoverageLinesTotal(hasBackfilledCoverage)
+
       this.testModuleSpan.setTag(TEST_STATUS, testStatus)
       this.testSessionSpan.setTag(TEST_STATUS, testStatus)
 
@@ -972,12 +1115,15 @@ class CypressPlugin {
           isSuitesSkipped: this.isTestsSkipped,
           isSuitesSkippingEnabled: this.isSuitesSkippingEnabled,
           isCodeCoverageEnabled: this.isCodeCoverageEnabled,
+          testCodeCoverageLinesTotal,
           skippingType: 'test',
           skippingCount: this.skippedTests.length,
           hasForcedToRunSuites: this.hasForcedToRunSuites,
           hasUnskippableSuites: this.hasUnskippableSuites,
         }
       )
+
+      this.reportTestSessionCoverage()
 
       if (this.isTestManagementTestsEnabled) {
         this.testSessionSpan.setTag(TEST_MANAGEMENT_ENABLED, 'true')
@@ -1296,11 +1442,18 @@ class CypressPlugin {
           isQuarantined: isQuarantinedFromSupport,
           isDisabled: isDisabledFromSupport,
         } = test
+        if (coverage && (this.isCodeCoverageEnabled || this.isCoverageReportUploadEnabled)) {
+          this.addTestSessionCoverage(coverage)
+        }
+
         if (coverage && this.isCodeCoverageEnabled && this.tracer._tracer._exporter?.exportCoverage) {
-          const coverageFiles = getCoveredFilenamesFromCoverage(coverage)
-          const relativeCoverageFiles = [...coverageFiles, testSuiteAbsolutePath].map(
-            file => getTestSuitePath(file, this.repositoryRoot || this.rootDir)
-          )
+          const coverageFiles = getCoveredFilesFromCoverage(coverage)
+          const relativeCoverageFiles = getRelativeCoverageFiles(coverageFiles, this.getCoverageRootDir())
+          if (testSuiteAbsolutePath) {
+            relativeCoverageFiles.push({
+              filename: getTestSuitePath(testSuiteAbsolutePath, this.getCoverageRootDir()),
+            })
+          }
           if (!relativeCoverageFiles.length) {
             incrementCountMetric(TELEMETRY_CODE_COVERAGE_EMPTY)
           }


### PR DESCRIPTION
### What does this PR do?

Adds Cypress support for TIA total line coverage reporting and executable-line session coverage payloads.

Because Cypress skips at the test level, this aggregates coverage from executed tests and applies backend skipped-test coverage before reporting session totals. Session executable-line coverage upload and backfill are gated by `coverage_report_upload_enabled`. `test.code_coverage.lines_pct` is reported only when no tests were skipped or when skipped coverage was backfilled.

### Motivation

Keep Cypress aligned with the product behavior introduced for Jest (#8541), Mocha (#8450), and Cucumber (#8452), while preserving Cypress per-test coverage payloads and its test-level skipping model.

### Additional Notes

- Skippable tests marked as missing line coverage are filtered when coverage report upload is enabled, so Cypress does not skip tests that cannot be backfilled.
- When code coverage upload is disabled but coverage report upload is enabled, Cypress can still aggregate browser coverage for session executable-line reporting without emitting per-test coverage payloads.
