### PR TITLE
fix(plugins/util): scope extractIp per-plugin instead of module-level

### DIFF
--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -14,8 +14,6 @@ const urlFilter = require('./urlfilter')
 const { createInferredProxySpan, finishInferredProxySpan } = require('./inferred_proxy')
 const { extractURL, obfuscateQs, calculateHttpEndpoint } = require('./url')
 
-let extractIp
-
 const WEB = types.WEB
 const SERVER = kinds.SERVER
 const RESOURCE_NAME = tags.RESOURCE_NAME
@@ -67,7 +65,9 @@ const web = {
     const middleware = getMiddlewareSetting(config)
     const queryStringObfuscation = getQsObfuscator(config)
 
-    extractIp = config.clientIpEnabled && require('./ip_extractor').extractIp
+    const extractIp = config.clientIpEnabled
+      ? require('./ip_extractor').extractIp
+      : undefined
 
     return {
       ...config,
@@ -77,6 +77,7 @@ const web = {
       filter,
       middleware,
       queryStringObfuscation,
+      extractIp,
     }
   },
 
@@ -393,8 +394,8 @@ function addRequestTags (context, spanType) {
   })
 
   // if client ip has already been set by appsec, no need to run it again
-  if (extractIp && !span.context().hasTag(HTTP_CLIENT_IP)) {
-    const clientIp = extractIp(config, req)
+  if (config.extractIp && !span.context().hasTag(HTTP_CLIENT_IP)) {
+    const clientIp = config.extractIp(config, req)
 
     if (clientIp) {
       span.setTag(HTTP_CLIENT_IP, clientIp)

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -10,6 +10,7 @@ require('../../setup/core')
 const tagsExt = require('../../../../../ext/tags')
 
 const ERROR = tagsExt.ERROR
+const HTTP_CLIENT_IP = tagsExt.HTTP_CLIENT_IP
 const HTTP_ENDPOINT = tagsExt.HTTP_ENDPOINT
 const HTTP_ROUTE = tagsExt.HTTP_ROUTE
 const RESOURCE_NAME = tagsExt.RESOURCE_NAME
@@ -126,6 +127,55 @@ describe('plugins/util/web', () => {
         assert.strictEqual(config.queryStringObfuscation, true)
       })
     })
+
+    describe('clientIpEnabled', () => {
+      it('leaves extractIp undefined when clientIpEnabled is not set', () => {
+        const config = web.normalizeConfig({})
+
+        assert.strictEqual(config.extractIp, undefined)
+      })
+
+      it('resolves extractIp to the ip_extractor implementation when clientIpEnabled is true', () => {
+        const config = web.normalizeConfig({ clientIpEnabled: true })
+        const { extractIp } = require('../../../src/plugins/util/ip_extractor')
+
+        assert.strictEqual(config.extractIp, extractIp)
+      })
+    })
+  })
+
+  describe('startSpan client IP extraction', () => {
+    it('tags the span with the extracted client IP when clientIpEnabled is set', () => {
+      const config = web.normalizeConfig({ clientIpEnabled: true })
+      req.headers['x-forwarded-for'] = '8.8.8.8'
+
+      const span = web.startSpan(tracer, config, req, res, 'test.request')
+
+      assert.strictEqual(span.context().getTag(HTTP_CLIENT_IP), '8.8.8.8')
+    })
+
+    it('leaves the client IP tag unset when clientIpEnabled is not set', () => {
+      const config = web.normalizeConfig({})
+      req.headers['x-forwarded-for'] = '8.8.8.8'
+
+      const span = web.startSpan(tracer, config, req, res, 'test.request')
+
+      assert.strictEqual(span.context().hasTag(HTTP_CLIENT_IP), false)
+    })
+
+    // Regression for the per-plugin scoping fix: a later normalizeConfig call
+    // for a different plugin must not disable IP extraction on the earlier
+    // plugin's config. Used to fail because extractIp lived on the module.
+    it('keeps extraction enabled on the first config after a second plugin normalizes without clientIpEnabled',
+      () => {
+        const enabledConfig = web.normalizeConfig({ clientIpEnabled: true })
+        web.normalizeConfig({})
+        req.headers['x-forwarded-for'] = '8.8.8.8'
+
+        const span = web.startSpan(tracer, enabledConfig, req, res, 'test.request')
+
+        assert.strictEqual(span.context().getTag(HTTP_CLIENT_IP), '8.8.8.8')
+      })
   })
 
   describe('root', () => {


### PR DESCRIPTION
`extractIp` was a module-level `let` that `normalizeConfig` overwrote on every call. With multiple web plugins loaded (e.g. http plus a framework plugin), whichever was configured last won the assignment, so a plugin that enabled `clientIpEnabled` could have its IP extraction silently disabled by a later plugin's config. The Koa test even hard-codes a setup order to work around it.

Move `extractIp` onto the returned config object. Each plugin carries its own resolver, and `addRequestTags` reads `config.extractIp`. The extra property lookup per IP-extracting request is negligible.

Drive-by fix:

* Switch the `hasOwnProperty` check to `Object.hasOwn`, matching the rest of the file.