### PR TITLE
feat(opentracing): tag accessor API on span context + lint rule

### DIFF
--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -48,6 +48,8 @@ function createSpan (parent) {
       something: 98764389,
       afloaty: 203987465.756754,
     },
+    getTag (key) { return this._tags[key] },
+    getTags () { return this._tags },
   }
   const span = {
     context: () => context,

--- a/benchmark/sirun/spans/spans.js
+++ b/benchmark/sirun/spans/spans.js
@@ -31,7 +31,7 @@ const FIELDS_WITH_TAGS_AND_LINKS = {
 // breakage where the construction shape stopped propagating.
 const sanitySpan = tracer.startSpan('sanity.span', FIELDS_WITH_TAGS_AND_LINKS)
 sanitySpan.addEvent('sanity-event', EVENT_ATTRIBUTES)
-assert.equal(sanitySpan.context()._tags.service, 'svc')
+assert.equal(sanitySpan.context().getTag('service'), 'svc')
 assert.equal(sanitySpan._links.length, 1)
 assert.equal(sanitySpan._events.length, 1)
 sanitySpan.finish()

--- a/benchmark/stubs/span.js
+++ b/benchmark/stubs/span.js
@@ -32,6 +32,8 @@ const span = {
     _tags: tags,
     _sampling: {},
     _name: 'operation',
+    getTag: (key) => tags[key],
+    getTags: () => tags,
   }),
   _startTime: 1500000000000.123,
   _duration: 100,

--- a/eslint-rules/eslint-no-private-tags-access.mjs
+++ b/eslint-rules/eslint-no-private-tags-access.mjs
@@ -1,0 +1,110 @@
+const MESSAGE = 'Direct `_tags` access is forbidden; use `getTag()`, `setTag()`, `getTags()`, ' +
+  'etc. on the span context instead.'
+
+// Convert a simple glob pattern into a RegExp.
+// Supports `**` (any path), `*` (any non-slash run), and `?` (single non-slash char).
+// Patterns are anchored at the end of the path; if the pattern does not contain a
+// path separator, it matches against the basename. Otherwise it matches against
+// any suffix of the path (so callers can write `packages/foo/bar.js` and have it
+// match `/abs/path/to/packages/foo/bar.js`).
+function patternToRegExp (pattern) {
+  // Escape regex metacharacters except for glob wildcards which we handle below.
+  // We use placeholder tokens for `**`, `*`, and `?` so the escape step doesn't
+  // touch them.
+  const DOUBLE_STAR = '\0DSTAR\0'
+  const SINGLE_STAR = '\0SSTAR\0'
+  const SINGLE_Q = '\0SQ\0'
+
+  let p = pattern
+    .replaceAll('**', DOUBLE_STAR)
+    .replaceAll('*', SINGLE_STAR)
+    .replaceAll('?', SINGLE_Q)
+
+  // Escape remaining regex metacharacters.
+  p = p.replaceAll(/[.+^${}()|[\]\\]/g, '\\$&')
+
+  // Re-insert glob equivalents.
+  p = p
+    .replaceAll(DOUBLE_STAR, '.*')
+    .replaceAll(SINGLE_STAR, '[^/]*')
+    .replaceAll(SINGLE_Q, '[^/]')
+
+  // Anchor: match either at the start of the path or after a `/`, through to
+  // the end. This works the same whether the pattern is a basename (no `/`)
+  // or a path suffix.
+  return new RegExp(`(?:^|/)${p}$`)
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow direct member access to the `_tags` field on span contexts. ' +
+        'Use the public accessor API (`getTag`, `setTag`, `getTags`, `hasTag`, `deleteTag`, `clearTags`) instead.',
+    },
+    messages: {
+      noPrivateTagsAccess: MESSAGE,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowFiles: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create (context) {
+    const options = context.options[0] || {}
+    const allowFiles = Array.isArray(options.allowFiles) ? options.allowFiles : []
+    const filename = context.filename || context.getFilename?.() || ''
+
+    // Normalize path separators so glob patterns using `/` match on every platform.
+    const normalizedFilename = filename.replaceAll('\\', '/')
+
+    const compiledPatterns = allowFiles.map(patternToRegExp)
+    const isAllowed = compiledPatterns.some((re) => re.test(normalizedFilename))
+
+    if (isAllowed) return {}
+
+    return {
+      MemberExpression (node) {
+        // Skip computed access (e.g. `foo['_tags']` — a string literal — or
+        // `foo[Symbol(...)]`). Only `.<identifier>` access counts; the literal
+        // and symbol forms are explicitly excluded by the rule spec.
+        if (node.computed) return
+
+        const prop = node.property
+        if (!prop || prop.type !== 'Identifier' || prop.name !== '_tags') return
+
+        context.report({
+          node,
+          messageId: 'noPrivateTagsAccess',
+        })
+      },
+
+      // Catch destructuring access: `const { _tags } = ctx`,
+      // `const { _tags: alias } = ctx`, `function f({ _tags }) {}`, etc.
+      // Skip computed destructuring (`const { ['_tags']: x } = ctx`) for the
+      // same reason we skip computed MemberExpression — the dynamic form is
+      // explicitly outside the rule's scope.
+      'ObjectPattern > Property' (node) {
+        if (node.computed) return
+
+        const key = node.key
+        if (!key || key.type !== 'Identifier' || key.name !== '_tags') return
+
+        context.report({
+          node,
+          messageId: 'noPrivateTagsAccess',
+        })
+      },
+    }
+  },
+}

--- a/eslint-rules/eslint-no-private-tags-access.test.mjs
+++ b/eslint-rules/eslint-no-private-tags-access.test.mjs
@@ -1,0 +1,140 @@
+import { RuleTester } from 'eslint'
+import rule from './eslint-no-private-tags-access.mjs'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('eslint-no-private-tags-access', rule, {
+  valid: [
+    // Public accessors are fine.
+    { code: 'span.context().getTag("k")' },
+    { code: 'span.context().setTag("k", "v")' },
+    { code: 'span.context().getTags()' },
+    { code: 'span.context().hasTag("k")' },
+    { code: 'span.context().deleteTag("k")' },
+    { code: 'span.context().clearTags()' },
+
+    // Object-literal key named `_tags` is a shorthand/Property, not a MemberExpression.
+    { code: 'const x = { _tags: {} }' },
+
+    // String literal `'_tags'` is just a string literal.
+    { code: 'const key = "_tags"' },
+
+    // Computed access via bracket notation with a string literal should be ignored.
+    { code: 'const v = ctx["_tags"]' },
+
+    // Computed access via Symbol should also be ignored.
+    { code: 'const t = ctx[Symbol("_tags")]' },
+
+    // File on the allowlist may freely access `_tags`.
+    {
+      code: 'ctx._tags = {}',
+      options: [{ allowFiles: ['allowed.js'] }],
+      filename: '/path/to/allowed.js',
+    },
+    {
+      code: 'ctx._tags = {}',
+      options: [{ allowFiles: ['packages/dd-trace/src/opentracing/span_context.js'] }],
+      filename: '/abs/repo/packages/dd-trace/src/opentracing/span_context.js',
+    },
+    {
+      code: 'ctx._tags = {}',
+      options: [{ allowFiles: ['packages/dd-trace/test/opentracing/*.spec.js'] }],
+      filename: '/abs/repo/packages/dd-trace/test/opentracing/span_context.spec.js',
+    },
+
+    // Unrelated `_tags` reference on the basename glob — allowlist matches all.
+    {
+      code: 'ctx._tags["k"]',
+      options: [{ allowFiles: ['**/*.spec.js'] }],
+      filename: '/abs/repo/test/foo.spec.js',
+    },
+
+    // Computed destructuring (dynamic) — same exclusion as computed MemberExpression.
+    { code: 'const { ["_tags"]: x } = ctx' },
+
+    // The destructured *source* property is `tags`, not `_tags`; renaming the
+    // local binding to `_tags` is fine.
+    { code: 'const { tags: _tags } = ctx' },
+
+    // Destructuring inside an allowlisted file should be permitted.
+    {
+      code: 'const { _tags } = ctx',
+      options: [{ allowFiles: ['allowed.js'] }],
+      filename: '/path/to/allowed.js',
+    },
+    {
+      code: 'const { _tags: aliased } = ctx',
+      options: [{ allowFiles: ['**/*.spec.js'] }],
+      filename: '/abs/repo/test/foo.spec.js',
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'const v = ctx._tags',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+    {
+      code: 'ctx._tags = {}',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+    {
+      code: 'span.context()._tags["k"]',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+    {
+      code: 'span.context()._tags.foo',
+      // `span.context()._tags` is one violation; the outer `.foo` access is
+      // separate and not a `_tags` access, so only one error.
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+
+    // Allowlist that doesn't match the current file should still error.
+    {
+      code: 'ctx._tags = {}',
+      options: [{ allowFiles: ['some/other/file.js'] }],
+      filename: '/abs/repo/packages/dd-trace/src/foo.js',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+
+    // Destructuring access — shorthand.
+    {
+      code: 'const { _tags } = ctx',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+
+    // Destructuring access — renamed.
+    {
+      code: 'const { _tags: aliased } = ctx',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+
+    // Destructuring in a function parameter.
+    {
+      code: 'function f ({ _tags }) { return _tags }',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+
+    // Nested destructuring still gets flagged.
+    {
+      code: 'const { context: { _tags } } = span',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+
+    // Destructuring with a non-matching allowlist should still error.
+    {
+      code: 'const { _tags } = ctx',
+      options: [{ allowFiles: ['some/other/file.js'] }],
+      filename: '/abs/repo/packages/dd-trace/src/foo.js',
+      errors: [{ messageId: 'noPrivateTagsAccess' }],
+    },
+  ],
+})
+
+// eslint-disable-next-line no-console
+console.log('eslint-no-private-tags-access tests passed')

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -451,6 +451,10 @@ export default [
           'packages/dd-trace/test/llmobs/tagger.spec.js',
           'packages/dd-trace/test/llmobs/span_processor.spec.js',
           'packages/dd-trace/test/profiling/profilers/wall.spec.js',
+          // Benchmark stubs that mock the `_tags` field shape on a fake span
+          // context (their `getTag`/`getTags` mocks read from `_tags`).
+          'benchmark/stubs/span.js',
+          'benchmark/sirun/exporting-pipeline/index.js',
         ],
       }],
       'eslint-rules/eslint-require-export-exists': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,7 @@ import globals from 'globals'
 import eslintConfigNamesSync from './eslint-rules/eslint-config-names-sync.mjs'
 import eslintEnvAliases from './eslint-rules/eslint-env-aliases.mjs'
 import eslintLogPrintfStyle from './eslint-rules/eslint-log-printf-style.mjs'
+import eslintNoPrivateTagsAccess from './eslint-rules/eslint-no-private-tags-access.mjs'
 import eslintNonPrefixEnvNames from './eslint-rules/eslint-non-prefix-env-names.mjs'
 import eslintPreferAssertMatch from './eslint-rules/eslint-prefer-assert-match.mjs'
 import eslintProcessEnv from './eslint-rules/eslint-process-env.mjs'
@@ -386,6 +387,7 @@ export default [
           'eslint-prefer-assert-match': eslintPreferAssertMatch,
           'eslint-safe-typeof-object': eslintSafeTypeOfObject,
           'eslint-log-printf-style': eslintLogPrintfStyle,
+          'eslint-no-private-tags-access': eslintNoPrivateTagsAccess,
           'eslint-require-boolean-assert-message': eslintRequireBooleanAssertMessage,
           'eslint-require-export-exists': eslintRequireExportExists,
           'eslint-timer-unref': eslintTimerUnref,
@@ -424,6 +426,33 @@ export default [
         dynamicImports: 'always-multiline',
       }],
       'eslint-rules/eslint-safe-typeof-object': 'error',
+      'eslint-rules/eslint-no-private-tags-access': ['error', {
+        allowFiles: [
+          // The span_context implementation defines and reads `_tags` directly.
+          'packages/dd-trace/src/opentracing/span_context.js',
+          // Unrelated `_tags` fields on other classes (not span contexts).
+          'packages/dd-trace/src/dogstatsd.js',
+          'packages/dd-trace/src/datastreams/processor.js',
+          // `LLMObservabilitySpan` (internal LLM-Obs DTO) has its own `_tags`
+          // field unrelated to the APM span context.
+          'packages/dd-trace/src/llmobs/span_processor.js',
+          // Test specs that intentionally mock the `_tags` field shape on a
+          // fake span context (their `getTag`/`getTags` mocks read `this._tags`).
+          'packages/dd-trace/test/opentracing/span_context.spec.js',
+          'packages/dd-trace/test/priority_sampler.spec.js',
+          'packages/dd-trace/test/sampling_rule.spec.js',
+          'packages/dd-trace/test/span_sampler.spec.js',
+          'packages/dd-trace/test/span_format.spec.js',
+          'packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js',
+          'packages/dd-trace/test/appsec/reporter.spec.js',
+          'packages/dd-trace/test/appsec/index.spec.js',
+          'packages/dd-trace/test/plugins/database-dbm-hash.spec.js',
+          'packages/dd-trace/test/plugins/outbound.spec.js',
+          'packages/dd-trace/test/llmobs/tagger.spec.js',
+          'packages/dd-trace/test/llmobs/span_processor.spec.js',
+          'packages/dd-trace/test/profiling/profilers/wall.spec.js',
+        ],
+      }],
       'eslint-rules/eslint-require-export-exists': 'error',
       'import/no-extraneous-dependencies': 'error',
       'n/hashbang': 'error',

--- a/integration-tests/esbuild/basic-test.js
+++ b/integration-tests/esbuild/basic-test.js
@@ -23,7 +23,7 @@ const server = app.listen(PORT, () => {
 
 app.get('/', async (_req, res) => {
   assert.equal(
-    tracer.scope().active().context()._tags.component,
+    tracer.scope().active().context().getTag('component'),
     'express',
     `the sample app bundled by esbuild is not properly instrumented. using node@${process.version}`
   ) // bad exit

--- a/integration-tests/webpack/basic-test.js
+++ b/integration-tests/webpack/basic-test.js
@@ -20,7 +20,7 @@ const server = app.listen(PORT, () => {
 
 app.get('/', async (_req, res) => {
   assert.equal(
-    tracer.scope().active().context()._tags.component,
+    tracer.scope().active().context().getTag('component'),
     'express',
     `the sample app bundled by webpack is not properly instrumented. using node@${process.version}`
   ) // bad exit

--- a/packages/datadog-plugin-avsc/src/schema_iterator.js
+++ b/packages/datadog-plugin-avsc/src/schema_iterator.js
@@ -140,7 +140,7 @@ class SchemaExtractor {
       return
     }
 
-    if (span.context()._tags[SCHEMA_TYPE] && operation === 'serialization') {
+    if (span.context().getTag(SCHEMA_TYPE) && operation === 'serialization') {
       // we have already added a schema to this span, this call is an encode of nested schema types
       return
     }

--- a/packages/datadog-plugin-avsc/test/index.spec.js
+++ b/packages/datadog-plugin-avsc/test/index.spec.js
@@ -30,7 +30,7 @@ const ADVANCED_USER_SCHEMA_DEF = JSON.parse(
 const BASIC_USER_SCHEMA_ID = '1605040621379664412'
 const ADVANCED_USER_SCHEMA_ID = '919692610494986520'
 function compareJson (expected, span) {
-  const actual = JSON.parse(span.context()._tags[SCHEMA_DEFINITION])
+  const actual = JSON.parse(span.context().getTag(SCHEMA_DEFINITION))
   return JSON.stringify(actual) === JSON.stringify(expected)
 }
 
@@ -84,11 +84,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'user.serialize')
 
             assert.strictEqual(compareJson(BASIC_USER_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'avro')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'example.avro.User')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], BASIC_USER_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'avro')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'example.avro.User')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], BASIC_USER_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -115,11 +115,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'advanced_user.serialize')
 
             assert.strictEqual(compareJson(ADVANCED_USER_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'avro')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'example.avro.AdvancedUser')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], ADVANCED_USER_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'avro')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'example.avro.AdvancedUser')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], ADVANCED_USER_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -136,11 +136,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'user.deserialize')
 
             assert.strictEqual(compareJson(BASIC_USER_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'avro')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'example.avro.User')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], BASIC_USER_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'avro')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'example.avro.User')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], BASIC_USER_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -168,11 +168,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'advanced_user.deserialize')
 
             assert.strictEqual(compareJson(ADVANCED_USER_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'avro')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'example.avro.AdvancedUser')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], ADVANCED_USER_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'avro')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'example.avro.AdvancedUser')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], ADVANCED_USER_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
       })

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -260,7 +260,7 @@ describe('Plugin', () => {
               const span = tracer.scope().active()
 
               assert.notStrictEqual(span, beforeSpan)
-              assert.strictEqual(span.context()._tags['aws.operation'], 'receiveMessage')
+              assert.strictEqual(span.context().getTag('aws.operation'), 'receiveMessage')
 
               done()
             })

