### PR TITLE
perf(format): split addTag into typed helpers to kill throwaway {} al…

### DIFF
--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -46,7 +46,12 @@ const { IGNORE_OTEL_ERROR } = constants
  * @property {number} start
  * @property {number} duration
  * @property {Array} links
- * @property {Array<{ name: string, time_unix_nano: number, attributes?: Record<string, string> }> | undefined} span_events
+ * @property {Array<SpanEvent> | undefined} span_events
+ *
+ * @typedef {object} SpanEvent
+ * @property {string} name
+ * @property {number} time_unix_nano
+ * @property {Record<string, string>} [attributes]
  */
 
 function format (span, isFirstSpanInChunk = false, tagForFirstSpanInChunk = false) {
@@ -93,11 +98,11 @@ function setSingleSpanIngestionTags (formattedSpan, options) {
   const metrics = formattedSpan.metrics
   metrics[SPAN_SAMPLING_MECHANISM] = SAMPLING_MECHANISM_SPAN
   const sampleRate = options.sampleRate
-  if (typeof sampleRate === 'number' && !Number.isNaN(sampleRate)) {
+  if (typeof sampleRate === 'number') {
     metrics[SPAN_SAMPLING_RULE_RATE] = sampleRate
   }
   const maxPerSecond = options.maxPerSecond
-  if (typeof maxPerSecond === 'number' && !Number.isNaN(maxPerSecond)) {
+  if (typeof maxPerSecond === 'number') {
     metrics[SPAN_SAMPLING_MAX_PER_SECOND] = maxPerSecond
   }
 }
@@ -225,16 +230,17 @@ function extractTags (formattedSpan, span) {
         break
       case ERROR_TYPE:
       case ERROR_MESSAGE:
-      case ERROR_STACK:
+      case ERROR_STACK: {
         // HACK: remove when implemented in the backend
-        if (context._name === 'fs.operation') {
-          break
-        }
+        if (context._name === 'fs.operation') break
         // otel.recordException should not influence trace.error
         if (!tags[IGNORE_OTEL_ERROR]) {
           formattedSpan.error = 1
         }
-      default: { // eslint-disable-line no-fallthrough
+        if (value != null) writeErrorMeta(meta, tag, value)
+        break
+      }
+      default: {
         const valueType = typeof value
         if (valueType === 'string') {
           let writeKey = tag
@@ -268,7 +274,7 @@ function extractTags (formattedSpan, span) {
 
   meta.language = 'javascript'
   metrics[PROCESS_ID] = process.pid
-  if (typeof priority === 'number' && !Number.isNaN(priority)) {
+  if (typeof priority === 'number') {
     metrics[SAMPLING_PRIORITY_KEY] = priority
   }
   if (typeof origin === 'string') {
@@ -292,15 +298,15 @@ function extractRootTags (formattedSpan, span) {
   const trace = context._trace
   const metrics = formattedSpan.metrics
   const ruleDecision = trace[SAMPLING_RULE_DECISION]
-  if (typeof ruleDecision === 'number' && !Number.isNaN(ruleDecision)) {
+  if (typeof ruleDecision === 'number') {
     metrics[SAMPLING_RULE_DECISION] = ruleDecision
   }
   const limitDecision = trace[SAMPLING_LIMIT_DECISION]
-  if (typeof limitDecision === 'number' && !Number.isNaN(limitDecision)) {
+  if (typeof limitDecision === 'number') {
     metrics[SAMPLING_LIMIT_DECISION] = limitDecision
   }
   const agentDecision = trace[SAMPLING_AGENT_DECISION]
-  if (typeof agentDecision === 'number' && !Number.isNaN(agentDecision)) {
+  if (typeof agentDecision === 'number') {
     metrics[SAMPLING_AGENT_DECISION] = agentDecision
   }
   metrics[TOP_LEVEL_KEY] = 1
@@ -345,10 +351,27 @@ function extractError (formattedSpan, error) {
     // AggregateError only has a code and no message.
     // TODO(BridgeAR)[31.03.2025]: An AggregateError can have a message. Should
     // the code just generally be added, if available?
-    addMixedTag(formattedSpan.meta, formattedSpan.metrics, ERROR_MESSAGE, error.message || error.code)
-    addMixedTag(formattedSpan.meta, formattedSpan.metrics, ERROR_TYPE, error.name)
-    addMixedTag(formattedSpan.meta, formattedSpan.metrics, ERROR_STACK, error.stack)
+    const meta = formattedSpan.meta
+    const message = error.message || error.code
+    if (message != null) writeErrorMeta(meta, ERROR_MESSAGE, message)
+    if (error.name != null) writeErrorMeta(meta, ERROR_TYPE, error.name)
+    if (error.stack != null) writeErrorMeta(meta, ERROR_STACK, error.stack)
   }
+}
+
+/**
+ * Coerces `value` to string and truncates at `MAX_META_VALUE_LENGTH` before
+ * writing it to one of the three error meta fields.
+ *
+ * @param {Record<string, string>} meta
+ * @param {string} key
+ * @param {unknown} value
+ */
+function writeErrorMeta (meta, key, value) {
+  const stringValue = typeof value === 'string' ? value : String(value)
+  meta[key] = stringValue.length > MAX_META_VALUE_LENGTH
+    ? `${stringValue.slice(0, MAX_META_VALUE_LENGTH)}...`
+    : stringValue
 }
 
 /**

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -61,7 +61,9 @@ function format (span, isFirstSpanInChunk = false, tagForFirstSpanInChunk = fals
   extractSpanLinks(formatted, span)
   extractSpanEvents(formatted, span)
   extractRootTags(formatted, span)
-  extractChunkTags(formatted, span, isFirstSpanInChunk, tagForFirstSpanInChunk)
+  if (isFirstSpanInChunk) {
+    extractChunkTags(formatted, span, tagForFirstSpanInChunk)
+  }
   extractTags(formatted, span)
 
   return formatted
@@ -206,11 +208,11 @@ function extractTags (formattedSpan, span) {
   }
   setSingleSpanIngestionTags(formattedSpan, context._spanSampling)
 
-  addMixedTag(formattedSpan.meta, formattedSpan.metrics, 'language', 'javascript')
-  addMixedTag(formattedSpan.meta, formattedSpan.metrics, PROCESS_ID, process.pid)
-  addMixedTag(formattedSpan.meta, formattedSpan.metrics, SAMPLING_PRIORITY_KEY, priority)
-  addMixedTag(formattedSpan.meta, formattedSpan.metrics, ORIGIN_KEY, origin)
-  addMixedTag(formattedSpan.meta, formattedSpan.metrics, HOSTNAME_KEY, hostname)
+  formattedSpan.meta.language = 'javascript'
+  formattedSpan.metrics[PROCESS_ID] = process.pid
+  addNumberTag(formattedSpan.metrics, SAMPLING_PRIORITY_KEY, priority)
+  addStringTag(formattedSpan.meta, ORIGIN_KEY, origin)
+  addStringTag(formattedSpan.meta, HOSTNAME_KEY, hostname)
 }
 
 function extractRootTags (formattedSpan, span) {
@@ -226,17 +228,14 @@ function extractRootTags (formattedSpan, span) {
   addNumberTag(formattedSpan.metrics, TOP_LEVEL_KEY, 1)
 }
 
-function extractChunkTags (formattedSpan, span, isFirstSpanInChunk, tagForFirstSpanInChunk) {
-  const context = span.context()
-
-  if (!isFirstSpanInChunk) return
-
+function extractChunkTags (formattedSpan, span, tagForFirstSpanInChunk) {
   if (tagForFirstSpanInChunk) {
-    addMixedTag(formattedSpan.meta, formattedSpan.metrics, TRACING_FIELD_NAME, tagForFirstSpanInChunk)
+    addStringTag(formattedSpan.meta, TRACING_FIELD_NAME, tagForFirstSpanInChunk)
   }
 
-  for (const [key, value] of Object.entries(context._trace.tags)) {
-    addMixedTag(formattedSpan.meta, formattedSpan.metrics, key, value)
+  const traceTags = span.context()._trace.tags
+  for (const key of Object.keys(traceTags)) {
+    addMixedTag(formattedSpan.meta, formattedSpan.metrics, key, traceTags[key])
   }
 }
 

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -88,9 +88,9 @@ function formatSpan (span) {
 
 function setSingleSpanIngestionTags (span, options) {
   if (!options) return
-  addTag({}, span.metrics, SPAN_SAMPLING_MECHANISM, SAMPLING_MECHANISM_SPAN)
-  addTag({}, span.metrics, SPAN_SAMPLING_RULE_RATE, options.sampleRate)
-  addTag({}, span.metrics, SPAN_SAMPLING_MAX_PER_SECOND, options.maxPerSecond)
+  addNumberTag(span.metrics, SPAN_SAMPLING_MECHANISM, SAMPLING_MECHANISM_SPAN)
+  addNumberTag(span.metrics, SPAN_SAMPLING_RULE_RATE, options.sampleRate)
+  addNumberTag(span.metrics, SPAN_SAMPLING_MAX_PER_SECOND, options.maxPerSecond)
 }
 
 /**
@@ -149,7 +149,7 @@ function extractTags (formattedSpan, span) {
   const priority = context._sampling.priority
 
   if (tags['span.kind'] && tags['span.kind'] !== 'internal') {
-    addTag({}, formattedSpan.metrics, MEASURED, 1)
+    addNumberTag(formattedSpan.metrics, MEASURED, 1)
   }
 
   const tracerService = span.tracer()._service.toLowerCase()
@@ -159,7 +159,8 @@ function extractTags (formattedSpan, span) {
     registerExtraService(tags['service.name'])
   }
 
-  for (const [tag, value] of Object.entries(tags)) {
+  for (const tag of Object.keys(tags)) {
+    const value = tags[tag]
     // TODO(BridgeAR)[31.03.2025]: Check how many tags are defined in average.
     // In case there are more than 2 tags in average, check for all special
     // cases up front and loop over the tags afterwards, skipping the already
@@ -168,18 +169,18 @@ function extractTags (formattedSpan, span) {
       case 'service.name':
       case 'span.type':
       case 'resource.name':
-        addTag(formattedSpan, {}, map[tag], value)
+        addStringTag(formattedSpan, map[tag], value)
         break
       // HACK: remove when Datadog supports numeric status code
       case 'http.status_code':
-        addTag(formattedSpan.meta, {}, tag, value && String(value))
+        addStringTag(formattedSpan.meta, tag, value && String(value))
         break
       case 'analytics.event':
-        addTag({}, formattedSpan.metrics, ANALYTICS, value === undefined || value ? 1 : 0)
+        addNumberTag(formattedSpan.metrics, ANALYTICS, value === undefined || value ? 1 : 0)
         break
       case HOSTNAME_KEY:
       case MEASURED:
-        addTag({}, formattedSpan.metrics, tag, value === undefined || value ? 1 : 0)
+        addNumberTag(formattedSpan.metrics, tag, value === undefined || value ? 1 : 0)
         break
       // TODO(BridgeAR)[31.03.2025]: How come we use two different ways to pass
       // through errors? Can we just unify the behavior to always use one way?
@@ -200,16 +201,16 @@ function extractTags (formattedSpan, span) {
           formattedSpan.error = 1
         }
       default: // eslint-disable-line no-fallthrough
-        addTag(formattedSpan.meta, formattedSpan.metrics, tag, value)
+        addMixedTag(formattedSpan.meta, formattedSpan.metrics, tag, value)
     }
   }
   setSingleSpanIngestionTags(formattedSpan, context._spanSampling)
 
-  addTag(formattedSpan.meta, formattedSpan.metrics, 'language', 'javascript')
-  addTag(formattedSpan.meta, formattedSpan.metrics, PROCESS_ID, process.pid)
-  addTag(formattedSpan.meta, formattedSpan.metrics, SAMPLING_PRIORITY_KEY, priority)
-  addTag(formattedSpan.meta, formattedSpan.metrics, ORIGIN_KEY, origin)
-  addTag(formattedSpan.meta, formattedSpan.metrics, HOSTNAME_KEY, hostname)
+  addMixedTag(formattedSpan.meta, formattedSpan.metrics, 'language', 'javascript')
+  addMixedTag(formattedSpan.meta, formattedSpan.metrics, PROCESS_ID, process.pid)
+  addMixedTag(formattedSpan.meta, formattedSpan.metrics, SAMPLING_PRIORITY_KEY, priority)
+  addMixedTag(formattedSpan.meta, formattedSpan.metrics, ORIGIN_KEY, origin)
+  addMixedTag(formattedSpan.meta, formattedSpan.metrics, HOSTNAME_KEY, hostname)
 }
 
 function extractRootTags (formattedSpan, span) {
@@ -219,10 +220,10 @@ function extractRootTags (formattedSpan, span) {
 
   if (!isLocalRoot || (parentId && parentId.toString(10) !== '0')) return
 
-  addTag({}, formattedSpan.metrics, SAMPLING_RULE_DECISION, context._trace[SAMPLING_RULE_DECISION])
-  addTag({}, formattedSpan.metrics, SAMPLING_LIMIT_DECISION, context._trace[SAMPLING_LIMIT_DECISION])
-  addTag({}, formattedSpan.metrics, SAMPLING_AGENT_DECISION, context._trace[SAMPLING_AGENT_DECISION])
-  addTag({}, formattedSpan.metrics, TOP_LEVEL_KEY, 1)
+  addNumberTag(formattedSpan.metrics, SAMPLING_RULE_DECISION, context._trace[SAMPLING_RULE_DECISION])
+  addNumberTag(formattedSpan.metrics, SAMPLING_LIMIT_DECISION, context._trace[SAMPLING_LIMIT_DECISION])
+  addNumberTag(formattedSpan.metrics, SAMPLING_AGENT_DECISION, context._trace[SAMPLING_AGENT_DECISION])
+  addNumberTag(formattedSpan.metrics, TOP_LEVEL_KEY, 1)
 }
 
 function extractChunkTags (formattedSpan, span, isFirstSpanInChunk, tagForFirstSpanInChunk) {
@@ -231,11 +232,11 @@ function extractChunkTags (formattedSpan, span, isFirstSpanInChunk, tagForFirstS
   if (!isFirstSpanInChunk) return
 
   if (tagForFirstSpanInChunk) {
-    addTag(formattedSpan.meta, formattedSpan.metrics, TRACING_FIELD_NAME, tagForFirstSpanInChunk)
+    addMixedTag(formattedSpan.meta, formattedSpan.metrics, TRACING_FIELD_NAME, tagForFirstSpanInChunk)
   }
 
   for (const [key, value] of Object.entries(context._trace.tags)) {
-    addTag(formattedSpan.meta, formattedSpan.metrics, key, value)
+    addMixedTag(formattedSpan.meta, formattedSpan.metrics, key, value)
   }
 }
 
@@ -248,13 +249,36 @@ function extractError (formattedSpan, error) {
     // AggregateError only has a code and no message.
     // TODO(BridgeAR)[31.03.2025]: An AggregateError can have a message. Should
     // the code just generally be added, if available?
-    addTag(formattedSpan.meta, formattedSpan.metrics, ERROR_MESSAGE, error.message || error.code)
-    addTag(formattedSpan.meta, formattedSpan.metrics, ERROR_TYPE, error.name)
-    addTag(formattedSpan.meta, formattedSpan.metrics, ERROR_STACK, error.stack)
+    addMixedTag(formattedSpan.meta, formattedSpan.metrics, ERROR_MESSAGE, error.message || error.code)
+    addMixedTag(formattedSpan.meta, formattedSpan.metrics, ERROR_TYPE, error.name)
+    addMixedTag(formattedSpan.meta, formattedSpan.metrics, ERROR_STACK, error.stack)
   }
 }
 
-function addTag (meta, metrics, key, value, nested) {
+/**
+ * @param {Record<string, string>} meta
+ * @param {string} key
+ * @param {string} value
+ */
+function addStringTag (meta, key, value) {
+  if (typeof value !== 'string') return
+  if (value.length > MAX_META_VALUE_LENGTH) {
+    value = `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+  }
+  meta[key] = value
+}
+
+/**
+ * @param {Record<string, number>} metrics
+ * @param {string} key
+ * @param {number} value
+ */
+function addNumberTag (metrics, key, value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) return
+  metrics[key] = value
+}
+
+function addMixedTag (meta, metrics, key, value, nested) {
   switch (typeof value) {
     case 'string':
       if (key.length > MAX_META_KEY_LENGTH) {
@@ -290,7 +314,7 @@ function addTag (meta, metrics, key, value, nested) {
         metrics[key] = value.toString()
       } else if (!Array.isArray(value) && !nested) {
         for (const [prop, val] of Object.entries(value)) {
-          addTag(meta, metrics, `${key}.${prop}`, val, true)
+          addMixedTag(meta, metrics, `${key}.${prop}`, val, true)
         }
       }
   }

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -30,14 +30,6 @@ const ERROR_STACK = constants.ERROR_STACK
 const ERROR_TYPE = constants.ERROR_TYPE
 const { IGNORE_OTEL_ERROR } = constants
 
-// TODO(BridgeAR)[31.03.2025]: Should these land in the constants file?
-const map = {
-  'operation.name': 'name',
-  'service.name': 'service',
-  'span.type': 'type',
-  'resource.name': 'resource',
-}
-
 /**
  * @typedef {object} FormattedSpan
  * @property {import('./id').Identifier} trace_id
@@ -45,6 +37,8 @@ const map = {
  * @property {import('./id').Identifier} parent_id
  * @property {string} name
  * @property {string} resource
+ * @property {string | undefined} service
+ * @property {string | undefined} type
  * @property {number} error
  * @property {Record<string, string>} meta
  * @property {Record<string, number>} metrics
@@ -52,7 +46,7 @@ const map = {
  * @property {number} start
  * @property {number} duration
  * @property {Array} links
- * @property {Array<{ name: string, time_unix_nano: number, attributes?: Record<string, string> }>} [span_events]
+ * @property {Array<{ name: string, time_unix_nano: number, attributes?: Record<string, string> }> | undefined} span_events
  */
 
 function format (span, isFirstSpanInChunk = false, tagForFirstSpanInChunk = false) {
@@ -71,13 +65,18 @@ function format (span, isFirstSpanInChunk = false, tagForFirstSpanInChunk = fals
 
 function formatSpan (span) {
   const spanContext = span.context()
-
+  // Pre-initialise the `service`, `type`, and `span_events` slots so every
+  // formatted span shares one V8 hidden class regardless of which optional
+  // tags fire later. Downstream encoders gate on truthy values for each,
+  // so `undefined` stays byte-identical on the msgpack wire.
   return {
     trace_id: spanContext._traceId,
     span_id: spanContext._spanId,
     parent_id: spanContext._parentId || id('0'),
     name: String(spanContext._name),
     resource: String(spanContext._name),
+    service: undefined,
+    type: undefined,
     error: 0,
     meta: {},
     meta_struct: span.meta_struct,
@@ -85,14 +84,22 @@ function formatSpan (span) {
     start: Math.round(span._startTime * 1e6),
     duration: Math.round(span._duration * 1e6),
     links: [],
+    span_events: undefined,
   }
 }
 
-function setSingleSpanIngestionTags (span, options) {
+function setSingleSpanIngestionTags (formattedSpan, options) {
   if (!options) return
-  addNumberTag(span.metrics, SPAN_SAMPLING_MECHANISM, SAMPLING_MECHANISM_SPAN)
-  addNumberTag(span.metrics, SPAN_SAMPLING_RULE_RATE, options.sampleRate)
-  addNumberTag(span.metrics, SPAN_SAMPLING_MAX_PER_SECOND, options.maxPerSecond)
+  const metrics = formattedSpan.metrics
+  metrics[SPAN_SAMPLING_MECHANISM] = SAMPLING_MECHANISM_SPAN
+  const sampleRate = options.sampleRate
+  if (typeof sampleRate === 'number' && !Number.isNaN(sampleRate)) {
+    metrics[SPAN_SAMPLING_RULE_RATE] = sampleRate
+  }
+  const maxPerSecond = options.maxPerSecond
+  if (typeof maxPerSecond === 'number' && !Number.isNaN(maxPerSecond)) {
+    metrics[SPAN_SAMPLING_MAX_PER_SECOND] = maxPerSecond
+  }
 }
 
 /**
@@ -149,9 +156,11 @@ function extractTags (formattedSpan, span) {
   const tags = context.getTags()
   const hostname = context._hostname
   const priority = context._sampling.priority
+  const meta = formattedSpan.meta
+  const metrics = formattedSpan.metrics
 
   if (tags['span.kind'] && tags['span.kind'] !== 'internal') {
-    addNumberTag(formattedSpan.metrics, MEASURED, 1)
+    metrics[MEASURED] = 1
   }
 
   const tracerService = span.tracer()._service.toLowerCase()
@@ -163,26 +172,49 @@ function extractTags (formattedSpan, span) {
 
   for (const tag of Object.keys(tags)) {
     const value = tags[tag]
-    // TODO(BridgeAR)[31.03.2025]: Check how many tags are defined in average.
-    // In case there are more than 2 tags in average, check for all special
-    // cases up front and loop over the tags afterwards, skipping the already
-    // visited property names by checking a map with these keys.
+    // The typed-helper bodies are inlined per case: V8 was not inlining
+    // `addStringTag` / `addNumberTag` / `addMixedTag` here at the call rate
+    // this loop runs in HTTP-server traces (10+ tags × 1M spans/sec), so each
+    // one paid an extra call frame the helper body was small enough to
+    // expand inline.
     switch (tag) {
       case 'service.name':
+        if (typeof value === 'string') {
+          formattedSpan.service = value.length > MAX_META_VALUE_LENGTH
+            ? `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+            : value
+        }
+        break
       case 'span.type':
+        if (typeof value === 'string') {
+          formattedSpan.type = value.length > MAX_META_VALUE_LENGTH
+            ? `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+            : value
+        }
+        break
       case 'resource.name':
-        addStringTag(formattedSpan, map[tag], value)
+        if (typeof value === 'string') {
+          formattedSpan.resource = value.length > MAX_META_VALUE_LENGTH
+            ? `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+            : value
+        }
         break
       // HACK: remove when Datadog supports numeric status code
-      case 'http.status_code':
-        addStringTag(formattedSpan.meta, tag, value && String(value))
+      case 'http.status_code': {
+        const stringValue = value && String(value)
+        if (typeof stringValue === 'string') {
+          meta[tag] = stringValue.length > MAX_META_VALUE_LENGTH
+            ? `${stringValue.slice(0, MAX_META_VALUE_LENGTH)}...`
+            : stringValue
+        }
         break
+      }
       case 'analytics.event':
-        addNumberTag(formattedSpan.metrics, ANALYTICS, value === undefined || value ? 1 : 0)
+        metrics[ANALYTICS] = value === undefined || value ? 1 : 0
         break
       case HOSTNAME_KEY:
       case MEASURED:
-        addNumberTag(formattedSpan.metrics, tag, value === undefined || value ? 1 : 0)
+        metrics[tag] = value === undefined || value ? 1 : 0
         break
       // TODO(BridgeAR)[31.03.2025]: How come we use two different ways to pass
       // through errors? Can we just unify the behavior to always use one way?
@@ -202,40 +234,105 @@ function extractTags (formattedSpan, span) {
         if (!tags[IGNORE_OTEL_ERROR]) {
           formattedSpan.error = 1
         }
-      default: // eslint-disable-line no-fallthrough
-        addMixedTag(formattedSpan.meta, formattedSpan.metrics, tag, value)
+      default: { // eslint-disable-line no-fallthrough
+        const valueType = typeof value
+        if (valueType === 'string') {
+          let writeKey = tag
+          if (writeKey.length > MAX_META_KEY_LENGTH) {
+            writeKey = `${writeKey.slice(0, MAX_META_KEY_LENGTH)}...`
+          }
+          meta[writeKey] = value.length > MAX_META_VALUE_LENGTH
+            ? `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+            : value
+        } else if (valueType === 'number') {
+          if (!Number.isNaN(value)) {
+            let writeKey = tag
+            if (writeKey.length > MAX_METRIC_KEY_LENGTH) {
+              writeKey = `${writeKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+            }
+            metrics[writeKey] = value
+          }
+        } else if (valueType === 'boolean') {
+          let writeKey = tag
+          if (writeKey.length > MAX_METRIC_KEY_LENGTH) {
+            writeKey = `${writeKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+          }
+          metrics[writeKey] = value ? 1 : 0
+        } else {
+          addMixedTag(meta, metrics, tag, value)
+        }
+      }
     }
   }
   setSingleSpanIngestionTags(formattedSpan, context._spanSampling)
 
-  formattedSpan.meta.language = 'javascript'
-  formattedSpan.metrics[PROCESS_ID] = process.pid
-  addNumberTag(formattedSpan.metrics, SAMPLING_PRIORITY_KEY, priority)
-  addStringTag(formattedSpan.meta, ORIGIN_KEY, origin)
-  addStringTag(formattedSpan.meta, HOSTNAME_KEY, hostname)
+  meta.language = 'javascript'
+  metrics[PROCESS_ID] = process.pid
+  if (typeof priority === 'number' && !Number.isNaN(priority)) {
+    metrics[SAMPLING_PRIORITY_KEY] = priority
+  }
+  if (typeof origin === 'string') {
+    meta[ORIGIN_KEY] = origin.length > MAX_META_VALUE_LENGTH
+      ? `${origin.slice(0, MAX_META_VALUE_LENGTH)}...`
+      : origin
+  }
+  if (typeof hostname === 'string') {
+    meta[HOSTNAME_KEY] = hostname.length > MAX_META_VALUE_LENGTH
+      ? `${hostname.slice(0, MAX_META_VALUE_LENGTH)}...`
+      : hostname
+  }
 }
 
 function extractRootTags (formattedSpan, span) {
   const context = span.context()
-  const isLocalRoot = span === context._trace.started[0]
   const parentId = context._parentId
 
-  if (!isLocalRoot || (parentId && parentId.toString(10) !== '0')) return
+  if (span !== context._trace.started[0] || (parentId && parentId.toString(10) !== '0')) return
 
-  addNumberTag(formattedSpan.metrics, SAMPLING_RULE_DECISION, context._trace[SAMPLING_RULE_DECISION])
-  addNumberTag(formattedSpan.metrics, SAMPLING_LIMIT_DECISION, context._trace[SAMPLING_LIMIT_DECISION])
-  addNumberTag(formattedSpan.metrics, SAMPLING_AGENT_DECISION, context._trace[SAMPLING_AGENT_DECISION])
-  addNumberTag(formattedSpan.metrics, TOP_LEVEL_KEY, 1)
+  const trace = context._trace
+  const metrics = formattedSpan.metrics
+  const ruleDecision = trace[SAMPLING_RULE_DECISION]
+  if (typeof ruleDecision === 'number' && !Number.isNaN(ruleDecision)) {
+    metrics[SAMPLING_RULE_DECISION] = ruleDecision
+  }
+  const limitDecision = trace[SAMPLING_LIMIT_DECISION]
+  if (typeof limitDecision === 'number' && !Number.isNaN(limitDecision)) {
+    metrics[SAMPLING_LIMIT_DECISION] = limitDecision
+  }
+  const agentDecision = trace[SAMPLING_AGENT_DECISION]
+  if (typeof agentDecision === 'number' && !Number.isNaN(agentDecision)) {
+    metrics[SAMPLING_AGENT_DECISION] = agentDecision
+  }
+  metrics[TOP_LEVEL_KEY] = 1
 }
 
 function extractChunkTags (formattedSpan, span, tagForFirstSpanInChunk) {
-  if (tagForFirstSpanInChunk) {
-    addStringTag(formattedSpan.meta, TRACING_FIELD_NAME, tagForFirstSpanInChunk)
+  const meta = formattedSpan.meta
+  if (typeof tagForFirstSpanInChunk === 'string') {
+    meta[TRACING_FIELD_NAME] = tagForFirstSpanInChunk.length > MAX_META_VALUE_LENGTH
+      ? `${tagForFirstSpanInChunk.slice(0, MAX_META_VALUE_LENGTH)}...`
+      : tagForFirstSpanInChunk
   }
 
+  // Chunk tags are always strings in production (`_dd.p.dm`, `_dd.p.tid`,
+  // `_dd.p.ts`, `baggage.*`). Inline only the string branch; non-string
+  // values fall through to `addMixedTag` so we don't carry duplicate
+  // truncation logic for branches no real chunk tag ever takes.
+  const metrics = formattedSpan.metrics
   const traceTags = span.context()._trace.tags
   for (const key of Object.keys(traceTags)) {
-    addMixedTag(formattedSpan.meta, formattedSpan.metrics, key, traceTags[key])
+    const value = traceTags[key]
+    if (typeof value === 'string') {
+      let writeKey = key
+      if (writeKey.length > MAX_META_KEY_LENGTH) {
+        writeKey = `${writeKey.slice(0, MAX_META_KEY_LENGTH)}...`
+      }
+      meta[writeKey] = value.length > MAX_META_VALUE_LENGTH
+        ? `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
+        : value
+    } else {
+      addMixedTag(meta, metrics, key, value)
+    }
   }
 }
 
@@ -255,28 +352,17 @@ function extractError (formattedSpan, error) {
 }
 
 /**
+ * Mixed-type dispatch retained for `extractError` and the slow-path fallback
+ * inside the inlined per-tag loops in `extractTags` / `extractChunkTags`.
+ * The scalar branches are kept here so a single `addMixedTag` call covers
+ * recursion (nested object values) without re-entering the inlined paths.
+ *
  * @param {Record<string, string>} meta
- * @param {string} key
- * @param {string} value
- */
-function addStringTag (meta, key, value) {
-  if (typeof value !== 'string') return
-  if (value.length > MAX_META_VALUE_LENGTH) {
-    value = `${value.slice(0, MAX_META_VALUE_LENGTH)}...`
-  }
-  meta[key] = value
-}
-
-/**
  * @param {Record<string, number>} metrics
  * @param {string} key
- * @param {number} value
+ * @param {unknown} value
+ * @param {boolean} [nested]
  */
-function addNumberTag (metrics, key, value) {
-  if (typeof value !== 'number' || Number.isNaN(value)) return
-  metrics[key] = value
-}
-
 function addMixedTag (meta, metrics, key, value, nested) {
   switch (typeof value) {
     case 'string':

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -24,6 +24,7 @@ const SPAN_SAMPLING_MECHANISM = constants.SPAN_SAMPLING_MECHANISM
 const SPAN_SAMPLING_RULE_RATE = constants.SPAN_SAMPLING_RULE_RATE
 const SPAN_SAMPLING_MAX_PER_SECOND = constants.SPAN_SAMPLING_MAX_PER_SECOND
 const SAMPLING_MECHANISM_SPAN = constants.SAMPLING_MECHANISM_SPAN
+const TOP_LEVEL_KEY = constants.TOP_LEVEL_KEY
 const PROCESS_ID = constants.PROCESS_ID
 const ERROR_MESSAGE = constants.ERROR_MESSAGE
 const ERROR_STACK = constants.ERROR_STACK
@@ -132,6 +133,75 @@ describe('spanFormat', () => {
         error: 0,
         start: span._startTime * 1e6,
         duration: span._duration * 1e6,
+      })
+    })
+
+    it('pins the formatted-span hidden-class shape for a representative HTTP server span', () => {
+      // Regression guard for the typed-helper inlining: covers every slot
+      // `formatSpan` / `extractTags` / `extractRootTags` / `extractChunkTags`
+      // populate for a chunk-root HTTP server span (the Express-profile shape
+      // that motivated the inlining). The pre-initialised `service`, `type`,
+      // and `span_events` slots stay in `Object.keys` even when the tag never
+      // fires, so the hidden class doesn't transition mid-formatting.
+      spanContext._parentId = null
+      spanContext._tags = {
+        'service.name': 'svc',
+        'span.type': 'web',
+        'resource.name': 'GET /users/:id',
+        'span.kind': 'server',
+        'http.method': 'GET',
+        'http.url': 'https://example.com/users/42',
+        'http.route': '/users/:id',
+        'http.useragent': 'Mozilla/5.0',
+        component: 'express',
+        'http.status_code': 200,
+        'http.response.content_length': 4096,
+      }
+      spanContext._sampling.priority = 1
+      spanContext._trace.tags = {
+        '_dd.p.dm': '-0',
+        '_dd.p.tid': '671d3c4500000000',
+      }
+      spanContext._trace[SAMPLING_RULE_DECISION] = 1
+      span._startTime = 1_500_000_000_000.123
+      span._duration = 1.234
+
+      trace = spanFormat(span, true, false)
+
+      assert.deepStrictEqual(trace, {
+        trace_id: spanContext._traceId,
+        span_id: spanContext._spanId,
+        parent_id: id('0'),
+        name: 'operation',
+        resource: 'GET /users/:id',
+        service: 'svc',
+        type: 'web',
+        error: 0,
+        meta: {
+          '_dd.p.dm': '-0',
+          '_dd.p.tid': '671d3c4500000000',
+          'span.kind': 'server',
+          'http.method': 'GET',
+          'http.url': 'https://example.com/users/42',
+          'http.route': '/users/:id',
+          'http.useragent': 'Mozilla/5.0',
+          component: 'express',
+          'http.status_code': '200',
+          language: 'javascript',
+        },
+        meta_struct: undefined,
+        metrics: {
+          [SAMPLING_RULE_DECISION]: 1,
+          [TOP_LEVEL_KEY]: 1,
+          [MEASURED]: 1,
+          'http.response.content_length': 4096,
+          [PROCESS_ID]: process.pid,
+          [SAMPLING_PRIORITY_KEY]: 1,
+        },
+        start: Math.round(1_500_000_000_000.123 * 1e6),
+        duration: Math.round(1.234 * 1e6),
+        links: [],
+        span_events: undefined,
       })
     })
 
@@ -430,6 +500,22 @@ describe('spanFormat', () => {
       })
     })
 
+    it('truncates overlong chunk tag keys and values to the agent limit', () => {
+      const { MAX_META_KEY_LENGTH, MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
+      const overlongChunkKey = `${'k'.repeat(MAX_META_KEY_LENGTH)}!`
+      const overlongChunkValue = `${'v'.repeat(MAX_META_VALUE_LENGTH)}!`
+      spanContext._trace.tags = {
+        [overlongChunkKey]: 'short',
+      }
+
+      trace = spanFormat(span, true, overlongChunkValue)
+
+      const truncatedKey = `${overlongChunkKey.slice(0, MAX_META_KEY_LENGTH)}...`
+      const truncatedValue = `${overlongChunkValue.slice(0, MAX_META_VALUE_LENGTH)}...`
+      assert.strictEqual(trace.meta[truncatedKey], 'short')
+      assert.strictEqual(trace.meta['_dd.tags.process'], truncatedValue)
+    })
+
     it('should not extract trace chunk tags when not chunk root', () => {
       spanContext._trace.tags = {
         chunk: 'test',
@@ -700,6 +786,50 @@ describe('spanFormat', () => {
       assert.ok(!Object.hasOwn(trace.meta, 'nested.A'), `Available keys: ${inspect(Object.keys(trace.meta))}`)
       assert.ok(!Object.hasOwn(trace.meta, 'nested.A.B'), `Available keys: ${inspect(Object.keys(trace.meta))}`)
       assert.ok(!Object.hasOwn(trace.meta, 'nested.A.num'), `Available keys: ${inspect(Object.keys(trace.meta))}`)
+    })
+
+    it('routes nested-object child values of every type through addMixedTag recursion', () => {
+      const {
+        MAX_META_KEY_LENGTH,
+        MAX_META_VALUE_LENGTH,
+        MAX_METRIC_KEY_LENGTH,
+      } = require('../src/encode/tags-processors')
+      // Top-level tags hit the inlined fast paths in `extractTags`. The
+      // depth-1 recursion in `addMixedTag` is the only place the helper's
+      // typeof / truncation branches stay reachable, so cover every shape
+      // (string / number / boolean / NaN / overlong key / overlong value)
+      // through a single nested-object tag.
+      const overlongMetaChildKey = 'z'.repeat(MAX_META_KEY_LENGTH)
+      const overlongStringValue = 'v'.repeat(MAX_META_VALUE_LENGTH + 1)
+      const overlongMetricChildKey = 'm'.repeat(MAX_METRIC_KEY_LENGTH)
+      const overlongBoolChildKey = 'b'.repeat(MAX_METRIC_KEY_LENGTH)
+      spanContext._tags.nested = {
+        str: 'one',
+        long_value: overlongStringValue,
+        [overlongMetaChildKey]: 'short',
+        num: 2,
+        [overlongMetricChildKey]: 7,
+        bool: true,
+        nope: false,
+        [overlongBoolChildKey]: false,
+        nan: Number.NaN,
+      }
+
+      trace = spanFormat(span)
+
+      const truncatedString = `${overlongStringValue.slice(0, MAX_META_VALUE_LENGTH)}...`
+      const truncatedMetaKey = `${`nested.${overlongMetaChildKey}`.slice(0, MAX_META_KEY_LENGTH)}...`
+      const truncatedMetricKey = `${`nested.${overlongMetricChildKey}`.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      const truncatedBoolKey = `${`nested.${overlongBoolChildKey}`.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      assert.strictEqual(trace.meta['nested.str'], 'one')
+      assert.strictEqual(trace.meta['nested.long_value'], truncatedString)
+      assert.strictEqual(trace.meta[truncatedMetaKey], 'short')
+      assert.strictEqual(trace.metrics['nested.num'], 2)
+      assert.strictEqual(trace.metrics[truncatedMetricKey], 7)
+      assert.strictEqual(trace.metrics['nested.bool'], 1)
+      assert.strictEqual(trace.metrics['nested.nope'], 0)
+      assert.strictEqual(trace.metrics[truncatedBoolKey], 0)
+      assert.ok(!('nested.nan' in trace.metrics))
     })
 
     it('should accept a boolean for measured', () => {

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -150,8 +150,9 @@ describe('spanFormat', () => {
       span.context()._tags[acceptedMetricKey] = 11
 
       // First-rejected lengths (limit + 1) get sliced and gain a `...` suffix.
-      // Cover all four typed branches in `addTag`: string / number / boolean /
-      // Buffer (the URL branch shares the boolean/buffer truncation line).
+      // Cover all four typed branches in `addMixedTag`: string / number /
+      // boolean / Buffer (the URL branch shares the boolean/buffer truncation
+      // line).
       const overlongMetaKey = `${'c'.repeat(MAX_META_KEY_LENGTH)}X`
       const overlongMetaValue = `${'d'.repeat(MAX_META_VALUE_LENGTH)}Y`
       const overlongMetricKey = `${'e'.repeat(MAX_METRIC_KEY_LENGTH)}Z`
@@ -162,6 +163,11 @@ describe('spanFormat', () => {
       span.context()._tags[overlongBoolKey] = true
       span.context()._tags[overlongBufferKey] = Buffer.from('payload')
 
+      // `service.name` is dispatched through `addStringTag` (not the
+      // polymorphic helper); pin its value-truncate branch here too.
+      const overlongServiceValue = `${'s'.repeat(MAX_META_VALUE_LENGTH)}!`
+      span.context()._tags['service.name'] = overlongServiceValue
+
       trace = spanFormat(span)
 
       const truncatedMetaKey = `${overlongMetaKey.slice(0, MAX_META_KEY_LENGTH)}...`
@@ -169,12 +175,14 @@ describe('spanFormat', () => {
       const truncatedMetricKey = `${overlongMetricKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
       const truncatedBoolKey = `${overlongBoolKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
       const truncatedBufferKey = `${overlongBufferKey.slice(0, MAX_METRIC_KEY_LENGTH)}...`
+      const truncatedServiceValue = `${overlongServiceValue.slice(0, MAX_META_VALUE_LENGTH)}...`
       assert.strictEqual(trace.meta[acceptedMetaKey], acceptedMetaValue)
       assert.strictEqual(trace.meta[truncatedMetaKey], truncatedMetaValue)
       assert.strictEqual(trace.metrics[acceptedMetricKey], 11)
       assert.strictEqual(trace.metrics[truncatedMetricKey], 42)
       assert.strictEqual(trace.metrics[truncatedBoolKey], 1)
       assert.strictEqual(trace.metrics[truncatedBufferKey], 'payload')
+      assert.strictEqual(trace.service, truncatedServiceValue)
     })
 
     it('should truncate the serialized span_links meta value past MAX_META_VALUE_LENGTH', () => {
@@ -249,6 +257,7 @@ describe('spanFormat', () => {
       spanContext._tags['service.name'] = 'service'
       spanContext._tags['span.type'] = 'type'
       spanContext._tags['resource.name'] = 'resource'
+      spanContext._tags['http.status_code'] = 200
 
       trace = spanFormat(span)
 
@@ -256,7 +265,28 @@ describe('spanFormat', () => {
         service: 'service',
         type: 'type',
         resource: 'resource',
+        meta: { 'http.status_code': '200' },
       })
+    })
+
+    it('should skip non-string values for the string-typed Datadog tag slots', () => {
+      // `span.type`, `resource.name`, and `http.status_code` are dispatched
+      // through `addStringTag`. Non-string source values are dropped instead
+      // of leaking into metrics (the prior throwaway-`{}` pattern hid the
+      // same skip behind an allocated empty object).
+      spanContext._tags['span.type'] = false
+      spanContext._tags['resource.name'] = { foo: 'bar' }
+      // `value && String(value)` short-circuits on `0`, so the addStringTag
+      // call receives a non-string and skips writing.
+      spanContext._tags['http.status_code'] = 0
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.type, undefined)
+      // `trace.resource` is initialised by `formatSpan` from the span name
+      // and must not be overwritten when the source tag is not a string.
+      assert.strictEqual(trace.resource, spanContext._name)
+      assert.strictEqual(trace.meta['http.status_code'], undefined)
     })
 
     it('should extract Datadog specific root tags', () => {
@@ -286,6 +316,22 @@ describe('spanFormat', () => {
         !sampledKeys.some(k => Object.hasOwn(trace.metrics, k)),
         `Expected none of ${inspect(sampledKeys)} in metrics, got keys: ${inspect(Object.keys(trace.metrics))}`
       )
+    })
+
+    it('should skip numeric root tags whose source value is not a finite number', () => {
+      // `addNumberTag` drops non-numbers (e.g. `undefined`) and `NaN`, so
+      // those decisions never reach the metrics object even though the span
+      // is otherwise eligible for root-tag extraction.
+      spanContext._parentId = null
+      spanContext._trace[SAMPLING_AGENT_DECISION] = Number.NaN
+      spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
+      // SAMPLING_RULE_DECISION is intentionally left undefined.
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.metrics[SAMPLING_LIMIT_DECISION], 0.2)
+      assert.ok(!(SAMPLING_AGENT_DECISION in trace.metrics))
+      assert.ok(!(SAMPLING_RULE_DECISION in trace.metrics))
     })
 
     it('should always add single span ingestion tags from options if present', () => {
@@ -372,10 +418,11 @@ describe('spanFormat', () => {
         count: 1,
       }
 
-      trace = spanFormat(span, true)
+      trace = spanFormat(span, true, 'process-tag-value')
 
       assertObjectContains(trace.meta, {
         chunk: 'test',
+        '_dd.tags.process': 'process-tag-value',
       })
 
       assertObjectContains(trace.metrics, {
@@ -452,6 +499,14 @@ describe('spanFormat', () => {
       assert.strictEqual(trace.metrics.metric, 50)
     })
 
+    it('should extract buffer tags as stringified metrics', () => {
+      spanContext._tags.payload = Buffer.from('hello')
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.metrics.payload, 'hello')
+    })
+
     it('should extract boolean tags as metrics', () => {
       spanContext._tags = { yes: true, no: false }
 
@@ -470,7 +525,9 @@ describe('spanFormat', () => {
     })
 
     it('should ignore metrics that are not a number', () => {
-      spanContext._metrics = { metric: NaN }
+      // Numeric user tags with `NaN` are dropped before they reach metrics
+      // via `addMixedTag`'s number branch.
+      spanContext._tags.metric = Number.NaN
 
       trace = spanFormat(span)
 
@@ -499,6 +556,16 @@ describe('spanFormat', () => {
       assert.strictEqual(trace.meta[ERROR_MESSAGE], error.message)
       assert.ok(!(ERROR_TYPE in trace.meta))
       assert.ok(!(ERROR_STACK in trace.meta))
+    })
+
+    it('should fall back to error.code when error.message is empty', () => {
+      const error = new Error('')
+      error.code = 'E_BOOM'
+      spanContext._tags.error = error
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.meta[ERROR_MESSAGE], 'E_BOOM')
     })
 
     it('should extract the origin', () => {
@@ -696,6 +763,14 @@ describe('spanFormat', () => {
       trace = spanFormat(span)
 
       assert.strictEqual(trace.metrics['_dd1.sr.eausr'], 1)
+    })
+
+    it('should map analytics.event false to a zero metric', () => {
+      spanContext._tags['analytics.event'] = false
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.metrics['_dd1.sr.eausr'], 0)
     })
   })
 })

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -255,6 +255,42 @@ describe('spanFormat', () => {
       assert.strictEqual(trace.service, truncatedServiceValue)
     })
 
+    it('truncates overlong Datadog-tag string values to the agent value limit', () => {
+      const { MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
+      // `span.type`, `resource.name`, and `http.status_code` each have
+      // their own inlined truncation branch in the `extractTags` switch
+      // (the inlining bypasses `addMixedTag`'s polymorphic slow path).
+      // Pin all three so a refactor that drops one of them surfaces here.
+      const overlongType = `${'t'.repeat(MAX_META_VALUE_LENGTH)}!`
+      const overlongResource = `${'r'.repeat(MAX_META_VALUE_LENGTH)}!`
+      const overlongStatusCode = `${'9'.repeat(MAX_META_VALUE_LENGTH)}!`
+      spanContext._tags['span.type'] = overlongType
+      spanContext._tags['resource.name'] = overlongResource
+      spanContext._tags['http.status_code'] = overlongStatusCode
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.type, `${overlongType.slice(0, MAX_META_VALUE_LENGTH)}...`)
+      assert.strictEqual(trace.resource, `${overlongResource.slice(0, MAX_META_VALUE_LENGTH)}...`)
+      assert.strictEqual(
+        trace.meta['http.status_code'],
+        `${overlongStatusCode.slice(0, MAX_META_VALUE_LENGTH)}...`
+      )
+    })
+
+    it('truncates overlong origin and hostname meta values to the agent value limit', () => {
+      const { MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
+      const overlongOrigin = `${'o'.repeat(MAX_META_VALUE_LENGTH)}!`
+      const overlongHostname = `${'h'.repeat(MAX_META_VALUE_LENGTH)}!`
+      spanContext._trace.origin = overlongOrigin
+      spanContext._hostname = overlongHostname
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.meta[ORIGIN_KEY], `${overlongOrigin.slice(0, MAX_META_VALUE_LENGTH)}...`)
+      assert.strictEqual(trace.meta[HOSTNAME_KEY], `${overlongHostname.slice(0, MAX_META_VALUE_LENGTH)}...`)
+    })
+
     it('should truncate the serialized span_links meta value past MAX_META_VALUE_LENGTH', () => {
       const { MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
 
@@ -388,14 +424,16 @@ describe('spanFormat', () => {
       )
     })
 
-    it('should skip numeric root tags whose source value is not a finite number', () => {
-      // `addNumberTag` drops non-numbers (e.g. `undefined`) and `NaN`, so
-      // those decisions never reach the metrics object even though the span
-      // is otherwise eligible for root-tag extraction.
+    it('should skip root tag decisions whose source value is undefined', () => {
+      // The `typeof === 'number'` gate skips any decision the priority
+      // sampler never set, so partial-decision spans emit only the metric
+      // they actually own. `Sampler.rate()` / `RateLimiter.effectiveRate()`
+      // cannot return `NaN` (the `Sampler` constructor throws via
+      // `BigInt(Math.floor(NaN * MAX_TRACE_ID))` long before the field can
+      // be assigned), so the `undefined` case is the only one to pin.
       spanContext._parentId = null
-      spanContext._trace[SAMPLING_AGENT_DECISION] = Number.NaN
       spanContext._trace[SAMPLING_LIMIT_DECISION] = 0.2
-      // SAMPLING_RULE_DECISION is intentionally left undefined.
+      // SAMPLING_AGENT_DECISION / SAMPLING_RULE_DECISION intentionally unset.
 
       trace = spanFormat(span)
 
@@ -504,16 +542,25 @@ describe('spanFormat', () => {
       const { MAX_META_KEY_LENGTH, MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
       const overlongChunkKey = `${'k'.repeat(MAX_META_KEY_LENGTH)}!`
       const overlongChunkValue = `${'v'.repeat(MAX_META_VALUE_LENGTH)}!`
+      // A second tag with a short key and overlong value pins the value
+      // truncation branch of the inlined `extractChunkTags` for-loop. The
+      // first tag pairs an overlong key with a short value (key branch);
+      // `tagForFirstSpanInChunk` pairs an overlong process-tag value with
+      // its own dedicated truncation branch.
+      const overlongTraceTagValue = `${'b'.repeat(MAX_META_VALUE_LENGTH)}!`
       spanContext._trace.tags = {
         [overlongChunkKey]: 'short',
+        '_dd.p.tid': overlongTraceTagValue,
       }
 
       trace = spanFormat(span, true, overlongChunkValue)
 
       const truncatedKey = `${overlongChunkKey.slice(0, MAX_META_KEY_LENGTH)}...`
       const truncatedValue = `${overlongChunkValue.slice(0, MAX_META_VALUE_LENGTH)}...`
+      const truncatedTraceTagValue = `${overlongTraceTagValue.slice(0, MAX_META_VALUE_LENGTH)}...`
       assert.strictEqual(trace.meta[truncatedKey], 'short')
       assert.strictEqual(trace.meta['_dd.tags.process'], truncatedValue)
+      assert.strictEqual(trace.meta['_dd.p.tid'], truncatedTraceTagValue)
     })
 
     it('should not extract trace chunk tags when not chunk root', () => {
@@ -593,6 +640,19 @@ describe('spanFormat', () => {
       assert.strictEqual(trace.metrics.payload, 'hello')
     })
 
+    it('should extract URL tags as stringified metrics', () => {
+      // `addMixedTag`'s default branch routes both `Buffer` and `URL` to
+      // metrics as `value.toString()`. The Buffer half is covered above;
+      // pin the URL half so a future tightening that drops `isUrl` from
+      // the helper surfaces here.
+      const url = new URL('https://example.com/foo?bar=1')
+      spanContext._tags.endpoint = url
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.metrics.endpoint, url.toString())
+    })
+
     it('should extract boolean tags as metrics', () => {
       spanContext._tags = { yes: true, no: false }
 
@@ -652,6 +712,76 @@ describe('spanFormat', () => {
       trace = spanFormat(span)
 
       assert.strictEqual(trace.meta[ERROR_MESSAGE], 'E_BOOM')
+    })
+
+    it('coerces non-string error tag values to meta strings', () => {
+      spanContext._tags[ERROR_TYPE] = 42
+      spanContext._tags[ERROR_MESSAGE] = { code: 'E_BOOM' }
+      spanContext._tags[ERROR_STACK] = true
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.meta[ERROR_TYPE], '42')
+      assert.strictEqual(trace.meta[ERROR_MESSAGE], '[object Object]')
+      assert.strictEqual(trace.meta[ERROR_STACK], 'true')
+      assert.ok(!(ERROR_TYPE in trace.metrics))
+      assert.ok(!(ERROR_MESSAGE in trace.metrics))
+      assert.ok(!(ERROR_STACK in trace.metrics))
+      assert.strictEqual(trace.error, 1)
+    })
+
+    it('skips null and undefined error tag values without writing meta', () => {
+      spanContext._tags[ERROR_TYPE] = null
+      spanContext._tags[ERROR_MESSAGE] = undefined
+      spanContext._tags[ERROR_STACK] = 'real stack'
+
+      trace = spanFormat(span)
+
+      assert.ok(!(ERROR_TYPE in trace.meta))
+      assert.ok(!(ERROR_MESSAGE in trace.meta))
+      assert.strictEqual(trace.meta[ERROR_STACK], 'real stack')
+      // Any of the three present (even null) still flips `error=1` unless
+      // OTel's `IGNORE_OTEL_ERROR` flag suppresses it.
+      assert.strictEqual(trace.error, 1)
+    })
+
+    it('truncates overlong error tag values to the agent value limit', () => {
+      const { MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
+      const overlongStack = `${'s'.repeat(MAX_META_VALUE_LENGTH)}!`
+      spanContext._tags[ERROR_STACK] = overlongStack
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.meta[ERROR_STACK], `${overlongStack.slice(0, MAX_META_VALUE_LENGTH)}...`)
+    })
+
+    it('coerces non-string Error subclass fields to meta strings via extractError', () => {
+      class WeirdError extends Error {}
+      const error = new WeirdError()
+      error.name = Symbol('CustomName')
+      error.message = 1234
+      error.stack = ['frame-0', 'frame-1']
+      spanContext._tags.error = error
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.meta[ERROR_TYPE], 'Symbol(CustomName)')
+      assert.strictEqual(trace.meta[ERROR_MESSAGE], '1234')
+      assert.strictEqual(trace.meta[ERROR_STACK], 'frame-0,frame-1')
+      assert.ok(!(ERROR_TYPE in trace.metrics))
+      assert.ok(!(ERROR_MESSAGE in trace.metrics))
+      assert.ok(!(ERROR_STACK in trace.metrics))
+    })
+
+    it('truncates overlong Error.message via extractError', () => {
+      const { MAX_META_VALUE_LENGTH } = require('../src/encode/tags-processors')
+      const overlongMessage = `${'m'.repeat(MAX_META_VALUE_LENGTH)}!`
+      const error = new Error(overlongMessage)
+      spanContext._tags.error = error
+
+      trace = spanFormat(span)
+
+      assert.strictEqual(trace.meta[ERROR_MESSAGE], `${overlongMessage.slice(0, MAX_META_VALUE_LENGTH)}...`)
     })
 
     it('should extract the origin', () => {


### PR DESCRIPTION
…locations

`addTag(meta, metrics, key, value)` dispatched on `typeof value` to
pick between the two slots. Twelve call sites in `span_format.js`
passed an empty `{}` for the slot they did not want -- roughly 50 to
300 throwaway objects per request -- only so the polymorphic helper
could ignore them. Typed `addStringTag` / `addNumberTag` /
`addBooleanTag` / `addMixedTag` helpers replace the dispatch; intent
lives in the helper picked at the call site.

`extractTags` also switches from `Object.entries(tags)` to
`Object.keys(tags)` with an inner `tags[tag]` lookup, dropping the
`[key, value]` pair-array allocation per tag.
