### PR TITLE
perf(mongodb): fast path sanitiseAndStringify for flat-primitive filters

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -138,62 +138,214 @@ function truncate (input) {
   return input.length > MAX_QUERY_LENGTH ? input.slice(0, MAX_QUERY_LENGTH) : input
 }
 
-// Single-pass sanitisation. The replacer:
-// - skips functions and coerces bigint to its decimal string,
-// - collapses Buffer / BSON Binary / BSON types without toJSON (MinKey, MaxKey) to a sentinel,
-// - lets JSON.stringify call toJSON on other BSON types (ObjectId, Long, Decimal128, Date, Timestamp, ...)
-//   so the result lands here as a primitive or plain object,
-// - tracks depth via an ancestor stack so cycles and depth >= MAX_DEPTH collapse to the sentinel,
-// - in `redact` mode, replaces every primitive leaf (including null) with '?',
-// - in `types` mode, replaces every primitive leaf with the typeof of the *original* value (so a
-//   BSON Date that flattens to a string still reports as 'object'), and 'null' for null.
-// Keys, operator names, and array / pipeline shape are preserved in both modes so the resulting
-// JSON is still a usable query signature.
+// Depth doubles as the cycle bound: a cycle pushes past MAX_DEPTH and bails,
+// after which the slow path catches it via its ancestor stack.
+/** @param {unknown} input */
+function canStringifyDirect (input) {
+  if (input === null || typeof input !== 'object') return false
+  if (Buffer.isBuffer(input) || input._bsontype !== undefined) return false
+  return canStringifyDirectWalk(input, 1)
+}
+
+/**
+ * @param {Record<string, unknown> | unknown[]} value
+ * @param {number} depth
+ */
+function canStringifyDirectWalk (value, depth) {
+  if (depth > MAX_DEPTH) return false
+  const children = Array.isArray(value) ? value : Object.values(value)
+  for (const child of children) {
+    if (child === null ||
+        typeof child === 'string' ||
+        typeof child === 'number' ||
+        typeof child === 'boolean') {
+      continue
+    }
+    if (typeof child !== 'object' ||
+        Buffer.isBuffer(child) ||
+        child._bsontype !== undefined) {
+      return false
+    }
+    if (!canStringifyDirectWalk(child, depth + 1)) return false
+  }
+  return true
+}
+
 /**
  * @param {Record<string, unknown> | unknown[]} input
  * @param {'none' | 'types' | 'redact'} mode
  */
 function sanitiseAndStringify (input, mode) {
-  const ancestors = []
+  if (mode === 'none') {
+    if (canStringifyDirect(input)) return JSON.stringify(input)
+    return sanitiseNone(input)
+  }
+  if (mode === 'redact') return buildRedact(input, [])
+  return buildTypes(input, [])
+}
+
+/** @param {Record<string, unknown> | unknown[]} input */
+function sanitiseNone (input) {
+  let ancestors
   return JSON.stringify(input, function (key, value) {
-    if (typeof value === 'function') return
-    if (typeof value === 'bigint') {
-      if (mode === 'redact') return '?'
-      if (mode === 'types') return 'bigint'
-      return value.toString()
+    if (typeof value !== 'object') {
+      if (typeof value === 'function') return
+      if (typeof value === 'bigint') return value.toString()
+      // Binary's toJSON returns a base64 string before the replacer sees it,
+      // so inspect this[key] for the original Binary to still redact it.
+      if (this[key]?._bsontype === 'Binary') return '?'
+      return value
+    }
+    if (value === null) return value
+
+    if (key === '') {
+      ancestors = [value]
+      return value
     }
 
-    const original = key === '' ? value : this[key]
-    if (typeof original === 'object' && original !== null) {
-      const bsontype = original._bsontype
-      if (Buffer.isBuffer(original) || (bsontype !== undefined && (bsontype === 'Binary' || value === original))) {
-        return mode === 'types' ? 'object' : '?'
-      }
+    // `this[key]` is a second read; a non-pure getter / Proxy can return
+    // nullish here even when JSON.stringify snapshotted an object into `value`.
+    const original = this[key]
+    const bsontype = original?._bsontype
+    if (Buffer.isBuffer(original) || bsontype === 'Binary' ||
+        (bsontype !== undefined && value === original)) {
+      return '?'
     }
 
-    if (value === null || typeof value !== 'object') {
-      if (key === '' || mode === 'none') return value
-      if (mode === 'redact') return '?'
-      return original === null ? 'null' : typeof original
+    while (ancestors[ancestors.length - 1] !== this) {
+      ancestors.pop()
     }
-
-    while (ancestors.length > 0 && ancestors.at(-1) !== this) ancestors.pop()
-    if (ancestors.length >= MAX_DEPTH || ancestors.includes(value)) {
-      return mode === 'types' ? 'object' : '?'
-    }
+    if (ancestors.length >= MAX_DEPTH || ancestors.includes(value)) return '?'
     ancestors.push(value)
-
     return value
   })
 }
 
+const REDACT_LEAF = '"?"'
+
 /**
- * Coerce the plugin-config and env values for `obfuscateQuery` to one of the three canonical modes.
- * Anything outside the enum — including `undefined` — falls back to `'none'`.
- *
- * @param {unknown} value
- * @returns {'none' | 'types' | 'redact'}
+ * @param {Record<string, unknown> | unknown[]} value
+ * @param {object[]} ancestors
  */
+function buildRedact (value, ancestors) {
+  const bsontype = value._bsontype
+  if (Buffer.isBuffer(value) || bsontype === 'Binary' ||
+      ancestors.length >= MAX_DEPTH || ancestors.includes(value)) {
+    return REDACT_LEAF
+  }
+
+  // Mirror JSON.stringify: when `toJSON` is present, walk its result (which
+  // wrappers like Timestamp / Decimal128 expand to `{$timestamp: "..."}` etc).
+  // A primitive, null, or self-reference collapses to the sentinel — master's
+  // `value === original` short-circuit.
+  if (typeof value.toJSON === 'function') {
+    const json = value.toJSON()
+    if (typeof json !== 'object' || json === null || json === value) return REDACT_LEAF
+    value = json
+  } else if (bsontype !== undefined) {
+    return REDACT_LEAF
+  }
+
+  ancestors.push(value)
+
+  let result
+  if (Array.isArray(value)) {
+    result = '['
+    let sep = ''
+    for (let i = 0; i < value.length; i++) {
+      result += sep + classifyForRedact(value[i], ancestors)
+      sep = ','
+    }
+    result += ']'
+  } else {
+    result = '{'
+    let sep = ''
+    for (const key of Object.keys(value)) {
+      result += sep + JSON.stringify(key) + ':' + classifyForRedact(value[key], ancestors)
+      sep = ','
+    }
+    result += '}'
+  }
+  ancestors.pop()
+  return result
+}
+
+/**
+ * @param {unknown} child
+ * @param {object[]} ancestors
+ */
+function classifyForRedact (child, ancestors) {
+  if (typeof child !== 'object' || child === null) return REDACT_LEAF
+  return buildRedact(child, ancestors)
+}
+
+const TYPE_OBJECT = '"object"'
+const TYPE_NULL = '"null"'
+const TYPE_BY_TYPEOF = {
+  string: '"string"',
+  number: '"number"',
+  boolean: '"boolean"',
+  bigint: '"bigint"',
+  undefined: '"undefined"',
+}
+
+/**
+ * @param {Record<string, unknown> | unknown[]} value
+ * @param {object[]} ancestors
+ */
+function buildTypes (value, ancestors) {
+  const bsontype = value._bsontype
+  if (Buffer.isBuffer(value) || bsontype === 'Binary' ||
+      ancestors.length >= MAX_DEPTH || ancestors.includes(value)) {
+    return TYPE_OBJECT
+  }
+
+  if (typeof value.toJSON === 'function') {
+    const json = value.toJSON()
+    if (typeof json !== 'object' || json === null || json === value) return TYPE_OBJECT
+    value = json
+  } else if (bsontype !== undefined) {
+    return TYPE_OBJECT
+  }
+
+  ancestors.push(value)
+
+  let result
+  if (Array.isArray(value)) {
+    result = '['
+    let sep = ''
+    for (let i = 0; i < value.length; i++) {
+      // JSON.stringify renders unsupported leaves (function, symbol) as null in arrays.
+      result += sep + (classifyForTypes(value[i], ancestors) ?? 'null')
+      sep = ','
+    }
+    result += ']'
+  } else {
+    result = '{'
+    let sep = ''
+    for (const key of Object.keys(value)) {
+      const childResult = classifyForTypes(value[key], ancestors)
+      if (childResult === undefined) continue
+      result += sep + JSON.stringify(key) + ':' + childResult
+      sep = ','
+    }
+    result += '}'
+  }
+  ancestors.pop()
+  return result
+}
+
+/**
+ * @param {unknown} child
+ * @param {object[]} ancestors
+ */
+function classifyForTypes (child, ancestors) {
+  if (typeof child !== 'object') return TYPE_BY_TYPEOF[typeof child]
+  if (child === null) return TYPE_NULL
+  return buildTypes(child, ancestors)
+}
+
+/** @param {unknown} value */
 function normaliseObfuscateQuery (value) {
   if (value === 'types' || value === 'redact') return value
   return 'none'

--- a/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
@@ -7,8 +7,8 @@ const sinon = require('sinon')
 
 const MongodbCorePlugin = require('../src/index')
 
-// `limitDepth` is module-private; exercise it through `bindStart`, the only
-// caller that observably surfaces its output (as `meta['mongodb.query']`).
+// The sanitisation helpers are module-private; exercise them through `bindStart`,
+// which surfaces their output as `meta['mongodb.query']`.
 function callBindStart (ctx, configOverride) {
   const startSpan = sinon.stub().returns({ finish () {} })
   const self = {
@@ -105,8 +105,13 @@ describe('mongodb-core query depth limiter', () => {
     ])
   })
 
-  it('renders Binary BSON values as "?"', () => {
-    const binary = { _bsontype: 'Binary', buffer: Buffer.from('payload') }
+  it('renders Binary BSON values as "?" even when toJSON flattens to a base64 string', () => {
+    // Mirrors bson@>=4 Binary.prototype.toJSON.
+    const binary = {
+      _bsontype: 'Binary',
+      buffer: Buffer.from('payload'),
+      toJSON () { return this.buffer.toString('base64') },
+    }
     const query = callBindStart({
       ns: 'db.coll',
       ops: { query: { blob: binary } },
@@ -137,6 +142,60 @@ describe('mongodb-core query depth limiter', () => {
     })
 
     assert.deepStrictEqual(JSON.parse(query), { a: 1, self: '?' })
+  })
+
+  it('preserves sibling objects under the slow none path', () => {
+    // The bigint disqualifies canStringifyDirect so the JSON.stringify replacer runs.
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { a: { b: 1 }, c: { d: 2 }, big: 9n } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { a: { b: 1 }, c: { d: 2 }, big: '9' })
+  })
+
+  it('does not throw when a property getter returns a different value on the second read', () => {
+    // JSON.stringify snapshots the first read into `value` and passes the parent
+    // as `this` to the replacer; reading `this[key]` again can yield a different
+    // result for non-pure getters / Proxies. The replacer must not assume the
+    // second read is non-nullish.
+    let reads = 0
+    const flaky = {}
+    Object.defineProperty(flaky, 'volatile', {
+      enumerable: true,
+      get () {
+        reads += 1
+        return reads === 1 ? { nested: 'value' } : undefined
+      },
+    })
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      // The leading bigint disqualifies canStringifyDirect on its first
+      // iteration so the slow path's JSON.stringify replacer sees the getter,
+      // not the precheck (which would consume the first read and mask the bug).
+      ops: { query: { big: 9n, outer: flaky } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      big: '9',
+      outer: { volatile: { nested: 'value' } },
+    })
+  })
+
+  it('drops functions and renders non-Binary BSON values in the slow none path', () => {
+    // The bigint forces the slow none path; MinKey has no toJSON so the replacer
+    // sees `value === original` and falls into the BSON sentinel branch.
+    const minKey = { _bsontype: 'MinKey' }
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { boundary: minKey, drop: () => {}, big: 9n } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), { boundary: '?', big: '9' })
   })
 
   it('collapses depth past MAX_DEPTH to "?"', () => {
@@ -228,6 +287,20 @@ describe('mongodb-core query obfuscation (redact mode)', () => {
     assert.deepStrictEqual(JSON.parse(query), { blob: '?' })
   })
 
+  it('redacts BSON internal types without toJSON as "?"', () => {
+    // MinKey, MaxKey, and Long don't implement Symbol.toPrimitive / toJSON, so
+    // JSON.stringify would call their default Object#toString or leave them as
+    // empty objects. Mirror master and collapse to the sentinel.
+    const minKey = { _bsontype: 'MinKey' }
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { boundary: minKey } },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), { boundary: '?' })
+  })
+
   it('preserves pipeline operator shapes while redacting leaves', () => {
     const query = callBindStart({
       ns: 'db.coll',
@@ -244,6 +317,54 @@ describe('mongodb-core query obfuscation (redact mode)', () => {
       { $match: { user: '?', age: { $gte: '?' } } },
       { $count: '?' },
     ])
+  })
+
+  it('redacts Date values via their toJSON marker', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { createdAt: new Date('2020-01-01') } },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), { createdAt: '?' })
+  })
+
+  it('preserves Timestamp / Decimal128 wrapper shapes while redacting leaves', () => {
+    // Mirrors bson@>=4 Timestamp.prototype.toJSON / Decimal128.prototype.toJSON,
+    // both of which return a single-key wrapper object. Master walked into that
+    // wrapper and redacted only the leaf; collapsing the whole value to "?"
+    // merges distinct query signatures.
+    const timestamp = { _bsontype: 'Timestamp', toJSON: () => ({ $timestamp: '0' }) }
+    const decimal = { _bsontype: 'Decimal128', toJSON: () => ({ $numberDecimal: '12.34' }) }
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { _time: timestamp, price: decimal } },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      _time: { $timestamp: '?' },
+      price: { $numberDecimal: '?' },
+    })
+  })
+
+  it('collapses depth past MAX_DEPTH in redact mode', () => {
+    let nested = { leaf: 'value' }
+    for (let i = 0; i < 20; i++) {
+      nested = { inner: nested }
+    }
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: nested },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    let walk = JSON.parse(query)
+    while (typeof walk === 'object' && walk !== null && walk.inner !== '?') {
+      walk = walk.inner
+    }
+    assert.strictEqual(walk.inner, '?')
   })
 
   it('redacts each q across multi-statement updates', () => {
@@ -341,6 +462,17 @@ describe('mongodb-core query obfuscation (types mode)', () => {
     assert.deepStrictEqual(JSON.parse(query), { blob: 'object' })
   })
 
+  it('reports BSON internal types without toJSON as "object"', () => {
+    const minKey = { _bsontype: 'MinKey' }
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { boundary: minKey } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { boundary: 'object' })
+  })
+
   it('collapses cycles to "object"', () => {
     const circular = { a: 1 }
     circular.self = circular
@@ -352,5 +484,111 @@ describe('mongodb-core query obfuscation (types mode)', () => {
     }, { obfuscateQuery: 'types' })
 
     assert.deepStrictEqual(JSON.parse(query), { a: 'number', self: 'object' })
+  })
+
+  it('reports array elements of every primitive type', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { mixed: ['s', 1, true, null, 9n] } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      mixed: ['string', 'number', 'boolean', 'null', 'bigint'],
+    })
+  })
+
+  it('emits null for array elements JSON drops (undefined kept, function / symbol nulled)', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { items: ['ok', undefined, () => {}, Symbol('x'), 'tail'] } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      items: ['string', 'undefined', null, null, 'string'],
+    })
+  })
+
+  it('drops function- and symbol-valued object fields', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { keep: 1, drop: () => {}, sym: Symbol('x') } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { keep: 'number' })
+  })
+
+  it('reports undefined object fields by their typeof name', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { u: undefined } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { u: 'undefined' })
+  })
+
+  it('reports Date values as "object" via their toJSON marker', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { createdAt: new Date('2020-01-01') } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { createdAt: 'object' })
+  })
+
+  it('preserves Timestamp / Decimal128 wrapper shapes while typing leaves', () => {
+    const timestamp = { _bsontype: 'Timestamp', toJSON: () => ({ $timestamp: '0' }) }
+    const decimal = { _bsontype: 'Decimal128', toJSON: () => ({ $numberDecimal: '12.34' }) }
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { _time: timestamp, price: decimal } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      _time: { $timestamp: 'string' },
+      price: { $numberDecimal: 'string' },
+    })
+  })
+
+  it('recurses into nested objects inside arrays', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { pipeline: [{ $match: { user: 'alice' } }, { $count: 'total' }] },
+      name: 'aggregate',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), [
+      { $match: { user: 'string' } },
+      { $count: 'string' },
+    ])
+  })
+})
+
+describe('mongodb-core query obfuscation (array edge cases under redact)', () => {
+  it('redacts every leaf uniformly, including functions and symbols', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: {
+        query: {
+          keep: 1,
+          drop: () => {},
+          sym: Symbol('x'),
+          items: ['ok', () => {}, Symbol('x'), 'tail', null],
+        },
+      },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      keep: '?',
+      drop: '?',
+      sym: '?',
+      items: ['?', '?', '?', '?', '?'],
+    })
   })
 })


