### PR TITLE
perf(graphql): key resolver state by info.path identity

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -256,11 +256,16 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 }
 
 /**
+ * @typedef {{ prev: PathNode | undefined, key: string | number }} PathNode
+ */
+
+/**
  * @param {{
  *   fields: Map<object, { error: unknown, ctx: object }>,
  *   collapse: boolean,
  *   depth: number,
  *   collapsedFields?: Set<string>,
+ *   pathCache?: Map<PathNode, string>,
  * }} rootCtx
  * @param {import('graphql').GraphQLResolveInfo} info
  * @param {Record<string, unknown>} args
@@ -270,21 +275,27 @@ function assertField (rootCtx, info, args) {
   const collapse = rootCtx.collapse
   const depth = rootCtx.depth
 
-  let length = 0
-  let stringSegments = 0
-  for (let curr = path; curr; curr = curr.prev) {
-    length += 1
-    if (typeof curr.key === 'string') stringSegments += 1
+  if (depth >= 0) {
+    let count = 0
+    if (collapse) {
+      for (let curr = path; curr; curr = curr.prev) count += 1
+    } else {
+      for (let curr = path; curr; curr = curr.prev) {
+        if (typeof curr.key === 'string') count += 1
+      }
+    }
+    if (depth < count) return
   }
 
-  if (depth >= 0 && depth < (collapse ? length : stringSegments)) return
+  const cache = rootCtx.pathCache ??= new Map()
+  const prev = path.prev
+  const key = path.key
+  const segment = collapse && typeof key !== 'string' ? '*' : key
 
-  const segments = new Array(length)
-  let index = length - 1
-  for (let curr = path; curr; curr = curr.prev) {
-    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
-  }
-  const pathString = segments.join('.')
+  const pathString = prev === undefined
+    ? String(segment)
+    : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
+  cache.set(path, pathString)
 
   if (collapse) {
     const collapsedFields = rootCtx.collapsedFields ??= new Set()
@@ -306,6 +317,29 @@ function assertField (rootCtx, info, args) {
   const field = { error: null, ctx: fieldCtx }
   rootCtx.fields.set(path, field)
   return field
+}
+
+/**
+ * Cold path for assertField. graphql-js inserts a synthetic array-index
+ * node between a list field and its items, and that node never reaches a
+ * resolver — so assertField has no chance to cache it. The first child of
+ * the list item that hits the path cache lands here to walk and populate
+ * back to a cached ancestor.
+ *
+ * @param {PathNode} path
+ * @param {Map<PathNode, string>} cache
+ * @param {boolean} collapse
+ */
+function buildCachedPathString (path, cache, collapse) {
+  const key = path.key
+  const segment = collapse && typeof key !== 'string' ? '*' : key
+  const prev = path.prev
+
+  const pathString = prev === undefined
+    ? String(segment)
+    : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
+  cache.set(path, pathString)
+  return pathString
 }
 
 function wrapFields (type) {

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -215,7 +215,6 @@ function wrapResolve (resolve) {
 
     return callInAsyncScope(resolve, this, arguments, ctx.abortController, (err) => {
       field.ctx.error = err
-      field.ctx.info = info
       field.ctx.field = field
       updateFieldCh.publish(field.ctx)
     })

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -171,7 +171,7 @@ function wrapExecute (execute) {
         args,
         docSource: source,
         source,
-        fields: Object.create(null),
+        fields: new Map(),
         abortController: new AbortController(),
       }
 
@@ -256,37 +256,21 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
   }
 }
 
