### PR TITLE
ci(appsec): split next jobs by individual version instead of range

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -372,34 +372,18 @@ jobs:
           - oldest
           - latest
         range:
-          [
-            ">=10.2.0 <11",
-            ">=11.0.0 <13",
-            "11.1.4",
-            ">=13.0.0 <14",
-            "13.2.0",
-            ">=14.0.0 <=14.2.6",
-            ">=14.2.7 <15",
-            ">=15.0.0",
-          ]
-        include:
-          - range: ">=10.2.0 <11"
-            range_clean: gte.10.2.0.and.lt.11
-          - range: ">=11.0.0 <13"
-            range_clean: gte.11.0.0.and.lt.13
-          - range: "11.1.4"
-            range_clean: 11.1.4
-          - range: ">=13.0.0 <14"
-            range_clean: gte.13.0.0.and.lt.14
-          - range: "13.2.0"
-            range_clean: 13.2.0
-          - range: ">=14.0.0 <=14.2.6"
-            range_clean: gte.14.0.0.and.lte.14.2.6
-          - range: ">=14.2.7 <15"
-            range_clean: gte.14.2.7.and.lt.15
-          - range: ">=15.0.0"
-            range_clean: gte.15.0.0
-    name: ${{ github.workflow }} / next (node-${{ matrix.version }}, ${{ matrix.range_clean }})
+          - "11.1.4"
+          - "12.3.7"
+          - "13.0.0"
+          - "13.2.0"
+          - "13.5.11"
+          - "14.0.0"
+          - "14.2.6"
+          - "14.2.7"
+          - "14.2.35"
+          - "15.0.0"
+          - "*"
+    name: ${{ github.workflow }} / next (node-${{ matrix.version }}, ${{ matrix.range }})
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -417,7 +401,7 @@ jobs:
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/coverage
         with:
-          flags: appsec-next-${{ matrix.version }}-${{ matrix.range_clean }}
+          flags: appsec-next-${{ matrix.version }}-${{ matrix.range }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
       - uses: ./.github/actions/push_to_test_optimization
         if: "!cancelled()"

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -383,7 +383,10 @@ jobs:
           - "14.2.35"
           - "15.0.0"
           - "*"
-    name: ${{ github.workflow }} / next (node-${{ matrix.version }}, ${{ matrix.range }})
+        include:
+          - range: "*"
+            range_clean: latest
+    name: ${{ github.workflow }} / next (node-${{ matrix.version }}, ${{ matrix.range_clean || matrix.range }})
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -401,7 +404,7 @@ jobs:
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/coverage
         with:
-          flags: appsec-next-${{ matrix.version }}-${{ matrix.range }}
+          flags: appsec-next-${{ matrix.version }}-${{ matrix.range_clean || matrix.range }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
       - uses: ./.github/actions/push_to_test_optimization
         if: "!cancelled()"

--- a/packages/dd-trace/test/appsec/extended-data-collection.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/extended-data-collection.next.plugin.spec.js
@@ -15,12 +15,13 @@ const { createDeepObject, getWebSpan } = require('./utils')
 
 describe('extended data collection', () => {
   withVersions('next', 'next', '>=11.1', version => {
-    if (version === '>=11.0.0 <13' && NODE_VERSION === '24.0.0') {
-      // node 24.0.0 fails, but 24.0.1 works
+    const realVersion = require(`../../../../versions/next@${version}`).version()
+
+    if (satisfies(realVersion, '>=12 <13') && NODE_VERSION === '24.0.0') {
+      // next 12.x fails on node 24.0.0, but 24.0.1 works
       return
     }
 
-    const realVersion = require(`../../../../versions/next@${version}`).version()
     if (satisfies(realVersion, '>=16') && NODE_MAJOR < 20) {
       return
     }

--- a/packages/dd-trace/test/appsec/index.next.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.next.plugin.spec.js
@@ -10,12 +10,13 @@ const { initApp, startServer } = require('./next.utils')
 
 describe('test suite', () => {
   withVersions('next', 'next', '>=11.1', version => {
-    if (version === '>=11.0.0 <13' && NODE_MAJOR === 24 &&
+    const realVersion = require(`../../../../versions/next@${version}`).version()
+
+    if (satisfies(realVersion, '>=12 <13') && NODE_MAJOR === 24 &&
       NODE_MINOR === 0 && NODE_PATCH === 0) {
-      return // node 24.0.0 fails, but 24.0.1 works
+      return // next 12.x fails on node 24.0.0, but 24.0.1 works
     }
 
-    const realVersion = require(`../../../../versions/next@${version}`).version()
     if (satisfies(realVersion, '>=16') && NODE_MAJOR < 20) {
       return
     }


### PR DESCRIPTION
### What does this PR do?

Replaces the semver ranges in the AppSec/next CI matrix with individual pinned versions so each job tests exactly one Next.js version and job names show a clear version number instead of a range expression.

### Motivation

With ranges like `>=13.0.0 <14`, a single CI job would test two Next.js versions (the coerced minimum and the latest within the range) under the same job name, making failures harder to pinpoint. Splitting to individual versions gives one job per version with an unambiguous name.

**Changes:**
- Removes `>=10.2.0 <11` — those versions are skipped by `next.utils.js` (10.x TODO) and filtered by the `>=11.1` guard in the spec files, so the jobs were no-ops
- Expands each range into its coerced minimum and resolved maximum as separate entries
- Uses `"*"` for the latest entry — unlike a range, `"*"` skips the coerce-min step so it installs and tests only the latest version (capped by `versions/package.json`), without duplicating the separately-pinned `15.0.0`
- Removes the `include`/`range_clean` section since plain version strings need no sanitisation
- Updates the `version === '>=11.0.0 <13'` checks in the spec files to `satisfies(realVersion, '>=12 <13')` since the version key is now a plain semver string, not a range

### Additional Notes

The job count goes from 8 ranges × 2 node versions = 16 jobs to 11 versions × 2 node versions = 22 jobs, but each job now tests exactly one Next.js version.

> This PR was generated by [Claude Code](https://claude.ai/claude-code)