### PR TITLE
ci(llmobs): parallelize openai job by Node version

### DIFF
--- a/.github/workflows/llmobs.yml
+++ b/.github/workflows/llmobs.yml
@@ -54,6 +54,10 @@ jobs:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
   openai:
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [oldest, latest]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -64,23 +68,21 @@ jobs:
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      - run: yarn test:plugins:ci
-      - run: yarn test:llmobs:plugins:ci
-        shell: bash
-      - uses: ./.github/actions/node/latest
       - run: yarn test:plugins:ci
       - run: yarn test:llmobs:plugins:ci
         shell: bash
       - uses: ./.github/actions/coverage
         with:
-          flags: llmobs-${{ github.job }}
+          flags: llmobs-openai-${{ matrix.version }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
       - if: always()
         uses: ./.github/actions/testagent/logs
         with:
-          suffix: llmobs-${{ github.job }}
+          suffix: llmobs-${{ github.job }}-${{ matrix.version }}
       - uses: ./.github/actions/push_to_test_optimization
         if: "!cancelled()"
         with:


### PR DESCRIPTION
## Summary

- Converts the `openai` job in the LLMObs workflow from sequential Node version testing to a parallel matrix strategy
- Uses `matrix.version: [oldest, latest]` matching the pattern already used by the `sdk` job
- Updates coverage flags to `llmobs-openai-<version>` and testagent log suffixes to include the version

## Test plan

- [ ] Verify CI passes for both matrix entries (`oldest` and `latest`)

---
> Generated by [Claude Code](https://claude.com/claude-code)