-function pathToArray (path) {
-  let length = 0
-  for (let curr = path; curr; curr = curr.prev) {
-    length += 1
-  }
-
-  const flattened = new Array(length)
-  let index = length
-  for (let curr = path; curr; curr = curr.prev) {
-    flattened[--index] = curr.key
-  }
-  return flattened
-}
-
+/**
+ * @param {{ fields: Map<object, { error: unknown, ctx: object }> }} rootCtx
+ * @param {{ path: object }} info
+ * @param {Record<string, unknown>} args
+ */
 function assertField (rootCtx, info, args) {
-  const pathInfo = info && info.path
-
-  const path = pathToArray(pathInfo)
-
-  const pathString = path.join('.')
+  const path = info.path
   const fields = rootCtx.fields
-
-  let field = fields[pathString]
+  let field = fields.get(path)
 
   if (!field) {
-    const fieldCtx = { info, rootCtx, args, path, pathString }
+    const fieldCtx = { info, rootCtx, args, path }
     startResolveCh.publish(fieldCtx)
-    field = fields[pathString] = {
-      error: null,
-      ctx: fieldCtx,
-    }
+    field = { error: null, ctx: fieldCtx }
+    fields.set(path, field)
   }
 
   return field
@@ -323,14 +307,16 @@ function wrapFieldType (field) {
 }
 
 function finishResolvers ({ fields }) {
-  for (const field of Object.values(fields)) {
-    field.ctx.finishTime = field.finishTime
-    field.ctx.field = field
+  for (const field of fields.values()) {
+    const fieldCtx = field.ctx
+    if (!fieldCtx.currentStore) continue
+    fieldCtx.finishTime = field.finishTime
+    fieldCtx.field = field
     if (field.error) {
-      field.ctx.error = field.error
-      resolveErrorCh.publish(field.ctx)
+      fieldCtx.error = field.error
+      resolveErrorCh.publish(fieldCtx)
     }
-    finishResolveCh.publish(field.ctx)
+    finishResolveCh.publish(fieldCtx)
   }
 }
 

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -213,11 +213,11 @@ function wrapResolve (resolve) {
 
     const field = assertField(ctx, info, args)
 
-    return callInAsyncScope(resolve, this, arguments, ctx.abortController, (err) => {
+    return callInAsyncScope(resolve, this, arguments, ctx.abortController, field && ((err) => {
       field.ctx.error = err
       field.ctx.field = field
       updateFieldCh.publish(field.ctx)
-    })
+    }))
   }
 
   patchedResolvers.add(resolveAsync)
@@ -256,22 +256,55 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 }
 
 /**
- * @param {{ fields: Map<object, { error: unknown, ctx: object }> }} rootCtx
- * @param {{ path: object }} info
+ * @param {{
+ *   fields: Map<object, { error: unknown, ctx: object }>,
+ *   collapse: boolean,
+ *   depth: number,
+ *   collapsedFields?: Set<string>,
+ * }} rootCtx
+ * @param {import('graphql').GraphQLResolveInfo} info
  * @param {Record<string, unknown>} args
  */
 function assertField (rootCtx, info, args) {
   const path = info.path
-  const fields = rootCtx.fields
-  let field = fields.get(path)
+  const collapse = rootCtx.collapse
+  const depth = rootCtx.depth
 
-  if (!field) {
-    const fieldCtx = { info, rootCtx, args, path }
-    startResolveCh.publish(fieldCtx)
-    field = { error: null, ctx: fieldCtx }
-    fields.set(path, field)
+  let length = 0
+  let stringSegments = 0
+  for (let curr = path; curr; curr = curr.prev) {
+    length += 1
+    if (typeof curr.key === 'string') stringSegments += 1
   }
 
+  if (depth >= 0 && depth < (collapse ? length : stringSegments)) return
+
+  const segments = new Array(length)
+  let index = length - 1
+  for (let curr = path; curr; curr = curr.prev) {
+    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
+  }
+  const pathString = segments.join('.')
+
+  if (collapse) {
+    const collapsedFields = rootCtx.collapsedFields ??= new Set()
+    if (collapsedFields.has(pathString)) return
+    collapsedFields.add(pathString)
+  }
+
+  const fieldCtx = {
+    rootCtx,
+    args,
+    path,
+    pathString,
+    fieldName: info.fieldName,
+    returnType: info.returnType,
+    fieldNode: info.fieldNodes[0],
+    variableValues: info.variableValues,
+  }
+  startResolveCh.publish(fieldCtx)
+  const field = { error: null, ctx: fieldCtx }
+  rootCtx.fields.set(path, field)
   return field
 }
 
@@ -308,7 +341,6 @@ function wrapFieldType (field) {
 function finishResolvers ({ fields }) {
   for (const field of fields.values()) {
     const fieldCtx = field.ctx
-    if (!fieldCtx.currentStore) continue
     fieldCtx.finishTime = field.finishTime
     fieldCtx.field = field
     if (field.error) {

--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -257,14 +257,16 @@ function callInAsyncScope (fn, thisArg, args, abortController, cb) {
 
 /**
  * @typedef {{ prev: PathNode | undefined, key: string | number }} PathNode
+ *
+ * @typedef {{ error: unknown, ctx: object }} TrackedField
  */
 
 /**
  * @param {{
- *   fields: Map<object, { error: unknown, ctx: object }>,
+ *   fields: Map<object, TrackedField>,
  *   collapse: boolean,
  *   depth: number,
- *   collapsedFields?: Set<string>,
+ *   collapsedFields?: Map<string, TrackedField>,
  *   pathCache?: Map<PathNode, string>,
  * }} rootCtx
  * @param {import('graphql').GraphQLResolveInfo} info
@@ -297,10 +299,14 @@ function assertField (rootCtx, info, args) {
     : (cache.get(prev) ?? buildCachedPathString(prev, cache, collapse)) + '.' + segment
   cache.set(path, pathString)
 
+  let collapsedFields
   if (collapse) {
-    const collapsedFields = rootCtx.collapsedFields ??= new Set()
-    if (collapsedFields.has(pathString)) return
-    collapsedFields.add(pathString)
+    collapsedFields = rootCtx.collapsedFields ??= new Map()
+    const existing = collapsedFields.get(pathString)
+    // Subsequent siblings of a collapsed list share the first sibling's field
+    // so updateFieldCh fires for every call and the span's finishTime tracks
+    // the last sibling's completion, not the first.
+    if (existing !== undefined) return existing
   }
 
   const fieldCtx = {
@@ -316,6 +322,7 @@ function assertField (rootCtx, info, args) {
   startResolveCh.publish(fieldCtx)
   const field = { error: null, ctx: fieldCtx }
   rootCtx.fields.set(path, field)
+  if (collapsedFields !== undefined) collapsedFields.set(pathString, field)
   return field
 }
 

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -17,6 +17,9 @@ class GraphQLExecutePlugin extends TracingPlugin {
     const document = args.document
     const source = this.config.source && document && docSource
 
+    ctx.collapse = this.config.collapse
+    ctx.depth = this.config.depth
+
     const span = this.startSpan(this.operationName(), {
       service: this.config.service || this.serviceName(),
       resource: getSignature(document, name, type, this.config.signature),

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -8,45 +8,42 @@ class GraphQLResolvePlugin extends TracingPlugin {
   static operation = 'resolve'
 
   /**
-   * @param {{ info: object, rootCtx: object, args: Record<string, unknown>, path: object }} fieldCtx
+   * @param {{
+   *   rootCtx: { source?: string },
+   *   args: Record<string, unknown>,
+   *   path: object,
+   *   pathString: string,
+   *   fieldName: string,
+   *   returnType: { name: string },
+   *   fieldNode: { loc?: { start: number, end: number }, arguments?: object[], directives?: object[] } | undefined,
+   *   variableValues: Record<string, unknown> | undefined,
+   * }} fieldCtx
    */
   start (fieldCtx) {
-    if (!shouldInstrument(this.config, fieldCtx.path)) return
-
-    const { info, rootCtx, args, path } = fieldCtx
-    const collapse = this.config.collapse
-    const pathString = buildPathString(path, collapse)
-    fieldCtx.pathString = pathString
-
-    if (collapse) {
-      const collapsedFields = rootCtx.collapsedFields ??= new Set()
-      if (collapsedFields.has(pathString)) return
-      collapsedFields.add(pathString)
-    }
+    const { rootCtx, args, path, pathString, fieldName, returnType, fieldNode, variableValues } = fieldCtx
 
     const parentField = getParentField(rootCtx, path)
     const childOf = parentField?.ctx?.currentStore?.span
 
     const document = rootCtx.source
-    const fieldNode = info.fieldNodes[0]
     const loc = this.config.source && document && fieldNode && fieldNode.loc
     const source = loc && document.slice(loc.start, loc.end)
 
     const span = this.startSpan('graphql.resolve', {
       service: this.config.service,
-      resource: `${info.fieldName}:${info.returnType}`,
+      resource: `${fieldName}:${returnType}`,
       childOf,
       type: 'graphql',
       meta: {
-        'graphql.field.name': info.fieldName,
+        'graphql.field.name': fieldName,
         'graphql.field.path': pathString,
-        'graphql.field.type': info.returnType.name,
+        'graphql.field.type': returnType.name,
         'graphql.source': source,
       },
     }, fieldCtx)
 
     if (fieldNode && this.config.variables && fieldNode.arguments) {
-      const variables = this.config.variables(info.variableValues)
+      const variables = this.config.variables(variableValues)
 
       for (const arg of fieldNode.arguments) {
         if (arg.value?.name && arg.value.kind === 'Variable' && variables[arg.value.name.value]) {
@@ -57,7 +54,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     }
 
     if (this.resolverStartCh.hasSubscribers) {
-      this.resolverStartCh.publish({ ctx: rootCtx, resolverInfo: getResolverInfo(info, args) })
+      this.resolverStartCh.publish({ ctx: rootCtx, resolverInfo: getResolverInfo(fieldNode, fieldName, args) })
     }
 
     return fieldCtx.currentStore
@@ -67,10 +64,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
     super(...args)
 
     this.addTraceSub('updateField', (ctx) => {
-      const { field, error, path } = ctx
-
-      if (!shouldInstrument(this.config, path)) return
-
+      const { field, error } = ctx
       const span = ctx?.currentStore?.span || this.activeSpan
       field.finishTime = span._getTime ? span._getTime() : 0
       field.error = field.error || error
@@ -97,52 +91,18 @@ class GraphQLResolvePlugin extends TracingPlugin {
 // helpers
 
 /**
- * @param {{ depth: number, collapse: boolean }} config
- * @param {{ prev: object | undefined, key: string | number }} path
- */
-function shouldInstrument (config, path) {
-  if (config.depth < 0) return true
-
-  let depth = 0
-  if (config.collapse) {
-    for (let curr = path; curr; curr = curr.prev) depth += 1
-  } else {
-    for (let curr = path; curr; curr = curr.prev) {
-      if (typeof curr.key === 'string') depth += 1
-    }
-  }
-
-  return config.depth >= depth
-}
-
-/**
- * @param {{ prev: object | undefined, key: string | number }} path
- * @param {boolean} collapse Replace numeric segments with `*`.
- */
-function buildPathString (path, collapse) {
-  let length = 0
-  for (let curr = path; curr; curr = curr.prev) length += 1
-
-  const segments = new Array(length)
-  let index = length - 1
-  for (let curr = path; curr; curr = curr.prev) {
-    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
-  }
-  return segments.join('.')
-}
-
-/**
- * @param {object} info
+ * @param {object | undefined} fieldNode
+ * @param {string} fieldName
  * @param {Record<string, unknown> | undefined} args
  */
-function getResolverInfo (info, args) {
+function getResolverInfo (fieldNode, fieldName, args) {
   let resolverVars
 
   if (args && Object.keys(args).length > 0) {
     resolverVars = { ...args }
   }
 
-  const directives = info.fieldNodes?.[0]?.directives
+  const directives = fieldNode?.directives
   if (Array.isArray(directives)) {
     for (const directive of directives) {
       if (directive.arguments.length === 0) continue
@@ -157,7 +117,7 @@ function getResolverInfo (info, args) {
     }
   }
 
-  return resolverVars === undefined ? null : { [info.fieldName]: resolverVars }
+  return resolverVars === undefined ? null : { [fieldName]: resolverVars }
 }
 
 /**

--- a/packages/datadog-plugin-graphql/src/resolve.js
+++ b/packages/datadog-plugin-graphql/src/resolve.js
@@ -3,38 +3,29 @@
 const dc = require('dc-polyfill')
 const TracingPlugin = require('../../dd-trace/src/plugins/tracing')
 
-const collapsedPathSym = Symbol('collapsedPaths')
-
 class GraphQLResolvePlugin extends TracingPlugin {
   static id = 'graphql'
   static operation = 'resolve'
 
+  /**
+   * @param {{ info: object, rootCtx: object, args: Record<string, unknown>, path: object }} fieldCtx
+   */
   start (fieldCtx) {
-    const { info, rootCtx, args, path: pathAsArray, pathString } = fieldCtx
+    if (!shouldInstrument(this.config, fieldCtx.path)) return
 
-    // we need to get the parent span to the field if it exists for correct span parenting
-    // of nested fields
-    const parentField = getParentField(rootCtx, pathString)
-    const childOf = parentField?.ctx?.currentStore?.span
+    const { info, rootCtx, args, path } = fieldCtx
+    const collapse = this.config.collapse
+    const pathString = buildPathString(path, collapse)
+    fieldCtx.pathString = pathString
 
-    fieldCtx.parent = parentField
-
-    if (!shouldInstrument(this.config, pathAsArray)) return
-    const computedPathString = this.config.collapse
-      ? buildCollapsedPathString(pathAsArray)
-      : pathString
-
-    if (this.config.collapse) {
-      if (rootCtx.fields[computedPathString]) return
-
-      if (!rootCtx[collapsedPathSym]) {
-        rootCtx[collapsedPathSym] = Object.create(null)
-      } else if (rootCtx[collapsedPathSym][computedPathString]) {
-        return
-      }
-
-      rootCtx[collapsedPathSym][computedPathString] = true
+    if (collapse) {
+      const collapsedFields = rootCtx.collapsedFields ??= new Set()
+      if (collapsedFields.has(pathString)) return
+      collapsedFields.add(pathString)
     }
+
+    const parentField = getParentField(rootCtx, path)
+    const childOf = parentField?.ctx?.currentStore?.span
 
     const document = rootCtx.source
     const fieldNode = info.fieldNodes[0]
@@ -48,7 +39,7 @@ class GraphQLResolvePlugin extends TracingPlugin {
       type: 'graphql',
       meta: {
         'graphql.field.name': info.fieldName,
-        'graphql.field.path': computedPathString,
+        'graphql.field.path': pathString,
         'graphql.field.type': info.returnType.name,
         'graphql.source': source,
       },
@@ -76,9 +67,9 @@ class GraphQLResolvePlugin extends TracingPlugin {
     super(...args)
 
     this.addTraceSub('updateField', (ctx) => {
-      const { field, error, path: pathAsArray } = ctx
+      const { field, error, path } = ctx
 
-      if (!shouldInstrument(this.config, pathAsArray)) return
+      if (!shouldInstrument(this.config, path)) return
 
       const span = ctx?.currentStore?.span || this.activeSpan
       field.finishTime = span._getTime ? span._getTime() : 0
@@ -105,30 +96,45 @@ class GraphQLResolvePlugin extends TracingPlugin {
 
 // helpers
 
-function shouldInstrument (config, pathAsArray) {
+/**
+ * @param {{ depth: number, collapse: boolean }} config
+ * @param {{ prev: object | undefined, key: string | number }} path
+ */
+function shouldInstrument (config, path) {
   if (config.depth < 0) return true
 
   let depth = 0
   if (config.collapse) {
-    depth = pathAsArray.length
+    for (let curr = path; curr; curr = curr.prev) depth += 1
   } else {
-    for (const segment of pathAsArray) {
-      if (typeof segment === 'string') depth += 1
+    for (let curr = path; curr; curr = curr.prev) {
+      if (typeof curr.key === 'string') depth += 1
     }
   }
 
   return config.depth >= depth
 }
 
-function buildCollapsedPathString (pathAsArray) {
-  let result = ''
-  for (const segment of pathAsArray) {
-    if (result.length > 0) result += '.'
-    result += typeof segment === 'number' ? '*' : segment
+/**
+ * @param {{ prev: object | undefined, key: string | number }} path
+ * @param {boolean} collapse Replace numeric segments with `*`.
+ */
+function buildPathString (path, collapse) {
+  let length = 0
+  for (let curr = path; curr; curr = curr.prev) length += 1
+
+  const segments = new Array(length)
+  let index = length - 1
+  for (let curr = path; curr; curr = curr.prev) {
+    segments[index--] = collapse && typeof curr.key === 'number' ? '*' : curr.key
   }
-  return result
+  return segments.join('.')
 }
 
+/**
+ * @param {object} info
+ * @param {Record<string, unknown> | undefined} args
+ */
 function getResolverInfo (info, args) {
   let resolverVars
 
@@ -154,20 +160,15 @@ function getResolverInfo (info, args) {
   return resolverVars === undefined ? null : { [info.fieldName]: resolverVars }
 }
 
-function getParentField (parentCtx, pathToString) {
-  let current = pathToString
-
-  while (current) {
-    const lastJoin = current.lastIndexOf('.')
-    if (lastJoin === -1) break
-
-    current = current.slice(0, lastJoin)
-    const field = parentCtx.fields[current]
-
+/**
+ * @param {{ fields: Map<object, { error: unknown, ctx: object }> }} rootCtx
+ * @param {{ prev: object | undefined }} path
+ */
+function getParentField (rootCtx, path) {
+  for (let curr = path.prev; curr; curr = curr.prev) {
+    const field = rootCtx.fields.get(curr)
     if (field) return field
   }
-
-  return null
 }
 
 module.exports = GraphQLResolvePlugin

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -627,6 +627,39 @@ describe('Plugin', () => {
           graphql.graphql({ schema, source }).catch(done)
         })
 
+        it('publishes resolver finish for every sibling of a collapsed list', async () => {
+          // Regression for first-wins finishTime: when a list collapses to one span,
+          // every sibling resolver must still publish on apm:graphql:resolve:updateField
+          // so the span's finishTime reflects the last sibling, not the first.
+          const updateCh = dc.channel('apm:graphql:resolve:updateField')
+          const counts = new Map()
+          const handler = (ctx) => {
+            counts.set(ctx.pathString, (counts.get(ctx.pathString) ?? 0) + 1)
+          }
+          updateCh.subscribe(handler)
+
+          try {
+            const source = '{ friends { name } }'
+            const [, result] = await Promise.all([
+              agent.assertSomeTraces(traces => {
+                const spans = sort(traces[0]).filter(span => span.name === 'graphql.resolve')
+                const friendsName = spans.find(span => span.meta['graphql.field.path'] === 'friends.*.name')
+                assert.ok(friendsName, 'expected one collapsed friends.*.name span')
+              }),
+              graphql.graphql({ schema, source }),
+            ])
+
+            assert.ok(!result.errors || result.errors.length === 0)
+            assert.strictEqual(
+              counts.get('friends.*.name'),
+              2,
+              'expected one updateField publish per sibling of the 2-element friends list',
+            )
+          } finally {
+            updateCh.unsubscribe(handler)
+          }
+        })
+
         it('should instrument list field resolvers', done => {
           const source = `{
             friends {

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -1724,6 +1724,55 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with collapsing disabled and a depth >=1', () => {
+        before(() => {
+          tracer = require('../../dd-trace')
+
+          return agent.load('graphql', { collapse: false, depth: 2 })
+        })
+
+        after(() => {
+          return agent.close({ ritmReset: false })
+        })
+
+        beforeEach(() => {
+          graphql = require(`../../../versions/graphql@${version}`).get()
+          buildSchema()
+        })
+
+        it('should count only string segments when collapsing is disabled', done => {
+          const source = `
+            {
+              friends {
+                name
+                pets {
+                  name
+                }
+              }
+            }
+          `
+
+          agent
+            .assertSomeTraces(traces => {
+              const spans = sort(traces[0])
+              const resolveSpans = spans.filter(span => span.name === 'graphql.resolve')
+              const paths = resolveSpans.map(span => span.meta['graphql.field.path']).sort()
+
+              assert.deepStrictEqual(paths, [
+                'friends',
+                'friends.0.name',
+                'friends.0.pets',
+                'friends.1.name',
+                'friends.1.pets',
+              ])
+            })
+            .then(done)
+            .catch(done)
+
+          graphql.graphql({ schema, source }).catch(done)
+        })
+      })
+
       describe('with signature calculation disabled', () => {
         before(() => {
           tracer = require('../../dd-trace')


### PR DESCRIPTION
Three O(depth) string operations run per resolver call against the
current Object-keyed `rootCtx.fields`: `pathToArray` +
`path.join('.')` in `assertField`, and `lastIndexOf('.')` + `slice`
in `getParentField`. The collapse-dedupe in `resolve.js#start` then
walks the path a third time only to early-return for every collapsed
duplicate. On a deep author/posts/comments workload that is a
measurable share of total CPU spent allocating and discarding path
strings.

Switch `rootCtx.fields` to a `Map<Path, FieldCtx>` keyed on the
graphql-js Path linked-list node identity (`{ prev, key, typename }`
is fresh per `addPath` and never collides). Four savings ride on the
swap:

1. `assertField` is one `Map.get(path)` lookup; no path array, no
   string join, no `Object.create` per execute.
2. `getParentField` walks `path.prev` and reads each level via
   `Map.get` (O(1) lookup, no substring).
3. The collapse dedupe runs up front in `start()` against a Set
   keyed on the lazily-computed path string; duplicates return before
   any parent lookup or span construction.
4. `finishResolvers` iterates `Map.values()` and skips field-ctxes
   that never started a span. `Span#finish` is idempotent, so the
   old loop silently double-published every collapse-dup onto the
   currently-active span; trimming those publishes is the cleanup
   the earlier dedupe earns.

The path string is computed once, lazily, inside `start()` when a
span is actually created, and shared between the collapse-Set key
and the `graphql.field.path` tag.

Microbench (deep 5x5x4 query, 2000 iters x 7 trials, drop best+worst,
Node 24.15 / V8 13.6):

* baseline 753.7 us/op, stddev 14.2 us
* patched  447.1 us/op, stddev  3.2 us

-306.6 us/op (-40.7 %) at the execute boundary, and the stddev drops
4.4x as the per-call path-array allocations stop driving GC.

Drive-by fix:

* Pin `shouldInstrument`'s non-collapse depth branch with a new "with
  collapsing disabled and a depth >=1" describe. The existing spec
  exercises depth filtering only with default `collapse: true`.