### PR TITLE
[test optimization] Stabilize Cypress intake payload waits

### DIFF
--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -135,77 +135,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
-            assert.strictEqual(testSuites.length, 1)
-            assert.strictEqual(testSuites[0].meta[TEST_STATUS], 'fail')
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 10)
-
-            assertObjectContains(tests.map(test => test.resource), [
-              'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
-              // passes at the second retry
-              'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              // never passes
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              // passes on the first try
-              'cypress/e2e/flaky-test-retries.js.flaky test retry always passes',
-            ])
-
-            const eventuallyPassingTest = tests.filter(
-              test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes'
-            )
-            assert.strictEqual(eventuallyPassingTest.length, 3)
-            assert.strictEqual(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 2)
-            assert.strictEqual(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
-            assert.strictEqual(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
-            assert.strictEqual(eventuallyPassingTest.filter(test =>
-              test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
-            ).length, 2)
-
-            const neverPassingTest = tests.filter(
-              test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry never passes'
-            )
-            assert.strictEqual(neverPassingTest.length, 6)
-            assert.strictEqual(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
-            assert.strictEqual(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
-            assert.strictEqual(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
-            assert.strictEqual(neverPassingTest.filter(
-              test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
-            ).length, 5)
-
-            // Verify execution order: retries happen right after the original test
-            const testExecutionOrder = tests.map(test => ({
-              name: test.meta[TEST_NAME],
-              isRetry: test.meta[TEST_IS_RETRY] === 'true',
-            }))
-
-            // Verify order for "flaky test retry eventually passes" (first 3)
-            for (let i = 0; i < 3; i++) {
-              assert.equal(testExecutionOrder[i].name, 'flaky test retry eventually passes')
-              assert.equal(testExecutionOrder[i].isRetry, i > 0)
-            }
-
-            // Verify order for "flaky test retry never passes" (next 6)
-            for (let i = 3; i < 9; i++) {
-              assert.equal(testExecutionOrder[i].name, 'flaky test retry never passes')
-              assert.equal(testExecutionOrder[i].isRetry, i > 3)
-            }
-
-            // Verify "flaky test retry always passes" comes last
-            assert.equal(testExecutionOrder[9].name, 'flaky test retry always passes')
-            assert.equal(testExecutionOrder[9].isRetry, false)
-          }, 30000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/flaky-test-retries.js'
@@ -221,6 +150,80 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+              assert.strictEqual(testSuites.length, 1)
+              assert.strictEqual(testSuites[0].meta[TEST_STATUS], 'fail')
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 10)
+
+              assertObjectContains(tests.map(test => test.resource), [
+                'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
+                // passes at the second retry
+                'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                // never passes
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                // passes on the first try
+                'cypress/e2e/flaky-test-retries.js.flaky test retry always passes',
+              ])
+
+              const eventuallyPassingTest = tests.filter(
+                test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes'
+              )
+              assert.strictEqual(eventuallyPassingTest.length, 3)
+              assert.strictEqual(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 2)
+              assert.strictEqual(eventuallyPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 1)
+              assert.strictEqual(eventuallyPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 2)
+              assert.strictEqual(eventuallyPassingTest.filter(test =>
+                test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+              ).length, 2)
+
+              const neverPassingTest = tests.filter(
+                test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry never passes'
+              )
+              assert.strictEqual(neverPassingTest.length, 6)
+              assert.strictEqual(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'fail').length, 6)
+              assert.strictEqual(neverPassingTest.filter(test => test.meta[TEST_STATUS] === 'pass').length, 0)
+              assert.strictEqual(neverPassingTest.filter(test => test.meta[TEST_IS_RETRY] === 'true').length, 5)
+              assert.strictEqual(neverPassingTest.filter(
+                test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr
+              ).length, 5)
+
+              // Verify execution order: retries happen right after the original test
+              const testExecutionOrder = tests.map(test => ({
+                name: test.meta[TEST_NAME],
+                isRetry: test.meta[TEST_IS_RETRY] === 'true',
+              }))
+
+              // Verify order for "flaky test retry eventually passes" (first 3)
+              for (let i = 0; i < 3; i++) {
+                assert.equal(testExecutionOrder[i].name, 'flaky test retry eventually passes')
+                assert.equal(testExecutionOrder[i].isRetry, i > 0)
+              }
+
+              // Verify order for "flaky test retry never passes" (next 6)
+              for (let i = 3; i < 9; i++) {
+                assert.equal(testExecutionOrder[i].name, 'flaky test retry never passes')
+                assert.equal(testExecutionOrder[i].isRetry, i > 3)
+              }
+
+              // Verify "flaky test retry always passes" comes last
+              assert.equal(testExecutionOrder[9].name, 'flaky test retry always passes')
+              assert.equal(testExecutionOrder[9].isRetry, false)
+            }, { hardTimeout: 30000 })
 
         // TODO: remove this once we have figured out flakiness
         childProcess.stdout?.pipe(process.stdout)
