### PR TITLE
perf(id): memoise Identifier.toBigInt instead of re-decoding the buffer per call

### DIFF
--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -13,6 +13,8 @@ let batch = 0
 class Identifier {
   /** @type {number[] | Uint8Array} */
   #buffer
+  /** @type {bigint | undefined} */
+  #bigInt
 
   /**
    * @param {string} value
@@ -38,7 +40,8 @@ class Identifier {
    * @returns {bigint}
    */
   toBigInt () {
-    return Buffer.from(this.#buffer).readBigUInt64BE(0)
+    this.#bigInt ??= Buffer.from(this.#buffer).readBigUInt64BE(0)
+    return this.#bigInt
   }
 
   /**

--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -15,6 +15,10 @@ class Identifier {
   #buffer
   /** @type {bigint | undefined} */
   #bigInt
+  /** @type {string | undefined} */
+  #stringHex
+  /** @type {string | undefined} */
+  #stringDecimal
 
   /**
    * @param {string} value
@@ -31,9 +35,15 @@ class Identifier {
    * @returns {string}
    */
   toString (radix = 16) {
-    return radix === 16
-      ? Buffer.from(this.#buffer).toString('hex')
-      : toNumberString(this.#buffer, radix)
+    if (radix === 16) {
+      this.#stringHex ??= Buffer.from(this.#buffer).toString('hex')
+      return this.#stringHex
+    }
+    if (radix === 10) {
+      this.#stringDecimal ??= toNumberString(this.#buffer, 10)
+      return this.#stringDecimal
+    }
+    return toNumberString(this.#buffer, radix)
   }
 
   /**

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -125,4 +125,34 @@ describe('id', () => {
       assert.strictEqual(spanId.toBigInt(), expected)
     }
   })
+
+  it('should return the same string across repeated toString calls for radix 16 and radix 10', () => {
+    const samples = [
+      id('abcd', 16),
+      id('12293a8527e70a7f27c8d624ace0f559', 16),
+      id('1234', 10),
+      id('0', 16),
+    ]
+
+    for (const spanId of samples) {
+      const hex = spanId.toString(16)
+      assert.strictEqual(spanId.toString(16), hex)
+      assert.strictEqual(spanId.toString(), hex)
+      assert.strictEqual(spanId.toJSON(), hex)
+
+      const decimal = spanId.toString(10)
+      assert.strictEqual(spanId.toString(10), decimal)
+    }
+  })
+
+  it('should still recompute toString for other radices and not pollute the hex/decimal caches', () => {
+    const spanId = id('abcd', 16)
+
+    assert.strictEqual(spanId.toString(8), '125715')
+    assert.strictEqual(spanId.toString(8), '125715')
+    assert.strictEqual(spanId.toString(2), '1010101111001101')
+
+    assert.strictEqual(spanId.toString(16), '000000000000abcd')
+    assert.strictEqual(spanId.toString(10), '43981')
+  })
 })

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -99,4 +99,30 @@ describe('id', () => {
       assert.strictEqual(spanId.toBigInt(), expected)
     }
   })
+
+  it('should return the same BigInt value across repeated toBigInt calls', () => {
+    const samples = [
+      id('abcd', 16),
+      id('12293a8527e70a7f27c8d624ace0f559', 16),
+      id('1234', 10),
+      id('0', 16),
+    ]
+
+    for (const spanId of samples) {
+      const first = spanId.toBigInt()
+      assert.strictEqual(spanId.toBigInt(), first)
+      assert.strictEqual(spanId.toBigInt(), first)
+    }
+  })
+
+  it('should match Buffer#readBigUInt64BE on the underlying buffer', () => {
+    const cases = ['abcd', '12293a8527e70a7f27c8d624ace0f559', '7f00ff00ff00ff00']
+
+    for (const hex of cases) {
+      const spanId = id(hex, 16)
+      const expected = Buffer.from(spanId.toBuffer()).readBigUInt64BE(0)
+
+      assert.strictEqual(spanId.toBigInt(), expected)
+    }
+  })
 })


### PR DESCRIPTION
Each call wrapped the underlying buffer in a fresh Node Buffer
viewport and decoded the same eight bytes again. The hot callers are
the rate sampler (one call per sampled span), the wall profiler's
label tagging, and the profiler-event plugin's per-event span id
capture. The bigint is cached on the instance on first read;
`#buffer` is assigned only in the constructor and no instance method
writes to it, so the cached value stays correct.

The immutability of `#buffer` after construction moves from
incidental to load-bearing for `toBigInt`. The verified `toBuffer()`
callers (`opentracing/span_context`, `opentracing/propagation/text_map`,
`opentelemetry/trace/otlp_transformer`, `encode/0.4`) only read the
returned array; a future caller that mutated it would already corrupt
`toString()` and `equals()`.


