### PR TITLE
test(debugger): widen sampling spec tolerance to absorb wall-clock skew

### DIFF
--- a/integration-tests/debugger/sampling.spec.js
+++ b/integration-tests/debugger/sampling.spec.js
@@ -28,9 +28,12 @@ describe('Dynamic Instrumentation', function () {
             const duration = timestamp - prev
             clearTimeout(timer)
 
-            // Allow for a variance of +50ms (time will tell if this is enough)
-            assert.ok(duration >= 1000)
-            assert.ok(duration < 1050)
+            // The sampling check inside the worker uses `process.hrtime.bigint()` (monotonic), but the snapshot
+            // `timestamp` is captured via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock
+            // to drift slightly relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms
+            // tolerance on both sides of the expected 1000ms gap.
+            assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
+            assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
 
             // Wait at least a full sampling period, to see if we get any more payloads
             timer = setTimeout(done, 1250)
@@ -81,9 +84,12 @@ describe('Dynamic Instrumentation', function () {
             const duration = timestamp - _state.prev
             clearTimeout(_state.timer)
 
-            // Allow for a variance of +50ms (time will tell if this is enough)
-            assert.ok(duration >= 1000)
-            assert.ok(duration < 1050)
+            // The sampling check inside the worker uses `process.hrtime.bigint()` (monotonic), but the snapshot
+            // `timestamp` is captured via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock
+            // to drift slightly relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms
+            // tolerance on both sides of the expected 1000ms gap.
+            assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
+            assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
 
             // Wait at least a full sampling period, to see if we get any more payloads
             _state.timer = setTimeout(doneWhenCalledTwice, 1250)


### PR DESCRIPTION
### What does this PR do?

Widens the timing tolerance in `integration-tests/debugger/sampling.spec.js` so the two `it` blocks no longer flake on CI when the wall clock drifts a few milliseconds relative to the monotonic clock.

- `assert.ok(duration >= 1000)` / `assert.ok(duration < 1050)` → `assert.ok(duration >= 925)` / `assert.ok(duration < 1075)` (75 ms tolerance on each side of the expected 1000 ms gap).
- Added an explanatory comment about the monotonic-vs-wall-clock interplay.
- Assertion messages now include the actual `duration` value, so the next failure is self-diagnosing instead of "evaluated to a falsy value".

### Motivation

The `Dynamic Instrumentation > sampling > should respect sampling rate for single probe` test failed on an unrelated PR (https://github.com/DataDog/dd-trace-js/actions/runs/26055211761/job/76601509732) with:

```
AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
  assert.ok(duration >= 1000)
  at integration-tests/debugger/sampling.spec.js:32:20
```

Root cause is a clock-source mismatch:

- The sampling enforcement in `packages/dd-trace/src/debugger/devtools_client/index.js` uses `process.hrtime.bigint()` (monotonic) for the `start - probe.lastCaptureNs < probe.nsBetweenSampling` check, guaranteeing the **monotonic** gap between sampled hits is `>= 1s`.
- The `timestamp` field written onto each snapshot — which the test diffs — uses `Date.now()` (wall clock). This is intentional: the timestamp is what we send to Datadog, and it must be a wall-clock value.

On CI runners, NTP slewing can move the wall clock backward (or slow it down) relative to the monotonic clock during the >=1 s sampling window. Even a few ms of negative skew makes `Date.now()`-derived `duration` fall just under 1000 ms while the underlying monotonic gap is correct. The assertion's previous tolerance was `+50 ms / 0 ms` — no headroom for negative skew at all.

We shouldn't change the production code: monotonic time is the right clock for sampling enforcement, and wall-clock time is the right value to ship in the snapshot. The sibling test `integration-tests/debugger/snapshot-global-sample-rate.spec.js` already accepts `duration >= 925` for the same reason; this PR brings `sampling.spec.js` in line with that precedent.

