### PR TITLE
[test optimization] Fix early metadata encoding bug

### DIFF
--- a/integration-tests/ci-visibility/vitest-early-span.js
+++ b/integration-tests/ci-visibility/vitest-early-span.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const tracer = require('dd-trace')
+const { channel } = require('dc-polyfill')
+
+// Force a payload to start before Vitest's async library configuration adds metadata tags.
+channel('ci:vitest:session:start').subscribe(() => {
+  const span = tracer.startSpan('vitest.early.span')
+  span.finish()
+})

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -103,7 +103,9 @@ versions.forEach((version) => {
             cwd,
             env: {
               ...getCiVisAgentlessConfig(receiver.port),
-              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              // Creates a span after ci/init but before library configuration adds capability metadata.
+              NODE_OPTIONS:
+                '--import dd-trace/register.js -r dd-trace/ci/init -r ./ci-visibility/vitest-early-span',
               DD_TEST_SESSION_NAME: 'my-test-session-name',
             },
           }

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -21,6 +21,9 @@ const TEST_AND_SPAN_KEYS_LENGTH = 11
 
 const INTAKE_SOFT_LIMIT = 2 * 1024 * 1024 // 2MB
 
+// Prefix is ~1 KB in practice; `MsgpackChunk` resizes on overflow.
+const PREFIX_CHUNK_INITIAL_SIZE = 2048
+
 function formatSpan (span) {
   let encodingVersion = ENCODING_VERSION
   if (span.type === 'test' && span.meta && span.meta.test_session_id) {
@@ -284,7 +287,7 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
     // diagnostic channels (`session:start` adds `test_session.name`, the async
     // `library-configuration` callback adds capability tags). Any span finished between
     // those calls would otherwise freeze the prefix with stale metadata.
-    const prefixBytes = new MsgpackChunk()
+    const prefixBytes = new MsgpackChunk(PREFIX_CHUNK_INITIAL_SIZE)
     this._encodePayloadStart(prefixBytes)
 
     const eventsOffset = this._eventsOffset

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -7,6 +7,7 @@ const {
   TELEMETRY_ENDPOINT_PAYLOAD_SERIALIZATION_MS,
   TELEMETRY_ENDPOINT_PAYLOAD_EVENTS_COUNT,
 } = require('../ci-visibility/telemetry')
+const { MsgpackChunk } = require('../msgpack')
 const { AgentEncoder } = require('./0.4')
 const { truncateSpan, normalizeSpan } = require('./tags-processors')
 
@@ -259,10 +260,6 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   }
 
   _encode (bytes, trace) {
-    if (this._isReset) {
-      this._encodePayloadStart(bytes)
-      this._isReset = false
-    }
     const startTime = Date.now()
 
     const events = trace.map(formatSpan)
@@ -281,20 +278,28 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
 
   makePayload () {
     distributionMetric(TELEMETRY_ENDPOINT_PAYLOAD_EVENTS_COUNT, { endpoint: 'test_cycle' }, this._eventCount)
-    const bytes = this._traceBytes
+
+    // Encode the payload prefix (version + metadata + events-array header) at flush time,
+    // not on the first `_encode`. The CI Visibility flow adds metadata across multiple
+    // diagnostic channels (`session:start` adds `test_session.name`, the async
+    // `library-configuration` callback adds capability tags). Any span finished between
+    // those calls would otherwise freeze the prefix with stale metadata.
+    const prefixBytes = new MsgpackChunk()
+    this._encodePayloadStart(prefixBytes)
+
     const eventsOffset = this._eventsOffset
     const eventsCount = this._eventCount
+    prefixBytes.buffer[eventsOffset] = 0xDD
+    prefixBytes.buffer[eventsOffset + 1] = eventsCount >> 24
+    prefixBytes.buffer[eventsOffset + 2] = eventsCount >> 16
+    prefixBytes.buffer[eventsOffset + 3] = eventsCount >> 8
+    prefixBytes.buffer[eventsOffset + 4] = eventsCount
 
-    bytes.buffer[eventsOffset] = 0xDD
-    bytes.buffer[eventsOffset + 1] = eventsCount >> 24
-    bytes.buffer[eventsOffset + 2] = eventsCount >> 16
-    bytes.buffer[eventsOffset + 3] = eventsCount >> 8
-    bytes.buffer[eventsOffset + 4] = eventsCount
-
-    const traceSize = bytes.length
-    const buffer = Buffer.allocUnsafe(traceSize)
-
-    bytes.buffer.copy(buffer, 0, 0, traceSize)
+    const eventsBytes = this._traceBytes
+    const totalSize = prefixBytes.length + eventsBytes.length
+    const buffer = Buffer.allocUnsafe(totalSize)
+    prefixBytes.buffer.copy(buffer, 0, 0, prefixBytes.length)
+    eventsBytes.buffer.copy(buffer, prefixBytes.length, 0, eventsBytes.length)
 
     this.reset()
 
@@ -302,7 +307,8 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   }
 
   _encodePayloadStart (bytes) {
-    // encodes the payload up to `events`. `events` will be encoded via _encode
+    // Encodes the payload up to (and including) the `events` array prefix. The 5 reserved
+    // bytes for the array length are patched in `makePayload`.
     const payload = {
       version: ENCODING_VERSION,
       metadata: {
@@ -346,7 +352,6 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
       this._encodeMap(bytes, payload.metadata.test_session_end)
     }
     this._encodeString(bytes, 'events')
-    // Get offset of the events list to update the length of the array when calling `makePayload`
     this._eventsOffset = bytes.length
     bytes.reserve(5)
   }
@@ -354,7 +359,6 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
   reset () {
     this._reset()
     this._eventCount = 0
-    this._isReset = true
   }
 }
 

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -288,5 +288,51 @@ describe('agentless-ci-visibility-encode', () => {
       encoder.addMetadataTags({})
       assert.deepStrictEqual(encoder.metadataTags, { test: { tag: 'value1' } })
     })
+
+    // The CI Visibility flow calls `addMetadataTags` from two channels —
+    // `ci:<framework>:session:start` adds `test_session.name`, and the async
+    // `ci:<framework>:library-configuration` callback adds capability tags
+    // once the backend responds. If an integration finishes a span between
+    // those two calls (e.g. a `dns.promises.lookup` from vite startup), the
+    // encoder previously flushed the payload prefix on the first `encode()`
+    // and the later capability tags never reached the wire.
+    it('encodes metadata at flush time, not at first encode', () => {
+      encoder.addMetadataTags({ test: { 'test_session.name': 'my-session' } })
+      encoder.encode(trace)
+      encoder.addMetadataTags({
+        test: { '_dd.library_capabilities.auto_test_retries': '1' },
+        test_session_end: { 'test_session.name': 'my-session' },
+      })
+
+      const buffer = encoder.makePayload()
+      const decoded = msgpack.decode(buffer, { useBigInt64: true })
+
+      assert.deepStrictEqual(decoded.metadata.test, {
+        'test_session.name': 'my-session',
+        '_dd.library_capabilities.auto_test_retries': '1',
+      })
+      assert.deepStrictEqual(decoded.metadata.test_session_end, {
+        'test_session.name': 'my-session',
+      })
+      assert.strictEqual(decoded.events.length, 1)
+    })
+
+    it('encodes metadata added across multiple flushes', () => {
+      encoder.encode(trace)
+      encoder.addMetadataTags({ test: { 'first.flush.tag': '1' } })
+      const firstBuffer = encoder.makePayload()
+      const firstDecoded = msgpack.decode(firstBuffer, { useBigInt64: true })
+      assert.deepStrictEqual(firstDecoded.metadata.test, { 'first.flush.tag': '1' })
+
+      encoder.encode(trace)
+      encoder.addMetadataTags({ test: { 'second.flush.tag': '2' } })
+      const secondBuffer = encoder.makePayload()
+      const secondDecoded = msgpack.decode(secondBuffer, { useBigInt64: true })
+
+      assert.deepStrictEqual(secondDecoded.metadata.test, {
+        'first.flush.tag': '1',
+        'second.flush.tag': '2',
+      })
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
This PR includes the metadata encoding fix from #8411 and adds an end-to-end Vitest regression for it.

The agentless test optimization encoder used to write the payload prefix (`version`, `metadata`, and the `events` array header) on the first `encode()` call. Later `addMetadataTags()` calls updated the in-memory metadata map, but those updates could not reach an already-started payload.

The fix moves prefix encoding into `makePayload()`: events accumulate in `_traceBytes` during `encode()`, the prefix is built at flush time from the current metadata tags, and the final buffer concatenates the prefix with the encoded events. It also starts the temporary prefix `MsgpackChunk` at 2 KB instead of the default 2 MB, since the prefix is usually around 1 KB.

This PR also adds a Vitest preload regression that finishes a span after `dd-trace/ci/init` and `ci:vitest:session:start`, but before library configuration adds capability metadata.

### Motivation
Test optimization metadata comes from multiple points in the lifecycle: session start adds the test session name synchronously, while library configuration adds capability tags asynchronously. If any span finishes between those two steps, the old encoder could freeze the first payload without capability metadata and break the test-management protocol.

The new Vitest regression proves the full behavior: without the encoder changes, the early span produces a payload without `metadata.test` and the capabilities assertion fails.

### Additional Notes
Tested with:

    ./node_modules/.bin/mocha packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
    ./node_modules/.bin/mocha --timeout 60000 integration-tests/vitest/vitest.advanced.spec.js --grep "adds capabilities to tests"

Refs: #8411 and #8404.
