### PR TITLE
[test optimization] stabilize `vitest` async setup instrumentation

### DIFF
--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -1,5 +1,19 @@
 import { defineConfig } from 'vite'
 
+class CustomSequencer {
+  async shard (files) {
+    return files
+  }
+
+  async sort (files) {
+    if (process.env.CUSTOM_SEQUENCER_MARKER) {
+      // eslint-disable-next-line no-console
+      console.log(process.env.CUSTOM_SEQUENCER_MARKER)
+    }
+    return files
+  }
+}
+
 const config = {
   test: {
     include: [
@@ -8,6 +22,12 @@ const config = {
     pool: process.env.POOL_CONFIG || 'forks',
     reporters: ['default'],
   },
+}
+
+if (process.env.CUSTOM_SEQUENCER) {
+  config.test.sequence = {
+    sequencer: CustomSequencer,
+  }
 }
 
 if (process.env.COVERAGE_PROVIDER) {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -48,6 +48,13 @@ const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/
 const { NODE_MAJOR } = require('../../version')
 
 const NUM_RETRIES_EFD = 3
+const CUSTOM_SEQUENCER_MARKER = 'dd-trace custom vitest sequencer was used'
+const FLAKY_EVENTUALLY_PASSING_RESOURCE =
+  'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that eventually pass'
+const FLAKY_NEVER_PASSING_RESOURCE =
+  'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass'
+const FLAKY_UNNECESSARY_RETRY_RESOURCE =
+  'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary'
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 
 // vitest@4.x requires Node.js >= 20
@@ -127,6 +134,20 @@ versions.forEach((version) => {
             assert.strictEqual(testModuleEvent.content.meta[TEST_STATUS], 'fail')
             assert.strictEqual(testSessionEvent.content.meta[TEST_TYPE], 'test')
             assert.strictEqual(testModuleEvent.content.meta[TEST_TYPE], 'test')
+            assert.strictEqual(
+              testModuleEvent.content.test_session_id.toString(),
+              testSessionEvent.content.test_session_id.toString()
+            )
+            testSuiteEvents.forEach(testSuiteEvent => {
+              assert.strictEqual(
+                testSuiteEvent.content.test_session_id.toString(),
+                testSessionEvent.content.test_session_id.toString()
+              )
+              assert.strictEqual(
+                testSuiteEvent.content.test_module_id.toString(),
+                testModuleEvent.content.test_module_id.toString()
+              )
+            })
 
             const passedSuite = testSuiteEvents.find(
               suite =>
@@ -446,54 +467,61 @@ versions.forEach((version) => {
           },
         })
 
-        receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
+        const eventsPromise = receiver.gatherPayloadsMaxTimeout(
+          ({ url }) => url === '/api/v2/citestcycle',
+          payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
 
-          const testEvents = events.filter(event => event.type === 'test')
-          assert.strictEqual(testEvents.length, 11)
-          assertObjectContains(testEvents.map(test => test.content.resource), [
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that eventually pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that eventually pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that eventually pass',
-            // passes at the third retry
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that eventually pass',
-            // never passes
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass',
-            // passes on the first try
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries does not retry if unnecessary',
-          ])
-          const eventuallyPassingTest = testEvents.filter(
-            test => test.content.resource ===
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that eventually pass'
-          )
-          assert.strictEqual(eventuallyPassingTest.length, 4)
-          assert.strictEqual(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 3)
-          assert.strictEqual(eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 1)
-          assert.strictEqual(
-            eventuallyPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length,
-            3
-          )
-          assert.strictEqual(eventuallyPassingTest.filter(test =>
-            test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
-          ).length, 3)
+            const testEvents = events.filter(event => event.type === 'test')
+            assert.strictEqual(testEvents.length, 11)
+            assertObjectContains(testEvents.map(test => test.content.resource), [
+              FLAKY_EVENTUALLY_PASSING_RESOURCE,
+              FLAKY_EVENTUALLY_PASSING_RESOURCE,
+              FLAKY_EVENTUALLY_PASSING_RESOURCE,
+              // passes at the third retry
+              FLAKY_NEVER_PASSING_RESOURCE,
+              FLAKY_NEVER_PASSING_RESOURCE,
+              FLAKY_NEVER_PASSING_RESOURCE,
+              FLAKY_NEVER_PASSING_RESOURCE,
+              FLAKY_NEVER_PASSING_RESOURCE,
+              FLAKY_EVENTUALLY_PASSING_RESOURCE,
+              // never passes
+              FLAKY_NEVER_PASSING_RESOURCE,
+              // passes on the first try
+              FLAKY_UNNECESSARY_RETRY_RESOURCE,
+            ])
+            const eventuallyPassingTest = testEvents.filter(
+              test => test.content.resource === FLAKY_EVENTUALLY_PASSING_RESOURCE
+            )
+            assert.strictEqual(eventuallyPassingTest.length, 4)
+            assert.strictEqual(
+              eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length,
+              3
+            )
+            assert.strictEqual(
+              eventuallyPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length,
+              1
+            )
+            assert.strictEqual(
+              eventuallyPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length,
+              3
+            )
+            assert.strictEqual(eventuallyPassingTest.filter(test =>
+              test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+            ).length, 3)
 
-          const neverPassingTest = testEvents.filter(
-            test => test.content.resource ===
-            'ci-visibility/vitest-tests/flaky-test-retries.mjs.flaky test retries can retry tests that never pass'
-          )
-          assert.strictEqual(neverPassingTest.length, 6)
-          assert.strictEqual(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 6)
-          assert.strictEqual(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 0)
-          assert.strictEqual(neverPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 5)
-          assert.strictEqual(neverPassingTest.filter(test =>
-            test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
-          ).length, 5)
-        }).then(() => done()).catch(done)
+            const neverPassingTest = testEvents.filter(
+              test => test.content.resource === FLAKY_NEVER_PASSING_RESOURCE
+            )
+            assert.strictEqual(neverPassingTest.length, 6)
+            assert.strictEqual(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'fail').length, 6)
+            assert.strictEqual(neverPassingTest.filter(test => test.content.meta[TEST_STATUS] === 'pass').length, 0)
+            assert.strictEqual(neverPassingTest.filter(test => test.content.meta[TEST_IS_RETRY] === 'true').length, 5)
+            assert.strictEqual(neverPassingTest.filter(test =>
+              test.content.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+            ).length, 5)
+          }
+        )
 
         childProcess = exec(
           './node_modules/.bin/vitest run',
@@ -502,10 +530,21 @@ versions.forEach((version) => {
             env: {
               ...getCiVisAgentlessConfig(receiver.port),
               TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries*',
+              CUSTOM_SEQUENCER: version === '1.6.0' ? undefined : 'true',
+              CUSTOM_SEQUENCER_MARKER: version === '1.6.0' ? undefined : CUSTOM_SEQUENCER_MARKER,
               NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init', // ESM requires more flags
             },
           }
         )
+        let childStdout = ''
+        childProcess.stdout?.on('data', chunk => { childStdout += chunk.toString() })
+
+        Promise.all([eventsPromise, once(childProcess, 'exit')]).then(() => {
+          if (version !== '1.6.0') {
+            assert.ok(childStdout.includes(CUSTOM_SEQUENCER_MARKER))
+          }
+          done()
+        }).catch(done)
       })
 
       it('is disabled if DD_CIVISIBILITY_FLAKY_RETRY_ENABLED is false', (done) => {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -43,6 +43,7 @@ const testSuiteErrorCh = channel('ci:vitest:test-suite:error')
 // test session hooks
 const testSessionStartCh = channel('ci:vitest:session:start')
 const testSessionFinishCh = channel('ci:vitest:session:finish')
+const testSessionConfigurationCh = channel('ci:vitest:session:configuration')
 const libraryConfigurationCh = channel('ci:vitest:library-configuration')
 const knownTestsCh = channel('ci:vitest:known-tests')
 const isEarlyFlakeDetectionFaultyCh = channel('ci:vitest:is-early-flake-detection-faulty')
@@ -74,6 +75,9 @@ let isRetryReasonEfd = false
 let isRetryReasonAttemptToFix = false
 const switchedStatuses = new WeakSet()
 const workerProcesses = new WeakSet()
+const mainProcessSetupPromises = new WeakMap()
+const coverageWrappedProviders = new WeakSet()
+const finishWrappedContexts = new WeakSet()
 let isFlakyTestRetriesEnabled = false
 let flakyTestRetriesCount = 0
 let isEarlyFlakeDetectionEnabled = false
@@ -134,6 +138,9 @@ function getProvidedContext () {
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
       _ddIsImpactedTestsEnabled: isImpactedTestsEnabled,
       _ddModifiedFiles: modifiedFiles,
+      _ddTestSessionId: testSessionId,
+      _ddTestModuleId: testModuleId,
+      _ddTestCommand: testCommand,
     } = globalThis.__vitest_worker__.providedContext
 
     return {
@@ -150,6 +157,9 @@ function getProvidedContext () {
       flakyTestRetriesCount: flakyTestRetriesCount ?? 0,
       isImpactedTestsEnabled,
       modifiedFiles,
+      testSessionId,
+      testModuleId,
+      testCommand,
     }
   } catch {
     log.error('Vitest workers could not parse provided context, so some features will not work.')
@@ -167,6 +177,9 @@ function getProvidedContext () {
       flakyTestRetriesCount: 0,
       isImpactedTestsEnabled: false,
       modifiedFiles: {},
+      testSessionId: undefined,
+      testModuleId: undefined,
+      testCommand: undefined,
     }
   }
 }
@@ -215,6 +228,10 @@ function isCliApiPackage (vitestPackage) {
 
 function getTestRunnerExport (testPackage) {
   return findExportByName(testPackage, 'VitestTestRunner') || findExportByName(testPackage, 'TestRunner')
+}
+
+function getVitestExport (vitestPackage) {
+  return findExportByName(vitestPackage, 'Vitest')
 }
 
 function getForksPoolWorkerExport (vitestPackage) {
@@ -329,170 +346,212 @@ function wrapBeforeEachCleanupResult (task, result) {
   return result
 }
 
-function getSortWrapper (sort, frameworkVersion) {
-  return async function () {
-    if (!testSessionFinishCh.hasSubscribers) {
-      return sort.apply(this, arguments)
-    }
-    // There isn't any other async function that we seem to be able to hook into
-    // So we will use the sort from BaseSequencer. This means that a custom sequencer
-    // will not work. This will be a known limitation.
+function getWorkspaceProject (ctx) {
+  return ctx.getCoreWorkspaceProject
+    ? ctx.getCoreWorkspaceProject()
+    : ctx.getRootProject()
+}
+
+function setProvidedContext (ctx, values, warningMessage) {
+  try {
+    Object.assign(getWorkspaceProject(ctx)._provided, values)
+  } catch {
+    log.warn(warningMessage)
+  }
+}
+
+function getTestFilepathsFromSpecifications (testSpecifications) {
+  if (!Array.isArray(testSpecifications) || !testSpecifications.length) {
+    return
+  }
+
+  return testSpecifications.map(testSpecification => {
+    const testFile = Array.isArray(testSpecification) ? testSpecification[1] : testSpecification
+    return testFile?.moduleId || testFile?.filepath || testFile
+  })
+}
+
+function getTestFilepaths (ctx, testSpecifications) {
+  const testFilepaths = getTestFilepathsFromSpecifications(testSpecifications)
+  if (testFilepaths) {
+    return testFilepaths
+  }
+
+  const getFilePaths = ctx.getTestFilepaths || ctx._globTestFilepaths
+  return getFilePaths.call(ctx)
+}
+
+function wrapCoverageProvider (ctx) {
+  const { coverageProvider } = ctx
+  if (!coverageProvider?.generateCoverage || coverageWrappedProviders.has(coverageProvider)) {
+    return
+  }
+  coverageWrappedProviders.add(coverageProvider)
+
+  // Capture coverage root directory from config (default is 'coverage' in cwd)
+  try {
+    const coverageConfig = ctx.config?.coverage
+    const reportsDirectory = coverageConfig?.reportsDirectory || 'coverage'
+    const rootDir = ctx.config?.root || process.cwd()
+    coverageRootDir = path.isAbsolute(reportsDirectory) ? reportsDirectory : path.join(rootDir, reportsDirectory)
+  } catch {
+    // Fallback to cwd if we can't get config
+    coverageRootDir = process.cwd()
+  }
+
+  shimmer.wrap(coverageProvider, 'generateCoverage', generateCoverage => async function () {
+    const totalCodeCoverage = await generateCoverage.apply(this, arguments)
 
     try {
-      const { err, libraryConfig } = await getChannelPromise(libraryConfigurationCh, frameworkVersion)
-      if (!err) {
-        isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
-        flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
-        isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
-        earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
-        earlyFlakeDetectionSlowTestRetries = libraryConfig.earlyFlakeDetectionSlowTestRetries ?? {}
-        isDiEnabled = libraryConfig.isDiEnabled
-        isKnownTestsEnabled = libraryConfig.isKnownTestsEnabled
-        isTestManagementTestsEnabled = libraryConfig.isTestManagementEnabled
-        testManagementAttemptToFixRetries = libraryConfig.testManagementAttemptToFixRetries
-        isImpactedTestsEnabled = libraryConfig.isImpactedTestsEnabled
-      }
+      testCodeCoverageLinesTotal = totalCodeCoverage.getCoverageSummary().lines.pct
     } catch {
-      isFlakyTestRetriesEnabled = false
+      // ignore errors
+    }
+    return totalCodeCoverage
+  })
+}
+
+function wrapSessionFinish (ctx) {
+  if (finishWrappedContexts.has(ctx)) {
+    return
+  }
+  finishWrappedContexts.add(ctx)
+
+  shimmer.wrap(ctx, 'exit', getFinishWrapper)
+  shimmer.wrap(ctx, 'close', getFinishWrapper)
+}
+
+async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
+  if (!testSessionFinishCh.hasSubscribers) {
+    return
+  }
+
+  try {
+    const { err, libraryConfig } = await getChannelPromise(libraryConfigurationCh, frameworkVersion)
+    if (!err) {
+      isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
+      flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
+      isEarlyFlakeDetectionEnabled = libraryConfig.isEarlyFlakeDetectionEnabled
+      earlyFlakeDetectionNumRetries = libraryConfig.earlyFlakeDetectionNumRetries
+      earlyFlakeDetectionSlowTestRetries = libraryConfig.earlyFlakeDetectionSlowTestRetries ?? {}
+      isDiEnabled = libraryConfig.isDiEnabled
+      isKnownTestsEnabled = libraryConfig.isKnownTestsEnabled
+      isTestManagementTestsEnabled = libraryConfig.isTestManagementEnabled
+      testManagementAttemptToFixRetries = libraryConfig.testManagementAttemptToFixRetries
+      isImpactedTestsEnabled = libraryConfig.isImpactedTestsEnabled
+    }
+  } catch {
+    isFlakyTestRetriesEnabled = false
+    isEarlyFlakeDetectionEnabled = false
+    isDiEnabled = false
+    isKnownTestsEnabled = false
+    isImpactedTestsEnabled = false
+  }
+
+  if (testSessionConfigurationCh.hasSubscribers) {
+    const { testSessionId, testModuleId, testCommand } = await getChannelPromise(
+      testSessionConfigurationCh,
+      frameworkVersion
+    )
+    setProvidedContext(ctx, {
+      _ddTestSessionId: testSessionId,
+      _ddTestModuleId: testModuleId,
+      _ddTestCommand: testCommand,
+    }, 'Could not send test session configuration to workers.')
+  }
+
+  if (isFlakyTestRetriesEnabled && !ctx.config.retry && flakyTestRetriesCount > 0) {
+    ctx.config.retry = flakyTestRetriesCount
+    setProvidedContext(ctx, {
+      _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
+      _ddFlakyTestRetriesCount: flakyTestRetriesCount,
+    }, 'Could not send library configuration to workers.')
+  }
+
+  if (isKnownTestsEnabled) {
+    const knownTestsResponse = await getChannelPromise(knownTestsCh)
+    if (knownTestsResponse.err) {
       isEarlyFlakeDetectionEnabled = false
-      isDiEnabled = false
-      isKnownTestsEnabled = false
-      isImpactedTestsEnabled = false
-    }
+    } else {
+      const knownTests = knownTestsResponse.knownTests
+      const testFilepaths = await getTestFilepaths(ctx, testSpecifications)
 
-    if (isFlakyTestRetriesEnabled && !this.ctx.config.retry && flakyTestRetriesCount > 0) {
-      this.ctx.config.retry = flakyTestRetriesCount
-      try {
-        const workspaceProject = this.ctx.getCoreWorkspaceProject
-          ? this.ctx.getCoreWorkspaceProject()
-          : this.ctx.getRootProject()
-        workspaceProject._provided._ddIsFlakyTestRetriesEnabled = isFlakyTestRetriesEnabled
-        workspaceProject._provided._ddFlakyTestRetriesCount = flakyTestRetriesCount
-      } catch {
-        log.warn('Could not send library configuration to workers.')
-      }
-    }
-
-    if (isKnownTestsEnabled) {
-      const knownTestsResponse = await getChannelPromise(knownTestsCh)
-      if (knownTestsResponse.err) {
-        isEarlyFlakeDetectionEnabled = false
-      } else {
-        const knownTests = knownTestsResponse.knownTests
-        const getFilePaths = this.ctx.getTestFilepaths || this.ctx._globTestFilepaths
-
-        const testFilepaths = await getFilePaths.call(this.ctx)
-
-        if (isValidKnownTests(knownTests)) {
-          isEarlyFlakeDetectionFaultyCh.publish({
-            knownTests: knownTests.vitest,
-            testFilepaths,
-            onDone: (isFaulty) => {
-              isEarlyFlakeDetectionFaulty = isFaulty
-            },
-          })
-          if (isEarlyFlakeDetectionFaulty) {
-            isEarlyFlakeDetectionEnabled = false
-            log.warn('New test detection is disabled because the number of new tests is too high.')
-          } else {
-            // TODO: use this to pass session and module IDs to the worker, instead of polluting process.env
-            // Note: setting this.ctx.config.provide directly does not work because it's cached
-            try {
-              const workspaceProject = this.ctx.getCoreWorkspaceProject
-                ? this.ctx.getCoreWorkspaceProject()
-                : this.ctx.getRootProject()
-              workspaceProject._provided._ddIsKnownTestsEnabled = isKnownTestsEnabled
-              workspaceProject._provided._ddKnownTests = knownTests
-              workspaceProject._provided._ddIsEarlyFlakeDetectionEnabled = isEarlyFlakeDetectionEnabled
-              workspaceProject._provided._ddEarlyFlakeDetectionNumRetries =
-                getConfiguredEfdRetryCount(earlyFlakeDetectionSlowTestRetries, earlyFlakeDetectionNumRetries)
-              workspaceProject._provided._ddEarlyFlakeDetectionSlowTestRetries = earlyFlakeDetectionSlowTestRetries
-            } catch {
-              log.warn('Could not send known tests to workers so Early Flake Detection will not work.')
-            }
-          }
-        } else {
-          isEarlyFlakeDetectionFaulty = true
+      if (isValidKnownTests(knownTests)) {
+        isEarlyFlakeDetectionFaultyCh.publish({
+          knownTests: knownTests.vitest,
+          testFilepaths,
+          onDone: (isFaulty) => {
+            isEarlyFlakeDetectionFaulty = isFaulty
+          },
+        })
+        if (isEarlyFlakeDetectionFaulty) {
           isEarlyFlakeDetectionEnabled = false
+          log.warn('New test detection is disabled because the number of new tests is too high.')
+        } else {
+          setProvidedContext(ctx, {
+            _ddIsKnownTestsEnabled: isKnownTestsEnabled,
+            _ddKnownTests: knownTests,
+            _ddIsEarlyFlakeDetectionEnabled: isEarlyFlakeDetectionEnabled,
+            _ddEarlyFlakeDetectionNumRetries:
+              getConfiguredEfdRetryCount(earlyFlakeDetectionSlowTestRetries, earlyFlakeDetectionNumRetries),
+            _ddEarlyFlakeDetectionSlowTestRetries: earlyFlakeDetectionSlowTestRetries,
+          }, 'Could not send known tests to workers so Early Flake Detection will not work.')
         }
-      }
-    }
-
-    if (isDiEnabled) {
-      try {
-        const workspaceProject = this.ctx.getCoreWorkspaceProject
-          ? this.ctx.getCoreWorkspaceProject()
-          : this.ctx.getRootProject()
-        workspaceProject._provided._ddIsDiEnabled = isDiEnabled
-      } catch {
-        log.warn('Could not send Dynamic Instrumentation configuration to workers.')
-      }
-    }
-
-    if (isTestManagementTestsEnabled) {
-      const { err, testManagementTests: receivedTestManagementTests } = await getChannelPromise(testManagementTestsCh)
-      if (err) {
-        isTestManagementTestsEnabled = false
-        log.error('Could not get test management tests.')
       } else {
-        const testManagementTests = receivedTestManagementTests
-        try {
-          const workspaceProject = this.ctx.getCoreWorkspaceProject
-            ? this.ctx.getCoreWorkspaceProject()
-            : this.ctx.getRootProject()
-          workspaceProject._provided._ddIsTestManagementTestsEnabled = isTestManagementTestsEnabled
-          workspaceProject._provided._ddTestManagementAttemptToFixRetries = testManagementAttemptToFixRetries
-          workspaceProject._provided._ddTestManagementTests = testManagementTests
-        } catch {
-          log.warn('Could not send test management tests to workers so Test Management will not work.')
-        }
+        isEarlyFlakeDetectionFaulty = true
+        isEarlyFlakeDetectionEnabled = false
       }
     }
+  }
 
-    if (isImpactedTestsEnabled) {
-      const { err, modifiedFiles } = await getChannelPromise(modifiedFilesCh)
-      if (err) {
-        log.error('Could not get modified tests.')
-      } else {
-        try {
-          const workspaceProject = this.ctx.getCoreWorkspaceProject
-            ? this.ctx.getCoreWorkspaceProject()
-            : this.ctx.getRootProject()
-          workspaceProject._provided._ddIsImpactedTestsEnabled = isImpactedTestsEnabled
-          workspaceProject._provided._ddModifiedFiles = modifiedFiles
-        } catch {
-          log.warn('Could not send modified tests to workers so Impacted Tests will not work.')
-        }
-      }
+  if (isDiEnabled) {
+    setProvidedContext(ctx, {
+      _ddIsDiEnabled: isDiEnabled,
+    }, 'Could not send Dynamic Instrumentation configuration to workers.')
+  }
+
+  if (isTestManagementTestsEnabled) {
+    const { err, testManagementTests: receivedTestManagementTests } = await getChannelPromise(testManagementTestsCh)
+    if (err) {
+      isTestManagementTestsEnabled = false
+      log.error('Could not get test management tests.')
+    } else {
+      setProvidedContext(ctx, {
+        _ddIsTestManagementTestsEnabled: isTestManagementTestsEnabled,
+        _ddTestManagementAttemptToFixRetries: testManagementAttemptToFixRetries,
+        _ddTestManagementTests: receivedTestManagementTests,
+      }, 'Could not send test management tests to workers so Test Management will not work.')
     }
+  }
 
-    if (this.ctx.coverageProvider?.generateCoverage) {
-      // Capture coverage root directory from config (default is 'coverage' in cwd)
-      try {
-        const coverageConfig = this.ctx.config?.coverage
-        const reportsDirectory = coverageConfig?.reportsDirectory || 'coverage'
-        const rootDir = this.ctx.config?.root || process.cwd()
-        coverageRootDir = path.isAbsolute(reportsDirectory) ? reportsDirectory : path.join(rootDir, reportsDirectory)
-      } catch {
-        // Fallback to cwd if we can't get config
-        coverageRootDir = process.cwd()
-      }
-
-      shimmer.wrap(this.ctx.coverageProvider, 'generateCoverage', generateCoverage => async function () {
-        const totalCodeCoverage = await generateCoverage.apply(this, arguments)
-
-        try {
-          testCodeCoverageLinesTotal = totalCodeCoverage.getCoverageSummary().lines.pct
-        } catch {
-          // ignore errors
-        }
-        return totalCodeCoverage
-      })
+  if (isImpactedTestsEnabled) {
+    const { err, modifiedFiles } = await getChannelPromise(modifiedFilesCh)
+    if (err) {
+      log.error('Could not get modified tests.')
+    } else {
+      setProvidedContext(ctx, {
+        _ddIsImpactedTestsEnabled: isImpactedTestsEnabled,
+        _ddModifiedFiles: modifiedFiles,
+      }, 'Could not send modified tests to workers so Impacted Tests will not work.')
     }
+  }
 
-    shimmer.wrap(this.ctx, 'exit', getFinishWrapper)
-    shimmer.wrap(this.ctx, 'close', getFinishWrapper)
+  wrapCoverageProvider(ctx)
+  wrapSessionFinish(ctx)
+}
 
+function ensureMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
+  let setupPromise = mainProcessSetupPromises.get(ctx)
+  if (!setupPromise) {
+    setupPromise = runMainProcessSetup(ctx, frameworkVersion, testSpecifications)
+    mainProcessSetupPromises.set(ctx, setupPromise)
+  }
+  return setupPromise
+}
+
+function getSortWrapper (sort, frameworkVersion) {
+  return async function () {
+    await ensureMainProcessSetup(this.ctx, frameworkVersion, arguments[0])
     return sort.apply(this, arguments)
   }
 }
@@ -504,6 +563,11 @@ function getFinishWrapper (exitOrClose) {
       return exitOrClose.apply(this, arguments)
     }
     isClosed = true
+
+    if (!testSessionFinishCh.hasSubscribers) {
+      return exitOrClose.apply(this, arguments)
+    }
+
     let onFinish
 
     const flushPromise = new Promise(resolve => {
@@ -553,6 +617,17 @@ function getCliOrStartVitestWrapper (frameworkVersion) {
       return oldCliOrStartVitest.apply(this, args)
     }
   }
+}
+
+function wrapVitestRunFiles (Vitest, frameworkVersion) {
+  if (!Vitest?.prototype?.runFiles) {
+    return
+  }
+
+  shimmer.wrap(Vitest.prototype, 'runFiles', runFiles => async function (testSpecifications) {
+    await ensureMainProcessSetup(this, frameworkVersion, testSpecifications)
+    return runFiles.apply(this, arguments)
+  })
 }
 
 function getCreateCliWrapper (vitestPackage, frameworkVersion) {
@@ -657,6 +732,11 @@ function getStartVitestWrapper (cliApiPackage, frameworkVersion) {
   }
   const startVitestExport = findExportByName(cliApiPackage, 'startVitest')
   shimmer.wrap(cliApiPackage, startVitestExport.key, getCliOrStartVitestWrapper(frameworkVersion))
+
+  const vitest = getVitestExport(cliApiPackage)
+  if (vitest) {
+    wrapVitestRunFiles(vitest.value, frameworkVersion)
+  }
 
   const forksPoolWorker = getForksPoolWorkerExport(cliApiPackage)
   if (forksPoolWorker) {
@@ -921,7 +1001,6 @@ function wrapVitestTestRunner (VitestTestRunner) {
       // Here we finish the earlier iteration,
       // as long as it's not the _last_ iteration (which will be finished normally)
 
-      // TODO: check test duration (not to repeat if it's too slow)
       const ctx = taskToCtx.get(task)
       if (ctx) {
         if (lastExecutionStatus === 'fail') {
@@ -1269,8 +1348,15 @@ addHook({
     }
     // From >=3.0.1, the first arguments changes from a string to an object containing the filepath
     const testSuiteAbsolutePath = testPaths[0]?.filepath || testPaths[0]
+    const providedContext = getProvidedContext()
 
-    const testSuiteCtx = { testSuiteAbsolutePath, frameworkVersion }
+    const testSuiteCtx = {
+      testSuiteAbsolutePath,
+      frameworkVersion,
+      testSessionId: providedContext.testSessionId,
+      testModuleId: providedContext.testModuleId,
+      testCommand: providedContext.testCommand,
+    }
     testSuiteStartCh.runStores(testSuiteCtx, () => {})
     const startTestsResponse = await startTests.apply(this, arguments)
 
@@ -1288,7 +1374,6 @@ addHook({
       // We have to trick vitest into thinking that the test has passed
       // but we want to report it as failed if it did fail
       const isSwitchedStatus = switchedStatuses.has(task)
-      const providedContext = getProvidedContext()
 
       if (result) {
         const { state, duration, errors } = result

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -56,6 +56,16 @@ class VitestPlugin extends CiPlugin {
 
     this.taskToFinishTime = new WeakMap()
 
+    this.addSub('ci:vitest:session:configuration', ({ onDone }) => {
+      const testSessionSpanContext = this.testSessionSpan?.context()
+      const testModuleSpanContext = this.testModuleSpan?.context()
+      onDone({
+        testSessionId: testSessionSpanContext?.toTraceId(),
+        testModuleId: testModuleSpanContext?.toSpanId(),
+        testCommand: this.command,
+      })
+    })
+
     this.addSub('ci:vitest:test:is-new', ({ knownTests, testSuiteAbsolutePath, testName, onDone }) => {
       // if for whatever reason the worker does not receive valid known tests, we don't consider it as new
       if (!knownTests.vitest) {
@@ -299,14 +309,16 @@ class VitestPlugin extends CiPlugin {
     this.addBind('ci:vitest:test-suite:start', (ctx) => {
       const { testSuiteAbsolutePath, frameworkVersion } = ctx
 
-      // TODO: Handle case where the command is not set
-      this.command = this._tracerConfig.DD_CIVISIBILITY_TEST_COMMAND
+      const testCommand = ctx.testCommand || 'vitest run'
+      const { testSessionId, testModuleId } = ctx
+      this.command = testCommand
       this.frameworkVersion = frameworkVersion
-      const testSessionSpanContext = this.tracer.extract('text_map', {
-        // TODO: Handle case where the session ID or module ID is not set
-        'x-datadog-trace-id': this._tracerConfig.DD_CIVISIBILITY_TEST_SESSION_ID,
-        'x-datadog-parent-id': this._tracerConfig.DD_CIVISIBILITY_TEST_MODULE_ID,
-      })
+      const testSessionSpanContext = testSessionId && testModuleId
+        ? this.tracer.extract('text_map', {
+          'x-datadog-trace-id': testSessionId,
+          'x-datadog-parent-id': testModuleId,
+        })
+        : undefined
 
       const trimmedCommand = DD_MAJOR < 6 ? this.command : 'vitest run'
       // test suites run in a different process, so they also need to init the metadata dictionary

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -249,18 +249,6 @@ module.exports = class CiPlugin extends Plugin {
         integrationName: this.constructor.id,
       })
       setItrSkippingEnabledTagFromLibraryConfig(this, frameworkVersion)
-      // only for vitest
-      // These are added for the worker threads to use
-      if (this.constructor.id === 'vitest') {
-        // TODO: Figure out alternative ways to pass this information to the worker threads
-        // eslint-disable-next-line eslint-rules/eslint-process-env
-        process.env.DD_CIVISIBILITY_TEST_SESSION_ID = this.testSessionSpan.context().toTraceId()
-        // eslint-disable-next-line eslint-rules/eslint-process-env
-        process.env.DD_CIVISIBILITY_TEST_MODULE_ID = this.testModuleSpan.context().toSpanId()
-        // eslint-disable-next-line eslint-rules/eslint-process-env
-        process.env.DD_CIVISIBILITY_TEST_COMMAND = this.command
-      }
-
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'module')
     })
 


### PR DESCRIPTION
### What does this PR do?

Stabilizes Vitest Test Optimization setup by moving the async main-process setup to `Vitest.prototype.runFiles` when that API is available, while keeping `BaseSequencer.sort` as the compatibility fallback for Vitest 1.6.

The change also passes session and module IDs to workers through Vitest provided context instead of mutating `process.env`, removes obsolete TODOs, and adds coverage for custom sequencers plus worker session/module ID propagation.

### Motivation

The previous instrumentation relied on `BaseSequencer.sort` because it was an async hook that ran before tests. Users can configure a custom sequencer, though, which means `sort` is not always called and the setup for EFD, Test Management, Impacted Tests, DI, and worker parenting could be skipped.

Hooking `runFiles` gives newer Vitest versions a more reliable instrumentation point before worker contexts are created, while the sort fallback preserves older-version support.

### Additional Notes

`vitest@1.6.0` passes `[project, filepath]` tuples through the sequencer path, so the fallback setup normalizes both that tuple shape and newer spec objects before checking EFD faultiness.