### PR TITLE
ci: split integration-bundler into integration-esbuild and integration-webpack

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -386,13 +386,13 @@ jobs:
         with:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
-  integration-bundler:
+  integration-esbuild:
     strategy:
       fail-fast: false
       matrix:
         version: [oldest, maintenance, active, latest]
-        bundler: [esbuild, webpack]
-    name: ${{ github.workflow }} / integration (node-${{ matrix.version }})
+        esbuild_version: ['0.16.12', 'latest']
+    name: ${{ github.workflow }} / integration-esbuild (node-${{ matrix.version }}, esbuild-${{ matrix.esbuild_version }})
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -406,18 +406,41 @@ jobs:
       # Disable core dumps since some integration tests intentionally abort and core dump generation takes around 5-10s
       - uses: ./.github/actions/install
       - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
-      - if: matrix.bundler == 'esbuild'
-        run: yarn test:integration:esbuild:coverage
+      - run: yarn test:integration:esbuild:coverage
+        env:
+          ESBUILD_VERSION: ${{ matrix.esbuild_version }}
+      - uses: ./.github/actions/coverage
+        with:
+          flags: instrumentations-integration-esbuild-${{ matrix.esbuild_version }}-${{ matrix.version }}
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+
+  integration-webpack:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [oldest, maintenance, active, latest]
+    name: ${{ github.workflow }} / integration-webpack (node-${{ matrix.version }})
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
+      # Disable core dumps since some integration tests intentionally abort and core dump generation takes around 5-10s
+      - uses: ./.github/actions/install
+      - run: sudo sysctl -w kernel.core_pattern='|/bin/false'
       # TODO: Webpack bundles dd-trace into a single file with the customer code, so the
       # NYC counters end up bundled too and the bootstrap can't find them at the original
       # paths. Switch to `:coverage` once the harness handles bundled output.
-      - if: matrix.bundler == 'webpack'
-        run: yarn test:integration:webpack
-      - if: matrix.bundler == 'esbuild'
-        uses: ./.github/actions/coverage
-        with:
-          flags: instrumentations-integration-esbuild-${{ matrix.version }}
-          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+      - run: yarn test:integration:webpack
       - uses: ./.github/actions/push_to_test_optimization
         if: "!cancelled()"
         with:

--- a/integration-tests/esbuild/esm.integration.spec.js
+++ b/integration-tests/esbuild/esm.integration.spec.js
@@ -8,7 +8,8 @@ const axios = require('axios')
 
 const { FakeAgent, spawnProc, sandboxCwd, useSandbox } = require('../helpers')
 
-const esbuildVersions = ['latest', '0.16.12']
+const { ESBUILD_VERSION } = process.env
+const esbuildVersions = ESBUILD_VERSION ? [ESBUILD_VERSION] : ['latest', '0.16.12']
 
 function findWebSpan (payload) {
   for (const trace of payload) {

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -25,7 +25,8 @@ const versionsPackageJson = require('../../packages/dd-trace/test/plugins/versio
 const maximumEsbuildVersion = versionsPackageJson.dependencies.esbuild
 
 // This should switch to our withVersion helper. The order here currently matters.
-const esbuildVersions = ['0.16.12', maximumEsbuildVersion]
+const { ESBUILD_VERSION } = process.env
+const esbuildVersions = ESBUILD_VERSION ? [ESBUILD_VERSION] : ['0.16.12', maximumEsbuildVersion]
 const timeout = 1000 * 45
 
 esbuildVersions.forEach((version) => {

--- a/integration-tests/esbuild/openfeature.spec.js
+++ b/integration-tests/esbuild/openfeature.spec.js
@@ -6,7 +6,8 @@ const path = require('node:path')
 const { FakeAgent, sandboxCwd, useSandbox } = require('../helpers')
 
 // This should switch to our withVersion helper. The order here currently matters.
-const esbuildVersions = ['latest', '0.16.12']
+const { ESBUILD_VERSION } = process.env
+const esbuildVersions = ESBUILD_VERSION ? [ESBUILD_VERSION] : ['latest', '0.16.12']
 
 esbuildVersions.forEach((version) => {
   describe('OpenFeature', () => {


### PR DESCRIPTION
### What does this PR do?

Replaces the `integration-bundler` matrix job (which used `if: matrix.bundler ==` conditionals to split esbuild/webpack work) with two dedicated jobs: `integration-esbuild` and `integration-webpack`.

The esbuild job also gains a second matrix dimension (`esbuild_version: ['0.16.12', 'latest']`) so both esbuild versions run in parallel instead of sequentially within a single job. Each spec file reads `ESBUILD_VERSION` from the environment and runs only that version; local dev (no env var) still runs both.

### Motivation

The combined job was hard to read due to `if:` conditionals on nearly every step. Splitting into dedicated jobs makes each one self-contained and halves the wall-clock time of the esbuild jobs.

### Additional Notes

Generated by Claude Code.