### PR TITLE
[test optimization] parallelize test optimization requests

### DIFF
--- a/packages/datadog-instrumentations/src/cucumber.js
+++ b/packages/datadog-instrumentations/src/cucumber.js
@@ -19,6 +19,7 @@ const {
   collectAttemptToFixExecutionsFromTraces,
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
+  getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const satisfies = require('../../../vendor/dist/semifies')
 const { addHook, channel } = require('./helpers/instrument')
@@ -639,18 +640,31 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
     testManagementAttemptToFixRetries = configurationResponse.libraryConfig?.testManagementAttemptToFixRetries
     isImpactedTestsEnabled = configurationResponse.libraryConfig?.isImpactedTestsEnabled
 
+    const {
+      knownTestsResponse,
+      testManagementTestsResponse,
+      skippableSuitesResponse,
+    } = await getTestOptimizationRequestResults({
+      isKnownTestsEnabled,
+      isTestManagementTestsEnabled,
+      isSuitesSkippingEnabled,
+      getKnownTests: () => getChannelPromise(knownTestsCh),
+      getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
+      getSkippableSuites: () => getChannelPromise(skippableSuitesCh),
+    })
+
     if (isKnownTestsEnabled) {
-      const knownTestsResponse = await getChannelPromise(knownTestsCh)
-      if (knownTestsResponse.err) {
+      const currentKnownTestsResponse = knownTestsResponse || await getChannelPromise(knownTestsCh)
+      if (currentKnownTestsResponse.err) {
         isEarlyFlakeDetectionEnabled = false
         isKnownTestsEnabled = false
       } else {
-        knownTests = knownTestsResponse.knownTests
+        knownTests = currentKnownTestsResponse.knownTests
       }
     }
 
     if (isSuitesSkippingEnabled) {
-      const skippableResponse = await getChannelPromise(skippableSuitesCh)
+      const skippableResponse = skippableSuitesResponse || await getChannelPromise(skippableSuitesCh)
 
       errorSkippableRequest = skippableResponse.err
       skippableSuites = skippableResponse.skippableSuites ?? []
@@ -694,11 +708,12 @@ function getWrappedStart (start, frameworkVersion, isParallel = false, isCoordin
     }
 
     if (isTestManagementTestsEnabled) {
-      const testManagementTestsResponse = await getChannelPromise(testManagementTestsCh)
-      if (testManagementTestsResponse.err) {
+      const currentTestManagementTestsResponse =
+        testManagementTestsResponse || await getChannelPromise(testManagementTestsCh)
+      if (currentTestManagementTestsResponse.err) {
         isTestManagementTestsEnabled = false
       } else {
-        testManagementTests = testManagementTestsResponse.testManagementTests
+        testManagementTests = currentTestManagementTestsResponse.testManagementTests
       }
     }
 

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -30,6 +30,7 @@ const {
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
   getEfdRetryCount,
+  getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const {
   SEED_SUFFIX_RE,
@@ -1173,6 +1174,12 @@ function getWrappedScheduleTests (scheduleTests, frameworkVersion) {
   }
 }
 
+function getChannelPromise (channelToPublishTo, payload = {}) {
+  return new Promise(resolve => {
+    channelToPublishTo.publish({ ...payload, onDone: resolve })
+  })
+}
+
 function searchSourceWrapper (searchSourcePackage, frameworkVersion) {
   const SearchSource = searchSourcePackage.default ?? searchSourcePackage
 
@@ -1234,17 +1241,14 @@ function getCliWrapper (isNewJestVersion) {
     }
     return shimmer.wrap(cli, 'runCLI', runCLI => async function () {
       let onDone
-      const configurationPromise = new Promise((resolve) => {
-        onDone = resolve
-      })
       if (!libraryConfigurationCh.hasSubscribers) {
         return runCLI.apply(this, arguments)
       }
 
-      libraryConfigurationCh.publish({ onDone, frameworkVersion: jestVersion })
-
       try {
-        const { err, libraryConfig } = await configurationPromise
+        const { err, libraryConfig } = await getChannelPromise(libraryConfigurationCh, {
+          frameworkVersion: jestVersion,
+        })
         if (!err) {
           isCodeCoverageEnabled = libraryConfig.isCodeCoverageEnabled
           isSuitesSkippingEnabled = libraryConfig.isSuitesSkippingEnabled
@@ -1263,15 +1267,22 @@ function getCliWrapper (isNewJestVersion) {
         log.error('Jest library configuration error', err)
       }
 
+      const {
+        knownTestsResponse,
+        testManagementTestsResponse,
+        skippableSuitesResponse,
+      } = await getTestOptimizationRequestResults({
+        isKnownTestsEnabled,
+        isTestManagementTestsEnabled,
+        isSuitesSkippingEnabled,
+        getKnownTests: () => getChannelPromise(knownTestsCh),
+        getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
+        getSkippableSuites: () => getChannelPromise(skippableSuitesCh),
+      })
+
       if (isKnownTestsEnabled) {
-        const knownTestsPromise = new Promise((resolve) => {
-          onDone = resolve
-        })
-
-        knownTestsCh.publish({ onDone })
-
         try {
-          const { err, knownTests: receivedKnownTests } = await knownTestsPromise
+          const { err, knownTests: receivedKnownTests } = knownTestsResponse || await getChannelPromise(knownTestsCh)
           if (err) {
             // We disable EFD if there has been an error in the known tests request
             isEarlyFlakeDetectionEnabled = false
@@ -1285,14 +1296,9 @@ function getCliWrapper (isNewJestVersion) {
       }
 
       if (isSuitesSkippingEnabled) {
-        const skippableSuitesPromise = new Promise((resolve) => {
-          onDone = resolve
-        })
-
-        skippableSuitesCh.publish({ onDone })
-
         try {
-          const { err, skippableSuites: receivedSkippableSuites } = await skippableSuitesPromise
+          const { err, skippableSuites: receivedSkippableSuites } =
+            skippableSuitesResponse || await getChannelPromise(skippableSuitesCh)
           if (!err) {
             skippableSuites = receivedSkippableSuites
           }
@@ -1302,14 +1308,9 @@ function getCliWrapper (isNewJestVersion) {
       }
 
       if (isTestManagementTestsEnabled) {
-        const testManagementTestsPromise = new Promise((resolve) => {
-          onDone = resolve
-        })
-
-        testManagementTestsCh.publish({ onDone })
-
         try {
-          const { err, testManagementTests: receivedTestManagementTests } = await testManagementTestsPromise
+          const { err, testManagementTests: receivedTestManagementTests } =
+            testManagementTestsResponse || await getChannelPromise(testManagementTestsCh)
           if (err) {
             isTestManagementTestsEnabled = false
             testManagementTests = {}
@@ -1323,14 +1324,8 @@ function getCliWrapper (isNewJestVersion) {
       }
 
       if (isImpactedTestsEnabled) {
-        const impactedTestsPromise = new Promise((resolve) => {
-          onDone = resolve
-        })
-
-        modifiedFilesCh.publish({ onDone })
-
         try {
-          const { err, modifiedFiles: receivedModifiedFiles } = await impactedTestsPromise
+          const { err, modifiedFiles: receivedModifiedFiles } = await getChannelPromise(modifiedFilesCh)
           if (!err) {
             modifiedFiles = receivedModifiedFiles
           }

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -18,6 +18,7 @@ const {
   getIsFaultyEarlyFlakeDetection,
   collectTestOptimizationSummariesFromTraces,
   logTestOptimizationSummary,
+  getTestOptimizationRequestResults,
 } = require('../../../dd-trace/src/plugins/util/test')
 
 const {
@@ -249,11 +250,38 @@ function getOnEndHandler (isParallel) {
   }
 }
 
+function getRunStoresPromise (channelToPublishTo, ctx) {
+  return new Promise(resolve => {
+    channelToPublishTo.runStores({ ...ctx, onDone: resolve }, () => {})
+  })
+}
+
+function applyKnownTestsResponse ({ err, knownTests }) {
+  if (err) {
+    config.knownTests = []
+    config.isEarlyFlakeDetectionEnabled = false
+    config.isKnownTestsEnabled = false
+  } else {
+    config.knownTests = knownTests
+  }
+}
+
+function applyTestManagementTestsResponse ({ err, testManagementTests: receivedTestManagementTests }) {
+  if (err) {
+    config.testManagementTests = {}
+    config.isTestManagementTestsEnabled = false
+    config.testManagementAttemptToFixRetries = 0
+  } else {
+    config.testManagementTests = receivedTestManagementTests
+  }
+}
+
 function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFinishRequest) {
   const ctx = {
     isParallel,
     frameworkVersion,
   }
+  let skippableSuitesResponse
 
   const onReceivedSkippableSuites = ({ err, skippableSuites, itrCorrelationId: responseItrCorrelationId }) => {
     if (err) {
@@ -279,6 +307,16 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     })
   }
 
+  const requestSkippableSuites = () => {
+    if (skippableSuitesResponse) {
+      onReceivedSkippableSuites(skippableSuitesResponse)
+      return
+    }
+
+    ctx.onDone = onReceivedSkippableSuites
+    skippableSuitesCh.runStores(ctx, () => {})
+  }
+
   const onReceivedImpactedTests = ({ err, modifiedFiles: receivedModifiedFiles }) => {
     if (err) {
       config.modifiedFiles = []
@@ -287,8 +325,7 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
       config.modifiedFiles = receivedModifiedFiles
     }
     if (config.isSuitesSkippingEnabled) {
-      ctx.onDone = onReceivedSkippableSuites
-      skippableSuitesCh.runStores(ctx, () => {})
+      requestSkippableSuites()
     } else {
       mochaGlobalRunCh.runStores(ctx, () => {
         onFinishRequest()
@@ -296,44 +333,12 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     }
   }
 
-  const onReceivedTestManagementTests = ({ err, testManagementTests: receivedTestManagementTests }) => {
-    if (err) {
-      config.testManagementTests = {}
-      config.isTestManagementTestsEnabled = false
-      config.testManagementAttemptToFixRetries = 0
-    } else {
-      config.testManagementTests = receivedTestManagementTests
-    }
+  const continueAfterTestRequests = () => {
     if (config.isImpactedTestsEnabled) {
       ctx.onDone = onReceivedImpactedTests
       modifiedFilesCh.runStores(ctx, () => {})
     } else if (config.isSuitesSkippingEnabled) {
-      ctx.onDone = onReceivedSkippableSuites
-      skippableSuitesCh.runStores(ctx, () => {})
-    } else {
-      mochaGlobalRunCh.runStores(ctx, () => {
-        onFinishRequest()
-      })
-    }
-  }
-
-  const onReceivedKnownTests = ({ err, knownTests }) => {
-    if (err) {
-      config.knownTests = []
-      config.isEarlyFlakeDetectionEnabled = false
-      config.isKnownTestsEnabled = false
-    } else {
-      config.knownTests = knownTests
-    }
-    if (config.isTestManagementTestsEnabled) {
-      ctx.onDone = onReceivedTestManagementTests
-      testManagementTestsCh.runStores(ctx, () => {})
-    } else if (config.isImpactedTestsEnabled) {
-      ctx.onDone = onReceivedImpactedTests
-      modifiedFilesCh.runStores(ctx, () => {})
-    } else if (config.isSuitesSkippingEnabled) {
-      ctx.onDone = onReceivedSkippableSuites
-      skippableSuitesCh.runStores(ctx, () => {})
+      requestSkippableSuites()
     } else {
       mochaGlobalRunCh.runStores(ctx, () => {
         onFinishRequest()
@@ -359,23 +364,30 @@ function getExecutionConfiguration (runner, isParallel, frameworkVersion, onFini
     config.isFlakyTestRetriesEnabled = libraryConfig.isFlakyTestRetriesEnabled
     config.flakyTestRetriesCount = libraryConfig.flakyTestRetriesCount
 
-    if (config.isKnownTestsEnabled) {
-      ctx.onDone = onReceivedKnownTests
-      knownTestsCh.runStores(ctx, () => {})
-    } else if (config.isTestManagementTestsEnabled) {
-      ctx.onDone = onReceivedTestManagementTests
-      testManagementTestsCh.runStores(ctx, () => {})
-    } else if (config.isImpactedTestsEnabled) {
-      ctx.onDone = onReceivedImpactedTests
-      modifiedFilesCh.runStores(ctx, () => {})
-    } else if (config.isSuitesSkippingEnabled) {
-      ctx.onDone = onReceivedSkippableSuites
-      skippableSuitesCh.runStores(ctx, () => {})
-    } else {
-      mochaGlobalRunCh.runStores(ctx, () => {
-        onFinishRequest()
-      })
-    }
+    getTestOptimizationRequestResults({
+      isKnownTestsEnabled: config.isKnownTestsEnabled,
+      isTestManagementTestsEnabled: config.isTestManagementTestsEnabled,
+      isSuitesSkippingEnabled: config.isSuitesSkippingEnabled,
+      getKnownTests: () => getRunStoresPromise(knownTestsCh, ctx),
+      getTestManagementTests: () => getRunStoresPromise(testManagementTestsCh, ctx),
+      getSkippableSuites: () => getRunStoresPromise(skippableSuitesCh, ctx),
+    }).then(requestResults => {
+      const {
+        knownTestsResponse,
+        testManagementTestsResponse,
+        skippableSuitesResponse: requestSkippableSuitesResponse,
+      } = requestResults
+
+      if (knownTestsResponse) {
+        applyKnownTestsResponse(knownTestsResponse)
+      }
+      if (testManagementTestsResponse) {
+        applyTestManagementTestsResponse(testManagementTestsResponse)
+      }
+      skippableSuitesResponse = requestSkippableSuitesResponse
+
+      continueAfterTestRequests()
+    })
   }
 
   ctx.onDone = onReceivedConfiguration

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -18,6 +18,7 @@ const {
   recordAttemptToFixExecution,
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
+  getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const log = require('../../dd-trace/src/log')
 const {
@@ -1075,9 +1076,24 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       log.error('Playwright session start error', e)
     }
 
-    if (isKnownTestsEnabled && satisfies(playwrightVersion, MINIMUM_SUPPORTED_VERSION_RANGE_EFD)) {
+    const isTestOptimizationSupported = satisfies(playwrightVersion, MINIMUM_SUPPORTED_VERSION_RANGE_EFD)
+    const shouldGetKnownTests = isKnownTestsEnabled && isTestOptimizationSupported
+    const shouldGetTestManagementTests = isTestManagementTestsEnabled && isTestOptimizationSupported
+
+    const {
+      knownTestsResponse,
+      testManagementTestsResponse,
+    } = await getTestOptimizationRequestResults({
+      isKnownTestsEnabled: shouldGetKnownTests,
+      isTestManagementTestsEnabled: shouldGetTestManagementTests,
+      getKnownTests: () => getChannelPromise(knownTestsCh),
+      getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
+    })
+
+    if (shouldGetKnownTests) {
       try {
-        const { err, knownTests: receivedKnownTests } = await getChannelPromise(knownTestsCh)
+        const { err, knownTests: receivedKnownTests } =
+          knownTestsResponse || await getChannelPromise(knownTestsCh)
         if (err) {
           isEarlyFlakeDetectionEnabled = false
           isKnownTestsEnabled = false
@@ -1096,9 +1112,10 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       }
     }
 
-    if (isTestManagementTestsEnabled && satisfies(playwrightVersion, MINIMUM_SUPPORTED_VERSION_RANGE_EFD)) {
+    if (shouldGetTestManagementTests) {
       try {
-        const { err, testManagementTests: receivedTestManagementTests } = await getChannelPromise(testManagementTestsCh)
+        const { err, testManagementTests: receivedTestManagementTests } =
+          testManagementTestsResponse || await getChannelPromise(testManagementTestsCh)
         if (err) {
           isTestManagementTestsEnabled = false
         } else {
@@ -1110,7 +1127,7 @@ function runAllTestsWrapper (runAllTests, playwrightVersion) {
       }
     }
 
-    if (isImpactedTestsEnabled && satisfies(playwrightVersion, MINIMUM_SUPPORTED_VERSION_RANGE_EFD)) {
+    if (isImpactedTestsEnabled && isTestOptimizationSupported) {
       try {
         const { err, modifiedFiles: receivedModifiedFiles } = await getChannelPromise(modifiedFilesCh)
         if (err) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -19,6 +19,7 @@ const {
   collectTestOptimizationSummariesFromTraces,
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
+  getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const { addHook, channel } = require('./helpers/instrument')
 
@@ -460,6 +461,16 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
     }, 'Could not send test session configuration to workers.')
   }
 
+  const {
+    knownTestsResponse,
+    testManagementTestsResponse,
+  } = await getTestOptimizationRequestResults({
+    isKnownTestsEnabled,
+    isTestManagementTestsEnabled,
+    getKnownTests: () => getChannelPromise(knownTestsCh),
+    getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
+  })
+
   if (isFlakyTestRetriesEnabled && !ctx.config.retry && flakyTestRetriesCount > 0) {
     ctx.config.retry = flakyTestRetriesCount
     setProvidedContext(ctx, {
@@ -469,11 +480,11 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
   }
 
   if (isKnownTestsEnabled) {
-    const knownTestsResponse = await getChannelPromise(knownTestsCh)
-    if (knownTestsResponse.err) {
+    const currentKnownTestsResponse = knownTestsResponse || await getChannelPromise(knownTestsCh)
+    if (currentKnownTestsResponse.err) {
       isEarlyFlakeDetectionEnabled = false
     } else {
-      const knownTests = knownTestsResponse.knownTests
+      const knownTests = currentKnownTestsResponse.knownTests
       const testFilepaths = await getTestFilepaths(ctx, testSpecifications)
 
       if (isValidKnownTests(knownTests)) {
@@ -511,7 +522,8 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
   }
 
   if (isTestManagementTestsEnabled) {
-    const { err, testManagementTests: receivedTestManagementTests } = await getChannelPromise(testManagementTestsCh)
+    const { err, testManagementTests: receivedTestManagementTests } =
+      testManagementTestsResponse || await getChannelPromise(testManagementTestsCh)
     if (err) {
       isTestManagementTestsEnabled = false
       log.error('Could not get test management tests.')

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -70,6 +70,7 @@ const {
   getMaxEfdRetryCount,
   getPullRequestBaseBranch,
   TEST_FINAL_STATUS,
+  getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const { isMarkedAsUnskippable } = require('../../datadog-plugin-jest/src/util')
 const { ORIGIN_KEY, COMPONENT } = require('../../dd-trace/src/constants')
@@ -787,19 +788,29 @@ class CypressPlugin {
     this.frameworkVersion = getCypressVersion(details)
     this.rootDir = getRootDir(details)
 
+    const {
+      knownTestsResponse,
+      testManagementTestsResponse,
+      skippableSuitesResponse: skippableTestsRequestResponse,
+    } = await getTestOptimizationRequestResults({
+      isKnownTestsEnabled: this.isKnownTestsEnabled,
+      isTestManagementTestsEnabled: this.isTestManagementTestsEnabled,
+      isSuitesSkippingEnabled: this.isSuitesSkippingEnabled,
+      getKnownTests: () => getKnownTests(this.tracer, this.testConfiguration),
+      getTestManagementTests: () => getTestManagementTests(this.tracer, this.testConfiguration),
+      getSkippableSuites: () => getSkippableTests(this.tracer, this.testConfiguration),
+    })
+
     if (this.isKnownTestsEnabled) {
-      const knownTestsResponse = await getKnownTests(
-        this.tracer,
-        this.testConfiguration
-      )
-      if (knownTestsResponse.err) {
-        log.error('Cypress known tests response error', knownTestsResponse.err)
+      const currentKnownTestsResponse = knownTestsResponse || await getKnownTests(this.tracer, this.testConfiguration)
+      if (currentKnownTestsResponse.err) {
+        log.error('Cypress known tests response error', currentKnownTestsResponse.err)
         this._pendingRequestErrorTags.push({ tag: DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS, value: 'true' })
         this.isEarlyFlakeDetectionEnabled = false
         this.isKnownTestsEnabled = false
       } else {
-        if (knownTestsResponse.knownTests?.[TEST_FRAMEWORK_NAME]) {
-          this.knownTestsByTestSuite = knownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]
+        if (currentKnownTestsResponse.knownTests?.[TEST_FRAMEWORK_NAME]) {
+          this.knownTestsByTestSuite = currentKnownTestsResponse.knownTests[TEST_FRAMEWORK_NAME]
         } else {
           this.isEarlyFlakeDetectionEnabled = false
           this.isKnownTestsEnabled = false
@@ -823,10 +834,8 @@ class CypressPlugin {
     }
 
     if (this.isSuitesSkippingEnabled) {
-      const skippableTestsResponse = await getSkippableTests(
-        this.tracer,
-        this.testConfiguration
-      )
+      const skippableTestsResponse =
+        skippableTestsRequestResponse || await getSkippableTests(this.tracer, this.testConfiguration)
       if (skippableTestsResponse.err) {
         log.error('Cypress skippable tests response error', skippableTestsResponse.err)
         this._pendingRequestErrorTags.push({ tag: DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS, value: 'true' })
@@ -839,19 +848,17 @@ class CypressPlugin {
     }
 
     if (this.isTestManagementTestsEnabled) {
-      const testManagementTestsResponse = await getTestManagementTests(
-        this.tracer,
-        this.testConfiguration
-      )
-      if (testManagementTestsResponse.err) {
-        log.error('Cypress test management tests response error', testManagementTestsResponse.err)
+      const currentTestManagementTestsResponse =
+        testManagementTestsResponse || await getTestManagementTests(this.tracer, this.testConfiguration)
+      if (currentTestManagementTestsResponse.err) {
+        log.error('Cypress test management tests response error', currentTestManagementTestsResponse.err)
         this._pendingRequestErrorTags.push({
           tag: DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS,
           value: 'true',
         })
         this.isTestManagementTestsEnabled = false
       } else {
-        this.testManagementTests = testManagementTestsResponse.testManagementTests
+        this.testManagementTests = currentTestManagementTestsResponse.testManagementTests
       }
     }
 

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -267,6 +267,87 @@ function getSessionItrSkippingEnabledTags (sessionSpan) {
   return {}
 }
 
+/**
+ * Starts supported test optimization requests together when each feature is enabled.
+ *
+ * @param {{
+ *   isKnownTestsEnabled: boolean,
+ *   isTestManagementTestsEnabled: boolean,
+ *   isSuitesSkippingEnabled?: boolean,
+ *   getKnownTests: () => Promise<object>,
+ *   getTestManagementTests: () => Promise<object>,
+ *   getSkippableSuites?: () => Promise<object>
+ * }} options - Test optimization request factories.
+ * @returns {Promise<{
+ *   knownTestsResponse?: object,
+ *   testManagementTestsResponse?: object,
+ *   skippableSuitesResponse?: object
+ * }>}
+ */
+function getTestOptimizationRequestResults ({
+  isKnownTestsEnabled,
+  isTestManagementTestsEnabled,
+  isSuitesSkippingEnabled,
+  getKnownTests,
+  getTestManagementTests,
+  getSkippableSuites,
+}) {
+  const requestPromises = []
+  const responseNames = []
+
+  if (isKnownTestsEnabled) {
+    addTestOptimizationRequest(requestPromises, responseNames, 'knownTestsResponse', getKnownTests)
+  }
+
+  if (isTestManagementTestsEnabled) {
+    addTestOptimizationRequest(
+      requestPromises,
+      responseNames,
+      'testManagementTestsResponse',
+      getTestManagementTests
+    )
+  }
+
+  if (isSuitesSkippingEnabled && getSkippableSuites) {
+    addTestOptimizationRequest(requestPromises, responseNames, 'skippableSuitesResponse', getSkippableSuites)
+  }
+
+  if (!requestPromises.length) {
+    return Promise.resolve({})
+  }
+
+  return Promise.allSettled(requestPromises).then(requestResults => {
+    const responses = {}
+
+    for (let index = 0; index < requestResults.length; index++) {
+      const requestResult = requestResults[index]
+      responses[responseNames[index]] = requestResult.status === 'fulfilled'
+        ? requestResult.value
+        : { err: requestResult.reason }
+    }
+
+    return responses
+  })
+}
+
+/**
+ * Starts a test optimization request.
+ *
+ * @param {Promise<object>[]} requestPromises - Test optimization request promises.
+ * @param {string[]} responseNames - Response keys matching request promises.
+ * @param {string} responseName - Response key for this request.
+ * @param {() => Promise<object>} getRequest - Test optimization request factory.
+ */
+function addTestOptimizationRequest (requestPromises, responseNames, responseName, getRequest) {
+  responseNames.push(responseName)
+
+  try {
+    requestPromises.push(Promise.resolve(getRequest()))
+  } catch (err) {
+    requestPromises.push(Promise.reject(err))
+  }
+}
+
 module.exports = {
   TEST_CODE_OWNERS,
   TEST_SESSION_NAME,
@@ -383,6 +464,7 @@ module.exports = {
   DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS,
   DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS,
   getSessionItrSkippingEnabledTags,
+  getTestOptimizationRequestResults,
   checkShaDiscrepancies,
   getPullRequestDiff,
   getPullRequestBaseBranch,

--- a/packages/dd-trace/test/plugins/util/test.spec.js
+++ b/packages/dd-trace/test/plugins/util/test.spec.js
@@ -34,6 +34,7 @@ const {
   formatAttemptToFixSummary,
   logAttemptToFixTestExecution,
   logTestOptimizationSummary,
+  getTestOptimizationRequestResults,
 } = require('../../../src/plugins/util/test')
 
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA, CI_PIPELINE_URL } = require('../../../src/plugins/util/tags')
@@ -41,6 +42,120 @@ const {
   TELEMETRY_GIT_COMMIT_SHA_DISCREPANCY,
   TELEMETRY_GIT_SHA_MATCH,
 } = require('../../../src/ci-visibility/telemetry')
+
+describe('getTestOptimizationRequestResults', () => {
+  it('starts known tests, test management, and skippable requests together when enabled', async () => {
+    const startedRequests = []
+    let resolveKnownTests
+    let resolveTestManagementTests
+    let resolveSkippableSuites
+
+    const getKnownTests = sinon.stub().callsFake(() => new Promise(resolve => {
+      startedRequests.push('known-tests')
+      resolveKnownTests = resolve
+    }))
+    const getTestManagementTests = sinon.stub().callsFake(() => new Promise(resolve => {
+      startedRequests.push('test-management-tests')
+      resolveTestManagementTests = resolve
+    }))
+    const getSkippableSuites = sinon.stub().callsFake(() => new Promise(resolve => {
+      startedRequests.push('skippable-suites')
+      resolveSkippableSuites = resolve
+    }))
+
+    const requestResultsPromise = getTestOptimizationRequestResults({
+      isKnownTestsEnabled: true,
+      isTestManagementTestsEnabled: true,
+      isSuitesSkippingEnabled: true,
+      getKnownTests,
+      getTestManagementTests,
+      getSkippableSuites,
+    })
+
+    assert.deepStrictEqual(startedRequests, ['known-tests', 'test-management-tests', 'skippable-suites'])
+    sinon.assert.calledOnce(getKnownTests)
+    sinon.assert.calledOnce(getTestManagementTests)
+    sinon.assert.calledOnce(getSkippableSuites)
+
+    resolveSkippableSuites({ skippableSuites: [] })
+    resolveTestManagementTests({ testManagementTests: { jest: {} } })
+    resolveKnownTests({ knownTests: { jest: {} } })
+
+    assert.deepStrictEqual(await requestResultsPromise, {
+      knownTestsResponse: { knownTests: { jest: {} } },
+      testManagementTestsResponse: { testManagementTests: { jest: {} } },
+      skippableSuitesResponse: { skippableSuites: [] },
+    })
+  })
+
+  it('starts each supported request only when its feature is enabled', async () => {
+    const getKnownTests = sinon.stub().resolves({ knownTests: { jest: {} } })
+    const getTestManagementTests = sinon.stub().resolves({ testManagementTests: { jest: {} } })
+    const getSkippableSuites = sinon.stub().resolves({ skippableSuites: [] })
+
+    const requestResults = await getTestOptimizationRequestResults({
+      isKnownTestsEnabled: true,
+      isTestManagementTestsEnabled: false,
+      isSuitesSkippingEnabled: true,
+      getKnownTests,
+      getTestManagementTests,
+      getSkippableSuites,
+    })
+
+    assert.deepStrictEqual(requestResults, {
+      knownTestsResponse: { knownTests: { jest: {} } },
+      skippableSuitesResponse: { skippableSuites: [] },
+    })
+
+    sinon.assert.calledOnce(getKnownTests)
+    sinon.assert.notCalled(getTestManagementTests)
+    sinon.assert.calledOnce(getSkippableSuites)
+  })
+
+  it('does not start skippable requests for frameworks without a skippable request factory', async () => {
+    const getKnownTests = sinon.stub()
+    const getTestManagementTests = sinon.stub()
+
+    assert.deepStrictEqual(
+      await getTestOptimizationRequestResults({
+        isKnownTestsEnabled: false,
+        isTestManagementTestsEnabled: false,
+        isSuitesSkippingEnabled: true,
+        getKnownTests,
+        getTestManagementTests,
+      }),
+      {}
+    )
+
+    sinon.assert.notCalled(getKnownTests)
+    sinon.assert.notCalled(getTestManagementTests)
+  })
+
+  it('uses successful responses when another request rejects before the caller awaits results', async () => {
+    const rejection = new Error('test optimization request failed')
+    const getKnownTests = sinon.stub().returns(new Promise(resolve => {
+      setImmediate(() => resolve({ knownTests: { jest: {} } }))
+    }))
+    const getTestManagementTests = sinon.stub().rejects(rejection)
+    const getSkippableSuites = sinon.stub().throws(rejection)
+
+    const requestResultsPromise = getTestOptimizationRequestResults({
+      isKnownTestsEnabled: true,
+      isTestManagementTestsEnabled: true,
+      isSuitesSkippingEnabled: true,
+      getKnownTests,
+      getTestManagementTests,
+      getSkippableSuites,
+    })
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    const requestResults = await requestResultsPromise
+    assert.deepStrictEqual(requestResults.knownTestsResponse, { knownTests: { jest: {} } })
+    assert.strictEqual(requestResults.testManagementTestsResponse.err, rejection)
+    assert.strictEqual(requestResults.skippableSuitesResponse.err, rejection)
+  })
+})
 
 describe('getTestParametersString', () => {
   it('returns formatted test parameters and removes params from input', () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Starts known-tests and test-management requests in parallel when both features are enabled, using a shared helper across Jest, Mocha, Cucumber, Vitest, Playwright, and Cypress.

Preserves the existing request flow when only one of the two features is enabled.

### Motivation
The requests are independent after library configuration is fetched, so running them sequentially adds avoidable startup latency to test optimization sessions.
