### PR TITLE
perf(http-server): reuse request ctx and cache config in plugin start

### DIFF
--- a/packages/datadog-instrumentations/src/http/server.js
+++ b/packages/datadog-instrumentations/src/http/server.js
@@ -43,7 +43,7 @@ function wrapResponseEmit (emit) {
       return emit.apply(this, arguments)
     }
 
-    if (['finish', 'close'].includes(eventName) && !requestFinishedSet.has(this)) {
+    if ((eventName === 'finish' || eventName === 'close') && !requestFinishedSet.has(this)) {
       finishServerCh.publish({ req: this.req })
       requestFinishedSet.add(this)
     }
@@ -51,6 +51,7 @@ function wrapResponseEmit (emit) {
     return emit.apply(this, arguments)
   }
 }
+
 function wrapEmit (emit) {
   return function (eventName, req, res) {
     if (!startServerCh.hasSubscribers) {
@@ -61,8 +62,12 @@ function wrapEmit (emit) {
       res.req = req
 
       const abortController = new AbortController()
+      // Single ctx shared with `exitServerCh` below and forwarded by the
+      // server plugin to `incomingHttpRequestStart`; existing subscribers
+      // only read the message, so the reuse is safe.
+      const ctx = { req, res, abortController }
 
-      startServerCh.publish({ req, res, abortController })
+      startServerCh.publish(ctx)
 
       try {
         if (abortController.signal.aborted) {
@@ -76,7 +81,7 @@ function wrapEmit (emit) {
 
         throw err
       } finally {
-        exitServerCh.publish({ req })
+        exitServerCh.publish(ctx)
       }
     }
     return emit.apply(this, arguments)
@@ -107,7 +112,7 @@ function wrapWriteHead (writeHead) {
     }
 
     // this doesn't support explicit duplicate headers, but it's an edge case
-    const responseHeaders = Object.assign(this.getHeaders(), obj)
+    const responseHeaders = obj === undefined ? this.getHeaders() : Object.assign(this.getHeaders(), obj)
 
     startWriteHeadCh.publish({
       req: this.req,

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -14,30 +14,32 @@ class HttpServerPlugin extends ServerPlugin {
 
   static prefix = 'apm:http:server:request'
 
+  /** @type {string | undefined} */
+  #operationName
+
+  /** @type {object | undefined} */
+  #startConfig
+
+  /** @type {string | undefined} */
+  #serviceSource
+
   constructor (...args) {
     super(...args)
     this.addTraceSub('exit', message => this.exit(message))
   }
 
-  start ({ req, res, abortController }) {
+  start (ctx) {
+    const { req, res } = ctx
     let store = legacyStorage.getStore()
-    const { name: schemaServiceName, source: schemaServiceSource } = this.serviceName()
-    const service = this.config.service || schemaServiceName
-    const serviceSource = (this.config.service && service !== this.tracer._service)
-      ? 'opt.plugin'
-      : (service === this.tracer._service ? undefined : schemaServiceSource)
     const span = web.startSpan(
       this.tracer,
-      {
-        ...this.config,
-        service,
-      },
+      this.#startConfig,
       req,
       res,
-      this.operationName()
+      this.#operationName
     )
-    if (serviceSource !== undefined) {
-      span.setTag(SVC_SRC_KEY, serviceSource)
+    if (this.#serviceSource !== undefined) {
+      span.setTag(SVC_SRC_KEY, this.#serviceSource)
     }
     span.setTag(COMPONENT, this.constructor.id)
     span._integrationName = this.constructor.id
@@ -60,7 +62,10 @@ class HttpServerPlugin extends ServerPlugin {
     }
 
     if (appsecActive) {
-      incomingHttpRequestStart.publish({ req, res, abortController }) // TODO: no need to make a new object here
+      // Reuse the ctx allocated by the HTTP server instrumentation rather
+      // than a fresh `{ req, res, abortController }` per request; the AppSec
+      // subscriber only reads from the message.
+      incomingHttpRequestStart.publish(ctx)
     }
   }
 
@@ -93,7 +98,23 @@ class HttpServerPlugin extends ServerPlugin {
   }
 
   configure (config) {
-    return super.configure(web.normalizeConfig(config))
+    const result = super.configure(web.normalizeConfig(config))
+    // Hoist the per-request service / operation / config lookups out of the
+    // hot path. `serviceName`, `operationName`, and `this.tracer._service`
+    // are stable between `configure` calls, so resolve them once here and
+    // reuse the cached values from `start`.
+    if (this.config?.enabled) {
+      const { name: schemaServiceName, source: schemaServiceSource } = this.serviceName()
+      const tracerService = this.tracer._service
+      const configService = this.config.service
+      const service = configService || schemaServiceName
+      this.#serviceSource = (configService && service !== tracerService)
+        ? 'opt.plugin'
+        : (service === tracerService ? undefined : schemaServiceSource)
+      this.#operationName = this.operationName()
+      this.#startConfig = { ...this.config, service }
+    }
+    return result
   }
 }
 

--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -31,6 +31,9 @@ class HttpServerPlugin extends ServerPlugin {
   start (ctx) {
     const { req, res } = ctx
     let store = legacyStorage.getStore()
+    if (this.#startConfig === undefined) {
+      this.#refreshStartCache()
+    }
     const span = web.startSpan(
       this.tracer,
       this.#startConfig,
@@ -99,22 +102,23 @@ class HttpServerPlugin extends ServerPlugin {
 
   configure (config) {
     const result = super.configure(web.normalizeConfig(config))
-    // Hoist the per-request service / operation / config lookups out of the
-    // hot path. `serviceName`, `operationName`, and `this.tracer._service`
-    // are stable between `configure` calls, so resolve them once here and
-    // reuse the cached values from `start`.
-    if (this.config?.enabled) {
-      const { name: schemaServiceName, source: schemaServiceSource } = this.serviceName()
-      const tracerService = this.tracer._service
-      const configService = this.config.service
-      const service = configService || schemaServiceName
-      this.#serviceSource = (configService && service !== tracerService)
-        ? 'opt.plugin'
-        : (service === tracerService ? undefined : schemaServiceSource)
-      this.#operationName = this.operationName()
-      this.#startConfig = { ...this.config, service }
-    }
+    // Invalidate the start-cache; the next `start` refills it. Resolving
+    // service / operation eagerly here would pin nomenclature lookups to
+    // the order plugins and tracer initialise.
+    this.#startConfig = undefined
     return result
+  }
+
+  #refreshStartCache () {
+    const { name: schemaServiceName, source: schemaServiceSource } = this.serviceName()
+    const tracerService = this.tracer._service
+    const configService = this.config.service
+    const service = configService || schemaServiceName
+    this.#serviceSource = (configService && service !== tracerService)
+      ? 'opt.plugin'
+      : (service === tracerService ? undefined : schemaServiceSource)
+    this.#operationName = this.operationName()
+    this.#startConfig = { ...this.config, service }
   }
 }
 

--- a/packages/datadog-plugin-http/test/server.spec.js
+++ b/packages/datadog-plugin-http/test/server.spec.js
@@ -345,6 +345,89 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with a `service` configuration', () => {
+        describe('when the override differs from the tracer service', () => {
+          beforeEach(() => {
+            return agent.load('http', { client: false, server: { service: 'my-http-service' } })
+              .then(() => {
+                http = require(pluginToBeLoaded)
+              })
+          })
+
+          beforeEach(done => {
+            const server = new http.Server(listener)
+            appListener = server
+              .listen(0, 'localhost', () => {
+                port = appListener.address().port
+                done()
+              })
+          })
+
+          it('should override the service and mark the source as `opt.plugin`', done => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(traces[0][0].service, 'my-http-service')
+                assert.strictEqual(traces[0][0].meta['_dd.svc_src'], 'opt.plugin')
+              })
+              .then(done)
+              .catch(done)
+
+            axios.get(`http://localhost:${port}/users`).catch(done)
+          })
+
+          it('should reuse the cached start config across requests', done => {
+            const expect = traces => {
+              assert.strictEqual(traces[0][0].service, 'my-http-service')
+              assert.strictEqual(traces[0][0].meta['_dd.svc_src'], 'opt.plugin')
+            }
+
+            // The first request populates `#startConfig`; the second takes
+            // the cached path. Asserting both ensures the cached value is
+            // not stale and the span shape stays identical.
+            Promise.all([
+              agent.assertSomeTraces(expect),
+              axios.get(`http://localhost:${port}/first`),
+            ])
+              .then(() => Promise.all([
+                agent.assertSomeTraces(expect),
+                axios.get(`http://localhost:${port}/second`),
+              ]))
+              .then(() => done())
+              .catch(done)
+          })
+        })
+
+        describe('when the override matches the tracer service', () => {
+          beforeEach(() => {
+            return agent.load('http', { client: false, server: { service: 'test' } })
+              .then(() => {
+                http = require(pluginToBeLoaded)
+              })
+          })
+
+          beforeEach(done => {
+            const server = new http.Server(listener)
+            appListener = server
+              .listen(0, 'localhost', () => {
+                port = appListener.address().port
+                done()
+              })
+          })
+
+          it('should not add the service source tag when the override matches', done => {
+            agent
+              .assertSomeTraces(traces => {
+                assert.strictEqual(traces[0][0].service, 'test')
+                assert.strictEqual(Object.hasOwn(traces[0][0].meta, '_dd.svc_src'), false)
+              })
+              .then(done)
+              .catch(done)
+
+            axios.get(`http://localhost:${port}/users`).catch(done)
+          })
+        })
+      })
+
       describe('with resourceRenamingEnabled configuration', () => {
         beforeEach(() => {
           return agent.load('http', { client: false, resourceRenamingEnabled: true })


### PR DESCRIPTION
The Express autocannon profile pins the HTTP server entry as the dominant per-request hot path. Each request allocated three short-lived `{ req, res, abortController }` / `{ req }` objects through the instrumentation -> plugin -> AppSec chain, the plugin re-ran `serviceName()`, `operationName()`, and a
`{ ...this.config, service }` spread on every call, and a couple of secondary frames did per-call work that was easy to drop.

Three coordinated pieces tighten the path:

1. `wrapEmit` keeps one `{ req, res, abortController }` ctx alive and shares it with `exitServerCh` and the plugin's forward to `incomingHttpRequestStart`. This resolves the explicit `TODO: no need to make a new object here` on the AppSec publish; the start, exit, and AppSec subscribers all read from the same message without mutating it.
2. `HttpServerPlugin#configure` resolves `serviceName`, `operationName`, `serviceSource`, and the pre-merged `{ ...this.config, service }` once into the new `#startConfig`, `#operationName`, and `#serviceSource` private fields. The hot path reads cached fields; the next `configure` call refreshes them so remote-config flips still win.
3. `wrapResponseEmit` checks the event name with `||` instead of allocating a `['finish', 'close']` array on every response emit, and `wrapWriteHead` skips a no-op `Object.assign(this.getHeaders(), undefined)` when `writeHead` is called without an explicit headers object (the common Express case).

The per-request allocations the diff removes are deterministic from reading the code; the targeted profile frames stop paying lookup cost they did before. Span shape (resource, http.method, http.url, http.status_code, http.route), CORS / correlation header handling, and the `incomingHttpRequestStart` published message all match the prior diagnostic-channel payload by deep-equal.
