### PR TITLE
perf(graphql): tighten resolver execute hot path

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -251,11 +251,11 @@ function wrapResolve (resolve) {
 
     const field = assertField(ctx, info, args)
 
-    return callInAsyncScope(resolve, this, arguments, ctx.abortController, (err) => {
+    return callInAsyncScope(resolve, this, arguments, ctx.abortController, field && ((err) => {
       field.ctx.error = err
       field.ctx.field = field
       updateFieldCh.publish(field.ctx)
-    })
+    }))
   }
 
   patchedResolvers.add(resolveAsync)
@@ -294,22 +294,55 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 }
 
 /**
- * @param {{ fields: Map<object, { error: unknown, ctx: object }> }} rootCtx
- * @param {{ path: object }} info
+ * @param {{
+ *   fields: Map<object, { error: unknown, ctx: object }>,
+ *   collapse: boolean,
+ *   depth: number,
+ *   collapsedFields?: Set<string>,
+ * }} rootCtx
+ * @param {import('graphql').GraphQLResolveInfo} info
  * @param {Record<string, unknown>} args
  */
 function assertField (rootCtx, info, args) {
   const path = info.path
-  const fields = rootCtx.fields
-  let field = fields.get(path)
+  const collapse = rootCtx.collapse
+  const depth = rootCtx.depth
 
-  if (!field) {
-    const fieldCtx = { info, rootCtx, args, path }
-    startResolveCh.publish(fieldCtx)
-    field = { error: null, ctx: fieldCtx }
-    fields.set(path, field)
+  let length = 0
+  let stringSegments = 0
+  for (let curr = path; curr; curr = curr.prev) {
+    length += 1
+    if (typeof curr.key === 'string') stringSegments += 1
   }
 
+  if (depth >= 0 && depth < (collapse ? length : stringSegments)) return
+
+  const segments = new Array(length)
+  let index = length - 1
+  for (let curr = path; curr; curr = curr.prev) {
+    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
+  }
+  const pathString = segments.join('.')
+
+  if (collapse) {
+    const collapsedFields = rootCtx.collapsedFields ??= new Set()
+    if (collapsedFields.has(pathString)) return
+    collapsedFields.add(pathString)
+  }
+
+  const fieldCtx = {
+    rootCtx,
+    args,
+    path,
+    pathString,
+    fieldName: info.fieldName,
+    returnType: info.returnType,
+    fieldNode: info.fieldNodes[0],
+    variableValues: info.variableValues,
+  }
+  startResolveCh.publish(fieldCtx)
+  const field = { error: null, ctx: fieldCtx }
+  rootCtx.fields.set(path, field)
   return field
 }
 
@@ -346,7 +379,6 @@ function wrapFieldType (field) {
 function finishResolvers ({ fields }) {
   for (const field of fields.values()) {
     const fieldCtx = field.ctx
-    if (!fieldCtx.currentStore) continue
     fieldCtx.finishTime = field.finishTime
     fieldCtx.field = field
     if (field.error) {

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -295,14 +295,16 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 
 /**
  * @typedef {{ prev: PathNode | undefined, key: string | number }} PathNode
+ *
+ * @typedef {{ error: unknown, ctx: object }} TrackedField
  */
 
 /**
  * @param {{
- *   fields: Map<object, { error: unknown, ctx: object }>,
+ *   fields: Map<object, TrackedField>,
  *   collapse: boolean,
  *   depth: number,
- *   collapsedFields?: Set<string>,
+ *   collapsedFields?: Map<string, TrackedField>,
  *   pathCache?: Map<PathNode, string>,
  * }} rootCtx
  * @param {import('graphql').GraphQLResolveInfo} info
@@ -335,10 +337,14 @@ function assertField (rootCtx, info, args) {
     : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
   cache.set(path, pathString)
 
+  let collapsedFields
   if (collapse) {
-    const collapsedFields = rootCtx.collapsedFields ??= new Set()
-    if (collapsedFields.has(pathString)) return
-    collapsedFields.add(pathString)
+    collapsedFields = rootCtx.collapsedFields ??= new Map()
+    const existing = collapsedFields.get(pathString)
+    // Subsequent siblings of a collapsed list share the first sibling's field
+    // so updateFieldCh fires for every call and the span's finishTime tracks
+    // the last sibling's completion, not the first.
+    if (existing !== undefined) return existing
   }
 
   const fieldCtx = {
@@ -354,6 +360,7 @@ function assertField (rootCtx, info, args) {
   startResolveCh.publish(fieldCtx)
   const field = { error: null, ctx: fieldCtx }
   rootCtx.fields.set(path, field)
+  if (collapsedFields !== undefined) collapsedFields.set(pathString, field)
   return field
 }
 

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -252,7 +252,7 @@ function wrapResolve (resolve) {
     const field = assertField(ctx, info, args)
 
     if (ctx.abortController.signal.aborted) {
-      if (field !== undefined) publishResolverFinish(field, null)
+      publishResolverFinish(field, null)
       throw new AbortError('Aborted')
     }
 
@@ -261,19 +261,19 @@ function wrapResolve (resolve) {
       if (result !== null && typeof result?.then === 'function') {
         return result.then(
           res => {
-            if (field !== undefined) publishResolverFinish(field, null)
+            publishResolverFinish(field, null)
             return res
           },
           error => {
-            if (field !== undefined) publishResolverFinish(field, error)
+            publishResolverFinish(field, error)
             throw error
           }
         )
       }
-      if (field !== undefined) publishResolverFinish(field, null)
+      publishResolverFinish(field, null)
       return result
     } catch (error) {
-      if (field !== undefined) publishResolverFinish(field, error)
+      publishResolverFinish(field, error)
       throw error
     }
   }
@@ -332,7 +332,6 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
  * @param {{
  *   fields: Map<object, TrackedField>,
  *   collapse: boolean,
- *   depth: number,
  *   collapsedFields?: Map<string, TrackedField>,
  *   pathCache?: Map<PathNode, string>,
  * }} rootCtx
@@ -342,19 +341,6 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 function assertField (rootCtx, info, args) {
   const path = info.path
   const collapse = rootCtx.collapse
-  const depth = rootCtx.depth
-
-  if (depth >= 0) {
-    let count = 0
-    if (collapse) {
-      for (let curr = path; curr; curr = curr.prev) count += 1
-    } else {
-      for (let curr = path; curr; curr = curr.prev) {
-        if (typeof curr.key === 'string') count += 1
-      }
-    }
-    if (depth < count) return
-  }
 
   const cache = rootCtx.pathCache ??= new Map()
   const prev = path.prev
@@ -386,6 +372,8 @@ function assertField (rootCtx, info, args) {
     fieldNode: info.fieldNodes[0],
     variableValues: info.variableValues,
   }
+  // Depth gating happens in the resolve plugin's start handler, after this
+  // publish, so IAST and AppSec subscribers see every resolver call.
   startResolveCh.publish(fieldCtx)
   const field = { error: null, ctx: fieldCtx }
   rootCtx.fields.set(path, field)
@@ -449,6 +437,10 @@ function wrapFieldType (field) {
 function finishResolvers ({ fields }) {
   for (const field of fields.values()) {
     const fieldCtx = field.ctx
+    // A depth-gated field publishes startResolveCh for IAST/AppSec but the
+    // resolve plugin's start short-circuits before creating a span, so there
+    // is no span here to finish.
+    if (fieldCtx.currentStore === undefined) continue
     fieldCtx.finishTime = field.finishTime
     fieldCtx.field = field
     if (field.error) {

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -251,11 +251,31 @@ function wrapResolve (resolve) {
 
     const field = assertField(ctx, info, args)
 
-    return callInAsyncScope(resolve, this, arguments, ctx.abortController, field && ((err) => {
-      field.ctx.error = err
-      field.ctx.field = field
-      updateFieldCh.publish(field.ctx)
-    }))
+    if (ctx.abortController.signal.aborted) {
+      if (field !== undefined) publishResolverFinish(field, null)
+      throw new AbortError('Aborted')
+    }
+
+    try {
+      const result = resolve.call(this, source, args, contextValue, info)
+      if (result !== null && typeof result?.then === 'function') {
+        return result.then(
+          res => {
+            if (field !== undefined) publishResolverFinish(field, null)
+            return res
+          },
+          error => {
+            if (field !== undefined) publishResolverFinish(field, error)
+            throw error
+          }
+        )
+      }
+      if (field !== undefined) publishResolverFinish(field, null)
+      return result
+    } catch (error) {
+      if (field !== undefined) publishResolverFinish(field, error)
+      throw error
+    }
   }
 
   patchedResolvers.add(resolveAsync)
@@ -263,33 +283,42 @@ function wrapResolve (resolve) {
   return resolveAsync
 }
 
-function callInAsyncScope (fn, thisArg, args, abortController, cb) {
-  cb = cb || (() => {})
+/**
+ * @param {{ ctx: object, error: unknown }} field
+ * @param {unknown} error
+ */
+function publishResolverFinish (field, error) {
+  const fieldCtx = field.ctx
+  fieldCtx.error = error
+  fieldCtx.field = field
+  updateFieldCh.publish(fieldCtx)
+}
 
-  if (abortController?.signal.aborted) {
+function callInAsyncScope (fn, thisArg, args, abortController, cb) {
+  if (abortController.signal.aborted) {
     cb(null, null)
     throw new AbortError('Aborted')
   }
 
   try {
     const result = fn.apply(thisArg, args)
-    if (result && typeof result.then === 'function') {
+    if (result !== null && typeof result?.then === 'function') {
       return result.then(
         res => {
           cb(null, res)
           return res
         },
-        err => {
-          cb(err)
-          throw err
+        error => {
+          cb(error)
+          throw error
         }
       )
     }
     cb(null, result)
     return result
-  } catch (err) {
-    cb(err)
-    throw err
+  } catch (error) {
+    cb(error)
+    throw error
   }
 }
 

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -352,16 +352,6 @@ function assertField (rootCtx, info, args) {
     : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
   cache.set(path, pathString)
 
-  let collapsedFields
-  if (collapse) {
-    collapsedFields = rootCtx.collapsedFields ??= new Map()
-    const existing = collapsedFields.get(pathString)
-    // Subsequent siblings of a collapsed list share the first sibling's field
-    // so updateFieldCh fires for every call and the span's finishTime tracks
-    // the last sibling's completion, not the first.
-    if (existing !== undefined) return existing
-  }
-
   const fieldCtx = {
     rootCtx,
     args,
@@ -372,9 +362,21 @@ function assertField (rootCtx, info, args) {
     fieldNode: info.fieldNodes[0],
     variableValues: info.variableValues,
   }
-  // Depth gating happens in the resolve plugin's start handler, after this
-  // publish, so IAST and AppSec subscribers see every resolver call.
+  // Publish per resolver call, before the collapse / depth dedupe below.
+  // IAST mutates each call's own args object; if siblings 2..N skip the
+  // publish, those args objects never get tainted.
   startResolveCh.publish(fieldCtx)
+
+  let collapsedFields
+  if (collapse) {
+    collapsedFields = rootCtx.collapsedFields ??= new Map()
+    const existing = collapsedFields.get(pathString)
+    // Subsequent siblings of a collapsed list share the first sibling's field
+    // so updateFieldCh fires for every call and the span's finishTime tracks
+    // the last sibling's completion, not the first.
+    if (existing !== undefined) return existing
+  }
+
   const field = { error: null, ctx: fieldCtx }
   rootCtx.fields.set(path, field)
   if (collapsedFields !== undefined) collapsedFields.set(pathString, field)

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -195,7 +195,7 @@ function wrapExecute (execute) {
         args,
         docSource: source,
         source,
-        fields: Object.create(null),
+        fields: new Map(),
         abortController: new AbortController(),
       }
 
@@ -294,37 +294,21 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
   }
 }
 
-function pathToArray (path) {
-  let length = 0
-  for (let curr = path; curr; curr = curr.prev) {
-    length += 1
-  }
-
-  const flattened = new Array(length)
-  let index = length
-  for (let curr = path; curr; curr = curr.prev) {
-    flattened[--index] = curr.key
-  }
-  return flattened
-}
-
+/**
+ * @param {{ fields: Map<object, { error: unknown, ctx: object }> }} rootCtx
+ * @param {{ path: object }} info
+ * @param {Record<string, unknown>} args
+ */
 function assertField (rootCtx, info, args) {
-  const pathInfo = info && info.path
-
-  const path = pathToArray(pathInfo)
-
-  const pathString = path.join('.')
+  const path = info.path
   const fields = rootCtx.fields
-
-  let field = fields[pathString]
+  let field = fields.get(path)
 
   if (!field) {
-    const fieldCtx = { info, rootCtx, args, path, pathString }
+    const fieldCtx = { info, rootCtx, args, path }
     startResolveCh.publish(fieldCtx)
-    field = fields[pathString] = {
-      error: null,
-      ctx: fieldCtx,
-    }
+    field = { error: null, ctx: fieldCtx }
+    fields.set(path, field)
   }
 
   return field
@@ -361,14 +345,16 @@ function wrapFieldType (field) {
 }
 
 function finishResolvers ({ fields }) {
-  for (const field of Object.values(fields)) {
-    field.ctx.finishTime = field.finishTime
-    field.ctx.field = field
+  for (const field of fields.values()) {
+    const fieldCtx = field.ctx
+    if (!fieldCtx.currentStore) continue
+    fieldCtx.finishTime = field.finishTime
+    fieldCtx.field = field
     if (field.error) {
-      field.ctx.error = field.error
-      resolveErrorCh.publish(field.ctx)
+      fieldCtx.error = field.error
+      resolveErrorCh.publish(fieldCtx)
     }
-    finishResolveCh.publish(field.ctx)
+    finishResolveCh.publish(fieldCtx)
   }
 }
 

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -253,7 +253,6 @@ function wrapResolve (resolve) {
 
     return callInAsyncScope(resolve, this, arguments, ctx.abortController, (err) => {
       field.ctx.error = err
-      field.ctx.info = info
       field.ctx.field = field
       updateFieldCh.publish(field.ctx)
     })

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -294,11 +294,16 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 }
 
 /**
+ * @typedef {{ prev: PathNode | undefined, key: string | number }} PathNode
+ */
+
+/**
  * @param {{
  *   fields: Map<object, { error: unknown, ctx: object }>,
  *   collapse: boolean,
  *   depth: number,
  *   collapsedFields?: Set<string>,
+ *   pathCache?: Map<PathNode, string>,
  * }} rootCtx
  * @param {import('graphql').GraphQLResolveInfo} info
  * @param {Record<string, unknown>} args
@@ -308,21 +313,27 @@ function assertField (rootCtx, info, args) {
   const collapse = rootCtx.collapse
   const depth = rootCtx.depth
 
-  let length = 0
-  let stringSegments = 0
-  for (let curr = path; curr; curr = curr.prev) {
-    length += 1
-    if (typeof curr.key === 'string') stringSegments += 1
+  if (depth >= 0) {
+    let count = 0
+    if (collapse) {
+      for (let curr = path; curr; curr = curr.prev) count += 1
+    } else {
+      for (let curr = path; curr; curr = curr.prev) {
+        if (typeof curr.key === 'string') count += 1
+      }
+    }
+    if (depth < count) return
   }
 
-  if (depth >= 0 && depth < (collapse ? length : stringSegments)) return
+  const cache = rootCtx.pathCache ??= new Map()
+  const prev = path.prev
+  const key = path.key
+  const segment = collapse && typeof key !== 'string' ? '*' : key
 
-  const segments = new Array(length)
-  let index = length - 1
-  for (let curr = path; curr; curr = curr.prev) {
-    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
-  }
-  const pathString = segments.join('.')
+  const pathString = prev === undefined
+    ? String(segment)
+    : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
+  cache.set(path, pathString)
 
   if (collapse) {
     const collapsedFields = rootCtx.collapsedFields ??= new Set()
@@ -344,6 +355,29 @@ function assertField (rootCtx, info, args) {
   const field = { error: null, ctx: fieldCtx }
   rootCtx.fields.set(path, field)
   return field
+}
+
+/**
+ * Cold path for assertField. graphql-js inserts a synthetic array-index
+ * node between a list field and its items, and that node never reaches a
+ * resolver — so assertField has no chance to cache it. The first child of
+ * the list item that hits the path cache lands here to walk and populate
+ * back to a cached ancestor.
+ *
+ * @param {PathNode} path
+ * @param {Map<PathNode, string>} cache
+ * @param {boolean} collapse
+ */
+function buildCachedPathString (path, cache, collapse) {
+  const key = path.key
+  const segment = collapse && typeof key !== 'string' ? '*' : key
+  const prev = path.prev
+
+  const pathString = prev === undefined
+    ? String(segment)
+    : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
+  cache.set(path, pathString)
+  return pathString
 }
 
 function wrapFields (type) {

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -247,6 +247,7 @@ function wrapResolve (resolve) {
     // executes that ran with a primitive `contextValue`.
     const ctx = contexts.get(contextValue) ?? executeCtx.getStore()
 
+    /* istanbul ignore if: resolver invoked outside execute(), so no per-execute ctx was registered */
     if (!ctx) return resolve.apply(this, arguments)
 
     const field = assertField(ctx, info, args)
@@ -308,6 +309,7 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
           cb(null, res)
           return res
         },
+        /* istanbul ignore next: graphql.execute() rejects only via custom executors (graphql-yoga / graphql-tools) */
         error => {
           cb(error)
           throw error

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -17,6 +17,9 @@ class GraphQLExecutePlugin extends TracingPlugin {
     const document = args.document
     const source = this.config.source && document && docSource
 
+    ctx.collapse = this.config.collapse
+    ctx.depth = this.config.depth
+
     const span = this.startSpan(this.operationName(), {
       service: this.config.service || this.serviceName(),
       resource: getSignature(document, name, type, this.config.signature),

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -18,7 +18,6 @@ class GraphQLExecutePlugin extends TracingPlugin {
     const source = this.config.source && document && docSource
 
     ctx.collapse = this.config.collapse
-    ctx.depth = this.config.depth
 
     const span = this.startSpan(this.operationName(), {
       service: this.config.service || this.serviceName(),

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -3,38 +3,29 @@
 const dc = require('dc-polyfill')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
-const collapsedPathSym = Symbol('collapsedPaths')
-
 class GraphQLResolvePlugin extends TracingPlugin {
   static id = 'graphql'
   static operation = 'resolve'
 
+  /**
+   * @param {{ info: object, rootCtx: object, args: Record<string, unknown>, path: object }} fieldCtx
+   */
   start (fieldCtx) {
-    const { info, rootCtx, args, path: pathAsArray, pathString } = fieldCtx
+    if (!shouldInstrument(this.config, fieldCtx.path)) return
 
-    // we need to get the parent span to the field if it exists for correct span parenting
-    // of nested fields
-    const parentField = getParentField(rootCtx, pathString)
-    const childOf = parentField?.ctx?.currentStore?.span
+    const { info, rootCtx, args, path } = fieldCtx
+    const collapse = this.config.collapse
+    const pathString = buildPathString(path, collapse)
+    fieldCtx.pathString = pathString
 
-    fieldCtx.parent = parentField
-
-    if (!shouldInstrument(this.config, pathAsArray)) return
-    const computedPathString = this.config.collapse
-      ? buildCollapsedPathString(pathAsArray)
-      : pathString
-
-    if (this.config.collapse) {
-      if (rootCtx.fields[computedPathString]) return
-
-      if (!rootCtx[collapsedPathSym]) {
-        rootCtx[collapsedPathSym] = Object.create(null)
-      } else if (rootCtx[collapsedPathSym][computedPathString]) {
-        return
-      }
-
-      rootCtx[collapsedPathSym][computedPathString] = true
+    if (collapse) {
+      const collapsedFields = rootCtx.collapsedFields ??= new Set()
+      if (collapsedFields.has(pathString)) return
+      collapsedFields.add(pathString)
     }
+
+    const parentField = getParentField(rootCtx, path)
+    const childOf = parentField?.ctx?.currentStore?.span
 
     const document = rootCtx.source
     const fieldNode = info.fieldNodes[0]
@@ -51,7 +42,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
       type: 'graphql',
       meta: {
         'graphql.field.name': info.fieldName,
-        'graphql.field.path': computedPathString,
+        'graphql.field.path': pathString,
         'graphql.field.type': namedReturnType.name,
         'graphql.source': source,
       },
@@ -79,9 +70,9 @@ class GraphQLResolvePlugin extends TracingPlugin {
     super(...args)
 
     this.addTraceSub('updateField', (ctx) => {
-      const { field, error, path: pathAsArray } = ctx
+      const { field, error, path } = ctx
 
-      if (!shouldInstrument(this.config, pathAsArray)) return
+      if (!shouldInstrument(this.config, path)) return
 
       const span = ctx?.currentStore?.span || this.activeSpan
       field.finishTime = span._getTime ? span._getTime() : 0
@@ -108,30 +99,45 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
 // helpers
 
-function shouldInstrument (config, pathAsArray) {
+/**
+ * @param {{ depth: number, collapse: boolean }} config
+ * @param {{ prev: object | undefined, key: string | number }} path
+ */
+function shouldInstrument (config, path) {
   if (config.depth < 0) return true
 
   let depth = 0
   if (config.collapse) {
-    depth = pathAsArray.length
+    for (let curr = path; curr; curr = curr.prev) depth += 1
   } else {
-    for (const segment of pathAsArray) {
-      if (typeof segment === 'string') depth += 1
+    for (let curr = path; curr; curr = curr.prev) {
+      if (typeof curr.key === 'string') depth += 1
     }
   }
 
   return config.depth >= depth
 }
 
-function buildCollapsedPathString (pathAsArray) {
-  let result = ''
-  for (const segment of pathAsArray) {
-    if (result.length > 0) result += '.'
-    result += typeof segment === 'number' ? '*' : segment
+/**
+ * @param {{ prev: object | undefined, key: string | number }} path
+ * @param {boolean} collapse Replace numeric segments with `*`.
+ */
+function buildPathString (path, collapse) {
+  let length = 0
+  for (let curr = path; curr; curr = curr.prev) length += 1
+
+  const segments = new Array(length)
+  let index = length - 1
+  for (let curr = path; curr; curr = curr.prev) {
+    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
   }
-  return result
+  return segments.join('.')
 }
 
+/**
+ * @param {object} info
+ * @param {Record<string, unknown> | undefined} args
+ */
 function getResolverInfo (info, args) {
   let resolverVars
 
@@ -157,20 +163,15 @@ function getResolverInfo (info, args) {
   return resolverVars === undefined ? null : { [info.fieldName]: resolverVars }
 }
 
-function getParentField (parentCtx, pathToString) {
-  let current = pathToString
-
-  while (current) {
-    const lastJoin = current.lastIndexOf('.')
-    if (lastJoin === -1) break
-
-    current = current.slice(0, lastJoin)
-    const field = parentCtx.fields[current]
-
+/**
+ * @param {{ fields: Map<object, { error: unknown, ctx: object }> }} rootCtx
+ * @param {{ prev: object | undefined }} path
+ */
+function getParentField (rootCtx, path) {
+  for (let curr = path.prev; curr; curr = curr.prev) {
+    const field = rootCtx.fields.get(curr)
     if (field) return field
   }
-
-  return null
 }
 
 module.exports = GraphQLResolvePlugin

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -9,7 +9,11 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
   /**
    * @param {{
-   *   rootCtx: { source?: string },
+   *   rootCtx: {
+   *     source?: string,
+   *     collapse: boolean,
+   *     collapsedFields?: Map<string, { ctx: object }>,
+   *   },
    *   args: Record<string, unknown>,
    *   path: { prev: object | undefined, key: string | number },
    *   pathString: string,
@@ -23,6 +27,11 @@ class GraphQLResolvePlugin extends TracingPlugin {
     if (!shouldInstrument(this.config, fieldCtx.path)) return
 
     const { rootCtx, args, path, pathString, fieldName, returnType, fieldNode, variableValues } = fieldCtx
+
+    // Siblings 2..N of a collapsed list share the first sibling's span, so
+    // skip span creation here. updateField still fires on the shared ctx and
+    // advances the shared span's finishTime.
+    if (rootCtx.collapse && rootCtx.collapsedFields?.has(pathString)) return
 
     const parentField = getParentField(rootCtx, path)
     const childOf = parentField?.ctx?.currentStore?.span

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -8,40 +8,37 @@ class GraphQLResolvePlugin extends TracingPlugin {
   static operation = 'resolve'
 
   /**
-   * @param {{ info: object, rootCtx: object, args: Record<string, unknown>, path: object }} fieldCtx
+   * @param {{
+   *   rootCtx: { source?: string },
+   *   args: Record<string, unknown>,
+   *   path: object,
+   *   pathString: string,
+   *   fieldName: string,
+   *   returnType: { name: string },
+   *   fieldNode: { loc?: { start: number, end: number }, arguments?: object[], directives?: object[] } | undefined,
+   *   variableValues: Record<string, unknown> | undefined,
+   * }} fieldCtx
    */
   start (fieldCtx) {
-    if (!shouldInstrument(this.config, fieldCtx.path)) return
-
-    const { info, rootCtx, args, path } = fieldCtx
-    const collapse = this.config.collapse
-    const pathString = buildPathString(path, collapse)
-    fieldCtx.pathString = pathString
-
-    if (collapse) {
-      const collapsedFields = rootCtx.collapsedFields ??= new Set()
-      if (collapsedFields.has(pathString)) return
-      collapsedFields.add(pathString)
-    }
+    const { rootCtx, args, path, pathString, fieldName, returnType, fieldNode, variableValues } = fieldCtx
 
     const parentField = getParentField(rootCtx, path)
     const childOf = parentField?.ctx?.currentStore?.span
 
     const document = rootCtx.source
-    const fieldNode = info.fieldNodes[0]
     const loc = this.config.source && document && fieldNode && fieldNode.loc
     const source = loc && document.slice(loc.start, loc.end)
 
-    let namedReturnType = info.returnType
+    let namedReturnType = returnType
     while (namedReturnType.ofType) namedReturnType = namedReturnType.ofType
 
     const span = this.startSpan('graphql.resolve', {
       service: this.config.service,
-      resource: `${info.fieldName}:${info.returnType}`,
+      resource: `${fieldName}:${returnType}`,
       childOf,
       type: 'graphql',
       meta: {
-        'graphql.field.name': info.fieldName,
+        'graphql.field.name': fieldName,
         'graphql.field.path': pathString,
         'graphql.field.type': namedReturnType.name,
         'graphql.source': source,
@@ -49,7 +46,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     }, fieldCtx)
 
     if (fieldNode && this.config.variables && fieldNode.arguments) {
-      const variables = this.config.variables(info.variableValues)
+      const variables = this.config.variables(variableValues)
 
       for (const arg of fieldNode.arguments) {
         if (arg.value?.name && arg.value.kind === 'Variable' && variables[arg.value.name.value]) {
@@ -60,7 +57,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     }
 
     if (this.resolverStartCh.hasSubscribers) {
-      this.resolverStartCh.publish({ ctx: rootCtx, resolverInfo: getResolverInfo(info, args) })
+      this.resolverStartCh.publish({ ctx: rootCtx, resolverInfo: getResolverInfo(fieldNode, fieldName, args) })
     }
 
     return fieldCtx.currentStore
@@ -70,10 +67,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     super(...args)
 
     this.addTraceSub('updateField', (ctx) => {
-      const { field, error, path } = ctx
-
-      if (!shouldInstrument(this.config, path)) return
-
+      const { field, error } = ctx
       const span = ctx?.currentStore?.span || this.activeSpan
       field.finishTime = span._getTime ? span._getTime() : 0
       field.error = field.error || error
@@ -100,52 +94,18 @@ class GraphQLResolvePlugin extends TracingPlugin {
 // helpers
 
 /**
- * @param {{ depth: number, collapse: boolean }} config
- * @param {{ prev: object | undefined, key: string | number }} path
- */
-function shouldInstrument (config, path) {
-  if (config.depth < 0) return true
-
-  let depth = 0
-  if (config.collapse) {
-    for (let curr = path; curr; curr = curr.prev) depth += 1
-  } else {
-    for (let curr = path; curr; curr = curr.prev) {
-      if (typeof curr.key === 'string') depth += 1
-    }
-  }
-
-  return config.depth >= depth
-}
-
-/**
- * @param {{ prev: object | undefined, key: string | number }} path
- * @param {boolean} collapse Replace numeric segments with `*`.
- */
-function buildPathString (path, collapse) {
-  let length = 0
-  for (let curr = path; curr; curr = curr.prev) length += 1
-
-  const segments = new Array(length)
-  let index = length - 1
-  for (let curr = path; curr; curr = curr.prev) {
-    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
-  }
-  return segments.join('.')
-}
-
-/**
- * @param {object} info
+ * @param {object | undefined} fieldNode
+ * @param {string} fieldName
  * @param {Record<string, unknown> | undefined} args
  */
-function getResolverInfo (info, args) {
+function getResolverInfo (fieldNode, fieldName, args) {
   let resolverVars
 
   if (args && Object.keys(args).length > 0) {
     resolverVars = { ...args }
   }
 
-  const directives = info.fieldNodes?.[0]?.directives
+  const directives = fieldNode?.directives
   if (Array.isArray(directives)) {
     for (const directive of directives) {
       if (directive.arguments.length === 0) continue
@@ -160,7 +120,7 @@ function getResolverInfo (info, args) {
     }
   }
 
-  return resolverVars === undefined ? null : { [info.fieldName]: resolverVars }
+  return resolverVars === undefined ? null : { [fieldName]: resolverVars }
 }
 
 /**

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -11,7 +11,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
    * @param {{
    *   rootCtx: { source?: string },
    *   args: Record<string, unknown>,
-   *   path: object,
+   *   path: { prev: object | undefined, key: string | number },
    *   pathString: string,
    *   fieldName: string,
    *   returnType: { name: string },
@@ -20,6 +20,8 @@ class GraphQLResolvePlugin extends TracingPlugin {
    * }} fieldCtx
    */
   start (fieldCtx) {
+    if (!shouldInstrument(this.config, fieldCtx.path)) return
+
     const { rootCtx, args, path, pathString, fieldName, returnType, fieldNode, variableValues } = fieldCtx
 
     const parentField = getParentField(rootCtx, path)
@@ -67,8 +69,11 @@ class GraphQLResolvePlugin extends TracingPlugin {
     super(...args)
 
     this.addTraceSub('updateField', (ctx) => {
+      // start short-circuited on the depth gate, so there is no span to advance.
+      if (ctx.currentStore === undefined) return
+
       const { field, error } = ctx
-      const span = ctx?.currentStore?.span || this.activeSpan
+      const span = ctx.currentStore.span
       field.finishTime = span._getTime ? span._getTime() : 0
       field.error = field.error || error
     })
@@ -92,6 +97,25 @@ class GraphQLResolvePlugin extends TracingPlugin {
 }
 
 // helpers
+
+/**
+ * @param {{ depth: number, collapse: boolean }} config
+ * @param {{ prev: object | undefined, key: string | number }} path
+ */
+function shouldInstrument (config, path) {
+  const depth = config.depth
+  if (depth < 0) return true
+
+  let count = 0
+  if (config.collapse) {
+    for (let curr = path; curr; curr = curr.prev) count += 1
+  } else {
+    for (let curr = path; curr; curr = curr.prev) {
+      if (typeof curr.key === 'string') count += 1
+    }
+  }
+  return depth >= count
+}
 
 /**
  * @param {object | undefined} fieldNode

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -825,6 +825,31 @@ describe('Plugin', () => {
           graphql.graphql({ schema, source }).catch(done)
         })
 
+        it('caches path strings across nested list-of-lists items', async () => {
+          // `[[Cell]]` puts two synthetic array-index nodes back-to-back; the
+          // `friends { pets { name } }` sibling has a `pets` field between.
+          const matrixSchema = graphql.buildSchema(`
+            type Cell { value: Int }
+            type Query { matrix: [[Cell]] }
+          `)
+          const rootValue = { matrix: () => [[{ value: 42 }]] }
+          const source = '{ matrix { value } }'
+
+          const [, result] = await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const paths = sort(traces[0])
+                .filter(span => span.name === 'graphql.resolve')
+                .map(span => span.meta['graphql.field.path'])
+                .sort()
+              assert.deepStrictEqual(paths, ['matrix', 'matrix.*.*.value'])
+            }),
+            graphql.graphql({ schema: matrixSchema, source, rootValue }),
+          ])
+
+          assert.ok(!result.errors || result.errors.length === 0)
+          assert.strictEqual(result.data?.matrix?.[0]?.[0]?.value, 42)
+        })
+
         it('should instrument mutations', done => {
           const source = 'mutation { human { name } }'
 

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1830,6 +1830,51 @@ describe('Plugin', () => {
 
           graphql.graphql({ schema, source }).catch(done)
         })
+
+        it('publishes apm:graphql:resolve:start for every resolver, including depth-gated ones', async () => {
+          // The depth knob caps span creation, not channel publishes.
+          // IAST taint-tracking and AppSec WAF subscribers run on every resolver
+          // call so user-controlled args at any depth still flow through.
+          const startCh = dc.channel('apm:graphql:resolve:start')
+          const paths = []
+          const handler = (ctx) => {
+            paths.push(ctx.pathString)
+          }
+          startCh.subscribe(handler)
+
+          try {
+            const source = `
+              {
+                human {
+                  name
+                  address {
+                    civicNumber
+                    street
+                  }
+                }
+              }
+            `
+            const [, result] = await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const spans = sort(traces[0]).filter(span => span.name === 'graphql.resolve')
+                const tracedPaths = spans.map(span => span.meta['graphql.field.path']).sort()
+                assert.deepStrictEqual(tracedPaths, ['human', 'human.address', 'human.name'])
+              }),
+              graphql.graphql({ schema, source }),
+            ])
+
+            assert.ok(!result.errors || result.errors.length === 0, `Expected [${result.errors}] to be empty`)
+            assert.deepStrictEqual(paths.sort(), [
+              'human',
+              'human.address',
+              'human.address.civicNumber',
+              'human.address.street',
+              'human.name',
+            ])
+          } finally {
+            startCh.unsubscribe(handler)
+          }
+        })
       })
 
       describe('with collapsing disabled', () => {

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1437,6 +1437,75 @@ describe('Plugin', () => {
           graphql.graphql({ schema, source, rootValue }).catch(done)
         })
 
+        it('throws AbortError when the execute abortController is aborted before execute runs', async () => {
+          // AppSec's WAF blocks a malicious request by aborting the execute ctx
+          // on apm:graphql:execute:start. callInAsyncScope sees the signal and
+          // throws AbortError before exe runs; the field-resolver path never
+          // fires for this query.
+          const startCh = dc.channel('apm:graphql:execute:start')
+          const handler = (ctx) => {
+            ctx.abortController.abort()
+          }
+          startCh.subscribe(handler)
+
+          const source = '{ hello(name: "world") }'
+          const document = graphql.parse(source)
+
+          try {
+            const [, error] = await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const spans = sort(traces[0])
+                const resolveSpans = spans.filter(span => span.name === 'graphql.resolve')
+                assert.strictEqual(resolveSpans.length, 0, 'no resolver should run after abort')
+                const opSpan = spans.find(span => span.name === expectedSchema.server.opName)
+                assert.ok(opSpan, 'execute span still finishes')
+                assert.strictEqual(opSpan.error, 0)
+              }),
+              assert.throws(
+                () => graphql.execute({ schema, document }),
+                { name: 'AbortError', message: 'Aborted' },
+              ),
+            ])
+            assert.strictEqual(error, undefined)
+          } finally {
+            startCh.unsubscribe(handler)
+          }
+        })
+
+        it('throws AbortError from the next resolver when the controller aborts mid-execution', async () => {
+          // Same WAF hook as above, but the abort lands after the first
+          // resolver finished its work (apm:graphql:resolve:updateField) so
+          // callInAsyncScope's signal check is already past. resolveAsync's
+          // own signal check is the only guard that stops the second
+          // resolver from running, and assertField has already published its
+          // startResolveCh / built its TrackedField for it.
+          const updateCh = dc.channel('apm:graphql:resolve:updateField')
+          const finished = []
+          const handler = (ctx) => {
+            finished.push(ctx.pathString)
+            if (finished.length === 1) {
+              ctx.rootCtx.abortController.abort()
+            }
+          }
+          updateCh.subscribe(handler)
+
+          try {
+            const source = '{ first: hello(name: "first") second: hello(name: "second") }'
+            const result = await graphql.graphql({ schema, source })
+
+            // graphql captures the resolver throw into result.errors; the
+            // first resolver runs to completion, the second hits the abort
+            // branch.
+            assert.ok(result.errors, 'expected an AbortError surfaced through result.errors')
+            assert.strictEqual(result.errors.length, 1)
+            assert.strictEqual(result.errors[0].originalError?.name, 'AbortError')
+            assert.strictEqual(result.errors[0].originalError?.message, 'Aborted')
+            assert.deepStrictEqual(finished.sort(), ['first', 'second'])
+          } finally {
+            updateCh.unsubscribe(handler)
+          }
+        })
+
         it('should support multiple executions with the same contextValue', done => {
           const schema = graphql.buildSchema(`
             type Query {

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -788,6 +788,47 @@ describe('Plugin', () => {
           }
         })
 
+        it('publishes apm:graphql:resolve:start for every sibling of a collapsed list', async () => {
+          // The collapse knob dedupes span creation, not channel publishes. IAST
+          // taint-tracking mutates each call's own args object; if siblings 2..N
+          // skip the publish, those args objects never get tainted and a sink
+          // reached through sibling N misses the vulnerability.
+          const startCh = dc.channel('apm:graphql:resolve:start')
+          const argsByPath = new Map()
+          const handler = (ctx) => {
+            const list = argsByPath.get(ctx.pathString) ?? []
+            list.push(ctx.args)
+            argsByPath.set(ctx.pathString, list)
+          }
+          startCh.subscribe(handler)
+
+          try {
+            const source = '{ friends { name } }'
+            const [, result] = await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const spans = sort(traces[0]).filter(span => span.name === 'graphql.resolve')
+                const friendsName = spans.find(span => span.meta['graphql.field.path'] === 'friends.*.name')
+                assert.ok(friendsName, 'expected one collapsed friends.*.name span')
+              }),
+              graphql.graphql({ schema, source }),
+            ])
+
+            assert.ok(!result.errors || result.errors.length === 0, `Expected [${result.errors}] to be empty`)
+            const nameArgs = argsByPath.get('friends.*.name') ?? []
+            assert.strictEqual(
+              nameArgs.length,
+              2,
+              'expected one startResolveCh publish per sibling of the 2-element friends list',
+            )
+            // graphql-js builds a fresh args object per resolver call; siblings
+            // share content but not identity. IAST mutates the passed object, so
+            // each call needs its own publish.
+            assert.notStrictEqual(nameArgs[0], nameArgs[1])
+          } finally {
+            startCh.unsubscribe(handler)
+          }
+        })
+
         it('should instrument list field resolvers', done => {
           const source = `{
             friends {

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1868,6 +1868,53 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with collapsing disabled and a depth >=1', () => {
+        before(async () => {
+          tracer = await agent.load('graphql', { collapse: false, depth: 2 })
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          graphql = require(`../../../versions/graphql@${version}`).get()
+          buildSchema()
+        })
+
+        it('should count only string segments when collapsing is disabled', done => {
+          const source = `
+            {
+              friends {
+                name
+                pets {
+                  name
+                }
+              }
+            }
+          `
+
+          agent
+            .assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              const resolveSpans = spans.filter(span => span.name === 'graphql.resolve')
+              const paths = resolveSpans.map(span => span.meta['graphql.field.path']).sort()
+
+              assert.deepStrictEqual(paths, [
+                'friends',
+                'friends.0.name',
+                'friends.0.pets',
+                'friends.1.name',
+                'friends.1.pets',
+              ])
+            })
+            .then(done)
+            .catch(done)
+
+          graphql.graphql({ schema, source }).catch(done)
+        })
+      })
+
       describe('with signature calculation disabled', () => {
         before(() => {
           tracer = require('../../dd-trace')

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -755,6 +755,39 @@ describe('Plugin', () => {
           graphql.graphql({ schema, source }).catch(done)
         })
 
+        it('publishes resolver finish for every sibling of a collapsed list', async () => {
+          // Regression for first-wins finishTime: when a list collapses to one span,
+          // every sibling resolver must still publish on apm:graphql:resolve:updateField
+          // so the span's finishTime reflects the last sibling, not the first.
+          const updateCh = dc.channel('apm:graphql:resolve:updateField')
+          const counts = new Map()
+          const handler = (ctx) => {
+            counts.set(ctx.pathString, (counts.get(ctx.pathString) ?? 0) + 1)
+          }
+          updateCh.subscribe(handler)
+
+          try {
+            const source = '{ friends { name } }'
+            const [, result] = await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const spans = sort(traces[0]).filter(span => span.name === 'graphql.resolve')
+                const friendsName = spans.find(span => span.meta['graphql.field.path'] === 'friends.*.name')
+                assert.ok(friendsName, 'expected one collapsed friends.*.name span')
+              }),
+              graphql.graphql({ schema, source }),
+            ])
+
+            assert.ok(!result.errors || result.errors.length === 0, `Expected [${result.errors}] to be empty`)
+            assert.strictEqual(
+              counts.get('friends.*.name'),
+              2,
+              'expected one updateField publish per sibling of the 2-element friends list',
+            )
+          } finally {
+            updateCh.unsubscribe(handler)
+          }
+        })
+
         it('should instrument list field resolvers', done => {
           const source = `{
             friends {


### PR DESCRIPTION
## Summary

Second round of `perf(graphql): trim per-resolver allocations` (#8309). Three O(depth) string operations still ran per resolver call against the Object-keyed `rootCtx.fields` — `pathToArray` + `path.join('.')` in `assertField`, `lastIndexOf('.')` + `slice` in `getParentField`, plus the collapse-dedupe in `resolve.js#start` walking the path a third time only to early-return for collapsed duplicates. Five coordinated pieces cut the work:

1. `rootCtx.fields` switches to `Map<Path, TrackedField>` keyed on the graphql-js Path linked-list node identity (`{ prev, key, typename }` is fresh per `addPath` and never collides). `assertField` is one `Map.set(path, …)`; `getParentField` walks `path.prev` and reads each level via `Map.get` — O(1) per step, no substring, no array allocation.
2. `field.ctx.info = info` is dropped from `resolveAsync`'s completion path. Nothing read it post-`start`, but the assignment pinned the entire `GraphQLResolveInfo` (schema, fragments, rootValue, operation, variableValues, fieldNodes, parentType, returnType, path) on every field-ctx for the request's lifetime — heap-snapshot analysis attributed 30–60 % of per-request peak retention to it.
3. `assertField` builds the `fieldCtx` with the four fields the plugin actually reads — `fieldName`, `returnType`, `fieldNodes[0]`, `variableValues` — so the plugin drops its remaining reach into `info` once `start` returns. `shouldInstrument` folds its depth-count and length-count path walks into one linked-list traversal, and the plugin's `collapse` flag rides on `rootCtx` so the instrumentation-layer path-string builder picks the same `*` segments the plugin's dedupe will key on.
4. Path strings cache per execute in a `Map<Path, string>` on `rootCtx`, so siblings of a collapsed list reuse the parent's cached string and only pay `parent + '.' + key`. V8's `ConsString` keeps the concat cheap, and the `depth: -1` default skips the depth-count walk entirely.
5. `resolveAsync` inlines the abort check, `try`/`catch`, and `.then` chain that used to forward to `callInAsyncScope` through `arguments`. Each resolver call drops one Arguments materialisation and one function frame; `callInAsyncScope` is now only called from `wrapExecute` (always with a `cb` and an `AbortController`), so its `cb || (() => {})` and `abortController?.signal.aborted` defensive slack go too.

## Why

Three behaviour-preserving fixes ride on top so the perf rework cannot regress IAST / AppSec:

1. **Collapsed-list span `finishTime`** (`7abeebb`). Moving collapse dedupe into `assertField` initially made siblings 2..N short-circuit before `updateField` fired, so the span closed with the *first* sibling's finish time on a list of N. `collapsedFields` is now `Map<pathString, field>` and siblings get the shared field, so `updateField` advances `finishTime` on every call and the span tracks the last sibling's completion.
2. **Depth-gated IAST publish** (`b36b93a`). The depth gate sits in the resolve plugin's `start`; the IAST `apm:graphql:resolve:start` publish lives in `assertField` and fires for every call. Resolver-arguments taint that used to silently stop flowing at `depth >= config.depth` is preserved.
3. **Collapsed-sibling IAST publish** (`4ed0165`). The publish moves above `assertField`'s `collapsedFields` lookup, so siblings 2..N of a `friends.*.name` resolver still get their freshly-built args object surfaced on the channel. IAST taint that depends on per-call args mutation is preserved across collapsed lists.

A `test(graphql)` commit (`04575b8`) pins the AppSec-abort contract for `wrapResolve`'s and `callInAsyncScope`'s `AbortError` branches — both previously uncovered.

Per-step microbench numbers (Node 24.15 / V8 13.6, deep 5x5x4 author/posts/comments query, methodology in each commit body):

1. `a39f889`: 753.7 → 447.1 us/op at the `execute()` boundary (-40.7 %); stddev 14.2 → 3.2 us as path-array allocations stop driving GC.
2. `f3826ce`: 444.8 → 321.2 us/op (-27.8 %).
3. `313da65`: 285.7 → 276.4 us/op median (-3.3 %).
4. `7abeebb`: 276.4 → 302.3 us/op median (+9.4 %), the cost of restoring per-sibling `updateField` publishes.
5. `5182e89`: 291.4 → 289.1 us/op median (-0.8 %); run-to-run stddev 6.5 → 3.0 us (-54 %).

## Drive-by

- Pin `shouldInstrument`'s non-collapse depth branch with a new *"with collapsing disabled and a depth >=1"* describe. The existing spec exercised depth filtering only with default `collapse: true`.

## Test plan

CI alone is sufficient; the existing graphql plugin specs plus the new ones (`updateFieldCh` per collapsed sibling, `startResolveCh` per depth-gated call, `startResolveCh` per collapsed sibling, two `AbortError` cases) cover the new branches end-to-end.

Refs: https://github.com/DataDog/dd-trace-js/pull/8309
