### PR TITLE
fix(llmobs): write OTel bridge tags from plugin path too (MLOS-591)

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/base.js
+++ b/packages/dd-trace/src/llmobs/plugins/base.js
@@ -3,6 +3,7 @@
 const log = require('../../log')
 const { storage: llmobsStorage } = require('../storage')
 const telemetry = require('../telemetry')
+const { writeBridgeTags } = require('../util')
 
 const TracingPlugin = require('../../plugins/tracing')
 const LLMObsTagger = require('../tagger')
@@ -48,6 +49,8 @@ class LLMObsPlugin extends TracingPlugin {
         integration: this.constructor.integration,
         ...registerOptions,
       })
+
+      writeBridgeTags(span)
     }
   }
 

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -11,12 +11,11 @@ const {
   SPAN_KIND,
   OUTPUT_VALUE,
   INPUT_VALUE,
-  LLMOBS_TRACE_ID_BRIDGE_KEY,
-  LLMOBS_PARENT_ID_BRIDGE_KEY,
 } = require('./constants/tags')
 const {
   getFunctionArguments,
   validateKind,
+  writeBridgeTags,
 } = require('./util')
 const { storage } = require('./storage')
 const telemetry = require('./telemetry')
@@ -544,19 +543,7 @@ class LLMObs extends NoopLLMObs {
         parent: parentStore?.span,
       })
 
-      // Bridge tags read by the dd-go LLMObs trace-indexer to correlate OTel
-      // gen_ai.* spans with SDK LLMObs spans. Written once per local trace,
-      // on the first successful SDK LLMObs span registration. The shared
-      // _trace.tags bag is serialized to the first span in every flushed
-      // chunk's meta, so partial flush is covered automatically without a
-      // separate flush-time processor. Writing only after registerLLMObsSpan
-      // succeeds avoids poisoning _trace.tags with bridge tags pointing at a
-      // span that will never produce an LLMObs event.
-      const traceTags = span?.context?.()._trace?.tags
-      if (this.enabled && traceTags && !traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) {
-        traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY] = span.context().toTraceId(true)
-        traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
-      }
+      if (this.enabled) writeBridgeTags(span)
     }
 
     try {

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const log = require('../log')
-const { SPAN_KINDS } = require('./constants/tags')
+const {
+  LLMOBS_PARENT_ID_BRIDGE_KEY,
+  LLMOBS_TRACE_ID_BRIDGE_KEY,
+  SPAN_KINDS,
+} = require('./constants/tags')
 
 // LLM I/O is overwhelmingly ASCII (English prompts and code). Walk once
 // looking for the first non-ASCII char; if there is none, hand the input
@@ -248,6 +252,22 @@ function safeJsonParse (value, fallback) {
   }
 }
 
