### PR TITLE
[test optimization] Fix playwright v5 tests

### DIFF
--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -53,6 +53,13 @@ versions.forEach((version) => {
   if (PLAYWRIGHT_VERSION === 'oldest' && version !== oldest) return
   if (PLAYWRIGHT_VERSION === 'latest' && version !== latest) return
 
+  // TODO: Remove this once we drop suppport for v5
+  const contextNewVersions = (...args) => {
+    if (satisfies(version, '>=1.38.0') || version === 'latest') {
+      context(...args)
+    }
+  }
+
   describe(`playwright@${version}`, function () {
     let cwd, receiver, childProcess, webAppPort, webAppServer
 
@@ -139,81 +146,88 @@ versions.forEach((version) => {
 
           // No skippable_tests test: playwright does not request skippable suites (TIA unsupported).
 
-          it(
-            'tags session and children with _dd.ci.library_configuration_error.known_tests when request fails 4xx',
-            async () => {
-              const envVars = reportMethod === 'agentless'
-                ? getCiVisAgentlessConfig(receiver.port)
-                : getCiVisEvpProxyConfig(receiver.port)
-              receiver.setSettings({ known_tests_enabled: true })
-              receiver.setKnownTestsResponseCode(404)
-              const eventsPromise = receiver
-                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-                  const events = payloads.flatMap(({ payload }) => payload.events)
-                  const testSession = events.find(event => event.type === 'test_session_end').content
-                  assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
-                  const testModule = events.find(event => event.type === 'test_module_end').content
-                  assert.strictEqual(testModule.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
-                  const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-                  assert.ok(testSuiteEvent, 'should have test suite event')
-                  assert.strictEqual(testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
-                  const testEvent = events.find(event => event.type === 'test')
-                  assert.ok(testEvent, 'should have test event')
-                  assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
-                })
-              childProcess = exec(
-                './node_modules/.bin/playwright test -c playwright.config.js',
-                {
-                  cwd,
-                  env: {
-                    ...envVars,
-                    PW_BASE_URL: `http://localhost:${webAppPort}`,
-                    DD_TEST_SESSION_NAME: 'my-test-session',
-                  },
-                }
-              )
-              await Promise.all([eventsPromise, once(childProcess, 'exit')])
-            })
+          contextNewVersions('new version requests', () => {
+            it(
+              'tags session and children with _dd.ci.library_configuration_error.known_tests when request fails 4xx',
+              async () => {
+                const envVars = reportMethod === 'agentless'
+                  ? getCiVisAgentlessConfig(receiver.port)
+                  : getCiVisEvpProxyConfig(receiver.port)
+                receiver.setSettings({ known_tests_enabled: true })
+                receiver.setKnownTestsResponseCode(404)
+                const eventsPromise = receiver
+                  .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+                    const events = payloads.flatMap(({ payload }) => payload.events)
+                    const testSession = events.find(event => event.type === 'test_session_end').content
+                    assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
+                    const testModule = events.find(event => event.type === 'test_module_end').content
+                    assert.strictEqual(testModule.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
+                    const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+                    assert.ok(testSuiteEvent, 'should have test suite event')
+                    assert.strictEqual(
+                      testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true'
+                    )
+                    const testEvent = events.find(event => event.type === 'test')
+                    assert.ok(testEvent, 'should have test event')
+                    assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true')
+                  })
+                childProcess = exec(
+                  './node_modules/.bin/playwright test -c playwright.config.js',
+                  {
+                    cwd,
+                    env: {
+                      ...envVars,
+                      PW_BASE_URL: `http://localhost:${webAppPort}`,
+                      DD_TEST_SESSION_NAME: 'my-test-session',
+                    },
+                  }
+                )
+                await Promise.all([eventsPromise, once(childProcess, 'exit')])
+              })
 
-          it(
-            'tags session and children with _dd.ci.library_configuration_error.test_management_tests when request fail',
-            async () => {
-              const envVars = reportMethod === 'agentless'
-                ? getCiVisAgentlessConfig(receiver.port)
-                : getCiVisEvpProxyConfig(receiver.port)
-              receiver.setSettings({ test_management: { enabled: true } })
-              receiver.setTestManagementTestsResponseCode(404)
-              const eventsPromise = receiver
-                .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-                  const events = payloads.flatMap(({ payload }) => payload.events)
-                  const testSession = events.find(event => event.type === 'test_session_end').content
-                  assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true')
-                  const testModule = events.find(event => event.type === 'test_module_end').content
-                  assert.strictEqual(testModule.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true')
-                  const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-                  assert.ok(testSuiteEvent, 'should have test suite event')
-                  assert.strictEqual(
-                    testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true'
-                  )
-                  const testEvent = events.find(event => event.type === 'test')
-                  assert.ok(testEvent, 'should have test event')
-                  assert.strictEqual(
-                    testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true'
-                  )
-                })
-              childProcess = exec(
-                './node_modules/.bin/playwright test -c playwright.config.js',
-                {
-                  cwd,
-                  env: {
-                    ...envVars,
-                    PW_BASE_URL: `http://localhost:${webAppPort}`,
-                    DD_TEST_SESSION_NAME: 'my-test-session',
-                  },
-                }
-              )
-              await Promise.all([eventsPromise, once(childProcess, 'exit')])
-            })
+            it(
+              'tags session and children with _dd.ci.library_configuration_error.test_management_tests ' +
+              'when request fail',
+              async () => {
+                const envVars = reportMethod === 'agentless'
+                  ? getCiVisAgentlessConfig(receiver.port)
+                  : getCiVisEvpProxyConfig(receiver.port)
+                receiver.setSettings({ test_management: { enabled: true } })
+                receiver.setTestManagementTestsResponseCode(404)
+                const eventsPromise = receiver
+                  .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+                    const events = payloads.flatMap(({ payload }) => payload.events)
+                    const testSession = events.find(event => event.type === 'test_session_end').content
+                    assert.strictEqual(
+                      testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true'
+                    )
+                    const testModule = events.find(event => event.type === 'test_module_end').content
+                    assert.strictEqual(testModule.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true')
+                    const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+                    assert.ok(testSuiteEvent, 'should have test suite event')
+                    assert.strictEqual(
+                      testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true'
+                    )
+                    const testEvent = events.find(event => event.type === 'test')
+                    assert.ok(testEvent, 'should have test event')
+                    assert.strictEqual(
+                      testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true'
+                    )
+                  })
+                childProcess = exec(
+                  './node_modules/.bin/playwright test -c playwright.config.js',
+                  {
+                    cwd,
+                    env: {
+                      ...envVars,
+                      PW_BASE_URL: `http://localhost:${webAppPort}`,
+                      DD_TEST_SESSION_NAME: 'my-test-session',
+                    },
+                  }
+                )
+                await Promise.all([eventsPromise, once(childProcess, 'exit')])
+              })
+          })
         })
 
         it('can run and report tests', (done) => {


### PR DESCRIPTION


### What does this PR do?
Do not run certain tests in 1.18.0, which is only run in v5

### Motivation
https://github.com/DataDog/dd-trace-js/actions/runs/25802977505/job/75799169668?pr=8436

