### PR TITLE
test(electron): raise plugin-spec startApp beforeEach timeout to 10s

### DIFF
--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -50,7 +50,10 @@ describe('Plugin', () => {
     describe('electron', () => {
       describe('without configuration', () => {
         beforeEach(() => agent.load('electron'))
-        beforeEach(done => startApp(done))
+        beforeEach(function (done) {
+          this.timeout(10_000)
+          startApp(done)
+        })
 
         afterEach(() => agent.close({ ritmReset: false }))
         afterEach(done => {


### PR DESCRIPTION
## Summary

`packages/datadog-plugin-electron/test/index.spec.js` cold-launches the matrix's Electron binary (Chromium init plus the dd-trace `-r` preload) inside a `beforeEach`. On slow GitHub-hosted ubuntu runners the launch can exceed the 5 s mocha default and the hook times out before `app.on('ready')` fires — observed on https://github.com/DataDog/dd-trace-js/actions/runs/26069262904 (electron 37.0.0, both rerun attempts: `"before each" hook for "should do automatic instrumentation for fetch": Error: Timeout of 5000ms exceeded`). The same job's electron 39.2.4 entry passed each time on a warmer cache.

## Why

Scoping the bump to `this.timeout(10_000)` inside the cold-start `beforeEach` matches the integration-tests electron spec's per-hook shape; the `it` bodies stay on the 5 s default since the requests themselves complete in milliseconds.

Refs: https://github.com/DataDog/dd-trace-js/actions/runs/26069262904