+// Bridge tags read by the dd-go LLMObs trace-indexer to correlate OTel
+// gen_ai.* spans with LLMObs spans (SDK-created or auto-instrumented). Written
+// once per local trace, on the first successful LLMObs span registration. The
+// shared _trace.tags bag is serialized to the first span in every flushed
+// chunk's meta, so partial flush is covered automatically. The mirrored Python
+// implementation is `_activate_llmobs_span` in dd-trace-py's _llmobs.py, which
+// fires from a global span-start hook gated on SpanTypes.LLM — JS has two
+// registration sites (SDK and plugin base) so this helper is invoked from both
+// to achieve the same single-hook semantics.
+function writeBridgeTags (span) {
+  const traceTags = span?.context?.()._trace?.tags
+  if (!traceTags || traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) return
+  traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY] = span.context().toTraceId(true)
+  traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
+}
+
 module.exports = {
   encodeUnicode,
   validateCostTags,
@@ -255,4 +275,5 @@ module.exports = {
   getFunctionArguments,
   safeJsonParse,
   spanHasError,
+  writeBridgeTags,
 }

--- a/packages/dd-trace/test/llmobs/plugins/base.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/base.spec.js
@@ -1,0 +1,123 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+describe('LLMObsPlugin base', () => {
+  let LLMObsPlugin
+  let registerLLMObsSpan
+  let tagMap
+
+  beforeEach(() => {
+    registerLLMObsSpan = sinon.stub()
+    tagMap = new WeakMap()
+
+    class FakeTracingPlugin {}
+
+    class FakeLLMObsTagger {
+      constructor () {
+        this.registerLLMObsSpan = registerLLMObsSpan
+      }
+
+      static get tagMap () { return tagMap }
+    }
+
+    LLMObsPlugin = proxyquire('../../../src/llmobs/plugins/base', {
+      '../../plugins/tracing': FakeTracingPlugin,
+      '../tagger': FakeLLMObsTagger,
+      '../storage': { storage: { getStore () { return undefined }, enterWith () {} } },
+      '../telemetry': { incrementLLMObsSpanStartCount () {} },
+    })
+  })
+
+  function makeSpan (traceTags = {}, traceId = '00000000000000001111111111111111', spanId = '2222222222222222') {
+    return {
+      context () {
+        return {
+          _trace: { tags: traceTags },
+          toTraceId () { return traceId },
+          toSpanId () { return spanId },
+        }
+      },
+    }
+  }
+
+  describe('start', () => {
+    let TestPlugin
+
+    beforeEach(() => {
+      TestPlugin = class extends LLMObsPlugin {
+        static integration = 'test-integration'
+        getLLMObsSpanRegisterOptions (ctx) {
+          return ctx.registerOptions
+        }
+      }
+    })
+
+    function makePlugin (enabled = true) {
+      const plugin = new TestPlugin()
+      plugin._tracerConfig = { llmobs: { enabled } }
+      plugin._tagger = { registerLLMObsSpan }
+      return plugin
+    }
+
+    it('writes bridge tags on first plugin-registered span', () => {
+      const traceTags = {}
+      const span = makeSpan(traceTags)
+      const ctx = { currentStore: { span }, registerOptions: {} }
+
+      makePlugin().start(ctx)
+
+      assert.equal(registerLLMObsSpan.callCount, 1)
+      assert.equal(traceTags.llmobs_trace_id, '00000000000000001111111111111111')
+      assert.equal(traceTags.llmobs_parent_id, '2222222222222222')
+    })
+
+    it('does not overwrite bridge tags on a subsequent plugin span in the same local trace', () => {
+      const traceTags = {}
+      const ctx1 = { currentStore: { span: makeSpan(traceTags, 'aaaa', 'first') }, registerOptions: {} }
+      const ctx2 = { currentStore: { span: makeSpan(traceTags, 'bbbb', 'second') }, registerOptions: {} }
+
+      const plugin = makePlugin()
+      plugin.start(ctx1)
+      plugin.start(ctx2)
+
+      assert.equal(traceTags.llmobs_trace_id, 'aaaa')
+      assert.equal(traceTags.llmobs_parent_id, 'first')
+    })
+
+    it('does not write bridge tags when llmobs is disabled', () => {
+      const traceTags = {}
+      const span = makeSpan(traceTags)
+      const ctx = { currentStore: { span }, registerOptions: {} }
+
+      makePlugin(false).start(ctx)
+
+      assert.equal(registerLLMObsSpan.callCount, 0)
+      assert.equal(traceTags.llmobs_trace_id, undefined)
+      assert.equal(traceTags.llmobs_parent_id, undefined)
+    })
+
+    it('does not write bridge tags when the plugin returns no register options', () => {
+      const NoRegisterPlugin = class extends LLMObsPlugin {
+        static integration = 'test-integration'
+        getLLMObsSpanRegisterOptions () { return null }
+      }
+      const traceTags = {}
+      const span = makeSpan(traceTags)
+      const ctx = { currentStore: { span } }
+
+      const plugin = new NoRegisterPlugin()
+      plugin._tracerConfig = { llmobs: { enabled: true } }
+      plugin._tagger = { registerLLMObsSpan }
+      plugin.start(ctx)
+
+      assert.equal(registerLLMObsSpan.callCount, 0)
+      assert.equal(traceTags.llmobs_trace_id, undefined)
+      assert.equal(traceTags.llmobs_parent_id, undefined)
+    })
+  })
+})

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -12,6 +12,7 @@ const {
   safeJsonParse,
   validateKind,
   spanHasError,
+  writeBridgeTags,
 } = require('../../src/llmobs/util')
 
 describe('util', () => {
@@ -234,6 +235,43 @@ describe('util', () => {
       span.setTag('error.stack', err.stack)
 
       assert.strictEqual(spanHasError(span), true)
+    })
+  })
+
+  describe('writeBridgeTags', () => {
+    function makeSpan (traceTags = {}) {
+      return {
+        context () {
+          return {
+            _trace: { tags: traceTags },
+            toTraceId () { return '00000000000000001111111111111111' },
+            toSpanId () { return '2222222222222222' },
+          }
+        },
+      }
+    }
+
+    it('writes llmobs_trace_id and llmobs_parent_id to _trace.tags', () => {
+      const traceTags = {}
+      writeBridgeTags(makeSpan(traceTags))
+      assert.strictEqual(traceTags.llmobs_trace_id, '00000000000000001111111111111111')
+      assert.strictEqual(traceTags.llmobs_parent_id, '2222222222222222')
+    })
+
+    it('does not overwrite bridge tags when already set', () => {
+      const traceTags = { llmobs_trace_id: 'preexisting', llmobs_parent_id: 'preexisting' }
+      writeBridgeTags(makeSpan(traceTags))
+      assert.strictEqual(traceTags.llmobs_trace_id, 'preexisting')
+      assert.strictEqual(traceTags.llmobs_parent_id, 'preexisting')
+    })
+
+    it('is a no-op when _trace.tags is absent', () => {
+      const span = { context () { return { _trace: undefined } } }
+      writeBridgeTags(span)
+    })
+
+    it('is a no-op when span is undefined', () => {
+      writeBridgeTags(undefined)
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #8127. That PR added the dd-go bridge-tag writes (`llmobs_trace_id`, `llmobs_parent_id`) and the `_dd.llmobs.submitted` marker, but wired the bridge-tag write inside `LLMObs._activate` — the SDK-only path (`LLMObs.trace` / `LLMObs.wrap`). Automatic LLMObs plugins (`genai`, `vertexai`, `bedrockruntime`, `openai`, `anthropic`, `ai`, `langchain`, `langgraph`) register their span via `LLMObsPlugin.start` and never call `_activate`, so the bridge tags were never written for plugin-only flows.

The MLOS-591 / Accenture customer repro is exactly this shape: manual OTel `gen_ai.*` ancestor (e.g. an \"Overall Question\" workflow with `gen_ai.conversation.id`) → auto-instrumented LLMObs descendant (e.g. a Gemini or Bedrock call). APM trace is intact, but in LLMObs the two halves split into separate traces / conversations because the indexer has no bridge tags to correlate on.

`_dd.llmobs.submitted` already works for plugin spans — it's written in `LLMObsSpanProcessor.process`, which runs for both SDK and plugin paths. Only the bridge-tag write needed to be lifted out.

## Python parity

In dd-trace-py the bridge-tag write lives in `_activate_llmobs_span` (`ddtrace/llmobs/_llmobs.py:1969-1971`), invoked from a global `core.on(\"trace.span_start\", ...)` hook gated on `span.span_type == SpanTypes.LLM`. A single hook covers both SDK-created spans and every integration because all integrations create spans with `span_type=SpanTypes.LLM`.

dd-trace-js has no equivalent `span_type=LLM` marker — LLMObs membership is tracked via `LLMObsTagger.tagMap` (a WeakMap), populated inside `registerLLMObsSpan`. The two callers of `registerLLMObsSpan` are:
1. `LLMObs._activate` (`sdk.js`) — SDK path
2. `LLMObsPlugin.start` (`plugins/base.js`) — plugin path

This PR extracts `writeBridgeTags(span)` into `llmobs/util.js` and calls it from both sites. Mirrors Python's single-hook semantics with two call sites.

## Files changed

| File | Change |
|---|---|
| `packages/dd-trace/src/llmobs/util.js` | New `writeBridgeTags(span)` helper. Idempotent per local trace via the existing `!traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]` guard. |
| `packages/dd-trace/src/llmobs/sdk.js` | `_activate` now calls `writeBridgeTags(span)` instead of inlining the write. Bridge-key imports removed from this file. |
| `packages/dd-trace/src/llmobs/plugins/base.js` | `start()` calls `writeBridgeTags(span)` after `registerLLMObsSpan` succeeds, closing the plugin-path gap. |

## Tests

- `test/llmobs/util.spec.js` — 4 `writeBridgeTags` unit tests (writes, no-overwrite, no-op when `_trace.tags` absent, no-op when span is undefined).
- `test/llmobs/plugins/base.spec.js` — 4 plugin-start tests (writes on first plugin span; no overwrite on second plugin span in same local trace; no write when LLMObs is disabled; no write when the subclass returns no register options). Uses proxyquire to stub `TracingPlugin` so the suite stays unit-weight.
- Existing #8127 SDK bridge-tag tests in `test/llmobs/sdk/index.spec.js` (5 tests) and `test/llmobs/sdk/integration.spec.js` continue to pass.

## Test plan
- [x] `mocha packages/dd-trace/test/llmobs/util.spec.js` — 42 tests pass (38 existing + 4 new)
- [x] `mocha packages/dd-trace/test/llmobs/plugins/base.spec.js` — 4 new tests pass
- [x] `mocha packages/dd-trace/test/llmobs/sdk/index.spec.js` — 91 tests pass (existing #8127 bridge-tag suite included)
- [x] `mocha packages/dd-trace/test/llmobs/span_processor.spec.js` — 22 tests pass
- [x] `mocha packages/dd-trace/test/llmobs/tagger.spec.js` — 85 tests pass
- [x] `npm run lint` clean
- [ ] Manual repro against MLOS-591 (Accenture) — to verify the merged trace + conversation in LLMObs against staging, after review

## Notes / scope

- **Distributed tracing across services** remains out of scope (same as #8127). Bridge tags are non-`_dd.p.*` and don't propagate cross-process.
- **`_dd.llmobs.submitted`** already covers plugin spans via `LLMObsSpanProcessor.process` — no change needed there.
- **Whole-trace scope** is preserved: once any LLMObs span (SDK or plugin) registers in a local APM trace, all flushed chunks carry the bridge tags via the existing `_trace.tags` → first-span-meta chunk path.

Claude session: `1aab3929-3f74-41e4-9da2-b74f44f9b5bc`
Resume: `claude --resume 1aab3929-3f74-41e4-9da2-b74f44f9b5bc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)