### PR TITLE
ci: increase mocha timeout to 10s in CI

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -4,7 +4,7 @@ module.exports = {
   allowUncaught: true,
   color: true,
   exit: true,
-  timeout: process.env.CI ? 15_000 : 5000,
+  timeout: process.env.CI ? 10_000 : 5000,
   require: ['packages/dd-trace/test/setup/mocha.js'],
   reporter: 'mocha-multi-reporters',
   reporterOption: [

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -4,7 +4,7 @@ module.exports = {
   allowUncaught: true,
   color: true,
   exit: true,
-  timeout: 5000,
+  timeout: process.env.CI ? 15_000 : 5000,
   require: ['packages/dd-trace/test/setup/mocha.js'],
   reporter: 'mocha-multi-reporters',
   reporterOption: [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -587,6 +587,7 @@ export default [
   {
     name: 'dd-trace/scripts',
     files: [
+      '.mocharc.js',
       'scripts/**/*.js',
       'scripts/**/*.mjs',
     ],


### PR DESCRIPTION
## Summary

- Increase the default mocha timeout from 5 s to 10 s when running in CI (`process.env.CI`)
- Allow `.mocharc.js` in the `eslint-process-env` scripts override so it can read `process.env`

Plugins like aerospike, electron, and oracledb regularly exceed the 5 s default in their `before`/`beforeEach` hooks on loaded CI runners: aerospike loads a heavy native C client, electron spawns a full Chromium binary (with Xvfb), and oracledb runs `bun add` for a sandbox. The 10 s limit gives them headroom without affecting local development.

## Test plan

- [ ] Verify `npm run lint` passes
- [ ] Verify aerospike/electron/oracledb jobs no longer time out on before hooks in CI

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)