### PR TITLE
fix(llmobs): cover every LLMObs span registration with OTel bridge tags (MLOS-591)

### DIFF
--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -11,8 +11,6 @@ const {
   SPAN_KIND,
   OUTPUT_VALUE,
   INPUT_VALUE,
-  LLMOBS_TRACE_ID_BRIDGE_KEY,
-  LLMOBS_PARENT_ID_BRIDGE_KEY,
 } = require('./constants/tags')
 const {
   getFunctionArguments,
@@ -553,20 +551,6 @@ class LLMObs extends NoopLLMObs {
         ...options,
         parent: parentStore?.span,
       })
-
-      // Bridge tags read by the dd-go LLMObs trace-indexer to correlate OTel
-      // gen_ai.* spans with SDK LLMObs spans. Written once per local trace,
-      // on the first successful SDK LLMObs span registration. The shared
-      // _trace.tags bag is serialized to the first span in every flushed
-      // chunk's meta, so partial flush is covered automatically without a
-      // separate flush-time processor. Writing only after registerLLMObsSpan
-      // succeeds avoids poisoning _trace.tags with bridge tags pointing at a
-      // span that will never produce an LLMObs event.
-      const traceTags = span?.context?.()._trace?.tags
-      if (this.enabled && traceTags && !traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) {
-        traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY] = span.context().toTraceId(true)
-        traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
-      }
     }
 
     try {

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -98,24 +98,11 @@ class LLMObsTagger {
 
     this._register(span)
 
-    // Detect whether the registering span sits below an OTel `gen_ai.*`
-    // ancestor in the APM trace (MLOS-591 shape — manual OTel
-    // workflow/agent wrapping an auto-instrumented LLMObs leaf). When it
-    // does, suppress the `llmobs_parent_id` bridge tag (the indexer would
-    // otherwise reparent the gen_ai ancestors under this leaf — see
-    // dd-go/trace/apps/trace-indexer/processors/llmobs/processor.go:184-191
-    // and :298-302) and fall through to using that ancestor as the
-    // SDK-emitted event's `parent_id` so this span renders under the OTel
-    // workflow rather than as a parallel root.
+    // When the registering span sits below an OTel `gen_ai.*` ancestor, use
+    // that ancestor as the parent_id fallback and suppress the bridge
+    // parent_id tag so the indexer doesn't invert the trace.
     const genAIAncestorSpanId = findGenAIAncestorSpanId(span)
 
-    // Single bridge-tag hook for the dd-go LLMObs trace-indexer. Mirrors
-    // dd-trace-py's `_activate_llmobs_span` (in `_llmobs.py`), which is wired
-    // as a global span-start hook gated on `SpanTypes.LLM`. JS has no
-    // span_type=LLM marker — LLMObs membership is established here via the
-    // tagMap registration — so calling `writeBridgeTags` from this single
-    // chokepoint covers every caller (SDK, default plugin path, and
-    // bespoke plugin registrations like `bedrockruntime.setLLMObsTags`).
     writeBridgeTags(span, { includeParentId: genAIAncestorSpanId === null })
 
     this._setTag(span, ML_APP, spanMlApp)

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -43,7 +43,7 @@ const {
   INSTRUMENTATION_METHOD_ANNOTATED,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { writeBridgeTags } = require('./util')
+const { findGenAIAncestorSpanId, writeBridgeTags } = require('./util')
 const { validateCostTags } = require('./util')
 
 // global registry of LLMObs spans
@@ -98,6 +98,17 @@ class LLMObsTagger {
 
     this._register(span)
 
+    // Detect whether the registering span sits below an OTel `gen_ai.*`
+    // ancestor in the APM trace (MLOS-591 shape — manual OTel
+    // workflow/agent wrapping an auto-instrumented LLMObs leaf). When it
+    // does, suppress the `llmobs_parent_id` bridge tag (the indexer would
+    // otherwise reparent the gen_ai ancestors under this leaf — see
+    // dd-go/trace/apps/trace-indexer/processors/llmobs/processor.go:184-191
+    // and :298-302) and fall through to using that ancestor as the
+    // SDK-emitted event's `parent_id` so this span renders under the OTel
+    // workflow rather than as a parallel root.
+    const genAIAncestorSpanId = findGenAIAncestorSpanId(span)
+
     // Single bridge-tag hook for the dd-go LLMObs trace-indexer. Mirrors
     // dd-trace-py's `_activate_llmobs_span` (in `_llmobs.py`), which is wired
     // as a global span-start hook gated on `SpanTypes.LLM`. JS has no
@@ -105,7 +116,7 @@ class LLMObsTagger {
     // tagMap registration — so calling `writeBridgeTags` from this single
     // chokepoint covers every caller (SDK, default plugin path, and
     // bespoke plugin registrations like `bedrockruntime.setLLMObsTags`).
-    writeBridgeTags(span)
+    writeBridgeTags(span, { includeParentId: genAIAncestorSpanId === null })
 
     this._setTag(span, ML_APP, spanMlApp)
 
@@ -123,6 +134,7 @@ class LLMObsTagger {
     const parentId =
       parent?.context().toSpanId() ??
       span.context()._trace.tags[PROPAGATED_PARENT_ID_KEY] ??
+      genAIAncestorSpanId ??
       ROOT_PARENT_ID
     this._setTag(span, PARENT_ID_KEY, parentId)
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -43,6 +43,7 @@ const {
   INSTRUMENTATION_METHOD_ANNOTATED,
 } = require('./constants/tags')
 const { storage } = require('./storage')
+const { writeBridgeTags } = require('./util')
 const { validateCostTags } = require('./util')
 
 // global registry of LLMObs spans
@@ -96,6 +97,15 @@ class LLMObsTagger {
     }
 
     this._register(span)
+
+    // Single bridge-tag hook for the dd-go LLMObs trace-indexer. Mirrors
+    // dd-trace-py's `_activate_llmobs_span` (in `_llmobs.py`), which is wired
+    // as a global span-start hook gated on `SpanTypes.LLM`. JS has no
+    // span_type=LLM marker — LLMObs membership is established here via the
+    // tagMap registration — so calling `writeBridgeTags` from this single
+    // chokepoint covers every caller (SDK, default plugin path, and
+    // bespoke plugin registrations like `bedrockruntime.setLLMObsTags`).
+    writeBridgeTags(span)
 
     this._setTag(span, ML_APP, spanMlApp)
 

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -43,8 +43,7 @@ const {
   INSTRUMENTATION_METHOD_ANNOTATED,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { findGenAIAncestorSpanId, writeBridgeTags } = require('./util')
-const { validateCostTags } = require('./util')
+const { findGenAIAncestorSpanId, validateCostTags, writeBridgeTags } = require('./util')
 
 // global registry of LLMObs spans
 // maps LLMObs spans to their annotations

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -295,29 +295,49 @@ function writeBridgeTags (span, { includeParentId = true } = {}) {
 // LLMObs event then renders under the workflow rather than as a parallel
 // root. OTel `setAttribute(...)` lands in `context()._tags` via
 // `setOtelAttribute -> ddSpan.setTag` (see opentelemetry/span-helpers.js), so
-// scanning `_tags` keys for the `gen_ai.` prefix is the right check.
+// scanning `_tags` keys for the `gen_ai.` prefix is the right check. The
+// prefix matches dd-go's `isRelevantForLLMObs` in
+// `trace/apps/trace-indexer/processors/llmobs/processor.go` so what we treat
+// as a "gen_ai ancestor" here lines up with what the indexer will convert
+// into an LLMObs span on the other side.
+//
+// Trade-off: this fires only on the FIRST LLMObs registration per local
+// trace (writeBridgeTags has a first-writer-wins guard on `_trace.tags`).
+// For mixed topologies — e.g. OTel agent wrapping an auto-instr leaf AND a
+// later SDK workflow — the suppression decision is locked in by whichever
+// LLMObs span registers first. The result is still a unified trace via
+// `llmobs_trace_id`; the LLMObs root is the APM root rather than the SDK
+// workflow. Optimizing that case would mean revisiting the bridge-tag write
+// at flush time instead of at register time.
 /**
  * @param {import('../opentracing/span')} span
  * @returns {string | null}
  */
 function findGenAIAncestorSpanId (span) {
   const ctx = span?.context?.()
-  const started = ctx?._trace?.started
+  let parentId = ctx?._parentId?.toString(10)
+  // Short-circuit before scanning `_trace.started` — orphan / root spans
+  // shouldn't pay the walk cost (this runs on every LLMObs registration).
+  if (!parentId || parentId === '0') return null
+
+  const started = ctx._trace?.started
   if (!started || started.length === 0) return null
 
-  const byId = new Map()
-  for (const s of started) {
-    byId.set(s.context()._spanId.toString(10), s)
-  }
-
-  let parentId = ctx._parentId?.toString(10)
+  // Parent chains are short (typically ≤ 5 hops); a linear scan per hop
+  // avoids allocating a Map over every started span on every registration.
   while (parentId && parentId !== '0') {
-    const parent = byId.get(parentId)
+    let parent = null
+    for (const s of started) {
+      if (s.context()._spanId.toString(10) === parentId) {
+        parent = s
+        break
+      }
+    }
     if (!parent) return null
 
     const tags = parent.context()._tags
     if (tags) {
-      for (const key in tags) {
+      for (const key of Object.keys(tags)) {
         if (key.startsWith('gen_ai.')) return parentId
       }
     }

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -297,7 +297,7 @@ function findGenAIAncestorSpanId (span) {
     }
     if (!parent) return null
 
-    const tags = parent.context()._tags
+    const tags = parent.context().getTags()
     if (tags) {
       for (const key of Object.keys(tags)) {
         if (key.startsWith('gen_ai.')) return parentId

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -258,9 +258,11 @@ function safeJsonParse (value, fallback) {
 // shared _trace.tags bag is serialized to the first span in every flushed
 // chunk's meta, so partial flush is covered automatically. The mirrored Python
 // implementation is `_activate_llmobs_span` in dd-trace-py's _llmobs.py, which
-// fires from a global span-start hook gated on SpanTypes.LLM — JS has two
-// registration sites (SDK and plugin base) so this helper is invoked from both
-// to achieve the same single-hook semantics.
+// fires from a global span-start hook gated on SpanTypes.LLM. JS has no
+// SpanTypes.LLM marker, so this helper is invoked from the single
+// `LLMObsTagger.registerLLMObsSpan` chokepoint, which every registration path
+// (SDK, default plugin start, and bespoke plugin registrations like
+// `bedrockruntime.setLLMObsTags`) flows through.
 function writeBridgeTags (span) {
   const traceTags = span?.context?.()._trace?.tags
   if (!traceTags || traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) return

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -252,28 +252,11 @@ function safeJsonParse (value, fallback) {
   }
 }
 
-// Bridge tags read by the dd-go LLMObs trace-indexer to correlate OTel
-// gen_ai.* spans with LLMObs spans (SDK-created or auto-instrumented). Written
-// once per local trace, on the first successful LLMObs span registration. The
-// shared _trace.tags bag is serialized to the first span in every flushed
-// chunk's meta, so partial flush is covered automatically. The mirrored Python
-// implementation is `_activate_llmobs_span` in dd-trace-py's _llmobs.py, which
-// fires from a global span-start hook gated on SpanTypes.LLM. JS has no
-// SpanTypes.LLM marker, so this helper is invoked from the single
-// `LLMObsTagger.registerLLMObsSpan` chokepoint, which every registration path
-// (SDK, default plugin start, and bespoke plugin registrations like
-// `bedrockruntime.setLLMObsTags`) flows through.
-//
-// When the registering span sits below an OTel `gen_ai.*` ancestor (MLOS-591
-// shape — manual OTel workflow wrapping an auto-instrumented LLMObs leaf), the
-// caller passes `includeParentId: false`. We still publish `llmobs_trace_id`
-// so the indexer pulls the OTel-converted spans into the same LLMObs trace,
-// but we skip `llmobs_parent_id` — the indexer treats that tag as "the SDK
-// LLMObs span is the LLMObs root, reparent gen_ai children under it"
-// (processor.go:184-191, 298-302). When the SDK span is a leaf rather than a
-// root, that reparenting produces a cycle/inversion (gen_ai parents hoisted
-// under the leaf). Suppressing `llmobs_parent_id` lets the indexer fall back
-// to including the APM root and reparenting gen_ai spans naturally.
+// Bridge tags read by the trace-indexer to pull OTel `gen_ai.*` spans into
+// the same LLMObs trace. Written once per local trace (first-writer wins on
+// `_trace.tags`). Pass `includeParentId: false` when the span sits below an
+// OTel `gen_ai.*` ancestor — without it the indexer treats this span as the
+// LLMObs root and hoists the gen_ai ancestors under it, inverting the trace.
 /**
  * @param {import('../opentracing/span')} span
  * @param {{ includeParentId?: boolean }} [opts]
@@ -287,28 +270,10 @@ function writeBridgeTags (span, { includeParentId = true } = {}) {
   }
 }
 
-// Walks up the APM parent chain looking for the nearest ancestor with any
-// `gen_ai.*` tag. Returns the decimal span_id string of that ancestor, or
-// `null`. Used by `LLMObsTagger.registerLLMObsSpan` so an auto-instrumented
-// LLMObs span nested under a manual OTel workflow points its `parent_id` at
-// the OTel parent instead of the default `ROOT_PARENT_ID` — the SDK-emitted
-// LLMObs event then renders under the workflow rather than as a parallel
-// root. OTel `setAttribute(...)` lands in `context()._tags` via
-// `setOtelAttribute -> ddSpan.setTag` (see opentelemetry/span-helpers.js), so
-// scanning `_tags` keys for the `gen_ai.` prefix is the right check. The
-// prefix matches dd-go's `isRelevantForLLMObs` in
-// `trace/apps/trace-indexer/processors/llmobs/processor.go` so what we treat
-// as a "gen_ai ancestor" here lines up with what the indexer will convert
-// into an LLMObs span on the other side.
-//
-// Trade-off: this fires only on the FIRST LLMObs registration per local
-// trace (writeBridgeTags has a first-writer-wins guard on `_trace.tags`).
-// For mixed topologies — e.g. OTel agent wrapping an auto-instr leaf AND a
-// later SDK workflow — the suppression decision is locked in by whichever
-// LLMObs span registers first. The result is still a unified trace via
-// `llmobs_trace_id`; the LLMObs root is the APM root rather than the SDK
-// workflow. Optimizing that case would mean revisiting the bridge-tag write
-// at flush time instead of at register time.
+// Walks the APM parent chain for the nearest ancestor with any `gen_ai.*`
+// tag. Lets an auto-instrumented LLMObs span nested under a manual OTel
+// workflow point its `parent_id` at the OTel parent so the SDK-emitted
+// event renders under it instead of as a parallel root.
 /**
  * @param {import('../opentracing/span')} span
  * @returns {string | null}
@@ -316,15 +281,12 @@ function writeBridgeTags (span, { includeParentId = true } = {}) {
 function findGenAIAncestorSpanId (span) {
   const ctx = span?.context?.()
   let parentId = ctx?._parentId?.toString(10)
-  // Short-circuit before scanning `_trace.started` — orphan / root spans
-  // shouldn't pay the walk cost (this runs on every LLMObs registration).
   if (!parentId || parentId === '0') return null
 
   const started = ctx._trace?.started
   if (!started || started.length === 0) return null
 
-  // Parent chains are short (typically ≤ 5 hops); a linear scan per hop
-  // avoids allocating a Map over every started span on every registration.
+  // Linear scan per hop — parent chains are short, avoids a per-call Map.
   while (parentId && parentId !== '0') {
     let parent = null
     for (const s of started) {

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const log = require('../log')
-const { SPAN_KINDS } = require('./constants/tags')
+const {
+  LLMOBS_PARENT_ID_BRIDGE_KEY,
+  LLMOBS_TRACE_ID_BRIDGE_KEY,
+  SPAN_KINDS,
+} = require('./constants/tags')
 
 // LLM I/O is overwhelmingly ASCII (English prompts and code). Walk once
 // looking for the first non-ASCII char; if there is none, hand the input
@@ -248,6 +252,22 @@ function safeJsonParse (value, fallback) {
   }
 }
 
+// Bridge tags read by the dd-go LLMObs trace-indexer to correlate OTel
+// gen_ai.* spans with LLMObs spans (SDK-created or auto-instrumented). Written
+// once per local trace, on the first successful LLMObs span registration. The
+// shared _trace.tags bag is serialized to the first span in every flushed
+// chunk's meta, so partial flush is covered automatically. The mirrored Python
+// implementation is `_activate_llmobs_span` in dd-trace-py's _llmobs.py, which
+// fires from a global span-start hook gated on SpanTypes.LLM — JS has two
+// registration sites (SDK and plugin base) so this helper is invoked from both
+// to achieve the same single-hook semantics.
+function writeBridgeTags (span) {
+  const traceTags = span?.context?.()._trace?.tags
+  if (!traceTags || traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) return
+  traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY] = span.context().toTraceId(true)
+  traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
+}
+
 module.exports = {
   encodeUnicode,
   validateCostTags,
@@ -255,4 +275,5 @@ module.exports = {
   getFunctionArguments,
   safeJsonParse,
   spanHasError,
+  writeBridgeTags,
 }

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -263,15 +263,73 @@ function safeJsonParse (value, fallback) {
 // `LLMObsTagger.registerLLMObsSpan` chokepoint, which every registration path
 // (SDK, default plugin start, and bespoke plugin registrations like
 // `bedrockruntime.setLLMObsTags`) flows through.
-function writeBridgeTags (span) {
+//
+// When the registering span sits below an OTel `gen_ai.*` ancestor (MLOS-591
+// shape — manual OTel workflow wrapping an auto-instrumented LLMObs leaf), the
+// caller passes `includeParentId: false`. We still publish `llmobs_trace_id`
+// so the indexer pulls the OTel-converted spans into the same LLMObs trace,
+// but we skip `llmobs_parent_id` — the indexer treats that tag as "the SDK
+// LLMObs span is the LLMObs root, reparent gen_ai children under it"
+// (processor.go:184-191, 298-302). When the SDK span is a leaf rather than a
+// root, that reparenting produces a cycle/inversion (gen_ai parents hoisted
+// under the leaf). Suppressing `llmobs_parent_id` lets the indexer fall back
+// to including the APM root and reparenting gen_ai spans naturally.
+/**
+ * @param {import('../opentracing/span')} span
+ * @param {{ includeParentId?: boolean }} [opts]
+ */
+function writeBridgeTags (span, { includeParentId = true } = {}) {
   const traceTags = span?.context?.()._trace?.tags
   if (!traceTags || traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY]) return
   traceTags[LLMOBS_TRACE_ID_BRIDGE_KEY] = span.context().toTraceId(true)
-  traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
+  if (includeParentId) {
+    traceTags[LLMOBS_PARENT_ID_BRIDGE_KEY] = span.context().toSpanId()
+  }
+}
+
+// Walks up the APM parent chain looking for the nearest ancestor with any
+// `gen_ai.*` tag. Returns the decimal span_id string of that ancestor, or
+// `null`. Used by `LLMObsTagger.registerLLMObsSpan` so an auto-instrumented
+// LLMObs span nested under a manual OTel workflow points its `parent_id` at
+// the OTel parent instead of the default `ROOT_PARENT_ID` — the SDK-emitted
+// LLMObs event then renders under the workflow rather than as a parallel
+// root. OTel `setAttribute(...)` lands in `context()._tags` via
+// `setOtelAttribute -> ddSpan.setTag` (see opentelemetry/span-helpers.js), so
+// scanning `_tags` keys for the `gen_ai.` prefix is the right check.
+/**
+ * @param {import('../opentracing/span')} span
+ * @returns {string | null}
+ */
+function findGenAIAncestorSpanId (span) {
+  const ctx = span?.context?.()
+  const started = ctx?._trace?.started
+  if (!started || started.length === 0) return null
+
+  const byId = new Map()
+  for (const s of started) {
+    byId.set(s.context()._spanId.toString(10), s)
+  }
+
+  let parentId = ctx._parentId?.toString(10)
+  while (parentId && parentId !== '0') {
+    const parent = byId.get(parentId)
+    if (!parent) return null
+
+    const tags = parent.context()._tags
+    if (tags) {
+      for (const key in tags) {
+        if (key.startsWith('gen_ai.')) return parentId
+      }
+    }
+
+    parentId = parent.context()._parentId?.toString(10)
+  }
+  return null
 }
 
 module.exports = {
   encodeUnicode,
+  findGenAIAncestorSpanId,
   validateCostTags,
   validateKind,
   getFunctionArguments,

--- a/packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/anthropic/index.spec.js
@@ -68,6 +68,14 @@ describe('Plugin', () => {
 
         const { apmSpans, llmobsSpans } = await getEvents()
         assertLLMObsSpan(apmSpans, llmobsSpans)
+
+        // MLOS-591 regression: the default `LLMObsPlugin.start` registration
+        // path must emit OTel bridge tags onto the local trace so dd-go can
+        // correlate manual OTel `gen_ai.*` spans with this LLMObs span.
+        const apmMeta = apmSpans[0].meta
+        assert.match(apmMeta.llmobs_trace_id, /^[0-9a-f]{32}$/)
+        assert.ok(apmMeta.llmobs_parent_id)
+        assert.strictEqual(apmMeta['_dd.llmobs.submitted'], '1')
       })
 
       it('sets model_provider to unknown for unrecognized base URLs', async () => {

--- a/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/aws-sdk/bedrockruntime.spec.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const assert = require('node:assert')
+
 const { describe, it, before } = require('mocha')
 
 const { assertLlmObsSpanEvent, useLlmObs } = require('../../util')
@@ -326,6 +328,30 @@ describe('Plugin', () => {
             },
             tags: { ml_app: 'test', integration: 'bedrock' },
           })
+        })
+
+        // MLOS-591 regression: `bedrockruntime` registers its LLMObs span from
+        // `setLLMObsTags` rather than the inherited `LLMObsPlugin.start`. The
+        // dd-go LLMObs trace-indexer needs `llmobs_trace_id` /
+        // `llmobs_parent_id` on the local trace tags so OTel `gen_ai.*` spans
+        // share an LLMObs trace with this bedrock span. The first model is
+        // enough — bridge-tag plumbing is not per-model.
+        it('writes otel bridge tags onto the apm span meta', async () => {
+          const model = models[0]
+          const command = new AWS.InvokeModelCommand({
+            body: JSON.stringify(model.requestBody),
+            contentType: 'application/json',
+            accept: 'application/json',
+            modelId: model.modelId,
+          })
+
+          await bedrockRuntimeClient.send(command)
+
+          const { apmSpans } = await getEvents()
+          const apmMeta = apmSpans[0].meta
+          assert.match(apmMeta.llmobs_trace_id, /^[0-9a-f]{32}$/)
+          assert.ok(apmMeta.llmobs_parent_id)
+          assert.strictEqual(apmMeta['_dd.llmobs.submitted'], '1')
         })
       })
     })

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -6,7 +6,7 @@ const { beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { INPUT_PROMPT } = require('../../src/llmobs/constants/tags')
-const { writeBridgeTags } = require('../../src/llmobs/util')
+const { writeBridgeTags, findGenAIAncestorSpanId } = require('../../src/llmobs/util')
 
 function unserializableObject () {
   const obj = {}
@@ -37,12 +37,10 @@ describe('tagger', () => {
       },
     }
 
-    // Pass `writeBridgeTags` through to the real helper so the bridge-tag
-    // hook in `registerLLMObsSpan` is exercised end-to-end. Unit coverage
-    // for the helper itself lives in `util.spec.js`.
-    // Default `findGenAIAncestorSpanId` to a stub returning null so existing
-    // tests get the "no OTel gen_ai ancestor" branch — individual tests can
-    // re-stub it to exercise the suppression behavior.
+    // Pass real helpers through so bridge-tag logic is exercised end-to-end.
+    // `findGenAIAncestorSpanId` is defaulted to a stub returning null so
+    // existing tests get the "no gen_ai ancestor" branch; individual tests
+    // can call `.returns(id)` on the stub to exercise suppression.
     util = {
       generateTraceId: sinon.stub().returns('0123'),
       writeBridgeTags,
@@ -286,6 +284,58 @@ describe('tagger', () => {
 
             const tags = Tagger.tagMap.get(span)
             assert.strictEqual(tags['_ml_obs.llmobs_parent_id'], '777777')
+          })
+        })
+
+        // Integration test: real findGenAIAncestorSpanId detection (no stub).
+        // Verifies the full pipeline from APM span shape → detection → bridge
+        // tag suppression → LLMObs event parent_id assignment.
+        describe('with real gen_ai.* detection (unstubbed)', () => {
+          let RealTagger
+          let realTagger
+
+          before(() => {
+            RealTagger = proxyquire('../../src/llmobs/tagger', {
+              '../log': { warn () {} },
+              './util': { generateTraceId: sinon.stub().returns('0123'), writeBridgeTags, findGenAIAncestorSpanId },
+            })
+            realTagger = new RealTagger({ llmobs: { enabled: true, mlApp: 'test-app' } })
+          })
+
+          it('detects a real gen_ai.* APM ancestor, suppresses llmobs_parent_id, and sets the ancestor as event parent', () => {
+            const genAISpanId = '333333333333333'
+            const leafSpanId = '444444444444444'
+            const traceTags = {}
+            const traceStarted = []
+
+            const genAISpanCtx = {
+              _spanId: { toString: () => genAISpanId },
+              _parentId: null,
+              _tags: { 'gen_ai.operation.name': 'invoke_agent' },
+              _trace: { tags: traceTags, started: traceStarted },
+            }
+            const genAISpan = { context: () => genAISpanCtx }
+
+            const leafSpanCtx = {
+              _spanId: { toString: () => leafSpanId },
+              _parentId: { toString: () => genAISpanId },
+              _tags: {},
+              _trace: { tags: traceTags, started: traceStarted },
+              toTraceId () { return '00000000000000009999999999999999' },
+              toSpanId () { return leafSpanId },
+            }
+            const leafSpan = {
+              context: () => leafSpanCtx,
+              setTag (k, v) { leafSpanCtx._tags[k] = v },
+            }
+
+            traceStarted.push(genAISpan, leafSpan)
+
+            realTagger.registerLLMObsSpan(leafSpan, { kind: 'llm' })
+
+            assert.strictEqual(traceTags.llmobs_trace_id, '00000000000000009999999999999999')
+            assert.strictEqual(traceTags.llmobs_parent_id, undefined)
+            assert.strictEqual(RealTagger.tagMap.get(leafSpan)['_ml_obs.llmobs_parent_id'], genAISpanId)
           })
         })
       })

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -6,6 +6,7 @@ const { beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
 const sinon = require('sinon')
 const { INPUT_PROMPT } = require('../../src/llmobs/constants/tags')
+const { writeBridgeTags } = require('../../src/llmobs/util')
 
 function unserializableObject () {
   const obj = {}
@@ -25,6 +26,8 @@ describe('tagger', () => {
     spanContext = {
       _tags: {},
       _trace: { tags: {} },
+      toTraceId () { return '00000000000000001111111111111111' },
+      toSpanId () { return '2222222222222222' },
     }
 
     span = {
@@ -34,8 +37,12 @@ describe('tagger', () => {
       },
     }
 
+    // Pass `writeBridgeTags` through to the real helper so the bridge-tag
+    // hook in `registerLLMObsSpan` is exercised end-to-end. Unit coverage
+    // for the helper itself lives in `util.spec.js`.
     util = {
       generateTraceId: sinon.stub().returns('0123'),
+      writeBridgeTags,
     }
 
     logger = {
@@ -196,6 +203,47 @@ describe('tagger', () => {
 
           const tags = Tagger.tagMap.get(span)
           assert.strictEqual(tags['_ml_obs.meta.ml_app'], 'my-service')
+        })
+      })
+
+      describe('bridge tags for otel correlation', () => {
+        it('writes llmobs_trace_id and llmobs_parent_id to _trace.tags after a successful register', () => {
+          tagger.registerLLMObsSpan(span, { kind: 'workflow' })
+
+          assert.strictEqual(spanContext._trace.tags.llmobs_trace_id, '00000000000000001111111111111111')
+          assert.strictEqual(spanContext._trace.tags.llmobs_parent_id, '2222222222222222')
+        })
+
+        it('does not overwrite bridge tags when a second llmobs span registers on the same trace', () => {
+          tagger.registerLLMObsSpan(span, { kind: 'workflow' })
+
+          const secondSpanContext = {
+            _tags: {},
+            _trace: spanContext._trace, // sibling shares the local trace
+            toTraceId () { return 'ffffffffffffffffffffffffffffffff' },
+            toSpanId () { return '9999999999999999' },
+          }
+          const secondSpan = { context () { return secondSpanContext } }
+
+          tagger.registerLLMObsSpan(secondSpan, { kind: 'task' })
+
+          assert.strictEqual(spanContext._trace.tags.llmobs_trace_id, '00000000000000001111111111111111')
+          assert.strictEqual(spanContext._trace.tags.llmobs_parent_id, '2222222222222222')
+        })
+
+        it('does not write bridge tags when llmobs is disabled', () => {
+          tagger = new Tagger({ llmobs: { enabled: false } })
+          tagger.registerLLMObsSpan(span, { kind: 'workflow' })
+
+          assert.strictEqual(spanContext._trace.tags.llmobs_trace_id, undefined)
+          assert.strictEqual(spanContext._trace.tags.llmobs_parent_id, undefined)
+        })
+
+        it('does not write bridge tags when no span kind is provided', () => {
+          tagger.registerLLMObsSpan(span, {})
+
+          assert.strictEqual(spanContext._trace.tags.llmobs_trace_id, undefined)
+          assert.strictEqual(spanContext._trace.tags.llmobs_parent_id, undefined)
         })
       })
     })

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -302,7 +302,7 @@ describe('tagger', () => {
             realTagger = new RealTagger({ llmobs: { enabled: true, mlApp: 'test-app' } })
           })
 
-          it('detects a real gen_ai.* APM ancestor, suppresses llmobs_parent_id, and sets the ancestor as event parent', () => {
+          it('detects a real gen_ai.* ancestor, suppresses llmobs_parent_id, and uses ancestor as event parent', () => {
             const genAISpanId = '333333333333333'
             const leafSpanId = '444444444444444'
             const traceTags = {}
@@ -311,22 +311,23 @@ describe('tagger', () => {
             const genAISpanCtx = {
               _spanId: { toString: () => genAISpanId },
               _parentId: null,
-              _tags: { 'gen_ai.operation.name': 'invoke_agent' },
+              getTags () { return { 'gen_ai.operation.name': 'invoke_agent' } },
               _trace: { tags: traceTags, started: traceStarted },
             }
             const genAISpan = { context: () => genAISpanCtx }
 
+            const leafTags = {}
             const leafSpanCtx = {
               _spanId: { toString: () => leafSpanId },
               _parentId: { toString: () => genAISpanId },
-              _tags: {},
+              getTags () { return leafTags },
               _trace: { tags: traceTags, started: traceStarted },
               toTraceId () { return '00000000000000009999999999999999' },
               toSpanId () { return leafSpanId },
             }
             const leafSpan = {
               context: () => leafSpanCtx,
-              setTag (k, v) { leafSpanCtx._tags[k] = v },
+              setTag (k, v) { leafTags[k] = v },
             }
 
             traceStarted.push(genAISpan, leafSpan)

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -40,9 +40,13 @@ describe('tagger', () => {
     // Pass `writeBridgeTags` through to the real helper so the bridge-tag
     // hook in `registerLLMObsSpan` is exercised end-to-end. Unit coverage
     // for the helper itself lives in `util.spec.js`.
+    // Default `findGenAIAncestorSpanId` to a stub returning null so existing
+    // tests get the "no OTel gen_ai ancestor" branch — individual tests can
+    // re-stub it to exercise the suppression behavior.
     util = {
       generateTraceId: sinon.stub().returns('0123'),
       writeBridgeTags,
+      findGenAIAncestorSpanId: sinon.stub().returns(null),
     }
 
     logger = {
@@ -244,6 +248,45 @@ describe('tagger', () => {
 
           assert.strictEqual(spanContext._trace.tags.llmobs_trace_id, undefined)
           assert.strictEqual(spanContext._trace.tags.llmobs_parent_id, undefined)
+        })
+
+        // MLOS-591: when the registering LLMObs span sits below an OTel
+        // `gen_ai.*` ancestor in the APM trace, we suppress
+        // `llmobs_parent_id` (which would otherwise tell the indexer to
+        // reparent gen_ai ancestors under this leaf) and use the ancestor
+        // as the SDK-emitted event's `parent_id` so the span renders under
+        // the OTel workflow rather than as a parallel root.
+        describe('with an OTel gen_ai.* APM ancestor', () => {
+          beforeEach(() => {
+            // Mutate the existing sinon stub in place; reassigning
+            // `util.findGenAIAncestorSpanId` here would create a new stub
+            // that Tagger's captured destructured reference doesn't see.
+            util.findGenAIAncestorSpanId.returns('444444')
+          })
+
+          it('writes llmobs_trace_id but omits llmobs_parent_id', () => {
+            tagger.registerLLMObsSpan(span, { kind: 'llm' })
+
+            assert.strictEqual(spanContext._trace.tags.llmobs_trace_id, '00000000000000001111111111111111')
+            assert.strictEqual(spanContext._trace.tags.llmobs_parent_id, undefined)
+          })
+
+          it('uses the gen_ai ancestor span_id as the SDK-emitted parent_id', () => {
+            tagger.registerLLMObsSpan(span, { kind: 'llm' })
+
+            const tags = Tagger.tagMap.get(span)
+            assert.strictEqual(tags['_ml_obs.llmobs_parent_id'], '444444')
+          })
+
+          it('still prefers an explicit LLMObs storage parent over the gen_ai ancestor', () => {
+            const sdkParent = { context () { return { toSpanId () { return '777777' } } } }
+            Tagger.tagMap.set(sdkParent, { '_ml_obs.meta.ml_app': 'app' })
+
+            tagger.registerLLMObsSpan(span, { kind: 'llm', parent: sdkParent })
+
+            const tags = Tagger.tagMap.get(span)
+            assert.strictEqual(tags['_ml_obs.llmobs_parent_id'], '777777')
+          })
         })
       })
     })

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -7,6 +7,7 @@ const { before, describe, it } = require('mocha')
 const getConfig = require('../../src/config')
 const {
   encodeUnicode,
+  findGenAIAncestorSpanId,
   getFunctionArguments,
   validateCostTags,
   safeJsonParse,
@@ -272,6 +273,78 @@ describe('util', () => {
 
     it('is a no-op when span is undefined', () => {
       writeBridgeTags(undefined)
+    })
+
+    it('omits llmobs_parent_id when includeParentId is false', () => {
+      const traceTags = {}
+      writeBridgeTags(makeSpan(traceTags), { includeParentId: false })
+      assert.strictEqual(traceTags.llmobs_trace_id, '00000000000000001111111111111111')
+      assert.strictEqual(traceTags.llmobs_parent_id, undefined)
+    })
+  })
+
+  describe('findGenAIAncestorSpanId', () => {
+    // Build a minimal Datadog-shaped span fixture: each span has `_spanId`,
+    // optional `_parentId`, `_tags`, and shares the `_trace.started` array
+    // so the helper can walk up the chain via `_parentId` lookup.
+    function makeTrace (spanDefs) {
+      const started = []
+      const trace = { started, tags: {} }
+      for (const def of spanDefs) {
+        started.push({
+          context: () => ({
+            _spanId: { toString: () => def.spanId },
+            _parentId: def.parentId ? { toString: () => def.parentId } : null,
+            _tags: def.tags || {},
+            _trace: trace,
+          }),
+        })
+      }
+      return started
+    }
+
+    it('returns the nearest gen_ai.* ancestor span_id', () => {
+      const [root, agent, workflow, leaf] = makeTrace([
+        { spanId: '100', tags: {} }, // http.request
+        { spanId: '200', parentId: '100', tags: { 'gen_ai.operation.name': 'invoke_agent' } },
+        { spanId: '300', parentId: '200', tags: { 'gen_ai.operation.name': 'workflow' } },
+        { spanId: '400', parentId: '300', tags: {} }, // the LLMObs leaf
+      ])
+      void root; void agent; void workflow
+      assert.strictEqual(findGenAIAncestorSpanId(leaf), '300')
+    })
+
+    it('skips non-gen_ai ancestors and returns the first gen_ai.* match', () => {
+      const [root, plain, agent, leaf] = makeTrace([
+        { spanId: '100', tags: {} },
+        { spanId: '200', parentId: '100', tags: { 'http.method': 'GET' } },
+        { spanId: '300', parentId: '200', tags: { 'gen_ai.system': 'gemini' } },
+        { spanId: '400', parentId: '300', tags: {} },
+      ])
+      void root; void plain; void agent
+      assert.strictEqual(findGenAIAncestorSpanId(leaf), '300')
+    })
+
+    it('returns null when no ancestor has gen_ai.* tags', () => {
+      const [root, plain, leaf] = makeTrace([
+        { spanId: '100', tags: { 'service.name': 'web' } },
+        { spanId: '200', parentId: '100', tags: { 'http.method': 'GET' } },
+        { spanId: '300', parentId: '200', tags: {} },
+      ])
+      void root; void plain
+      assert.strictEqual(findGenAIAncestorSpanId(leaf), null)
+    })
+
+    it('returns null when the span has no parent', () => {
+      const [orphan] = makeTrace([
+        { spanId: '100', tags: {} },
+      ])
+      assert.strictEqual(findGenAIAncestorSpanId(orphan), null)
+    })
+
+    it('is a no-op-safe when span has no context', () => {
+      assert.strictEqual(findGenAIAncestorSpanId(undefined), null)
+      assert.strictEqual(findGenAIAncestorSpanId({}), null)
     })
   })
 })

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -291,11 +291,12 @@ describe('util', () => {
       const started = []
       const trace = { started, tags: {} }
       for (const def of spanDefs) {
+        const tags = def.tags || {}
         started.push({
           context: () => ({
             _spanId: { toString: () => def.spanId },
             _parentId: def.parentId ? { toString: () => def.parentId } : null,
-            _tags: def.tags || {},
+            getTags () { return tags },
             _trace: trace,
           }),
         })

--- a/packages/dd-trace/test/llmobs/util.spec.js
+++ b/packages/dd-trace/test/llmobs/util.spec.js
@@ -12,6 +12,7 @@ const {
   safeJsonParse,
   validateKind,
   spanHasError,
+  writeBridgeTags,
 } = require('../../src/llmobs/util')
 
 describe('util', () => {
@@ -234,6 +235,43 @@ describe('util', () => {
       span.setTag('error.stack', err.stack)
 
       assert.strictEqual(spanHasError(span), true)
+    })
+  })
+
+  describe('writeBridgeTags', () => {
+    function makeSpan (traceTags = {}) {
+      return {
+        context () {
+          return {
+            _trace: { tags: traceTags },
+            toTraceId () { return '00000000000000001111111111111111' },
+            toSpanId () { return '2222222222222222' },
+          }
+        },
+      }
+    }
+
+    it('writes llmobs_trace_id and llmobs_parent_id to _trace.tags', () => {
+      const traceTags = {}
+      writeBridgeTags(makeSpan(traceTags))
+      assert.strictEqual(traceTags.llmobs_trace_id, '00000000000000001111111111111111')
+      assert.strictEqual(traceTags.llmobs_parent_id, '2222222222222222')
+    })
+
+    it('does not overwrite bridge tags when already set', () => {
+      const traceTags = { llmobs_trace_id: 'preexisting', llmobs_parent_id: 'preexisting' }
+      writeBridgeTags(makeSpan(traceTags))
+      assert.strictEqual(traceTags.llmobs_trace_id, 'preexisting')
+      assert.strictEqual(traceTags.llmobs_parent_id, 'preexisting')
+    })
+
+    it('is a no-op when _trace.tags is absent', () => {
+      const span = { context () { return { _trace: undefined } } }
+      writeBridgeTags(span)
+    })
+
+    it('is a no-op when span is undefined', () => {
+      writeBridgeTags(undefined)
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #8127. Bridge-tag writes were only wired in `LLMObs._activate` (the SDK path), so auto-instrumented plugin spans never got `llmobs_trace_id` / `llmobs_parent_id`. This PR moves the write into `LLMObsTagger.registerLLMObsSpan` — the single chokepoint for all LLMObs span registration (SDK, default plugins, bespoke plugins like Bedrock).

However, naively writing both bridge tags on every LLMObs span causes a hierarchy inversion when an OTel `gen_ai.*` span *wraps* an auto-instrumented LLMObs leaf: the trace-indexer reads `llmobs_parent_id` as "this span is the LLMObs root — hoist gen_ai ancestors under it," inverting the tree.

The full fix is two-part:
1. Always write `llmobs_trace_id` so the indexer pulls all spans into one LLMObs trace.
2. Suppress `llmobs_parent_id` when a `gen_ai.*` ancestor is detected above the registering span, and use that ancestor's span ID as the LLMObs event's `parent_id` so the span renders under the OTel workflow rather than as a parallel root.

## Files changed

| File | Change |
|---|---|
| `util.js` | New `writeBridgeTags(span, { includeParentId })` and `findGenAIAncestorSpanId(span)` helpers |
| `tagger.js` | `registerLLMObsSpan` calls both; suppresses `llmobs_parent_id` when a gen_ai ancestor is detected |
| `sdk.js` | Removed redundant inline bridge-tag write from `_activate` |
| `plugins/base.js` | Removed redundant bridge-tag write |
| `test/llmobs/plugins/base.spec.js` | Removed — tests moved to `tagger.spec.js` |

## Test plan
- [x] `mocha packages/dd-trace/test/llmobs/tagger.spec.js` — 93 passing (includes integration test with real span fixtures, no stub)
- [x] `mocha packages/dd-trace/test/llmobs/util.spec.js` — 50 passing
- [x] `npm run lint` clean
- [x] Manual repro (HTTP → OTel `invoke_agent` → OTel `workflow` → Bedrock auto-instrumented leaf) — correct hierarchy confirmed

Claude session: `1aab3929-3f74-41e4-9da2-b74f44f9b5bc`
Resume: `claude --resume 1aab3929-3f74-41e4-9da2-b74f44f9b5bc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)