### PR TITLE
DRAFT: Testing out Bits Dev for FRAPMS-5916 add postgres auto tracing

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -121,6 +121,7 @@ module.exports = {
   'passport-local': () => require('../passport-local'),
   'path-to-regexp': () => require('../path-to-regexp'),
   pg: () => require('../pg'),
+  postgres: () => require('../postgres'),
   pino: () => require('../pino'),
   'pino-pretty': () => require('../pino'),
   playwright: () => require('../playwright'),

--- a/packages/datadog-instrumentations/src/postgres.js
+++ b/packages/datadog-instrumentations/src/postgres.js
@@ -7,7 +7,6 @@ const finishCh = channel('apm:pg:query:finish')
 const errorCh = channel('apm:pg:query:error')
 
 const wrappedClients = new WeakMap()
-const wrappedUnsafe = new WeakMap()
 
 addHook({ name: 'postgres', versions: ['>=3.0.0'] }, wrapPostgres)
 
@@ -26,6 +25,8 @@ function wrapClient (sql, params) {
   const cached = wrappedClients.get(sql)
   if (cached) return cached
 
+  const wrappedMethods = new WeakMap()
+
   const wrappedSql = new Proxy(sql, {
     apply (target, thisArg, args) {
       return traceQuery(target, thisArg, args, params, false)
@@ -37,14 +38,14 @@ function wrapClient (sql, params) {
         return value
       }
 
-      const cachedUnsafe = wrappedUnsafe.get(value)
+      const cachedUnsafe = wrappedMethods.get(value)
       if (cachedUnsafe) return cachedUnsafe
 
       const wrappedUnsafeMethod = function (...args) {
         return traceQuery(value, target, args, params, true)
       }
 
-      wrappedUnsafe.set(value, wrappedUnsafeMethod)
+      wrappedMethods.set(value, wrappedUnsafeMethod)
       return wrappedUnsafeMethod
     },
   })

--- a/packages/datadog-instrumentations/src/postgres.js
+++ b/packages/datadog-instrumentations/src/postgres.js
@@ -1,0 +1,163 @@
+'use strict'
+
+const { addHook, channel } = require('./helpers/instrument')
+
+const startCh = channel('apm:pg:query:start')
+const finishCh = channel('apm:pg:query:finish')
+const errorCh = channel('apm:pg:query:error')
+
+const wrappedClients = new WeakMap()
+const wrappedUnsafe = new WeakMap()
+
+addHook({ name: 'postgres', versions: ['>=3.0.0'] }, wrapPostgres)
+
+function wrapPostgres (postgres) {
+  if (typeof postgres !== 'function') return postgres
+
+  return function wrappedPostgres (...args) {
+    const sql = postgres.apply(this, args)
+    return wrapClient(sql, extractConnectionParams(sql, args[0]))
+  }
+}
+
+function wrapClient (sql, params) {
+  if (typeof sql !== 'function') return sql
+
+  const cached = wrappedClients.get(sql)
+  if (cached) return cached
+
+  const wrappedSql = new Proxy(sql, {
+    apply (target, thisArg, args) {
+      return traceQuery(target, thisArg, args, params, false)
+    },
+    get (target, property, receiver) {
+      const value = Reflect.get(target, property, receiver)
+
+      if (property !== 'unsafe' || typeof value !== 'function') {
+        return value
+      }
+
+      const cachedUnsafe = wrappedUnsafe.get(value)
+      if (cachedUnsafe) return cachedUnsafe
+
+      const wrappedUnsafeMethod = function (...args) {
+        return traceQuery(value, target, args, params, true)
+      }
+
+      wrappedUnsafe.set(value, wrappedUnsafeMethod)
+      return wrappedUnsafeMethod
+    },
+  })
+
+  wrappedClients.set(sql, wrappedSql)
+  return wrappedSql
+}
+
+function traceQuery (queryFn, thisArg, args, params, isUnsafe) {
+  if (!startCh.hasSubscribers) {
+    return queryFn.apply(thisArg, args)
+  }
+
+  const queryText = getQueryText(args, isUnsafe)
+  if (!queryText) {
+    return queryFn.apply(thisArg, args)
+  }
+
+  const ctx = {
+    params,
+    query: { text: queryText },
+    originalText: queryText,
+  }
+
+  return startCh.runStores(ctx, () => {
+    if (isUnsafe && typeof ctx.injected === 'string') {
+      args[0] = ctx.injected
+      ctx.query.text = ctx.injected
+    }
+
+    try {
+      const result = queryFn.apply(thisArg, args)
+
+      if (result?.then) {
+        return result.then((value) => {
+          ctx.result = value
+          finishCh.publish(ctx)
+          return value
+        }, (error) => {
+          ctx.error = error
+          errorCh.publish(ctx)
+          finishCh.publish(ctx)
+          throw error
+        })
+      }
+
+      ctx.result = result
+      finishCh.publish(ctx)
+      return result
+    } catch (error) {
+      ctx.error = error
+      errorCh.publish(ctx)
+      finishCh.publish(ctx)
+      throw error
+    }
+  })
+}
+
+function getQueryText (args, isUnsafe) {
+  if (isUnsafe) {
+    return typeof args[0] === 'string' ? args[0] : undefined
+  }
+
+  const [strings] = args
+  if (!Array.isArray(strings) || !Array.isArray(strings.raw)) {
+    return undefined
+  }
+
+  let queryText = ''
+  for (let i = 0; i < strings.length; i++) {
+    queryText += strings[i]
+    if (i < strings.length - 1) {
+      queryText += `$${i + 1}`
+    }
+  }
+
+  return queryText
+}
+
+function extractConnectionParams (sql, options) {
+  const sqlOptions = sql?.options
+
+  if (sqlOptions && typeof sqlOptions === 'object') {
+    return {
+      host: sqlOptions.host,
+      port: sqlOptions.port,
+      database: sqlOptions.database,
+      user: sqlOptions.user ?? sqlOptions.username,
+    }
+  }
+
+  if (typeof options === 'string') {
+    try {
+      const parsed = new URL(options)
+      return {
+        host: parsed.hostname,
+        port: parsed.port ? Number(parsed.port) : undefined,
+        database: parsed.pathname ? parsed.pathname.slice(1) : undefined,
+        user: parsed.username || undefined,
+      }
+    } catch (_) {}
+  }
+
+  if (options && typeof options === 'object') {
+    return {
+      host: options.host,
+      port: options.port,
+      database: options.database ?? options.db,
+      user: options.user ?? options.username,
+    }
+  }
+
+  return {}
+}
+
+module.exports = { wrapPostgres }

--- a/packages/datadog-instrumentations/test/postgres.spec.js
+++ b/packages/datadog-instrumentations/test/postgres.spec.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const dc = require('dc-polyfill')
+
+const { afterEach, describe, it } = require('mocha')
+
+const { wrapPostgres } = require('../src/postgres')
+
+const startCh = dc.channel('apm:pg:query:start')
+const finishCh = dc.channel('apm:pg:query:finish')
+const errorCh = dc.channel('apm:pg:query:error')
+
+const subscriptions = []
+
+function subscribe (channel, handler) {
+  channel.subscribe(handler)
+  subscriptions.push({ channel, handler })
+}
+
+function createPostgres (queryImpl, unsafeImpl) {
+  return function postgres (options) {
+    function sql (strings, ...values) {
+      return queryImpl(strings, values)
+    }
+
+    sql.options = options
+    sql.unsafe = function (query) {
+      return unsafeImpl(query)
+    }
+
+    return sql
+  }
+}
+
+afterEach(() => {
+  while (subscriptions.length > 0) {
+    const { channel, handler } = subscriptions.pop()
+    channel.unsubscribe(handler)
+  }
+})
+
+describe('postgres instrumentation', () => {
+  it('publishes start and finish for template queries', async () => {
+    let startCtx
+    let finishCtx
+
+    subscribe(startCh, ctx => { startCtx = ctx })
+    subscribe(finishCh, ctx => { finishCtx = ctx })
+
+    const postgres = createPostgres(
+      () => Promise.resolve('ok'),
+      query => Promise.resolve(query)
+    )
+    const wrappedPostgres = wrapPostgres(postgres)
+    const sql = wrappedPostgres({
+      host: '127.0.0.1',
+      port: 5432,
+      database: 'postgres',
+      username: 'postgres',
+    })
+
+    await sql`SELECT ${1}::int`
+
+    assert.strictEqual(startCtx.originalText, 'SELECT $1::int')
+    assert.deepStrictEqual(startCtx.params, {
+      host: '127.0.0.1',
+      port: 5432,
+      database: 'postgres',
+      user: 'postgres',
+    })
+    assert.strictEqual(finishCtx, startCtx)
+  })
+
+  it('uses injected query for unsafe calls', async () => {
+    let unsafeQuery
+
+    subscribe(startCh, ctx => {
+      ctx.injected = '/*trace*/ SELECT 1'
+    })
+
+    const postgres = createPostgres(
+      () => Promise.resolve('ok'),
+      query => {
+        unsafeQuery = query
+        return Promise.resolve(query)
+      }
+    )
+    const sql = wrapPostgres(postgres)({})
+
+    await sql.unsafe('SELECT 1')
+
+    assert.strictEqual(unsafeQuery, '/*trace*/ SELECT 1')
+  })
+
+  it('publishes error channel on promise rejection', async () => {
+    const expectedError = new Error('query failed')
+    let errorCtx
+
+    subscribe(startCh, () => {})
+    subscribe(errorCh, ctx => { errorCtx = ctx })
+
+    const postgres = createPostgres(
+      () => Promise.reject(expectedError),
+      query => Promise.resolve(query)
+    )
+    const sql = wrapPostgres(postgres)({})
+
+    await assert.rejects(sql`SELECT ${1}`, expectedError)
+
+    assert.strictEqual(errorCtx.error, expectedError)
+    assert.strictEqual(errorCtx.originalText, 'SELECT $1')
+  })
+})

--- a/packages/datadog-instrumentations/test/postgres.spec.js
+++ b/packages/datadog-instrumentations/test/postgres.spec.js
@@ -26,9 +26,7 @@ function createPostgres (queryImpl, unsafeImpl) {
     }
 
     sql.options = options
-    sql.unsafe = function (query) {
-      return unsafeImpl(query)
-    }
+    sql.unsafe = unsafeImpl
 
     return sql
   }
@@ -111,5 +109,34 @@ describe('postgres instrumentation', () => {
 
     assert.strictEqual(errorCtx.error, expectedError)
     assert.strictEqual(errorCtx.originalText, 'SELECT $1')
+  })
+
+  it('binds unsafe calls to each client instance', async () => {
+    const seenDatabases = []
+    const unsafeQueries = []
+
+    subscribe(startCh, ctx => {
+      seenDatabases.push(ctx.params.database)
+      ctx.injected = `/*db=${ctx.params.database}*/ ${ctx.originalText}`
+    })
+
+    const unsafe = function (query) {
+      unsafeQueries.push(query)
+      return Promise.resolve(query)
+    }
+
+    const postgres = createPostgres(
+      () => Promise.resolve('ok'),
+      unsafe
+    )
+    const wrappedPostgres = wrapPostgres(postgres)
+    const sqlA = wrappedPostgres({ database: 'db-a' })
+    const sqlB = wrappedPostgres({ database: 'db-b' })
+
+    await sqlA.unsafe('SELECT 1')
+    await sqlB.unsafe('SELECT 2')
+
+    assert.deepStrictEqual(seenDatabases, ['db-a', 'db-b'])
+    assert.deepStrictEqual(unsafeQueries, ['/*db=db-a*/ SELECT 1', '/*db=db-b*/ SELECT 2'])
   })
 })

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -101,6 +101,7 @@ const plugins = {
   get oracledb () { return require('../../../datadog-plugin-oracledb/src') },
   get openai () { return require('../../../datadog-plugin-openai/src') },
   get pg () { return require('../../../datadog-plugin-pg/src') },
+  get postgres () { return require('../../../datadog-plugin-pg/src') },
   get pino () { return require('../../../datadog-plugin-pino/src') },
   get 'pino-pretty' () { return require('../../../datadog-plugin-pino/src') },
   get playwright () { return require('../../../datadog-plugin-playwright/src') },


### PR DESCRIPTION
<!-- dd-meta {"pullId":"83b29055-e900-4f51-84f8-e1bc3dc6dd19","source":"chat","resourceId":"30e9d902-80ed-4a1f-a25e-92d8571c3a01","workflowId":"a5f910c0-7f80-4cc7-9b72-48e10a0f3fc4","codeChangeId":"a5f910c0-7f80-4cc7-9b72-48e10a0f3fc4","sourceType":"chat"} -->
### What does this PR do?
Adds automatic tracing support for the `postgres` (porsager/postgres) client by wiring it into the existing Postgres tracing pipeline, plus a follow-up correctness fix for `unsafe` query wrapping across multiple clients.

### Motivation
FRAPMS-5916 requests auto-instrumentation support for customers migrating from `pg` to `postgres`. Without this, `postgres` queries are not traced automatically, which creates an observability gap during migration.

### Additional Notes
- Added a new instrumentation module at `packages/datadog-instrumentations/src/postgres.js` that wraps `postgres` clients and publishes `apm:pg:query:*` lifecycle events for template and `unsafe` queries.
- Added hook registration for `postgres` in `packages/datadog-instrumentations/src/helpers/hooks.js`.
- Added plugin alias mapping for `postgres` to reuse the existing pg plugin in `packages/dd-trace/src/plugins/index.js`.
- Added focused unit tests in `packages/datadog-instrumentations/test/postgres.spec.js` to validate start/finish/error event behavior and injected `unsafe` query handling.
- Fixed `unsafe` wrapper caching so wrappers are cached per-client instance rather than globally by function identity, preventing cross-client parameter/context leakage.
- Added regression coverage for two client instances sharing the same `unsafe` function to ensure each call uses its own client metadata and injected SQL.

### Testing/Validation
- `./node_modules/.bin/mocha packages/datadog-instrumentations/test/postgres.spec.js`
- Attempted targeted lint run with `./node_modules/.bin/eslint ...` in the earlier iteration, but eslint failed in this environment with `SyntaxError: Invalid regular expression flags` before file-level checks executed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/30e9d902-80ed-4a1f-a25e-92d8571c3a01)

Comment @datadog to request changes