### PR TITLE
chore(benchmark): reduce sirun log iterations from 40 to 10

### DIFF
--- a/benchmark/sirun/log/meta.json
+++ b/benchmark/sirun/log/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 40,
+  "iterations": 10,
   "instructions": true,
   "variants": {
     "without-log": { "env": { "DD_TRACE_DEBUG": "false" } },


### PR DESCRIPTION
## Summary
- Reduce the number of iterations in the sirun `log` benchmark scenario from 40 to 10.

## Test Plan
- [ ] Benchmark runs successfully with the reduced iteration count.

---
*Generated by [Claude Code](https://claude.ai/code)*