### PR TITLE
fix(types): import opentracing from the consumer's installed package

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -25,7 +25,7 @@ import {
   SPAN_TYPE,
 } from '../ext/tags'
 import { HTTP, WEB } from '../ext/types'
-import * as opentracing from '../vendor/dist/opentracing';
+import * as opentracing from 'opentracing';
 import { IncomingMessage, OutgoingMessage } from 'http';
 
 opentracing.initGlobalTracer(tracer);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import { ClientRequest, IncomingMessage, OutgoingMessage, ServerResponse } from "http";
 import { LookupFunction } from 'net';
-import * as opentracing from "./vendor/dist/opentracing";
+import * as opentracing from "opentracing";
 import * as otel from "@opentelemetry/api";
 
 /**

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -1,6 +1,6 @@
 import { ClientRequest, IncomingMessage, OutgoingMessage, ServerResponse } from "http";
 import { LookupFunction } from 'net';
-import * as opentracing from "./vendor/dist/opentracing";
+import * as opentracing from "opentracing";
 import * as otel from "@opentelemetry/api";
 
 /**

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
   "dependencies": {
     "dc-polyfill": "^0.1.11",
     "import-in-the-middle": "^3.0.1",
-    "opentracing": ">=0.14.0"
+    "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {
     "@datadog/libdatadog": "0.9.3",

--- a/package.json
+++ b/package.json
@@ -161,7 +161,8 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.11",
-    "import-in-the-middle": "^3.0.1"
+    "import-in-the-middle": "^3.0.1",
+    "opentracing": ">=0.14.0"
   },
   "optionalDependencies": {
     "@datadog/libdatadog": "0.9.3",
@@ -218,7 +219,6 @@
     "node-preload": "^0.2.1",
     "nyc": "^18.0.0",
     "octokit": "^5.0.3",
-    "opentracing": ">=0.14.7",
     "p-limit": "^7.2.0",
     "proxyquire": "^2.1.3",
     "retry": "^0.13.1",

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -7,7 +7,7 @@ const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const opentracing = require('../../../../vendor/dist/opentracing')
+const opentracing = require('opentracing')
 require('../setup/core')
 const SpanContext = require('../../src/opentracing/span_context')
 const formats = require('../../../../ext/formats')

--- a/packages/dd-trace/test/scope.spec.js
+++ b/packages/dd-trace/test/scope.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach } = require('mocha')
 const sinon = require('sinon')
 
-const { Span } = require('../../../vendor/dist/opentracing')
+const { Span } = require('opentracing')
 require('./setup/core')
 const Scope = require('../src/scope')
 

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -25,7 +25,6 @@
         "meriyah": "^6.1.4",
         "module-details-from-path": "^1.0.4",
         "mutexify": "^1.4.0",
-        "opentracing": ">=0.14.7",
         "pprof-format": "^2.1.1",
         "protobufjs": "^8.0.1",
         "retry": "^0.13.1",
@@ -637,7 +636,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -723,15 +721,6 @@
       "license": "MIT",
       "dependencies": {
         "queue-tick": "^1.0.0"
-      }
-    },
-    "node_modules/opentracing": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/opentracing/-/opentracing-0.14.7.tgz",
-      "integrity": "sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/pprof-format": {

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -22,7 +22,6 @@
     "meriyah": "^6.1.4",
     "module-details-from-path": "^1.0.4",
     "mutexify": "^1.4.0",
-    "opentracing": ">=0.14.7",
     "pprof-format": "^2.1.1",
     "protobufjs": "^8.0.1",
     "retry": "^0.13.1",

--- a/vendor/rspack.config.js
+++ b/vendor/rspack.config.js
@@ -80,13 +80,6 @@ module.exports = {
     }),
     new CopyRspackPlugin({
       patterns: [
-        // The OpenTracing types are exposed in the public API of dd-trace so
-        // they need to be available in the package.
-        {
-          from: '**/*.d.ts',
-          context: join(__dirname, 'node_modules', 'opentracing', 'lib'),
-          to: 'opentracing'
-        },
         // Binaries need to be copied manually.
         {
           from: 'source-map/lib/mappings.wasm',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,7 +3435,7 @@ once@^1.4.0:
   dependencies:
     wrappy "1"
 
-opentracing@>=0.14.0:
+opentracing@>=0.14.7:
   version "0.14.7"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
   integrity sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3435,7 +3435,7 @@ once@^1.4.0:
   dependencies:
     wrappy "1"
 
-opentracing@>=0.14.7:
+opentracing@>=0.14.0:
   version "0.14.7"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
   integrity sha512-vz9iS7MJ5+Bp1URw8Khvdyw1H/hGvzHWlKQ7eRrQojSCDL1/SrWfrY9QebLw97n2deyRtzHRC3MkQfVNUCo91Q==


### PR DESCRIPTION
## Summary

`opentracing.initGlobalTracer(tracer)` fails to type-check because dd-trace's public types reach into `./vendor/dist/opentracing` while consumers reach into their own `node_modules/opentracing`. opentracing's `Reference` / `Tracer` / `Span` declare `protected` members, so the two copies are nominally distinct classes and the dd-trace `Tracer` is not a subtype of the consumer's `opentracing.Tracer`.

`index.d.ts` imports from `"opentracing"` directly and the package becomes a regular runtime dependency. npm, yarn, and pnpm hoist a single copy that both dd-trace and the consumer resolve to, and TypeScript dedupes the nominal class identity by `name@version` Package ID, so `initGlobalTracer(tracer)` accepts dd-trace's `Tracer`. The range is `>=0.14.0` rather than `>=0.14.7` to widen the hoist window for consumers pinned to an older patch — the repository was archived on 2023-05-23 and the type surface is identical across 0.14.0–0.14.7.

The vendored type copy and its rspack build step are dropped; dd-trace's runtime never required the package.

## Test plan

- [x] `cd docs && yarn test` — `tsc -p .` against the user-facing `import 'opentracing'` is the regression assertion; fails on master, passes here.
- [x] `mocha packages/dd-trace/test/scope.spec.js packages/dd-trace/test/opentracing/**/*.spec.js` — 228 passing / 2 pending (pre-existing).
- [x] `yarn lint` — green (license check, eslint, docker checks).
- [x] Sandbox install (`bun add file:dd-trace.tgz --linker=hoisted`) hoists a single `opentracing` next to `dd-trace`; `tsc --target ES6 ... noop.ts` compiles cleanly without a consumer-level `opentracing` install — confirms the dep auto-installs and resolves at the consumer's tree.
- [x] Regression check that an *optional* peer dependency would not work: with `peerDependenciesMeta.optional: true` and no top-level `opentracing` install, `tsc` fails with `TS2307: Cannot find module 'opentracing'` on the consumer's `index.d.ts` resolution — confirming the bot's pushback and motivating the move to a regular dep.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8523
Refs: https://github.com/DataDog/dd-trace-js/pull/6958