@@ -243,24 +246,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
-            assert.strictEqual(testSuites.length, 1)
-            assert.strictEqual(testSuites[0].meta[TEST_STATUS], 'fail')
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 3)
-
-            assertObjectContains(tests.map(test => test.resource), [
-              'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry always passes',
-            ])
-            assert.ok(!tests.some(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr))
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/flaky-test-retries.js'
@@ -277,6 +262,27 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+              assert.strictEqual(testSuites.length, 1)
+              assert.strictEqual(testSuites[0].meta[TEST_STATUS], 'fail')
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 3)
+
+              assertObjectContains(tests.map(test => test.resource), [
+                'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry always passes',
+              ])
+              assert.ok(!tests.some(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr))
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -295,30 +301,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
-            assert.strictEqual(testSuites.length, 1)
-            assert.strictEqual(testSuites[0].meta[TEST_STATUS], 'fail')
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 5)
-
-            assertObjectContains(tests.map(test => test.resource), [
-              'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
-              'cypress/e2e/flaky-test-retries.js.flaky test retry always passes',
-            ])
-
-            assert.strictEqual(
-              tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length,
-              2
-            )
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/flaky-test-retries.js'
@@ -335,6 +317,33 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testSuites = events.filter(event => event.type === 'test_suite_end').map(event => event.content)
+              assert.strictEqual(testSuites.length, 1)
+              assert.strictEqual(testSuites[0].meta[TEST_STATUS], 'fail')
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 5)
+
+              assertObjectContains(tests.map(test => test.resource), [
+                'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry eventually passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry never passes',
+                'cypress/e2e/flaky-test-retries.js.flaky test retry always passes',
+              ])
+
+              assert.strictEqual(
+                tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length,
+                2
+              )
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -354,22 +363,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            const neverPassingTests = tests.filter(
-              test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry never passes'
-            )
-            assert.strictEqual(neverPassingTests.length, 2, 'initial + 1 ATR retry')
-            const failedNeverPassing = neverPassingTests.filter(test => test.meta[TEST_STATUS] === 'fail')
-            assert.strictEqual(failedNeverPassing.length, 2)
-            const lastFailed = failedNeverPassing[failedNeverPassing.length - 1]
-            assert.strictEqual(lastFailed.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
-            assert.strictEqual(lastFailed.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/flaky-test-retries.js'
@@ -386,6 +379,25 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              const neverPassingTests = tests.filter(
+                test => test.resource === 'cypress/e2e/flaky-test-retries.js.flaky test retry never passes'
+              )
+              assert.strictEqual(neverPassingTests.length, 2, 'initial + 1 ATR retry')
+              const failedNeverPassing = neverPassingTests.filter(test => test.meta[TEST_STATUS] === 'fail')
+              assert.strictEqual(failedNeverPassing.length, 2)
+              const lastFailed = failedNeverPassing[failedNeverPassing.length - 1]
+              assert.strictEqual(lastFailed.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+              assert.strictEqual(lastFailed.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -404,19 +416,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            // Should only have 3 tests, no retries
-            assert.equal(tests.length, 3)
-
-            // No retries should occur when testIsolation is false
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 0)
-            assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length, 0)
-          }, 30000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/flaky-test-retries.js'
@@ -433,6 +432,22 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              // Should only have 3 tests, no retries
+              assert.equal(tests.length, 3)
+
+              // No retries should occur when testIsolation is false
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.equal(retriedTests.length, 0)
+              assert.equal(tests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.atr).length, 0)
+            }, { hardTimeout: 30000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -456,32 +471,6 @@ moduleTypes.forEach(({
 
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
-      const eventsPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const testEvent = events.find(event => event.type === 'test')
-          const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-          const eventSummary = JSON.stringify(events.map(event => ({
-            type: event.type,
-            resource: event.content.resource,
-            status: event.content.meta?.[TEST_STATUS],
-          })), null, 2)
-
-          assert.ok(testEvent, `expected a test event, got events: ${eventSummary}\nCypress output:\n${testOutput}`)
-          assert.ok(
-            testSuiteEvent,
-            `expected a test_suite_end event, got events: ${eventSummary}\nCypress output:\n${testOutput}`
-          )
-
-          const test = testEvent.content
-          const testSuite = testSuiteEvent.content
-          // The test is in a subproject
-          assert.notStrictEqual(test.meta[TEST_SOURCE_FILE], test.meta[TEST_SUITE])
-          assert.strictEqual(test.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
-          assert.strictEqual(testSuite.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
-        }, 60000)
-
       childProcess = exec(
         command,
         {
@@ -492,6 +481,35 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const eventsPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const testEvent = events.find(event => event.type === 'test')
+            const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+            const eventSummary = JSON.stringify(events.map(event => ({
+              type: event.type,
+              resource: event.content.resource,
+              status: event.content.meta?.[TEST_STATUS],
+            })), null, 2)
+
+            assert.ok(testEvent, `expected a test event, got events: ${eventSummary}\nCypress output:\n${testOutput}`)
+            assert.ok(
+              testSuiteEvent,
+            `expected a test_suite_end event, got events: ${eventSummary}\nCypress output:\n${testOutput}`
+            )
+
+            const test = testEvent.content
+            const testSuite = testSuiteEvent.content
+            // The test is in a subproject
+            assert.notStrictEqual(test.meta[TEST_SOURCE_FILE], test.meta[TEST_SUITE])
+            assert.strictEqual(test.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
+            assert.strictEqual(testSuite.meta[TEST_CODE_OWNERS], JSON.stringify(['@datadog-dd-trace-js']))
+          }, { hardTimeout: 60000 })
       childProcess.stdout?.on('data', chunk => {
         testOutput += chunk.toString()
       })
@@ -521,7 +539,22 @@ moduleTypes.forEach(({
         },
       })
 
-      const eventsPromise = receiver.gatherPayloadsMaxTimeout(
+      const specToRun = 'cypress/e2e/dynamic-name-test.cy.js'
+
+      childProcess = exec(
+        version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
+        {
+          cwd,
+          env: {
+            ...getCiVisEvpProxyConfig(receiver.port),
+            CYPRESS_BASE_URL: webAppBaseUrl,
+            SPEC_PATTERN: specToRun,
+          },
+        }
+      )
+
+      const eventsPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
         ({ url }) => url.endsWith('/api/v2/citestcycle'),
         (payloads) => {
           const events = payloads.flatMap(({ payload }) => payload.events)
@@ -542,21 +575,7 @@ moduleTypes.forEach(({
             assert.strictEqual(test.meta[TEST_IS_NEW], 'true')
           })
         },
-        25000
-      )
-
-      const specToRun = 'cypress/e2e/dynamic-name-test.cy.js'
-
-      childProcess = exec(
-        version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
-        {
-          cwd,
-          env: {
-            ...getCiVisEvpProxyConfig(receiver.port),
-            CYPRESS_BASE_URL: webAppBaseUrl,
-            SPEC_PATTERN: specToRun,
-          },
-        }
+        { hardTimeout: 25000 }
       )
 
       let testOutput = ''

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -143,34 +143,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 5)
-
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, NUM_RETRIES_EFD + 1)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD)
-
-            retriedTests.forEach((retriedTest) => {
-              assert.strictEqual(retriedTest.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
-            })
-
-            newTests.forEach(newTest => {
-              assert.strictEqual(newTest.resource, 'cypress/e2e/spec.cy.js.context passes')
-            })
-
-            const knownTest = tests.filter(test => !test.meta[TEST_IS_NEW])
-            assert.strictEqual(knownTest.length, 1)
-            assert.strictEqual(knownTest[0].resource, 'cypress/e2e/spec.cy.js.other context fails')
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
@@ -186,6 +158,37 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 5)
+
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, NUM_RETRIES_EFD + 1)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD)
+
+              retriedTests.forEach((retriedTest) => {
+                assert.strictEqual(retriedTest.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+              })
+
+              newTests.forEach(newTest => {
+                assert.strictEqual(newTest.resource, 'cypress/e2e/spec.cy.js.context passes')
+              })
+
+              const knownTest = tests.filter(test => !test.meta[TEST_IS_NEW])
+              assert.strictEqual(knownTest.length, 1)
+              assert.strictEqual(knownTest[0].resource, 'cypress/e2e/spec.cy.js.other context fails')
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -210,31 +213,6 @@ moduleTypes.forEach(({
           cypress: {},
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            const instantTests = tests.filter(test => test.resource ===
-              'cypress/e2e/efd-duration.cy.js.efd duration retries instant test'
-            )
-            assert.strictEqual(instantTests.length, 3)
-            assert.strictEqual(
-              instantTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd).length,
-              2
-            )
-
-            const slowTests = tests.filter(test => test.resource ===
-              'cypress/e2e/efd-duration.cy.js.efd duration retries slightly slow test'
-            )
-            assert.strictEqual(slowTests.length, 1)
-            assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
-            assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
-            assert.strictEqual(slowTests[0].meta[TEST_STATUS], 'pass')
-            assert.strictEqual(slowTests[0].meta[TEST_FINAL_STATUS], 'pass')
-            assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
-          }, 30_000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
         const specToRun = 'cypress/e2e/efd-duration.cy.js'
 
@@ -249,6 +227,34 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              const instantTests = tests.filter(test => test.resource ===
+              'cypress/e2e/efd-duration.cy.js.efd duration retries instant test'
+              )
+              assert.strictEqual(instantTests.length, 3)
+              assert.strictEqual(
+                instantTests.filter(test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd).length,
+                2
+              )
+
+              const slowTests = tests.filter(test => test.resource ===
+              'cypress/e2e/efd-duration.cy.js.efd duration retries slightly slow test'
+              )
+              assert.strictEqual(slowTests.length, 1)
+              assert.strictEqual(slowTests[0].meta[TEST_IS_NEW], 'true')
+              assert.strictEqual(slowTests[0].meta[TEST_EARLY_FLAKE_ABORT_REASON], 'slow')
+              assert.strictEqual(slowTests[0].meta[TEST_STATUS], 'pass')
+              assert.strictEqual(slowTests[0].meta[TEST_FINAL_STATUS], 'pass')
+              assert.ok(!(TEST_IS_RETRY in slowTests[0].meta))
+            }, { hardTimeout: 30_000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -278,23 +284,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 2)
-
-            // new tests are detected but not retried
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 1)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.strictEqual(retriedTests.length, 0)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-          }, 25000)
-
         const specToRun = 'cypress/e2e/spec.cy.js'
         childProcess = exec(
           version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
@@ -308,6 +297,26 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 2)
+
+              // new tests are detected but not retried
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, 1)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.strictEqual(retriedTests.length, 0)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -332,22 +341,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 1)
-
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 0)
-
-            assert.strictEqual(tests[0].resource, 'cypress/e2e/skipped-test.js.skipped skipped')
-            assert.strictEqual(tests[0].meta[TEST_STATUS], 'skip')
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
-          }, 25000)
-
         const specToRun = 'cypress/e2e/skipped-test.js'
 
         childProcess = exec(
@@ -361,6 +354,25 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 1)
+
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, 0)
+
+              assert.strictEqual(tests[0].resource, 'cypress/e2e/skipped-test.js.skipped skipped')
+              assert.strictEqual(tests[0].meta[TEST_STATUS], 'skip')
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -387,21 +399,6 @@ moduleTypes.forEach(({
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         // Request module waits before retrying; browser runs are slow — need longer gather timeout
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testSessionEnd = events.find(event => event.type === 'test_session_end')
-            assert.ok(testSessionEnd, 'expected test_session_end event in payloads')
-            const testSession = testSessionEnd.content
-            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 2)
-
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 0)
-          }, 60000)
-
         const specToRun = 'cypress/e2e/spec.cy.js'
 
         childProcess = exec(
@@ -415,6 +412,24 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testSessionEnd = events.find(event => event.type === 'test_session_end')
+              assert.ok(testSessionEnd, 'expected test_session_end event in payloads')
+              const testSession = testSessionEnd.content
+              assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 2)
+
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, 0)
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -440,23 +455,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 2)
-
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 0)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.strictEqual(retriedTests.length, 0)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-            assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
-          }, 60000)
-
         const specToRun = 'cypress/e2e/spec.cy.js'
 
         childProcess = exec(
@@ -470,6 +468,26 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 2)
+
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, 0)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.strictEqual(retriedTests.length, 0)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+              assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ABORT_REASON], 'faulty')
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -499,23 +517,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 2)
-
-            // new tests are not detected
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 0)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.strictEqual(retriedTests.length, 0)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-          }, 25000)
-
         const specToRun = 'cypress/e2e/spec.cy.js'
         childProcess = exec(
           version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
@@ -529,6 +530,26 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 2)
+
+              // new tests are not detected
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, 0)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.strictEqual(retriedTests.length, 0)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -557,23 +578,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            assert.strictEqual(tests.length, 2)
-
-            // new tests are not detected
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, 0)
-
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.strictEqual(retriedTests.length, 0)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-          }, 25000)
-
         const specToRun = 'cypress/e2e/spec.cy.js'
 
         childProcess = exec(
@@ -587,6 +591,26 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              assert.strictEqual(tests.length, 2)
+
+              // new tests are not detected
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, 0)
+
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.strictEqual(retriedTests.length, 0)
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -614,30 +638,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            // Should only have 2 tests, no retries
-            assert.equal(tests.length, 2)
-
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.equal(newTests.length, 1)
-
-            // No retries should occur when testIsolation is false
-            const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
-            assert.equal(retriedTests.length, 0)
-
-            newTests.forEach(newTest => {
-              assert.equal(newTest.resource, 'cypress/e2e/spec.cy.js.context passes')
-            })
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assertObjectContains(testSession.meta, {
-              [TEST_EARLY_FLAKE_ENABLED]: 'true',
-            })
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
@@ -654,6 +654,33 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              // Should only have 2 tests, no retries
+              assert.equal(tests.length, 2)
+
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.equal(newTests.length, 1)
+
+              // No retries should occur when testIsolation is false
+              const retriedTests = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+              assert.equal(retriedTests.length, 0)
+
+              newTests.forEach(newTest => {
+                assert.equal(newTest.resource, 'cypress/e2e/spec.cy.js.context passes')
+              })
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assertObjectContains(testSession.meta, {
+                [TEST_EARLY_FLAKE_ENABLED]: 'true',
+              })
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -682,59 +709,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // 1 known test + 1 new test with retries: 1 + (1 + 3) = 5 tests
-            assert.equal(tests.length, 5)
-
-            // Extract test execution order: [testName, isRetry]
-            const testExecutionOrder = tests.map(test => ({
-              name: test.meta[TEST_NAME],
-              isRetry: test.meta[TEST_IS_RETRY] === 'true',
-              isNew: test.meta[TEST_IS_NEW] === 'true',
-            }))
-
-            // Expected order:
-            // 1. "context passes" (original, known - not retried)
-            // 2. "other context fails" (original, new)
-            // 3. "other context fails" (retry 1)
-            // 4. "other context fails" (retry 2)
-            // 5. "other context fails" (retry 3)
-
-            assertObjectContains(testExecutionOrder, [
-              { name: 'context passes', isRetry: false, isNew: false },
-              { name: 'other context fails', isRetry: false, isNew: true },
-              { name: 'other context fails', isRetry: true, isNew: true },
-              { name: 'other context fails', isRetry: true, isNew: true },
-              { name: 'other context fails', isRetry: true, isNew: true },
-            ])
-
-            // Verify TEST_HAS_FAILED_ALL_RETRIES is set correctly
-            const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
-            assert.strictEqual(newTests.length, NUM_RETRIES_EFD + 1)
-
-            const testsWithFailedAllRetries = newTests.filter(
-              test => test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true'
-            )
-            assert.strictEqual(
-              testsWithFailedAllRetries.length,
-              1,
-              'Exactly one test should have TEST_HAS_FAILED_ALL_RETRIES set'
-            )
-            assert.strictEqual(newTests[newTests.length - 1].meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
-            for (let i = 0; i < newTests.length - 1; i++) {
-              assert.ok(!(TEST_HAS_FAILED_ALL_RETRIES in newTests[i].meta))
-            }
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assertObjectContains(testSession.meta, {
-              [TEST_EARLY_FLAKE_ENABLED]: 'true',
-            })
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
@@ -750,6 +724,62 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // 1 known test + 1 new test with retries: 1 + (1 + 3) = 5 tests
+              assert.equal(tests.length, 5)
+
+              // Extract test execution order: [testName, isRetry]
+              const testExecutionOrder = tests.map(test => ({
+                name: test.meta[TEST_NAME],
+                isRetry: test.meta[TEST_IS_RETRY] === 'true',
+                isNew: test.meta[TEST_IS_NEW] === 'true',
+              }))
+
+              // Expected order:
+              // 1. "context passes" (original, known - not retried)
+              // 2. "other context fails" (original, new)
+              // 3. "other context fails" (retry 1)
+              // 4. "other context fails" (retry 2)
+              // 5. "other context fails" (retry 3)
+
+              assertObjectContains(testExecutionOrder, [
+                { name: 'context passes', isRetry: false, isNew: false },
+                { name: 'other context fails', isRetry: false, isNew: true },
+                { name: 'other context fails', isRetry: true, isNew: true },
+                { name: 'other context fails', isRetry: true, isNew: true },
+                { name: 'other context fails', isRetry: true, isNew: true },
+              ])
+
+              // Verify TEST_HAS_FAILED_ALL_RETRIES is set correctly
+              const newTests = tests.filter(test => test.meta[TEST_IS_NEW] === 'true')
+              assert.strictEqual(newTests.length, NUM_RETRIES_EFD + 1)
+
+              const testsWithFailedAllRetries = newTests.filter(
+                test => test.meta[TEST_HAS_FAILED_ALL_RETRIES] === 'true'
+              )
+              assert.strictEqual(
+                testsWithFailedAllRetries.length,
+                1,
+                'Exactly one test should have TEST_HAS_FAILED_ALL_RETRIES set'
+              )
+              assert.strictEqual(newTests[newTests.length - 1].meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+              for (let i = 0; i < newTests.length - 1; i++) {
+                assert.ok(!(TEST_HAS_FAILED_ALL_RETRIES in newTests[i].meta))
+              }
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assertObjectContains(testSession.meta, {
+                [TEST_EARLY_FLAKE_ENABLED]: 'true',
+              })
+            }, { hardTimeout: 25000 })
 
         childProcess.stdout?.on('data', (data) => {
           testOutput += data.toString()

--- a/integration-tests/cypress/cypress-final-status.spec.js
+++ b/integration-tests/cypress/cypress-final-status.spec.js
@@ -132,48 +132,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/{spec.cy,skipped-test,hook-describe-error.cy}.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // Every test's final status should match its actual status
-            tests.forEach(test => {
-              assert.strictEqual(
-                test.meta[TEST_FINAL_STATUS],
-                test.meta[TEST_STATUS],
-                `Expected TEST_FINAL_STATUS to match TEST_STATUS for "${test.meta[TEST_NAME]}"`
-              )
-            })
-
-            // Verify each status type explicitly
-            const passingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.context passes')
-            assert.ok(passingTest, 'passing test not found')
-            assert.strictEqual(passingTest.meta[TEST_FINAL_STATUS], 'pass')
-
-            const failingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.other context fails')
-            assert.ok(failingTest, 'failing test not found')
-            assert.strictEqual(failingTest.meta[TEST_FINAL_STATUS], 'fail')
-
-            const skippedTest = tests.find(t => t.resource === 'cypress/e2e/skipped-test.js.skipped skipped')
-            assert.ok(skippedTest, 'skipped test not found')
-            assert.strictEqual(skippedTest.meta[TEST_FINAL_STATUS], 'skip')
-
-            // Hooks: after() failure retroactively marks the last test in the suite as failed
-            const afterHookFailed = tests.find(t =>
-              t.resource === 'cypress/e2e/hook-describe-error.cy.js.after will be marked as failed'
-            )
-            assert.ok(afterHookFailed, 'test with failing after() not found')
-            assert.strictEqual(afterHookFailed.meta[TEST_FINAL_STATUS], 'fail')
-
-            // Hooks: before() failure causes tests in the suite to be skipped
-            const beforeHookSkipped = tests.find(t =>
-              t.resource === 'cypress/e2e/hook-describe-error.cy.js.before will be skipped'
-            )
-            assert.ok(beforeHookSkipped, 'test skipped by before() not found')
-            assert.strictEqual(beforeHookSkipped.meta[TEST_FINAL_STATUS], 'skip')
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -187,6 +145,51 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // Every test's final status should match its actual status
+              tests.forEach(test => {
+                assert.strictEqual(
+                  test.meta[TEST_FINAL_STATUS],
+                  test.meta[TEST_STATUS],
+                `Expected TEST_FINAL_STATUS to match TEST_STATUS for "${test.meta[TEST_NAME]}"`
+                )
+              })
+
+              // Verify each status type explicitly
+              const passingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.context passes')
+              assert.ok(passingTest, 'passing test not found')
+              assert.strictEqual(passingTest.meta[TEST_FINAL_STATUS], 'pass')
+
+              const failingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.other context fails')
+              assert.ok(failingTest, 'failing test not found')
+              assert.strictEqual(failingTest.meta[TEST_FINAL_STATUS], 'fail')
+
+              const skippedTest = tests.find(t => t.resource === 'cypress/e2e/skipped-test.js.skipped skipped')
+              assert.ok(skippedTest, 'skipped test not found')
+              assert.strictEqual(skippedTest.meta[TEST_FINAL_STATUS], 'skip')
+
+              // Hooks: after() failure retroactively marks the last test in the suite as failed
+              const afterHookFailed = tests.find(t =>
+                t.resource === 'cypress/e2e/hook-describe-error.cy.js.after will be marked as failed'
+              )
+              assert.ok(afterHookFailed, 'test with failing after() not found')
+              assert.strictEqual(afterHookFailed.meta[TEST_FINAL_STATUS], 'fail')
+
+              // Hooks: before() failure causes tests in the suite to be skipped
+              const beforeHookSkipped = tests.find(t =>
+                t.resource === 'cypress/e2e/hook-describe-error.cy.js.before will be skipped'
+              )
+              assert.ok(beforeHookSkipped, 'test skipped by before() not found')
+              assert.strictEqual(beforeHookSkipped.meta[TEST_FINAL_STATUS], 'skip')
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -224,50 +227,6 @@ moduleTypes.forEach(({
 
           const specToRun = 'cypress/e2e/{flaky-test-retries,flaky-with-hooks.cy}.js'
 
-          const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-              const sortByStart = arr =>
-                arr.slice().sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
-
-              // Eventually-passing and always-failing tests are retried by ATR:
-              // only the last attempt should have TEST_FINAL_STATUS
-              for (const [suite, name] of [
-                ['cypress/e2e/flaky-test-retries.js', 'flaky test retry eventually passes'],
-                ['cypress/e2e/flaky-test-retries.js', 'flaky test retry never passes'],
-                ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks eventually passes'],
-                ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks never passes'],
-              ]) {
-                const group = sortByStart(tests.filter(t =>
-                  t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
-                ))
-                assert.ok(group.length > 1, `Expected ATR retries for "${name}"`)
-                group.forEach((test, idx) => {
-                  if (idx < group.length - 1) {
-                    assert.ok(!(TEST_FINAL_STATUS in test.meta),
-                      `TEST_FINAL_STATUS should not be set on intermediate run of "${name}"`)
-                  } else {
-                    assert.ok(TEST_FINAL_STATUS in test.meta,
-                      `TEST_FINAL_STATUS should be set on last run of "${name}"`)
-                  }
-                })
-              }
-
-              // Always-passing tests have a single execution and get TEST_FINAL_STATUS immediately
-              for (const [suite, name] of [
-                ['cypress/e2e/flaky-test-retries.js', 'flaky test retry always passes'],
-                ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks always passes'],
-              ]) {
-                const group = tests.filter(t =>
-                  t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
-                )
-                assert.strictEqual(group.length, 1, `Expected 1 execution for "${name}"`)
-                assert.strictEqual(group[0].meta[TEST_FINAL_STATUS], 'pass')
-              }
-            }, 60000)
-
           const envVars = getCiVisEvpProxyConfig(receiver.port)
 
           childProcess = exec(
@@ -281,6 +240,53 @@ moduleTypes.forEach(({
               },
             }
           )
+
+          const eventsPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+                const sortByStart = arr =>
+                  arr.slice().sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+                // Eventually-passing and always-failing tests are retried by ATR:
+                // only the last attempt should have TEST_FINAL_STATUS
+                for (const [suite, name] of [
+                  ['cypress/e2e/flaky-test-retries.js', 'flaky test retry eventually passes'],
+                  ['cypress/e2e/flaky-test-retries.js', 'flaky test retry never passes'],
+                  ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks eventually passes'],
+                  ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks never passes'],
+                ]) {
+                  const group = sortByStart(tests.filter(t =>
+                    t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
+                  ))
+                  assert.ok(group.length > 1, `Expected ATR retries for "${name}"`)
+                  group.forEach((test, idx) => {
+                    if (idx < group.length - 1) {
+                      assert.ok(!(TEST_FINAL_STATUS in test.meta),
+                      `TEST_FINAL_STATUS should not be set on intermediate run of "${name}"`)
+                    } else {
+                      assert.ok(TEST_FINAL_STATUS in test.meta,
+                      `TEST_FINAL_STATUS should be set on last run of "${name}"`)
+                    }
+                  })
+                }
+
+                // Always-passing tests have a single execution and get TEST_FINAL_STATUS immediately
+                for (const [suite, name] of [
+                  ['cypress/e2e/flaky-test-retries.js', 'flaky test retry always passes'],
+                  ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks always passes'],
+                ]) {
+                  const group = tests.filter(t =>
+                    t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
+                  )
+                  assert.strictEqual(group.length, 1, `Expected 1 execution for "${name}"`)
+                  assert.strictEqual(group[0].meta[TEST_FINAL_STATUS], 'pass')
+                }
+              }, { hardTimeout: 60000 })
 
           await Promise.all([
             once(childProcess, 'exit'),
@@ -308,50 +314,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/{spec,flaky-with-hooks}.cy.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            const sortByStart = arr =>
-              arr.slice().sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
-
-            // Known test: single execution, TEST_FINAL_STATUS set immediately
-            const knownTests = tests.filter(t =>
-              t.meta[TEST_SUITE] === 'cypress/e2e/spec.cy.js' && t.meta[TEST_NAME] === 'other context fails'
-            )
-            assert.strictEqual(knownTests.length, 1)
-            assert.ok(!(TEST_IS_NEW in knownTests[0].meta))
-            assert.strictEqual(knownTests[0].meta[TEST_FINAL_STATUS], 'fail')
-
-            // New test (no hooks): EFD retries NUM_RETRIES_EFD times, only last has TEST_FINAL_STATUS
-            const newTests = sortByStart(tests.filter(t =>
-              t.meta[TEST_SUITE] === 'cypress/e2e/spec.cy.js' && t.meta[TEST_NAME] === 'context passes'
-            ))
-            assert.strictEqual(newTests.length, NUM_RETRIES_EFD + 1)
-            newTests.forEach((test, idx) => {
-              if (idx < newTests.length - 1) {
-                assert.ok(!(TEST_FINAL_STATUS in test.meta))
-              } else {
-                assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'pass')
-              }
-            })
-
-            // New tests with hooks: same — only last execution has TEST_FINAL_STATUS
-            const newTestsWithHooks = sortByStart(tests.filter(t =>
-              t.meta[TEST_SUITE] === 'cypress/e2e/flaky-with-hooks.cy.js' &&
-              t.meta[TEST_NAME] === 'flaky with hooks always passes'
-            ))
-            assert.strictEqual(newTestsWithHooks.length, NUM_RETRIES_EFD + 1)
-            newTestsWithHooks.forEach((test, idx) => {
-              if (idx < newTestsWithHooks.length - 1) {
-                assert.ok(!(TEST_FINAL_STATUS in test.meta))
-              } else {
-                assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'pass')
-              }
-            })
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -365,6 +327,53 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              const sortByStart = arr =>
+                arr.slice().sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              // Known test: single execution, TEST_FINAL_STATUS set immediately
+              const knownTests = tests.filter(t =>
+                t.meta[TEST_SUITE] === 'cypress/e2e/spec.cy.js' && t.meta[TEST_NAME] === 'other context fails'
+              )
+              assert.strictEqual(knownTests.length, 1)
+              assert.ok(!(TEST_IS_NEW in knownTests[0].meta))
+              assert.strictEqual(knownTests[0].meta[TEST_FINAL_STATUS], 'fail')
+
+              // New test (no hooks): EFD retries NUM_RETRIES_EFD times, only last has TEST_FINAL_STATUS
+              const newTests = sortByStart(tests.filter(t =>
+                t.meta[TEST_SUITE] === 'cypress/e2e/spec.cy.js' && t.meta[TEST_NAME] === 'context passes'
+              ))
+              assert.strictEqual(newTests.length, NUM_RETRIES_EFD + 1)
+              newTests.forEach((test, idx) => {
+                if (idx < newTests.length - 1) {
+                  assert.ok(!(TEST_FINAL_STATUS in test.meta))
+                } else {
+                  assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'pass')
+                }
+              })
+
+              // New tests with hooks: same — only last execution has TEST_FINAL_STATUS
+              const newTestsWithHooks = sortByStart(tests.filter(t =>
+                t.meta[TEST_SUITE] === 'cypress/e2e/flaky-with-hooks.cy.js' &&
+              t.meta[TEST_NAME] === 'flaky with hooks always passes'
+              ))
+              assert.strictEqual(newTestsWithHooks.length, NUM_RETRIES_EFD + 1)
+              newTestsWithHooks.forEach((test, idx) => {
+                if (idx < newTestsWithHooks.length - 1) {
+                  assert.ok(!(TEST_FINAL_STATUS in test.meta))
+                } else {
+                  assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'pass')
+                }
+              })
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -383,61 +392,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/{flaky-test-retries,flaky-with-hooks.cy}.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            const sortByStart = arr =>
-              arr.slice().sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
-
-            // Eventually-passing tests: final_status='pass' only on last ATR attempt
-            for (const [suite, name] of [
-              ['cypress/e2e/flaky-test-retries.js', 'flaky test retry eventually passes'],
-              ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks eventually passes'],
-            ]) {
-              const group = sortByStart(tests.filter(t =>
-                t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
-              ))
-              group.forEach((test, idx) => {
-                if (idx < group.length - 1) {
-                  assert.ok(!(TEST_FINAL_STATUS in test.meta))
-                } else {
-                  assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'pass')
-                }
-              })
-            }
-
-            // Always-failing tests: final_status='fail' only on last ATR attempt
-            for (const [suite, name] of [
-              ['cypress/e2e/flaky-test-retries.js', 'flaky test retry never passes'],
-              ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks never passes'],
-            ]) {
-              const group = sortByStart(tests.filter(t =>
-                t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
-              ))
-              group.forEach((test, idx) => {
-                if (idx < group.length - 1) {
-                  assert.ok(!(TEST_FINAL_STATUS in test.meta))
-                } else {
-                  assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'fail')
-                }
-              })
-            }
-
-            // Always-passing tests have a single execution — final_status='pass' immediately
-            for (const [suite, name] of [
-              ['cypress/e2e/flaky-test-retries.js', 'flaky test retry always passes'],
-              ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks always passes'],
-            ]) {
-              const group = tests.filter(t =>
-                t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
-              )
-              assert.strictEqual(group.length, 1)
-              assert.strictEqual(group[0].meta[TEST_FINAL_STATUS], 'pass')
-            }
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -451,6 +405,64 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              const sortByStart = arr =>
+                arr.slice().sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              // Eventually-passing tests: final_status='pass' only on last ATR attempt
+              for (const [suite, name] of [
+                ['cypress/e2e/flaky-test-retries.js', 'flaky test retry eventually passes'],
+                ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks eventually passes'],
+              ]) {
+                const group = sortByStart(tests.filter(t =>
+                  t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
+                ))
+                group.forEach((test, idx) => {
+                  if (idx < group.length - 1) {
+                    assert.ok(!(TEST_FINAL_STATUS in test.meta))
+                  } else {
+                    assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'pass')
+                  }
+                })
+              }
+
+              // Always-failing tests: final_status='fail' only on last ATR attempt
+              for (const [suite, name] of [
+                ['cypress/e2e/flaky-test-retries.js', 'flaky test retry never passes'],
+                ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks never passes'],
+              ]) {
+                const group = sortByStart(tests.filter(t =>
+                  t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
+                ))
+                group.forEach((test, idx) => {
+                  if (idx < group.length - 1) {
+                    assert.ok(!(TEST_FINAL_STATUS in test.meta))
+                  } else {
+                    assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'fail')
+                  }
+                })
+              }
+
+              // Always-passing tests have a single execution — final_status='pass' immediately
+              for (const [suite, name] of [
+                ['cypress/e2e/flaky-test-retries.js', 'flaky test retry always passes'],
+                ['cypress/e2e/flaky-with-hooks.cy.js', 'flaky with hooks always passes'],
+              ]) {
+                const group = tests.filter(t =>
+                  t.meta[TEST_SUITE] === suite && t.meta[TEST_NAME] === name
+                )
+                assert.strictEqual(group.length, 1)
+                assert.strictEqual(group[0].meta[TEST_FINAL_STATUS], 'pass')
+              }
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -469,24 +481,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/spec.cy.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            assert.strictEqual(tests.length, 2, 'Expected no retries when flaky retry count is 0')
-
-            const passingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.context passes')
-            assert.ok(passingTest, 'passing test not found')
-            assert.strictEqual(passingTest.meta[TEST_FINAL_STATUS], 'pass')
-
-            const failingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.other context fails')
-            assert.ok(failingTest, 'failing test not found')
-            assert.strictEqual(failingTest.meta[TEST_STATUS], 'fail')
-            assert.ok(!(TEST_IS_RETRY in failingTest.meta), 'failing test should not be marked as a retry')
-            assert.strictEqual(failingTest.meta[TEST_FINAL_STATUS], 'fail')
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -501,6 +495,27 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              assert.strictEqual(tests.length, 2, 'Expected no retries when flaky retry count is 0')
+
+              const passingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.context passes')
+              assert.ok(passingTest, 'passing test not found')
+              assert.strictEqual(passingTest.meta[TEST_FINAL_STATUS], 'pass')
+
+              const failingTest = tests.find(t => t.resource === 'cypress/e2e/spec.cy.js.other context fails')
+              assert.ok(failingTest, 'failing test not found')
+              assert.strictEqual(failingTest.meta[TEST_STATUS], 'fail')
+              assert.ok(!(TEST_IS_RETRY in failingTest.meta), 'failing test should not be marked as a retry')
+              assert.strictEqual(failingTest.meta[TEST_FINAL_STATUS], 'fail')
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -529,24 +544,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/{disable,test-management-with-hooks.cy}.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            const disabledTest = tests.find(t => t.meta[TEST_NAME] === 'disable is disabled')
-            assert.ok(disabledTest)
-            assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
-            assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
-            assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
-
-            const disabledWithHooks = tests.find(t => t.meta[TEST_NAME] === 'disabled with hooks is disabled')
-            assert.ok(disabledWithHooks)
-            assert.strictEqual(disabledWithHooks.meta[TEST_STATUS], 'skip')
-            assert.strictEqual(disabledWithHooks.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
-            assert.strictEqual(disabledWithHooks.meta[TEST_FINAL_STATUS], 'skip')
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -560,6 +557,27 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              const disabledTest = tests.find(t => t.meta[TEST_NAME] === 'disable is disabled')
+              assert.ok(disabledTest)
+              assert.strictEqual(disabledTest.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(disabledTest.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+              assert.strictEqual(disabledTest.meta[TEST_FINAL_STATUS], 'skip')
+
+              const disabledWithHooks = tests.find(t => t.meta[TEST_NAME] === 'disabled with hooks is disabled')
+              assert.ok(disabledWithHooks)
+              assert.strictEqual(disabledWithHooks.meta[TEST_STATUS], 'skip')
+              assert.strictEqual(disabledWithHooks.meta[TEST_MANAGEMENT_IS_DISABLED], 'true')
+              assert.strictEqual(disabledWithHooks.meta[TEST_FINAL_STATUS], 'skip')
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -588,36 +606,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/{quarantine,test-management-with-hooks.cy}.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // Quarantined: runs but failure suppressed → TEST_STATUS='fail', TEST_FINAL_STATUS='skip'
-            const quarantinedTest = tests.find(t => t.meta[TEST_NAME] === 'quarantine is quarantined')
-            assert.ok(quarantinedTest)
-            assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'fail')
-            assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
-            assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
-
-            // Quarantined with hooks: same behavior
-            const quarantinedWithHooks = tests.find(t =>
-              t.meta[TEST_NAME] === 'quarantined with hooks is quarantined'
-            )
-            assert.ok(quarantinedWithHooks)
-            assert.strictEqual(quarantinedWithHooks.meta[TEST_STATUS], 'fail')
-            assert.strictEqual(quarantinedWithHooks.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
-            assert.strictEqual(quarantinedWithHooks.meta[TEST_FINAL_STATUS], 'skip')
-
-            // Non-quarantined test with hooks: final_status='pass'
-            const passingWithHooks = tests.find(t =>
-              t.meta[TEST_NAME] === 'quarantined with hooks passes normally'
-            )
-            assert.ok(passingWithHooks)
-            assert.strictEqual(passingWithHooks.meta[TEST_STATUS], 'pass')
-            assert.strictEqual(passingWithHooks.meta[TEST_FINAL_STATUS], 'pass')
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -631,6 +619,39 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // Quarantined: runs but failure suppressed → TEST_STATUS='fail', TEST_FINAL_STATUS='skip'
+              const quarantinedTest = tests.find(t => t.meta[TEST_NAME] === 'quarantine is quarantined')
+              assert.ok(quarantinedTest)
+              assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+              assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
+
+              // Quarantined with hooks: same behavior
+              const quarantinedWithHooks = tests.find(t =>
+                t.meta[TEST_NAME] === 'quarantined with hooks is quarantined'
+              )
+              assert.ok(quarantinedWithHooks)
+              assert.strictEqual(quarantinedWithHooks.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(quarantinedWithHooks.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+              assert.strictEqual(quarantinedWithHooks.meta[TEST_FINAL_STATUS], 'skip')
+
+              // Non-quarantined test with hooks: final_status='pass'
+              const passingWithHooks = tests.find(t =>
+                t.meta[TEST_NAME] === 'quarantined with hooks passes normally'
+              )
+              assert.ok(passingWithHooks)
+              assert.strictEqual(passingWithHooks.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(passingWithHooks.meta[TEST_FINAL_STATUS], 'pass')
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -656,21 +677,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/test-management-with-hooks.cy.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // Test body passes but afterEach throws; failure suppressed because test is quarantined
-            const quarantinedTest = tests.find(t =>
-              t.meta[TEST_NAME] === 'quarantined with failing afterEach is quarantined'
-            )
-            assert.ok(quarantinedTest)
-            assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'fail')
-            assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
-            assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -684,6 +690,24 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // Test body passes but afterEach throws; failure suppressed because test is quarantined
+              const quarantinedTest = tests.find(t =>
+                t.meta[TEST_NAME] === 'quarantined with failing afterEach is quarantined'
+              )
+              assert.ok(quarantinedTest)
+              assert.strictEqual(quarantinedTest.meta[TEST_STATUS], 'fail')
+              assert.strictEqual(quarantinedTest.meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+              assert.strictEqual(quarantinedTest.meta[TEST_FINAL_STATUS], 'skip')
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -711,27 +735,6 @@ moduleTypes.forEach(({
 
         const specToRun = 'cypress/e2e/attempt-to-fix.js'
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // 1 original + 3 ATF retries = 4 executions; all fail (default behavior)
-            const atfTests = tests.filter(t => t.meta[TEST_NAME] === 'attempt to fix is attempt to fix')
-            assert.strictEqual(atfTests.length, 4)
-
-            const sorted = atfTests.sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
-            sorted.forEach((test, idx) => {
-              if (idx < sorted.length - 1) {
-                assert.ok(!(TEST_FINAL_STATUS in test.meta),
-                  `TEST_FINAL_STATUS should not be set on intermediate ATF run ${idx}`)
-              } else {
-                // All attempts failed → hasPassedAllRetries=false → final_status='fail'
-                assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'fail')
-              }
-            })
-          }, 60000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         childProcess = exec(
@@ -745,6 +748,30 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // 1 original + 3 ATF retries = 4 executions; all fail (default behavior)
+              const atfTests = tests.filter(t => t.meta[TEST_NAME] === 'attempt to fix is attempt to fix')
+              assert.strictEqual(atfTests.length, 4)
+
+              const sorted = atfTests.sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+              sorted.forEach((test, idx) => {
+                if (idx < sorted.length - 1) {
+                  assert.ok(!(TEST_FINAL_STATUS in test.meta),
+                  `TEST_FINAL_STATUS should not be set on intermediate ATF run ${idx}`)
+                } else {
+                // All attempts failed → hasPassedAllRetries=false → final_status='fail'
+                  assert.strictEqual(test.meta[TEST_FINAL_STATUS], 'fail')
+                }
+              })
+            }, { hardTimeout: 60000 })
 
         await Promise.all([
           once(childProcess, 'exit'),

--- a/integration-tests/cypress/cypress-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-impacted-tests.spec.js
@@ -133,27 +133,6 @@ moduleTypes.forEach(({
 
     context('libraries capabilities', () => {
       it('adds capabilities to tests', async () => {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-            const metadataDicts = payloads
-              .filter(({ payload }) => payload.metadata?.test)
-              .flatMap(({ payload }) => payload.metadata)
-
-            assert.ok(metadataDicts.length > 0)
-            metadataDicts.forEach(metadata => {
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_IMPACT_ANALYSIS], '1')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_EARLY_FLAKE_DETECTION], '1')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_IMPACTED_TESTS], '1')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '5')
-              assert.strictEqual(metadata.test[DD_CAPABILITIES_FAILED_TEST_REPLAY], '1')
-              // capabilities logic does not overwrite test session name
-              assert.strictEqual(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
-            })
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/spec.cy.js'
@@ -170,6 +149,30 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const metadataDicts = payloads
+                .filter(({ payload }) => payload.metadata?.test)
+                .flatMap(({ payload }) => payload.metadata)
+
+              assert.ok(metadataDicts.length > 0)
+              metadataDicts.forEach(metadata => {
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_IMPACT_ANALYSIS], '1')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_EARLY_FLAKE_DETECTION], '1')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_AUTO_TEST_RETRIES], '1')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_IMPACTED_TESTS], '1')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_QUARANTINE], '1')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_DISABLE], '1')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_TEST_MANAGEMENT_ATTEMPT_TO_FIX], '5')
+                assert.strictEqual(metadata.test[DD_CAPABILITIES_FAILED_TEST_REPLAY], '1')
+                // capabilities logic does not overwrite test session name
+                assert.strictEqual(metadata.test[TEST_SESSION_NAME], 'my-test-session-name')
+              })
+            }, { hardTimeout: 25000 })
 
         // TODO: remove this once we have figured out flakiness
         childProcess.stdout?.pipe(process.stdout)
