### PR TITLE
ci(apm-integrations): split next jobs by individual version instead of range

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -954,31 +954,17 @@ jobs:
           - 18
           - latest
         range:
-          - ">=10.2.0 <11"
-          - ">=11.0.0 <13"
           - "11.1.4"
-          - ">=13.0.0 <14"
+          - "12.3.7"
+          - "13.0.0"
           - "13.2.0"
-          - ">=14.0.0 <=14.2.6"
-          - ">=14.2.7 <15"
-          - ">=15.0.0 <15.4.1"
-        include:
-          - range: ">=10.2.0 <11"
-            range_clean: gte.10.2.0.and.lt.11
-          - range: ">=11.0.0 <13"
-            range_clean: gte.11.0.0.and.lt.13
-          - range: "11.1.4"
-            range_clean: 11.1.4
-          - range: ">=13.0.0 <14"
-            range_clean: gte.13.0.0.and.lt.14
-          - range: "13.2.0"
-            range_clean: 13.2.0
-          - range: ">=14.0.0 <=14.2.6"
-            range_clean: gte.14.0.0.and.lte.14.2.6
-          - range: ">=14.2.7 <15"
-            range_clean: gte.14.2.7.and.lt.15
-          - range: ">=15.0.0 <15.4.1"
-            range_clean: gte.15.0.0
+          - "13.5.11"
+          - "14.0.0"
+          - "14.2.6"
+          - "14.2.7"
+          - "14.2.35"
+          - "15.0.0"
+          - "15.4.0"
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -994,7 +980,7 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/coverage
         with:
-          flags: apm-integrations-next-${{ matrix.range_clean }}
+          flags: apm-integrations-next-${{ matrix.range }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
       - uses: ./.github/actions/push_to_test_optimization
         if: "!cancelled()"


### PR DESCRIPTION
### What does this PR do?

Replaces the semver ranges in the APM integrations/next CI matrix with individual pinned versions, so each job tests exactly one Next.js version and job names show a clear version number.

### Motivation

Same motivation as #8472 (the AppSec equivalent). With ranges like `>=13.0.0 <14`, a single CI job tests two Next.js versions (the coerced minimum and the latest within the range) under the same job name. Splitting to individual versions gives one job per version with an unambiguous name.

**Changes:**
- Removes `>=10.2.0 <11` — 10.x is explicitly skipped in the test file with a TODO comment
- Expands each range into its coerced minimum and resolved maximum as separate entries
- The closed `>=15.0.0 <15.4.1` range resolves to `15.4.0` as the maximum, so both `15.0.0` and `15.4.0` are pinned individually (unlike the AppSec PR, no `"*"` is used here since the test file caps at `<15.4.1`, which would filter out the absolute latest 16.x)
- Removes the `include`/`range_clean` section since plain version strings contain only digits and dots, which are all valid Codecov flag characters

### Additional Notes

The job count goes from 8 ranges × 2 node versions = 16 jobs to 11 versions × 2 node versions = 22 jobs, but each job now tests exactly one Next.js version.

> This PR was generated by [Claude Code](https://claude.ai/claude-code)