### PR TITLE
feat(oracledb): inject DBM SQL comment

### DIFF
--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -72,9 +72,7 @@ addHook({ name: 'oracledb', versions: ['>=5'], file: 'lib/oracledb.js' }, oracle
       }
 
       return startChannel.runStores(ctx, () => {
-        if (ctx.injected !== undefined) {
-          arguments[0] = ctx.injected
-        }
+        arguments[0] = ctx.injected
         try {
           let result = execute.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -22,7 +22,7 @@ function finish (ctx) {
 
 addHook({ name: 'oracledb', versions: ['>=5'], file: 'lib/oracledb.js' }, oracledb => {
   shimmer.wrap(oracledb.Connection.prototype, 'execute', execute => {
-    return function wrappedExecute (dbQuery, ...args) {
+    return function wrappedExecute (dbQuery) {
       if (!startChannel.hasSubscribers) {
         return execute.apply(this, arguments)
       }
@@ -72,6 +72,9 @@ addHook({ name: 'oracledb', versions: ['>=5'], file: 'lib/oracledb.js' }, oracle
       }
 
       return startChannel.runStores(ctx, () => {
+        if (ctx.injected !== undefined) {
+          arguments[0] = ctx.injected
+        }
         try {
           let result = execute.apply(this, arguments)
 

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -28,18 +28,11 @@ class OracledbPlugin extends DatabasePlugin {
     // in addition to a plain SQL string. Extract the SQL text either way so we can tag
     // the resource and inject DBM into the statement, then re-wrap if needed to keep
     // the caller's binds.
-    let sql
-    let isObjectForm = false
-    if (typeof query === 'string') {
-      sql = query
-    } else if (typeof query?.statement === 'string') {
-      sql = query.statement
-      isObjectForm = true
-    }
+    const sql = query?.statement ?? query
 
     const span = this.startSpan(this.operationName(), {
       service,
-      resource: sql ?? query,
+      resource: sql,
       type: 'sql',
       kind: 'client',
       meta: {
@@ -52,13 +45,8 @@ class OracledbPlugin extends DatabasePlugin {
       },
     }, ctx)
 
-    ctx.injected = query
-    if (sql !== undefined) {
-      const injected = this.injectDbmQuery(span, sql, service.name)
-      if (injected !== sql) {
-        ctx.injected = isObjectForm ? { ...query, statement: injected } : injected
-      }
-    }
+    const injected = this.injectDbmQuery(span, sql, service.name)
+    ctx.injected = query?.statement ? { ...query, statement: injected } : injected
 
     return ctx.currentStore
   }

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -24,9 +24,22 @@ class OracledbPlugin extends DatabasePlugin {
       dbInstance ??= dbInfo.dbInstance
     }
 
+    // oracledb >= 6.4 accepts `execute({ statement, values })` (sql-template-tag form)
+    // in addition to a plain SQL string. Extract the SQL text either way so we can tag
+    // the resource and inject DBM into the statement, then re-wrap if needed to keep
+    // the caller's binds.
+    let sql
+    let isObjectForm = false
+    if (typeof query === 'string') {
+      sql = query
+    } else if (typeof query?.statement === 'string') {
+      sql = query.statement
+      isObjectForm = true
+    }
+
     const span = this.startSpan(this.operationName(), {
       service,
-      resource: query,
+      resource: sql ?? query,
       type: 'sql',
       kind: 'client',
       meta: {
@@ -39,7 +52,13 @@ class OracledbPlugin extends DatabasePlugin {
       },
     }, ctx)
 
-    ctx.injected = this.injectDbmQuery(span, query, service.name)
+    ctx.injected = query
+    if (sql !== undefined) {
+      const injected = this.injectDbmQuery(span, sql, service.name)
+      if (injected !== sql) {
+        ctx.injected = isObjectForm ? { ...query, statement: injected } : injected
+      }
+    }
 
     return ctx.currentStore
   }

--- a/packages/datadog-plugin-oracledb/src/index.js
+++ b/packages/datadog-plugin-oracledb/src/index.js
@@ -24,7 +24,7 @@ class OracledbPlugin extends DatabasePlugin {
       dbInstance ??= dbInfo.dbInstance
     }
 
-    this.startSpan(this.operationName(), {
+    const span = this.startSpan(this.operationName(), {
       service,
       resource: query,
       type: 'sql',
@@ -32,10 +32,14 @@ class OracledbPlugin extends DatabasePlugin {
       meta: {
         'db.user': this.config.user,
         'db.instance': dbInstance,
+        'db.name': dbInstance,
         'db.hostname': hostname,
+        'out.host': hostname,
         [CLIENT_PORT_KEY]: port,
       },
     }, ctx)
+
+    ctx.injected = this.injectDbmQuery(span, query, service.name)
 
     return ctx.currentStore
   }

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -446,6 +446,9 @@ describe('Plugin', () => {
         })
       })
 
+      // oracledb has no stable JS-side queue across v5 thick / v6 thin, so the DBM tests below capture
+      // the plugin-produced SQL via `apm:oracledb:query:start` instead of reading a driver-internal queue
+      // (the pattern pg / mysql / mysql2 tests use).
       describe('with DBM propagation disabled (default)', () => {
         let injected
         const onStart = (ctx) => { injected = ctx.injected }

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -599,10 +599,10 @@ describe('Plugin', () => {
             injected = undefined
           })
 
-          it('should pass through the original object without allocating a new one', async () => {
+          it('should pass through the original statement and binds unchanged', async () => {
             const query = { statement: dbQuery, values: [] }
             await connection.execute(query)
-            assert.strictEqual(injected, query)
+            assert.deepStrictEqual(injected, { statement: dbQuery, values: [] })
           })
         })
       }

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const assert = require('node:assert')
-const dc = require('node:diagnostics_channel')
 
+const dc = require('dc-polyfill')
 const { after, before, beforeEach, describe, it } = require('mocha')
 
 const ddpv = require('mocha/package.json').version

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -465,7 +465,7 @@ describe('Plugin', () => {
         after(async () => {
           dc.unsubscribe('apm:oracledb:query:start', onStart)
           await connection.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         beforeEach(() => {
@@ -493,7 +493,7 @@ describe('Plugin', () => {
         after(async () => {
           dc.unsubscribe('apm:oracledb:query:start', onStart)
           await connection.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         beforeEach(() => {
@@ -554,7 +554,7 @@ describe('Plugin', () => {
           after(async () => {
             dc.unsubscribe('apm:oracledb:query:start', onStart)
             await connection.close()
-            await agent.close({ ritmReset: false })
+            await agent.close()
           })
 
           beforeEach(() => {
@@ -596,7 +596,7 @@ describe('Plugin', () => {
           after(async () => {
             dc.unsubscribe('apm:oracledb:query:start', onStart)
             await connection.close()
-            await agent.close({ ritmReset: false })
+            await agent.close()
           })
 
           beforeEach(() => {
@@ -626,7 +626,7 @@ describe('Plugin', () => {
         after(async () => {
           dc.unsubscribe('apm:oracledb:query:start', onStart)
           await connection.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         beforeEach(() => {
@@ -667,7 +667,7 @@ describe('Plugin', () => {
         after(async () => {
           dc.unsubscribe('apm:oracledb:query:start', onStart)
           await connection.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         beforeEach(() => {
@@ -731,7 +731,7 @@ describe('Plugin', () => {
         after(async () => {
           dc.unsubscribe('apm:oracledb:query:start', onStart)
           await connection.close()
-          await agent.close({ ritmReset: false })
+          await agent.close()
         })
 
         beforeEach(() => {
@@ -749,18 +749,11 @@ describe('Plugin', () => {
       })
     })
 
-    // Lives outside `withVersions` so the global-tracer wipe needed to test
-    // tracer-level config (third `agent.load` arg) does not strand sibling
-    // describe blocks in the next oracledb-version iteration.
     describe('with DBM propagation enabled with append comment using tracer configuration', () => {
       let injected
       const onStart = (ctx) => { injected = ctx.injected }
 
       before(async () => {
-        // Tracer-level config (third arg) only takes effect if the global
-        // tracer is wiped first; tracer.init() short-circuits once the
-        // process-wide singleton has been initialized by an earlier load.
-        agent.wipe()
         await agent.load('oracledb', {
           appendComment: true,
           service: () => 'serviced',
@@ -776,7 +769,7 @@ describe('Plugin', () => {
       after(async () => {
         dc.unsubscribe('apm:oracledb:query:start', onStart)
         await connection.close()
-        await agent.close({ ritmReset: false, wipe: true })
+        await agent.close()
       })
 
       beforeEach(() => {

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -4,6 +4,7 @@ const assert = require('node:assert')
 
 const dc = require('dc-polyfill')
 const { after, before, beforeEach, describe, it } = require('mocha')
+const semver = require('semver')
 
 const ddpv = require('mocha/package.json').version
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
@@ -533,6 +534,82 @@ describe('Plugin', () => {
           ])
         })
       })
+
+      // oracledb 6.4 added object-form execute (`{ statement, values }`) to support
+      // sql-template-tag style usage. Earlier drivers reject the object outright at
+      // argument validation, so the test only runs on >= 6.4.
+      if (semver.intersects(version, '>=6.4.0')) {
+        describe('with DBM propagation enabled and object-form execute', () => {
+          let injected
+          const onStart = (ctx) => { injected = ctx.injected }
+
+          before(async () => {
+            await agent.load('oracledb', { dbmPropagationMode: 'service', service: () => 'serviced' })
+            oracledb = require(`../../../versions/oracledb@${version}`).get()
+            tracer = require('../../dd-trace')
+            dc.subscribe('apm:oracledb:query:start', onStart)
+            connection = await oracledb.getConnection(config)
+          })
+
+          after(async () => {
+            dc.unsubscribe('apm:oracledb:query:start', onStart)
+            await connection.close()
+            await agent.close({ ritmReset: false })
+          })
+
+          beforeEach(() => {
+            injected = undefined
+          })
+
+          it('should inject comment into statement and preserve binds', async () => {
+            await connection.execute({ statement: dbQuery, values: [] })
+            assert.deepStrictEqual(injected, {
+              statement:
+                `/*dddb='${dbInstance}',dddbs='serviced',dde='tester',ddh='${hostname}',ddps='test',` +
+                `ddpv='${ddpv}'*/ ${dbQuery}`,
+              values: [],
+            })
+          })
+
+          it('trace query resource should reflect the statement string', async () => {
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                assert.strictEqual(traces[0][0].resource, dbQuery)
+              }),
+              connection.execute({ statement: dbQuery, values: [] }),
+            ])
+          })
+        })
+
+        describe('with DBM propagation disabled and object-form execute', () => {
+          let injected
+          const onStart = (ctx) => { injected = ctx.injected }
+
+          before(async () => {
+            await agent.load('oracledb')
+            oracledb = require(`../../../versions/oracledb@${version}`).get()
+            tracer = require('../../dd-trace')
+            dc.subscribe('apm:oracledb:query:start', onStart)
+            connection = await oracledb.getConnection(config)
+          })
+
+          after(async () => {
+            dc.unsubscribe('apm:oracledb:query:start', onStart)
+            await connection.close()
+            await agent.close({ ritmReset: false })
+          })
+
+          beforeEach(() => {
+            injected = undefined
+          })
+
+          it('should pass through the original object without allocating a new one', async () => {
+            const query = { statement: dbQuery, values: [] }
+            await connection.execute(query)
+            assert.strictEqual(injected, query)
+          })
+        })
+      }
 
       describe('DBM propagation should handle special characters', () => {
         let injected

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -1,12 +1,15 @@
 'use strict'
 
 const assert = require('node:assert')
+const dc = require('node:diagnostics_channel')
 
-const { after, before, describe, it } = require('mocha')
+const { after, before, beforeEach, describe, it } = require('mocha')
 
+const ddpv = require('mocha/package.json').version
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 const hostname = 'localhost'
 // TODO: Use another port or db instance to differentiate it better from defaults
@@ -98,7 +101,9 @@ describe('Plugin', () => {
                 'span.kind': 'client',
                 component: 'oracledb',
                 'db.instance': dbInstance,
+                'db.name': dbInstance,
                 'db.hostname': hostname,
+                'out.host': hostname,
                 'network.destination.port': port,
               },
             })
@@ -122,7 +127,9 @@ describe('Plugin', () => {
                 'span.kind': 'client',
                 component: 'oracledb',
                 'db.instance': dbInstance,
+                'db.name': dbInstance,
                 'db.hostname': hostname,
+                'out.host': hostname,
                 'network.destination.port': port,
               },
             }).then(done, done)
@@ -166,7 +173,9 @@ describe('Plugin', () => {
                 'span.kind': 'client',
                 component: 'oracledb',
                 'db.instance': dbInstance,
+                'db.name': dbInstance,
                 'db.hostname': hostname,
+                'out.host': hostname,
                 'network.destination.port': port,
                 [ERROR_MESSAGE]: error.message,
                 [ERROR_TYPE]: error.name,
@@ -435,6 +444,272 @@ describe('Plugin', () => {
             await connection.close()
           })
         })
+      })
+
+      describe('with DBM propagation disabled (default)', () => {
+        let injected
+        const onStart = (ctx) => { injected = ctx.injected }
+
+        before(async () => {
+          await agent.load('oracledb')
+          oracledb = require(`../../../versions/oracledb@${version}`).get()
+          tracer = require('../../dd-trace')
+          dc.subscribe('apm:oracledb:query:start', onStart)
+          connection = await oracledb.getConnection(config)
+        })
+
+        after(async () => {
+          dc.unsubscribe('apm:oracledb:query:start', onStart)
+          await connection.close()
+          await agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          injected = undefined
+        })
+
+        it('should not inject a comment when propagation is disabled', async () => {
+          await connection.execute(dbQuery)
+          assert.strictEqual(injected, dbQuery)
+        })
+      })
+
+      describe('with DBM propagation enabled with service using plugin configurations', () => {
+        let injected
+        const onStart = (ctx) => { injected = ctx.injected }
+
+        before(async () => {
+          await agent.load('oracledb', { dbmPropagationMode: 'service', service: () => 'serviced' })
+          oracledb = require(`../../../versions/oracledb@${version}`).get()
+          tracer = require('../../dd-trace')
+          dc.subscribe('apm:oracledb:query:start', onStart)
+          connection = await oracledb.getConnection(config)
+        })
+
+        after(async () => {
+          dc.unsubscribe('apm:oracledb:query:start', onStart)
+          await connection.close()
+          await agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          injected = undefined
+        })
+
+        it('should contain comment in query text', async () => {
+          await connection.execute(dbQuery)
+          assert.strictEqual(
+            injected,
+            `/*dddb='${dbInstance}',dddbs='serviced',dde='tester',ddh='${hostname}',ddps='test',` +
+            `ddpv='${ddpv}'*/ ${dbQuery}`
+          )
+        })
+
+        it('should contain comment in query text for callback-form execute', done => {
+          connection.execute(dbQuery, err => {
+            if (err) return done(err)
+            try {
+              assert.strictEqual(
+                injected,
+                `/*dddb='${dbInstance}',dddbs='serviced',dde='tester',ddh='${hostname}',ddps='test',` +
+                `ddpv='${ddpv}'*/ ${dbQuery}`
+              )
+              done()
+            } catch (e) {
+              done(e)
+            }
+          })
+        })
+
+        it('trace query resource should not be changed when propagation is enabled', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].resource, dbQuery)
+            }),
+            connection.execute(dbQuery),
+          ])
+        })
+      })
+
+      describe('DBM propagation should handle special characters', () => {
+        let injected
+        const onStart = (ctx) => { injected = ctx.injected }
+
+        before(async () => {
+          await agent.load('oracledb', { dbmPropagationMode: 'service', service: '~!@#$%^&*()_+|??/<>' })
+          oracledb = require(`../../../versions/oracledb@${version}`).get()
+          tracer = require('../../dd-trace')
+          dc.subscribe('apm:oracledb:query:start', onStart)
+          connection = await oracledb.getConnection(config)
+        })
+
+        after(async () => {
+          dc.unsubscribe('apm:oracledb:query:start', onStart)
+          await connection.close()
+          await agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          injected = undefined
+        })
+
+        it('DBM propagation should handle special characters', async () => {
+          await connection.execute(dbQuery)
+          assert.strictEqual(
+            injected,
+            `/*dddb='${dbInstance}',dddbs='~!%40%23%24%25%5E%26*()_%2B%7C%3F%3F%2F%3C%3E',dde='tester',` +
+            `ddh='${hostname}',ddps='test',ddpv='${ddpv}'*/ ${dbQuery}`
+          )
+        })
+      })
+
+      describe('with DBM propagation enabled with full using tracer configurations', () => {
+        let seenTraceParent
+        let seenTraceId
+        let seenSpanId
+        const onStart = (ctx) => {
+          const m = ctx.injected?.match(/traceparent='([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})'/)
+          if (m) {
+            seenTraceParent = true
+            seenTraceId = m[2]
+            seenSpanId = m[3]
+          }
+        }
+
+        before(async () => {
+          await agent.load('oracledb')
+          oracledb = require(`../../../versions/oracledb@${version}`).get()
+          tracer = require('../../dd-trace')
+          dc.subscribe('apm:oracledb:query:start', onStart)
+          connection = await oracledb.getConnection(config)
+        })
+
+        after(async () => {
+          dc.unsubscribe('apm:oracledb:query:start', onStart)
+          await connection.close()
+          await agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          tracer.use('oracledb', { dbmPropagationMode: 'full' })
+          seenTraceParent = undefined
+          seenTraceId = undefined
+          seenSpanId = undefined
+        })
+
+        it('query text should contain traceparent', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const expectedTimePrefix = traces[0][0].meta['_dd.p.tid'].toString(16).padStart(16, '0')
+              const traceId = expectedTimePrefix + traces[0][0].trace_id.toString(16).padStart(16, '0')
+              const spanId = traces[0][0].span_id.toString(16).padStart(16, '0')
+              assert.strictEqual(seenTraceParent, true)
+              assert.strictEqual(seenTraceId, traceId)
+              assert.strictEqual(seenSpanId, spanId)
+            }),
+            connection.execute(dbQuery),
+          ])
+        })
+
+        it('query should inject _dd.dbm_trace_injected into span', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assertObjectContains(traces[0][0].meta, {
+                '_dd.dbm_trace_injected': 'true',
+              })
+            }),
+            connection.execute(dbQuery),
+          ])
+        })
+
+        it('service should default to tracer service name', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].service, expectedSchema.outbound.serviceName)
+            }),
+            connection.execute(dbQuery),
+          ])
+        })
+      })
+
+      describe('with DBM propagation enabled with append comment configurations', () => {
+        let injected
+        const onStart = (ctx) => { injected = ctx.injected }
+
+        before(async () => {
+          await agent.load('oracledb', {
+            appendComment: true,
+            dbmPropagationMode: 'service',
+            service: () => 'serviced',
+          })
+          oracledb = require(`../../../versions/oracledb@${version}`).get()
+          tracer = require('../../dd-trace')
+          dc.subscribe('apm:oracledb:query:start', onStart)
+          connection = await oracledb.getConnection(config)
+        })
+
+        after(async () => {
+          dc.unsubscribe('apm:oracledb:query:start', onStart)
+          await connection.close()
+          await agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          injected = undefined
+        })
+
+        it('should append comment in query text', async () => {
+          await connection.execute(dbQuery)
+          assert.strictEqual(
+            injected,
+            `${dbQuery} /*dddb='${dbInstance}',dddbs='serviced',dde='tester',ddh='${hostname}',` +
+            `ddps='test',ddpv='${ddpv}'*/`
+          )
+        })
+      })
+    })
+
+    // Lives outside `withVersions` so the global-tracer wipe needed to test
+    // tracer-level config (third `agent.load` arg) does not strand sibling
+    // describe blocks in the next oracledb-version iteration.
+    describe('with DBM propagation enabled with append comment using tracer configuration', () => {
+      let injected
+      const onStart = (ctx) => { injected = ctx.injected }
+
+      before(async () => {
+        // Tracer-level config (third arg) only takes effect if the global
+        // tracer is wiped first; tracer.init() short-circuits once the
+        // process-wide singleton has been initialized by an earlier load.
+        agent.wipe()
+        await agent.load('oracledb', {
+          appendComment: true,
+          service: () => 'serviced',
+        }, {
+          dbmPropagationMode: 'service',
+        })
+        oracledb = require('../../../versions/oracledb').get()
+        tracer = require('../../dd-trace')
+        dc.subscribe('apm:oracledb:query:start', onStart)
+        connection = await oracledb.getConnection(config)
+      })
+
+      after(async () => {
+        dc.unsubscribe('apm:oracledb:query:start', onStart)
+        await connection.close()
+        await agent.close({ ritmReset: false, wipe: true })
+      })
+
+      beforeEach(() => {
+        injected = undefined
+      })
+
+      it('should append service mode comment in query text', async () => {
+        await connection.execute(dbQuery)
+        assert.strictEqual(
+          injected,
+          `${dbQuery} /*dddb='${dbInstance}',dddbs='serviced',dde='tester',ddh='${hostname}',` +
+          `ddps='test',ddpv='${ddpv}'*/`
+        )
       })
     })
   })

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -455,9 +455,8 @@ describe('Plugin', () => {
         const onStart = (ctx) => { injected = ctx.injected }
 
         before(async () => {
-          await agent.load('oracledb')
+          tracer = await agent.load('oracledb')
           oracledb = require(`../../../versions/oracledb@${version}`).get()
-          tracer = require('../../dd-trace')
           dc.subscribe('apm:oracledb:query:start', onStart)
           connection = await oracledb.getConnection(config)
         })
@@ -483,9 +482,8 @@ describe('Plugin', () => {
         const onStart = (ctx) => { injected = ctx.injected }
 
         before(async () => {
-          await agent.load('oracledb', { dbmPropagationMode: 'service', service: () => 'serviced' })
+          tracer = await agent.load('oracledb', { dbmPropagationMode: 'service', service: () => 'serviced' })
           oracledb = require(`../../../versions/oracledb@${version}`).get()
-          tracer = require('../../dd-trace')
           dc.subscribe('apm:oracledb:query:start', onStart)
           connection = await oracledb.getConnection(config)
         })
@@ -544,9 +542,8 @@ describe('Plugin', () => {
           const onStart = (ctx) => { injected = ctx.injected }
 
           before(async () => {
-            await agent.load('oracledb', { dbmPropagationMode: 'service', service: () => 'serviced' })
+            tracer = await agent.load('oracledb', { dbmPropagationMode: 'service', service: () => 'serviced' })
             oracledb = require(`../../../versions/oracledb@${version}`).get()
-            tracer = require('../../dd-trace')
             dc.subscribe('apm:oracledb:query:start', onStart)
             connection = await oracledb.getConnection(config)
           })
@@ -586,9 +583,8 @@ describe('Plugin', () => {
           const onStart = (ctx) => { injected = ctx.injected }
 
           before(async () => {
-            await agent.load('oracledb')
+            tracer = await agent.load('oracledb')
             oracledb = require(`../../../versions/oracledb@${version}`).get()
-            tracer = require('../../dd-trace')
             dc.subscribe('apm:oracledb:query:start', onStart)
             connection = await oracledb.getConnection(config)
           })
@@ -616,9 +612,8 @@ describe('Plugin', () => {
         const onStart = (ctx) => { injected = ctx.injected }
 
         before(async () => {
-          await agent.load('oracledb', { dbmPropagationMode: 'service', service: '~!@#$%^&*()_+|??/<>' })
+          tracer = await agent.load('oracledb', { dbmPropagationMode: 'service', service: '~!@#$%^&*()_+|??/<>' })
           oracledb = require(`../../../versions/oracledb@${version}`).get()
-          tracer = require('../../dd-trace')
           dc.subscribe('apm:oracledb:query:start', onStart)
           connection = await oracledb.getConnection(config)
         })
@@ -657,9 +652,8 @@ describe('Plugin', () => {
         }
 
         before(async () => {
-          await agent.load('oracledb')
+          tracer = await agent.load('oracledb')
           oracledb = require(`../../../versions/oracledb@${version}`).get()
-          tracer = require('../../dd-trace')
           dc.subscribe('apm:oracledb:query:start', onStart)
           connection = await oracledb.getConnection(config)
         })
@@ -717,13 +711,12 @@ describe('Plugin', () => {
         const onStart = (ctx) => { injected = ctx.injected }
 
         before(async () => {
-          await agent.load('oracledb', {
+          tracer = await agent.load('oracledb', {
             appendComment: true,
             dbmPropagationMode: 'service',
             service: () => 'serviced',
           })
           oracledb = require(`../../../versions/oracledb@${version}`).get()
-          tracer = require('../../dd-trace')
           dc.subscribe('apm:oracledb:query:start', onStart)
           connection = await oracledb.getConnection(config)
         })
@@ -754,14 +747,13 @@ describe('Plugin', () => {
       const onStart = (ctx) => { injected = ctx.injected }
 
       before(async () => {
-        await agent.load('oracledb', {
+        tracer = await agent.load('oracledb', {
           appendComment: true,
           service: () => 'serviced',
         }, {
           dbmPropagationMode: 'service',
         })
         oracledb = require('../../../versions/oracledb').get()
-        tracer = require('../../dd-trace')
         dc.subscribe('apm:oracledb:query:start', onStart)
         connection = await oracledb.getConnection(config)
       })


### PR DESCRIPTION
### What does this PR do?

  Enables DBM SQL-comment propagation for the `oracledb` plugin. 
  - Plugin emits `db.name`/`out.host` (aliases of existing `db.instance`/`db.hostname`) and calls `injectDbmQuery`.
  - Instrumentation forwards the rewritten SQL to the driver via `arguments[0]`.
  - Tests `packages/datadog-plugin-pg/test/index.spec.js`: disabled, service, special-characters, full, append-comment (plugin + tracer config)

  ### Motivation
  Fixes [APMS-19440](https://datadoghq.atlassian.net/browse/APMS-19440). 

**Root cause**: the `oracledb` plugin never called `injectDbmQuery`, so no SQL comment was ever injected regardless of the env var. The plugin also emitted `db.instance`/`db.hostname` tags, but `DatabasePlugin` reads `db.name`/`out.host` when building the comment.


  ### Additional Notes
  - **New tags.** `db.name` and `out.host` are added as aliases; existing tags are unchanged. `peerServicePrecursors` is unchanged, so `peer.service` resolution is unaffected.
  - **Downstream caveat.** `dddb` will carry whatever the connect string exposes (often `SERVICE_NAME` like `MDUATDB`). The alias→instance join (e.g., `MDUATDB` → `pfmddb1a`) is a
  DBM-Oracle backend responsibility, not part of this PR.
  




[APMS-19440]: https://datadoghq.atlassian.net/browse/APMS-19440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