### PR TITLE
perf(plugin): drop per-publish storage lookup and handler rest-spread

### DIFF
--- a/packages/dd-trace/src/plugins/plugin.js
+++ b/packages/dd-trace/src/plugins/plugin.js
@@ -6,6 +6,8 @@ const dc = require('dc-polyfill')
 const logger = require('../log')
 const { storage } = require('../../../datadog-core')
 
+const legacyStorage = storage('legacy')
+
 /**
  * Base class for all Datadog plugins.
  *
@@ -28,7 +30,7 @@ class Subscription {
   constructor (event, handler) {
     this._channel = dc.channel(event)
     this._handler = (message, name) => {
-      const store = storage('legacy').getStore()
+      const store = legacyStorage.getStore()
       if (!store || !store.noop) {
         handler(message, name)
       }
@@ -50,7 +52,7 @@ class StoreBinding {
   constructor (event, transform) {
     this._channel = dc.channel(event)
     this._transform = data => {
-      const store = storage('legacy').getStore()
+      const store = legacyStorage.getStore()
 
       return !store || !store.noop || (data && Object.hasOwn(data, 'currentStore'))
         ? transform(data)
@@ -59,11 +61,11 @@ class StoreBinding {
   }
 
   enable () {
-    this._channel.bindStore(storage('legacy'), this._transform)
+    this._channel.bindStore(legacyStorage, this._transform)
   }
 
   disable () {
-    this._channel.unbindStore(storage('legacy'))
+    this._channel.unbindStore(legacyStorage)
   }
 }
 
@@ -102,24 +104,21 @@ module.exports = class Plugin {
    * @returns {void}
    */
   enter (span, store) {
-    store = store || storage('legacy').getStore()
-    storage('legacy').enterWith({ ...store, span })
+    store = store || legacyStorage.getStore()
+    legacyStorage.enterWith({ ...store, span })
   }
 
   /**
    * Subscribe to a diagnostic channel with automatic error handling and enable/disable lifecycle.
    *
    * @param {string} channelName Diagnostic channel name.
-   * @param {(...args: unknown[]) => unknown} handler Handler invoked on messages.
+   * @param {(message: unknown, name: string) => unknown} handler Handler invoked on messages.
    * @returns {void}
    */
   addSub (channelName, handler) {
-    /**
-     * @type {typeof handler}
-     */
-    const wrappedHandler = (...args) => {
+    const wrappedHandler = (message, name) => {
       try {
-        return handler.apply(this, args)
+        return handler.call(this, message, name)
       } catch (error) {
         logger.error('Error in plugin handler:', error)
         logger.info('Disabling plugin: %s', this.constructor.name)
@@ -147,7 +146,7 @@ module.exports = class Plugin {
    * @returns {void}
    */
   addError (error) {
-    const store = storage('legacy').getStore()
+    const store = legacyStorage.getStore()
 
     if (!store || !store.span) return
 


### PR DESCRIPTION
Every diagnostic-channel publish through a dd-trace plugin subscriber runs the dispatch shell twice (`Subscription._handler` for the noop-store guard, then `wrappedHandler` for try / catch and the user handler call). Both ran `storage('legacy')` -- a `storages[namespace]` map lookup plus a truthy check -- per publish, and the wrapper materialised an `(...args)` rest array on every call only to feed it back into `.apply(this, args)`, even though `diagnostics_channel.publish` always invokes handlers with exactly `(message, channelName)`. Cache the storage instance once at module load and pin `wrappedHandler` to `(message, name)` with `handler.call(this, message, name)`.

Microbench (Node 24.15.0 / V8 13.6, 5M iterations x 7 trials, drop best + worst, no-op user handler):

* publish-enabled   12.5 -> 5.0 ns/op   (-7.5 ns, ~60 %)
* publish-disabled   1.8 -> 1.8 ns/op   (no-subscriber, unchanged)
* runStores         ~440 -> ~440 ns/op  (dominated by ALS)
* plugin.enter      ~270 -> ~270 ns/op  (dominated by ALS)

End-to-end local `bench/express-autocannon.js BENCH_DURATION=30` (50 connections, 4 routes, ~7 s each, agent send stubbed):

* aggregate     492 359 -> 556 756 requests   (+13 %)
* /static       17 403 -> 20 582 req/s        (+18 %)
* /params/:id   17 976 -> 20 577 req/s        (+14 %)
* /echo (POST)  16 239 -> 18 838 req/s        (+16 %)
* /async        18 719 -> 19 542 req/s        (+4 %)

The public Plugin / Subscription API and observable behaviour are unchanged.