@@ -223,77 +226,78 @@ moduleTypes.forEach(({
         execSync('git branch -D feature-branch', { cwd, stdio: 'ignore' })
       })
 
-      const getTestAssertions = ({ isModified, isEfd, isNew }) =>
+      const getTestAssertions = ({ isModified, isEfd, isNew }, childProcess) =>
         receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            const testSession = events.find(event => event.type === 'test_session_end').content
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const testSession = events.find(event => event.type === 'test_session_end').content
 
-            if (isEfd) {
-              assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
-            } else {
-              assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
-            }
+              if (isEfd) {
+                assert.strictEqual(testSession.meta[TEST_EARLY_FLAKE_ENABLED], 'true')
+              } else {
+                assert.ok(!(TEST_EARLY_FLAKE_ENABLED in testSession.meta))
+              }
 
-            const resourceNames = tests.map(span => span.resource)
+              const resourceNames = tests.map(span => span.resource)
 
-            assertObjectContains(resourceNames,
-              [
-                'cypress/e2e/impacted-test.js.impacted test is impacted test',
-              ]
-            )
+              assertObjectContains(resourceNames,
+                [
+                  'cypress/e2e/impacted-test.js.impacted test is impacted test',
+                ]
+              )
 
-            const impactedTests = tests.filter(test =>
-              test.meta[TEST_SOURCE_FILE] === 'cypress/e2e/impacted-test.js' &&
+              const impactedTests = tests.filter(test =>
+                test.meta[TEST_SOURCE_FILE] === 'cypress/e2e/impacted-test.js' &&
               test.meta[TEST_NAME] === 'impacted test is impacted test')
 
-            if (isEfd) {
-              assert.strictEqual(impactedTests.length, NUM_RETRIES_EFD + 1) // Retries + original test
-            } else {
-              assert.strictEqual(impactedTests.length, 1)
-            }
-
-            for (const impactedTest of impactedTests) {
-              if (isModified) {
-                assert.strictEqual(impactedTest.meta[TEST_IS_MODIFIED], 'true')
+              if (isEfd) {
+                assert.strictEqual(impactedTests.length, NUM_RETRIES_EFD + 1) // Retries + original test
               } else {
-                assert.ok(!(TEST_IS_MODIFIED in impactedTest.meta))
+                assert.strictEqual(impactedTests.length, 1)
               }
-              if (isNew) {
-                assert.strictEqual(impactedTest.meta[TEST_IS_NEW], 'true')
-              } else {
-                assert.ok(!(TEST_IS_NEW in impactedTest.meta))
-              }
-            }
 
-            if (isEfd) {
-              const retriedTests = tests.filter(
-                test => test.meta[TEST_IS_RETRY] === 'true' &&
+              for (const impactedTest of impactedTests) {
+                if (isModified) {
+                  assert.strictEqual(impactedTest.meta[TEST_IS_MODIFIED], 'true')
+                } else {
+                  assert.ok(!(TEST_IS_MODIFIED in impactedTest.meta))
+                }
+                if (isNew) {
+                  assert.strictEqual(impactedTest.meta[TEST_IS_NEW], 'true')
+                } else {
+                  assert.ok(!(TEST_IS_NEW in impactedTest.meta))
+                }
+              }
+
+              if (isEfd) {
+                const retriedTests = tests.filter(
+                  test => test.meta[TEST_IS_RETRY] === 'true' &&
                 test.meta[TEST_NAME] === 'impacted test is impacted test'
-              )
-              assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD)
-              let retriedTestNew = 0
-              let retriedTestsWithReason = 0
-              retriedTests.forEach(test => {
-                if (test.meta[TEST_IS_NEW] === 'true') {
-                  retriedTestNew++
-                }
-                if (test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd) {
-                  retriedTestsWithReason++
-                }
-              })
-              assert.strictEqual(retriedTestNew, isNew ? NUM_RETRIES_EFD : 0)
-              assert.strictEqual(retriedTestsWithReason, NUM_RETRIES_EFD)
-            }
-          }, 25000)
+                )
+                assert.strictEqual(retriedTests.length, NUM_RETRIES_EFD)
+                let retriedTestNew = 0
+                let retriedTestsWithReason = 0
+                retriedTests.forEach(test => {
+                  if (test.meta[TEST_IS_NEW] === 'true') {
+                    retriedTestNew++
+                  }
+                  if (test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.efd) {
+                    retriedTestsWithReason++
+                  }
+                })
+                assert.strictEqual(retriedTestNew, isNew ? NUM_RETRIES_EFD : 0)
+                assert.strictEqual(retriedTestsWithReason, NUM_RETRIES_EFD)
+              }
+            }, 25000)
 
       const runImpactedTest = async (
         { isModified, isEfd = false, isNew = false },
         extraEnvVars = {}
       ) => {
-        const testAssertionsPromise = getTestAssertions({ isModified, isEfd, isNew })
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/impacted-test.js'
@@ -311,6 +315,8 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const testAssertionsPromise = getTestAssertions({ isModified, isEfd, isNew }, childProcess)
 
         // TODO: remove this once we have figured out flakiness
         childProcess.stdout?.pipe(process.stdout)
@@ -379,37 +385,6 @@ moduleTypes.forEach(({
           known_tests_enabled: true,
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            const testSession = events.find(event => event.type === 'test_session_end').content
-
-            assertObjectContains(testSession.meta, {
-              [TEST_EARLY_FLAKE_ENABLED]: 'true',
-            })
-
-            const impactedTests = tests.filter(test =>
-              test.meta[TEST_SOURCE_FILE] === 'cypress/e2e/impacted-test.js' &&
-              test.meta[TEST_NAME] === 'impacted test is impacted test')
-
-            // Should only have 1 test, no retries when testIsolation is false
-            assert.equal(impactedTests.length, 1)
-
-            for (const impactedTest of impactedTests) {
-              assertObjectContains(impactedTest.meta, {
-                [TEST_IS_MODIFIED]: 'true',
-              })
-            }
-
-            // No retries should occur when testIsolation is false
-            const retriedTests = tests.filter(
-              test => test.meta[TEST_IS_RETRY] === 'true' &&
-              test.meta[TEST_NAME] === 'impacted test is impacted test'
-            )
-            assert.equal(retriedTests.length, 0)
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/impacted-test.js'
@@ -427,6 +402,40 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const testSession = events.find(event => event.type === 'test_session_end').content
+
+              assertObjectContains(testSession.meta, {
+                [TEST_EARLY_FLAKE_ENABLED]: 'true',
+              })
+
+              const impactedTests = tests.filter(test =>
+                test.meta[TEST_SOURCE_FILE] === 'cypress/e2e/impacted-test.js' &&
+              test.meta[TEST_NAME] === 'impacted test is impacted test')
+
+              // Should only have 1 test, no retries when testIsolation is false
+              assert.equal(impactedTests.length, 1)
+
+              for (const impactedTest of impactedTests) {
+                assertObjectContains(impactedTest.meta, {
+                  [TEST_IS_MODIFIED]: 'true',
+                })
+              }
+
+              // No retries should occur when testIsolation is false
+              const retriedTests = tests.filter(
+                test => test.meta[TEST_IS_RETRY] === 'true' &&
+              test.meta[TEST_NAME] === 'impacted test is impacted test'
+              )
+              assert.equal(retriedTests.length, 0)
+            }, { hardTimeout: 25000 })
 
         await Promise.all([
           once(childProcess, 'exit'),
@@ -456,50 +465,6 @@ moduleTypes.forEach(({
           },
         })
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-
-            // All tests in the file are new and modified, so they should all be retried
-            // 2 tests * (1 original + 2 retries) = 6 tests total
-            assert.equal(tests.length, 6)
-
-            // Extract test execution order with full details
-            const testExecutionOrder = tests.map(test => ({
-              name: test.meta[TEST_NAME],
-              isRetry: test.meta[TEST_IS_RETRY] === 'true',
-              isModified: test.meta[TEST_IS_MODIFIED] === 'true',
-            }))
-
-            // All should be marked as modified
-            testExecutionOrder.forEach(test => {
-              assert.equal(test.isModified, true)
-            })
-
-            // Expected order:
-            // 1. "first test" (original)
-            // 2. "first test" (retry 1)
-            // 3. "first test" (retry 2)
-            // 4. "second test" (original)
-            // 5. "second test" (retry 1)
-            // 6. "second test" (retry 2)
-
-            assertObjectContains(testExecutionOrder, [
-              { name: 'impacted test order first test', isRetry: false },
-              { name: 'impacted test order first test', isRetry: true },
-              { name: 'impacted test order first test', isRetry: true },
-              { name: 'impacted test order second test', isRetry: false },
-              { name: 'impacted test order second test', isRetry: true },
-              { name: 'impacted test order second test', isRetry: true },
-            ])
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assertObjectContains(testSession.meta, {
-              [TEST_EARLY_FLAKE_ENABLED]: 'true',
-            })
-          }, 25000)
-
         const envVars = getCiVisEvpProxyConfig(receiver.port)
 
         const specToRun = 'cypress/e2e/impacted-test-order.js'
@@ -516,6 +481,53 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+              // All tests in the file are new and modified, so they should all be retried
+              // 2 tests * (1 original + 2 retries) = 6 tests total
+              assert.equal(tests.length, 6)
+
+              // Extract test execution order with full details
+              const testExecutionOrder = tests.map(test => ({
+                name: test.meta[TEST_NAME],
+                isRetry: test.meta[TEST_IS_RETRY] === 'true',
+                isModified: test.meta[TEST_IS_MODIFIED] === 'true',
+              }))
+
+              // All should be marked as modified
+              testExecutionOrder.forEach(test => {
+                assert.equal(test.isModified, true)
+              })
+
+              // Expected order:
+              // 1. "first test" (original)
+              // 2. "first test" (retry 1)
+              // 3. "first test" (retry 2)
+              // 4. "second test" (original)
+              // 5. "second test" (retry 1)
+              // 6. "second test" (retry 2)
+
+              assertObjectContains(testExecutionOrder, [
+                { name: 'impacted test order first test', isRetry: false },
+                { name: 'impacted test order first test', isRetry: true },
+                { name: 'impacted test order first test', isRetry: true },
+                { name: 'impacted test order second test', isRetry: false },
+                { name: 'impacted test order second test', isRetry: true },
+                { name: 'impacted test order second test', isRetry: true },
+              ])
+
+              const testSession = events.find(event => event.type === 'test_session_end').content
+              assertObjectContains(testSession.meta, {
+                [TEST_EARLY_FLAKE_ENABLED]: 'true',
+              })
+            }, { hardTimeout: 25000 })
 
         childProcess.stdout?.on('data', (data) => {
           testOutput += data.toString()

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -32,12 +32,22 @@ const requestedVersion = process.env.CYPRESS_VERSION
 const oldestVersion = DD_MAJOR >= 6 ? '12.0.0' : '6.7.0'
 const version = requestedVersion === 'oldest' ? oldestVersion : requestedVersion
 const hookFile = 'dd-trace/loader-hook.mjs'
+const CYPRESS_RUN_HARD_TIMEOUT = 70_000
 
 function assertItrSkippingEnabledTags (events, expected) {
   const testSuite = events.find(event => event.type === 'test_suite_end').content
   assert.strictEqual(testSuite.meta[TEST_ITR_SKIPPING_ENABLED], expected)
   const test = events.find(event => event.type === 'test').content
   assert.strictEqual(test.meta[TEST_ITR_SKIPPING_ENABLED], expected)
+}
+
+function gatherCypressPayloads (receiver, childProcess, endpoint, onPayload) {
+  return receiver.gatherPayloadsUntilChildExit(
+    childProcess,
+    ({ url }) => url.endsWith(endpoint),
+    onPayload,
+    { hardTimeout: CYPRESS_RUN_HARD_TIMEOUT }
+  )
 }
 
 function shouldTestsRun (type) {
@@ -173,13 +183,6 @@ moduleTypes.forEach(({
           hasReportedCodeCoverage = true
         }, ({ url }) => url.endsWith('/api/v2/citestcov')).catch(() => {})
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const eventTypes = events.map(event => event.type)
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
-          }, 25000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         childProcess = exec(
@@ -194,10 +197,13 @@ moduleTypes.forEach(({
           }
         )
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          receiverPromise,
-        ])
+        const receiverPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const eventTypes = events.map(event => event.type)
+          assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+        })
+
+        await receiverPromise
         assert.strictEqual(hasReportedCodeCoverage, false)
       })
 
