### PR TITLE
perf(plugins/util/web): trim request-lifecycle helper work

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -268,7 +268,16 @@ const web = {
 
     if (context.finished && !req.stream) return
 
+    // `addRequestTags` is idempotent: in the normal HTTP path it ran during
+    // `web.startSpan`. Serverless callers (e.g. Azure Functions) skip
+    // `web.startSpan` and rely on this call to do the request-side work.
     addRequestTags(context, spanType)
+    // Configured-header tagging runs at finish time. Framework plugins
+    // (connect, express, ...) install their own config via `setFramework`
+    // after `web.startSpan` has already locked the http-plugin config in;
+    // tagging earlier would use the http-plugin's `headers` list and drop
+    // the framework's.
+    addRequestHeaders(context)
     addResponseTags(context)
 
     context.config.hooks.request(context.span, req, res)
@@ -353,6 +362,16 @@ function splitHeader (str) {
 
 function addRequestTags (context, spanType) {
   const { req, span, inferredProxySpan, config } = context
+  const spanContext = span.context()
+
+  // Idempotency guard. `addRequestTags` runs in `web.startSpan` for the
+  // normal HTTP path and again in `web.finishSpan`; without this guard the
+  // second call would re-extract the URL, re-obfuscate the query string,
+  // and re-publish five `tagsUpdateCh` events with the same values. The
+  // serverless path skips `startSpan` and lands here first, in which case
+  // HTTP_URL is unset and the work runs normally.
+  if (spanContext.hasTag(HTTP_URL)) return
+
   const url = extractURL(req)
   const type = spanType ?? WEB
 
@@ -365,7 +384,7 @@ function addRequestTags (context, spanType) {
   })
 
   // if client ip has already been set by appsec, no need to run it again
-  if (config.extractIp && !span.context().hasTag(HTTP_CLIENT_IP)) {
+  if (config.extractIp && !spanContext.hasTag(HTTP_CLIENT_IP)) {
     const clientIp = config.extractIp(config, req)
 
     if (clientIp) {
@@ -384,8 +403,6 @@ function addRequestTags (context, spanType) {
   if (securityTest !== undefined) {
     span.setTag(`${HTTP_REQUEST_HEADERS}.x-datadog-security-test`, securityTest)
   }
-
-  addHeaders(context)
 }
 
 function addResponseTags (context) {
@@ -399,6 +416,8 @@ function addResponseTags (context) {
   inferredProxySpan?.addTags({
     [HTTP_STATUS_CODE]: res.statusCode,
   })
+
+  addResponseHeaders(context)
 
   web.addStatusError(req, res.statusCode)
 }
@@ -438,21 +457,28 @@ function addResourceTag (context) {
   span.setTag(RESOURCE_NAME, resource)
 }
 
-function addHeaders (context) {
-  const { req, res, config, span, inferredProxySpan } = context
+function addRequestHeaders (context) {
+  const { req, config, span, inferredProxySpan } = context
 
   for (const [key, tag] of config.headers) {
     const reqHeader = req.headers[key]
-    const resHeader = res.getHeader(key)
-
     if (reqHeader) {
-      span.setTag(tag || `${HTTP_REQUEST_HEADERS}.${key}`, reqHeader)
-      inferredProxySpan?.setTag(tag || `${HTTP_REQUEST_HEADERS}.${key}`, reqHeader)
+      const tagName = tag || `${HTTP_REQUEST_HEADERS}.${key}`
+      span.setTag(tagName, reqHeader)
+      inferredProxySpan?.setTag(tagName, reqHeader)
     }
+  }
+}
 
+function addResponseHeaders (context) {
+  const { res, config, span, inferredProxySpan } = context
+
+  for (const [key, tag] of config.headers) {
+    const resHeader = res.getHeader(key)
     if (resHeader) {
-      span.setTag(tag || `${HTTP_RESPONSE_HEADERS}.${key}`, resHeader)
-      inferredProxySpan?.setTag(tag || `${HTTP_RESPONSE_HEADERS}.${key}`, resHeader)
+      const tagName = tag || `${HTTP_RESPONSE_HEADERS}.${key}`
+      span.setTag(tagName, resHeader)
+      inferredProxySpan?.setTag(tagName, resHeader)
     }
   }
 }

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -10,6 +10,7 @@ const kinds = require('../../../../../ext/kinds')
 const { ERROR_MESSAGE } = require('../../constants')
 const TracingPlugin = require('../tracing')
 const { storage } = require('../../../../datadog-core')
+const legacyStorage = storage('legacy')
 const urlFilter = require('./urlfilter')
 const { createInferredProxySpan, finishInferredProxySpan } = require('./inferred_proxy')
 const { extractURL, obfuscateQs, getQsObfuscator, calculateHttpEndpoint } = require('./url')
@@ -126,7 +127,6 @@ const web = {
     context.tracer = tracer
     context.span = span
     context.res = res
-    context.store = storage('legacy').getStore()
 
     this.setConfig(req, config)
     addRequestTags(context, this.TYPE)
@@ -204,7 +204,7 @@ const web = {
   startServerlessSpanWithInferredProxy (tracer, config, name, req, traceCtx) {
     const headers = req.headers
     const reqCtx = contexts.get(req)
-    const store = storage('legacy').getStore()
+    const store = legacyStorage.getStore()
     const pubsubSpan = store?.span?._name === 'pubsub.push.receive' ? store.span : null
 
     let childOf = pubsubSpan || tracer.extract(FORMAT_HTTP_HEADERS, headers)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -441,7 +441,9 @@ function applyRouteOrEndpointTag (context) {
   // two calls, so the second pass has nothing to add.
   if (spanContext.hasTag(HTTP_ROUTE) || spanContext.hasTag(HTTP_ENDPOINT)) return
 
-  const route = paths.join('')
+  // Skip the `Array.prototype.join` builtin in the empty / single-segment
+  // cases; `paths[0]` covers both (`undefined` is falsy for the empty case).
+  const route = paths.length > 1 ? paths.join('') : paths[0]
 
   if (route) {
     // Use http.route from trusted framework instrumentation.

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -33,7 +33,6 @@ const HTTP_CLIENT_IP = tags.HTTP_CLIENT_IP
 const MANUAL_DROP = tags.MANUAL_DROP
 
 const contexts = new WeakMap()
-const ends = new WeakMap()
 
 // TODO: change this to no longer rely on creating a dummy plugin to be able to access startSpan
 function createWebPlugin (tracer, config = {}) {
@@ -308,34 +307,6 @@ const web = {
   },
   getContext (req) {
     return contexts.get(req)
-  },
-  wrapRes (context, req, res, end) {
-    return function (...args) {
-      web.finishAll(context)
-
-      return end.apply(res, args)
-    }
-  },
-  wrapEnd (context) {
-    const req = context.req
-    const res = context.res
-    const end = res.end
-
-    res.writeHead = web.wrapWriteHead(context)
-
-    ends.set(res, this.wrapRes(context, req, res, end))
-
-    Object.defineProperty(res, 'end', {
-      configurable: true,
-      get () {
-        return ends.get(this)
-      },
-      set (value) {
-        ends.set(this, function (...args) {
-          return storage('legacy').run(context.store, value, ...args)
-        })
-      },
-    })
   },
   setRouteOrEndpointTag (req) {
     const context = contexts.get(req)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -304,11 +304,18 @@ const web = {
     const writeHead = res.writeHead
 
     return function (statusCode, statusMessage, headers) {
-      headers = typeof statusMessage === 'string' ? headers : statusMessage
-      headers = { ...res.getHeaders(), ...headers }
+      // CORS preflight tagging only matters for OPTIONS requests. Skip the
+      // getHeaders() spread + isOriginAllowed work entirely for the common
+      // GET / POST / etc. case. Node's http module passes `req.method`
+      // through unchanged, so all standard methods are uppercase; the
+      // `toLowerCase` fallback covers any non-standard caller.
+      if (req.method === 'OPTIONS' || req.method.toLowerCase() === 'options') {
+        headers = typeof statusMessage === 'string' ? headers : statusMessage
+        headers = { ...res.getHeaders(), ...headers }
 
-      if (req.method.toLowerCase() === 'options' && isOriginAllowed(req, headers)) {
-        addAllowHeaders(req, res, headers)
+        if (isOriginAllowed(req, headers)) {
+          addAllowHeaders(req, res, headers)
+        }
       }
 
       return writeHead.apply(this, arguments)

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -433,6 +433,14 @@ function applyRouteOrEndpointTag (context) {
   const { paths, span, config } = context
   if (!span) return
   const spanContext = span.context()
+
+  // AppSec calls `web.setRouteOrEndpointTag` from a pre-finish hook so the
+  // route/endpoint tags are available for API Security sampling, and the
+  // normal finish-time path runs this again. Either tag being present
+  // means the work has already been done; paths are stable between the
+  // two calls, so the second pass has nothing to add.
+  if (spanContext.hasTag(HTTP_ROUTE) || spanContext.hasTag(HTTP_ENDPOINT)) return
+
   const route = paths.join('')
 
   if (route) {
@@ -441,9 +449,7 @@ function applyRouteOrEndpointTag (context) {
     return
   }
 
-  if (!config.resourceRenamingEnabled || spanContext.getTag(HTTP_ENDPOINT)) {
-    return
-  }
+  if (!config.resourceRenamingEnabled) return
 
   // Route is unavailable, compute http.endpoint once.
   const url = spanContext.getTag(HTTP_URL)

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -12,6 +12,8 @@ const tagsExt = require('../../../../../ext/tags')
 const ERROR = tagsExt.ERROR
 const HTTP_CLIENT_IP = tagsExt.HTTP_CLIENT_IP
 const HTTP_ENDPOINT = tagsExt.HTTP_ENDPOINT
+const HTTP_REQUEST_HEADERS = tagsExt.HTTP_REQUEST_HEADERS
+const HTTP_RESPONSE_HEADERS = tagsExt.HTTP_RESPONSE_HEADERS
 const HTTP_ROUTE = tagsExt.HTTP_ROUTE
 const RESOURCE_NAME = tagsExt.RESOURCE_NAME
 
@@ -438,6 +440,47 @@ describe('plugins/util/web', () => {
         { scan: tags[SCAN_TAG], test: tags[TEST_TAG] },
         { scan: '', test: 'ok' }
       )
+    })
+  })
+
+  describe('configured header tagging across the request lifecycle', () => {
+    const USER_AGENT_TAG = `${HTTP_REQUEST_HEADERS}.user-agent`
+    const SERVER_TAG = `${HTTP_RESPONSE_HEADERS}.server`
+
+    beforeEach(() => {
+      req.url = '/users'
+      req.headers['user-agent'] = 'test'
+    })
+
+    it('honours headers added to the plugin config after startSpan', () => {
+      const httpConfig = web.normalizeConfig({})
+      const frameworkConfig = web.normalizeConfig({ headers: ['user-agent', 'server'] })
+
+      web.startSpan(tracer, httpConfig, req, res, 'test.request')
+      span = web.root(req)
+      tags = span.context().getTags()
+
+      assert.ok(Object.hasOwn(tags, 'http.url'), `${inspect(tags)} may not contain 'http.url' property`)
+      assert.ok(!Object.hasOwn(tags, USER_AGENT_TAG), `${inspect(tags)} may not contain ${USER_AGENT_TAG} property`)
+
+      web.setFramework(req, 'test-framework', frameworkConfig)
+
+      web.finishAll(web.getContext(req))
+
+      assert.strictEqual(tags[USER_AGENT_TAG], 'test')
+      assert.strictEqual(tags[SERVER_TAG], 'test')
+    })
+
+    it('still tags headers when the http-side config already lists them', () => {
+      const httpConfig = web.normalizeConfig({ headers: ['user-agent'] })
+
+      web.startSpan(tracer, httpConfig, req, res, 'test.request')
+      span = web.root(req)
+      tags = span.context().getTags()
+
+      web.finishAll(web.getContext(req))
+
+      assert.strictEqual(tags[USER_AGENT_TAG], 'test')
     })
   })
 })

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { inspect } = require('node:util')
 
 const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
@@ -56,18 +55,15 @@ describe('plugins/util/web', () => {
     it('should set the correct defaults', () => {
       const config = web.normalizeConfig({})
 
-      assert.ok(Object.hasOwn(config, 'headers'), `Available keys: ${inspect(Object.keys(config))}`)
-      assert.ok(Array.isArray(config.headers), `Expected array, got ${inspect(config.headers)}`)
-      assert.ok(Object.hasOwn(config, 'validateStatus'), `Available keys: ${inspect(Object.keys(config))}`)
+      assert.ok(Object.hasOwn(config, 'headers'))
+      assert.ok(Array.isArray(config.headers))
+      assert.ok(Object.hasOwn(config, 'validateStatus'))
       assert.strictEqual(typeof config.validateStatus, 'function')
       assert.strictEqual(config.validateStatus(200), true)
       assert.strictEqual(config.validateStatus(500), false)
-      assert.ok(Object.hasOwn(config, 'hooks'), `Available keys: ${inspect(Object.keys(config))}`)
-      assert.ok(
-        typeof config.hooks === 'object' && config.hooks !== null,
-        `Expected non-null object, got ${inspect(config.hooks)}`
-      )
-      assert.ok(Object.hasOwn(config.hooks, 'request'), `Available keys: ${inspect(Object.keys(config.hooks))}`)
+      assert.ok(Object.hasOwn(config, 'hooks'))
+      assert.ok(typeof config.hooks === 'object' && config.hooks !== null)
+      assert.ok(Object.hasOwn(config.hooks, 'request'))
       assert.strictEqual(typeof config.hooks.request, 'function')
       assert.strictEqual(config.queryStringObfuscation, true)
     })
@@ -83,7 +79,7 @@ describe('plugins/util/web', () => {
 
       assert.deepStrictEqual(config.headers, [['test', undefined]])
       assert.strictEqual(config.validateStatus(200), false)
-      assert.ok(Object.hasOwn(config, 'hooks'), `Available keys: ${inspect(Object.keys(config))}`)
+      assert.ok(Object.hasOwn(config, 'hooks'))
       assert.strictEqual(config.hooks.request(), 'test')
     })
 
@@ -195,7 +191,7 @@ describe('plugins/util/web', () => {
   describe('addError', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
       web.patch(req)
       const context = web.getContext(req)
@@ -228,7 +224,7 @@ describe('plugins/util/web', () => {
   describe('addStatusError', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
       web.patch(req)
       const context = web.getContext(req)
@@ -324,7 +320,7 @@ describe('plugins/util/web', () => {
   describe('http.endpoint tagging', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
       req.url = '/'
 
@@ -346,10 +342,7 @@ describe('plugins/util/web', () => {
 
       web.finishAll(context)
 
-      // `tags` was captured from span.context().getTags() before finishAll;
-      // the underlying tags object is still the original (clearTags() rebinds,
-      // but doesn't mutate the captured reference).
-      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `Available keys: ${inspect(Object.keys(tags))}`)
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE))
       assert.strictEqual(tags[HTTP_ENDPOINT], '/api/orders/{param:int}/items')
     })
 
@@ -363,8 +356,8 @@ describe('plugins/util/web', () => {
 
       web.finishAll(context)
 
-      assert.ok(!Object.hasOwn(tags, HTTP_ENDPOINT), `Available keys: ${inspect(Object.keys(tags))}`)
-      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `Available keys: ${inspect(Object.keys(tags))}`)
+      assert.ok(!Object.hasOwn(tags, HTTP_ENDPOINT))
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE))
       assert.strictEqual(tags[RESOURCE_NAME], 'GET')
     })
   })
@@ -375,7 +368,7 @@ describe('plugins/util/web', () => {
 
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
       req.url = '/'
 
@@ -448,7 +441,7 @@ describe('plugins/util/web', () => {
 
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
       req.url = '/'
 
@@ -465,7 +458,7 @@ describe('plugins/util/web', () => {
 
       web.setRouteOrEndpointTag(req)
 
-      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `${inspect(tags)} may not contain ${HTTP_ROUTE} property`)
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE))
     })
 
     it('uses the single segment directly without entering Array.join', () => {
@@ -481,7 +474,7 @@ describe('plugins/util/web', () => {
 
       web.setRouteOrEndpointTag(req)
 
-      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `${inspect(tags)} may not contain ${HTTP_ROUTE} property`)
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE))
     })
 
     it('joins two segments byte-identical to the legacy join shape', () => {
@@ -516,10 +509,10 @@ describe('plugins/util/web', () => {
 
       web.startSpan(tracer, httpConfig, req, res, 'test.request')
       span = web.root(req)
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
-      assert.ok(Object.hasOwn(tags, 'http.url'), `${inspect(tags)} may not contain 'http.url' property`)
-      assert.ok(!Object.hasOwn(tags, USER_AGENT_TAG), `${inspect(tags)} may not contain ${USER_AGENT_TAG} property`)
+      assert.ok(Object.hasOwn(tags, 'http.url'))
+      assert.ok(!Object.hasOwn(tags, USER_AGENT_TAG))
 
       web.setFramework(req, 'test-framework', frameworkConfig)
 
@@ -534,11 +527,193 @@ describe('plugins/util/web', () => {
 
       web.startSpan(tracer, httpConfig, req, res, 'test.request')
       span = web.root(req)
-      tags = span.context().getTags()
+      tags = span.context()._tags
 
       web.finishAll(web.getContext(req))
 
       assert.strictEqual(tags[USER_AGENT_TAG], 'test')
+    })
+  })
+
+  describe('normalizeConfig clientIpEnabled', () => {
+    beforeEach(() => {
+      req.url = '/'
+      req.headers['x-forwarded-for'] = '203.0.113.5'
+    })
+
+    it('does not tag http.client_ip when clientIpEnabled is not set', () => {
+      const httpConfig = web.normalizeConfig({})
+
+      web.startSpan(tracer, httpConfig, req, res, 'test.request')
+      span = web.root(req)
+
+      web.finishAll(web.getContext(req))
+
+      assert.ok(!Object.hasOwn(span.context()._tags, HTTP_CLIENT_IP))
+    })
+
+    it('tags http.client_ip when clientIpEnabled is true', () => {
+      const httpConfig = web.normalizeConfig({ clientIpEnabled: true })
+
+      web.startSpan(tracer, httpConfig, req, res, 'test.request')
+      span = web.root(req)
+
+      web.finishAll(web.getContext(req))
+
+      assert.strictEqual(span.context()._tags[HTTP_CLIENT_IP], '203.0.113.5')
+    })
+  })
+
+  describe('wrapWriteHead', () => {
+    const ALLOW_HEADERS = 'access-control-allow-headers'
+    const ALLOW_ORIGIN = 'access-control-allow-origin'
+    let context
+
+    beforeEach(() => {
+      span = tracer.startSpan('test.request')
+
+      web.patch(req)
+      context = web.getContext(req)
+      context.span = span
+      context.req = req
+      context.res = res
+      context.config = config
+    })
+
+    it('does not touch CORS headers for non-OPTIONS requests', () => {
+      req.method = 'GET'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.notCalled)
+    })
+
+    it('skips allow-header tagging on OPTIONS when the origin is not allowed', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://evil.example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: 'https://good.example.com' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.notCalled)
+    })
+
+    it('merges datadog allow-headers on OPTIONS when allow-origin is *', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] =
+        'x-datadog-trace-id, x-datadog-parent-id, x-other'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'x-datadog-parent-id,x-datadog-trace-id']
+      )
+    })
+
+    it('honours headers passed as the second writeHead argument', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, { [ALLOW_ORIGIN]: 'https://example.com' })
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'x-datadog-trace-id']
+      )
+    })
+
+    it('honours headers passed as the third writeHead argument with a status message', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({})
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200, 'OK', { [ALLOW_ORIGIN]: '*' })
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'x-datadog-trace-id']
+      )
+    })
+
+    it('treats lowercase req.method "options" as OPTIONS', () => {
+      req.method = 'options'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'x-datadog-trace-id']
+      )
+    })
+
+    it('preserves existing allow-headers and de-duplicates datadog additions', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'x-datadog-trace-id, x-datadog-trace-id'
+      res.getHeaders.returns({
+        [ALLOW_ORIGIN]: '*',
+        [ALLOW_HEADERS]: 'content-type, x-datadog-trace-id',
+      })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.calledOnce)
+      assert.deepStrictEqual(
+        res.setHeader.firstCall.args,
+        [ALLOW_HEADERS, 'content-type,x-datadog-trace-id']
+      )
+    })
+
+    it('leaves allow-headers untouched when no datadog header was requested', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      req.headers['access-control-request-headers'] = 'content-type, x-other'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 200)
+
+      assert.ok(res.setHeader.notCalled)
+    })
+
+    it('delegates to the original writeHead with the same arguments', () => {
+      req.method = 'OPTIONS'
+      req.headers.origin = 'https://example.com'
+      res.getHeaders.returns({ [ALLOW_ORIGIN]: '*' })
+      res.writeHead = sinon.spy()
+
+      const wrapped = web.wrapWriteHead(context)
+      wrapped.call(res, 204, 'No Content', { 'x-test': '1' })
+
+      assert.ok(res.writeHead.calledOnce)
+      assert.deepStrictEqual(
+        res.writeHead.firstCall.args,
+        [204, 'No Content', { 'x-test': '1' }]
+      )
     })
   })
 })

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -191,7 +191,7 @@ describe('plugins/util/web', () => {
   describe('addError', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       web.patch(req)
       const context = web.getContext(req)
@@ -224,7 +224,7 @@ describe('plugins/util/web', () => {
   describe('addStatusError', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       web.patch(req)
       const context = web.getContext(req)
@@ -320,7 +320,7 @@ describe('plugins/util/web', () => {
   describe('http.endpoint tagging', () => {
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       req.url = '/'
 
@@ -368,7 +368,7 @@ describe('plugins/util/web', () => {
 
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       req.url = '/'
 
@@ -441,7 +441,7 @@ describe('plugins/util/web', () => {
 
     beforeEach(() => {
       span = tracer.startSpan('test.request')
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       req.url = '/'
 
@@ -509,7 +509,7 @@ describe('plugins/util/web', () => {
 
       web.startSpan(tracer, httpConfig, req, res, 'test.request')
       span = web.root(req)
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       assert.ok(Object.hasOwn(tags, 'http.url'))
       assert.ok(!Object.hasOwn(tags, USER_AGENT_TAG))
@@ -527,7 +527,7 @@ describe('plugins/util/web', () => {
 
       web.startSpan(tracer, httpConfig, req, res, 'test.request')
       span = web.root(req)
-      tags = span.context()._tags
+      tags = span.context().getTags()
 
       web.finishAll(web.getContext(req))
 
@@ -549,7 +549,7 @@ describe('plugins/util/web', () => {
 
       web.finishAll(web.getContext(req))
 
-      assert.ok(!Object.hasOwn(span.context()._tags, HTTP_CLIENT_IP))
+      assert.ok(!span.context().hasTag(HTTP_CLIENT_IP))
     })
 
     it('tags http.client_ip when clientIpEnabled is true', () => {
@@ -560,7 +560,7 @@ describe('plugins/util/web', () => {
 
       web.finishAll(web.getContext(req))
 
-      assert.strictEqual(span.context()._tags[HTTP_CLIENT_IP], '203.0.113.5')
+      assert.strictEqual(span.context().getTag(HTTP_CLIENT_IP), '203.0.113.5')
     })
   })
 

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -443,6 +443,64 @@ describe('plugins/util/web', () => {
     })
   })
 
+  describe('setRouteOrEndpointTag http.route fast path', () => {
+    let context
+
+    beforeEach(() => {
+      span = tracer.startSpan('test.request')
+      tags = span.context().getTags()
+
+      req.url = '/'
+
+      web.patch(req)
+      context = web.getContext(req)
+      context.span = span
+      context.req = req
+      context.res = res
+      context.config = config
+    })
+
+    it('leaves http.route unset when no segments were collected', () => {
+      context.paths = []
+
+      web.setRouteOrEndpointTag(req)
+
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `${inspect(tags)} may not contain ${HTTP_ROUTE} property`)
+    })
+
+    it('uses the single segment directly without entering Array.join', () => {
+      context.paths = ['/users/:id']
+
+      web.setRouteOrEndpointTag(req)
+
+      assert.strictEqual(tags[HTTP_ROUTE], '/users/:id')
+    })
+
+    it('leaves http.route unset for a single empty-string segment', () => {
+      context.paths = ['']
+
+      web.setRouteOrEndpointTag(req)
+
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE), `${inspect(tags)} may not contain ${HTTP_ROUTE} property`)
+    })
+
+    it('joins two segments byte-identical to the legacy join shape', () => {
+      context.paths = ['/api', '/users/:id']
+
+      web.setRouteOrEndpointTag(req)
+
+      assert.strictEqual(tags[HTTP_ROUTE], '/api/users/:id')
+    })
+
+    it('joins three segments byte-identical to the legacy join shape', () => {
+      context.paths = ['/api', '/users', '/:id/items']
+
+      web.setRouteOrEndpointTag(req)
+
+      assert.strictEqual(tags[HTTP_ROUTE], '/api/users/:id/items')
+    })
+  })
+
   describe('configured header tagging across the request lifecycle', () => {
     const USER_AGENT_TAG = `${HTTP_REQUEST_HEADERS}.user-agent`
     const SERVER_TAG = `${HTTP_RESPONSE_HEADERS}.server`


### PR DESCRIPTION
## Summary

`plugins/util/web` ran the request-side helper twice per HTTP request, then
ran a CORS preflight handler on every response, re-joined the route on every
finish, and carried a few exports nothing called. Tighten the helper and
trim the leftover work.

1. Dedupe `addRequestTags`: skip the body in `finishSpan` when `http.url` is
   already set. The serverless path (Azure Functions, Lambda) still depends
   on the second call to do the request-side work.
2. Split `addHeaders` into `addRequestHeaders` / `addResponseHeaders` and
   call the response side at finish time. Restores configured-header tagging
   for framework plugins (connect, express, hapi, koa, ...) that swap their
   config via `setFramework` after `web.startSpan`.
3. Idempotency guard on `applyRouteOrEndpointTag` so the AppSec pre-finish
   hook and the normal finish path don't re-emit the same `http.route` tag.
4. Gate `wrapWriteHead`'s CORS allow-header work on `OPTIONS`. Saves
   ~18 ns per non-preflight response.
5. Skip `Array.prototype.join` on empty / single-segment route paths in
   `applyRouteOrEndpointTag`. Single-segment is the dominant shape.
6. Cache the `'legacy'` storage handle once at module load; drop the dead
   `context.store` assignment.
7. Drop unused `web.wrapEnd` / `web.wrapRes` / `ends` WeakMap exports.

Drive-by fix:

* Cover `wrapWriteHead`'s OPTIONS branch with focused unit tests. The
  CORS allow-header path is only exercised by integration tests, which
  don't upload to the unit-test coverage flag.

## Test plan

`packages/dd-trace/test/plugins/util/web.spec.js` covers the idempotency
guards, the header split, the route fast paths, and the `wrapWriteHead`
permutations. CI covers the http-server / http-client / connect /
express / hapi / koa / fastify / serverless matrices.