### PR TITLE
refactor(graphql): drop unused @graphql-tools/executor deep hook

### DIFF
--- a/packages/datadog-instrumentations/src/graphql.js
+++ b/packages/datadog-instrumentations/src/graphql.js
@@ -343,11 +343,6 @@ addHook({ name: '@graphql-tools/executor', versions: ['>=0.0.14'] }, executor =>
   return executor
 })
 
-addHook({ name: '@graphql-tools/executor', file: 'cjs/execution/execute.js', versions: ['>=0.0.14'] }, execute => {
-  shimmer.wrap(execute, 'execute', wrapExecute(execute))
-  return execute
-})
-
 addHook({ name: 'graphql', file: 'execution/execute.js', versions: ['>=0.10'] }, execute => {
   shimmer.wrap(execute, 'execute', wrapExecute(execute))
   return execute


### PR DESCRIPTION
The package-root hook on `@graphql-tools/executor` re-exports `execute` and `normalizedExecutor` via tslib's `__exportStar` live getters, so wrapping at the root delivers the wrapper to every public import path graphql-yoga or @apollo/gateway actually uses. The second hook on `cjs/execution/execute.js` only fires when a caller imports the inner path directly, which is not a supported public entry. Every caller that reached the inner wrapper had already passed through the root one, where `contexts.has(contextValue)` short-circuits to the unwrapped function, so the inner hook only paid an `addHook` callback on package load and a defensive `contexts.has` re-check on every invocation it never genuinely owned.
