### PR TITLE
perf(router): consolidate per-request state, drop redundant ALS read

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -464,6 +464,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-router:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: router
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-url:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/datadog-instrumentations/src/router.js
+++ b/packages/datadog-instrumentations/src/router.js
@@ -8,7 +8,6 @@ const { getCompileToRegexp } = require('./path-to-regexp')
 const {
   getRouterMountPaths,
   joinPath,
-  getLayerMatchers,
   setLayerMatchers,
   isAppMounted,
   setRouterMountPath,
@@ -42,34 +41,47 @@ function createWrapRouterMethod (name, compile) {
   const nextChannel = channel(`apm:${name}:middleware:next`)
   const routeAddedChannel = channel(`apm:${name}:route:added`)
 
-  function wrapLayerHandle (layer, original) {
-    original._name = original._name || layer.name
+  function wrapLayerHandle (layer, original, matchers) {
+    // Resolve `name` once at wrap time: cached on the original for any code
+    // that reads `_name`, captured in the closure so the per-call body avoids
+    // the property-lookup / `||` fallback.
+    const name = original._name || layer.name || original.name
+    original._name = name
 
-    return shimmer.wrapFunction(original, original => function (...args) {
-      if (!enterChannel.hasSubscribers) return original.apply(this, args)
-
-      const matchers = getLayerMatchers(layer)
-      const lastIndex = args.length - 1
-      const name = original._name || original.name
-      const req = args[args.length > 3 ? 1 : 0]
-      const next = args[lastIndex]
-
-      if (typeof next === 'function') {
-        args[lastIndex] = wrapNext(req, next)
+    // Wrap-time matcher analysis. The single-pattern case yields a constant
+    // route; only multi-pattern stacks need a per-request layer.path match.
+    let captureRoute
+    let needMultiMatch = false
+    if (matchers.length !== 0 && !isFastStar(layer, matchers) && !isFastSlash(layer, matchers)) {
+      if (matchers.length === 1) {
+        captureRoute = matchers[0].path
+      } else {
+        needMultiMatch = true
       }
+    }
 
-      let route
+    // Split by arity: router only ever dispatches 3-arg request handlers
+    // through `Layer.handleRequest` and 4-arg error handlers through
+    // `Layer.handleError`. Specialising lets the per-call body use named
+    // parameters and `.call`, avoiding the rest-spread Array allocation that
+    // the unified shape forced on every middleware invocation.
+    return original.length === 4
+      ? shimmer.wrapFunction(original, errorHandlerLayerWrap(layer, name, captureRoute, needMultiMatch, matchers))
+      : shimmer.wrapFunction(original, requestHandlerLayerWrap(layer, name, captureRoute, needMultiMatch, matchers))
+  }
 
-      if (matchers?.length && !isFastStar(layer, matchers) && !isFastSlash(layer, matchers)) {
-        if (matchers.length === 1) {
-          // The host already matched this layer; the lone pattern is the route.
-          route = matchers[0].path
-        } else {
-          for (const matcher of matchers) {
-            if (matcher.regex?.test(layer.path)) {
-              route = matcher.path
-              break
-            }
+  function requestHandlerLayerWrap (layer, name, captureRoute, needMultiMatch, matchers) {
+    return original => function (req, res, next) {
+      if (!enterChannel.hasSubscribers) return original.call(this, req, res, next)
+
+      const wrappedNext = typeof next === 'function' ? wrapNext(req, next) : next
+
+      let route = captureRoute
+      if (needMultiMatch) {
+        for (const matcher of matchers) {
+          if (matcher.regex?.test(layer.path)) {
+            route = matcher.path
+            break
           }
         }
       }
@@ -77,7 +89,7 @@ function createWrapRouterMethod (name, compile) {
       enterChannel.publish({ name, req, route, layer })
 
       try {
-        return original.apply(this, args)
+        return original.call(this, req, res, wrappedNext)
       } catch (error) {
         errorChannel.publish({ req, error })
         nextChannel.publish({ req })
@@ -87,15 +99,47 @@ function createWrapRouterMethod (name, compile) {
       } finally {
         exitChannel.publish({ req })
       }
-    })
+    }
+  }
+
+  function errorHandlerLayerWrap (layer, name, captureRoute, needMultiMatch, matchers) {
+    return original => function (error, req, res, next) {
+      if (!enterChannel.hasSubscribers) return original.call(this, error, req, res, next)
+
+      const wrappedNext = typeof next === 'function' ? wrapNext(req, next) : next
+
+      let route = captureRoute
+      if (needMultiMatch) {
+        for (const matcher of matchers) {
+          if (matcher.regex?.test(layer.path)) {
+            route = matcher.path
+            break
+          }
+        }
+      }
+
+      enterChannel.publish({ name, req, route, layer })
+
+      try {
+        return original.call(this, error, req, res, wrappedNext)
+      } catch (caught) {
+        errorChannel.publish({ req, error: caught })
+        nextChannel.publish({ req })
+        finishChannel.publish({ req })
+
+        throw caught
+      } finally {
+        exitChannel.publish({ req })
+      }
+    }
   }
 
   function wrapStack (layers, matchers) {
     for (const layer of layers) {
       if (layer.__handle) { // express-async-errors
-        layer.__handle = wrapLayerHandle(layer, layer.__handle)
+        layer.__handle = wrapLayerHandle(layer, layer.__handle, matchers)
       } else {
-        layer.handle = wrapLayerHandle(layer, layer.handle)
+        layer.handle = wrapLayerHandle(layer, layer.handle, matchers)
       }
 
       setLayerMatchers(layer, matchers)
@@ -258,15 +302,15 @@ addHook({ name: 'router', versions: ['>=2'] }, Router => {
 
       shimmer.wrap(router, 'handle', function wrapHandle (originalHandle) {
         return function wrappedHandle (req, res, next) {
-          const abortController = new AbortController()
-
           if (queryParserReadCh.hasSubscribers && req) {
+            const abortController = new AbortController()
+
             queryParserReadCh.publish({ req, res, query: req.query, abortController })
 
             if (abortController.signal.aborted) return
           }
 
-          return originalHandle.apply(this, arguments)
+          return originalHandle.call(this, req, res, next)
         }
       })
 

--- a/packages/datadog-instrumentations/test/router.spec.js
+++ b/packages/datadog-instrumentations/test/router.spec.js
@@ -1,0 +1,599 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const dc = require('dc-polyfill')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+const { createWrapRouterMethod } = require('../src/router')
+const { assertObjectContains } = require('../../../integration-tests/helpers')
+
+// `createWrapRouterMethod` is exercised end-to-end by the express and router
+// plugin specs, but those run over real HTTP and only ever dispatch 3-arg
+// request handlers with a single matcher path. The new arity split, the
+// multi-matcher loop, the no-subscriber fast paths, the sync-throw catches,
+// and the `_name` resolution chain need explicit unit coverage so a future
+// regression on any of them shows up here, not in a downstream tracer test.
+
+/**
+ * Minimal subset of an express/router `Layer` the wrap code reads. `regexp` is
+ * the host's compiled mount regex — only `fast_star` / `fast_slash` matter for
+ * the wrap-time short-circuit.
+ * @typedef {{
+ *   handle: Function,
+ *   __handle?: Function,
+ *   name?: string,
+ *   path?: string,
+ *   regexp?: { fast_star?: boolean, fast_slash?: boolean },
+ * }} FakeLayer
+ *
+ * @typedef {{ stack: FakeLayer[] }} FakeRouter
+ */
+
+describe('createWrapRouterMethod', () => {
+  let counter = 0
+  let namespace
+  let enterChannel
+  let exitChannel
+  let nextChannel
+  let finishChannel
+  let errorChannel
+  let events
+  let subscriptions
+
+  beforeEach(() => {
+    namespace = `router-spec-${++counter}`
+    enterChannel = dc.channel(`apm:${namespace}:middleware:enter`)
+    exitChannel = dc.channel(`apm:${namespace}:middleware:exit`)
+    nextChannel = dc.channel(`apm:${namespace}:middleware:next`)
+    finishChannel = dc.channel(`apm:${namespace}:middleware:finish`)
+    errorChannel = dc.channel(`apm:${namespace}:middleware:error`)
+    events = []
+    subscriptions = []
+  })
+
+  afterEach(() => {
+    for (const [channel, listener] of subscriptions) {
+      channel.unsubscribe(listener)
+    }
+  })
+
+  // Subscribe to the per-request middleware channels only. `apm:*:route:added`
+  // publishes during the wrap step, before any request fires, so leaving it
+  // unsubscribed keeps the recorded `events` ordering aligned with the
+  // per-request lifecycle the assertions below check.
+  function subscribeAll () {
+    const all = [
+      ['enter', enterChannel],
+      ['exit', exitChannel],
+      ['next', nextChannel],
+      ['finish', finishChannel],
+      ['error', errorChannel],
+    ]
+    for (const [label, channel] of all) {
+      const listener = (data) => events.push({ label, data })
+      channel.subscribe(listener)
+      subscriptions.push([channel, listener])
+    }
+  }
+
+  /**
+   * Build a fake `.use`-shaped router method whose body appends one layer per
+   * handler to `this.stack`. `layerPath` is the request-time `layer.path`
+   * value the wrapped handler sees during the multi-matcher loop.
+   *
+   * @param {object} [options]
+   * @param {string} [options.layerPath] Request path the layer reports.
+   * @param {object} [options.regexp]    `{ fast_star, fast_slash }` overrides.
+   * @returns {Function} The fake `.use` implementation.
+   */
+  function makeFakeUse ({ layerPath = '/some-path', regexp = {} } = {}) {
+    function use (...args) {
+      // Mirror the host shape: the first arg is a path or array of paths, the
+      // rest are middleware. Plain handlers (`use(handler)`) start at index 0.
+      const startIdx = typeof args[0] === 'function' ? 0 : 1
+      for (let i = startIdx; i < args.length; i++) {
+        const handler = args[i]
+        if (typeof handler !== 'function') continue
+        this.stack.push({ handle: handler, path: layerPath, regexp })
+      }
+    }
+    return use
+  }
+
+  function compileRegex (pattern) {
+    if (pattern instanceof RegExp) return pattern
+    if (typeof pattern !== 'string') return undefined
+    return new RegExp(`^${pattern.replace(/\//g, '\\/')}$`)
+  }
+
+  describe('request handler (3-arg) wrap', () => {
+    it('publishes enter/next/finish/exit and captures the single-pattern route', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function namedHandler (req, res, next) {
+        next()
+      })
+
+      const req = { url: '/' }
+      const res = {}
+      const downstreamNext = () => events.push({ label: 'downstream-next' })
+
+      router.stack[0].handle.call({}, req, res, downstreamNext)
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'downstream-next', 'exit',
+      ])
+      assertObjectContains(events[0].data, {
+        name: 'namedHandler',
+        req,
+        route: '/foo',
+        layer: router.stack[0],
+      })
+    })
+
+    it('matches a multi-pattern path against layer.path and captures the matching route', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/users' }))
+      wrappedUse.call(router, ['/users', '/products'], function pickedFromList (req, res, next) {
+        next()
+      })
+
+      const req = {}
+      router.stack[0].handle.call({}, req, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, '/users')
+    })
+
+    it('leaves route undefined when no multi-pattern matcher matches', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/unrelated' }))
+      wrappedUse.call(router, ['/users', '/products'], function noMatch (req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, undefined)
+    })
+
+    it('skips matcher analysis when the host passes a handler with no mount path', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      // `.use(handler)` with no mount path produces an empty matchers list.
+      const wrappedUse = wrapMethod(makeFakeUse())
+      wrappedUse.call(router, function rootHandler (req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, undefined)
+    })
+
+    it('short-circuits the matcher loop on a fast-star (`*`) layer', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ regexp: { fast_star: true } }))
+      wrappedUse.call(router, '*', function starHandler (req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, undefined)
+    })
+
+    it('short-circuits the matcher loop on a fast-slash (`/`) layer', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ regexp: { fast_slash: true } }))
+      wrappedUse.call(router, '/', function slashHandler (req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, undefined)
+    })
+
+    it('skips wrapping work when enterChannel has no subscribers', () => {
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      // With no subscriber on enterChannel the wrapped handler should forward
+      // `this`, `req`, `res`, `next` and the return value straight through —
+      // no allocation, no wrapNext, no channel publish.
+      const captured = { thisArg: undefined, args: /** @type {unknown[]} */ ([]) }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function (req, res, next) {
+        captured.thisArg = this
+        captured.args = [req, res, next]
+        return 'forwarded-return'
+      })
+
+      const req = {}
+      const res = {}
+      const next = () => 'original-next'
+      const ctx = { tag: 'this-arg' }
+
+      const result = router.stack[0].handle.call(ctx, req, res, next)
+
+      assert.strictEqual(result, 'forwarded-return')
+      assert.strictEqual(captured.thisArg, ctx)
+      assert.deepStrictEqual(captured.args, [req, res, next])
+    })
+
+    it('passes a non-function next through unchanged', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const captured = { next: /** @type {unknown} */ (undefined) }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function (req, res, next) {
+        captured.next = next
+      })
+
+      router.stack[0].handle.call({}, {}, {}, 'not-a-function')
+
+      assert.strictEqual(captured.next, 'not-a-function')
+    })
+
+    it('publishes error/next/finish/exit when the handler throws synchronously', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const failure = new Error('boom')
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function thrower (req, res, next) {
+        throw failure
+      })
+
+      const req = {}
+      assert.throws(() => {
+        router.stack[0].handle.call({}, req, {}, () => {})
+      }, error => error === failure)
+
+      // The throw skips the wrapped-next path; finish/exit publish via the
+      // catch block before the throw is re-raised.
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'error', 'next', 'finish', 'exit',
+      ])
+      assert.strictEqual(events[1].data.error, failure)
+      assert.strictEqual(events[1].data.req, req)
+    })
+  })
+
+  describe('error handler (4-arg) wrap', () => {
+    it('publishes enter/next/finish/exit and forwards error/req/res/next to the original', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      const received = /** @type {{ error?: Error, req?: object, res?: object }} */ ({})
+      wrappedUse.call(router, '/foo', function errorHandler (error, req, res, next) {
+        received.error = error
+        received.req = req
+        received.res = res
+        // Real error handlers either call next() to continue, or next(error)
+        // to keep propagating; both shapes go through wrappedNext.
+        next()
+      })
+
+      const failure = new Error('upstream')
+      const req = {}
+      const res = {}
+      const downstreamNext = () => events.push({ label: 'downstream-next' })
+
+      router.stack[0].handle.call({}, failure, req, res, downstreamNext)
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'next', 'finish', 'downstream-next', 'exit',
+      ])
+      assert.strictEqual(received.error, failure)
+      assert.strictEqual(received.req, req)
+      assert.strictEqual(received.res, res)
+
+      assertObjectContains(events[0].data, {
+        name: 'errorHandler',
+        req,
+        route: '/foo',
+        layer: router.stack[0],
+      })
+    })
+
+    it('matches a multi-pattern path against layer.path and captures the matching route', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/products' }))
+      wrappedUse.call(router, ['/users', '/products'], function (error, req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, new Error('e'), {}, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, '/products')
+    })
+
+    it('leaves route undefined when no multi-pattern matcher matches', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/none' }))
+      wrappedUse.call(router, ['/users', '/products'], function (error, req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, new Error('e'), {}, {}, () => {})
+
+      const enterEvent = events.find(e => e.label === 'enter')
+      assert.strictEqual(enterEvent.data.route, undefined)
+    })
+
+    it('skips wrapping work when enterChannel has no subscribers', () => {
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const captured = { thisArg: undefined, args: /** @type {unknown[]} */ ([]) }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function (error, req, res, next) {
+        captured.thisArg = this
+        captured.args = [error, req, res, next]
+        return 'forwarded-return'
+      })
+
+      const failure = new Error('e')
+      const req = {}
+      const res = {}
+      const next = () => {}
+      const ctx = { tag: 'this-arg' }
+
+      const result = router.stack[0].handle.call(ctx, failure, req, res, next)
+
+      assert.strictEqual(result, 'forwarded-return')
+      assert.strictEqual(captured.thisArg, ctx)
+      assert.deepStrictEqual(captured.args, [failure, req, res, next])
+    })
+
+    it('passes a non-function next through unchanged', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const captured = { next: /** @type {unknown} */ (undefined) }
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function (error, req, res, next) {
+        captured.next = next
+      })
+
+      router.stack[0].handle.call({}, new Error('e'), {}, {}, 'not-a-function')
+
+      assert.strictEqual(captured.next, 'not-a-function')
+    })
+
+    it('publishes error/next/finish/exit when the handler throws synchronously', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const failure = new Error('throws-in-error-handler')
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function (error, req, res, next) {
+        throw failure
+      })
+
+      const req = {}
+      assert.throws(() => {
+        router.stack[0].handle.call({}, new Error('upstream'), req, {}, () => {})
+      }, error => error === failure)
+
+      assert.deepStrictEqual(events.map(e => e.label), [
+        'enter', 'error', 'next', 'finish', 'exit',
+      ])
+      assert.strictEqual(events[1].data.error, failure)
+      assert.strictEqual(events[1].data.req, req)
+    })
+  })
+
+  describe('handler name resolution', () => {
+    it('prefers `original._name` when it is already set', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const handler = /** @type {Function & { _name?: string }} */ (
+        function handlerWithCachedName (req, res, next) { next() }
+      )
+      handler._name = 'pre-cached'
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', handler)
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      assert.strictEqual(events.find(e => e.label === 'enter').data.name, 'pre-cached')
+    })
+
+    it('falls back to `layer.name` when `_name` is missing and `layer.name` is set', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod((handler) => {
+        router.stack.push({ handle: handler, name: 'layer-named', path: '/foo', regexp: {} })
+      })
+      // The fake use above doesn't follow the standard signature; pass the
+      // handler at the head of args so extractMatchers sees a function and
+      // returns an empty matcher list.
+      wrappedUse.call(router, (req, res, next) => next())
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      assert.strictEqual(events.find(e => e.label === 'enter').data.name, 'layer-named')
+    })
+
+    it('falls back to `original.name` when both `_name` and `layer.name` are missing', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', function fallbackToOriginalName (req, res, next) {
+        next()
+      })
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      assert.strictEqual(
+        events.find(e => e.label === 'enter').data.name,
+        'fallbackToOriginalName'
+      )
+    })
+
+    it('caches the resolved name on `original._name` so the next wrap reuses it', () => {
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const handler = /** @type {Function & { _name?: string }} */ (
+        function originalName (req, res, next) { next() }
+      )
+      assert.strictEqual(handler._name, undefined)
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', handler)
+
+      assert.strictEqual(handler._name, 'originalName')
+    })
+  })
+
+  describe('wrapNext', () => {
+    it('does not publish errorChannel when next is called with no argument', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', (req, res, next) => next())
+
+      router.stack[0].handle.call({}, {}, {}, () => {})
+
+      assert.strictEqual(events.some(e => e.label === 'error'), false)
+    })
+
+    it('does not publish errorChannel on next("route")', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', (req, res, next) => next('route'))
+
+      let receivedRouteToken
+      router.stack[0].handle.call({}, {}, {}, (token) => { receivedRouteToken = token })
+
+      assert.strictEqual(receivedRouteToken, 'route')
+      assert.strictEqual(events.some(e => e.label === 'error'), false)
+    })
+
+    it('does not publish errorChannel on next("router")', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      wrappedUse.call(router, '/foo', (req, res, next) => next('router'))
+
+      let receivedRouterToken
+      router.stack[0].handle.call({}, {}, {}, (token) => { receivedRouterToken = token })
+
+      assert.strictEqual(receivedRouterToken, 'router')
+      assert.strictEqual(events.some(e => e.label === 'error'), false)
+    })
+
+    it('publishes errorChannel with the error when next is called with an Error', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const wrappedUse = wrapMethod(makeFakeUse({ layerPath: '/foo' }))
+      const failure = new Error('downstream-error')
+      wrappedUse.call(router, '/foo', (req, res, next) => next(failure))
+
+      const req = {}
+      router.stack[0].handle.call({}, req, {}, () => {})
+
+      const errorEvent = events.find(e => e.label === 'error')
+      assert.ok(errorEvent, 'errorChannel should publish on next(error)')
+      assert.strictEqual(errorEvent.data.error, failure)
+      assert.strictEqual(errorEvent.data.req, req)
+    })
+  })
+
+  describe('layer.__handle (express-async-errors compatibility)', () => {
+    it('wraps `__handle` instead of `handle` when the layer exposes both', () => {
+      subscribeAll()
+      const wrapMethod = createWrapRouterMethod(namespace, compileRegex)
+      const router = /** @type {FakeRouter} */ ({ stack: [] })
+
+      const originalHandle = (req, res, next) => next()
+      const originalUnderscoreHandle = function patchedHandle (req, res, next) {
+        events.push({ label: '__handle-called' })
+        next()
+      }
+
+      function fakeUseWithUnderscoreHandle (path, handler) {
+        this.stack.push({
+          handle: originalHandle,
+          __handle: originalUnderscoreHandle,
+          path: '/foo',
+          regexp: {},
+        })
+      }
+
+      const wrappedUse = wrapMethod(fakeUseWithUnderscoreHandle)
+      wrappedUse.call(router, '/foo', () => {})
+
+      // `handle` should be left alone; `__handle` should be the new wrapper.
+      const wrappedLayer = router.stack[0]
+      assert.strictEqual(wrappedLayer.handle, originalHandle)
+      assert.notStrictEqual(wrappedLayer.__handle, originalUnderscoreHandle)
+      assert.strictEqual(typeof wrappedLayer.__handle, 'function')
+
+      const wrappedUnderscoreHandle = /** @type {Function} */ (wrappedLayer.__handle)
+      wrappedUnderscoreHandle.call({}, {}, {}, () => {})
+
+      assert.ok(
+        events.find(e => e.label === '__handle-called'),
+        'the inner __handle should run via the wrap'
+      )
+      assert.ok(events.find(e => e.label === 'enter'), 'enterChannel should publish for __handle')
+    })
+  })
+})

