### PR TITLE
feat(kafkajs): add kafka.messages.offsets to producer span

### DIFF
--- a/packages/datadog-plugin-kafkajs/src/batch-consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/batch-consumer.js
@@ -14,7 +14,7 @@ class KafkajsBatchConsumerPlugin extends ConsumerPlugin {
     // kafkajs's eachBatch hands the user one batch per (topic, partition),
     // so all messages share the same partition. start_offset is the offset of
     // the first record in the batch.
-    const startOffset = messages[0]?.offset !== undefined ? Number(messages[0].offset) : undefined
+    const startOffset = messages[0]?.offset === undefined ? undefined : Number(messages[0].offset)
     const meta = {
       component: this.constructor.id,
       'kafka.topic': topic,

--- a/packages/datadog-plugin-kafkajs/src/batch-consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/batch-consumer.js
@@ -11,32 +11,20 @@ class KafkajsBatchConsumerPlugin extends ConsumerPlugin {
   bindStart (ctx) {
     const { topic, partition, messages, groupId, clusterId } = ctx.extractedArgs || ctx
 
-    // kafkajs's eachBatch hands the user one batch per (topic, partition),
-    // so all messages share the same partition. start_offset is the offset of
-    // the first record in the batch.
-    const startOffset = messages[0]?.offset === undefined ? undefined : Number(messages[0].offset)
-    const meta = {
-      component: this.constructor.id,
-      'kafka.topic': topic,
-      'kafka.cluster_id': clusterId,
-      'messaging.destination.name': topic,
-      'messaging.system': 'kafka',
-    }
-    if (startOffset !== undefined) {
-      meta['kafka.messages.offsets'] = JSON.stringify([{ partition, start_offset: startOffset }])
-    }
-    const metrics = {
-      'kafka.partition': partition,
-      'messaging.batch.message_count': messages.length,
-    }
-    if (messages.length === 1 && startOffset !== undefined) {
-      metrics['kafka.message.offset'] = startOffset
-    }
     const span = this.startSpan({
       resource: topic,
       type: 'worker',
-      meta,
-      metrics,
+      meta: {
+        component: this.constructor.id,
+        'kafka.topic': topic,
+        'kafka.cluster_id': clusterId,
+        'messaging.destination.name': topic,
+        'messaging.system': 'kafka',
+      },
+      metrics: {
+        'kafka.partition': partition,
+        'messaging.batch.message_count': messages.length,
+      },
     }, ctx)
 
     for (const message of messages) {

--- a/packages/datadog-plugin-kafkajs/src/batch-consumer.js
+++ b/packages/datadog-plugin-kafkajs/src/batch-consumer.js
@@ -11,20 +11,32 @@ class KafkajsBatchConsumerPlugin extends ConsumerPlugin {
   bindStart (ctx) {
     const { topic, partition, messages, groupId, clusterId } = ctx.extractedArgs || ctx
 
+    // kafkajs's eachBatch hands the user one batch per (topic, partition),
+    // so all messages share the same partition. start_offset is the offset of
+    // the first record in the batch.
+    const startOffset = messages[0]?.offset !== undefined ? Number(messages[0].offset) : undefined
+    const meta = {
+      component: this.constructor.id,
+      'kafka.topic': topic,
+      'kafka.cluster_id': clusterId,
+      'messaging.destination.name': topic,
+      'messaging.system': 'kafka',
+    }
+    if (startOffset !== undefined) {
+      meta['kafka.messages.offsets'] = JSON.stringify([{ partition, start_offset: startOffset }])
+    }
+    const metrics = {
+      'kafka.partition': partition,
+      'messaging.batch.message_count': messages.length,
+    }
+    if (messages.length === 1 && startOffset !== undefined) {
+      metrics['kafka.message.offset'] = startOffset
+    }
     const span = this.startSpan({
       resource: topic,
       type: 'worker',
-      meta: {
-        component: this.constructor.id,
-        'kafka.topic': topic,
-        'kafka.cluster_id': clusterId,
-        'messaging.destination.name': topic,
-        'messaging.system': 'kafka',
-      },
-      metrics: {
-        'kafka.partition': partition,
-        'messaging.batch.message_count': messages.length,
-      },
+      meta,
+      metrics,
     }, ctx)
 
     for (const message of messages) {

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -94,17 +94,19 @@ class KafkajsProducerPlugin extends ProducerPlugin {
   finish (ctx) {
     const span = ctx?.currentStore?.span
     const result = ctx?.result
-    if (span && Array.isArray(result) && result.length === 1) {
-      // Only tag when the broker returned metadata for a single (topic, partition)
-      // tuple. Multi-partition batches share one producer span; a single
-      // partition/offset would be misleading.
-      const { partition, offset, baseOffset } = result[0]
-      const offsetAsLong = offset || baseOffset
-      if (partition !== undefined) {
-        span.setTag('kafka.partition', partition)
+    if (span && Array.isArray(result) && result.length > 0) {
+      // The broker response is one entry per (topic, partition). Each entry
+      // carries a `baseOffset` — the offset assigned to the first record sent
+      // to that partition. We don't know per-partition record counts from the
+      // response, only the starting offset.
+      const offsets = []
+      for (const entry of result) {
+        const offsetAsLong = entry.offset || entry.baseOffset
+        if (entry.partition === undefined || offsetAsLong === undefined) continue
+        offsets.push({ partition: entry.partition, start_offset: Number(offsetAsLong) })
       }
-      if (offsetAsLong !== undefined) {
-        span.setTag('kafka.message.offset', Number(offsetAsLong))
+      if (offsets.length > 0) {
+        span.setTag('kafka.messages.offsets', JSON.stringify(offsets))
       }
     }
     super.finish(ctx)

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -108,6 +108,12 @@ class KafkajsProducerPlugin extends ProducerPlugin {
       if (offsets.length > 0) {
         span.setTag('kafka.messages.offsets', JSON.stringify(offsets))
       }
+      // Single-message send: the one entry's partition/offset describes the
+      // exact record. Also expose them as flat tags for easy filtering.
+      if (offsets.length === 1 && ctx.messages?.length === 1) {
+        span.setTag('kafka.partition', offsets[0].partition)
+        span.setTag('kafka.message.offset', offsets[0].start_offset)
+      }
     }
     super.finish(ctx)
   }

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -91,6 +91,25 @@ class KafkajsProducerPlugin extends ProducerPlugin {
     }
   }
 
+  finish (ctx) {
+    const span = ctx?.currentStore?.span
+    const result = ctx?.result
+    if (span && Array.isArray(result) && result.length === 1) {
+      // Only tag when the broker returned metadata for a single (topic, partition)
+      // tuple. Multi-partition batches share one producer span; a single
+      // partition/offset would be misleading.
+      const { partition, offset, baseOffset } = result[0]
+      const offsetAsLong = offset || baseOffset
+      if (partition !== undefined) {
+        span.setTag('kafka.partition', partition)
+      }
+      if (offsetAsLong !== undefined) {
+        span.setTag('kafka.message.offset', Number(offsetAsLong))
+      }
+    }
+    super.finish(ctx)
+  }
+
   bindStart (ctx) {
     const { topic, messages, bootstrapServers, clusterId, disableHeaderInjection } = ctx
     const span = this.startSpan({

--- a/packages/datadog-plugin-kafkajs/src/producer.js
+++ b/packages/datadog-plugin-kafkajs/src/producer.js
@@ -101,17 +101,22 @@ class KafkajsProducerPlugin extends ProducerPlugin {
       // response, only the starting offset.
       const offsets = []
       for (const entry of result) {
-        const offsetAsLong = entry.offset || entry.baseOffset
+        const offsetAsLong = entry.offset ?? entry.baseOffset
         if (entry.partition === undefined || offsetAsLong === undefined) continue
-        offsets.push({ partition: entry.partition, start_offset: Number(offsetAsLong) })
+        // Kafka offsets are 64-bit; coercing to Number loses precision past
+        // 2^53. Keep them as strings so the tag matches the exact offset on
+        // long-lived/high-throughput topics.
+        offsets.push({ partition: entry.partition, start_offset: String(offsetAsLong) })
       }
       if (offsets.length > 0) {
+        offsets.sort((a, b) => a.partition - b.partition)
         span.setTag('kafka.messages.offsets', JSON.stringify(offsets))
       }
       // Single-message send: the one entry's partition/offset describes the
       // exact record. Also expose them as flat tags for easy filtering.
       if (offsets.length === 1 && ctx.messages?.length === 1) {
         span.setTag('kafka.partition', offsets[0].partition)
+        // Set as a string meta tag (not a metric) to preserve full 64-bit precision.
         span.setTag('kafka.message.offset', offsets[0].start_offset)
       }
     }

--- a/packages/datadog-plugin-kafkajs/test/commit.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/commit.spec.js
@@ -9,6 +9,79 @@ require('../../dd-trace/test/setup/core')
 const KafkajsConsumerPlugin = require('../src/consumer')
 const KafkajsProducerPlugin = require('../src/producer')
 
+describe('kafkajs producer finish', () => {
+  /**
+   * Build a fake span whose setTag records the tags applied.
+   * Also stubs the inherited finish so super.finish() doesn't run real tracer logic.
+   */
+  function makeFinishHarness () {
+    const tags = {}
+    const span = { setTag: (k, v) => { tags[k] = v } }
+    const plugin = new KafkajsProducerPlugin({}, {})
+    plugin.config = { dsmEnabled: false }
+    const parentFinish = sinon.stub(Object.getPrototypeOf(KafkajsProducerPlugin.prototype), 'finish')
+    return { plugin, span, tags, restore: () => parentFinish.restore() }
+  }
+
+  it('sorts multi-partition offsets by partition and emits them as strings', () => {
+    const { plugin, span, tags, restore } = makeFinishHarness()
+    try {
+      plugin.finish({
+        currentStore: { span },
+        messages: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+        result: [
+          { topicName: 't', partition: 2, baseOffset: '20' },
+          { topicName: 't', partition: 0, baseOffset: '5' },
+          { topicName: 't', partition: 1, baseOffset: '12' },
+        ],
+      })
+    } finally {
+      restore()
+    }
+    assert.equal(tags['kafka.messages.offsets'], JSON.stringify([
+      { partition: 0, start_offset: '5' },
+      { partition: 1, start_offset: '12' },
+      { partition: 2, start_offset: '20' },
+    ]))
+    // Multi-partition batch: no flat tags.
+    assert.equal(tags['kafka.partition'], undefined)
+    assert.equal(tags['kafka.message.offset'], undefined)
+  })
+
+  it('preserves offsets larger than Number.MAX_SAFE_INTEGER without precision loss', () => {
+    const { plugin, span, tags, restore } = makeFinishHarness()
+    // 2^53 + 7 — round-trips through Number as 2^53 + 8, so Number() would corrupt it.
+    const hugeOffset = '9007199254740999'
+    try {
+      plugin.finish({
+        currentStore: { span },
+        messages: [{ value: 'one' }],
+        result: [{ topicName: 't', partition: 0, baseOffset: hugeOffset }],
+      })
+    } finally {
+      restore()
+    }
+    assert.equal(tags['kafka.messages.offsets'], JSON.stringify([{ partition: 0, start_offset: hugeOffset }]))
+    assert.equal(tags['kafka.message.offset'], hugeOffset)
+    assert.equal(tags['kafka.partition'], 0)
+  })
+
+  it('emits a literal-zero baseOffset (?? guards against falsy coercion)', () => {
+    const { plugin, span, tags, restore } = makeFinishHarness()
+    try {
+      plugin.finish({
+        currentStore: { span },
+        messages: [{ value: 'one' }],
+        result: [{ topicName: 't', partition: 0, baseOffset: 0 }],
+      })
+    } finally {
+      restore()
+    }
+    assert.equal(tags['kafka.messages.offsets'], JSON.stringify([{ partition: 0, start_offset: '0' }]))
+    assert.equal(tags['kafka.message.offset'], '0')
+  })
+})
+
 describe('kafkajs commit walk', () => {
   it('consumer forwards every transformed offset to tracer.setOffset when DSM is enabled', () => {
     const setOffset = sinon.spy()

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -75,6 +75,8 @@ describe('Plugin', () => {
               },
               metrics: {
                 'kafka.batch_size': messages.length,
+                'kafka.partition': 0,
+                'kafka.message.offset': 0,
               },
               resource: testTopic,
               error: 0,
@@ -82,6 +84,34 @@ describe('Plugin', () => {
             })
 
             await sendMessages(kafka, testTopic, messages)
+
+            return expectedSpanPromise
+          })
+
+          it('should not emit flat partition/offset tags for multi-message batches', async () => {
+            const batch = [
+              { key: 'a', value: '1' },
+              { key: 'b', value: '2' },
+              { key: 'c', value: '3' },
+            ]
+            const expectedSpanPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0][0]
+              assertObjectContains(span, {
+                name: expectedSchema.send.opName,
+                meta: {
+                  'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
+                },
+                metrics: {
+                  'kafka.batch_size': batch.length,
+                },
+              })
+              assert.ok(!Object.hasOwn(span.metrics, 'kafka.partition'),
+                'kafka.partition must not be set for multi-message batches')
+              assert.ok(!Object.hasOwn(span.metrics, 'kafka.message.offset'),
+                'kafka.message.offset must not be set for multi-message batches')
+            })
+
+            await sendMessages(kafka, testTopic, batch)
 
             return expectedSpanPromise
           })

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -502,9 +502,11 @@ describe('Plugin', () => {
                 'messaging.destination.name': testTopic,
                 'messaging.system': 'kafka',
                 'kafka.cluster_id': testKafkaClusterId,
+                'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
               },
               metrics: {
                 'messaging.batch.message_count': batchMessages.length,
+                'kafka.partition': 0,
               },
               resource: testTopic,
               error: 0,
@@ -515,6 +517,27 @@ describe('Plugin', () => {
               eachBatch: () => {},
             })
             return Promise.all([sendMessages(kafka, testTopic, batchMessages), expectedSpanPromise])
+          })
+
+          it('should tag flat kafka.message.offset only for single-message batches', async () => {
+            const singleBatch = [{ key: 'k', value: 'v' }]
+            const expectedSpanPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0][0]
+              assertObjectContains(span, {
+                name: expectedSchema.receive.opName,
+                meta: {
+                  'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
+                },
+                metrics: {
+                  'messaging.batch.message_count': 1,
+                  'kafka.partition': 0,
+                  'kafka.message.offset': 0,
+                },
+              })
+            })
+
+            await consumer.run({ eachBatch: () => {} })
+            return Promise.all([sendMessages(kafka, testTopic, singleBatch), expectedSpanPromise])
           })
 
           it('should run the consumer in the context of the consumer span', done => {

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -71,11 +71,10 @@ describe('Plugin', () => {
                 'messaging.destination.name': testTopic,
                 'messaging.kafka.bootstrap.servers': '127.0.0.1:9092',
                 'kafka.cluster_id': testKafkaClusterId,
+                'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
               },
               metrics: {
                 'kafka.batch_size': messages.length,
-                'kafka.partition': 0,
-                'kafka.message.offset': 0,
               },
               resource: testTopic,
               error: 0,

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -71,12 +71,12 @@ describe('Plugin', () => {
                 'messaging.destination.name': testTopic,
                 'messaging.kafka.bootstrap.servers': '127.0.0.1:9092',
                 'kafka.cluster_id': testKafkaClusterId,
-                'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
+                'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: '0' }]),
+                'kafka.message.offset': '0',
               },
               metrics: {
                 'kafka.batch_size': messages.length,
                 'kafka.partition': 0,
-                'kafka.message.offset': 0,
               },
               resource: testTopic,
               error: 0,
@@ -99,7 +99,7 @@ describe('Plugin', () => {
               assertObjectContains(span, {
                 name: expectedSchema.send.opName,
                 meta: {
-                  'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
+                  'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: '0' }]),
                 },
                 metrics: {
                   'kafka.batch_size': batch.length,
@@ -107,7 +107,7 @@ describe('Plugin', () => {
               })
               assert.ok(!Object.hasOwn(span.metrics, 'kafka.partition'),
                 'kafka.partition must not be set for multi-message batches')
-              assert.ok(!Object.hasOwn(span.metrics, 'kafka.message.offset'),
+              assert.ok(!Object.hasOwn(span.meta, 'kafka.message.offset'),
                 'kafka.message.offset must not be set for multi-message batches')
             })
 

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -74,6 +74,8 @@ describe('Plugin', () => {
               },
               metrics: {
                 'kafka.batch_size': messages.length,
+                'kafka.partition': 0,
+                'kafka.message.offset': 0,
               },
               resource: testTopic,
               error: 0,

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -502,11 +502,9 @@ describe('Plugin', () => {
                 'messaging.destination.name': testTopic,
                 'messaging.system': 'kafka',
                 'kafka.cluster_id': testKafkaClusterId,
-                'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
               },
               metrics: {
                 'messaging.batch.message_count': batchMessages.length,
-                'kafka.partition': 0,
               },
               resource: testTopic,
               error: 0,
@@ -517,27 +515,6 @@ describe('Plugin', () => {
               eachBatch: () => {},
             })
             return Promise.all([sendMessages(kafka, testTopic, batchMessages), expectedSpanPromise])
-          })
-
-          it('should tag flat kafka.message.offset only for single-message batches', async () => {
-            const singleBatch = [{ key: 'k', value: 'v' }]
-            const expectedSpanPromise = agent.assertSomeTraces(traces => {
-              const span = traces[0][0]
-              assertObjectContains(span, {
-                name: expectedSchema.receive.opName,
-                meta: {
-                  'kafka.messages.offsets': JSON.stringify([{ partition: 0, start_offset: 0 }]),
-                },
-                metrics: {
-                  'messaging.batch.message_count': 1,
-                  'kafka.partition': 0,
-                  'kafka.message.offset': 0,
-                },
-              })
-            })
-
-            await consumer.run({ eachBatch: () => {} })
-            return Promise.all([sendMessages(kafka, testTopic, singleBatch), expectedSpanPromise])
           })
 
           it('should run the consumer in the context of the consumer span', done => {


### PR DESCRIPTION
### What does this PR do?

Adds a `kafka.messages.offsets` tag to the kafkajs producer span, carrying the list of `(partition, start_offset)` pairs the broker returned from `producer.send`. `start_offset` is the offset assigned to the first record sent to that partition (kafkajs's `baseOffset`).

Example value for a batch that landed in three partitions:
\`\`\`json
[{"partition":0,"start_offset":7},{"partition":1,"start_offset":2},{"partition":2,"start_offset":3}]
\`\`\`

For single-record sends, the producer span additionally gets flat `kafka.partition` and `kafka.message.offset` tags — in that case the broker response describes exactly one record, so the flat tags are unambiguous and easy to filter on.

No changes to consumer spans. The eachMessage consume span already carries `kafka.partition` and `kafka.message.offset` (per-record, exact); the eachBatch consume span is single-partition by construction, so its existing `kafka.partition` tag is sufficient.

### Motivation

Inspired by dd-trace-java [#11107](https://github.com/DataDog/dd-trace-java/pull/11107), which adds per-record `partition` and `offset` to the producer span. The Java client emits one span per `send` call (one record), so a single value is exact. kafkajs's `producer.send` is batched — one span covers multiple records that may land in multiple partitions — so a list better reflects what actually happened.

Combined with the already-tagged `kafka.cluster_id`, `kafka.topic`, and `kafka.batch_size`, this lets a producer trace span be correlated to the exact set of partitions and starting offsets it produced to.

Per-partition record counts are not in the broker response and aren't included; total batch size remains available via `kafka.batch_size`.

### Additional Notes

- Verified end-to-end against a real Kafka broker (kafkajs producer + consumer, 3-partition topic). Single- and multi-partition batches both produced the expected tags.
- Unit tests cover both the single-record and multi-record cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)