### PR TITLE
chore(llmobs): fix flaky openai test

### DIFF
--- a/packages/datadog-plugin-openai/test/index.spec.js
+++ b/packages/datadog-plugin-openai/test/index.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { spawn } = require('child_process')
+const { execFileSync } = require('child_process')
 const fs = require('fs')
 const assert = require('node:assert/strict')
 const Path = require('path')
@@ -100,8 +100,8 @@ describe('Plugin', () => {
       })
 
       describe('without initialization', () => {
-        it('should not error', (done) => {
-          spawn('node', ['no-init'], {
+        it('should not error', () => {
+          execFileSync(process.execPath, ['no-init.js'], {
             cwd: __dirname,
             stdio: 'inherit',
             env: {
@@ -109,7 +109,7 @@ describe('Plugin', () => {
               PATH_TO_DDTRACE: tracerRequirePath,
               PATH_TO_OPENAI: moduleRequirePath,
             },
-          }).on('exit', done) // non-zero exit status fails test
+          })
         })
       })
 

--- a/packages/datadog-plugin-openai/test/no-init.js
+++ b/packages/datadog-plugin-openai/test/no-init.js
@@ -10,4 +10,3 @@
  */
 require(process.env.PATH_TO_DDTRACE)
 require(process.env.PATH_TO_OPENAI).get()
-process.exit(0)

--- a/packages/datadog-plugin-openai/test/no-init.js
+++ b/packages/datadog-plugin-openai/test/no-init.js
@@ -10,3 +10,4 @@
  */
 require(process.env.PATH_TO_DDTRACE)
 require(process.env.PATH_TO_OPENAI).get()
+process.exit(0)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes a seemingly flaky `"without initialization"` OpenAI test that is a regression test against the OpenAI plugin crashing apps when the tracer is not initialized. Likely happens because the process it spawns hangs. Changed to exec synchronously and cleanly `process.exit` once the tracer and openai imports happen.

### Motivation
<!-- What inspired you to submit this pull request? -->

No more CI flakes 🔥 