### PR TITLE
fix(mocha): bound root-level suites by file execution

### DIFF
--- a/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-a.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-a.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+it('covers top-level dependency a', () => {
+  assert.strictEqual(require('./coverage-top-level-dep-a')(), 'a')
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-b.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-b.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+it('covers top-level dependency b', () => {
+  assert.strictEqual(require('./coverage-top-level-dep-b')(), 'b')
+})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-dep-a.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-dep-a.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function depA () {
+  return 'a'
+}

--- a/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-dep-b.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-dep-b.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function depB () {
+  return 'b'
+}

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-fast.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-fast.js
@@ -1,0 +1,3 @@
+'use strict'
+
+it('top-level fast test', () => {})

--- a/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-slow.js
+++ b/integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-slow.js
@@ -1,0 +1,7 @@
+'use strict'
+
+it('top-level slow test', () => {
+  const waitBuffer = new SharedArrayBuffer(4)
+  const waitArray = new Int32Array(waitBuffer)
+  Atomics.wait(waitArray, 0, 0, 200)
+})

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -1193,6 +1193,34 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
 
+        it('starts each suite event when its first top-level test runs', async () => {
+          const fastSuiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-fast.js'
+          const slowSuiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-slow.js'
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end').map(e => e.content)
+              const fastSuite = suiteEvents.find(event => event.meta[TEST_SUITE] === fastSuiteFile)
+              const slowSuite = suiteEvents.find(event => event.meta[TEST_SUITE] === slowSuiteFile)
+
+              assert.ok(fastSuite, `Expected suite event for ${fastSuiteFile}`)
+              assert.ok(slowSuite, `Expected suite event for ${slowSuiteFile}`)
+              assert.ok(
+                fastSuite.duration * 2 < slowSuite.duration,
+                `Expected ${fastSuiteFile} duration to be much shorter than ${slowSuiteFile}`
+              )
+            })
+
+          childProcess = exec(
+            'node node_modules/mocha/bin/mocha' +
+            ` ./${fastSuiteFile} ./${slowSuiteFile}`,
+            { cwd, env: envVars }
+          )
+
+          await Promise.all([eventsPromise, once(childProcess, 'exit')])
+        })
+
         it('reports a suite event for a file with mixed top-level and nested tests', async () => {
           const suiteFile = 'ci-visibility/mocha-plugin-tests/top-level-it-mixed.js'
           const eventsPromise = receiver
@@ -1819,6 +1847,58 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         assert.match(testOutput, /Lines {7}/)
         done()
       })