--- a/packages/datadog-plugin-router/src/index.js
+++ b/packages/datadog-plugin-router/src/index.js
@@ -9,31 +9,35 @@ const { COMPONENT } = require('../../dd-trace/src/constants')
 class RouterPlugin extends WebPlugin {
   static id = 'router'
 
-  #storeStacks = new WeakMap()
   #contexts = new WeakMap()
 
   constructor (...args) {
     super(...args)
 
     this.addSub(`apm:${this.constructor.id}:middleware:enter`, ({ req, name, route }) => {
-      const childOf = this.#getActive(req) || this.#getStoreSpan()
-
+      // One ALS hop covers both the parent-span fallback (when no
+      // per-request context exists yet) and the `storeStack` push below.
+      // The previous shape paid an ALS read inside `#getStoreSpan` and a
+      // second one here for the saved-store push.
+      const store = storage('legacy').getStore()
+      let context = this.#contexts.get(req)
+      let childOf
+      if (context !== undefined) {
+        const middleware = context.middleware
+        childOf = middleware.length === 0 ? context.span : middleware[middleware.length - 1]
+      } else if (store) {
+        childOf = store.span
+      }
       if (!childOf) return
 
       const span = this.#getMiddlewareSpan(name, childOf)
-      const context = this.#createContext(req, route, childOf)
+      context = this.#updateContext(req, context, route, childOf)
 
       if (childOf !== span) {
         context.middleware.push(span)
       }
 
-      const store = storage('legacy').getStore()
-      let storeStack = this.#storeStacks.get(req)
-      if (!storeStack) {
-        storeStack = []
-        this.#storeStacks.set(req, storeStack)
-      }
-      storeStack.push(store)
+      context.storeStack.push(store)
       this.enter(span, store)
 
       web.patch(req)
@@ -57,11 +61,8 @@ class RouterPlugin extends WebPlugin {
     })
 
     this.addSub(`apm:${this.constructor.id}:middleware:exit`, ({ req }) => {
-      const storeStack = this.#storeStacks.get(req)
-      const savedStore = storeStack && storeStack.pop()
-      if (storeStack && storeStack.length === 0) {
-        this.#storeStacks.delete(req)
-      }
+      const context = this.#contexts.get(req)
+      const savedStore = context && context.storeStack.pop()
       const span = savedStore && savedStore.span
       this.enter(span, savedStore)
     })
@@ -71,8 +72,10 @@ class RouterPlugin extends WebPlugin {
 
       if (!this.config.middleware) return
 
-      const span = this.#getActive(req)
-
+      const context = this.#contexts.get(req)
+      if (!context) return
+      const middleware = context.middleware
+      const span = middleware.length === 0 ? context.span : middleware[middleware.length - 1]
       if (!span) return
 
       span.setTag('error', error)
@@ -89,21 +92,6 @@ class RouterPlugin extends WebPlugin {
         span.finish()
       }
     })
-  }
-
-  #getActive (req) {
-    const context = this.#contexts.get(req)
-
-    if (!context) return
-    if (context.middleware.length === 0) return context.span
-
-    return context.middleware.at(-1)
-  }
-
-  #getStoreSpan () {
-    const store = storage('legacy').getStore()
-
-    return store && store.span
   }
 
   #getMiddlewareSpan (name, childOf) {
