### PR TITLE
test: targeted aerospike and electron suite timeouts

### DIFF
--- a/integration-tests/electron/electron.spec.js
+++ b/integration-tests/electron/electron.spec.js
@@ -100,7 +100,7 @@ describe('Electron integration', function () {
   })
 
   beforeEach(function (done) {
-    this.timeout(15_000)
+    this.timeout(30_000)
 
     child = spawn(binaryPath, process.platform === 'linux' ? ['--no-sandbox'] : [], {
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -20,7 +20,9 @@ describe('Plugin', () => {
   let key
   let keyString
 
-  describe('aerospike', () => {
+  describe('aerospike', function () {
+    this.timeout(8000)
+
     withVersions('aerospike', 'aerospike', version => {
       beforeEach(() => {
         tracer = require('../../dd-trace')
@@ -51,7 +53,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          aerospike.releaseEventLoop()
+          aerospike?.releaseEventLoop()
         })
 
         describe('client', () => {
@@ -306,7 +308,7 @@ describe('Plugin', () => {
         })
 
         after(() => {
-          aerospike.releaseEventLoop()
+          aerospike?.releaseEventLoop()
         })
 
         it('should be configured with the correct values', done => {


### PR DESCRIPTION
## Summary

Narrower counter-proposal to #8486, scoped to the two places with reproducible CI evidence.

**aerospike** — the `without configuration` `before` hook timed out twice on master in April (`apm-integrations` runs `25009710560` and `25053278499`). The reported error was a secondary `TypeError` from `aerospike.releaseEventLoop()` in `after`, because `aerospike` is assigned in `beforeEach` (which Mocha skips when `before` fails), so the real `agent.load('aerospike')` failure never reached the test report.

1. `this.timeout(8000)` on `describe('aerospike', …)` — the native binding plus `proxyquire` cold-load exceeds the 5 s default on cold CI disk cache. 8 s is the minimal headroom; bump again only if a real flake reproduces.
2. `aerospike?.releaseEventLoop()` in both `after` hooks — teardown tolerates a failed `before`, so the next `agent.load` failure surfaces its real cause instead of the masked `TypeError`.

**electron** — `integration-tests/electron/electron.spec.js`'s `beforeEach` (`spawn`-ing the freshly-packaged Electron binary) blew its existing 15 s ceiling on master twice in the last week (electron-workflow runs `25919871105` and `26037630300`). The packaged binary was just written to disk in `before` (cold page cache) and has to load the bundled Chromium plus dd-trace on first launch. Raising `beforeEach` to 30 s matches what the `before` hook of the same suite already reserves.

## Why this and not #8486

#8486 bumps the global mocha timeout to 15 s under `process.env.CI`, citing aerospike, electron, and oracledb. Checking the actual evidence on master:

- **aerospike**: real failures in April. Fixed here.
- **electron**: real failures in the last week. Fixed here. #8486's blanket 15 s would *not* have fixed this — the failing hook is already at 15 s, and the packaged-binary spawn genuinely needs more.
- **oracledb**: no master-CI timeout failures in `apm-integrations` history back to late February. The `bun add` path #8486 cites runs inside `useSandbox`, which already does `this.timeout(300_000)`. Not changed.
- **`packages/datadog-plugin-electron/test/index.spec.js`**: spawns the *unpacked* Electron framework against a tiny app; running comfortably under 5 s on master. Not changed — no documented failure.

Keeping these targeted preserves the global default so the proxyquire work in flight can move the floor in the other direction.

## Test plan

- `apm-integrations` matrix: the `aerospike` jobs (especially `aerospike (eol, >=4.0.0 <5.2.0, ce-5.7.0.15, ubuntu-22.04)`) complete.
- `electron` workflow's `ubuntu` job (where the `beforeEach` was hitting 15 s) completes.

Refs: https://github.com/DataDog/dd-trace-js/pull/8486