@@ -209,34 +215,6 @@ moduleTypes.forEach(({
             suite: 'cypress/e2e/other.cy.js',
           },
         }])
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const eventTypes = events.map(event => event.type)
-
-            const skippedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/other.cy.js.context passes'
-            ).content
-            assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
-            assert.strictEqual(skippedTest.meta[TEST_SKIPPED_BY_ITR], 'true')
-
-            assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'true')
-            assert.strictEqual(testSession.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
-            assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
-            assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 1)
-            assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_TYPE], 'test')
-            const testModule = events.find(event => event.type === 'test_module_end').content
-            assert.strictEqual(testModule.meta[TEST_ITR_TESTS_SKIPPED], 'true')
-            assert.strictEqual(testModule.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
-            assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
-            assert.strictEqual(testModule.metrics[TEST_ITR_SKIPPING_COUNT], 1)
-            assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_TYPE], 'test')
-            assertItrSkippingEnabledTags(events, 'true')
-          }, 25000)
-
         const coverageRequestPromise = receiver
           .payloadReceived(({ url }) => url.endsWith('/api/v2/citestcov'), 25000)
           .then(coverageRequest => {
@@ -267,8 +245,34 @@ moduleTypes.forEach(({
         childProcess.stdout?.pipe(process.stdout)
         childProcess.stderr?.pipe(process.stderr)
 
+        const eventsPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const eventTypes = events.map(event => event.type)
+
+          const skippedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/other.cy.js.context passes'
+          ).content
+          assert.strictEqual(skippedTest.meta[TEST_STATUS], 'skip')
+          assert.strictEqual(skippedTest.meta[TEST_SKIPPED_BY_ITR], 'true')
+
+          assertObjectContains(eventTypes, ['test', 'test_session_end', 'test_module_end', 'test_suite_end'])
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'true')
+          assert.strictEqual(testSession.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
+          assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
+          assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 1)
+          assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_TYPE], 'test')
+          const testModule = events.find(event => event.type === 'test_module_end').content
+          assert.strictEqual(testModule.meta[TEST_ITR_TESTS_SKIPPED], 'true')
+          assert.strictEqual(testModule.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
+          assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
+          assert.strictEqual(testModule.metrics[TEST_ITR_SKIPPING_COUNT], 1)
+          assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_TYPE], 'test')
+          assertItrSkippingEnabledTags(events, 'true')
+        })
+
         await Promise.all([
-          once(childProcess, 'exit'),
           eventsPromise,
           skippableRequestPromise,
           coverageRequestPromise,
@@ -294,16 +298,6 @@ moduleTypes.forEach(({
           hasRequestedSkippable = true
         }, ({ url }) => url.endsWith('/api/v2/ci/tests/skippable'), 25000).catch(() => {})
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const notSkippedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/other.cy.js.context passes'
-            )
-            assert.ok(notSkippedTest)
-            assert.strictEqual(notSkippedTest.content.meta[TEST_STATUS], 'pass')
-          }, 25000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         childProcess = exec(
@@ -322,10 +316,16 @@ moduleTypes.forEach(({
         childProcess.stdout?.pipe(process.stdout)
         childProcess.stderr?.pipe(process.stderr)
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          receiverPromise,
-        ])
+        const receiverPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const notSkippedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/other.cy.js.context passes'
+          )
+          assert.ok(notSkippedTest)
+          assert.strictEqual(notSkippedTest.content.meta[TEST_STATUS], 'pass')
+        })
+
+        await receiverPromise
         assert.strictEqual(hasRequestedSkippable, false)
       })
 
