### PR TITLE
perf: reduce redis and ioredis bindStart overhead

### DIFF
--- a/packages/datadog-instrumentations/src/ioredis.js
+++ b/packages/datadog-instrumentations/src/ioredis.js
@@ -14,9 +14,9 @@ const connectionOptionsCache = new WeakMap()
 
 function wrapRedis (Redis) {
   shimmer.wrap(Redis.prototype, 'sendCommand', sendCommand => function (command, stream) {
-    if (!startCh.hasSubscribers) return sendCommand.apply(this, arguments)
+    if (!startCh.hasSubscribers) return sendCommand.call(this, command, stream)
 
-    if (!command || !command.promise) return sendCommand.apply(this, arguments)
+    if (!command?.promise) return sendCommand.call(this, command, stream)
 
     const options = this.options || {}
     let connectionOptions = connectionOptionsCache.get(this)
@@ -35,7 +35,7 @@ function wrapRedis (Redis) {
     return startCh.runStores(ctx, () => {
       command.promise.then(() => finish(finishCh, errorCh, ctx), err => finish(finishCh, errorCh, ctx, err))
 
-      return sendCommand.apply(this, arguments)
+      return sendCommand.call(this, command, stream)
     })
   })
   return Redis

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -11,6 +11,17 @@ class RedisPlugin extends CachePlugin {
   static id = 'redis'
   static system = 'redis'
 
+  /** @type {string} */
+  #rawCommandKey
+  /** @type {Map<string | undefined, { name: string, source: string | undefined }>} */
+  #serviceByConnection = new Map()
+  // `nomenclature.config` identity at last cache fill. `withNamingSchema` swaps it without
+  // running this plugin's `configure`, so identity drives invalidation in `bindStart`.
+  /** @type {object | undefined} */
+  #lastNomenclatureConfig
+  /** @type {string | undefined} */
+  #cachedOperationName
+
   constructor (...args) {
     super(...args)
     this._spanType = 'redis'
@@ -25,14 +36,27 @@ class RedisPlugin extends CachePlugin {
       return { noop: true }
     }
 
+    const nomConfig = this._tracer._nomenclature.config
+    if (this.#lastNomenclatureConfig !== nomConfig) {
+      this.#lastNomenclatureConfig = nomConfig
+      this.#cachedOperationName = undefined
+      this.#serviceByConnection.clear()
+    }
+
+    let service = this.#serviceByConnection.get(connectionName)
+    if (service === undefined) {
+      service = this.serviceName({ pluginConfig: this.config, system: this.system, connectionName })
+      this.#serviceByConnection.set(connectionName, service)
+    }
+
     this.startSpan({
       resource,
-      service: this.serviceName({ pluginConfig: this.config, system: this.system, connectionName }),
+      service,
       type: this._spanType,
       meta: {
         'db.type': this._spanType,
         'db.name': db || '0',
-        [`${this._spanType}.raw_command`]: formatCommand(normalizedCommand, args, argsStartIndex),
+        [this.#rawCommandKey]: formatCommand(normalizedCommand, args, argsStartIndex),
         'out.host': connectionOptions.host,
         [CLIENT_PORT_KEY]: connectionOptions.port,
       },
@@ -41,8 +65,19 @@ class RedisPlugin extends CachePlugin {
     return ctx.currentStore
   }
 
+  operationName () {
+    this.#cachedOperationName ??= super.operationName()
+    return this.#cachedOperationName
+  }
+
   configure (config) {
     super.configure(normalizeConfig(config))
+    // Subclasses (iovalkey) overwrite `_spanType` in their constructor, before any `configure`,
+    // so reading it here is stable.
+    this.#rawCommandKey = `${this._spanType}.raw_command`
+    this.#lastNomenclatureConfig = undefined
+    this.#cachedOperationName = undefined
+    this.#serviceByConnection.clear()
   }
 }
 

--- a/packages/datadog-plugin-redis/test/bindstart-cache.spec.js
+++ b/packages/datadog-plugin-redis/test/bindstart-cache.spec.js
@@ -1,0 +1,128 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach } = require('mocha')
+const sinon = require('sinon')
+
+require('../../dd-trace/test/setup/core')
+
+const RedisPlugin = require('../src')
+
+function makeNomenclatureStub () {
+  return {
+    config: { spanAttributeSchema: 'v0', spanRemoveIntegrationFromService: false },
+    opName () {
+      return 'redis.command'
+    },
+    serviceName (type, kind, id, opts) {
+      const { pluginConfig, system, connectionName } = opts
+      if (pluginConfig.splitByInstance && connectionName) {
+        if (this.config.spanAttributeSchema === 'v1') {
+          return { name: pluginConfig.service || 'tracer-svc', source: 'opt.plugin' }
+        }
+        return {
+          name: pluginConfig.service ? `${pluginConfig.service}-${connectionName}` : connectionName,
+          source: 'opt.split_by_instance',
+        }
+      }
+      return {
+        name: pluginConfig.service || `tracer-svc-${system}`,
+        source: pluginConfig.service ? 'opt.plugin' : system,
+      }
+    },
+  }
+}
+
+function makeTracerStub (nomenclature, startSpan) {
+  return {
+    _service: 'tracer-svc',
+    _nomenclature: nomenclature,
+    startSpan,
+  }
+}
+
+function makeCtx (connectionName) {
+  return {
+    db: 0,
+    command: 'get',
+    args: ['foo'],
+    argsStartIndex: 0,
+    connectionOptions: { host: '127.0.0.1', port: 6379 },
+    connectionName,
+    currentStore: {},
+  }
+}
+
+describe('RedisPlugin bindStart service caching', () => {
+  let plugin
+  let nomenclature
+  let startSpan
+
+  beforeEach(() => {
+    nomenclature = makeNomenclatureStub()
+    startSpan = sinon.stub().returns({
+      _spanContext: { _tags: {} },
+      setTag () {},
+      finish () {},
+      addLink () {},
+    })
+    plugin = new RedisPlugin(makeTracerStub(nomenclature, startSpan), {
+      codeOriginForSpans: { enabled: false, experimental: { exit_spans: { enabled: false } } },
+    })
+    plugin.configure({
+      service: 'custom',
+      splitByInstance: true,
+      enabled: false,
+    })
+  })
+
+  it('caches the service name across repeated bindStart calls with the same connection', () => {
+    plugin.bindStart(makeCtx('test'))
+    plugin.bindStart(makeCtx('test'))
+
+    assert.strictEqual(startSpan.firstCall.args[1].tags['service.name'], 'custom-test')
+    assert.strictEqual(startSpan.secondCall.args[1].tags['service.name'], 'custom-test')
+  })
+
+  it('re-derives the service name when the nomenclature config flips (schema v0 -> v1)', () => {
+    plugin.bindStart(makeCtx('test'))
+    assert.strictEqual(startSpan.firstCall.args[1].tags['service.name'], 'custom-test')
+
+    // Replace the object the way `SchemaManager.configure` does -- not mutate.
+    nomenclature.config = {
+      spanAttributeSchema: 'v1',
+      spanRemoveIntegrationFromService: false,
+    }
+
+    plugin.bindStart(makeCtx('test'))
+    assert.strictEqual(startSpan.secondCall.args[1].tags['service.name'], 'custom')
+  })
+
+  it('clears the cache on configure() so a new plugin config takes effect', () => {
+    plugin.bindStart(makeCtx('test'))
+    assert.strictEqual(startSpan.firstCall.args[1].tags['service.name'], 'custom-test')
+
+    plugin.configure({
+      service: 'renamed',
+      splitByInstance: true,
+      enabled: false,
+    })
+
+    plugin.bindStart(makeCtx('test'))
+    assert.strictEqual(startSpan.secondCall.args[1].tags['service.name'], 'renamed-test')
+  })
+
+  it('still caches across multiple connections separately', () => {
+    plugin.bindStart(makeCtx('a'))
+    plugin.bindStart(makeCtx('b'))
+    plugin.bindStart(makeCtx('a'))
+    plugin.bindStart(makeCtx('b'))
+
+    const calls = startSpan.getCalls()
+    assert.strictEqual(calls[0].args[1].tags['service.name'], 'custom-a')
+    assert.strictEqual(calls[1].args[1].tags['service.name'], 'custom-b')
+    assert.strictEqual(calls[2].args[1].tags['service.name'], 'custom-a')
+    assert.strictEqual(calls[3].args[1].tags['service.name'], 'custom-b')
+  })
+})


### PR DESCRIPTION
`bindStart` was the dominant per-redis-command cost in production
profiles (1.89 % self / 7.28 % total). Every call re-allocated the
`{ name, source }` service pair, the operation name, the computed
`${_spanType}.raw_command` meta key, and two intermediate options
objects through `this.serviceName({ ... })` and `this.operationName()`,
all fully determined by the plugin instance plus `connectionName`
(which only changes when `configure` runs).

Span shape stays byte-identical -- same `operation`, `service`,
`resource`, and `meta` keys / source tags -- verified through the
existing `datadog-plugin-redis`, `datadog-plugin-ioredis`, and
`datadog-plugin-iovalkey` specs.

Microbench (Node 24.15 / V8 13.6, 1M iterations x 7 trials, trimmed
mean of 5 dropping best + worst):

* bindStart GET (steady)        273 ns/op -> 205 ns/op   -25 %
* bindStart SET (steady)        283 ns/op -> 213 ns/op   -25 %
* bindStart splitByInstance(4)  275 ns/op -> 211 ns/op   -23 %

The harness stubs `tracer.startSpan` to a no-op that materialises
the options object so V8 cannot fold the meta literal away.