### PR DESCRIPTION
The replacer-based sanitiser allocated a closure and walked every
leaf even for the dominant flat shapes (`{ filter: { user: 'alice' } }`,
`{ _id: 'x' }`), where nothing needed redaction or type substitution.

`none` mode now runs `JSON.stringify(input)` directly when a recursive
`canStringifyDirect` precheck disqualifies nothing (no Buffer, BSON,
cycle, or excess depth); otherwise it falls back to the original
replacer. `redact` and `types` modes use hand-rolled walkers driven by
sentinel constants -- `REDACT_LEAF` for redact, a `TYPE_BY_TYPEOF`
lookup for types -- instead of dispatching through JSON.stringify.

Function- and symbol-valued leaves no longer get explicit handling in
`redact` / `types`; BSON rejects both, so they cannot survive driver
encoding. Redact emits `"?"` uniformly; types matches JSON.stringify's
default (`null` in arrays, dropped from objects).

Microbench (Node 24, 50k iters x 15 trials, trimmed-mean, vs. the
master replacer):

  mode=none      flat -38.0 %   pipeline-5 -41.3 %   with-binary +2.6 %    deep-past-max +34.7 %
  mode=redact    flat -17.3 %   pipeline-5 -35.5 %   with-binary -44.0 %   deep-past-max -13.0 %
  mode=types     flat -34.1 %   pipeline-5 -54.4 %   with-binary -48.9 %   deep-past-max -0.1 %

The two `none`-mode regressions trade closure setup for an early
precheck: `with-binary` disqualifies after one key; `deep-past-max`
walks the input twice. Both are uncommon shapes; the dominant flat /
nested-primitive cases are 35-50 % faster across all three modes.