@@ -351,34 +351,6 @@ moduleTypes.forEach(({
             },
           },
         ])
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            const testModule = events.find(event => event.type === 'test_session_end').content
-
-            assert.strictEqual(testSession.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            assert.strictEqual(testSession.meta[TEST_ITR_FORCED_RUN], 'true')
-            assert.strictEqual(testModule.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            assert.strictEqual(testModule.meta[TEST_ITR_FORCED_RUN], 'true')
-
-            const unskippablePassedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/spec.cy.js.context passes'
-            )
-            const unskippableFailedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/spec.cy.js.other context fails'
-            )
-            assert.strictEqual(unskippablePassedTest.content.meta[TEST_STATUS], 'pass')
-            assert.strictEqual(unskippablePassedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            assert.strictEqual(unskippablePassedTest.content.meta[TEST_ITR_FORCED_RUN], 'true')
-
-            assert.strictEqual(unskippableFailedTest.content.meta[TEST_STATUS], 'fail')
-            assert.strictEqual(unskippableFailedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            // This was not going to be skipped
-            assert.ok(!(TEST_ITR_FORCED_RUN in unskippableFailedTest.content.meta))
-          }, 25000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         childProcess = exec(
@@ -397,10 +369,34 @@ moduleTypes.forEach(({
         childProcess.stdout?.pipe(process.stdout)
         childProcess.stderr?.pipe(process.stderr)
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          receiverPromise,
-        ])
+        const receiverPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          const testModule = events.find(event => event.type === 'test_module_end').content
+
+          assert.strictEqual(testSession.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          assert.strictEqual(testSession.meta[TEST_ITR_FORCED_RUN], 'true')
+          assert.strictEqual(testModule.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          assert.strictEqual(testModule.meta[TEST_ITR_FORCED_RUN], 'true')
+
+          const unskippablePassedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/spec.cy.js.context passes'
+          )
+          const unskippableFailedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/spec.cy.js.other context fails'
+          )
+          assert.strictEqual(unskippablePassedTest.content.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(unskippablePassedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          assert.strictEqual(unskippablePassedTest.content.meta[TEST_ITR_FORCED_RUN], 'true')
+
+          assert.strictEqual(unskippableFailedTest.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(unskippableFailedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          // This was not going to be skipped
+          assert.ok(!(TEST_ITR_FORCED_RUN in unskippableFailedTest.content.meta))
+        })
+
+        await receiverPromise
       })
 
       it('only sets forced to run if test was going to be skipped by ITR', async () => {
@@ -419,35 +415,6 @@ moduleTypes.forEach(({
           },
         ])
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            const testModule = events.find(event => event.type === 'test_session_end').content
-
-            assert.strictEqual(testSession.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            assert.ok(!(TEST_ITR_FORCED_RUN in testSession.meta))
-            assert.strictEqual(testModule.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            assert.ok(!(TEST_ITR_FORCED_RUN in testModule.meta))
-
-            const unskippablePassedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/spec.cy.js.context passes'
-            )
-            const unskippableFailedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/spec.cy.js.other context fails'
-            )
-            assert.strictEqual(unskippablePassedTest.content.meta[TEST_STATUS], 'pass')
-            assert.strictEqual(unskippablePassedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            // This was not going to be skipped
-            assert.ok(!(TEST_ITR_FORCED_RUN in unskippablePassedTest.content.meta))
-
-            assert.strictEqual(unskippableFailedTest.content.meta[TEST_STATUS], 'fail')
-            assert.strictEqual(unskippableFailedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
-            // This was not going to be skipped
-            assert.ok(!(TEST_ITR_FORCED_RUN in unskippableFailedTest.content.meta))
-          }, 25000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         childProcess = exec(
@@ -466,10 +433,35 @@ moduleTypes.forEach(({
         childProcess.stdout?.pipe(process.stdout)
         childProcess.stderr?.pipe(process.stderr)
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          receiverPromise,
-        ])
+        const receiverPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          const testModule = events.find(event => event.type === 'test_module_end').content
+
+          assert.strictEqual(testSession.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          assert.ok(!(TEST_ITR_FORCED_RUN in testSession.meta))
+          assert.strictEqual(testModule.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          assert.ok(!(TEST_ITR_FORCED_RUN in testModule.meta))
+
+          const unskippablePassedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/spec.cy.js.context passes'
+          )
+          const unskippableFailedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/spec.cy.js.other context fails'
+          )
+          assert.strictEqual(unskippablePassedTest.content.meta[TEST_STATUS], 'pass')
+          assert.strictEqual(unskippablePassedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          // This was not going to be skipped
+          assert.ok(!(TEST_ITR_FORCED_RUN in unskippablePassedTest.content.meta))
+
+          assert.strictEqual(unskippableFailedTest.content.meta[TEST_STATUS], 'fail')
+          assert.strictEqual(unskippableFailedTest.content.meta[TEST_ITR_UNSKIPPABLE], 'true')
+          // This was not going to be skipped
+          assert.ok(!(TEST_ITR_FORCED_RUN in unskippableFailedTest.content.meta))
+        })
+
+        await receiverPromise
       })
 
       it('sets _dd.ci.itr.tests_skipped to false if the received test is not skipped', async () => {
@@ -480,22 +472,6 @@ moduleTypes.forEach(({
             suite: 'i/dont/exist.spec.js',
           },
         }])
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const testSession = events.find(event => event.type === 'test_session_end').content
-            assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'false')
-            assert.strictEqual(testSession.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
-            assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
-            assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 0)
-            const testModule = events.find(event => event.type === 'test_module_end').content
-            assert.strictEqual(testModule.meta[TEST_ITR_TESTS_SKIPPED], 'false')
-            assert.strictEqual(testModule.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
-            assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
-            assert.strictEqual(testModule.metrics[TEST_ITR_SKIPPING_COUNT], 0)
-            assertItrSkippingEnabledTags(events, 'true')
-          }, 30000)
-
         const skippableRequestPromise = receiver
           .payloadReceived(({ url }) => url.endsWith('/api/v2/ci/tests/skippable'), 30000)
           .then(skippableRequest => {
@@ -520,8 +496,22 @@ moduleTypes.forEach(({
         childProcess.stdout?.pipe(process.stdout)
         childProcess.stderr?.pipe(process.stderr)
 
+        const eventsPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const testSession = events.find(event => event.type === 'test_session_end').content
+          assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'false')
+          assert.strictEqual(testSession.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
+          assert.strictEqual(testSession.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
+          assert.strictEqual(testSession.metrics[TEST_ITR_SKIPPING_COUNT], 0)
+          const testModule = events.find(event => event.type === 'test_module_end').content
+          assert.strictEqual(testModule.meta[TEST_ITR_TESTS_SKIPPED], 'false')
+          assert.strictEqual(testModule.meta[TEST_CODE_COVERAGE_ENABLED], 'true')
+          assert.strictEqual(testModule.meta[TEST_ITR_SKIPPING_ENABLED], 'true')
+          assert.strictEqual(testModule.metrics[TEST_ITR_SKIPPING_COUNT], 0)
+          assertItrSkippingEnabledTags(events, 'true')
+        })
+
         await Promise.all([
-          once(childProcess, 'exit'),
           eventsPromise,
           skippableRequestPromise,
         ])
@@ -530,14 +520,6 @@ moduleTypes.forEach(({
       it('reports itr_correlation_id in tests', async () => {
         const itrCorrelationId = '4321'
         receiver.setItrCorrelationId(itrCorrelationId)
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tests = events.filter(event => event.type === 'test').map(event => event.content)
-            tests.forEach(test => {
-              assert.strictEqual(test.itr_correlation_id, itrCorrelationId)
-            })
-          }, 25000)
 
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
@@ -553,10 +535,16 @@ moduleTypes.forEach(({
           }
         )
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          eventsPromise,
-        ])
+        const eventsPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          assert.ok(tests.length > 0)
+          tests.forEach(test => {
+            assert.strictEqual(test.itr_correlation_id, itrCorrelationId)
+          })
+        })
+
+        await eventsPromise
       })
 
       it('reports code coverage relative to the repository root, not working directory', async () => {
@@ -578,22 +566,6 @@ moduleTypes.forEach(({
 
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
-        const eventsPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcov'), (payloads) => {
-            const coveredFiles = payloads
-              .flatMap(({ payload }) => payload)
-              .flatMap(({ content: { coverages } }) => coverages)
-              .flatMap(({ files }) => files)
-              .map(({ filename }) => filename)
-
-            assertObjectContains(coveredFiles, [
-              'ci-visibility/subproject/src/utils.tsx',
-              'ci-visibility/subproject/src/App.tsx',
-              'ci-visibility/subproject/src/index.tsx',
-              'ci-visibility/subproject/cypress/e2e/spec.cy.js',
-            ])
-          }, 25000)
-
         childProcess = exec(
           command,
           {
@@ -609,30 +581,27 @@ moduleTypes.forEach(({
         childProcess.stdout?.pipe(process.stdout)
         childProcess.stderr?.pipe(process.stderr)
 
-        await Promise.all([
-          once(childProcess, 'exit'),
-          eventsPromise,
-        ])
+        const eventsPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcov', payloads => {
+          const coveredFiles = payloads
+            .flatMap(({ payload }) => payload)
+            .flatMap(({ content: { coverages } }) => coverages)
+            .flatMap(({ files }) => files)
+            .map(({ filename }) => filename)
+
+          assertObjectContains(coveredFiles, [
+            'ci-visibility/subproject/src/utils.tsx',
+            'ci-visibility/subproject/src/App.tsx',
+            'ci-visibility/subproject/src/index.tsx',
+            'ci-visibility/subproject/cypress/e2e/spec.cy.js',
+          ])
+        })
+
+        await eventsPromise
       })
     })
 
     it('still reports correct format if there is a plugin incompatibility', async () => {
       const envVars = getCiVisEvpProxyConfig(receiver.port)
-
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const testEvents = events.filter(event => event.type === 'test')
-          const testModuleEvent = events.find(event => event.type === 'test_module_end')
-
-          testEvents.forEach(testEvent => {
-            assert.ok(testEvent.content.test_suite_id)
-            assert.ok(testEvent.content.test_module_id)
-            assert.ok(testEvent.content.test_session_id)
-            assert.notStrictEqual(testEvent.content.test_suite_id, testModuleEvent.content.test_module_id)
-          })
-        }, 25000)
 
       childProcess = exec(
         testCommand,
@@ -647,10 +616,23 @@ moduleTypes.forEach(({
         }
       )
 
-      await Promise.all([
-        once(childProcess, 'exit'),
-        receiverPromise,
-      ])
+      const receiverPromise = gatherCypressPayloads(receiver, childProcess, '/api/v2/citestcycle', payloads => {
+        const events = payloads.flatMap(({ payload }) => payload.events)
+
+        const testEvents = events.filter(event => event.type === 'test')
+        const testModuleEvent = events.find(event => event.type === 'test_module_end')
+        assert.ok(testEvents.length > 0)
+        assert.ok(testModuleEvent)
+
+        testEvents.forEach(testEvent => {
+          assert.ok(testEvent.content.test_suite_id)
+          assert.ok(testEvent.content.test_module_id)
+          assert.ok(testEvent.content.test_session_id)
+          assert.notStrictEqual(testEvent.content.test_suite_id, testModuleEvent.content.test_module_id)
+        })
+      })
+
+      await receiverPromise
     })
   })
 })

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -181,65 +181,6 @@ moduleTypes.forEach(({
     it('instruments tests with the APM protocol (old agents)', async () => {
       receiver.setInfoResponse({ endpoints: [] })
 
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url === '/v0.4/traces', (payloads) => {
-          const testSpans = payloads.flatMap(({ payload }) => payload.flatMap(trace => trace))
-
-          const passedTestSpan = testSpans.find(span =>
-            span.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-          const failedTestSpan = testSpans.find(span =>
-            span.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail'
-          )
-
-          assertObjectContains(passedTestSpan, {
-            name: 'cypress.test',
-            resource: 'cypress/e2e/basic-pass.js.basic pass suite can pass',
-            type: 'test',
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_NAME]: 'basic pass suite can pass',
-              [TEST_SUITE]: 'cypress/e2e/basic-pass.js',
-              [TEST_FRAMEWORK]: 'cypress',
-              [TEST_TYPE]: 'browser',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@datadog-dd-trace-js']),
-              customTag: 'customValue',
-              addTagsBeforeEach: 'customBeforeEach',
-              addTagsAfterEach: 'customAfterEach',
-            },
-          })
-          assert.match(passedTestSpan.meta[TEST_SOURCE_FILE], /cypress\/e2e\/basic-pass\.js/)
-          assert.ok(passedTestSpan.meta[TEST_FRAMEWORK_VERSION])
-          assert.ok(passedTestSpan.meta[COMPONENT])
-          assert.ok(passedTestSpan.metrics[TEST_SOURCE_START])
-
-          assertObjectContains(failedTestSpan, {
-            name: 'cypress.test',
-            resource: 'cypress/e2e/basic-fail.js.basic fail suite can fail',
-            type: 'test',
-            meta: {
-              [TEST_STATUS]: 'fail',
-              [TEST_NAME]: 'basic fail suite can fail',
-              [TEST_SUITE]: 'cypress/e2e/basic-fail.js',
-              [TEST_FRAMEWORK]: 'cypress',
-              [TEST_TYPE]: 'browser',
-              [TEST_CODE_OWNERS]: JSON.stringify(['@datadog-dd-trace-js']),
-              customTag: 'customValue',
-              addTagsBeforeEach: 'customBeforeEach',
-              addTagsAfterEach: 'customAfterEach',
-            },
-          })
-          assert.match(failedTestSpan.meta[TEST_SOURCE_FILE], /cypress\/e2e\/basic-fail\.js/)
-          assert.ok(failedTestSpan.meta[TEST_FRAMEWORK_VERSION])
-          assert.ok(failedTestSpan.meta[COMPONENT])
-          assert.ok(failedTestSpan.meta[ERROR_MESSAGE])
-          assert.match(failedTestSpan.meta[ERROR_MESSAGE], /expected/)
-          assert.ok(failedTestSpan.meta[ERROR_TYPE])
-          assert.ok(failedTestSpan.metrics[TEST_SOURCE_START])
-          // Tags added after failure should not be present because test failed
-          assert.ok(!('addTagsAfterFailure' in failedTestSpan.meta))
-        }, 60000)
-
       const envVars = getCiVisEvpProxyConfig(receiver.port)
 
       const specToRun = 'cypress/e2e/basic-*.js'
@@ -260,6 +201,68 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url === '/v0.4/traces',
+          (payloads) => {
+            const testSpans = payloads.flatMap(({ payload }) => payload.flatMap(trace => trace))
+
+            const passedTestSpan = testSpans.find(span =>
+              span.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+            const failedTestSpan = testSpans.find(span =>
+              span.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail'
+            )
+
+            assertObjectContains(passedTestSpan, {
+              name: 'cypress.test',
+              resource: 'cypress/e2e/basic-pass.js.basic pass suite can pass',
+              type: 'test',
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_NAME]: 'basic pass suite can pass',
+                [TEST_SUITE]: 'cypress/e2e/basic-pass.js',
+                [TEST_FRAMEWORK]: 'cypress',
+                [TEST_TYPE]: 'browser',
+                [TEST_CODE_OWNERS]: JSON.stringify(['@datadog-dd-trace-js']),
+                customTag: 'customValue',
+                addTagsBeforeEach: 'customBeforeEach',
+                addTagsAfterEach: 'customAfterEach',
+              },
+            })
+            assert.match(passedTestSpan.meta[TEST_SOURCE_FILE], /cypress\/e2e\/basic-pass\.js/)
+            assert.ok(passedTestSpan.meta[TEST_FRAMEWORK_VERSION])
+            assert.ok(passedTestSpan.meta[COMPONENT])
+            assert.ok(passedTestSpan.metrics[TEST_SOURCE_START])
+
+            assertObjectContains(failedTestSpan, {
+              name: 'cypress.test',
+              resource: 'cypress/e2e/basic-fail.js.basic fail suite can fail',
+              type: 'test',
+              meta: {
+                [TEST_STATUS]: 'fail',
+                [TEST_NAME]: 'basic fail suite can fail',
+                [TEST_SUITE]: 'cypress/e2e/basic-fail.js',
+                [TEST_FRAMEWORK]: 'cypress',
+                [TEST_TYPE]: 'browser',
+                [TEST_CODE_OWNERS]: JSON.stringify(['@datadog-dd-trace-js']),
+                customTag: 'customValue',
+                addTagsBeforeEach: 'customBeforeEach',
+                addTagsAfterEach: 'customAfterEach',
+              },
+            })
+            assert.match(failedTestSpan.meta[TEST_SOURCE_FILE], /cypress\/e2e\/basic-fail\.js/)
+            assert.ok(failedTestSpan.meta[TEST_FRAMEWORK_VERSION])
+            assert.ok(failedTestSpan.meta[COMPONENT])
+            assert.ok(failedTestSpan.meta[ERROR_MESSAGE])
+            assert.match(failedTestSpan.meta[ERROR_MESSAGE], /expected/)
+            assert.ok(failedTestSpan.meta[ERROR_TYPE])
+            assert.ok(failedTestSpan.metrics[TEST_SOURCE_START])
+            // Tags added after failure should not be present because test failed
+            assert.ok(!('addTagsAfterFailure' in failedTestSpan.meta))
+          }, { hardTimeout: 60000 })
 
       await Promise.all([
         once(childProcess, 'exit'),
@@ -310,24 +313,6 @@ moduleTypes.forEach(({
     over10It('is backwards compatible with the old manual plugin approach', async () => {
       receiver.setInfoResponse({ endpoints: [] })
 
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url === '/v0.4/traces', (payloads) => {
-          const testSpans = payloads.flatMap(({ payload }) => payload.flatMap(trace => trace))
-
-          const passedTestSpan = testSpans.find(span =>
-            span.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-
-          assertObjectContains(passedTestSpan, {
-            name: 'cypress.test',
-            type: 'test',
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 60000)
-
       const envVars = getCiVisEvpProxyConfig(receiver.port)
 
       const legacyConfigFile = type === 'esm'
@@ -346,6 +331,27 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url === '/v0.4/traces',
+          (payloads) => {
+            const testSpans = payloads.flatMap(({ payload }) => payload.flatMap(trace => trace))
+
+            const passedTestSpan = testSpans.find(span =>
+              span.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+
+            assertObjectContains(passedTestSpan, {
+              name: 'cypress.test',
+              type: 'test',
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 60000 })
+
       await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -353,52 +359,6 @@ moduleTypes.forEach(({
     })
 
     over10It('reports tests with old manual plugin approach without NODE_OPTIONS', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          // Verify full span hierarchy: session, module, suites, and tests
-          const sessionEvents = events.filter(event => event.type === 'test_session_end')
-          const moduleEvents = events.filter(event => event.type === 'test_module_end')
-          const suiteEvents = events.filter(event => event.type === 'test_suite_end')
-          const testEvents = events.filter(event => event.type === 'test')
-
-          assert.strictEqual(sessionEvents.length, 1)
-          assert.strictEqual(moduleEvents.length, 1)
-          assert.strictEqual(suiteEvents.length, 2, 'one suite per spec file')
-          assert.ok(testEvents.length >= 2, 'at least one pass and one fail test')
-
-          const passedTest = testEvents.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-          const failedTest = testEvents.find(event =>
-            event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail'
-          )
-
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-              [TEST_TYPE]: 'browser',
-            },
-          })
-          assert.ok(passedTest?.content.meta[TEST_SOURCE_FILE])
-          assert.ok(passedTest?.content.meta[COMPONENT])
-
-          // Sanity-check _now() time tracking: duration should be positive and under 60s
-          assert.ok(passedTest.content.duration > 0, 'test duration should be positive')
-          assert.ok(passedTest.content.duration < 60_000_000_000, 'test duration should be under 60s')
-
-          assertObjectContains(failedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'fail',
-              [TEST_FRAMEWORK]: 'cypress',
-              [TEST_TYPE]: 'browser',
-            },
-          })
-          assert.ok(failedTest?.content.meta[ERROR_MESSAGE])
-        }, 60000)
-
       // Use EVP proxy config but strip NODE_OPTIONS so the tracer is NOT preloaded.
       // The legacy config file initializes dd-trace itself via require('dd-trace/ci/cypress/plugin').
       const { NODE_OPTIONS, ...envVars } = getCiVisEvpProxyConfig(receiver.port)
@@ -419,6 +379,55 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            // Verify full span hierarchy: session, module, suites, and tests
+            const sessionEvents = events.filter(event => event.type === 'test_session_end')
+            const moduleEvents = events.filter(event => event.type === 'test_module_end')
+            const suiteEvents = events.filter(event => event.type === 'test_suite_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            assert.strictEqual(sessionEvents.length, 1)
+            assert.strictEqual(moduleEvents.length, 1)
+            assert.strictEqual(suiteEvents.length, 2, 'one suite per spec file')
+            assert.ok(testEvents.length >= 2, 'at least one pass and one fail test')
+
+            const passedTest = testEvents.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+            const failedTest = testEvents.find(event =>
+              event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail'
+            )
+
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+                [TEST_TYPE]: 'browser',
+              },
+            })
+            assert.ok(passedTest?.content.meta[TEST_SOURCE_FILE])
+            assert.ok(passedTest?.content.meta[COMPONENT])
+
+            // Sanity-check _now() time tracking: duration should be positive and under 60s
+            assert.ok(passedTest.content.duration > 0, 'test duration should be positive')
+            assert.ok(passedTest.content.duration < 60_000_000_000, 'test duration should be under 60s')
+
+            assertObjectContains(failedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'fail',
+                [TEST_FRAMEWORK]: 'cypress',
+                [TEST_TYPE]: 'browser',
+              },
+            })
+            assert.ok(failedTest?.content.meta[ERROR_MESSAGE])
+          }, { hardTimeout: 60000 })
+
       await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -426,23 +435,6 @@ moduleTypes.forEach(({
     })
 
     over10It('reports tests when using cypress.config.mjs with NODE_OPTIONS', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads
-            .flatMap(({ payload }) => payload.events)
-            .filter(event => event.type === 'test')
-          const passedTest = events.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 20000)
-
       let testOutput = ''
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
@@ -458,6 +450,26 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads
+              .flatMap(({ payload }) => payload.events)
+              .filter(event => event.type === 'test')
+            const passedTest = events.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 20000 })
       childProcess.stdout?.on('data', (d) => { testOutput += d })
       childProcess.stderr?.on('data', (d) => { testOutput += d })
 
@@ -470,24 +482,6 @@ moduleTypes.forEach(({
     })
 
     over10It('reports tests when cypress.run is called twice (multi-run state reset)', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const passedTests = payloads
-            .flatMap(({ payload }) => payload.events)
-            .filter(event => event.type === 'test')
-            .filter(event => event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass')
-
-          assert.strictEqual(passedTests.length, 2)
-          passedTests.forEach((passedTest) => {
-            assertObjectContains(passedTest.content, {
-              meta: {
-                [TEST_STATUS]: 'pass',
-                [TEST_FRAMEWORK]: 'cypress',
-              },
-            })
-          })
-        }, 60000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       const doubleRunScript = type === 'esm'
@@ -506,6 +500,27 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const passedTests = payloads
+              .flatMap(({ payload }) => payload.events)
+              .filter(event => event.type === 'test')
+              .filter(event => event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass')
+
+            assert.strictEqual(passedTests.length, 2)
+            passedTests.forEach((passedTest) => {
+              assertObjectContains(passedTest.content, {
+                meta: {
+                  [TEST_STATUS]: 'pass',
+                  [TEST_FRAMEWORK]: 'cypress',
+                },
+              })
+            })
+          }, { hardTimeout: 60000 })
+
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -517,23 +532,6 @@ moduleTypes.forEach(({
     over10It(
       'reports tests with a plain-object config when dd-trace is manually configured',
       async () => {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads
-              .flatMap(({ payload }) => payload.events)
-              .filter(event => event.type === 'test')
-            const passedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-            )
-
-            assertObjectContains(passedTest?.content, {
-              meta: {
-                [TEST_STATUS]: 'pass',
-                [TEST_FRAMEWORK]: 'cypress',
-              },
-            })
-          }, 60000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         const plainObjectConfigFile = type === 'esm'
@@ -552,6 +550,26 @@ moduleTypes.forEach(({
           }
         )
 
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads
+                .flatMap(({ payload }) => payload.events)
+                .filter(event => event.type === 'test')
+              const passedTest = events.find(event =>
+                event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+              )
+
+              assertObjectContains(passedTest?.content, {
+                meta: {
+                  [TEST_STATUS]: 'pass',
+                  [TEST_FRAMEWORK]: 'cypress',
+                },
+              })
+            }, { hardTimeout: 60000 })
+
         const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),
           receiverPromise,
@@ -564,23 +582,6 @@ moduleTypes.forEach(({
     over10It(
       'auto-instruments a plain-object config without defineConfig or manual plugin',
       async () => {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads
-              .flatMap(({ payload }) => payload.events)
-              .filter(event => event.type === 'test')
-            const passedTest = events.find(event =>
-              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-            )
-
-            assertObjectContains(passedTest?.content, {
-              meta: {
-                [TEST_STATUS]: 'pass',
-                [TEST_FRAMEWORK]: 'cypress',
-              },
-            })
-          }, 20000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         const plainObjectAutoConfigFile = type === 'esm'
@@ -598,6 +599,26 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads
+                .flatMap(({ payload }) => payload.events)
+                .filter(event => event.type === 'test')
+              const passedTest = events.find(event =>
+                event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+              )
+
+              assertObjectContains(passedTest?.content, {
+                meta: {
+                  [TEST_STATUS]: 'pass',
+                  [TEST_FRAMEWORK]: 'cypress',
+                },
+              })
+            }, { hardTimeout: 20000 })
 
         const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),
@@ -620,23 +641,6 @@ moduleTypes.forEach(({
         fs.copyFileSync(plainObjectConfig, originalConfig)
 
         try {
-          const receiverPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads
-                .flatMap(({ payload }) => payload.events)
-                .filter(event => event.type === 'test')
-              const passedTest = events.find(event =>
-                event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-              )
-
-              assertObjectContains(passedTest?.content, {
-                meta: {
-                  [TEST_STATUS]: 'pass',
-                  [TEST_FRAMEWORK]: 'cypress',
-                },
-              })
-            }, 20000)
-
           const envVars = getCiVisAgentlessConfig(receiver.port)
 
           childProcess = exec(
@@ -650,6 +654,26 @@ moduleTypes.forEach(({
               },
             }
           )
+
+          const receiverPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads
+                  .flatMap(({ payload }) => payload.events)
+                  .filter(event => event.type === 'test')
+                const passedTest = events.find(event =>
+                  event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+                )
+
+                assertObjectContains(passedTest?.content, {
+                  meta: {
+                    [TEST_STATUS]: 'pass',
+                    [TEST_FRAMEWORK]: 'cypress',
+                  },
+                })
+              }, { hardTimeout: 20000 })
 
           const [[exitCode]] = await Promise.all([
             once(childProcess, 'exit'),
@@ -665,29 +689,6 @@ moduleTypes.forEach(({
 
     over10It('reports tests with a TypeScript config file', async () => {
       let testOutput = ''
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads
-            .flatMap(({ payload }) => payload.events)
-            .filter(event => event.type === 'test')
-          const passedTest = events.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          }, `got events: ${JSON.stringify(events.map(event => ({
-            resource: event.content.resource,
-            sourceFile: event.content.meta?.[TEST_SOURCE_FILE],
-            status: event.content.meta?.[TEST_STATUS],
-            framework: event.content.meta?.[TEST_FRAMEWORK],
-            error: event.content.meta?.[ERROR_MESSAGE],
-          })), null, 2)}\nCypress output:\n${testOutput}`)
-        }, 20000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       childProcess = exec(
@@ -701,6 +702,32 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads
+              .flatMap(({ payload }) => payload.events)
+              .filter(event => event.type === 'test')
+            const passedTest = events.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            }, `got events: ${JSON.stringify(events.map(event => ({
+            resource: event.content.resource,
+            sourceFile: event.content.meta?.[TEST_SOURCE_FILE],
+            status: event.content.meta?.[TEST_STATUS],
+            framework: event.content.meta?.[TEST_FRAMEWORK],
+            error: event.content.meta?.[ERROR_MESSAGE],
+          })), null, 2)}\nCypress output:\n${testOutput}`)
+          }, { hardTimeout: 20000 })
       childProcess.stdout?.on('data', chunk => {
         testOutput += chunk.toString()
       })
@@ -780,31 +807,6 @@ moduleTypes.forEach(({
 
       let testOutput = ''
       try {
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-
-            // Full span hierarchy must be present — not just a stray telemetry span.
-            const sessionEvents = events.filter(event => event.type === 'test_session_end')
-            const moduleEvents = events.filter(event => event.type === 'test_module_end')
-            const suiteEvents = events.filter(event => event.type === 'test_suite_end')
-            const testEvents = events.filter(event => event.type === 'test')
-
-            assert.strictEqual(sessionEvents.length, 1, `one test_session span\n${testOutput}`)
-            assert.strictEqual(moduleEvents.length, 1, `one test_module span\n${testOutput}`)
-            assert.ok(suiteEvents.length >= 1, `at least one test_suite span\n${testOutput}`)
-
-            const passedTest = testEvents.find(event =>
-              event.content.resource === 'cypress/e2e/basic-pass.cy.js.basic pass suite can pass'
-            )
-            assertObjectContains(passedTest?.content, {
-              meta: {
-                [TEST_STATUS]: 'pass',
-                [TEST_FRAMEWORK]: 'cypress',
-              },
-            })
-          }, 20000)
-
         const envVars = getCiVisAgentlessConfig(receiver.port)
 
         // Run Cypress *from* the subproject so its project root is the
@@ -820,6 +822,34 @@ moduleTypes.forEach(({
             },
           }
         )
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+
+              // Full span hierarchy must be present — not just a stray telemetry span.
+              const sessionEvents = events.filter(event => event.type === 'test_session_end')
+              const moduleEvents = events.filter(event => event.type === 'test_module_end')
+              const suiteEvents = events.filter(event => event.type === 'test_suite_end')
+              const testEvents = events.filter(event => event.type === 'test')
+
+              assert.strictEqual(sessionEvents.length, 1, `one test_session span\n${testOutput}`)
+              assert.strictEqual(moduleEvents.length, 1, `one test_module span\n${testOutput}`)
+              assert.ok(suiteEvents.length >= 1, `at least one test_suite span\n${testOutput}`)
+
+              const passedTest = testEvents.find(event =>
+                event.content.resource === 'cypress/e2e/basic-pass.cy.js.basic pass suite can pass'
+              )
+              assertObjectContains(passedTest?.content, {
+                meta: {
+                  [TEST_STATUS]: 'pass',
+                  [TEST_FRAMEWORK]: 'cypress',
+                },
+              })
+            }, { hardTimeout: 20000 })
         childProcess.stdout?.on('data', (d) => { testOutput += d })
         childProcess.stderr?.on('data', (d) => { testOutput += d })
 
@@ -841,26 +871,6 @@ moduleTypes.forEach(({
     // Optimization exporter with OtlpHttpTraceExporter and dropping all
     // test_session / test_module / test_suite / test spans.
     over10It('keeps Test Optimization exporter when OTEL_TRACES_EXPORTER=otlp is set', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const sessionEvents = events.filter(event => event.type === 'test_session_end')
-          const testEvents = events.filter(event => event.type === 'test')
-
-          assert.strictEqual(sessionEvents.length, 1, 'one test_session span must reach citestcycle')
-
-          const passedTest = testEvents.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 20000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       childProcess = exec(
@@ -878,6 +888,29 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const sessionEvents = events.filter(event => event.type === 'test_session_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            assert.strictEqual(sessionEvents.length, 1, 'one test_session span must reach citestcycle')
+
+            const passedTest = testEvents.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 20000 })
 
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
@@ -901,23 +934,6 @@ moduleTypes.forEach(({
 
       fs.writeFileSync(supportFilePath, supportContentWithoutDdTrace)
 
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads
-            .flatMap(({ payload }) => payload.events)
-            .filter(event => event.type === 'test')
-          const passedTest = events.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 60000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
       const wrapperFilesBefore = getSupportWrappers()
 
@@ -930,6 +946,28 @@ moduleTypes.forEach(({
             SPEC_PATTERN: 'cypress/e2e/basic-pass.js',
           },
         })
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads
+                .flatMap(({ payload }) => payload.events)
+                .filter(event => event.type === 'test')
+              const passedTest = events.find(event =>
+                event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+              )
+
+              assertObjectContains(passedTest?.content, {
+                meta: {
+                  [TEST_STATUS]: 'pass',
+                  [TEST_FRAMEWORK]: 'cypress',
+                },
+              })
+            },
+            { hardTimeout: 60000 }
+          )
 
         const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),
@@ -946,24 +984,6 @@ moduleTypes.forEach(({
     })
 
     over10It('preserves config returned from setupNodeEvents', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads
-            .flatMap(({ payload }) => payload.events)
-            .filter(event => event.type === 'test')
-          const passedTest = events.find(event =>
-            event.content.resource ===
-              'cypress/e2e/returned-config.cy.js.returned config uses env from setupNodeEvents return value'
-          )
-
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 60000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       const returnConfigFile = type === 'esm'
@@ -978,6 +998,27 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads
+              .flatMap(({ payload }) => payload.events)
+              .filter(event => event.type === 'test')
+            const passedTest = events.find(event =>
+              event.content.resource ===
+              'cypress/e2e/returned-config.cy.js.returned config uses env from setupNodeEvents return value'
+            )
+
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 60000 })
+
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -987,22 +1028,6 @@ moduleTypes.forEach(({
     })
 
     over10It('custom after:spec and after:run handlers are chained with dd-trace instrumentation', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads
-            .flatMap(({ payload }) => payload.events)
-            .filter(event => event.type === 'test')
-          const passedTest = events.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 60000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       let testOutput = ''
@@ -1021,6 +1046,25 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads
+              .flatMap(({ payload }) => payload.events)
+              .filter(event => event.type === 'test')
+            const passedTest = events.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 60000 })
       childProcess.stdout?.on('data', (d) => { testOutput += d })
       childProcess.stderr?.on('data', (d) => { testOutput += d })
 
@@ -1041,15 +1085,6 @@ moduleTypes.forEach(({
     // Tests the old manual API: dd-trace/ci/cypress/after-run and after-spec
     // used alongside the manual plugin, without NODE_OPTIONS auto-instrumentation.
     over10It('works if after:run and after:spec are explicitly used with the manual plugin', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-          const testSessionEvent = events.find(event => event.type === 'test_session_end')
-          assert.ok(testSessionEvent)
-          const testEvents = events.filter(event => event.type === 'test')
-          assert.ok(testEvents.length > 0)
-        }, 30000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       childProcess = exec(
@@ -1067,6 +1102,18 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSessionEvent = events.find(event => event.type === 'test_session_end')
+            assert.ok(testSessionEvent)
+            const testEvents = events.filter(event => event.type === 'test')
+            assert.ok(testEvents.length > 0)
+          }, { hardTimeout: 30000 })
+
       await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -1079,27 +1126,6 @@ moduleTypes.forEach(({
     // Differs from the backwards-compat test (APM protocol, single pass) by validating
     // the full citestcycle span hierarchy through the channel's _isInit=true branch.
     over10It('correctly chains hooks when auto-instrumentation and manual plugin are both active', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const sessionEvents = events.filter(event => event.type === 'test_session_end')
-          const testEvents = events.filter(event => event.type === 'test')
-
-          assert.strictEqual(sessionEvents.length, 1, 'should have one test session')
-          assert.ok(testEvents.length >= 1, 'should have at least one test')
-
-          const passedTest = testEvents.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 60000)
-
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
       const legacyConfigFile = type === 'esm'
@@ -1118,6 +1144,30 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const sessionEvents = events.filter(event => event.type === 'test_session_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            assert.strictEqual(sessionEvents.length, 1, 'should have one test session')
+            assert.ok(testEvents.length >= 1, 'should have at least one test')
+
+            const passedTest = testEvents.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 60000 })
+
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -1132,27 +1182,6 @@ moduleTypes.forEach(({
     // replace earlier registrations. This test verifies the system does not crash and
     // spans are still correctly reported through the manual plugin's own hooks.
     over10It('manual plugin with custom after hooks works without NODE_OPTIONS', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-
-          const sessionEvents = events.filter(event => event.type === 'test_session_end')
-          const testEvents = events.filter(event => event.type === 'test')
-
-          assert.strictEqual(sessionEvents.length, 1, 'should have one test session')
-          assert.ok(testEvents.length >= 1, 'should have at least one test')
-
-          const passedTest = testEvents.find(event =>
-            event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
-          )
-          assertObjectContains(passedTest?.content, {
-            meta: {
-              [TEST_STATUS]: 'pass',
-              [TEST_FRAMEWORK]: 'cypress',
-            },
-          })
-        }, 60000)
-
       // Strip NODE_OPTIONS — the manual plugin initializes dd-trace itself.
       const { NODE_OPTIONS, ...envVars } = getCiVisEvpProxyConfig(receiver.port)
 
@@ -1174,6 +1203,30 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+
+            const sessionEvents = events.filter(event => event.type === 'test_session_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            assert.strictEqual(sessionEvents.length, 1, 'should have one test session')
+            assert.ok(testEvents.length >= 1, 'should have at least one test')
+
+            const passedTest = testEvents.find(event =>
+              event.content.resource === 'cypress/e2e/basic-pass.js.basic pass suite can pass'
+            )
+            assertObjectContains(passedTest?.content, {
+              meta: {
+                [TEST_STATUS]: 'pass',
+                [TEST_FRAMEWORK]: 'cypress',
+              },
+            })
+          }, { hardTimeout: 60000 })
+
       const [[exitCode]] = await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -1192,48 +1245,6 @@ moduleTypes.forEach(({
         // the original TypeScript source file and line via the adjacent .js.map file.
         compilePrecompiledTypeScriptSpecs(cwd, envVars)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const tsTestEvents = events.filter(event =>
-              event.type === 'test' &&
-              event.content.resource.includes('spec source line')
-            )
-
-            assert.strictEqual(tsTestEvents.length, 2, 'should have two typescript test events')
-
-            const itTestEvent = tsTestEvents.find(e => e.content.resource.includes('reports correct line number'))
-            const testTestEvent = tsTestEvents.find(
-              e => e.content.resource.includes('template interpolated string test name')
-            )
-
-            assert.ok(itTestEvent, 'it() test event should exist')
-            // 'it' is defined at line 11 in the TypeScript source file spec-source-line.cy.ts
-            assert.strictEqual(
-              itTestEvent.content.metrics[TEST_SOURCE_START],
-              11,
-              'should report the correct source line for it() test'
-            )
-            assert.ok(
-              itTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
-            )
-
-            // 'specify' with a template literal test name is defined at line 16.
-            // The plugin resolves the TS line by scanning the compiled JS for the template literal
-            // call (fuzzy-matching ${expr} placeholders) and mapping via the adjacent .js.map.
-            assert.ok(testTestEvent, 'specify() with template literal name should exist')
-            assert.strictEqual(
-              testTestEvent.content.metrics[TEST_SOURCE_START],
-              16,
-              'should report the correct source line for specify() with template literal name'
-            )
-            assert.ok(
-              testTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
-            )
-          }, 60000)
-
         // Run Cypress with the pre-compiled JS spec (compiled from spec-source-line.cy.ts).
         // Cypress bundles the compiled JS via its own preprocessor; the plugin resolves
         // the original TypeScript source line by scanning the compiled JS and mapping
@@ -1246,6 +1257,51 @@ moduleTypes.forEach(({
             SPEC_PATTERN: 'cypress/e2e/dist/spec-source-line.cy.js',
           },
         })
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tsTestEvents = events.filter(event =>
+                event.type === 'test' &&
+              event.content.resource.includes('spec source line')
+              )
+
+              assert.strictEqual(tsTestEvents.length, 2, 'should have two typescript test events')
+
+              const itTestEvent = tsTestEvents.find(e => e.content.resource.includes('reports correct line number'))
+              const testTestEvent = tsTestEvents.find(
+                e => e.content.resource.includes('template interpolated string test name')
+              )
+
+              assert.ok(itTestEvent, 'it() test event should exist')
+              // 'it' is defined at line 11 in the TypeScript source file spec-source-line.cy.ts
+              assert.strictEqual(
+                itTestEvent.content.metrics[TEST_SOURCE_START],
+                11,
+                'should report the correct source line for it() test'
+              )
+              assert.ok(
+                itTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
+              `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
+              )
+
+              // 'specify' with a template literal test name is defined at line 16.
+              // The plugin resolves the TS line by scanning the compiled JS for the template literal
+              // call (fuzzy-matching ${expr} placeholders) and mapping via the adjacent .js.map.
+              assert.ok(testTestEvent, 'specify() with template literal name should exist')
+              assert.strictEqual(
+                testTestEvent.content.metrics[TEST_SOURCE_START],
+                16,
+                'should report the correct source line for specify() with template literal name'
+              )
+              assert.ok(
+                testTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
+              `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
+              )
+            }, { hardTimeout: 60000 })
 
         const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), receiverPromise])
         assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
@@ -1330,27 +1386,6 @@ moduleTypes.forEach(({
 
         compilePrecompiledTypeScriptSpecs(cwd, envVars)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const fallbackEvent = events.find(event =>
-              event.type === 'test' &&
-              event.content.resource.includes('spec source line fallback branch') &&
-              event.content.resource.includes('fallback branch literal title')
-            )
-
-            assert.ok(fallbackEvent, 'fallback-resolution test event should exist')
-            assert.strictEqual(
-              fallbackEvent.content.metrics[TEST_SOURCE_START],
-              7,
-              'should report TS source line resolved via declaration scanning fallback'
-            )
-            assert.ok(
-              fallbackEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-fallback.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${fallbackEvent.content.meta[TEST_SOURCE_FILE]}`
-            )
-          }, 60000)
-
         childProcess = exec(testCommand, {
           cwd,
           env: {
@@ -1359,6 +1394,30 @@ moduleTypes.forEach(({
             SPEC_PATTERN: 'cypress/e2e/dist/spec-source-line-fallback.cy.js',
           },
         })
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const fallbackEvent = events.find(event =>
+                event.type === 'test' &&
+              event.content.resource.includes('spec source line fallback branch') &&
+              event.content.resource.includes('fallback branch literal title')
+              )
+
+              assert.ok(fallbackEvent, 'fallback-resolution test event should exist')
+              assert.strictEqual(
+                fallbackEvent.content.metrics[TEST_SOURCE_START],
+                7,
+                'should report TS source line resolved via declaration scanning fallback'
+              )
+              assert.ok(
+                fallbackEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-fallback.cy.ts'),
+              `TEST_SOURCE_FILE should point to TypeScript source, got: ${fallbackEvent.content.meta[TEST_SOURCE_FILE]}`
+              )
+            }, { hardTimeout: 60000 })
 
         const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), receiverPromise])
         assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
@@ -1376,29 +1435,6 @@ moduleTypes.forEach(({
 
         compilePrecompiledTypeScriptSpecs(cwd, envVars)
 
-        const receiverPromise = receiver
-          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-            const events = payloads.flatMap(({ payload }) => payload.events)
-            const noMatchEvent = events.find(event =>
-              event.type === 'test' &&
-              event.content.resource.includes('spec source line no match') &&
-              event.content.resource.includes('no match title')
-            )
-
-            assert.ok(noMatchEvent, 'no-match test event should exist')
-            assert.ok(
-              Number.isInteger(noMatchEvent.content.metrics[TEST_SOURCE_START]) &&
-                noMatchEvent.content.metrics[TEST_SOURCE_START] > 100,
-              `expected unresolved source line to remain a large generated/invocation line, got: ${
-                noMatchEvent.content.metrics[TEST_SOURCE_START]
-              }`
-            )
-            assert.ok(
-              noMatchEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-no-match.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${noMatchEvent.content.meta[TEST_SOURCE_FILE]}`
-            )
-          }, 60000)
-
         childProcess = exec(testCommand, {
           cwd,
           env: {
@@ -1407,6 +1443,32 @@ moduleTypes.forEach(({
             SPEC_PATTERN: 'cypress/e2e/dist/spec-source-line-no-match.cy.js',
           },
         })
+
+        const receiverPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const noMatchEvent = events.find(event =>
+                event.type === 'test' &&
+              event.content.resource.includes('spec source line no match') &&
+              event.content.resource.includes('no match title')
+              )
+
+              assert.ok(noMatchEvent, 'no-match test event should exist')
+              assert.ok(
+                Number.isInteger(noMatchEvent.content.metrics[TEST_SOURCE_START]) &&
+                noMatchEvent.content.metrics[TEST_SOURCE_START] > 100,
+              `expected unresolved source line to remain a large generated/invocation line, got: ${
+                noMatchEvent.content.metrics[TEST_SOURCE_START]
+              }`
+              )
+              assert.ok(
+                noMatchEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-no-match.cy.ts'),
+              `TEST_SOURCE_FILE should point to TypeScript source, got: ${noMatchEvent.content.meta[TEST_SOURCE_FILE]}`
+              )
+            }, { hardTimeout: 60000 })
 
         const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), receiverPromise])
         assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
@@ -1418,30 +1480,6 @@ moduleTypes.forEach(({
     over12It('uses invocationDetails line directly for plain javascript specs without source maps', async function () {
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-          const jsInvocationDetailsEvent = events.find(event =>
-            event.type === 'test' &&
-            event.content.resource.includes('spec source line invocation details js') &&
-            event.content.resource.includes('uses invocation details line as source line')
-          )
-
-          assert.ok(jsInvocationDetailsEvent, 'plain-js invocationDetails test event should exist')
-          // The exact value is a Cypress-generated bundle line that shifts when support code changes.
-          // It should stay as a generated invocationDetails line instead of resolving to the fixture declaration.
-          assert.ok(
-            jsInvocationDetailsEvent.content.metrics[TEST_SOURCE_START] > 100,
-            'should keep generated invocationDetails line directly for plain JS specs without source maps'
-          )
-          assert.ok(
-            jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-invocation.cy.js'),
-            `TEST_SOURCE_FILE should point to JS source, got: ${
-              jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE]
-            }`
-          )
-        }, 60000)
-
       childProcess = exec(testCommand, {
         cwd,
         env: {
@@ -1450,6 +1488,33 @@ moduleTypes.forEach(({
           SPEC_PATTERN: 'cypress/e2e/spec-source-line-invocation.cy.js',
         },
       })
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const jsInvocationDetailsEvent = events.find(event =>
+              event.type === 'test' &&
+            event.content.resource.includes('spec source line invocation details js') &&
+            event.content.resource.includes('uses invocation details line as source line')
+            )
+
+            assert.ok(jsInvocationDetailsEvent, 'plain-js invocationDetails test event should exist')
+            // The exact value is a Cypress-generated bundle line that shifts when support code changes.
+            // It should stay as a generated invocationDetails line instead of resolving to the fixture declaration.
+            assert.ok(
+              jsInvocationDetailsEvent.content.metrics[TEST_SOURCE_START] > 100,
+              'should keep generated invocationDetails line directly for plain JS specs without source maps'
+            )
+            assert.ok(
+              jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-invocation.cy.js'),
+            `TEST_SOURCE_FILE should point to JS source, got: ${
+              jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE]
+            }`
+            )
+          }, { hardTimeout: 60000 })
 
       const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), receiverPromise])
       assert.strictEqual(exitCode, 0, 'cypress process should exit successfully')
@@ -1460,57 +1525,6 @@ moduleTypes.forEach(({
       cleanupPrecompiledSourceLineDist(cwd)
       configureCypressTypeScriptCompilation(cwd)
       let testOutput = ''
-
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-          const events = payloads.flatMap(({ payload }) => payload.events)
-          const tsTestEvents = events.filter(event =>
-            event.type === 'test' &&
-            event.content.resource.includes('spec source line')
-          )
-
-          assert.strictEqual(
-            tsTestEvents.length,
-            2,
-            `should have two typescript test events, got events: ${JSON.stringify(events.map(event => ({
-              type: event.type,
-              resource: event.content.resource,
-              sourceFile: event.content.meta?.[TEST_SOURCE_FILE],
-              sourceStart: event.content.metrics?.[TEST_SOURCE_START],
-              status: event.content.meta?.[TEST_STATUS],
-              error: event.content.meta?.[ERROR_MESSAGE],
-            })), null, 2)}\nCypress output:\n${testOutput}`
-          )
-
-          const itTestEvent = tsTestEvents.find(e => e.content.resource.includes('reports correct line number'))
-          const testTestEvent = tsTestEvents.find(
-            e => e.content.resource.includes('template interpolated string test name')
-          )
-
-          assert.ok(itTestEvent, 'it() test event should exist')
-          // 'it' is defined at line 11 in the TypeScript source file spec-source-line.cy.ts
-          assert.strictEqual(
-            itTestEvent.content.metrics[TEST_SOURCE_START],
-            11,
-            'should report the correct source line for it() test'
-          )
-          assert.ok(
-            itTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-            `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
-          )
-
-          // 'specify' with a template literal test name is defined at line 16.
-          // Cypress's webpack preprocessor in headless mode does not resolve eval source maps
-          // in Error.stack, so invocationDetails.line is the webpack bundle line rather than
-          // the TS source line. Name-scanning cannot match template-literal names (the source
-          // contains interpolated variables), so the exact TS line cannot be recovered in this
-          // mode. We verify the event exists and that TEST_SOURCE_FILE points to the TS source.
-          assert.ok(testTestEvent, 'specify() with template literal name should exist')
-          assert.ok(
-            testTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-            `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
-          )
-        }, 60000)
 
       const envVars = getCiVisAgentlessConfig(receiver.port)
 
@@ -1524,6 +1538,60 @@ moduleTypes.forEach(({
           SPEC_PATTERN: 'cypress/e2e/spec-source-line.cy.ts',
         },
       })
+
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tsTestEvents = events.filter(event =>
+              event.type === 'test' &&
+            event.content.resource.includes('spec source line')
+            )
+
+            assert.strictEqual(
+              tsTestEvents.length,
+              2,
+            `should have two typescript test events, got events: ${JSON.stringify(events.map(event => ({
+              type: event.type,
+              resource: event.content.resource,
+              sourceFile: event.content.meta?.[TEST_SOURCE_FILE],
+              sourceStart: event.content.metrics?.[TEST_SOURCE_START],
+              status: event.content.meta?.[TEST_STATUS],
+              error: event.content.meta?.[ERROR_MESSAGE],
+            })), null, 2)}\nCypress output:\n${testOutput}`
+            )
+
+            const itTestEvent = tsTestEvents.find(e => e.content.resource.includes('reports correct line number'))
+            const testTestEvent = tsTestEvents.find(
+              e => e.content.resource.includes('template interpolated string test name')
+            )
+
+            assert.ok(itTestEvent, 'it() test event should exist')
+            // 'it' is defined at line 11 in the TypeScript source file spec-source-line.cy.ts
+            assert.strictEqual(
+              itTestEvent.content.metrics[TEST_SOURCE_START],
+              11,
+              'should report the correct source line for it() test'
+            )
+            assert.ok(
+              itTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
+            `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
+            )
+
+            // 'specify' with a template literal test name is defined at line 16.
+            // Cypress's webpack preprocessor in headless mode does not resolve eval source maps
+            // in Error.stack, so invocationDetails.line is the webpack bundle line rather than
+            // the TS source line. Name-scanning cannot match template-literal names (the source
+            // contains interpolated variables), so the exact TS line cannot be recovered in this
+            // mode. We verify the event exists and that TEST_SOURCE_FILE points to the TS source.
+            assert.ok(testTestEvent, 'specify() with template literal name should exist')
+            assert.ok(
+              testTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
+            `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
+            )
+          }, { hardTimeout: 60000 })
       childProcess.stdout?.on('data', chunk => {
         testOutput += chunk.toString()
       })
@@ -1542,26 +1610,6 @@ moduleTypes.forEach(({
           const envVars = getCiVisAgentlessConfig(receiver.port)
 
           receiver.setSettingsResponseCode(404)
-          const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const testSession = events.find(event => event.type === 'test_session_end').content
-              assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
-                'test_session_end should have _dd.ci.library_configuration_error.settings tag')
-              const testModule = events.find(event => event.type === 'test_module_end')
-              assert.ok(testModule, 'should have test module event')
-              assert.strictEqual(testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
-                'test_module_end should have _dd.ci.library_configuration_error.settings tag')
-              const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-              assert.ok(testSuiteEvent, 'should have test suite event')
-              assert.strictEqual(testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
-                'test_suite_end should have _dd.ci.library_configuration_error.settings tag')
-              const testEvent = events.find(event => event.type === 'test')
-              assert.ok(testEvent, 'should have test event')
-              assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
-                'test event should have _dd.ci.library_configuration_error.settings tag')
-            })
-
           childProcess = exec(
             testCommand,
             {
@@ -1573,6 +1621,29 @@ moduleTypes.forEach(({
               },
             }
           )
+
+          const eventsPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const testSession = events.find(event => event.type === 'test_session_end').content
+                assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
+                  'test_session_end should have _dd.ci.library_configuration_error.settings tag')
+                const testModule = events.find(event => event.type === 'test_module_end')
+                assert.ok(testModule, 'should have test module event')
+                assert.strictEqual(testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
+                  'test_module_end should have _dd.ci.library_configuration_error.settings tag')
+                const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+                assert.ok(testSuiteEvent, 'should have test suite event')
+                assert.strictEqual(testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
+                  'test_suite_end should have _dd.ci.library_configuration_error.settings tag')
+                const testEvent = events.find(event => event.type === 'test')
+                assert.ok(testEvent, 'should have test event')
+                assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS], 'true',
+                  'test event should have _dd.ci.library_configuration_error.settings tag')
+              })
 
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
@@ -1583,26 +1654,6 @@ moduleTypes.forEach(({
           const envVars = getCiVisAgentlessConfig(receiver.port)
 
           receiver.setSkippableSuitesResponseCode(404)
-          const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const testSession = events.find(event => event.type === 'test_session_end').content
-              assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
-                'test_session_end should have _dd.ci.library_configuration_error.skippable_tests tag')
-              const testModule = events.find(event => event.type === 'test_module_end')
-              assert.ok(testModule, 'should have test module event')
-              assert.strictEqual(testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
-                'test_module_end should have _dd.ci.library_configuration_error.skippable_tests tag')
-              const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-              assert.ok(testSuiteEvent, 'should have test suite event')
-              assert.strictEqual(testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
-                'test_suite_end should have _dd.ci.library_configuration_error.skippable_tests tag')
-              const testEvent = events.find(event => event.type === 'test')
-              assert.ok(testEvent, 'should have test event')
-              assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
-                'test event should have _dd.ci.library_configuration_error.skippable_tests tag')
-            })
-
           childProcess = exec(
             testCommand,
             {
@@ -1614,6 +1665,31 @@ moduleTypes.forEach(({
               },
             }
           )
+
+          const eventsPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const testSession = events.find(event => event.type === 'test_session_end').content
+                assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
+                  'test_session_end should have _dd.ci.library_configuration_error.skippable_tests tag')
+                const testModule = events.find(event => event.type === 'test_module_end')
+                assert.ok(testModule, 'should have test module event')
+                assert.strictEqual(testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
+                  'test_module_end should have _dd.ci.library_configuration_error.skippable_tests tag')
+                const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+                assert.ok(testSuiteEvent, 'should have test suite event')
+                assert.strictEqual(
+                  testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS],
+                  'true',
+                  'test_suite_end should have _dd.ci.library_configuration_error.skippable_tests tag')
+                const testEvent = events.find(event => event.type === 'test')
+                assert.ok(testEvent, 'should have test event')
+                assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_SKIPPABLE_TESTS], 'true',
+                  'test event should have _dd.ci.library_configuration_error.skippable_tests tag')
+              })
 
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
@@ -1625,26 +1701,6 @@ moduleTypes.forEach(({
 
           receiver.setSettings({ known_tests_enabled: true })
           receiver.setKnownTestsResponseCode(404)
-          const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const testSession = events.find(event => event.type === 'test_session_end').content
-              assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
-                'test_session_end should have _dd.ci.library_configuration_error.known_tests tag')
-              const testModule = events.find(event => event.type === 'test_module_end')
-              assert.ok(testModule, 'should have test module event')
-              assert.strictEqual(testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
-                'test_module_end should have _dd.ci.library_configuration_error.known_tests tag')
-              const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-              assert.ok(testSuiteEvent, 'should have test suite event')
-              assert.strictEqual(testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
-                'test_suite_end should have _dd.ci.library_configuration_error.known_tests tag')
-              const testEvent = events.find(event => event.type === 'test')
-              assert.ok(testEvent, 'should have test event')
-              assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
-                'test event should have _dd.ci.library_configuration_error.known_tests tag')
-            })
-
           childProcess = exec(
             testCommand,
             {
@@ -1656,6 +1712,29 @@ moduleTypes.forEach(({
               },
             }
           )
+
+          const eventsPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const testSession = events.find(event => event.type === 'test_session_end').content
+                assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
+                  'test_session_end should have _dd.ci.library_configuration_error.known_tests tag')
+                const testModule = events.find(event => event.type === 'test_module_end')
+                assert.ok(testModule, 'should have test module event')
+                assert.strictEqual(testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
+                  'test_module_end should have _dd.ci.library_configuration_error.known_tests tag')
+                const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+                assert.ok(testSuiteEvent, 'should have test suite event')
+                assert.strictEqual(testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
+                  'test_suite_end should have _dd.ci.library_configuration_error.known_tests tag')
+                const testEvent = events.find(event => event.type === 'test')
+                assert.ok(testEvent, 'should have test event')
+                assert.strictEqual(testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS], 'true',
+                  'test event should have _dd.ci.library_configuration_error.known_tests tag')
+              })
 
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
@@ -1667,32 +1746,6 @@ moduleTypes.forEach(({
 
           receiver.setSettings({ test_management: { enabled: true } })
           receiver.setTestManagementTestsResponseCode(404)
-          const eventsPromise = receiver
-            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
-              const events = payloads.flatMap(({ payload }) => payload.events)
-              const testSession = events.find(event => event.type === 'test_session_end').content
-              assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
-                'test_session_end should have _dd.ci.library_configuration_error.test_management_tests tag')
-              const testModule = events.find(event => event.type === 'test_module_end')
-              assert.ok(testModule, 'should have test module event')
-              assert.strictEqual(
-                testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
-                'test_module_end should have _dd.ci.library_configuration_error.test_management_tests tag'
-              )
-              const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
-              assert.ok(testSuiteEvent, 'should have test suite event')
-              assert.strictEqual(
-                testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
-                'test_suite_end should have _dd.ci.library_configuration_error.test_management_tests tag'
-              )
-              const testEvent = events.find(event => event.type === 'test')
-              assert.ok(testEvent, 'should have test event')
-              assert.strictEqual(
-                testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
-                'test event should have _dd.ci.library_configuration_error.test_management_tests tag'
-              )
-            })
-
           childProcess = exec(
             testCommand,
             {
@@ -1704,6 +1757,35 @@ moduleTypes.forEach(({
               },
             }
           )
+
+          const eventsPromise = receiver
+            .gatherPayloadsUntilChildExit(
+              childProcess,
+              ({ url }) => url.endsWith('/api/v2/citestcycle'),
+              (payloads) => {
+                const events = payloads.flatMap(({ payload }) => payload.events)
+                const testSession = events.find(event => event.type === 'test_session_end').content
+                assert.strictEqual(testSession.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
+                  'test_session_end should have _dd.ci.library_configuration_error.test_management_tests tag')
+                const testModule = events.find(event => event.type === 'test_module_end')
+                assert.ok(testModule, 'should have test module event')
+                assert.strictEqual(
+                  testModule.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
+                  'test_module_end should have _dd.ci.library_configuration_error.test_management_tests tag'
+                )
+                const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+                assert.ok(testSuiteEvent, 'should have test suite event')
+                assert.strictEqual(
+                  testSuiteEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
+                  'test_suite_end should have _dd.ci.library_configuration_error.test_management_tests tag'
+                )
+                const testEvent = events.find(event => event.type === 'test')
+                assert.ok(testEvent, 'should have test event')
+                assert.strictEqual(
+                  testEvent.content.meta[DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS], 'true',
+                  'test event should have _dd.ci.library_configuration_error.test_management_tests tag'
+                )
+              })
 
           await Promise.all([eventsPromise, once(childProcess, 'exit')])
         })
@@ -1766,150 +1848,6 @@ moduleTypes.forEach(({
     })
 
     it('can run and report tests', async () => {
-      const receiverPromise = receiver
-        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
-          const ciVisPayloads = payloads.filter(({ payload }) => payload.metadata?.test)
-          const ciVisMetadataDicts = ciVisPayloads.flatMap(({ payload }) => payload.metadata)
-
-          ciVisMetadataDicts.forEach(metadata => {
-            for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
-              assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
-            }
-          })
-          const events = ciVisPayloads.flatMap(({ payload }) => payload.events)
-
-          const testSessionEvent = events.find(event => event.type === 'test_session_end')
-          const testModuleEvent = events.find(event => event.type === 'test_module_end')
-          const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
-          const testEvents = events.filter(event => event.type === 'test')
-
-          const { content: testSessionEventContent } = testSessionEvent
-          const { content: testModuleEventContent } = testModuleEvent
-
-          assert.ok(testSessionEventContent.test_session_id)
-          assert.ok(testSessionEventContent.meta[TEST_COMMAND])
-          assert.ok(testSessionEventContent.meta[TEST_TOOLCHAIN])
-          assert.strictEqual(testSessionEventContent.resource.startsWith('test_session.'), true)
-          assert.strictEqual(testSessionEventContent.meta[TEST_STATUS], 'fail')
-
-          assert.ok(testModuleEventContent.test_session_id)
-          assert.ok(testModuleEventContent.test_module_id)
-          assert.ok(testModuleEventContent.meta[TEST_COMMAND])
-          assert.ok(testModuleEventContent.meta[TEST_MODULE])
-          assert.strictEqual(testModuleEventContent.resource.startsWith('test_module.'), true)
-          assert.strictEqual(testModuleEventContent.meta[TEST_STATUS], 'fail')
-          assert.strictEqual(
-            testModuleEventContent.test_session_id.toString(10),
-            testSessionEventContent.test_session_id.toString(10)
-          )
-          assert.ok(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
-
-          assert.deepStrictEqual(
-            testSuiteEvents.map(suite => suite.content.resource).sort(),
-            [
-              'test_suite.cypress/e2e/hook-describe-error.cy.js',
-              'test_suite.cypress/e2e/hook-test-error.cy.js',
-              'test_suite.cypress/e2e/other.cy.js',
-              'test_suite.cypress/e2e/spec.cy.js',
-            ]
-          )
-
-          assertObjectContains(
-            testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]).sort(),
-            ['fail', 'fail', 'fail', 'pass']
-          )
-
-          testSuiteEvents.forEach(({
-            content: {
-              meta,
-              metrics,
-              test_suite_id: testSuiteId,
-              test_module_id: testModuleId,
-              test_session_id: testSessionId,
-            },
-          }) => {
-            assert.ok(meta[TEST_COMMAND])
-            assert.ok(meta[TEST_MODULE])
-            assert.ok(testSuiteId)
-            assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
-            assert.strictEqual(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-            assert.strictEqual(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
-            assert.strictEqual(metrics[TEST_SOURCE_START], 1)
-            assert.ok(metrics[DD_HOST_CPU_COUNT])
-          })
-
-          assertObjectContains(testEvents.map(test => test.content.resource).sort(), [
-            'cypress/e2e/other.cy.js.context passes',
-            'cypress/e2e/spec.cy.js.context passes',
-            'cypress/e2e/spec.cy.js.other context fails',
-          ])
-
-          testEvents.forEach(({
-            content: {
-              meta,
-              metrics,
-              test_suite_id: testSuiteId,
-              test_module_id: testModuleId,
-              test_session_id: testSessionId,
-            },
-          }) => {
-            assert.ok(meta[TEST_COMMAND])
-            assert.ok(meta[TEST_MODULE])
-            assert.ok(testSuiteId)
-            assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
-            assert.strictEqual(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
-            assert.strictEqual(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
-            // Can read DD_TAGS
-            assert.strictEqual(meta[DD_TEST_IS_USER_PROVIDED_SERVICE], 'false')
-            assert.strictEqual(meta['test.customtag'], 'customvalue')
-            assert.strictEqual(meta['test.customtag2'], 'customvalue2')
-            assert.ok(metrics[DD_HOST_CPU_COUNT])
-          })
-
-          // Verify hook errors are caught correctly
-          // test level hooks
-          const testHookSuite = events.find(
-            event => event.content.resource === 'test_suite.cypress/e2e/hook-test-error.cy.js'
-          )
-          const passedTest = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-test-error.cy.js.hook-test-error tests passes'
-          )
-          const failedTest = events.find(
-            event => event.content.resource ===
-            'cypress/e2e/hook-test-error.cy.js.hook-test-error tests will fail because afterEach fails'
-          )
-          const skippedTest = events.find(
-            event => event.content.resource ===
-            'cypress/e2e/hook-test-error.cy.js.hook-test-error tests does not run because earlier afterEach fails'
-          )
-          assert.strictEqual(passedTest.content.meta[TEST_STATUS], 'pass')
-          assert.strictEqual(failedTest.content.meta[TEST_STATUS], 'fail')
-          assert.match(failedTest.content.meta[ERROR_MESSAGE], /error in after each hook/)
-          assert.strictEqual(skippedTest.content.meta[TEST_STATUS], 'skip')
-          assert.strictEqual(testHookSuite.content.meta[TEST_STATUS], 'fail')
-          assert.match(testHookSuite.content.meta[ERROR_MESSAGE], /error in after each hook/)
-
-          // describe level hooks
-          const describeHookSuite = events.find(
-            event => event.content.resource === 'test_suite.cypress/e2e/hook-describe-error.cy.js'
-          )
-          const passedTestDescribe = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after passes'
-          )
-          const failedTestDescribe = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after will be marked as failed'
-          )
-          const skippedTestDescribe = events.find(
-            event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.before will be skipped'
-          )
-          assert.strictEqual(passedTestDescribe.content.meta[TEST_STATUS], 'pass')
-          assert.strictEqual(failedTestDescribe.content.meta[TEST_STATUS], 'fail')
-          assert.match(failedTestDescribe.content.meta[ERROR_MESSAGE], /error in after hook/)
-          assert.strictEqual(skippedTestDescribe.content.meta[TEST_STATUS], 'skip')
-          assert.strictEqual(describeHookSuite.content.meta[TEST_STATUS], 'fail')
-          assert.match(describeHookSuite.content.meta[ERROR_MESSAGE], /error in after hook/)
-        }, 25000)
-
       const envVars = getCiVisEvpProxyConfig(receiver.port)
 
       childProcess = exec(
@@ -1927,6 +1865,153 @@ moduleTypes.forEach(({
         }
       )
 
+      const receiverPromise = receiver
+        .gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          payloads => {
+            const ciVisPayloads = payloads.filter(({ payload }) => payload.metadata?.test)
+            const ciVisMetadataDicts = ciVisPayloads.flatMap(({ payload }) => payload.metadata)
+
+            ciVisMetadataDicts.forEach(metadata => {
+              for (const testLevel of TEST_LEVEL_EVENT_TYPES) {
+                assert.strictEqual(metadata[testLevel][TEST_SESSION_NAME], 'my-test-session')
+              }
+            })
+            const events = ciVisPayloads.flatMap(({ payload }) => payload.events)
+
+            const testSessionEvent = events.find(event => event.type === 'test_session_end')
+            const testModuleEvent = events.find(event => event.type === 'test_module_end')
+            const testSuiteEvents = events.filter(event => event.type === 'test_suite_end')
+            const testEvents = events.filter(event => event.type === 'test')
+
+            const { content: testSessionEventContent } = testSessionEvent
+            const { content: testModuleEventContent } = testModuleEvent
+
+            assert.ok(testSessionEventContent.test_session_id)
+            assert.ok(testSessionEventContent.meta[TEST_COMMAND])
+            assert.ok(testSessionEventContent.meta[TEST_TOOLCHAIN])
+            assert.strictEqual(testSessionEventContent.resource.startsWith('test_session.'), true)
+            assert.strictEqual(testSessionEventContent.meta[TEST_STATUS], 'fail')
+
+            assert.ok(testModuleEventContent.test_session_id)
+            assert.ok(testModuleEventContent.test_module_id)
+            assert.ok(testModuleEventContent.meta[TEST_COMMAND])
+            assert.ok(testModuleEventContent.meta[TEST_MODULE])
+            assert.strictEqual(testModuleEventContent.resource.startsWith('test_module.'), true)
+            assert.strictEqual(testModuleEventContent.meta[TEST_STATUS], 'fail')
+            assert.strictEqual(
+              testModuleEventContent.test_session_id.toString(10),
+              testSessionEventContent.test_session_id.toString(10)
+            )
+            assert.ok(testModuleEventContent.meta[TEST_FRAMEWORK_VERSION])
+
+            assert.deepStrictEqual(
+              testSuiteEvents.map(suite => suite.content.resource).sort(),
+              [
+                'test_suite.cypress/e2e/hook-describe-error.cy.js',
+                'test_suite.cypress/e2e/hook-test-error.cy.js',
+                'test_suite.cypress/e2e/other.cy.js',
+                'test_suite.cypress/e2e/spec.cy.js',
+              ]
+            )
+
+            assertObjectContains(
+              testSuiteEvents.map(suite => suite.content.meta[TEST_STATUS]).sort(),
+              ['fail', 'fail', 'fail', 'pass']
+            )
+
+            testSuiteEvents.forEach(({
+              content: {
+                meta,
+                metrics,
+                test_suite_id: testSuiteId,
+                test_module_id: testModuleId,
+                test_session_id: testSessionId,
+              },
+            }) => {
+              assert.ok(meta[TEST_COMMAND])
+              assert.ok(meta[TEST_MODULE])
+              assert.ok(testSuiteId)
+              assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+              assert.strictEqual(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+              assert.strictEqual(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
+              assert.strictEqual(metrics[TEST_SOURCE_START], 1)
+              assert.ok(metrics[DD_HOST_CPU_COUNT])
+            })
+
+            assertObjectContains(testEvents.map(test => test.content.resource).sort(), [
+              'cypress/e2e/other.cy.js.context passes',
+              'cypress/e2e/spec.cy.js.context passes',
+              'cypress/e2e/spec.cy.js.other context fails',
+            ])
+
+            testEvents.forEach(({
+              content: {
+                meta,
+                metrics,
+                test_suite_id: testSuiteId,
+                test_module_id: testModuleId,
+                test_session_id: testSessionId,
+              },
+            }) => {
+              assert.ok(meta[TEST_COMMAND])
+              assert.ok(meta[TEST_MODULE])
+              assert.ok(testSuiteId)
+              assert.strictEqual(testModuleId.toString(10), testModuleEventContent.test_module_id.toString(10))
+              assert.strictEqual(testSessionId.toString(10), testSessionEventContent.test_session_id.toString(10))
+              assert.strictEqual(meta[TEST_SOURCE_FILE].startsWith('cypress/e2e/'), true)
+              // Can read DD_TAGS
+              assert.strictEqual(meta[DD_TEST_IS_USER_PROVIDED_SERVICE], 'false')
+              assert.strictEqual(meta['test.customtag'], 'customvalue')
+              assert.strictEqual(meta['test.customtag2'], 'customvalue2')
+              assert.ok(metrics[DD_HOST_CPU_COUNT])
+            })
+
+            // Verify hook errors are caught correctly
+            // test level hooks
+            const testHookSuite = events.find(
+              event => event.content.resource === 'test_suite.cypress/e2e/hook-test-error.cy.js'
+            )
+            const passedTest = events.find(
+              event => event.content.resource === 'cypress/e2e/hook-test-error.cy.js.hook-test-error tests passes'
+            )
+            const failedTest = events.find(
+              event => event.content.resource ===
+            'cypress/e2e/hook-test-error.cy.js.hook-test-error tests will fail because afterEach fails'
+            )
+            const skippedTest = events.find(
+              event => event.content.resource ===
+            'cypress/e2e/hook-test-error.cy.js.hook-test-error tests does not run because earlier afterEach fails'
+            )
+            assert.strictEqual(passedTest.content.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(failedTest.content.meta[TEST_STATUS], 'fail')
+            assert.match(failedTest.content.meta[ERROR_MESSAGE], /error in after each hook/)
+            assert.strictEqual(skippedTest.content.meta[TEST_STATUS], 'skip')
+            assert.strictEqual(testHookSuite.content.meta[TEST_STATUS], 'fail')
+            assert.match(testHookSuite.content.meta[ERROR_MESSAGE], /error in after each hook/)
+
+            // describe level hooks
+            const describeHookSuite = events.find(
+              event => event.content.resource === 'test_suite.cypress/e2e/hook-describe-error.cy.js'
+            )
+            const passedTestDescribe = events.find(
+              event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after passes'
+            )
+            const failedTestDescribe = events.find(
+              event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.after will be marked as failed'
+            )
+            const skippedTestDescribe = events.find(
+              event => event.content.resource === 'cypress/e2e/hook-describe-error.cy.js.before will be skipped'
+            )
+            assert.strictEqual(passedTestDescribe.content.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(failedTestDescribe.content.meta[TEST_STATUS], 'fail')
+            assert.match(failedTestDescribe.content.meta[ERROR_MESSAGE], /error in after hook/)
+            assert.strictEqual(skippedTestDescribe.content.meta[TEST_STATUS], 'skip')
+            assert.strictEqual(describeHookSuite.content.meta[TEST_STATUS], 'fail')
+            assert.match(describeHookSuite.content.meta[ERROR_MESSAGE], /error in after hook/)
+          }, { hardTimeout: 25000 })
+
       await Promise.all([
         once(childProcess, 'exit'),
         receiverPromise,
@@ -1935,26 +2020,6 @@ moduleTypes.forEach(({
 
     it('can report code coverage if it is available', async () => {
       const envVars = getCiVisAgentlessConfig(receiver.port)
-
-      const receiverPromise = receiver.gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcov', payloads => {
-        const [{ payload: coveragePayloads }] = payloads
-
-        const coverages = coveragePayloads.map(coverage => coverage.content)
-          .flatMap(content => content.coverages)
-
-        coverages.forEach(coverage => {
-          assert.ok(Object.hasOwn(coverage, 'test_session_id'))
-          assert.ok(Object.hasOwn(coverage, 'test_suite_id'))
-          assert.ok(Object.hasOwn(coverage, 'span_id'))
-          assert.ok(Object.hasOwn(coverage, 'files'))
-        })
-
-        const fileNames = coverages
-          .flatMap(coverageAttachment => coverageAttachment.files)
-          .map(file => file.filename)
-
-        assertObjectContains(fileNames, Object.keys(coverageFixture))
-      }, 25000)
 
       childProcess = exec(
         testCommand,
@@ -1967,6 +2032,29 @@ moduleTypes.forEach(({
           },
         }
       )
+
+      const receiverPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url === '/api/v2/citestcov',
+        payloads => {
+          const [{ payload: coveragePayloads }] = payloads
+
+          const coverages = coveragePayloads.map(coverage => coverage.content)
+            .flatMap(content => content.coverages)
+
+          coverages.forEach(coverage => {
+            assert.ok(Object.hasOwn(coverage, 'test_session_id'))
+            assert.ok(Object.hasOwn(coverage, 'test_suite_id'))
+            assert.ok(Object.hasOwn(coverage, 'span_id'))
+            assert.ok(Object.hasOwn(coverage, 'files'))
+          })
+
+          const fileNames = coverages
+            .flatMap(coverageAttachment => coverageAttachment.files)
+            .map(file => file.filename)
+
+          assertObjectContains(fileNames, Object.keys(coverageFixture))
+        }, { hardTimeout: 25000 })
 
       await Promise.all([
         once(childProcess, 'exit'),


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?

Reorders Cypress integration tests so the Cypress child process is created before intake payload collection starts.

This replaces fixed wall-clock `gatherPayloadsMaxTimeout` waits with `gatherPayloadsUntilChildExit(childProcess, ...)` across the Cypress specs, so assertions inspect payloads after the spawned Cypress process has exited and flushed terminal CI Visibility events.

### Motivation

Some `integration-cypress` flakes asserted against partial intake buffers when CI was slow. The failure signature was missing terminal CI Visibility events such as `test_session_end` / `test_module_end`, or buffers that only contained stray span payloads.
