### PR TITLE
fix(config): keep v5 IAST programmatic aliases working

### DIFF
--- a/eslint-rules/eslint-config-names-sync.mjs
+++ b/eslint-rules/eslint-config-names-sync.mjs
@@ -19,10 +19,12 @@ const IGNORED_CONFIGURATION_NAMES = new Set([
 // v6. Keep these out of the `index.d.ts` ↔ JSON parity check.
 const IGNORED_CONFIGURATION_NAME_PREFIXES = [
   'experimental.appsec.',
+  'experimental.iast.',
   'ingestion.',
 ]
 const IGNORED_CONFIGURATION_LEAVES = new Set([
   'experimental.appsec',
+  'experimental.iast',
 ])
 const UNSUPPORTED_CONFIGURATION_ROOTS = new Set([
   'isCiVisibility',
@@ -87,6 +89,16 @@ function createInspectionResult (overrides) {
 }
 
 /**
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isIgnoredConfigurationName (name) {
+  return IGNORED_CONFIGURATION_NAMES.has(name) ||
+    IGNORED_CONFIGURATION_LEAVES.has(name) ||
+    IGNORED_CONFIGURATION_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))
+}
+
+/**
  * @param {string} filePath
  * @returns {SupportedConfigurationInfo}
  */
@@ -131,19 +143,19 @@ function getSupportedConfigurationInfo (filePath) {
       }
 
       for (const name of entry.configurationNames ?? []) {
-        if (typeof name !== 'string' || IGNORED_CONFIGURATION_NAMES.has(name)) {
+        if (typeof name !== 'string') {
           continue
         }
-        if (IGNORED_CONFIGURATION_LEAVES.has(name)) {
+
+        targets.add(name)
+
+        if (isIgnoredConfigurationName(name)) {
           continue
         }
-        if (IGNORED_CONFIGURATION_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))) {
-          continue
-        }
+
         if (!entry.deprecated) {
           names.add(name)
         }
-        targets.add(name)
       }
     }
 
@@ -497,14 +509,8 @@ function getIndexDtsConfigurationNames (filePath, supportedConfigurationInfo) {
 
   inspectMembers(tracerOptions.node.members, tracerOptions.namespaceKey, '')
 
-  for (const ignoredConfigurationName of IGNORED_CONFIGURATION_NAMES) {
-    names.delete(ignoredConfigurationName)
-  }
-  for (const leaf of IGNORED_CONFIGURATION_LEAVES) {
-    names.delete(leaf)
-  }
   for (const name of names) {
-    if (IGNORED_CONFIGURATION_NAME_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    if (isIgnoredConfigurationName(name)) {
       names.delete(name)
     }
   }

--- a/eslint-rules/eslint-config-names-sync.test.mjs
+++ b/eslint-rules/eslint-config-names-sync.test.mjs
@@ -51,6 +51,11 @@ ruleTester.run('eslint-config-names-sync', rule, {
       code: '',
       options: [getFixtureOptions('deprecated-skips-cross-check')],
     },
+    {
+      filename: path.join(fixturesDirectory, 'iast-experimental-alias-exception', 'lint-anchor.js'),
+      code: '',
+      options: [getFixtureOptions('iast-experimental-alias-exception')],
+    },
   ],
   invalid: [
     {
@@ -91,6 +96,17 @@ ruleTester.run('eslint-config-names-sync', rule, {
         messageId: 'configurationMissingInSupportedConfigurations',
         data: {
           configurationName: 'llmobs.agentlessEnabledasd',
+        },
+      }],
+    },
+    {
+      filename: path.join(fixturesDirectory, 'iast-canonical-still-checked', 'lint-anchor.js'),
+      code: '',
+      options: [getFixtureOptions('iast-canonical-still-checked')],
+      errors: [{
+        messageId: 'configurationMissingInIndexDts',
+        data: {
+          configurationName: 'iast.securityControlsConfiguration',
         },
       }],
     },

--- a/eslint-rules/fixtures/config-names-sync/iast-canonical-still-checked/index.d.ts
+++ b/eslint-rules/fixtures/config-names-sync/iast-canonical-still-checked/index.d.ts
@@ -1,0 +1,10 @@
+declare namespace tracer {
+  export interface TracerOptions {
+    iast?: boolean | {
+      /**
+       * @env DD_IAST_ENABLED
+       */
+      enabled?: boolean
+    }
+  }
+}

--- a/eslint-rules/fixtures/config-names-sync/iast-canonical-still-checked/supported-configurations.json
+++ b/eslint-rules/fixtures/config-names-sync/iast-canonical-still-checked/supported-configurations.json
@@ -1,0 +1,22 @@
+{
+  "supportedConfigurations": {
+    "DD_IAST_ENABLED": [
+      {
+        "configurationNames": [
+          "iast.enabled",
+          "iast",
+          "experimental.iast.enabled",
+          "experimental.iast"
+        ]
+      }
+    ],
+    "DD_IAST_SECURITY_CONTROLS_CONFIGURATION": [
+      {
+        "configurationNames": [
+          "iast.securityControlsConfiguration",
+          "experimental.iast.securityControlsConfiguration"
+        ]
+      }
+    ]
+  }
+}

--- a/eslint-rules/fixtures/config-names-sync/iast-experimental-alias-exception/index.d.ts
+++ b/eslint-rules/fixtures/config-names-sync/iast-experimental-alias-exception/index.d.ts
@@ -1,0 +1,15 @@
+declare namespace tracer {
+  export interface TracerOptions {
+    iast?: boolean | {
+      /**
+       * @env DD_IAST_ENABLED
+       */
+      enabled?: boolean
+
+      /**
+       * @env DD_IAST_SECURITY_CONTROLS_CONFIGURATION
+       */
+      securityControlsConfiguration?: string
+    }
+  }
+}

--- a/eslint-rules/fixtures/config-names-sync/iast-experimental-alias-exception/supported-configurations.json
+++ b/eslint-rules/fixtures/config-names-sync/iast-experimental-alias-exception/supported-configurations.json
@@ -1,0 +1,22 @@
+{
+  "supportedConfigurations": {
+    "DD_IAST_ENABLED": [
+      {
+        "configurationNames": [
+          "iast.enabled",
+          "iast",
+          "experimental.iast.enabled",
+          "experimental.iast"
+        ]
+      }
+    ],
+    "DD_IAST_SECURITY_CONTROLS_CONFIGURATION": [
+      {
+        "configurationNames": [
+          "iast.securityControlsConfiguration",
+          "experimental.iast.securityControlsConfiguration"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -17,22 +17,6 @@ let seqId = 0
 const configWithOrigin = new Map()
 const parseErrors = new Map()
 
-if (DD_MAJOR < 6) {
-  // Default value for DD_TRACE_STARTUP_LOGS is 'false' in older major versions.
-  // TODO: Remove this here once v5 is not supported anymore.
-  supportedConfigurations.DD_TRACE_STARTUP_LOGS[0].default = 'false'
-
-  // Programmatic configuration of DD_IAST_SECURITY_CONTROLS_CONFIGURATION is still supported
-  // on v5; restore the configurationNames that the env-only v6 shape drops.
-  // TODO: Remove this branch once v5 is not supported anymore.
-  const iastEntry = supportedConfigurations.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0]
-  iastEntry.configurationNames = [
-    iastEntry.internalPropertyName,
-    'experimental.iast.securityControlsConfiguration',
-  ]
-  delete iastEntry.internalPropertyName
-}
-
 /**
  * Warns about an invalid value for an option and adds the error to the last telemetry entry if it is not already set.
  * Logging happens only if the error is not already set or the option name is different from the last telemetry entry.

--- a/packages/dd-trace/src/config/major-overrides.js
+++ b/packages/dd-trace/src/config/major-overrides.js
@@ -13,7 +13,10 @@ const INGESTION_PREFIX = 'ingestion.'
  * @param {number} majorVersion
  */
 function applyMajorOverrides (supportedConfigurations, majorVersion) {
-  if (majorVersion < 6) return
+  if (majorVersion < 6) {
+    applyV5Overrides(supportedConfigurations)
+    return
+  }
 
   for (const entries of Object.values(supportedConfigurations)) {
     for (const entry of entries) {
@@ -58,7 +61,26 @@ function applyMajorOverrides (supportedConfigurations, majorVersion) {
 }
 
 /**
- * @param {SupportedConfigurations[string] | undefined} entries
+ * @param {SupportedConfigurations} supportedConfigurations Mutated in place.
+ */
+function applyV5Overrides (supportedConfigurations) {
+  const startupLogsEntry = supportedConfigurations.DD_TRACE_STARTUP_LOGS?.[0]
+  if (startupLogsEntry) {
+    startupLogsEntry.default = 'false'
+  }
+
+  const iastEntry = supportedConfigurations.DD_IAST_SECURITY_CONTROLS_CONFIGURATION?.[0]
+  if (!iastEntry) return
+
+  iastEntry.configurationNames = [
+    iastEntry.internalPropertyName || iastEntry.configurationNames?.[0],
+    `${EXPERIMENTAL_IAST_PREFIX}.securityControlsConfiguration`,
+  ]
+  delete iastEntry.internalPropertyName
+}
+
+/**
+ * @param {import('./helper').SupportedConfigurationEntry[] | undefined} entries
  * @param {string | ((alias: string) => boolean)} dropPredicate
  */
 function dropAlias (entries, dropPredicate) {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -226,6 +226,30 @@ describe('Config', () => {
       assert.strictEqual(Object.keys(supported).length, beforeKeyCount)
     })
 
+    it('applyMajorOverrides is idempotent for v5 security controls', () => {
+      const fresh = proxyquire.noPreserveCache()('../../src/config/supported-configurations.json', {})
+      const applyMajorOverrides = proxyquire.noPreserveCache()('../../src/config/major-overrides', {})
+      const supported = fresh.supportedConfigurations
+      const iastEntry = supported.DD_IAST_SECURITY_CONTROLS_CONFIGURATION[0]
+
+      applyMajorOverrides(supported, 5)
+      applyMajorOverrides(supported, 5)
+
+      assert.deepStrictEqual(iastEntry.configurationNames, [
+        'iast.securityControlsConfiguration',
+        'experimental.iast.securityControlsConfiguration',
+      ])
+      assert.strictEqual(iastEntry.internalPropertyName, undefined)
+    })
+
+    it('loads v5 config repeatedly after security controls are restored', () => {
+      const firstConfig = getConfig(undefined, { ddMajor: 5 })
+      const secondConfig = getConfig(undefined, { ddMajor: 5 })
+
+      assert.strictEqual(firstConfig.iast.securityControlsConfiguration, undefined)
+      assert.strictEqual(secondConfig.iast.securityControlsConfiguration, undefined)
+    })
+
     it('should pass through random envs', async () => {
       process.env.FOOBAR = 'true'
       const { FOOBAR } = getEnvironmentVariables()


### PR DESCRIPTION
v5 keeps the deprecated `iast.securityControlsConfiguration` and
   `experimental.iast.*` programmatic options. After the v6
   type/config gating, `defaults.js` rewrote
   `DD_IAST_SECURITY_CONTROLS_CONFIGURATION` in the cached
   supported-configurations object on every load, so the second
   reload wrote `[undefined,
   'experimental.iast.securityControlsConfiguration']` into
   `configurationNames` and crashed `addOption` on `name.indexOf`
   across every spec that reloads the config module.
   `eslint-config-names-sync` also flagged the surviving
   `experimental.iast.*` aliases as missing from `index.d.ts`.
   `applyV5Overrides` now reuses the existing
   `configurationNames[0]` when `internalPropertyName` is already
   gone, and the lint rule treats `experimental.iast.*` the same
   way it already treats `experimental.appsec.*` — visible to
   env-tag resolution, ignored by the JSON-vs-types parity check.