### PR TITLE
ci(all-green): rerun failed workflows on startup when all-green is rerun

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -35,6 +35,7 @@ jobs:
       - run: node scripts/all-green.mjs
         env:
           DELAY: ${{ github.run_attempt == 1 && '5' || '0' }} # 5 minutes on first attempt, no delay on reruns
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           POLLING_INTERVAL: 1

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -42,6 +42,7 @@ const conclusionEmojis = {
 }
 
 const failureConclusions = new Set(['failure', 'timed_out', 'cancelled'])
+const pollingRetryConclusions = new Set(['failure', 'timed_out'])
 
 let retries = 0
 const retriedRunIds = new Set()
@@ -106,7 +107,7 @@ async function pollUntilDone () {
 
   const toRetry = runs.filter(r =>
     r.status === 'completed' &&
-    failureConclusions.has(r.conclusion) &&
+    pollingRetryConclusions.has(r.conclusion) &&
     !retriedRunIds.has(r.id)
   )
 
@@ -141,7 +142,24 @@ async function rerunFailedWorkflows (workflowRuns) {
   )
 }
 
+async function retryCancelledOnStartup () {
+  const runs = await getRuns()
+  const cancelled = runs.filter(r =>
+    r.status === 'completed' &&
+    r.conclusion === 'cancelled'
+  )
+  if (cancelled.length > 0) {
+    await rerunFailedWorkflows(cancelled)
+    for (const run of cancelled) retriedRunIds.add(run.id)
+    runsCache = undefined
+    console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling.`)
+    await setTimeout(POLLING_INTERVAL * 60_000)
+  }
+}
+
 async function checkAllGreen () {
+  await retryCancelledOnStartup()
+
   const { runs, done } = await pollUntilDone()
 
   await printSummary(runs)

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -11,6 +11,7 @@ const {
   GITHUB_TOKEN,
   POLLING_INTERVAL,
   RETRIES,
+  RUN_ATTEMPT,
 } = process.env
 
 const octokit = new Octokit({
@@ -142,15 +143,17 @@ async function rerunFailedWorkflows (workflowRuns) {
   )
 }
 
-async function retryCancelledOnStartup () {
+async function rerunOnStartup () {
+  if (RUN_ATTEMPT <= 1) return
   const runs = await getRuns()
-  const cancelled = runs.filter(r =>
+  const toRerun = runs.filter(r =>
     r.status === 'completed' &&
-    r.conclusion === 'cancelled'
+    failureConclusions.has(r.conclusion)
   )
-  if (cancelled.length > 0) {
-    await rerunFailedWorkflows(cancelled)
-    for (const run of cancelled) retriedRunIds.add(run.id)
+  if (toRerun.length > 0) {
+    console.log(`Rerunning ${toRerun.length} failed workflow(s) before polling.`)
+    await rerunFailedWorkflows(toRerun)
+    for (const run of toRerun) retriedRunIds.add(run.id)
     runsCache = undefined
     console.log(`Waiting for ${POLLING_INTERVAL} minutes before polling.`)
     await setTimeout(POLLING_INTERVAL * 60_000)
@@ -158,7 +161,7 @@ async function retryCancelledOnStartup () {
 }
 
 async function checkAllGreen () {
-  await retryCancelledOnStartup()
+  await rerunOnStartup()
 
   const { runs, done } = await pollUntilDone()
 

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -41,7 +41,7 @@ const conclusionEmojis = {
   timed_out: '⌛',
 }
 
-const failureConclusions = new Set(['failure', 'timed_out'])
+const failureConclusions = new Set(['failure', 'timed_out', 'cancelled'])
 
 let retries = 0
 const retriedRunIds = new Set()
@@ -132,7 +132,10 @@ async function pollUntilDone () {
 async function rerunFailedWorkflows (workflowRuns) {
   await Promise.all(
     workflowRuns.map(workflowRun => {
-      console.log(`Rerunning failed jobs for workflow run ${workflowRun.id} (${workflowRun.name}).`)
+      console.log(`Rerunning ${workflowRun.conclusion} workflow run ${workflowRun.id} (${workflowRun.name}).`)
+      if (workflowRun.conclusion === 'cancelled') {
+        return octokit.rest.actions.reRunWorkflow({ owner, repo, run_id: workflowRun.id })
+      }
       return octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
     })
   )


### PR DESCRIPTION
## Summary

When all-green is rerun (attempt > 1), immediately rerun any workflows that are already in a failed or cancelled state before starting the polling loop:

- Adds a `rerunOnStartup()` step that triggers reruns for all `failure`, `timed_out`, and `cancelled` conclusions
- Uses `reRunWorkflow` for cancelled runs (since they have no failed jobs to re-run) and `reRunWorkflowFailedJobs` for others
- Waits one polling interval after startup reruns to let GitHub reflect the new run statuses before polling
- During the polling loop, only `failure` and `timed_out` conclusions are retried — cancelled runs that appear mid-poll are not retried again

## Test plan

- [ ] Re-run all-green on a PR where some workflows are already failed or cancelled, and verify they are rerun before polling starts

> Generated by [Claude Code](https://claude.com/claude-code)