### PR TITLE
perf(legacy-storage): cache storage('legacy') at module load

### DIFF
--- a/packages/dd-trace/src/ci-visibility/requests/request.js
+++ b/packages/dd-trace/src/ci-visibility/requests/request.js
@@ -14,6 +14,8 @@ const {
 } = require('../../exporters/common/retry')
 const { urlToHttpOptions } = require('../../exporters/common/url-to-http-options-polyfill')
 
+const legacyStorage = storage('legacy')
+
 function parseUrl (urlObjOrString) {
   if (urlObjOrString !== null && typeof urlObjOrString === 'object') {
     return urlToHttpOptions(urlObjOrString)
@@ -75,7 +77,7 @@ function request (data, options, callback) {
   let firstStatusCode = null
 
   const makeRequest = () => {
-    storage('legacy').run({ noop: true }, () => {
+    legacyStorage.run({ noop: true }, () => {
       const req = client.request(opts, (res) => {
         // Capture non-2xx status code as soon as we see it so telemetry preserves it if the retry
         // fails with a network error (no HTTP response) before 'end' fires

--- a/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
+++ b/packages/dd-trace/src/ci-visibility/test-api-manual/test-api-manual-plugin.js
@@ -8,6 +8,8 @@ const {
 } = require('../../plugins/util/test')
 const { storage } = require('../../../../datadog-core')
 
+const legacyStorage = storage('legacy')
+
 class TestApiManualPlugin extends CiPlugin {
   static id = 'test-api-manual'
 
@@ -17,13 +19,13 @@ class TestApiManualPlugin extends CiPlugin {
     this.sourceRoot = process.cwd()
 
     this.unconfiguredAddSub('dd-trace:ci:manual:test:start', ({ testName, testSuite }) => {
-      const store = storage('legacy').getStore()
+      const store = legacyStorage.getStore()
       const testSuiteRelative = getTestSuitePath(testSuite, this.sourceRoot)
       const testSpan = this.startTestSpan(testName, testSuiteRelative)
       this.enter(testSpan, store)
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:finish', ({ status, error }) => {
-      const store = storage('legacy').getStore()
+      const store = legacyStorage.getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.setTag(TEST_STATUS, status)
@@ -35,7 +37,7 @@ class TestApiManualPlugin extends CiPlugin {
       }
     })
     this.unconfiguredAddSub('dd-trace:ci:manual:test:addTags', (tags) => {
-      const store = storage('legacy').getStore()
+      const store = legacyStorage.getStore()
       const testSpan = store && store.span
       if (testSpan) {
         testSpan.addTags(tags)

--- a/packages/dd-trace/src/datastreams/context.js
+++ b/packages/dd-trace/src/datastreams/context.js
@@ -3,15 +3,17 @@
 const { storage } = require('../../../datadog-core')
 const log = require('../log')
 
+const legacyStorage = storage('legacy')
+
 function getDataStreamsContext () {
-  const store = storage('legacy').getStore()
+  const store = legacyStorage.getStore()
   return (store && store.dataStreamsContext) || null
 }
 
 function setDataStreamsContext (dataStreamsContext) {
   log.debug('Setting new DSM Context: %j.', dataStreamsContext)
 
-  if (dataStreamsContext) storage('legacy').enterWith({ ...(storage('legacy').getStore()), dataStreamsContext })
+  if (dataStreamsContext) legacyStorage.enterWith({ ...legacyStorage.getStore(), dataStreamsContext })
 }
 
 module.exports = {

--- a/packages/dd-trace/src/exporters/common/agents.js
+++ b/packages/dd-trace/src/exporters/common/agents.js
@@ -4,6 +4,8 @@ const http = require('http')
 const https = require('https')
 const { storage } = require('../../../../datadog-core')
 
+const legacyStorage = storage('legacy')
+
 const keepAlive = true
 const maxSockets = 1
 
@@ -26,7 +28,7 @@ function createAgentClass (BaseAgent) {
     }
 
     _noop (callback) {
-      return storage('legacy').run({ noop: true }, callback)
+      return legacyStorage.run({ noop: true }, callback)
     }
   }
 

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -20,6 +20,8 @@ const {
   markEndpointReached,
 } = require('./retry')
 
+const legacyStorage = storage('legacy')
+
 const maxActiveBufferSize = 1024 * 1024 * 64
 
 let activeBufferSize = 0
@@ -161,7 +163,7 @@ function request (data, options, callback) {
 
     activeBufferSize += options.headers['Content-Length'] ?? 0
 
-    storage('legacy').run({ noop: true }, () => {
+    legacyStorage.run({ noop: true }, () => {
       let finished = false
       const finalize = () => {
         if (finished) return

--- a/packages/dd-trace/src/log/writer.js
+++ b/packages/dd-trace/src/log/writer.js
@@ -3,6 +3,8 @@
 const { storage } = require('../../../datadog-core')
 const { LogChannel } = require('./channels')
 
+const legacyStorage = storage('legacy')
+
 const defaultLogger = {
   debug: msg => console.debug(msg), /* eslint-disable-line no-console */
   info: msg => console.info(msg), /* eslint-disable-line no-console */
@@ -15,7 +17,7 @@ let logger = defaultLogger
 let logChannel = new LogChannel()
 
 function withNoop (fn) {
-  storage('legacy').run({ noop: true }, fn)
+  legacyStorage.run({ noop: true }, fn)
 }
 
 function toggleSubscription (enable, level) {

--- a/packages/dd-trace/src/noop/span.js
+++ b/packages/dd-trace/src/noop/span.js
@@ -4,9 +4,11 @@ const id = require('../id')
 const { storage } = require('../../../datadog-core') // TODO: noop storage?
 const NoopSpanContext = require('./span_context')
 
+const legacyStorage = storage('legacy')
+
 class NoopSpan {
   constructor (tracer, parent) {
-    this._store = storage('legacy').getHandle()
+    this._store = legacyStorage.getHandle()
     this._noopTracer = tracer
     this._noopContext = this._createContext(parent)
   }

--- a/packages/dd-trace/src/plugins/apollo.js
+++ b/packages/dd-trace/src/plugins/apollo.js
@@ -3,13 +3,15 @@
 const { storage } = require('../../../datadog-core')
 const TracingPlugin = require('./tracing')
 
+const legacyStorage = storage('legacy')
+
 class ApolloBasePlugin extends TracingPlugin {
   static id = 'apollo.gateway'
   static type = 'web'
   static kind = 'server'
 
   bindStart (ctx) {
-    const store = storage('legacy').getStore()
+    const store = legacyStorage.getStore()
     const childOf = store ? /** @type {import('../opentracing/span') | undefined} */ (store.span) : null
 
     const span = this.startSpan(this.getOperationName(), {

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -82,6 +82,8 @@ const {
   DD_CAPABILITIES_TEST_IMPACT_ANALYSIS,
 } = require('./util/test')
 
+const legacyStorage = storage('legacy')
+
 const FRAMEWORK_TO_TRIMMED_COMMAND = {
   vitest: 'vitest run',
   mocha: 'mocha',
@@ -147,7 +149,7 @@ module.exports = class CiPlugin extends Plugin {
 
     this.addSub(`ci:${this.constructor.id}:library-configuration`, (ctx) => {
       const { onDone, frameworkVersion } = ctx
-      ctx.currentStore = storage('legacy').getStore()
+      ctx.currentStore = legacyStorage.getStore()
 
       if (!this.tracer._exporter || !this.tracer._exporter.getLibraryConfiguration) {
         return onDone({ err: new Error('Test optimization was not initialized correctly') })

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -4,6 +4,8 @@ const { LOG } = require('../../../../ext/formats')
 const { storage } = require('../../../datadog-core')
 const Plugin = require('./plugin')
 
+const legacyStorage = storage('legacy')
+
 function messageProxy (message, holder) {
   return new Proxy(message, {
     get (target, key) {
@@ -38,7 +40,7 @@ module.exports = class LogPlugin extends Plugin {
     super(...args)
 
     this.addSub(`apm:${this.constructor.id}:log`, (arg) => {
-      const span = storage('legacy').getStore()?.span
+      const span = legacyStorage.getStore()?.span
 
       // NOTE: This needs to run whether or not there is a span
       // so service, version, and env will always get injected.

--- a/packages/dd-trace/src/plugins/tracing.js
+++ b/packages/dd-trace/src/plugins/tracing.js
@@ -5,6 +5,8 @@ const analyticsSampler = require('../analytics_sampler')
 const { COMPONENT, SVC_SRC_KEY } = require('../constants')
 const Plugin = require('./plugin')
 
+const legacyStorage = storage('legacy')
+
 class TracingPlugin extends Plugin {
   constructor (...args) {
     super(...args)
@@ -16,7 +18,7 @@ class TracingPlugin extends Plugin {
   }
 
   get activeSpan () {
-    const store = /** @type {{ span?: import('../../../..').Span }} */ (storage('legacy').getStore())
+    const store = /** @type {{ span?: import('../../../..').Span }} */ (legacyStorage.getStore())
 
     return store?.span
   }
@@ -193,7 +195,7 @@ class TracingPlugin extends Plugin {
       serviceSource = service ? 'opt.plugin' : undefined
     }
 
-    const store = storage('legacy').getStore()
+    const store = legacyStorage.getStore()
     if (store && childOf === undefined) {
       childOf = /** @type {import('../opentracing/span') | undefined} */ (store.span)
     }
@@ -226,7 +228,7 @@ class TracingPlugin extends Plugin {
 
     // TODO: Remove this after migration to TracingChannel is done.
     if (enterOrCtx === true) {
-      storage('legacy').enterWith({ ...store, span })
+      legacyStorage.enterWith({ ...store, span })
     } else if (enterOrCtx) {
       enterOrCtx.parentStore = store
       enterOrCtx.currentStore = { ...store, span }

--- a/packages/dd-trace/src/plugins/util/git.js
+++ b/packages/dd-trace/src/plugins/util/git.js
@@ -37,6 +37,8 @@ const {
 const { filterSensitiveInfoFromRepository } = require('./url')
 const { cachedExec } = require('./git-cache')
 
+const legacyStorage = storage('legacy')
+
 const GIT_REV_LIST_MAX_BUFFER = 12 * 1024 * 1024 // 12MB
 
 function sanitizedExec (
@@ -47,7 +49,7 @@ function sanitizedExec (
   errorMetric,
   shouldTrim = true
 ) {
-  return storage('legacy').run({ noop: true }, () => {
+  return legacyStorage.run({ noop: true }, () => {
     let startTime
     if (operationMetric) {
       incrementCountMetric(operationMetric.name, operationMetric.tags)

--- a/packages/dd-trace/src/scope.js
+++ b/packages/dd-trace/src/scope.js
@@ -2,10 +2,12 @@
 
 const { storage } = require('../../datadog-core')
 
+const legacyStorage = storage('legacy')
+
 // TODO: refactor bind to use shimmer once the new internal tracer lands
 class Scope {
   active () {
-    const store = storage('legacy').getStore()
+    const store = legacyStorage.getStore()
 
     return store?.span ?? null
   }
@@ -13,10 +15,10 @@ class Scope {
   activate (span, callback) {
     if (typeof callback !== 'function') return callback
 
-    const oldStore = storage('legacy').getStore()
-    const newStore = span ? storage('legacy').getStore(span._store) : oldStore
+    const oldStore = legacyStorage.getStore()
+    const newStore = span ? legacyStorage.getStore(span._store) : oldStore
 
-    storage('legacy').enterWith({ ...newStore, span })
+    legacyStorage.enterWith({ ...newStore, span })
 
     try {
       return callback()
@@ -27,7 +29,7 @@ class Scope {
 
       throw e
     } finally {
-      storage('legacy').enterWith(oldStore)
+      legacyStorage.enterWith(oldStore)
     }
   }
 


### PR DESCRIPTION
Every span enter / activate / log-injection / DSM path re-resolved `legacy` against the namespace registry on each call. The handle is stable once registered, so each module captures it into a `legacyStorage` const and reads that constant instead. `scope.activate` alone reaches the factory four times per span entry.

Microbench (Node 24.15.0, 7-trial median, 1M iters/trial): `storage('legacy')` lookup is 7.12 ns/op (min 7.07, max 7.35). After this change the cost is paid once at require-time per module and zero ns/op on every subsequent call site.