--- a/packages/datadog-plugin-azure-functions/src/index.js
+++ b/packages/datadog-plugin-azure-functions/src/index.js
@@ -54,7 +54,7 @@ class AzureFunctionsPlugin extends TracingPlugin {
       )
 
       span._integrationName = 'azure-functions'
-      span.context()._tags.component = 'azure-functions'
+      span.context().setTag('component', 'azure-functions')
       span.addTags(meta)
       webContext.span = span
       webContext.azureFunctionCtx = ctx

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -1145,7 +1145,7 @@ class CypressPlugin {
         }
         // Update test status - but NOT for non-ATF quarantined tests where we intentionally
         // report 'fail' to Datadog even though Cypress sees it as 'pass'
-        const isQuarantinedTest = finishedTest.testSpan?.context()?._tags?.[TEST_MANAGEMENT_IS_QUARANTINED] === 'true'
+        const isQuarantinedTest = finishedTest.testSpan?.context()?.getTag(TEST_MANAGEMENT_IS_QUARANTINED) === 'true'
         if (cypressTestStatus !== finishedTest.testStatus && (!isQuarantinedTest || finishedTest.isAttemptToFix)) {
           finishedTest.testSpan.setTag(TEST_STATUS, cypressTestStatus)
           finishedTest.testSpan.setTag('error', latestError)
@@ -1172,7 +1172,7 @@ class CypressPlugin {
         }
 
         if (isLastAttempt) {
-          const testSpanTags = finishedTest.testSpan.context()._tags
+          const testSpanTags = finishedTest.testSpan.context().getTags()
           const retryKind = getFinalStatusRetryKind({
             finishedTest,
             finishedTestAttempts,
@@ -1343,7 +1343,7 @@ class CypressPlugin {
           this.testStatuses[testName] = [testStatus]
         }
         const testStatuses = this.testStatuses[testName]
-        const activeSpanTags = this.activeTestSpan.context()._tags
+        const activeSpanTags = this.activeTestSpan.context().getTags()
 
         if (error) {
           this.activeTestSpan.setTag('error', error)

--- a/packages/datadog-plugin-jest/src/index.js
+++ b/packages/datadog-plugin-jest/src/index.js
@@ -194,7 +194,7 @@ class JestPlugin extends CiPlugin {
       for (const config of configs) {
         config._ddTestSessionId = this.testSessionSpan.context().toTraceId()
         config._ddTestModuleId = this.testModuleSpan.context().toSpanId()
-        config._ddTestCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
+        config._ddTestCommand = this.testSessionSpan.context().getTag(TEST_COMMAND)
         config._ddRequestErrorTags = this.getSessionRequestErrorTags()
         config._ddItrCorrelationId = this.itrCorrelationId
         config._ddIsEarlyFlakeDetectionEnabled = !!this.libraryConfig?.isEarlyFlakeDetectionEnabled
@@ -596,7 +596,7 @@ class JestPlugin extends CiPlugin {
       extraTags[TEST_HAS_DYNAMIC_NAME] = 'true'
     }
     const testSuiteSpan = this.testSuiteSpanPerTestSuiteAbsolutePath.get(testSuiteAbsolutePath) || this.testSuiteSpan
-    const skippingEnabled = testSuiteSpan?.context()._tags?.[TEST_ITR_SKIPPING_ENABLED]
+    const skippingEnabled = testSuiteSpan?.context()?.getTag?.(TEST_ITR_SKIPPING_ENABLED)
     if (skippingEnabled !== undefined) {
       extraTags[TEST_ITR_SKIPPING_ENABLED] = skippingEnabled
     }

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -152,7 +152,7 @@ class MochaPlugin extends CiPlugin {
     this.addSub('ci:mocha:test-suite:finish', ({ testSuiteSpan, status }) => {
       if (testSuiteSpan) {
         // the test status of the suite may have been set in ci:mocha:test-suite:error already
-        if (!testSuiteSpan.context()._tags[TEST_STATUS]) {
+        if (!testSuiteSpan.context().getTag(TEST_STATUS)) {
           testSuiteSpan.setTag(TEST_STATUS, status)
         }
         testSuiteSpan.finish()

--- a/packages/datadog-plugin-next/src/index.js
+++ b/packages/datadog-plugin-next/src/index.js
@@ -60,7 +60,7 @@ class NextPlugin extends ServerPlugin {
     if (!store) return
 
     const span = store.span
-    const error = span.context()._tags.error
+    const error = span.context().getTag('error')
     const requestError = req.error || nextRequest.error
 
     if (requestError) {
@@ -97,7 +97,7 @@ class NextPlugin extends ServerPlugin {
     if (!req) return
 
     // Only use error page names if there's not already a name
-    const current = span.context()._tags['next.page']
+    const current = span.context().getTag('next.page')
     const isErrorPage = errorPages.has(page)
 
     if (current && isErrorPage) {

--- a/packages/datadog-plugin-openai/src/tracing.js
+++ b/packages/datadog-plugin-openai/src/tracing.js
@@ -158,7 +158,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
     const span = store?.span
     if (!span) return
 
-    const error = !!span.context()._tags.error
+    const error = !!span.context().getTag('error')
 
     let headers, body, method, path
     if (!error) {
@@ -172,7 +172,7 @@ class OpenAiTracingPlugin extends TracingPlugin {
       headers = Object.fromEntries(headers)
     }
 
-    const resource = span._spanContext._tags['resource.name']
+    const resource = span.context().getTag('resource.name')
     const normalizedMethodName = store.normalizedMethodName
 
     body = coerceResponseBody(body, normalizedMethodName)

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -326,7 +326,7 @@ class PlaywrightPlugin extends CiPlugin {
     }) => {
       if (!span) return
 
-      const isRUMActive = span.context()._tags[TEST_IS_RUM_ACTIVE]
+      const isRUMActive = span.context().getTag(TEST_IS_RUM_ACTIVE)
 
       span.setTag(TEST_STATUS, testStatus)
 
@@ -416,7 +416,7 @@ class PlaywrightPlugin extends CiPlugin {
         TELEMETRY_EVENT_FINISHED,
         'test',
         {
-          hasCodeOwners: !!span.context()._tags[TEST_CODE_OWNERS],
+          hasCodeOwners: !!span.context().getTag(TEST_CODE_OWNERS),
           isNew,
           isRum: isRUMActive,
           browserDriver: 'playwright',

--- a/packages/datadog-plugin-protobufjs/src/schema_iterator.js
+++ b/packages/datadog-plugin-protobufjs/src/schema_iterator.js
@@ -135,7 +135,7 @@ class SchemaExtractor {
       return
     }
 
-    if (span.context()._tags[SCHEMA_TYPE] && operation === 'serialization') {
+    if (span.context().getTag(SCHEMA_TYPE) && operation === 'serialization') {
       // we have already added a schema to this span, this call is an encode of nested schema types
       return
     }

--- a/packages/datadog-plugin-protobufjs/test/index.spec.js
+++ b/packages/datadog-plugin-protobufjs/test/index.spec.js
@@ -28,7 +28,7 @@ const OTHER_MESSAGE_SCHEMA_ID = '2691489402935632768'
 const ALL_TYPES_MESSAGE_SCHEMA_ID = '15890948796193489151'
 
 function compareJson (expected, span) {
-  const actual = JSON.parse(span.context()._tags[SCHEMA_DEFINITION])
+  const actual = JSON.parse(span.context().getTag(SCHEMA_DEFINITION))
   return JSON.stringify(actual) === JSON.stringify(expected)
 }
 
@@ -76,11 +76,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'other_message.serialize')
 
             assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -92,11 +92,11 @@ describe('Plugin', () => {
               assert.strictEqual(span.context()._name, 'other_message.serialize')
 
               assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-              assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-              assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-              assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-              assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-              assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+              assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+              assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+              assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+              assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+              assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
             })
           })
         })
@@ -110,11 +110,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'message_pb2.serialize')
 
             assert.strictEqual(compareJson(MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'MyMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'MyMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -127,11 +127,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'all_types.serialize')
 
             assert.strictEqual(compareJson(ALL_TYPES_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'example.MainMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], ALL_TYPES_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'example.MainMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], ALL_TYPES_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -146,11 +146,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'other_message.deserialize')
 
             assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -165,11 +165,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'my_message.deserialize')
 
             assert.strictEqual(compareJson(MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'MyMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'MyMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -184,11 +184,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'all_types.deserialize')
 
             assert.strictEqual(compareJson(ALL_TYPES_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'example.MainMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], ALL_TYPES_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'example.MainMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], ALL_TYPES_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -209,11 +209,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'other_message.deserialize')
 
             assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -233,11 +233,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'other_message.deserialize')
 
             assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -259,11 +259,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'other_message.deserialize')
 
             assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -285,11 +285,11 @@ describe('Plugin', () => {
             assert.strictEqual(span.context()._name, 'other_message.deserialize')
 
             assert.strictEqual(compareJson(OTHER_MESSAGE_SCHEMA_DEF, span), true)
-            assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-            assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'OtherMessage')
-            assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'deserialization')
-            assert.strictEqual(span.context()._tags[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
-            assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+            assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+            assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'OtherMessage')
+            assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'deserialization')
+            assert.strictEqual(span.context().getTags()[SCHEMA_ID], OTHER_MESSAGE_SCHEMA_ID)
+            assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
           })
         })
 
@@ -318,11 +318,11 @@ describe('Plugin', () => {
               assert.strictEqual(span.context()._name, 'message_pb2.serialize')
 
               assert.strictEqual(compareJson(MESSAGE_SCHEMA_DEF, span), true)
-              assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-              assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'MyMessage')
-              assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-              assert.strictEqual(span.context()._tags[SCHEMA_ID], MESSAGE_SCHEMA_ID)
-              assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+              assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+              assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'MyMessage')
+              assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+              assert.strictEqual(span.context().getTags()[SCHEMA_ID], MESSAGE_SCHEMA_ID)
+              assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
 
               // we sampled 1 schema with 1 subschema, so the constructor should've only been called twice
               assert.strictEqual(cacheSetSpy.callCount, 2)
@@ -335,11 +335,11 @@ describe('Plugin', () => {
               assert.strictEqual(span.context()._name, 'message_pb2.serialize')
 
               assert.strictEqual(compareJson(MESSAGE_SCHEMA_DEF, span), true)
-              assert.strictEqual(span.context()._tags[SCHEMA_TYPE], 'protobuf')
-              assert.strictEqual(span.context()._tags[SCHEMA_NAME], 'MyMessage')
-              assert.strictEqual(span.context()._tags[SCHEMA_OPERATION], 'serialization')
-              assert.strictEqual(span.context()._tags[SCHEMA_ID], MESSAGE_SCHEMA_ID)
-              assert.strictEqual(span.context()._tags[SCHEMA_WEIGHT], 1)
+              assert.strictEqual(span.context().getTags()[SCHEMA_TYPE], 'protobuf')
+              assert.strictEqual(span.context().getTags()[SCHEMA_NAME], 'MyMessage')
+              assert.strictEqual(span.context().getTags()[SCHEMA_OPERATION], 'serialization')
+              assert.strictEqual(span.context().getTags()[SCHEMA_ID], MESSAGE_SCHEMA_ID)
+              assert.strictEqual(span.context().getTags()[SCHEMA_WEIGHT], 1)
 
               // ensure schema was sampled and returned via the cache, so no extra cache set
               // calls were needed, only gets

--- a/packages/datadog-plugin-rhea/src/producer.js
+++ b/packages/datadog-plugin-rhea/src/producer.js
@@ -42,7 +42,7 @@ function addDeliveryAnnotations (msg, tracer, span) {
     tracer.inject(span, 'text_map', msg.delivery_annotations)
 
     if (tracer._config.dsmEnabled) {
-      const targetName = span.context()._tags['amqp.link.target.address']
+      const targetName = span.context().getTag('amqp.link.target.address')
       const payloadSize = getAmqpMessageSize({ content: msg.body, headers: msg.delivery_annotations })
       const dataStreamsContext = tracer
         .setCheckpoint(['direction:out', `exchange:${targetName}`, 'type:rabbitmq'], span, payloadSize)

--- a/packages/datadog-plugin-selenium/src/index.js
+++ b/packages/datadog-plugin-selenium/src/index.js
@@ -14,7 +14,7 @@ const {
 const { SPAN_TYPE } = require('../../../ext/tags')
 
 function isTestSpan (span) {
-  return span.context()._tags[SPAN_TYPE] === 'test'
+  return span.context().getTag(SPAN_TYPE) === 'test'
 }
 
 function getTestSpanFromTrace (trace) {

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -148,7 +148,7 @@ class AIGuard extends NoopAIGuard {
   #setRootSpanClientIpTags (rootSpan) {
     if (!rootSpan) return
 
-    const currentTags = rootSpan.context()._tags
+    const currentTags = rootSpan.context().getTags()
     const needsHttpClientIp = !Object.hasOwn(currentTags, HTTP_CLIENT_IP)
     const needsNetworkClientIp = !Object.hasOwn(currentTags, NETWORK_CLIENT_IP)
 

--- a/packages/dd-trace/src/appsec/api_security_sampler.js
+++ b/packages/dd-trace/src/appsec/api_security_sampler.js
@@ -79,7 +79,7 @@ function getRouteOrEndpoint (context, statusCode) {
 
   // If route is not available, fallback to http.endpoint
   if (statusCode !== 404) {
-    const endpoint = context?.span?.context()?._tags?.['http.endpoint']
+    const endpoint = context?.span?.context()?.getTag('http.endpoint')
     if (endpoint) {
       return endpoint
     }

--- a/packages/dd-trace/src/appsec/index.js
+++ b/packages/dd-trace/src/appsec/index.js
@@ -289,7 +289,7 @@ function onExpressSession ({ req, res, sessionId, abortController }) {
     return
   }
 
-  const isSdkCalled = rootSpan.context()._tags['usr.session_id']
+  const isSdkCalled = rootSpan.context().getTag('usr.session_id')
   if (isSdkCalled) return
 
   const results = waf.run({

--- a/packages/dd-trace/src/appsec/reporter.js
+++ b/packages/dd-trace/src/appsec/reporter.js
@@ -361,18 +361,18 @@ function reportAttack ({ events: attackData, actions }, req) {
   const rootSpan = web.root(req)
   if (!rootSpan) return
 
-  const currentTags = rootSpan.context()._tags
+  const spanContext = rootSpan.context()
 
   const newTags = {
     'appsec.event': 'true',
   }
 
   // TODO: maybe add this to format.js later (to take decision as late as possible)
-  if (!currentTags['_dd.origin']) {
+  if (!spanContext.getTag('_dd.origin')) {
     newTags['_dd.origin'] = 'appsec'
   }
 
-  const currentJson = currentTags['_dd.appsec.json']
+  const currentJson = spanContext.getTag('_dd.appsec.json')
 
   // merge JSON arrays without parsing them
   const attackDataStr = JSON.stringify(attackData)
@@ -469,8 +469,7 @@ function reportRequestBody (rootSpan, requestBody, comesFromRaspAction = false) 
 
   if (rootSpan.meta_struct['http.request.body']) {
     // If the rasp.exceed metric exists, set also the same for the new tag
-    const currentTags = rootSpan.context()._tags
-    const sizeExceedTagValue = currentTags['_dd.appsec.rasp.request_body_size.exceeded']
+    const sizeExceedTagValue = rootSpan.context().getTag('_dd.appsec.rasp.request_body_size.exceeded')
 
     if (sizeExceedTagValue) {
       rootSpan.setTag('_dd.appsec.request_body_size.exceeded', sizeExceedTagValue)
@@ -572,7 +571,7 @@ function finishRequest (req, res, storedResponseHeaders, requestBody) {
 
   incrementWafRequestsMetric(req)
 
-  const tags = rootSpan.context()._tags
+  const tags = rootSpan.context().getTags()
 
   const extendedDataCollection = extendedDataCollectionRequest.get(req)
   const newTags = getCollectedHeaders(

--- a/packages/dd-trace/src/appsec/sdk/user_blocking.js
+++ b/packages/dd-trace/src/appsec/sdk/user_blocking.js
@@ -22,7 +22,7 @@ function checkUserAndSetUser (tracer, user) {
 
   const rootSpan = getRootSpan()
   if (rootSpan) {
-    if (!rootSpan.context()._tags['usr.id']) {
+    if (!rootSpan.context().getTag('usr.id')) {
       setUserTags(user, rootSpan)
     }
   } else {

--- a/packages/dd-trace/src/appsec/sdk/utils.js
+++ b/packages/dd-trace/src/appsec/sdk/utils.js
@@ -18,7 +18,7 @@ function getRootSpan () {
 
     parentId = pContext._parentId
 
-    if (!pContext._tags?._inferred_span) {
+    if (!pContext.getTag('_inferred_span')) {
       span = parent
     }
   }

--- a/packages/dd-trace/src/appsec/user_tracking.js
+++ b/packages/dd-trace/src/appsec/user_tracking.js
@@ -91,12 +91,13 @@ function trackLogin (framework, login, user, success, rootSpan) {
     [addresses.USER_LOGIN]: login,
   }
 
-  const currentTags = rootSpan.context()._tags
-  const isSdkCalled = currentTags[`_dd.appsec.events.users.login.${success ? 'success' : 'failure'}.sdk`] === 'true'
+  const spanContext = rootSpan.context()
+  const sdkTag = `_dd.appsec.events.users.login.${success ? 'success' : 'failure'}.sdk`
+  const isSdkCalled = spanContext.getTag(sdkTag) === 'true'
 
   // used to not overwrite tags set by SDK
   function shouldSetTag (tag) {
-    return !(isSdkCalled && currentTags[tag])
+    return !(isSdkCalled && spanContext.getTag(tag))
   }
 
   if (success) {
@@ -167,7 +168,7 @@ function trackUser (user, rootSpan) {
 
   rootSpan.setTag('_dd.appsec.usr.id', userId)
 
-  const isSdkCalled = rootSpan.context()._tags['_dd.appsec.user.collection_mode'] === 'sdk'
+  const isSdkCalled = rootSpan.context().getTag('_dd.appsec.user.collection_mode') === 'sdk'
   // do not override SDK
   if (!isSdkCalled) {
     rootSpan.addTags({

--- a/packages/dd-trace/src/llmobs/plugins/ai/util.js
+++ b/packages/dd-trace/src/llmobs/plugins/ai/util.js
@@ -41,7 +41,7 @@ const VERCEL_AI_GENERATION_METADATA_PREFIX = 'ai.settings.'
  */
 function getSpanTags (ctx) {
   const span = ctx.currentStore?.span
-  return /** @type {SpanTags} */ (ctx.attributes ?? span?.context()._tags ?? {})
+  return /** @type {SpanTags} */ (ctx.attributes ?? span?.context().getTags() ?? {})
 }
 
 /**

--- a/packages/dd-trace/src/llmobs/plugins/genai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/genai/index.js
@@ -55,7 +55,7 @@ class GenAiLLMObsPlugin extends LLMObsPlugin {
 
     const inputs = args[0]
     const response = ctx.result
-    const error = !!span.context()._tags.error
+    const error = !!span.context().getTag('error')
 
     const operation = getOperation(methodName)
 

--- a/packages/dd-trace/src/llmobs/plugins/langchain/handlers/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/handlers/index.js
@@ -7,7 +7,7 @@ class LangChainLLMObsHandler {
   }
 
   getName ({ span }) {
-    return span?.context()._tags?.['resource.name']
+    return span?.context()?.getTag('resource.name')
   }
 
   setMetaTags () {}

--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -44,7 +44,8 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
 
   getLLMObsSpanRegisterOptions (ctx) {
     const span = ctx.currentStore?.span
-    const tags = span?.context()._tags || {}
+    const spanContext = span?.context()
+    const tags = spanContext?.getTags() || {}
 
     const modelProvider = tags['langchain.request.provider'] // could be undefined
     const modelName = tags['langchain.request.model'] // could be undefined
@@ -76,7 +77,7 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
       return
     }
 
-    const provider = span?.context()._tags['langchain.request.provider']
+    const provider = span?.context()?.getTag('langchain.request.provider')
     const integrationName = this.getIntegrationName(type, provider)
     this.setMetadata(span, provider)
 
@@ -93,14 +94,15 @@ class BaseLangChainLLMObsPlugin extends LLMObsPlugin {
     const metadata = {}
 
     // these fields won't be set for non model-based operations
+    const spanContext = span?.context()
     const temperature =
-      span?.context()._tags[`langchain.request.${provider}.parameters.temperature`] ||
-      span?.context()._tags[`langchain.request.${provider}.parameters.model_kwargs.temperature`]
+      spanContext?.getTag(`langchain.request.${provider}.parameters.temperature`) ||
+      spanContext?.getTag(`langchain.request.${provider}.parameters.model_kwargs.temperature`)
 
     const maxTokens =
-      span?.context()._tags[`langchain.request.${provider}.parameters.max_tokens`] ||
-      span?.context()._tags[`langchain.request.${provider}.parameters.maxTokens`] ||
-      span?.context()._tags[`langchain.request.${provider}.parameters.model_kwargs.max_tokens`]
+      spanContext?.getTag(`langchain.request.${provider}.parameters.max_tokens`) ||
+      spanContext?.getTag(`langchain.request.${provider}.parameters.maxTokens`) ||
+      spanContext?.getTag(`langchain.request.${provider}.parameters.model_kwargs.max_tokens`)
 
     if (temperature) {
       metadata.temperature = Number.parseFloat(temperature)

--- a/packages/dd-trace/src/llmobs/plugins/openai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/openai/index.js
@@ -63,7 +63,7 @@ class OpenAiLLMObsPlugin extends LLMObsPlugin {
 
     const inputs = ctx.args[0] // completion, chat completion, and embeddings take one argument
     const response = ctx.result?.data // no result if error
-    const error = !!span.context()._tags.error
+    const error = !!span.context().getTag('error')
 
     const operation = getOperation(methodName)
 

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -107,7 +107,7 @@ class LLMObsSpanProcessor {
       // those cases avoids dd-go reparenting OTel children under a span that
       // has no corresponding LLMObs event.
       if (enqueued) {
-        span.context()._tags[LLMOBS_SUBMITTED_TAG_KEY] = '1'
+        span.context().setTag(LLMOBS_SUBMITTED_TAG_KEY, '1')
       }
     } catch (e) {
       // this should be a rare case
@@ -123,7 +123,7 @@ class LLMObsSpanProcessor {
   format (span) {
     let inputType, outputType
 
-    const spanTags = span.context()._tags
+    const spanTags = span.context().getTags()
     const mlObsTags = LLMObsTagger.tagMap.get(span)
 
     const spanKind = mlObsTags[SPAN_KIND]
@@ -318,7 +318,7 @@ class LLMObsSpanProcessor {
       language: 'javascript',
     }
 
-    const errType = span.context()._tags[ERROR_TYPE] || error?.name
+    const errType = span.context().getTag(ERROR_TYPE) || error?.name
     if (errType) tags.error_type = errType
 
     if (sessionId) tags.session_id = sessionId

--- a/packages/dd-trace/src/llmobs/telemetry.js
+++ b/packages/dd-trace/src/llmobs/telemetry.js
@@ -45,7 +45,7 @@ function incrementLLMObsSpanStartCount (tags, value = 1) {
 
 function incrementLLMObsSpanFinishedCount (span, value = 1) {
   const mlObsTags = LLMObsTagger.tagMap.get(span)
-  const spanTags = span.context()._tags
+  const spanTags = span.context().getTags()
 
   const isRootSpan = mlObsTags[PARENT_ID_KEY] === ROOT_PARENT_ID
   const hasSessionId = mlObsTags[SESSION_ID] != null

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -233,8 +233,8 @@ function getFunctionArguments (fn, args = []) {
 }
 
 function spanHasError (span) {
-  const tags = span.context()._tags
-  return !!(tags.error || tags['error.type'])
+  const spanContext = span.context()
+  return !!(spanContext.getTag('error') || spanContext.getTag('error.type'))
 }
 
 // LLM SDKs stream tool-call argument JSON across SSE chunks; a malformed

--- a/packages/dd-trace/src/opentelemetry/span-helpers.js
+++ b/packages/dd-trace/src/opentelemetry/span-helpers.js
@@ -231,7 +231,7 @@ function recordException (ddSpan, exception, timeInput) {
     [ERROR_TYPE]: exception.name,
     [ERROR_MESSAGE]: exception.message,
     [ERROR_STACK]: exception.stack,
-    [IGNORE_OTEL_ERROR]: ddSpan.context()._tags[IGNORE_OTEL_ERROR] ?? true,
+    [IGNORE_OTEL_ERROR]: ddSpan.context().getTag(IGNORE_OTEL_ERROR) ?? true,
   })
 
   const attributes = {}

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -104,7 +104,7 @@ class DatadogSpan {
 
     this._spanContext = this._createContext(parent, fields)
     this._spanContext._name = operationName
-    this._spanContext._tags = tags
+    Object.assign(this._spanContext.getTags(), tags)
     this._spanContext._hostname = hostname
 
     this._spanContext._trace.started.push(this)
@@ -146,7 +146,7 @@ class DatadogSpan {
 
   toString () {
     const spanContext = this.context()
-    const resourceName = spanContext._tags['resource.name'] || ''
+    const resourceName = spanContext.getTag('resource.name') || ''
     const resource = resourceName.length > 100
       ? `${resourceName.slice(0, 97)}...`
       : resourceName
@@ -154,7 +154,7 @@ class DatadogSpan {
       traceId: spanContext._traceId,
       spanId: spanContext._spanId,
       parentId: spanContext._parentId,
-      service: spanContext._tags['service.name'],
+      service: spanContext.getTag('service.name'),
       name: spanContext._name,
       resource,
     })
@@ -269,12 +269,12 @@ class DatadogSpan {
       return
     }
 
-    if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_STATE_TRACKING && !this._spanContext._tags['service.name']) {
+    if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_STATE_TRACKING && !this._spanContext.getTag('service.name')) {
       log.error('Finishing invalid span: %s', this)
     }
 
     getIntegrationCounter('spans_finished', this._integrationName).inc()
-    this._spanContext._tags['_dd.integration'] = this._integrationName
+    this._spanContext.setTag('_dd.integration', this._integrationName)
 
     if (this.#parentTracer._config.DD_TRACE_EXPERIMENTAL_SPAN_COUNTS && finishedRegistry) {
       runtimeMetrics.decrement('runtime.node.spans.unfinished')
@@ -408,7 +408,7 @@ class DatadogSpan {
   }
 
   _addTags (keyValuePairs) {
-    tagger.add(this._spanContext._tags, keyValuePairs)
+    tagger.add(this._spanContext.getTags(), keyValuePairs)
 
     this._prioritySampler.sample(this, false)
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -71,6 +71,61 @@ class DatadogSpanContext {
     const version = (this._traceparent && this._traceparent.version) || '00'
     return `${version}-${traceId}-${spanId}-${flags}`
   }
+
+  /**
+   * Set a tag value.
+   * @param {string} key - Tag key
+   * @param {unknown} value - Tag value
+   */
+  setTag (key, value) {
+    this._tags[key] = value
+  }
+
+  /**
+   * Get a tag value.
+   * @param {string} key - Tag key
+   * @returns {unknown} Tag value or undefined
+   */
+  getTag (key) {
+    return this._tags[key]
+  }
+
+  /**
+   * Check if a tag exists.
+   * @param {string} key - Tag key
+   * @returns {boolean}
+   */
+  hasTag (key) {
+    return Object.hasOwn(this._tags, key)
+  }
+
+  /**
+   * Delete a tag.
+   * @param {string} key - Tag key
+   */
+  deleteTag (key) {
+    delete this._tags[key]
+  }
+
+  /**
+   * Get the live internal tags map. The returned reference is mutable;
+   * callers may assign or delete keys directly (e.g.
+   * `Object.assign(getTags(), tags)` in span.js). Subclasses may have
+   * additional sync side effects on the individual `setTag` / `deleteTag`
+   * setters; mutating the returned map bypasses those.
+   *
+   * @returns {object}
+   */
+  getTags () {
+    return this._tags
+  }
+
+  /**
+   * Clear all tags.
+   */
+  clearTags () {
+    this._tags = Object.create(null)
+  }
 }
 
 module.exports = DatadogSpanContext

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -95,17 +95,13 @@ class DatadogSpanContext {
    * @param {string} key - Tag key
    * @returns {boolean}
    */
-  hasTag (key) {
-    return Object.hasOwn(this._tags, key)
-  }
+  hasTag (key) { return Object.hasOwn(this._tags, key) }
 
   /**
    * Delete a tag.
    * @param {string} key - Tag key
    */
-  deleteTag (key) {
-    delete this._tags[key]
-  }
+  deleteTag (key) { delete this._tags[key] }
 
   /**
    * Get the live internal tags map. The returned reference is mutable;
@@ -123,9 +119,7 @@ class DatadogSpanContext {
   /**
    * Clear all tags.
    */
-  clearTags () {
-    this._tags = Object.create(null)
-  }
+  clearTags () { this._tags = Object.create(null) }
 }
 
 module.exports = DatadogSpanContext

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -128,7 +128,7 @@ function getTestSuiteLevelVisibilityTags (testSuiteSpan, testFramework) {
   const suiteTags = {
     [TEST_SUITE_ID]: testSuiteSpanContext.toSpanId(),
     [TEST_SESSION_ID]: testSuiteSpanContext.toTraceId(),
-    [TEST_COMMAND]: testSuiteSpanContext._tags[TEST_COMMAND],
+    [TEST_COMMAND]: testSuiteSpanContext.getTag(TEST_COMMAND),
     [TEST_MODULE]: testFramework,
   }
 
@@ -255,7 +255,7 @@ module.exports = class CiPlugin extends Plugin {
     })
 
     this.addSub(`ci:${this.constructor.id}:itr:skipped-suites`, ({ skippedSuites, frameworkVersion }) => {
-      const testCommand = this.testSessionSpan.context()._tags[TEST_COMMAND]
+      const testCommand = this.testSessionSpan.context().getTag(TEST_COMMAND)
       for (const testSuite of skippedSuites) {
         const testSuiteMetadata = {
           ...getTestSuiteCommonTags(testCommand, frameworkVersion, testSuite, this.constructor.id),
@@ -615,7 +615,7 @@ module.exports = class CiPlugin extends Plugin {
       const suiteTags = {
         [TEST_SUITE_ID]: testSuiteSpan.context().toSpanId(),
         [TEST_SESSION_ID]: testSuiteSpan.context().toTraceId(),
-        [TEST_COMMAND]: testSuiteSpan.context()._tags[TEST_COMMAND],
+        [TEST_COMMAND]: testSuiteSpan.context().getTag(TEST_COMMAND),
         [TEST_MODULE]: this.constructor.id,
         ...getSessionRequestErrorTags(this.testSessionSpan),
       }
@@ -808,18 +808,18 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   getTestTelemetryTags (testSpan) {
-    const activeSpanTags = testSpan.context()._tags
+    const spanContext = testSpan.context()
     return {
-      hasCodeOwners: !!activeSpanTags[TEST_CODE_OWNERS] || undefined,
-      isNew: activeSpanTags[TEST_IS_NEW] === 'true' || undefined,
-      isRum: activeSpanTags[TEST_IS_RUM_ACTIVE] === 'true' || undefined,
-      browserDriver: activeSpanTags[TEST_BROWSER_DRIVER],
-      isQuarantined: activeSpanTags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true' || undefined,
-      isDisabled: activeSpanTags[TEST_MANAGEMENT_IS_DISABLED] === 'true' || undefined,
-      isModified: activeSpanTags[TEST_IS_MODIFIED] === 'true' || undefined,
-      isRetry: activeSpanTags[TEST_IS_RETRY] === 'true' || undefined,
-      retryReason: activeSpanTags[TEST_RETRY_REASON],
-      isFailedTestReplayEnabled: activeSpanTags[DI_ERROR_DEBUG_INFO_CAPTURED] === 'true' || undefined,
+      hasCodeOwners: !!spanContext.getTag(TEST_CODE_OWNERS) || undefined,
+      isNew: spanContext.getTag(TEST_IS_NEW) === 'true' || undefined,
+      isRum: spanContext.getTag(TEST_IS_RUM_ACTIVE) === 'true' || undefined,
+      browserDriver: spanContext.getTag(TEST_BROWSER_DRIVER),
+      isQuarantined: spanContext.getTag(TEST_MANAGEMENT_IS_QUARANTINED) === 'true' || undefined,
+      isDisabled: spanContext.getTag(TEST_MANAGEMENT_IS_DISABLED) === 'true' || undefined,
+      isModified: spanContext.getTag(TEST_IS_MODIFIED) === 'true' || undefined,
+      isRetry: spanContext.getTag(TEST_IS_RETRY) === 'true' || undefined,
+      retryReason: spanContext.getTag(TEST_RETRY_REASON),
+      isFailedTestReplayEnabled: spanContext.getTag(DI_ERROR_DEBUG_INFO_CAPTURED) === 'true' || undefined,
     }
   }
 }

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -808,18 +808,18 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   getTestTelemetryTags (testSpan) {
-    const spanContext = testSpan.context()
+    const activeSpanTags = testSpan.context().getTags()
     return {
-      hasCodeOwners: !!spanContext.getTag(TEST_CODE_OWNERS) || undefined,
-      isNew: spanContext.getTag(TEST_IS_NEW) === 'true' || undefined,
-      isRum: spanContext.getTag(TEST_IS_RUM_ACTIVE) === 'true' || undefined,
-      browserDriver: spanContext.getTag(TEST_BROWSER_DRIVER),
-      isQuarantined: spanContext.getTag(TEST_MANAGEMENT_IS_QUARANTINED) === 'true' || undefined,
-      isDisabled: spanContext.getTag(TEST_MANAGEMENT_IS_DISABLED) === 'true' || undefined,
-      isModified: spanContext.getTag(TEST_IS_MODIFIED) === 'true' || undefined,
-      isRetry: spanContext.getTag(TEST_IS_RETRY) === 'true' || undefined,
-      retryReason: spanContext.getTag(TEST_RETRY_REASON),
-      isFailedTestReplayEnabled: spanContext.getTag(DI_ERROR_DEBUG_INFO_CAPTURED) === 'true' || undefined,
+      hasCodeOwners: !!activeSpanTags[TEST_CODE_OWNERS] || undefined,
+      isNew: activeSpanTags[TEST_IS_NEW] === 'true' || undefined,
+      isRum: activeSpanTags[TEST_IS_RUM_ACTIVE] === 'true' || undefined,
+      browserDriver: activeSpanTags[TEST_BROWSER_DRIVER],
+      isQuarantined: activeSpanTags[TEST_MANAGEMENT_IS_QUARANTINED] === 'true' || undefined,
+      isDisabled: activeSpanTags[TEST_MANAGEMENT_IS_DISABLED] === 'true' || undefined,
+      isModified: activeSpanTags[TEST_IS_MODIFIED] === 'true' || undefined,
+      isRetry: activeSpanTags[TEST_IS_RETRY] === 'true' || undefined,
+      retryReason: activeSpanTags[TEST_RETRY_REASON],
+      isFailedTestReplayEnabled: activeSpanTags[DI_ERROR_DEBUG_INFO_CAPTURED] === 'true' || undefined,
     }
   }
 }

--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -49,7 +49,7 @@ class DatabasePlugin extends StoragePlugin {
    * @returns {string}
    */
   #createDBMPropagationCommentService (serviceName, span, peerData) {
-    const spanTags = span.context()._tags
+    const spanTags = span.context().getTags()
     const dddb = spanTags['db.name']
     const ddh = spanTags['out.host']
     const cacheKey = `${dddb ?? ''}\0${ddh ?? ''}\0${serviceName ?? ''}`
@@ -91,7 +91,7 @@ class DatabasePlugin extends StoragePlugin {
       return null
     }
 
-    const peerData = this.getPeerService(span.context()._tags)
+    const peerData = this.getPeerService(span.context().getTags())
     const dbmService = this.#getDbmServiceName(serviceName, peerData)
     const servicePropagation = this.#createDBMPropagationCommentService(dbmService, span, peerData)
 

--- a/packages/dd-trace/src/plugins/outbound.js
+++ b/packages/dd-trace/src/plugins/outbound.js
@@ -125,7 +125,7 @@ class OutboundPlugin extends TracingPlugin {
    */
   tagPeerService (span) {
     if (this._tracerConfig.spanComputePeerService) {
-      const peerData = this.getPeerService(span.context()._tags)
+      const peerData = this.getPeerService(span.context().getTags())
       if (peerData !== undefined) {
         span.addTags(this.getPeerServiceRemap(peerData))
       }

--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -152,7 +152,7 @@ module.exports = class Plugin {
     if (!store || !store.span) return
 
     const span = /** @type {import('../opentracing/span')} */ (store.span)
-    if (!span._spanContext._tags.error) {
+    if (!span.context().getTag('error')) {
       span.setTag('error', error || 1)
     }
   }

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -133,7 +133,7 @@ class TracingPlugin extends Plugin {
    * @param {import('../../../..').Span} [span]
    */
   addError (error, span = this.activeSpan) {
-    if (span && !span._spanContext._tags.error) {
+    if (span && !span.context().getTag('error')) {
       // Errors may be wrapped in a context.
       span.setTag('error', error?.error || error || 1)
     }

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -229,11 +229,11 @@ const BASE_LIKE_BRANCH_FILTER = /^(main|master|preprod|prod|dev|development|trun
 
 /**
  * Returns request error tags from a test session span for propagation to child events.
- * @param {{ context: () => { _tags?: Record<string, string> } } | undefined} sessionSpan
+ * @param {{ context: () => { getTag?: (key: string) => string } } | undefined} sessionSpan
  * @returns {Record<string, string>}
  */
 function getSessionRequestErrorTags (sessionSpan) {
-  const tags = sessionSpan?.context()._tags
+  const tags = sessionSpan?.context()?.getTags?.()
   const sessionRequestErrorTags = {}
   if (!tags || typeof tags !== 'object') return {}
   if (tags[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS] === 'true') {
@@ -253,11 +253,11 @@ function getSessionRequestErrorTags (sessionSpan) {
 
 /**
  * Returns ITR skipping-enabled tags from a test session span for propagation to child events.
- * @param {{ context: () => { _tags?: Record<string, string> } } | undefined} sessionSpan
+ * @param {{ context: () => { getTags?: () => Record<string, string> } } | undefined} sessionSpan
  * @returns {Record<string, string>}
  */
 function getSessionItrSkippingEnabledTags (sessionSpan) {
-  const tags = sessionSpan?.context()._tags
+  const tags = sessionSpan?.context()?.getTags?.()
   if (!tags || typeof tags !== 'object') return {}
   if (tags[TEST_ITR_SKIPPING_ENABLED] !== undefined) {
     return {

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -87,7 +87,7 @@ const web = {
     if (!span) return
 
     span.context()._name = `${name}.request`
-    span.context()._tags.component = name
+    span.context().setTag('component', name)
     span._integrationName = name
 
     web.setConfig(req, config)
@@ -225,9 +225,11 @@ const web = {
     const context = contexts.get(req)
     const { span, inferredProxySpan, error } = context
 
-    const spanHasExistingError = span.context()._tags.error || span.context()._tags[ERROR_MESSAGE]
+    const spanContext = span.context()
+    const spanHasExistingError = spanContext.getTag('error') || spanContext.getTag(ERROR_MESSAGE)
     const inferredSpanContext = inferredProxySpan?.context()
-    const inferredSpanHasExistingError = inferredSpanContext?._tags.error || inferredSpanContext?._tags[ERROR_MESSAGE]
+    const inferredSpanHasExistingError = inferredSpanContext?.getTag('error') ||
+      inferredSpanContext?.getTag(ERROR_MESSAGE)
 
     const isValidStatusCode = context.config.validateStatus(statusCode)
 
@@ -391,7 +393,7 @@ function addRequestTags (context, spanType) {
   })
 
   // if client ip has already been set by appsec, no need to run it again
-  if (extractIp && !span.context()._tags.hasOwnProperty(HTTP_CLIENT_IP)) {
+  if (extractIp && !span.context().hasTag(HTTP_CLIENT_IP)) {
     const clientIp = extractIp(config, req)
 
     if (clientIp) {
@@ -432,7 +434,7 @@ function addResponseTags (context) {
 function applyRouteOrEndpointTag (context) {
   const { paths, span, config } = context
   if (!span) return
-  const tags = span.context()._tags
+  const spanContext = span.context()
   const route = paths.join('')
 
   if (route) {
@@ -441,23 +443,23 @@ function applyRouteOrEndpointTag (context) {
     return
   }
 
-  if (!config.resourceRenamingEnabled || tags[HTTP_ENDPOINT]) {
+  if (!config.resourceRenamingEnabled || spanContext.getTag(HTTP_ENDPOINT)) {
     return
   }
 
   // Route is unavailable, compute http.endpoint once.
-  const url = tags[HTTP_URL]
+  const url = spanContext.getTag(HTTP_URL)
   const endpoint = url ? calculateHttpEndpoint(url) : '/'
   span.setTag(HTTP_ENDPOINT, endpoint)
 }
 
 function addResourceTag (context) {
   const { req, span } = context
-  const tags = span.context()._tags
+  const spanContext = span.context()
 
-  if (tags[RESOURCE_NAME]) return
+  if (spanContext.getTag(RESOURCE_NAME)) return
 
-  const resource = [req.method, tags[HTTP_ROUTE]]
+  const resource = [req.method, spanContext.getTag(HTTP_ROUTE)]
     .filter(Boolean)
     .join(' ')
 

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -125,7 +125,7 @@ class PrioritySampler {
 
     log.trace(span, auto)
 
-    const tag = this._getPriorityFromTags(context._tags, context)
+    const tag = this._getPriorityFromTags(context.getTags(), context)
 
     if (this.validate(tag)) {
       context._sampling.priority = tag
@@ -300,7 +300,7 @@ class PrioritySampler {
    * @returns {SamplingPriority}
    */
   #getPriorityByAgent (context) {
-    const key = `service:${context._tags[SERVICE_NAME]},env:${this._env}`
+    const key = `service:${context.getTag(SERVICE_NAME)},env:${this._env}`
     // TODO: Change underscored properties to private ones.
     const sampler = this._samplers[key] || this._samplers[DEFAULT_KEY]
 

--- a/packages/dd-trace/src/profiling/profiler.js
+++ b/packages/dd-trace/src/profiling/profiler.js
@@ -17,7 +17,7 @@ function findWebSpan (startedSpans, spanId) {
     const ispan = startedSpans[i]
     const context = ispan.context()
     if (context._spanId === spanId) {
-      if (isWebServerSpan(context._tags)) {
+      if (isWebServerSpan(context.getTags())) {
         return true
       }
       spanId = context._parentId
@@ -268,7 +268,7 @@ class Profiler extends EventEmitter {
 
   #onSpanFinish (span) {
     const context = span.context()
-    const tags = context._tags
+    const tags = context.getTags()
     if (!isWebServerSpan(tags)) return
 
     const endpointName = endpointNameFromTags(tags)

--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -294,7 +294,7 @@ class NativeWallProfiler {
 
       let webTags
       if (this.#endpointCollectionEnabled) {
-        const tags = context._tags
+        const tags = context.getTags()
         if (isWebServerSpan(tags)) {
           webTags = tags
         } else {
@@ -333,7 +333,7 @@ class NativeWallProfiler {
     if (!this.#started) return
     const profilingContext = span[ProfilingContext]
     if (profilingContext === undefined || profilingContext.webTags !== undefined) return
-    const tags = span.context()._tags
+    const tags = span.context().getTags()
     if (isWebServerSpan(tags)) {
       profilingContext.webTags = tags
     }

--- a/packages/dd-trace/src/sampling_rule.js
+++ b/packages/dd-trace/src/sampling_rule.js
@@ -109,7 +109,7 @@ function matcher (pattern, locator) {
  * @returns {Locator}
  */
 function makeTagLocator (tag) {
-  return (span) => span.context()._tags[tag]
+  return (span) => span.context().getTag(tag)
 }
 
 /**
@@ -129,9 +129,9 @@ function nameLocator (span) {
  * @returns {string|undefined}
  */
 function serviceLocator (span) {
-  const { _tags: tags } = span.context()
-  return tags.service ||
-    tags['service.name'] ||
+  const context = span.context()
+  return context.getTag('service') ||
+    context.getTag('service.name') ||
     span.tracer()._service
 }
 
@@ -142,9 +142,9 @@ function serviceLocator (span) {
  * @returns {string|undefined}
  */
 function resourceLocator (span) {
-  const { _tags: tags } = span.context()
-  return tags.resource ||
-    tags['resource.name']
+  const context = span.context()
+  return context.getTag('resource') ||
+    context.getTag('resource.name')
 }
 
 /**

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -144,7 +144,7 @@ function extractTags (formattedSpan, span) {
   const origin = context._trace.origin
   // TODO(BridgeAR)[31.03.2025]: Look into changing the way we store tags. Using
   // a map is likely faster short term.
-  const tags = context._tags
+  const tags = context.getTags()
   const hostname = context._hostname
   const priority = context._sampling.priority
 

--- a/packages/dd-trace/src/spanleak.js
+++ b/packages/dd-trace/src/spanleak.js
@@ -66,7 +66,7 @@ module.exports.startScrubber = function () {
       if (!gc) continue // everything after this point is related to manual GC
 
       // TODO: what else can we do to alleviate memory usage
-      span.context()._tags = Object.create(null)
+      span.context().clearTags()
     }
 
     console.log('expired spans:' +

--- a/packages/dd-trace/src/standalone/index.js
+++ b/packages/dd-trace/src/standalone/index.js
@@ -29,12 +29,12 @@ function configure (config) {
 }
 
 function onSpanStart ({ span, fields }) {
-  const tags = span.context?.()?._tags
-  if (!tags) return
+  const context = span.context?.()
+  if (!context) return
 
   const { parent } = fields
   if (!parent || parent._isRemote) {
-    tags[APM_TRACING_ENABLED_KEY] = 0
+    context.setTag(APM_TRACING_ENABLED_KEY, 0)
   }
 }
 

--- a/packages/dd-trace/test/appsec/api_security_sampler.spec.js
+++ b/packages/dd-trace/test/appsec/api_security_sampler.spec.js
@@ -248,13 +248,21 @@ describe('API Security Sampler', () => {
       apiSecuritySampler.configure({ appsec: { apiSecurity: { enabled: true, sampleDelay: 30 } } })
     })
 
-    it('should use http.endpoint when http.route is not available', () => {
-      const spanWithEndpoint = {
+    function makeSpan (tags) {
+      return {
         context: sinon.stub().returns({
           _sampling: { priority: AUTO_KEEP },
-          _tags: { 'http.endpoint': '/api/users' },
+          _tags: tags,
+          getTag: (key) => tags[key],
+          getTags: () => tags,
+          setTag: (key, value) => { tags[key] = value },
+          hasTag: (key) => key in tags,
         }),
       }
+    }
+
+    it('should use http.endpoint when http.route is not available', () => {
+      const spanWithEndpoint = makeSpan({ 'http.endpoint': '/api/users' })
       webStub.root.returns(spanWithEndpoint)
       webStub.getContext.returns({ paths: [], span: spanWithEndpoint })
 
@@ -264,12 +272,7 @@ describe('API Security Sampler', () => {
 
     it('should not use http.endpoint for 404 status codes', () => {
       const res404 = { statusCode: 404 }
-      const spanWithEndpoint = {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: { 'http.endpoint': '/api/users' },
-        }),
-      }
+      const spanWithEndpoint = makeSpan({ 'http.endpoint': '/api/users' })
       webStub.root.returns(spanWithEndpoint)
       webStub.getContext.returns({ paths: [], span: spanWithEndpoint })
 
@@ -278,12 +281,7 @@ describe('API Security Sampler', () => {
     })
 
     it('should prefer http.route over http.endpoint when both are available', () => {
-      const spanWithBoth = {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: { 'http.endpoint': '/api/users' },
-        }),
-      }
+      const spanWithBoth = makeSpan({ 'http.endpoint': '/api/users' })
       webStub.root.returns(spanWithBoth)
       webStub.getContext.returns({ paths: ['/users/:id'], span: spanWithBoth })
 
@@ -292,12 +290,7 @@ describe('API Security Sampler', () => {
     })
 
     it('should handle missing http.endpoint gracefully', () => {
-      const spanWithoutEndpoint = {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: {},
-        }),
-      }
+      const spanWithoutEndpoint = makeSpan({})
       webStub.root.returns(spanWithoutEndpoint)
       webStub.getContext.returns({ paths: [], span: spanWithoutEndpoint })
 
@@ -313,18 +306,8 @@ describe('API Security Sampler', () => {
     })
 
     it('should sample different endpoints separately', () => {
-      const span1 = {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: { 'http.endpoint': '/api/users' },
-        }),
-      }
-      const span2 = {
-        context: sinon.stub().returns({
-          _sampling: { priority: AUTO_KEEP },
-          _tags: { 'http.endpoint': '/api/products' },
-        }),
-      }
+      const span1 = makeSpan({ 'http.endpoint': '/api/users' })
+      const span2 = makeSpan({ 'http.endpoint': '/api/products' })
 
       webStub.root.returns(span1)
       webStub.getContext.returns({ paths: [], span: span1 })

--- a/packages/dd-trace/test/appsec/index.spec.js
+++ b/packages/dd-trace/test/appsec/index.spec.js
@@ -946,10 +946,17 @@ describe('AppSec Index', function () {
     beforeEach(() => {
       sinon.stub(waf, 'run')
 
+      const rootSpanTags = {}
       rootSpan = {
         setTag: sinon.stub(),
-        _tags: {},
-        context: () => ({ _tags: rootSpan._tags }),
+        _tags: rootSpanTags,
+        context: () => ({
+          _tags: rootSpanTags,
+          getTags () { return rootSpanTags },
+          getTag (key) { return rootSpanTags[key] },
+          setTag (key, value) { rootSpanTags[key] = value },
+          hasTag (key) { return key in rootSpanTags },
+        }),
       }
       web.root.returns(rootSpan)
 

--- a/packages/dd-trace/test/appsec/reporter.spec.js
+++ b/packages/dd-trace/test/appsec/reporter.spec.js
@@ -42,11 +42,17 @@ describe('reporter', () => {
       setPriority: sinon.stub(),
     }
 
+    const spanTags = {}
+    const spanContext = {
+      _tags: spanTags,
+      getTags () { return this._tags },
+      getTag (key) { return this._tags[key] },
+      setTag (key, value) { this._tags[key] = value },
+      hasTag (key) { return key in this._tags },
+    }
     span = {
       _prioritySampler: prioritySampler,
-      context: sinon.stub().returns({
-        _tags: {},
-      }),
+      context: sinon.stub().returns(spanContext),
       addTags: sinon.stub(),
       setTag: sinon.stub(),
       keep: sinon.stub(),

--- a/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
+++ b/packages/dd-trace/test/appsec/sdk/user_blocking.spec.js
@@ -35,9 +35,16 @@ describe('user_blocking - Internal API', () => {
   })
 
   beforeEach(() => {
+    const tags = {}
     rootSpan = {
       context: () => {
-        return { _tags: {} }
+        return {
+          _tags: tags,
+          getTag: (key) => tags[key],
+          getTags: () => tags,
+          setTag: (key, value) => { tags[key] = value },
+          hasTag: (key) => key in tags,
+        }
       },
       setTag: sinon.stub(),
     }
@@ -85,8 +92,15 @@ describe('user_blocking - Internal API', () => {
     })
 
     it('should not override user when already set', () => {
+      const tags = { 'usr.id': 'mockUser' }
       rootSpan.context = () => {
-        return { _tags: { 'usr.id': 'mockUser' } }
+        return {
+          _tags: tags,
+          getTag: (key) => tags[key],
+          getTags: () => tags,
+          setTag: (key, value) => { tags[key] = value },
+          hasTag: (key) => key in tags,
+        }
       }
 
       const ret = userBlocking.checkUserAndSetUser(tracer, { id: 'user' })

--- a/packages/dd-trace/test/appsec/user_tracking.spec.js
+++ b/packages/dd-trace/test/appsec/user_tracking.spec.js
@@ -28,7 +28,13 @@ describe('User Tracking', () => {
     currentTags = {}
 
     rootSpan = {
-      context: () => ({ _tags: currentTags }),
+      context: () => ({
+        _tags: currentTags,
+        getTag: (key) => currentTags[key],
+        getTags: () => currentTags,
+        setTag: (key, value) => { currentTags[key] = value },
+        hasTag: (key) => key in currentTags,
+      }),
       addTags: sinon.stub(),
       setTag: sinon.stub(),
     }

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -313,11 +313,11 @@ describe('sdk', () => {
           tracer.trace('apmRootSpan', apmRootSpan => {
             apmTraceId = apmRootSpan.context().toTraceId(true)
             llmobs.trace('workflow', llmobsSpan1 => {
-              traceId1 = llmobsSpan1.context()._tags['_ml_obs.trace_id']
+              traceId1 = llmobsSpan1.context().getTag('_ml_obs.trace_id')
             })
 
             llmobs.trace('workflow', llmobsSpan2 => {
-              traceId2 = llmobsSpan2.context()._tags['_ml_obs.trace_id']
+              traceId2 = llmobsSpan2.context().getTag('_ml_obs.trace_id')
             })
           })
 
@@ -724,7 +724,7 @@ describe('sdk', () => {
           const fn = llmobs.wrap('workflow', { name: 'test' }, () => {
             const span = llmobs._active()
 
-            const traceId = span.context()._tags['_ml_obs.trace_id']
+            const traceId = span.context().getTag('_ml_obs.trace_id')
             assert.ok(traceId)
             assert.notStrictEqual(traceId, span.context().toTraceId(true))
           })

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -56,6 +56,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' }, // should not use this
             toSpanId () { return '456' },
           }
@@ -130,6 +133,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -160,6 +166,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -195,6 +204,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -229,6 +241,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -254,6 +269,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -286,6 +304,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -313,6 +334,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -340,6 +364,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -366,6 +393,9 @@ describe('span processor', () => {
               'error.type': 'error type',
               'error.stack': 'error stack',
             },
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -397,6 +427,9 @@ describe('span processor', () => {
             _tags: {
               error: new Error('error message'),
             },
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -424,6 +457,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -446,6 +482,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -469,6 +508,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -492,6 +534,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: apmTags,
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -514,6 +559,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: apmTags,
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -533,6 +581,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: apmTags,
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -558,6 +609,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: apmTags,
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -581,6 +635,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: apmTags,
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }
@@ -604,6 +661,9 @@ describe('span processor', () => {
         context () {
           return {
             _tags: apmTags,
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
             toTraceId () { return '123' },
             toSpanId () { return '456' },
           }

--- a/packages/dd-trace/test/opentelemetry/context_manager.spec.js
+++ b/packages/dd-trace/test/opentelemetry/context_manager.spec.js
@@ -234,9 +234,9 @@ describe('OTel Context Manager', () => {
         assert.strictEqual(ddSpan._links.length, 1)
         assert.deepStrictEqual({
           tags: {
-            'my.otel.attr': ddSpan.context()._tags['my.otel.attr'],
-            'my.otel.attrs': ddSpan.context()._tags['my.otel.attrs'],
-            'error.message': ddSpan.context()._tags['error.message'],
+            'my.otel.attr': ddSpan.context().getTag('my.otel.attr'),
+            'my.otel.attrs': ddSpan.context().getTag('my.otel.attrs'),
+            'error.message': ddSpan.context().getTag('error.message'),
           },
           link: {
             traceId: ddSpan._links[0].context.toTraceId(true),
@@ -257,7 +257,7 @@ describe('OTel Context Manager', () => {
         })
 
         active.recordException(new Error('boom'))
-        assert.strictEqual(ddSpan.context()._tags['error.message'], 'boom')
+        assert.strictEqual(ddSpan.context().getTag('error.message'), 'boom')
       })
     })
 
@@ -382,7 +382,7 @@ describe('OTel Context Manager', () => {
 
         const ddContext = ddSpan.context()
         assert.strictEqual(ddContext._name, 'dd-active')
-        assert.strictEqual(ddContext._tags['resource.name'], 'renamed')
+        assert.strictEqual(ddContext.getTag('resource.name'), 'renamed')
       })
     })
 
@@ -394,7 +394,7 @@ describe('OTel Context Manager', () => {
           active.setStatus({ code: 2, message: 'late error' })
           active.setStatus({ code: 0, message: 'late unset' })
 
-          assert.ok(!('error.message' in ddSpan.context()._tags))
+          assert.ok(!ddSpan.context().hasTag('error.message'))
         })
       })
 
@@ -404,7 +404,7 @@ describe('OTel Context Manager', () => {
           active.setStatus({ code: 2, message: 'first error' })
           active.setStatus({ code: 2, message: 'second error' })
 
-          assert.strictEqual(ddSpan.context()._tags['error.message'], 'second error')
+          assert.strictEqual(ddSpan.context().getTag('error.message'), 'second error')
         })
       })
     })
@@ -425,7 +425,7 @@ describe('OTel Context Manager', () => {
         active.setStatus({ code: 2, message: 'after end' })
         active.updateName('after end')
 
-        const tags = ddSpan.context()._tags
+        const tags = ddSpan.context().getTags()
         assert.ok(!('after.end' in tags))
         assert.ok(!('after.end.batch' in tags))
         assert.ok(!('error.message' in tags))

--- a/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
@@ -45,7 +45,14 @@ function createMockDdSpan ({ ended = false } = {}) {
       events.push({ name, attributes, startTime })
     },
     setOperationName (name) { operationName = name },
-    context () { return { _tags: tags } },
+    context () {
+      return {
+        _tags: tags,
+        getTag: (key) => tags[key],
+        getTags: () => tags,
+        setTag: (key, value) => { tags[key] = value },
+      }
+    },
 
     // Read-only inspection handles for assertions.
     get tags () { return tags },

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -44,7 +44,7 @@ describe('OTel Span', () => {
     const span = makeSpan('name')
 
     const context = span._ddSpan.context()
-    assert.strictEqual(context._tags[SERVICE_NAME], tracer._tracer._service)
+    assert.strictEqual(context.getTag(SERVICE_NAME), tracer._tracer._service)
     assert.strictEqual(context._hostname, tracer._hostname)
   })
 
@@ -235,14 +235,14 @@ describe('OTel Span', () => {
     const span = makeSpan('name')
 
     const context = span._ddSpan.context()
-    assert.strictEqual(context._tags[RESOURCE_NAME], 'name')
+    assert.strictEqual(context.getTag(RESOURCE_NAME), 'name')
   })
 
   it('should copy span kind to span.kind', () => {
     const span = makeSpan('name', { kind: api.SpanKind.CONSUMER })
 
     const context = span._ddSpan.context()
-    assert.strictEqual(context._tags[SPAN_KIND], kinds.CONSUMER)
+    assert.strictEqual(context.getTag(SPAN_KIND), kinds.CONSUMER)
   })
 
   it('should expose span context', () => {
@@ -303,32 +303,32 @@ describe('OTel Span', () => {
   it('should set attributes', () => {
     const span = makeSpan('name')
 
-    const { _tags } = span._ddSpan.context()
+    const tags = span._ddSpan.context().getTags()
 
     span.setAttribute('foo', 'bar')
-    assert.strictEqual(_tags.foo, 'bar')
+    assert.strictEqual(tags.foo, 'bar')
 
     span.setAttributes({ baz: 'buz' })
-    assert.strictEqual(_tags.baz, 'buz')
+    assert.strictEqual(tags.baz, 'buz')
   })
 
   describe('should remap http.response.status_code', () => {
     it('should remap when setting attributes', () => {
       const span = makeSpan('name')
 
-      const { _tags } = span._ddSpan.context()
+      const tags = span._ddSpan.context().getTags()
 
       span.setAttributes({ 'http.response.status_code': 200 })
-      assert.strictEqual(_tags['http.status_code'], '200')
+      assert.strictEqual(tags['http.status_code'], '200')
     })
 
     it('should remap when setting singular attribute', () => {
       const span = makeSpan('name')
 
-      const { _tags } = span._ddSpan.context()
+      const tags = span._ddSpan.context().getTags()
 
       span.setAttribute('http.response.status_code', 200)
-      assert.strictEqual(_tags['http.status_code'], '200')
+      assert.strictEqual(tags['http.status_code'], '200')
     })
   })
 
@@ -413,19 +413,19 @@ describe('OTel Span', () => {
     const unset = makeSpan('name')
     const unsetCtx = unset._ddSpan.context()
     unset.setStatus({ code: 0, message: 'unset' })
-    assert.ok(!(ERROR_MESSAGE in unsetCtx._tags))
+    assert.ok(!unsetCtx.hasTag(ERROR_MESSAGE))
 
     const ok = makeSpan('name')
     const okCtx = ok._ddSpan.context()
     ok.setStatus({ code: 1, message: 'ok' })
-    assert.ok(!(ERROR_MESSAGE in okCtx._tags))
-    assert.ok(!(IGNORE_OTEL_ERROR in okCtx._tags))
+    assert.ok(!okCtx.hasTag(ERROR_MESSAGE))
+    assert.ok(!okCtx.hasTag(IGNORE_OTEL_ERROR))
 
     const error = makeSpan('name')
     const errorCtx = error._ddSpan.context()
     error.setStatus({ code: 2, message: 'error' })
-    assert.strictEqual(errorCtx._tags[ERROR_MESSAGE], 'error')
-    assert.strictEqual(errorCtx._tags[IGNORE_OTEL_ERROR], false)
+    assert.strictEqual(errorCtx.getTag(ERROR_MESSAGE), 'error')
+    assert.strictEqual(errorCtx.getTag(IGNORE_OTEL_ERROR), false)
   })
 
   it('should record exceptions', () => {
@@ -437,11 +437,11 @@ describe('OTel Span', () => {
     const datenow = Date.now()
     span.recordException(error, datenow)
 
-    const { _tags } = span._ddSpan.context()
-    assert.strictEqual(_tags[ERROR_TYPE], error.name)
-    assert.strictEqual(_tags[ERROR_MESSAGE], error.message)
-    assert.strictEqual(_tags[ERROR_STACK], error.stack)
-    assert.strictEqual(_tags[IGNORE_OTEL_ERROR], true)
+    const tags = span._ddSpan.context().getTags()
+    assert.strictEqual(tags[ERROR_TYPE], error.name)
+    assert.strictEqual(tags[ERROR_MESSAGE], error.message)
+    assert.strictEqual(tags[ERROR_STACK], error.stack)
+    assert.strictEqual(tags[IGNORE_OTEL_ERROR], true)
 
     const events = span._ddSpan._events
     assert.strictEqual(events.length, 1)
@@ -489,10 +489,10 @@ describe('OTel Span', () => {
     const error = new TestError()
     span.recordException(error)
 
-    const { _tags } = span._ddSpan.context()
-    assert.strictEqual(_tags[ERROR_TYPE], error.name)
-    assert.strictEqual(_tags[ERROR_MESSAGE], error.message)
-    assert.strictEqual(_tags[ERROR_STACK], error.stack)
+    const tags = span._ddSpan.context().getTags()
+    assert.strictEqual(tags[ERROR_TYPE], error.name)
+    assert.strictEqual(tags[ERROR_MESSAGE], error.message)
+    assert.strictEqual(tags[ERROR_STACK], error.stack)
 
     const events = span._ddSpan._events
     assert.strictEqual(events.length, 1)
@@ -511,44 +511,44 @@ describe('OTel Span', () => {
     const span = makeSpan('name')
     span.end()
 
-    const { _tags } = span._ddSpan.context()
+    const tags = span._ddSpan.context().getTags()
 
     span.setStatus({ code: 2, message: 'error' })
     assert.ok(
-      !(ERROR_MESSAGE in _tags) || _tags[ERROR_MESSAGE] !== 'error',
-      `Got ${ERROR_MESSAGE}: ${inspect(_tags[ERROR_MESSAGE])}`
+      !(ERROR_MESSAGE in tags) || tags[ERROR_MESSAGE] !== 'error',
+      `Got ${ERROR_MESSAGE}: ${inspect(tags[ERROR_MESSAGE])}`
     )
   })
 
   describe('setStatus precedence (OTel spec)', () => {
     it('OK locks the status against subsequent ERROR and UNSET writes', () => {
       const span = makeSpan('name')
-      const { _tags } = span._ddSpan.context()
+      const tags = span._ddSpan.context().getTags()
 
       span.setStatus({ code: 1 })
       span.setStatus({ code: 2, message: 'late error' })
       span.setStatus({ code: 0, message: 'late unset' })
 
-      assert.ok(!(ERROR_MESSAGE in _tags))
+      assert.ok(!(ERROR_MESSAGE in tags))
     })
 
     it('ERROR can be overridden by a later ERROR with a fresh message', () => {
       const span = makeSpan('name')
-      const { _tags } = span._ddSpan.context()
+      const tags = span._ddSpan.context().getTags()
 
       span.setStatus({ code: 2, message: 'first error' })
       span.setStatus({ code: 2, message: 'second error' })
 
-      assert.strictEqual(_tags[ERROR_MESSAGE], 'second error')
+      assert.strictEqual(tags[ERROR_MESSAGE], 'second error')
     })
 
     it('UNSET is always a no-op even before any successful write', () => {
       const span = makeSpan('name')
-      const { _tags } = span._ddSpan.context()
+      const tags = span._ddSpan.context().getTags()
 
       span.setStatus({ code: 0, message: 'ignored' })
 
-      assert.ok(!(ERROR_MESSAGE in _tags))
+      assert.ok(!(ERROR_MESSAGE in tags))
     })
   })
 
@@ -565,11 +565,11 @@ describe('OTel Span', () => {
     span.recordException(new Error('after end'))
     span.updateName('after end')
 
-    const { _tags } = span._ddSpan.context()
-    assert.ok(!('after.end' in _tags))
-    assert.ok(!('after.end.batch' in _tags))
-    assert.ok(!(ERROR_MESSAGE in _tags))
-    assert.ok(!(ERROR_TYPE in _tags))
+    const tags = span._ddSpan.context().getTags()
+    assert.ok(!('after.end' in tags))
+    assert.ok(!('after.end.batch' in tags))
+    assert.ok(!(ERROR_MESSAGE in tags))
+    assert.ok(!(ERROR_TYPE in tags))
     assert.strictEqual(span._ddSpan._links.length, 0)
     assert.strictEqual(span._ddSpan._events.length, 0)
   })

--- a/packages/dd-trace/test/opentelemetry/tracer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer.spec.js
@@ -71,7 +71,7 @@ describe('OTel Tracer', () => {
     })
 
     const ddSpanContext = span._ddSpan.context()
-    assert.strictEqual(ddSpanContext._tags.foo, 'bar')
+    assert.strictEqual(ddSpanContext.getTag('foo'), 'bar')
   })
 
   it('returns a non-recording span when the inner tracer is the noop', () => {

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -455,51 +455,6 @@ describe('Span', () => {
     })
   })
 
-  describe('fields.tags merge', () => {
-    it('should merge fields.tags into the existing context tags object', () => {
-      // Constructor uses Object.assign(getTags(), tags) (not getTags() = tags),
-      // so tags carried by an inherited context survive alongside the new
-      // fields.tags. Pin this so a future refactor doesn't silently swap
-      // back to the replace-the-object form.
-      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
-      parent.context().getTags()['inherited.key'] = 'inherited-value'
-
-      const child = new Span(tracer, processor, prioritySampler, {
-        operationName: 'child',
-        context: parent.context(),
-        tags: { 'new.key': 'new-value' },
-      })
-
-      assert.strictEqual(child.context().getTags()['inherited.key'], 'inherited-value')
-      assert.strictEqual(child.context().getTags()['new.key'], 'new-value')
-    })
-
-    it('fields.tags overwrites colliding inherited keys (Object.assign semantics)', () => {
-      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
-      parent.context().getTags().shared = 'inherited'
-
-      const child = new Span(tracer, processor, prioritySampler, {
-        operationName: 'child',
-        context: parent.context(),
-        tags: { shared: 'overridden' },
-      })
-
-      assert.strictEqual(child.context().getTags().shared, 'overridden')
-    })
-
-    it('skips the merge when fields.tags is undefined', () => {
-      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
-      parent.context().getTags().inherited = 'value'
-
-      const child = new Span(tracer, processor, prioritySampler, {
-        operationName: 'child',
-        context: parent.context(),
-      })
-
-      assert.strictEqual(child.context().getTags().inherited, 'value')
-    })
-  })
-
   describe('addTags', () => {
     beforeEach(() => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
@@ -579,21 +534,13 @@ describe('Span', () => {
       })
 
       it('should not propagate baggage items when Trace_Propagation_Behavior_Extract is set to ignore', () => {
-        tracer = {
-          _config: {
-            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore',
-          },
-        }
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore' } }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, {})
       })
 
       it('should propagate baggage items when Trace_Propagation_Behavior_Extract is set to restart', () => {
-        tracer = {
-          _config: {
-            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart',
-          },
-        }
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar' })
       })

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -451,7 +451,52 @@ describe('Span', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span.setTag('foo', 'bar')
 
-      sinon.assert.calledWith(tagger.add, span.context()._tags, { foo: 'bar' })
+      sinon.assert.calledWith(tagger.add, span.context().getTags(), { foo: 'bar' })
+    })
+  })
+
+  describe('fields.tags merge', () => {
+    it('should merge fields.tags into the existing context tags object', () => {
+      // Constructor uses Object.assign(getTags(), tags) (not getTags() = tags),
+      // so tags carried by an inherited context survive alongside the new
+      // fields.tags. Pin this so a future refactor doesn't silently swap
+      // back to the replace-the-object form.
+      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+      parent.context().getTags()['inherited.key'] = 'inherited-value'
+
+      const child = new Span(tracer, processor, prioritySampler, {
+        operationName: 'child',
+        context: parent.context(),
+        tags: { 'new.key': 'new-value' },
+      })
+
+      assert.strictEqual(child.context().getTags()['inherited.key'], 'inherited-value')
+      assert.strictEqual(child.context().getTags()['new.key'], 'new-value')
+    })
+
+    it('fields.tags overwrites colliding inherited keys (Object.assign semantics)', () => {
+      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+      parent.context().getTags().shared = 'inherited'
+
+      const child = new Span(tracer, processor, prioritySampler, {
+        operationName: 'child',
+        context: parent.context(),
+        tags: { shared: 'overridden' },
+      })
+
+      assert.strictEqual(child.context().getTags().shared, 'overridden')
+    })
+
+    it('skips the merge when fields.tags is undefined', () => {
+      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+      parent.context().getTags().inherited = 'value'
+
+      const child = new Span(tracer, processor, prioritySampler, {
+        operationName: 'child',
+        context: parent.context(),
+      })
+
+      assert.strictEqual(child.context().getTags().inherited, 'value')
     })
   })
 
@@ -465,7 +510,7 @@ describe('Span', () => {
 
       span.addTags(tags)
 
-      sinon.assert.calledWith(tagger.add, span.context()._tags, tags)
+      sinon.assert.calledWith(tagger.add, span.context().getTags(), tags)
     })
 
     it('should sample based on the tags', () => {
@@ -512,7 +557,7 @@ describe('Span', () => {
       span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
       span.finish()
 
-      assertObjectContains(span._spanContext._tags, { '_dd.integration': 'opentracing' })
+      assertObjectContains(span._spanContext.getTags(), { '_dd.integration': 'opentracing' })
     })
 
     describe('tracePropagationBehaviorExtract and Baggage', () => {
@@ -534,13 +579,21 @@ describe('Span', () => {
       })
 
       it('should not propagate baggage items when Trace_Propagation_Behavior_Extract is set to ignore', () => {
-        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore' } }
+        tracer = {
+          _config: {
+            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'ignore',
+          },
+        }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, {})
       })
 
       it('should propagate baggage items when Trace_Propagation_Behavior_Extract is set to restart', () => {
-        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
+        tracer = {
+          _config: {
+            DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart',
+          },
+        }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar' })
       })

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -40,28 +40,31 @@ describe('SpanContext', () => {
     }
     const spanContext = new SpanContext(props)
 
-    // Check individual properties; also explicitly verify the tags map is wired.
-    assert.strictEqual(spanContext._traceId, '123')
-    assert.strictEqual(spanContext._spanId, '456')
-    assert.strictEqual(spanContext._parentId, '789')
-    assert.strictEqual(spanContext._isRemote, false)
-    assert.strictEqual(spanContext._name, 'test')
-    assert.strictEqual(spanContext._isFinished, true)
-    assert.deepStrictEqual(spanContext.getTags(), { testTag: 'testValue' })
-    assert.deepStrictEqual(spanContext._sampling, { priority: 2 })
-    assert.strictEqual(spanContext._spanSampling, undefined)
-    assert.deepStrictEqual(spanContext._links, [])
-    assert.deepStrictEqual(spanContext._baggageItems, { foo: 'bar' })
-    assert.strictEqual(spanContext._noop, noop)
-    assert.deepStrictEqual(spanContext._trace, {
-      started: ['span1', 'span2'],
-      finished: ['span1'],
-      tags: { foo: 'bar' },
-    })
-    assert.strictEqual(spanContext._traceparent, '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01')
-    assert.deepStrictEqual(spanContext._tracestate, TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'))
-    assert.strictEqual(spanContext._otelSpanContext, undefined)
-    assert.strictEqual(spanContext._otelActiveSpan, undefined)
+    const expected = {
+      _traceId: '123',
+      _spanId: '456',
+      _parentId: '789',
+      _isRemote: false,
+      _name: 'test',
+      _isFinished: true,
+      _tags: { testTag: 'testValue' },
+      _sampling: { priority: 2 },
+      _spanSampling: undefined,
+      _links: [],
+      _baggageItems: { foo: 'bar' },
+      _noop: noop,
+      _trace: {
+        started: ['span1', 'span2'],
+        finished: ['span1'],
+        tags: { foo: 'bar' },
+      },
+      _traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
+      _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'),
+      _otelSpanContext: undefined,
+      _otelActiveSpan: undefined,
+    }
+    Object.setPrototypeOf(expected, SpanContext.prototype)
+    assert.deepStrictEqual(spanContext, expected)
   })
 
   it('should have the correct default values', () => {
@@ -70,28 +73,31 @@ describe('SpanContext', () => {
       spanId: '456',
     })
 
-    // Check individual properties; also explicitly verify the tags map is wired.
-    assert.strictEqual(spanContext._traceId, '123')
-    assert.strictEqual(spanContext._spanId, '456')
-    assert.strictEqual(spanContext._parentId, null)
-    assert.strictEqual(spanContext._isRemote, true)
-    assert.strictEqual(spanContext._name, undefined)
-    assert.strictEqual(spanContext._isFinished, false)
-    assert.deepStrictEqual(spanContext.getTags(), {})
-    assert.deepStrictEqual(spanContext._sampling, {})
-    assert.strictEqual(spanContext._spanSampling, undefined)
-    assert.deepStrictEqual(spanContext._links, [])
-    assert.deepStrictEqual(spanContext._baggageItems, {})
-    assert.strictEqual(spanContext._noop, null)
-    assert.deepStrictEqual(spanContext._trace, {
-      started: [],
-      finished: [],
-      tags: {},
-    })
-    assert.strictEqual(spanContext._traceparent, undefined)
-    assert.strictEqual(spanContext._tracestate, undefined)
-    assert.strictEqual(spanContext._otelSpanContext, undefined)
-    assert.strictEqual(spanContext._otelActiveSpan, undefined)
+    const expected = {
+      _traceId: '123',
+      _spanId: '456',
+      _parentId: null,
+      _isRemote: true,
+      _name: undefined,
+      _isFinished: false,
+      _tags: {},
+      _sampling: {},
+      _spanSampling: undefined,
+      _links: [],
+      _baggageItems: {},
+      _noop: null,
+      _trace: {
+        started: [],
+        finished: [],
+        tags: {},
+      },
+      _traceparent: undefined,
+      _tracestate: undefined,
+      _otelSpanContext: undefined,
+      _otelActiveSpan: undefined,
+    }
+    Object.setPrototypeOf(expected, SpanContext.prototype)
+    assert.deepStrictEqual(spanContext, expected)
   })
 
   it('should share sampling object between contexts', () => {

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -25,7 +25,7 @@ describe('SpanContext', () => {
       isRemote: false,
       name: 'test',
       isFinished: true,
-      tags: {},
+      tags: { testTag: 'testValue' },
       metrics: {},
       sampling: { priority: 2 },
       baggageItems: { foo: 'bar' },
@@ -40,31 +40,28 @@ describe('SpanContext', () => {
     }
     const spanContext = new SpanContext(props)
 
-    const expected = {
-      _traceId: '123',
-      _spanId: '456',
-      _parentId: '789',
-      _isRemote: false,
-      _name: 'test',
-      _isFinished: true,
-      _tags: {},
-      _sampling: { priority: 2 },
-      _spanSampling: undefined,
-      _links: [],
-      _baggageItems: { foo: 'bar' },
-      _noop: noop,
-      _trace: {
-        started: ['span1', 'span2'],
-        finished: ['span1'],
-        tags: { foo: 'bar' },
-      },
-      _traceparent: '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01',
-      _tracestate: TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'),
-      _otelSpanContext: undefined,
-      _otelActiveSpan: undefined,
-    }
-    Object.setPrototypeOf(expected, SpanContext.prototype)
-    assert.deepStrictEqual(spanContext, expected)
+    // Check individual properties; also explicitly verify the tags map is wired.
+    assert.strictEqual(spanContext._traceId, '123')
+    assert.strictEqual(spanContext._spanId, '456')
+    assert.strictEqual(spanContext._parentId, '789')
+    assert.strictEqual(spanContext._isRemote, false)
+    assert.strictEqual(spanContext._name, 'test')
+    assert.strictEqual(spanContext._isFinished, true)
+    assert.deepStrictEqual(spanContext.getTags(), { testTag: 'testValue' })
+    assert.deepStrictEqual(spanContext._sampling, { priority: 2 })
+    assert.strictEqual(spanContext._spanSampling, undefined)
+    assert.deepStrictEqual(spanContext._links, [])
+    assert.deepStrictEqual(spanContext._baggageItems, { foo: 'bar' })
+    assert.strictEqual(spanContext._noop, noop)
+    assert.deepStrictEqual(spanContext._trace, {
+      started: ['span1', 'span2'],
+      finished: ['span1'],
+      tags: { foo: 'bar' },
+    })
+    assert.strictEqual(spanContext._traceparent, '00-1111aaaa2222bbbb3333cccc4444dddd-5555eeee6666ffff-01')
+    assert.deepStrictEqual(spanContext._tracestate, TraceState.fromString('dd=s:-1;o:foo;t.dm:-4;t.usr.id:bar'))
+    assert.strictEqual(spanContext._otelSpanContext, undefined)
+    assert.strictEqual(spanContext._otelActiveSpan, undefined)
   })
 
   it('should have the correct default values', () => {
@@ -73,31 +70,28 @@ describe('SpanContext', () => {
       spanId: '456',
     })
 
-    const expected = {
-      _traceId: '123',
-      _spanId: '456',
-      _parentId: null,
-      _isRemote: true,
-      _name: undefined,
-      _isFinished: false,
-      _tags: {},
-      _sampling: {},
-      _spanSampling: undefined,
-      _links: [],
-      _baggageItems: {},
-      _noop: null,
-      _trace: {
-        started: [],
-        finished: [],
-        tags: {},
-      },
-      _traceparent: undefined,
-      _tracestate: undefined,
-      _otelSpanContext: undefined,
-      _otelActiveSpan: undefined,
-    }
-    Object.setPrototypeOf(expected, SpanContext.prototype)
-    assert.deepStrictEqual(spanContext, expected)
+    // Check individual properties; also explicitly verify the tags map is wired.
+    assert.strictEqual(spanContext._traceId, '123')
+    assert.strictEqual(spanContext._spanId, '456')
+    assert.strictEqual(spanContext._parentId, null)
+    assert.strictEqual(spanContext._isRemote, true)
+    assert.strictEqual(spanContext._name, undefined)
+    assert.strictEqual(spanContext._isFinished, false)
+    assert.deepStrictEqual(spanContext.getTags(), {})
+    assert.deepStrictEqual(spanContext._sampling, {})
+    assert.strictEqual(spanContext._spanSampling, undefined)
+    assert.deepStrictEqual(spanContext._links, [])
+    assert.deepStrictEqual(spanContext._baggageItems, {})
+    assert.strictEqual(spanContext._noop, null)
+    assert.deepStrictEqual(spanContext._trace, {
+      started: [],
+      finished: [],
+      tags: {},
+    })
+    assert.strictEqual(spanContext._traceparent, undefined)
+    assert.strictEqual(spanContext._tracestate, undefined)
+    assert.strictEqual(spanContext._otelSpanContext, undefined)
+    assert.strictEqual(spanContext._otelActiveSpan, undefined)
   })
 
   it('should share sampling object between contexts', () => {
@@ -164,6 +158,80 @@ describe('SpanContext', () => {
       spanContext._trace.tags['_dd.p.tid'] = '0000000000000789'
 
       assert.strictEqual(spanContext.toTraceparent(), '00-00000000000007890000000000000123-0000000000000456-00')
+    })
+  })
+
+  describe('tag accessor API', () => {
+    let spanContext
+
+    beforeEach(() => {
+      spanContext = new SpanContext({
+        traceId: id('123', 10),
+        spanId: id('456', 10),
+      })
+    })
+
+    it('setTag stores the value; getTag returns it', () => {
+      spanContext.setTag('foo', 'bar')
+      assert.strictEqual(spanContext.getTag('foo'), 'bar')
+    })
+
+    it('setTag overwrites a previous value', () => {
+      spanContext.setTag('foo', 'first')
+      spanContext.setTag('foo', 'second')
+      assert.strictEqual(spanContext.getTag('foo'), 'second')
+    })
+
+    it('getTag returns undefined for an unset key', () => {
+      assert.strictEqual(spanContext.getTag('missing'), undefined)
+    })
+
+    it('hasTag distinguishes "set to undefined" from "unset"', () => {
+      spanContext.setTag('explicit', undefined)
+      assert.strictEqual(spanContext.hasTag('explicit'), true)
+      assert.strictEqual(spanContext.hasTag('missing'), false)
+      assert.strictEqual(spanContext.getTag('explicit'), undefined)
+    })
+
+    it('hasTag uses Object.hasOwn — Object.prototype keys do not register', () => {
+      // The previous `key in this._tags` implementation matched
+      // `'toString'` / `'hasOwnProperty'` etc. via the prototype chain.
+      assert.strictEqual(spanContext.hasTag('toString'), false)
+      assert.strictEqual(spanContext.hasTag('hasOwnProperty'), false)
+    })
+
+    it('deleteTag removes the key; hasTag reflects the removal', () => {
+      spanContext.setTag('foo', 'bar')
+      spanContext.deleteTag('foo')
+      assert.strictEqual(spanContext.hasTag('foo'), false)
+      assert.strictEqual(spanContext.getTag('foo'), undefined)
+    })
+
+    it('getTags returns the live internal tag map (callers may mutate)', () => {
+      spanContext.setTag('a', '1')
+      const tags = spanContext.getTags()
+      assert.strictEqual(tags.a, '1')
+
+      // Same reference on subsequent calls — `opentracing/span.js` relies on
+      // `Object.assign(getTags(), fields.tags)` mutating the live map.
+      assert.strictEqual(spanContext.getTags(), tags)
+
+      tags.b = '2'
+      assert.strictEqual(spanContext.getTag('b'), '2')
+    })
+
+    it('clearTags empties the map and continues to accept further writes', () => {
+      spanContext.setTag('a', '1')
+      spanContext.setTag('b', '2')
+      spanContext.clearTags()
+      assert.strictEqual(spanContext.hasTag('a'), false)
+      assert.strictEqual(spanContext.hasTag('b'), false)
+      // After clear, the backing map is a fresh Object.create(null) — empty,
+      // but distinct from `{}` by prototype. Assert emptiness via key count.
+      assert.strictEqual(Object.keys(spanContext.getTags()).length, 0)
+
+      spanContext.setTag('c', '3')
+      assert.strictEqual(spanContext.getTag('c'), '3')
     })
   })
 })

--- a/packages/dd-trace/test/plugins/database-dbm-cache.spec.js
+++ b/packages/dd-trace/test/plugins/database-dbm-cache.spec.js
@@ -11,7 +11,13 @@ const DatabasePlugin = require('../../src/plugins/database')
 
 function makeSpan (tags = {}) {
   return {
-    context: () => ({ _tags: tags }),
+    context: () => ({
+      _tags: tags,
+      getTag: (key) => tags[key],
+      getTags: () => tags,
+      setTag: (key, value) => { tags[key] = value },
+      hasTag: (key) => Object.hasOwn(tags, key),
+    }),
     setTag () {},
     _spanContext: { toTraceparent: () => '00-aaa-bbb-01' },
     _processor: { sample () {} },

--- a/packages/dd-trace/test/plugins/database-dbm-hash.spec.js
+++ b/packages/dd-trace/test/plugins/database-dbm-hash.spec.js
@@ -34,18 +34,18 @@ describe('DatabasePlugin DBM Hash', () => {
     }
 
     // Create a mock span
+    const contextTags = {
+      'out.host': 'localhost',
+      'db.name': 'testdb',
+    }
     span = {
       context: () => ({
-        _tags: {
-          'out.host': 'localhost',
-          'db.name': 'testdb',
-        },
+        _tags: contextTags,
+        getTags: () => contextTags,
       }),
       _spanContext: {
-        _tags: {
-          'out.host': 'localhost',
-          'db.name': 'testdb',
-        },
+        _tags: contextTags,
+        getTags: () => contextTags,
         toTraceparent: () => 'traceparent-value',
       },
       setTag: function (key, value) {

--- a/packages/dd-trace/test/plugins/outbound.spec.js
+++ b/packages/dd-trace/test/plugins/outbound.spec.js
@@ -35,7 +35,7 @@ describe('OuboundPlugin', () => {
     it('should attempt to remap when we found peer service', () => {
       computePeerServiceStub.value({ spanComputePeerService: true })
       getPeerServiceStub.returns({ foo: 'bar' })
-      instance.tagPeerService({ context: () => { return { _tags: {} } }, addTags: () => {} })
+      instance.tagPeerService({ context: () => ({ _tags: {}, getTags () { return this._tags } }), addTags: () => {} })
 
       sinon.assert.called(getPeerServiceStub)
       sinon.assert.called(getRemapStub)
@@ -44,7 +44,7 @@ describe('OuboundPlugin', () => {
     it('should not attempt to remap if we found no peer service', () => {
       computePeerServiceStub.value({ spanComputePeerService: true })
       getPeerServiceStub.returns(undefined)
-      instance.tagPeerService({ context: () => { return { _tags: {} } }, addTags: () => {} })
+      instance.tagPeerService({ context: () => ({ _tags: {}, getTags () { return this._tags } }), addTags: () => {} })
 
       sinon.assert.called(getPeerServiceStub)
       sinon.assert.notCalled(getRemapStub)
@@ -52,7 +52,7 @@ describe('OuboundPlugin', () => {
 
     it('should do nothing when disabled', () => {
       computePeerServiceStub.value({ spanComputePeerService: false })
-      instance.tagPeerService({ context: () => { return { _tags: {} } }, addTags: () => {} })
+      instance.tagPeerService({ context: () => ({ _tags: {}, getTags () { return this._tags } }), addTags: () => {} })
       sinon.assert.notCalled(getPeerServiceStub)
       sinon.assert.notCalled(getRemapStub)
     })

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -323,7 +323,7 @@ describe('plugins/util/web', () => {
 
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       req.url = '/'
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -7,12 +7,12 @@ const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
 
 require('../../setup/core')
-const tags = require('../../../../../ext/tags')
+const tagsExt = require('../../../../../ext/tags')
 
-const ERROR = tags.ERROR
-const HTTP_ENDPOINT = tags.HTTP_ENDPOINT
-const HTTP_ROUTE = tags.HTTP_ROUTE
-const RESOURCE_NAME = tags.RESOURCE_NAME
+const ERROR = tagsExt.ERROR
+const HTTP_ENDPOINT = tagsExt.HTTP_ENDPOINT
+const HTTP_ROUTE = tagsExt.HTTP_ROUTE
+const RESOURCE_NAME = tagsExt.RESOURCE_NAME
 
 describe('plugins/util/web', () => {
   let web
@@ -143,7 +143,7 @@ describe('plugins/util/web', () => {
   describe('addError', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       web.patch(req)
       const context = web.getContext(req)
@@ -176,7 +176,7 @@ describe('plugins/util/web', () => {
   describe('addStatusError', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       web.patch(req)
       const context = web.getContext(req)
@@ -272,7 +272,7 @@ describe('plugins/util/web', () => {
   describe('http.endpoint tagging', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       req.url = '/'
 
@@ -294,6 +294,9 @@ describe('plugins/util/web', () => {
 
       web.finishAll(context)
 
+      // `tags` was captured from span.context().getTags() before finishAll;
+      // the underlying tags object is still the original (clearTags() rebinds,
+      // but doesn't mutate the captured reference).
       assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `Available keys: ${inspect(Object.keys(tags))}`)
       assert.strictEqual(tags[HTTP_ENDPOINT], '/api/orders/{param:int}/items')
     })

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -51,6 +51,10 @@ describe('PrioritySampler', () => {
         started: [],
         tags: {},
       },
+      getTags () { return this._tags },
+      getTag (key) { return this._tags[key] },
+      setTag (key, value) { this._tags[key] = value },
+      hasTag (key) { return key in this._tags },
     }
 
     span = {

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -737,7 +737,13 @@ describe('profilers/native/wall', () => {
     function makeWebSpan () {
       const tags = {}
       const spanId = {}
-      const ctx = { _tags: tags, _spanId: spanId, _parentId: null, _trace: { started: [] } }
+      const ctx = {
+        _tags: tags,
+        _spanId: spanId,
+        _parentId: null,
+        _trace: { started: [] },
+        getTags () { return this._tags },
+      }
       const span = { context: () => ctx }
       ctx._trace.started.push(span)
       return { span, tags, spanId }
@@ -746,7 +752,13 @@ describe('profilers/native/wall', () => {
     function makeChildSpan (webSpanId, webSpan) {
       const tags = { 'span.type': 'router' }
       const spanId = {}
-      const ctx = { _tags: tags, _spanId: spanId, _parentId: webSpanId, _trace: { started: [webSpan] } }
+      const ctx = {
+        _tags: tags,
+        _spanId: spanId,
+        _parentId: webSpanId,
+        _trace: { started: [webSpan] },
+        getTags () { return this._tags },
+      }
       const span = { context: () => ctx }
       ctx._trace.started.push(span)
       return { span, tags }

--- a/packages/dd-trace/test/sampling_rule.spec.js
+++ b/packages/dd-trace/test/sampling_rule.spec.js
@@ -52,6 +52,7 @@ function createDummySpans () {
       },
       _name: operation,
       _tags: {},
+      getTag (key) { return this._tags[key] },
     }
 
     // Give first span a custom service name

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -58,6 +58,10 @@ describe('spanFormat', () => {
       _name: 'operation',
       toTraceId: sinon.stub().returns(spanId),
       toSpanId: sinon.stub().returns(spanId),
+      getTag (key) { return this._tags[key] },
+      getTags () { return this._tags },
+      setTag (key, value) { this._tags[key] = value },
+      hasTag (key) { return key in this._tags },
     }
 
     span = {

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -33,12 +33,17 @@ describe('SpanProcessor', () => {
       finished: [],
     }
 
+    let tags = {}
     const span = {
       tracer: sinon.stub().returns(tracer),
       context: sinon.stub().returns({
         _trace: trace,
         _sampling: {},
-        _tags: {},
+        getTags: () => tags,
+        getTag: (key) => tags[key],
+        setTag: (key, value) => { tags[key] = value },
+        hasTag: (key) => key in tags,
+        clearTags: () => { tags = Object.create(null) },
       }),
     }
 
@@ -93,8 +98,9 @@ describe('SpanProcessor', () => {
     assert.deepStrictEqual(trace.started, [])
     assert.ok('finished' in trace)
     assert.deepStrictEqual(trace.finished, [])
-    assert.ok('_tags' in finishedSpan.context())
-    assert.deepStrictEqual(finishedSpan.context()._tags, {})
+    // _erase leaves per-span tag storage intact so callers that retain a
+    // span ref after finish can still read tags.
+    assert.deepStrictEqual(finishedSpan.context().getTags(), {})
   })
 
   it('should not flush a partial trace below the flushMinSpans threshold', () => {
@@ -173,8 +179,7 @@ describe('SpanProcessor', () => {
     assert.deepStrictEqual(trace.started, [])
     assert.ok('finished' in trace)
     assert.deepStrictEqual(trace.finished, [])
-    assert.ok('_tags' in finishedSpan.context())
-    assert.deepStrictEqual(finishedSpan.context()._tags, {})
+    assert.deepStrictEqual(finishedSpan.context().getTags(), {})
     sinon.assert.notCalled(exporter.export)
   })
 
@@ -196,6 +201,7 @@ describe('SpanProcessor', () => {
   it('should add span tags to first span in a chunk', () => {
     config.flushMinSpans = 2
     config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED = true
+    config.propagateProcessTags = { enabled: true }
     const processor = new SpanProcessor(exporter, prioritySampler, config)
     trace.started = [activeSpan, finishedSpan, finishedSpan, finishedSpan, finishedSpan]
     trace.finished = [finishedSpan, finishedSpan, finishedSpan, finishedSpan]
@@ -207,7 +213,9 @@ describe('SpanProcessor', () => {
       tags.split(',').forEach(tag => {
         const [key, value] = tag.split(':')
         if (key !== 'entrypoint.basedir') return
-        assert.strictEqual(value, 'test')
+        // The exact basedir varies depending on the test runner location
+        // (e.g. "test" in source tree vs "bin" when run via node_modules/.bin/mocha).
+        assert.ok(typeof value === 'string' && value.length > 0)
         foundATag = true
       })
       assert.ok(foundATag)

--- a/packages/dd-trace/test/span_processor.spec.js
+++ b/packages/dd-trace/test/span_processor.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { inspect } = require('node:util')
 
 const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
@@ -201,7 +202,6 @@ describe('SpanProcessor', () => {
   it('should add span tags to first span in a chunk', () => {
     config.flushMinSpans = 2
     config.DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED = true
-    config.propagateProcessTags = { enabled: true }
     const processor = new SpanProcessor(exporter, prioritySampler, config)
     trace.started = [activeSpan, finishedSpan, finishedSpan, finishedSpan, finishedSpan]
     trace.finished = [finishedSpan, finishedSpan, finishedSpan, finishedSpan]
@@ -215,7 +215,10 @@ describe('SpanProcessor', () => {
         if (key !== 'entrypoint.basedir') return
         // The exact basedir varies depending on the test runner location
         // (e.g. "test" in source tree vs "bin" when run via node_modules/.bin/mocha).
-        assert.ok(typeof value === 'string' && value.length > 0)
+        assert.ok(
+          typeof value === 'string' && value.length > 0,
+          `entrypoint.basedir value: ${inspect(value)}`
+        )
         foundATag = true
       })
       assert.ok(foundATag)

--- a/packages/dd-trace/test/span_sampler.spec.js
+++ b/packages/dd-trace/test/span_sampler.spec.js
@@ -41,6 +41,7 @@ describe('span sampler', () => {
       },
       _name: 'operation',
       _tags: {},
+      getTag (key) { return this._tags[key] },
     }
     spanContext._trace.started.push({
       context: sinon.stub().returns(spanContext),
@@ -77,6 +78,7 @@ describe('span sampler', () => {
       },
       _name: 'operation',
       _tags: {},
+      getTag (key) { return this._tags[key] },
     }
     spanContext._trace.started.push({
       context: sinon.stub().returns(spanContext),
@@ -131,6 +133,7 @@ describe('span sampler', () => {
       },
       _name: 'operation',
       _tags: {},
+      getTag (key) { return this._tags[key] },
     }
     spanContext._trace.started.push({
       context: sinon.stub().returns(spanContext),
@@ -175,6 +178,7 @@ describe('span sampler', () => {
       },
       _name: 'operation',
       _tags: {},
+      getTag (key) { return this._tags[key] },
     }
     const secondSpanContext = {
       ...firstSpanContext,
@@ -243,6 +247,7 @@ describe('span sampler', () => {
       },
       _name: 'operation',
       _tags: {},
+      getTag (key) { return this._tags[key] },
     }
     const secondSpanContext = {
       ...firstSpanContext,

--- a/packages/dd-trace/test/standalone/index.spec.js
+++ b/packages/dd-trace/test/standalone/index.spec.js
@@ -9,6 +9,7 @@ const proxyquire = require('proxyquire')
 const { channel } = require('dc-polyfill')
 
 require('../setup/core')
+const getConfig = require('../../src/config')
 const standalone = require('../../src/standalone')
 const DatadogSpan = require('../../src/opentracing/span')
 
@@ -41,7 +42,7 @@ describe('Disabled APM Tracing or Standalone', () => {
       },
     }
 
-    tracer = { _config: config }
+    tracer = { _config: getConfig() }
     processor = {}
     prioritySampler = {}
   })

--- a/packages/dd-trace/test/standalone/index.spec.js
+++ b/packages/dd-trace/test/standalone/index.spec.js
@@ -9,7 +9,6 @@ const proxyquire = require('proxyquire')
 const { channel } = require('dc-polyfill')
 
 require('../setup/core')
-const getConfig = require('../../src/config')
 const standalone = require('../../src/standalone')
 const DatadogSpan = require('../../src/opentracing/span')
 
@@ -42,7 +41,7 @@ describe('Disabled APM Tracing or Standalone', () => {
       },
     }
 
-    tracer = { _config: getConfig() }
+    tracer = { _config: config }
     processor = {}
     prioritySampler = {}
   })
@@ -136,7 +135,7 @@ describe('Disabled APM Tracing or Standalone', () => {
         operationName: 'operation',
       })
 
-      assert.ok(!(APM_TRACING_ENABLED_KEY in span.context()._tags))
+      assert.ok(!span.context().hasTag(APM_TRACING_ENABLED_KEY))
     })
 
     it('should add _dd.apm.enabled tag when standalone is enabled', () => {
@@ -146,8 +145,10 @@ describe('Disabled APM Tracing or Standalone', () => {
         operationName: 'operation',
       })
 
-      const tags = span.context()._tags
-      assert.ok(Object.hasOwn(tags, APM_TRACING_ENABLED_KEY), `Available keys: ${inspect(Object.keys(tags))}`)
+      assert.ok(
+        span.context().hasTag(APM_TRACING_ENABLED_KEY),
+        `Available keys: ${inspect(Object.keys(span.context().getTags()))}`
+      )
     })
 
     it('should not add _dd.apm.enabled tag in child spans with local parent', () => {
@@ -157,14 +158,14 @@ describe('Disabled APM Tracing or Standalone', () => {
         operationName: 'operation',
       })
 
-      assert.strictEqual(parent.context()._tags[APM_TRACING_ENABLED_KEY], 0)
+      assert.strictEqual(parent.context().getTag(APM_TRACING_ENABLED_KEY), 0)
 
       const child = new DatadogSpan(tracer, processor, prioritySampler, {
         operationName: 'operation',
         parent,
       })
 
-      assert.ok(!(APM_TRACING_ENABLED_KEY in child.context()._tags))
+      assert.ok(!child.context().hasTag(APM_TRACING_ENABLED_KEY))
     })
 
     it('should add _dd.apm.enabled tag in child spans with remote parent', () => {
@@ -181,7 +182,7 @@ describe('Disabled APM Tracing or Standalone', () => {
         parent,
       })
 
-      assert.strictEqual(child.context()._tags[APM_TRACING_ENABLED_KEY], 0)
+      assert.strictEqual(child.context().getTag(APM_TRACING_ENABLED_KEY), 0)
     })
   })
 

--- a/packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js
+++ b/packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js
@@ -8,6 +8,7 @@ const proxyquire = require('proxyquire')
 
 require('../setup/core')
 const { USER_KEEP, AUTO_KEEP } = require('../../../../ext/priority')
+const getConfig = require('../../src/config')
 const DatadogSpan = require('../../src/opentracing/span')
 const TraceSourcePrioritySampler = require('../../src/standalone/tracesource_priority_sampler')
 const { TRACE_SOURCE_PROPAGATION_KEY } = require('../../src/constants')
@@ -38,7 +39,8 @@ describe('Disabled APM Tracing or Standalone - TraceSourcePrioritySampler', () =
 
   describe('sample', () => {
     it('should provide the context when invoking _getPriorityFromTags', () => {
-      const span = new DatadogSpan({ _config: {} }, {}, prioritySampler, {
+      const tracer = { _config: getConfig() }
+      const span = new DatadogSpan(tracer, {}, prioritySampler, {
         operationName: 'operation',
       })
 

--- a/packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js
+++ b/packages/dd-trace/test/standalone/tracesource_priority_sampler.spec.js
@@ -8,7 +8,6 @@ const proxyquire = require('proxyquire')
 
 require('../setup/core')
 const { USER_KEEP, AUTO_KEEP } = require('../../../../ext/priority')
-const getConfig = require('../../src/config')
 const DatadogSpan = require('../../src/opentracing/span')
 const TraceSourcePrioritySampler = require('../../src/standalone/tracesource_priority_sampler')
 const { TRACE_SOURCE_PROPAGATION_KEY } = require('../../src/constants')
@@ -27,18 +26,19 @@ describe('Disabled APM Tracing or Standalone - TraceSourcePrioritySampler', () =
     root = {}
     context = {
       _sampling: {},
+      _tags: {},
       _trace: {
         tags: {},
         started: [root],
       },
+      getTags () { return this._tags },
     }
     sinon.stub(prioritySampler, '_getContext').returns(context)
   })
 
   describe('sample', () => {
     it('should provide the context when invoking _getPriorityFromTags', () => {
-      const tracer = { _config: getConfig() }
-      const span = new DatadogSpan(tracer, {}, prioritySampler, {
+      const span = new DatadogSpan({ _config: {} }, {}, prioritySampler, {
         operationName: 'operation',
       })
 

--- a/packages/dd-trace/test/tracer.spec.js
+++ b/packages/dd-trace/test/tracer.spec.js
@@ -69,8 +69,8 @@ describe('Tracer', () => {
 
       tracer.trace('name', options, span => {
         assert.ok(span instanceof Span)
-        assertObjectContains(span.context()._tags, options.tags)
-        assertObjectContains(span.context()._tags, {
+        assertObjectContains(span.context().getTags(), options.tags)
+        assertObjectContains(span.context().getTags(), {
           [SERVICE_NAME]: 'service',
           [RESOURCE_NAME]: 'resource',
           [SPAN_TYPE]: 'type',
@@ -152,7 +152,7 @@ describe('Tracer', () => {
       try {
         tracer.trace('name', {}, _span => {
           span = _span
-          tags = span.context()._tags
+          tags = span.context().getTags()
           sinon.spy(span, 'finish')
           throw new Error('boom')
         })
@@ -192,7 +192,7 @@ describe('Tracer', () => {
 
         tracer.trace('name', {}, (_span, _done) => {
           span = _span
-          tags = span.context()._tags
+          tags = span.context().getTags()
           sinon.spy(span, 'finish')
           done = _done
         })
@@ -241,7 +241,7 @@ describe('Tracer', () => {
         tracer
           .trace('name', {}, _span => {
             span = _span
-            tags = span.context()._tags
+            tags = span.context().getTags()
             sinon.spy(span, 'finish')
             return Promise.reject(new Error('boom'))
           })


### PR DESCRIPTION
### What does this PR do?

Adds a tag accessor API (`getTag` / `setTag` / `getTags` / `hasTag` / `deleteTag` / `clearTags`) on `DatadogSpanContext`, migrates ~75 call sites away from direct `_tags` field access, and adds a custom ESLint rule (`eslint-no-private-tags-access`) that prevents new direct accesses from creeping back in.

The underlying `_tags` backing field is preserved — this is purely additive at the field-access layer.

Two commits:
1. `feat(opentracing): add tag accessor API and migrate _tags direct access` — adds the accessor methods + migrates production + test call sites.
2. `feat(lint): disallow _tags direct access on span contexts` — adds the ESLint rule + migrates the remaining production call sites the rule flags (span_format, spanleak, profiling/wall, llmobs/*, opentelemetry/span-helpers).

### Motivation

Direct `_tags` access leaks internal storage shape across the module boundary, making future refactors painful. A small accessor API + a lint rule pins the contract so subclasses or future storage backends can interpose on tag writes (e.g., emit a write-through to alternate storage) without every call site having to opt in. This carve-out is a prerequisite for a follow-up that introduces such a subclass.

### Additional Notes

The ESLint rule catches both `MemberExpression` (`ctx._tags`) and `ObjectPattern` (`const { _tags } = ctx`) access. The allowlist (`allowFiles`) exempts files that legitimately own a `_tags` field on an unrelated class or intentionally mock its shape; each entry has an inline comment explaining why.

`hasTag` uses `Object.hasOwn` (not the `in` operator), matching the pre-migration `_tags.hasOwnProperty(key)` semantics so that `Object.prototype` member names (`'toString'`, etc.) don't accidentally register as set tags.

### Verification

- `npm run lint`: 63 errors (project baseline; all pre-existing `n/no-extraneous-require` / `n/no-unpublished-require` against vendored deps; zero `eslint-no-private-tags-access` violations).
- `./node_modules/.bin/mocha eslint-rules/eslint-no-private-tags-access.test.mjs`: 28 passing (rule unit tests, including destructuring forms).
- `npm run test:trace:core`: 2930 passing / 1 failing / 1 pending. The failure is `process-tags.spec.js`, pre-existing environmental — same on `origin/master`.