### PR TITLE
fix(graphql): unwrap GraphQLNonNull / GraphQLList for the field-type tag

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { AsyncLocalStorage } = require('node:async_hooks')
+
 const shimmer = require('../../datadog-shimmer')
 const {
   addHook,
@@ -10,7 +12,13 @@ const ddGlobal = globalThis[Symbol.for('dd-trace')]
 
 /** cached objects */
 
+// `contexts` is the fast resolver-side lookup; `executeCtx` is the fallback
+// when `contextValue` is a primitive and cannot key a WeakMap.
 const contexts = new WeakMap()
+const executeCtx = new AsyncLocalStorage()
+// Tracks normalized args already instrumented in an outer wrap so graphql-yoga
+// (which stacks `execute` + `normalizedExecutor`) only emits one span per call.
+const instrumentedArgs = new WeakSet()
 const documentSources = new WeakMap()
 const patchedResolvers = new WeakSet()
 const patchedTypes = new WeakSet()
@@ -65,7 +73,6 @@ function normalizeArgs (args, defaultFieldResolver) {
   const original = args[0]
   const normalized = {
     ...original,
-    contextValue: original.contextValue ?? {},
     fieldResolver: wrapResolve(original.fieldResolver || defaultFieldResolver),
   }
 
@@ -74,7 +81,6 @@ function normalizeArgs (args, defaultFieldResolver) {
 }
 
 function normalizePositional (args, defaultFieldResolver) {
-  args[3] = args[3] || {} // contextValue
   args[6] = wrapResolve(args[6] || defaultFieldResolver) // fieldResolver
   args.length = Math.max(args.length, 7)
 
@@ -87,6 +93,12 @@ function normalizePositional (args, defaultFieldResolver) {
     operationName: args[5],
     fieldResolver: args[6],
   }
+}
+
+// `WeakMap.set` throws `TypeError` on a non-object key; `get`/`has`/`delete`
+// silently miss. Skip the WeakMap entirely for non-keyable `contextValue`.
+function isWeakMapKey (value) {
+  return value !== null && typeof value === 'object'
 }
 
 function wrapParse (parse) {
@@ -160,14 +172,21 @@ function wrapExecute (execute) {
         return exe.apply(this, arguments)
       }
 
+      // The outer wrap leaves its normalized args object in `arguments[0]`; on
+      // graphql-yoga's inner wrap that reference is already known here.
+      if (instrumentedArgs.has(arguments[0])) {
+        return exe.apply(this, arguments)
+      }
+
       const args = normalizeArgs(arguments, defaultFieldResolver)
       const schema = args.schema
       const document = args.document
       const source = documentSources.get(document)
       const contextValue = args.contextValue
+      const keyable = isWeakMapKey(contextValue)
       const operation = getOperation(document, args.operationName)
 
-      if (contexts.has(contextValue)) {
+      if (keyable && contexts.has(contextValue)) {
         return exe.apply(this, arguments)
       }
 
@@ -180,15 +199,19 @@ function wrapExecute (execute) {
         abortController: new AbortController(),
       }
 
+      // Only the object form leaves a stable single-object handle in
+      // `arguments[0]` for the inner wrap to see.
+      if (args === arguments[0]) instrumentedArgs.add(args)
+
       return startExecuteCh.runStores(ctx, () => {
         if (schema) {
           wrapFields(schema._queryType)
           wrapFields(schema._mutationType)
         }
 
-        contexts.set(contextValue, ctx)
+        if (keyable) contexts.set(contextValue, ctx)
 
-        return callInAsyncScope(exe, this, arguments, ctx.abortController, (err, res) => {
+        const finish = (err, res) => {
           if (finishResolveCh.hasSubscribers) finishResolvers(ctx)
 
           const error = err || (res && res.errors && res.errors[0])
@@ -199,9 +222,16 @@ function wrapExecute (execute) {
           }
 
           ctx.res = res
-          contexts.delete(contextValue)
+          if (keyable) contexts.delete(contextValue)
+          instrumentedArgs.delete(args)
           finishExecuteCh.publish(ctx)
-        })
+        }
+
+        // Skip the ALS entry on the common object-`contextValue` path; the
+        // resolver reaches `ctx` via the WeakMap there.
+        return keyable
+          ? callInAsyncScope(exe, this, arguments, ctx.abortController, finish)
+          : executeCtx.run(ctx, () => callInAsyncScope(exe, this, arguments, ctx.abortController, finish))
       })
     }
   }
@@ -213,7 +243,9 @@ function wrapResolve (resolve) {
   function resolveAsync (source, args, contextValue, info) {
     if (!startResolveCh.hasSubscribers) return resolve.apply(this, arguments)
 
-    const ctx = contexts.get(contextValue)
+    // `WeakMap.get(primitive)` returns `undefined`, so the fallback covers
+    // executes that ran with a primitive `contextValue`.
+    const ctx = contexts.get(contextValue) ?? executeCtx.getStore()
 
     if (!ctx) return resolve.apply(this, arguments)
 

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -343,6 +343,11 @@ addHook({ name: '@graphql-tools/executor', versions: ['>=0.0.14'] }, executor =>
   return executor
 })
 
+// TODO(BridgeAR): graphql >=17.0.0-alpha.9 routes execute() through
+// experimentalExecuteIncrementally(), bypassing this hook. The same
+// function returns { initialResult, subsequentResults } for @defer /
+// @stream which callInAsyncScope does not handle — execute finishes
+// before the streamed payloads land.
 addHook({ name: 'graphql', file: 'execution/execute.js', versions: ['>=0.10'] }, execute => {
   shimmer.wrap(execute, 'execute', wrapExecute(execute))
   return execute

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -194,6 +194,7 @@ function wrapExecute (execute) {
           }
 
           ctx.res = res
+          contexts.delete(contextValue)
           finishExecuteCh.publish(ctx)
         })
       })

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -62,10 +62,15 @@ function getOperation (document, operationName) {
 function normalizeArgs (args, defaultFieldResolver) {
   if (args.length !== 1) return normalizePositional(args, defaultFieldResolver)
 
-  args[0].contextValue ||= {}
-  args[0].fieldResolver = wrapResolve(args[0].fieldResolver || defaultFieldResolver)
+  const original = args[0]
+  const normalized = {
+    ...original,
+    contextValue: original.contextValue ?? {},
+    fieldResolver: wrapResolve(original.fieldResolver || defaultFieldResolver),
+  }
 
-  return args[0]
+  args[0] = normalized
+  return normalized
 }
 
 function normalizePositional (args, defaultFieldResolver) {

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -41,6 +41,9 @@ class GraphQLResolvePlugin extends TracingPlugin {
     const loc = this.config.source && document && fieldNode && fieldNode.loc
     const source = loc && document.slice(loc.start, loc.end)
 
+    let namedReturnType = info.returnType
+    while (namedReturnType.ofType) namedReturnType = namedReturnType.ofType
+
     const span = this.startSpan('graphql.resolve', {
       service: this.config.service,
       resource: `${info.fieldName}:${info.returnType}`,
@@ -49,7 +52,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
       meta: {
         'graphql.field.name': info.fieldName,
         'graphql.field.path': computedPathString,
-        'graphql.field.type': info.returnType.name,
+        'graphql.field.type': namedReturnType.name,
         'graphql.source': source,
       },
     }, fieldCtx)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -656,6 +656,7 @@ describe('Plugin', () => {
                 resource: 'friends:[Human]',
                 meta: {
                   'graphql.field.path': 'friends',
+                  'graphql.field.type': 'Human',
                 },
               })
               assert.strictEqual(friends.parent_id.toString(), execute.span_id.toString())
@@ -665,6 +666,7 @@ describe('Plugin', () => {
                 resource: 'name:String',
                 meta: {
                   'graphql.field.path': 'friends.*.name',
+                  'graphql.field.type': 'String',
                 },
               })
               assert.strictEqual(friendsName.parent_id.toString(), friends.span_id.toString())
@@ -674,6 +676,7 @@ describe('Plugin', () => {
                 resource: 'pets:[Pet!]',
                 meta: {
                   'graphql.field.path': 'friends.*.pets',
+                  'graphql.field.type': 'Pet',
                 },
               })
               assert.strictEqual(pets.parent_id.toString(), friends.span_id.toString())
@@ -683,6 +686,7 @@ describe('Plugin', () => {
                 resource: 'name:String',
                 meta: {
                   'graphql.field.path': 'friends.*.pets.*.name',
+                  'graphql.field.type': 'String',
                 },
               })
               assert.strictEqual(petsName.parent_id.toString(), pets.span_id.toString())

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -405,6 +405,24 @@ describe('Plugin', () => {
           graphql.graphql({ schema, source, variableValues }).catch(done)
         })
 
+        it('should instrument every execute even when the args object is reused', async () => {
+          const startChannel = dc.channel('apm:graphql:execute:start')
+          const document = graphql.parse('query MyQuery { hello(name: "world") }')
+          const args = { schema, document, contextValue: {} }
+
+          let starts = 0
+          const handler = () => { starts++ }
+          startChannel.subscribe(handler)
+
+          try {
+            await graphql.execute(args)
+            await graphql.execute(args)
+            assert.strictEqual(starts, 2)
+          } finally {
+            startChannel.unsubscribe(handler)
+          }
+        })
+
         it('should not include variables by default', done => {
           const source = 'query MyQuery($who: String!) { hello(name: $who) }'
           const variableValues = { who: 'world' }

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -423,6 +423,25 @@ describe('Plugin', () => {
           }
         })
 
+        it('should not add fieldResolver to a frozen caller-owned execute args object', async () => {
+          const document = graphql.parse('query MyQuery { hello(name: "world") }')
+          const args = Object.freeze({ schema, document, contextValue: {} })
+
+          assert.ok(await graphql.execute(args), 'execute returned a result')
+          assert.ok(!Object.hasOwn(args, 'fieldResolver'),
+            'instrumentation must not add fieldResolver to caller args')
+        })
+
+        it('should not overwrite the caller-supplied fieldResolver on the execute args object', async () => {
+          const document = graphql.parse('query MyQuery { hello(name: "world") }')
+          const callerFieldResolver = (source, args, contextValue, info) => 'caller-resolved'
+          const args = { schema, document, contextValue: {}, fieldResolver: callerFieldResolver }
+
+          assert.ok(await graphql.execute(args), 'execute returned a result')
+          assert.strictEqual(args.fieldResolver, callerFieldResolver,
+            'instrumentation must not overwrite the caller-supplied fieldResolver')
+        })
+
         it('should not include variables by default', done => {
           const source = 'query MyQuery($who: String!) { hello(name: $who) }'
           const variableValues = { who: 'world' }
@@ -1870,9 +1889,10 @@ describe('Plugin', () => {
                 contextValue: params.contextValue,
                 variableValues: params.variableValues,
                 operationName: params.operationName,
-                fieldResolver: params.fieldResolver,
                 typeResolver: params.typeResolver,
               })
+              assert.strictEqual(typeof args.fieldResolver, 'function')
+              assert.notStrictEqual(args.fieldResolver, params.fieldResolver)
               assert.strictEqual(res, result)
             })
             .then(done)

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -442,6 +442,93 @@ describe('Plugin', () => {
             'instrumentation must not overwrite the caller-supplied fieldResolver')
         })
 
+        describe('preserves the caller-supplied contextValue', () => {
+          let recordingSchema
+          let recordedContext
+
+          beforeEach(() => {
+            recordedContext = []
+            recordingSchema = new graphql.GraphQLSchema({
+              query: new graphql.GraphQLObjectType({
+                name: 'Query',
+                fields: {
+                  ctx: {
+                    type: graphql.GraphQLString,
+                    resolve: (_source, _args, contextValue) => {
+                      recordedContext.push(contextValue)
+                      return 'ok'
+                    },
+                  },
+                },
+              }),
+            })
+          })
+
+          for (const contextValue of [false, 0, '', null, undefined, 42, 'request-1', Symbol('ctx')]) {
+            const label = String(contextValue) || typeof contextValue
+
+            it(`forwards ${label} to resolvers (object form)`, async () => {
+              const document = graphql.parse('{ ctx }')
+
+              const result = await graphql.execute({ schema: recordingSchema, document, contextValue })
+
+              assert.strictEqual(result.data?.ctx, 'ok')
+              assert.strictEqual(recordedContext.length, 1)
+              assert.strictEqual(recordedContext[0], contextValue,
+                'resolver must receive the caller-supplied contextValue unchanged')
+            })
+
+            // graphql >=16 dropped positional execute(); see PR 2904 below.
+            if (!semver.intersects(version, '>=16')) {
+              it(`forwards ${label} to resolvers (positional form)`, async () => {
+                const document = graphql.parse('{ ctx }')
+
+                const result = await graphql.execute(recordingSchema, document, undefined, contextValue)
+
+                assert.strictEqual(result.data?.ctx, 'ok')
+                assert.strictEqual(recordedContext.length, 1)
+                assert.strictEqual(recordedContext[0], contextValue,
+                  'resolver must receive the caller-supplied contextValue unchanged')
+              })
+            }
+          }
+
+          it('emits the execute span for a primitive contextValue', done => {
+            agent
+              .assertSomeTraces(traces => {
+                const spans = sort(traces[0])
+                assert.strictEqual(spans[0].name, expectedSchema.server.opName)
+                assert.strictEqual(spans[0].error, 0)
+              })
+              .then(done)
+              .catch(done)
+
+            Promise.resolve(graphql.execute({
+              schema: recordingSchema,
+              document: graphql.parse('{ ctx }'),
+              contextValue: 'request-1',
+            })).catch(done)
+          })
+
+          it('emits resolver spans for a primitive contextValue', done => {
+            agent
+              .assertSomeTraces(traces => {
+                const spans = sort(traces[0])
+                const resolveSpan = spans.find(span => span.name === 'graphql.resolve')
+                assert.ok(resolveSpan, 'graphql.resolve span should be emitted')
+                assert.strictEqual(resolveSpan.meta['graphql.field.name'], 'ctx')
+              })
+              .then(done)
+              .catch(done)
+
+            Promise.resolve(graphql.execute({
+              schema: recordingSchema,
+              document: graphql.parse('{ ctx }'),
+              contextValue: 42,
+            })).catch(done)
+          })
+        })
+
         it('should not include variables by default', done => {
           const source = 'query MyQuery($who: String!) { hello(name: $who) }'
           const variableValues = { who: 'world' }


### PR DESCRIPTION
`GraphQLResolvePlugin#start` read `returnType.name` directly. For
wrapper types (`GraphQLNonNull(X)`, `GraphQLList(X)`) `.name` is
undefined, so resolve spans for any non-scalar list or required field
returned `'graphql.field.type': undefined` while the resource template
correctly captured the wrapper-aware `${returnType}` form (e.g.
`'pets:[Pet!]'`). The two views of the same field disagreed.

Walk `.ofType` down to the named type before reading `.name`, matching
the existing pattern in `wrapFieldType`. The list-resolver spec pins
both wrapped (`[Human]`, `[Pet!]`) and scalar (`String`) sides so the
next refactor cannot flip the boundary.