### PR TITLE
ci(codecov): restrict codecov/patch to PRs targeting master

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,13 +3,16 @@ coverage:
   round: down
   precision: 2
   status:
+    # The coverage action only attaches `master-coverage` on PRs targeting
+    # master; other PRs auto-pass codecov/patch via the rule below.
+    default_rules:
+      flag_coverage_not_uploaded_behavior: pass
     project: off
     patch:
       default:
         target: 95%
         if_not_found: success
         if_ci_failed: success
-        # PRs against `vN.x` release branches are typically backports / cherry-picks
-        # where the patch coverage is decided in the source PR; only enforce on master.
-        branches:
-          - master
+        only_pulls: true
+        flags:
+          - master-coverage

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -20,10 +20,26 @@ runs:
       shell: bash
       run: node scripts/verify-coverage.js --flags "${{ inputs.flags }}"
 
+    # `master-coverage` is the flag .codecov.yml gates codecov/patch on. Attach
+    # it only on PRs targeting master so release-branch PRs auto-pass.
+    - name: Compute Codecov flags
+      id: codecov-flags
+      shell: bash
+      env:
+        JOB_FLAGS: ${{ inputs.flags }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        flags="$JOB_FLAGS"
+        if [ "$EVENT_NAME" = "pull_request" ] && [ "$BASE_REF" = "master" ]; then
+          flags="${flags:+$flags,}master-coverage"
+        fi
+        echo "value=$flags" >> "$GITHUB_OUTPUT"
+
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
-        flags: ${{ inputs.flags }}
+        flags: ${{ steps.codecov-flags.outputs.value }}
 
     - name: Install datadog-ci
       if: always()


### PR DESCRIPTION
## Summary

Codecov's `branches:` filter matches the commit's branch — on a PR, the head ref, not the PR target — so the previous `branches: [master]` never fired on PRs and a base-branch filter is unsupported. Under the all-green policy that left `codecov/patch` effectively ungated on every PR.

Two coordinated pieces close it:

1. `.codecov.yml` filters `codecov/patch` on the `master-coverage` flag, sets `flag_coverage_not_uploaded_behavior: pass`, and `only_pulls: true`.
2. `.github/actions/coverage` attaches `master-coverage` only when `github.event_name == 'pull_request'` and `github.base_ref == 'master'`.

Master PRs compute patch coverage and gate at 95%. Release-branch PRs upload reports unchanged but the status auto-passes via `flag_coverage_not_uploaded_behavior`; master pushes don't post the status at all.

## Test plan

- [ ] CI on this PR exercises the master-targeting path; `codecov/patch` should compute on the diff and pin to the 95% threshold.
- [ ] Next PR targeting `v[0-9]+.x` should show `codecov/patch` as auto-passed green.
- [ ] Master pushes should not post `codecov/patch`.