@@ -125,9 +113,7 @@ class RouterPlugin extends WebPlugin {
     return span
   }
 
-  #createContext (req, route, span) {
-    let context = this.#contexts.get(req)
-
+  #updateContext (req, context, route, span) {
     if (!route || route === '/' || route === '*') {
       route = ''
     }
@@ -141,17 +127,20 @@ class RouterPlugin extends WebPlugin {
       if (isMoreSpecificThan(route, context.route)) {
         context.route = route
       }
-    } else {
-      context = {
-        span,
-        stack: [route],
-        route,
-        middleware: [],
-      }
-
-      this.#contexts.set(req, context)
+      return context
     }
 
+    // Five-property shape pinned at allocation so every request shares the
+    // same hidden class — no per-field transitions after construction.
+    context = {
+      span,
+      stack: [route],
+      route,
+      middleware: [],
+      storeStack: [],
+    }
+
+    this.#contexts.set(req, context)
     return context
   }
 }


### PR DESCRIPTION
`apm:router:middleware:enter` paid two `WeakMap.get` and two
`storage('legacy').getStore()` calls per middleware in steady state --
once via `#getActive` to resolve the parent span, once via
`#getStoreSpan` for the no-context fallback, once again at the bottom
of the handler to push the saved store, and once more in `:exit`. The
Express profile flagged the closure at 5.43 % cumulative / 0.75 %
self.

The saved-store stack now lives in the same `#contexts` shape as the
rest of the per-request state, so one `WeakMap.get` covers both. ALS
is read once at the top of `:enter` and reused for the parent-span
fallback and the `storeStack` push. The context object is allocated
with all five fields at once so every request shares the same V8
hidden class. The private helpers (`#getActive`, `#getStoreSpan`,
plus the inner `WeakMap.get` in `#createContext`) go away -- their
callers already have the value.

Microbench (7 trials x 200k iters, mean of inner 5; Node 24.15.0 /
V8 13.6.233.17; best of three alternating baseline / patched runs):

* cycleSingle  (1 middleware):   786 -> 710 ns/op  (-10 %)
* cycleNested  (3 middlewares): 2472 -> 2391 ns/op  (-3 %)