### PR TITLE
[test optimization] merge static mocked files with recorded mocks in `jest`

### DIFF
--- a/integration-tests/ci-visibility/jest/mocked-test.js
+++ b/integration-tests/ci-visibility/jest/mocked-test.js
@@ -3,6 +3,7 @@
 const assert = require('assert')
 
 jest.mock('../test/sum.js')
+jest.doMock('../test/static-mock.js')
 
 test('adds 1 + 2 to equal 3', () => {
   assert.strictEqual(1 + 2, 3)

--- a/integration-tests/ci-visibility/test/static-mock.js
+++ b/integration-tests/ci-visibility/test/static-mock.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = 'static mock'

--- a/integration-tests/jest/jest.itr-efd.spec.js
+++ b/integration-tests/jest/jest.itr-efd.spec.js
@@ -880,10 +880,10 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       })
     })
 
-    it('report code coverage with all mocked files', (done) => {
+    it('report code coverage with all mocked files', async () => {
       const codeCovRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcov')
 
-      codeCovRequestPromise.then((codeCovRequest) => {
+      const assertCodeCoverage = codeCovRequestPromise.then((codeCovRequest) => {
         const allCoverageFiles = codeCovRequest.payload
           .flatMap(coverage => coverage.content.coverages)
           .flatMap(file => file.files)
@@ -891,9 +891,10 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
         assertObjectContains(allCoverageFiles, [
           'ci-visibility/test/sum.js',
+          'ci-visibility/test/static-mock.js',
           'ci-visibility/jest/mocked-test.js',
         ])
-      }).catch(done)
+      })
 
       childProcess = exec(
         runTestsCommand,
@@ -905,9 +906,10 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           },
         }
       )
-      childProcess.on('exit', () => {
-        done()
-      })
+      await Promise.all([
+        once(childProcess, 'exit'),
+        assertCodeCoverage,
+      ])
     })
   })
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -2047,10 +2047,12 @@ function getStaticMockedFiles (suiteFilePath) {
 
 function getMockedFiles (suiteFilePath) {
   const mockedFiles = testSuiteMockedFiles.get(suiteFilePath)
+  const staticMockedFiles = getStaticMockedFiles(suiteFilePath)
+
   if (mockedFiles?.length) {
-    return mockedFiles
+    return [...new Set([...mockedFiles, ...staticMockedFiles])]
   }
-  return getStaticMockedFiles(suiteFilePath)
+  return staticMockedFiles
 }
 
 function wrapJestObject (jestObject, suiteFilePath) {


### PR DESCRIPTION
### What does this PR do?

Merge runtime-recorded Jest mocks with statically scanned mock calls when reporting mocked files for CI Visibility code coverage. This keeps files referenced by static `jest.mock()`, `jest.doMock()`, and `jest.unstable_mockModule()` calls in the `/api/v2/citestcov` payload even when the suite also records runtime mocks.

This also adds a regression fixture that combines a recorded mock with a static-only `jest.doMock()` call.

### Motivation

When a Jest suite used both recorded mocks and static-only mock calls, the instrumentation returned only the recorded mocks. That dropped static-only mocked files from coverage reporting, so the backend could miss files that should be considered covered by the suite.