+    })
+
+    it('reports per-file code coverage for suites with only top-level tests', async () => {
+      const suiteFiles = [
+        'ci-visibility/mocha-plugin-tests/coverage-top-level-a.js',
+        'ci-visibility/mocha-plugin-tests/coverage-top-level-b.js',
+      ]
+      const expectedCoverageBySuite = {
+        [suiteFiles[0]]: 'ci-visibility/mocha-plugin-tests/coverage-top-level-dep-a.js',
+        [suiteFiles[1]]: 'ci-visibility/mocha-plugin-tests/coverage-top-level-dep-b.js',
+      }
+
+      const coverageRequestPromise = receiver.gatherPayloads(({ url }) => url === '/api/v2/citestcov', 5000)
+      const eventsRequestPromise = receiver.payloadReceived(({ url }) => url === '/api/v2/citestcycle')
+
+      childProcess = exec(
+        './node_modules/nyc/bin/nyc.js -r=text-summary node node_modules/mocha/bin/mocha' +
+        ` ./${suiteFiles[0]} ./${suiteFiles[1]}`,
+        {
+          cwd,
+          env: getCiVisAgentlessConfig(receiver.port),
+        }
+      )
+
+      const [coverageRequests, eventsRequest] = await Promise.all([
+        coverageRequestPromise,
+        eventsRequestPromise,
+        once(childProcess, 'exit'),
+      ])
+
+      const suiteEventsByName = eventsRequest.payload.events
+        .filter(event => event.type === 'test_suite_end')
+        .reduce((acc, event) => {
+          acc[event.content.meta[TEST_SUITE]] = event.content
+          return acc
+        }, {})
+      const coverageFileGroups = coverageRequests
+        .flatMap(({ payload }) => payload)
+        .flatMap(coverage => coverage.content.coverages)
+        .map(coverage => coverage.files.map(file => file.filename))
+
+      for (const [suiteFile, expectedCoverageFile] of Object.entries(expectedCoverageBySuite)) {
+        const unexpectedCoverageFiles = Object.values(expectedCoverageBySuite)
+          .filter(coverageFile => coverageFile !== expectedCoverageFile)
+        const matchingCoverageGroup = coverageFileGroups.find(coverageFiles =>
+          coverageFiles.includes(expectedCoverageFile) &&
+          unexpectedCoverageFiles.every(unexpectedCoverageFile => !coverageFiles.includes(unexpectedCoverageFile))
+        )
+
+        assert.ok(suiteEventsByName[suiteFile], `Expected suite event for ${suiteFile}`)
+        assert.ok(matchingCoverageGroup, `Expected isolated coverage for ${suiteFile}`)
+      }
     })
 
     it('does not report code coverage if disabled by the API', (done) => {

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -450,6 +450,56 @@ addHook({
   return run
 })
 
+function ensureSuiteContext (file) {
+  let ctx = testFileToSuiteCtx.get(file)
+  if (ctx) return ctx
+
+  const isUnskippable = unskippableSuites.includes(file)
+  isForcedToRun = isUnskippable && suitesToSkip.includes(getTestSuitePath(file, process.cwd()))
+  ctx = {
+    testSuiteAbsolutePath: file,
+    isUnskippable,
+    isForcedToRun,
+    itrCorrelationId,
+  }
+  testFileToSuiteCtx.set(file, ctx)
+  testSuiteStartCh.runStores(ctx, () => {})
+  return ctx
+}
+
+function publishSuiteCoverage (file) {
+  if (!global.__coverage__) return
+
+  const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
+  testSuiteCodeCoverageCh.publish({ coverageFiles, suiteFile: file })
+  mergeCoverage(global.__coverage__, originalCoverageMap)
+  resetCoverage(global.__coverage__)
+}
+
+function getRootSuiteStatus (tests) {
+  if (tests.every(test => test.isPending())) {
+    return 'skip'
+  }
+  for (const test of tests) {
+    if (test.state === 'failed' || test.timedOut) {
+      return 'fail'
+    }
+  }
+  return 'pass'
+}
+
+function finishRootOnlySuite (file, suitesByTestFile, rootTestsByFile, finishedRootTestFiles) {
+  if (finishedRootTestFiles.has(file) || suitesByTestFile[file]) return
+
+  const tests = rootTestsByFile.get(file) || []
+  const ctx = testFileToSuiteCtx.get(file) || ensureSuiteContext(file)
+  const status = getRootSuiteStatus(tests)
+
+  publishSuiteCoverage(file)
+  testSuiteFinishCh.publish({ status, ...ctx.currentStore }, () => {})
+  finishedRootTestFiles.add(file)
+}
+
 // Only used in serial mode (no --parallel flag is passed)
 // This hook is used to generate session, module, suite and test events
 addHook({
@@ -473,10 +523,22 @@ addHook({
     // Populated during the root 'suite' event so the normal finish path can include them
     // in mixed-file status calculation.
     const rootTestsByFile = new Map()
+    const finishedRootTestFiles = new Set()
+    let activeRootTestFile
 
     this.once('start', getOnStartHandler(frameworkVersion))
 
     this.once('end', getOnEndHandler(false))
+
+    this.on('test', function (test) {
+      if (test.parent?.root && test.file) {
+        if (activeRootTestFile && activeRootTestFile !== test.file) {
+          finishRootOnlySuite(activeRootTestFile, suitesByTestFile, rootTestsByFile, finishedRootTestFiles)
+        }
+        ensureSuiteContext(test.file)
+        activeRootTestFile = test.file
+      }
+    })
 
     this.on('test', getOnTestHandler(true))
 
@@ -497,82 +559,34 @@ addHook({
         // In that case, they all (even if they are from different files) are going to be
         // children of the root suite.
         // Note: We could have suites that contain top level it(...) and also it(...) nested
-        // inside describe(...) ("mixed case"). Duplication is avoided by the context guard
-        // below. Since 'suite' fires for root first, in the mixed case the ctx is created
-        // here and the describe-based handler finds it already set.
+        // inside describe(...) ("mixed case"). Duplication is avoided because the root-only
+        // finish path skips files that also have describe-based suites.
         if (suite.root && suite.tests.length > 0) {
-          const files = new Set(suite.tests.map(test => test.file).filter(Boolean))
-          for (const file of files) {
-            rootTestsByFile.set(file, suite.tests.filter(t => t.file === file))
-            if (testFileToSuiteCtx.get(file)) continue
-            const isUnskippable = unskippableSuites.includes(file)
-            isForcedToRun = isUnskippable && suitesToSkip.includes(getTestSuitePath(file, process.cwd()))
-            const ctx = {
-              testSuiteAbsolutePath: file,
-              isUnskippable,
-              isForcedToRun,
-              itrCorrelationId,
+          for (const test of suite.tests) {
+            if (!test.file) continue
+            let rootTests = rootTestsByFile.get(test.file)
+            if (!rootTests) {
+              rootTests = []
+              rootTestsByFile.set(test.file, rootTests)
             }
-            testFileToSuiteCtx.set(file, ctx)
-            testSuiteStartCh.runStores(ctx, () => {})
+            rootTests.push(test)
           }
         }
         return
       }
-      let ctx = testFileToSuiteCtx.get(suite.file)
-      if (!ctx) {
-        const isUnskippable = unskippableSuites.includes(suite.file)
-        isForcedToRun = isUnskippable && suitesToSkip.includes(getTestSuitePath(suite.file, process.cwd()))
-        ctx = {
-          testSuiteAbsolutePath: suite.file,
-          isUnskippable,
-          isForcedToRun,
-          itrCorrelationId,
-        }
-        testFileToSuiteCtx.set(suite.file, ctx)
-        testSuiteStartCh.runStores(ctx, () => {})
-      }
+      ensureSuiteContext(suite.file)
     })
 
     this.on('suite end', function (suite) {
       if (suite.root) {
         // Symmetric to the suite start fix
-        const fileToTests = new Map()
-        for (const test of suite.tests) {
-          if (!test.file) continue
-          if (!fileToTests.has(test.file)) fileToTests.set(test.file, [])
-          fileToTests.get(test.file).push(test)
-        }
-        for (const [file, tests] of fileToTests) {
+        for (const file of rootTestsByFile.keys()) {
           // Mixed case: if a file appears in suitesByTestFile (pre-populated before the run),
           // its numSuitesByTestFile counter hits zero when its last describe-based suite ends
           // and the normal path below fires testSuiteFinishCh. Since root is last when
           // 'suite end' fires, any such file has already been handled — skipping it here
           // avoids duplication.
-          if (suitesByTestFile[file]) continue
-          let status = 'pass'
-          if (tests.every(test => test.isPending())) {
-            status = 'skip'
-          } else {
-            for (const test of tests) {
-              if (test.state === 'failed' || test.timedOut) {
-                status = 'fail'
-                break
-              }
-            }
-          }
-          if (global.__coverage__) {
-            const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
-            testSuiteCodeCoverageCh.publish({ coverageFiles, suiteFile: file })
-            mergeCoverage(global.__coverage__, originalCoverageMap)
-            resetCoverage(global.__coverage__)
-          }
-          const ctx = testFileToSuiteCtx.get(file)
-          if (ctx) {
-            testSuiteFinishCh.publish({ status, ...ctx.currentStore }, () => {})
-          } else {
-            log.warn('No ctx found for suite', file)
-          }
+          finishRootOnlySuite(file, suitesByTestFile, rootTestsByFile, finishedRootTestFiles)
         }
         return
       }
@@ -604,18 +618,7 @@ addHook({
         }
       }
 
-      if (global.__coverage__) {
-        const coverageFiles = getCoveredFilenamesFromCoverage(global.__coverage__)
-
-        testSuiteCodeCoverageCh.publish({
-          coverageFiles,
-          suiteFile: suite.file,
-        })
-        // We need to reset coverage to get a code coverage per suite
-        // Before that, we preserve the original coverage
-        mergeCoverage(global.__coverage__, originalCoverageMap)
-        resetCoverage(global.__coverage__)
-      }
+      publishSuiteCoverage(suite.file)
 
       const ctx = testFileToSuiteCtx.get(suite.file)
       if (ctx) {


### PR DESCRIPTION
## What
- Start root-level-only Mocha suite spans when the first top-level test for a file actually runs instead of when the root suite is discovered.
- Finish root-level-only suites at file boundaries so each file gets its own duration and coverage payload.
- Add regressions for per-file top-level suite duration and isolated per-file coverage.

## Why
Top-level tests across multiple files were sharing discovery-time root suite boundaries. That could inflate durations for earlier files and merge coverage for files that only contain root-level tests.

## Testing
- `./node_modules/.bin/mocha --timeout 120000 integration-tests/mocha/mocha.spec.js --grep "(starts each suite event when its first top-level test runs|reports per-file code coverage for suites with only top-level tests)"`
- `./node_modules/.bin/eslint packages/datadog-instrumentations/src/mocha/main.js integration-tests/mocha/mocha.spec.js integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-fast.js integration-tests/ci-visibility/mocha-plugin-tests/top-level-it-slow.js integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-a.js integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-b.js integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-dep-a.js integration-tests/ci-visibility/mocha-plugin-tests/coverage-top-level-dep-b.js`