### PR TITLE
test: prefer assert.match for string matching

### DIFF
--- a/eslint-rules/eslint-prefer-assert-match.mjs
+++ b/eslint-rules/eslint-prefer-assert-match.mjs
@@ -1,0 +1,214 @@
+// Flag `assert.ok(...)` calls whose first argument is a plain string-matching
+// expression and recommend `assert.match()` / `assert.doesNotMatch()` instead.
+//
+// `assert.match()` gives much nicer failure messages than `assert.ok()`:
+// it prints both the actual string and the regex, while `assert.ok(false)`
+// just prints `false`.
+//
+// Patterns recognized as the first argument to `assert.ok(...)`:
+//
+//   x.startsWith(y)   -> assert.match(x, /^y/)
+//   x.endsWith(y)     -> assert.match(x, /y$/)
+//   x.match(/r/)      -> assert.match(x, /r/)
+//   /r/.test(x)       -> assert.match(x, /r/)
+//
+// A leading `!` negates the assertion, producing `assert.doesNotMatch(...)`.
+//
+// `x.includes(...)` is intentionally NOT handled because it is ambiguous at
+// lint time between String.prototype.includes (a string match) and
+// Array.prototype.includes (membership in a collection).
+
+// Regex metacharacters that need escaping when embedding a string value as a
+// regex pattern. We also escape `/` so the result is safe to wrap in `/.../`.
+const REGEX_META = /[.*+?^${}()|[\]\\/]/g
+
+// Characters that can't appear literally inside a regex literal (line
+// terminators break out of the literal). If a string contains any of these,
+// we report but don't auto-fix.
+const UNSAFE_IN_REGEX_LITERAL = /[\n\r\u2028\u2029]/
+
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer `assert.match()` / `assert.doesNotMatch()` over `assert.ok()` for string-matching assertions',
+      recommended: true,
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      preferMatch:
+        'Prefer `assert.match(string, regexp)` over `assert.ok({{method}}(...))` for string-matching assertions.',
+      preferDoesNotMatch:
+        'Prefer `assert.doesNotMatch(string, regexp)` over `assert.ok(!{{method}}(...))` ' +
+        'for string-matching assertions.',
+    },
+  },
+
+  create (context) {
+    const sourceCode = context.getSourceCode()
+
+    return {
+      CallExpression (node) {
+        if (!isAssertOkCall(node)) return
+        if (node.arguments.length < 1 || node.arguments.length > 2) return
+
+        const [firstArg, messageArg] = node.arguments
+        if (!firstArg || firstArg.type === 'SpreadElement') return
+        if (messageArg && messageArg.type === 'SpreadElement') return
+
+        let inner = unwrapChain(firstArg)
+        let negated = false
+        if (inner.type === 'UnaryExpression' && inner.operator === '!') {
+          negated = true
+          inner = unwrapChain(inner.argument)
+        }
+
+        const match = matchStringMethod(inner)
+        if (!match) return
+
+        const { stringNode, regexText, autofixable } = buildReplacementParts(match, sourceCode)
+        if (!stringNode) return
+
+        const assertMethod = negated ? 'doesNotMatch' : 'match'
+        const messageId = negated ? 'preferDoesNotMatch' : 'preferMatch'
+
+        context.report({
+          node,
+          messageId,
+          data: { method: match.methodName },
+          fix: autofixable && regexText
+            ? fixer => {
+              const stringText = sourceCode.getText(stringNode)
+              const messageText = messageArg ? `, ${sourceCode.getText(messageArg)}` : ''
+              return fixer.replaceText(node, `assert.${assertMethod}(${stringText}, ${regexText}${messageText})`)
+            }
+            : null,
+        })
+      },
+    }
+  },
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {import('estree').Node}
+ */
+function unwrapChain (node) {
+  return node?.type === 'ChainExpression' ? node.expression : node
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isAssertOkCall (node) {
+  return (
+    node.type === 'CallExpression' &&
+    node.callee?.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.object?.type === 'Identifier' &&
+    node.callee.object.name === 'assert' &&
+    node.callee.property?.type === 'Identifier' &&
+    node.callee.property.name === 'ok'
+  )
+}
+
+/**
+ * Returns the kind of string-matching call this expression is, or null if it
+ * isn't one of the patterns we care about.
+ *
+ * @param {import('estree').Node} node
+ * @returns {{ methodName: string, callee: import('estree').MemberExpression, arg: import('estree').Node } | null}
+ */
+function matchStringMethod (node) {
+  if (!node || node.type !== 'CallExpression') return null
+  if (node.arguments.length !== 1) return null
+  const arg = node.arguments[0]
+  if (!arg || arg.type === 'SpreadElement') return null
+
+  const callee = node.callee
+  if (!callee || callee.type !== 'MemberExpression' || callee.computed) return null
+  if (callee.property?.type !== 'Identifier') return null
+
+  const methodName = callee.property.name
+  if (methodName !== 'startsWith' &&
+      methodName !== 'endsWith' &&
+      methodName !== 'match' &&
+      methodName !== 'test') {
+    return null
+  }
+
+  return { methodName, callee, arg }
+}
+
+/**
+ * @param {{ methodName: string, callee: import('estree').MemberExpression, arg: import('estree').Node }} match
+ * @param {import('eslint').SourceCode} sourceCode
+ * @returns {{ stringNode: import('estree').Node | null, regexText: string | null, autofixable: boolean }}
+ */
+function buildReplacementParts (match, sourceCode) {
+  const { methodName, callee, arg } = match
+
+  switch (methodName) {
+    case 'startsWith':
+    case 'endsWith': {
+      const stringNode = callee.object
+      if (isStringLiteral(arg)) {
+        const pattern = stringLiteralToRegexBody(arg.value)
+        if (pattern !== null) {
+          const regexText = methodName === 'startsWith' ? `/^${pattern}/` : `/${pattern}$/`
+          return { stringNode, regexText, autofixable: true }
+        }
+      }
+      return { stringNode, regexText: null, autofixable: false }
+    }
+
+    case 'match': {
+      const stringNode = callee.object
+      if (isRegexLiteral(arg)) {
+        return { stringNode, regexText: sourceCode.getText(arg), autofixable: true }
+      }
+      return { stringNode, regexText: null, autofixable: false }
+    }
+
+    case 'test': {
+      const stringNode = arg
+      const regexNode = callee.object
+      return { stringNode, regexText: sourceCode.getText(regexNode), autofixable: true }
+    }
+
+    default:
+      return { stringNode: null, regexText: null, autofixable: false }
+  }
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {node is import('estree').Literal & { value: string }}
+ */
+function isStringLiteral (node) {
+  return node?.type === 'Literal' && typeof node.value === 'string'
+}
+
+/**
+ * @param {import('estree').Node} node
+ * @returns {boolean}
+ */
+function isRegexLiteral (node) {
+  return node?.type === 'Literal' && node.regex != null
+}
+
+/**
+ * Convert a JS string value into a body that's safe to embed between `/.../`.
+ * Returns null when the value contains characters that can't appear literally
+ * in a regex literal (e.g. raw newlines).
+ *
+ * @param {string} value
+ * @returns {string | null}
+ */
+function stringLiteralToRegexBody (value) {
+  if (UNSAFE_IN_REGEX_LITERAL.test(value)) return null
+  return value.replace(REGEX_META, '\\$&')
+}

--- a/eslint-rules/eslint-prefer-assert-match.mjs
+++ b/eslint-rules/eslint-prefer-assert-match.mjs
@@ -176,7 +176,10 @@ function buildReplacementParts (match, sourceCode) {
     case 'test': {
       const stringNode = arg
       const regexNode = callee.object
-      return { stringNode, regexText: sourceCode.getText(regexNode), autofixable: true }
+      if (isRegexLiteral(regexNode)) {
+        return { stringNode, regexText: sourceCode.getText(regexNode), autofixable: true }
+      }
+      return { stringNode, regexText: null, autofixable: false }
     }
 
     default:

--- a/eslint-rules/eslint-prefer-assert-match.test.mjs
+++ b/eslint-rules/eslint-prefer-assert-match.test.mjs
@@ -1,0 +1,191 @@
+import { RuleTester } from 'eslint'
+import rule from './eslint-prefer-assert-match.mjs'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('eslint-prefer-assert-match', /** @type {import('eslint').Rule.RuleModule} */ (rule), {
+  valid: [
+    // Direct, idiomatic assertions we don't want to touch.
+    'assert.match(x, /foo/)',
+    'assert.doesNotMatch(x, /foo/)',
+    'assert.ok(x)',
+    'assert.ok(x === y)',
+    'assert.ok(x.length > 0)',
+    'assert.ok(fn())',
+
+    // .includes() is intentionally not handled (could be Array or String).
+    'assert.ok(arr.includes(item))',
+    "assert.ok(str.includes('foo'))",
+    'assert.ok(!arr.includes(item))',
+
+    // Patterns wrapped in .some() / .every() etc. aren't direct string matches.
+    "assert.ok(tags.some(tag => tag.startsWith('entrypoint.')))",
+    'assert.ok(items.every(item => /foo/.test(item)))',
+    'assert.ok(!names.some(n => /foo/.test(n)))',
+
+    // The .ok must be on `assert` specifically, not arbitrary identifiers.
+    "expect.ok(x.startsWith('foo'))",
+    "result.ok(x.endsWith('bar'))",
+    "ok(x.startsWith('foo'))",
+
+    // Computed property access shouldn't match.
+    "assert['ok'](x.startsWith('foo'))",
+
+    // Too many arguments (assert.ok accepts at most 2).
+    "assert.ok(x.startsWith('foo'), 'msg', 'extra')",
+
+    // Method called with wrong arity on the inner side.
+    'assert.ok(x.startsWith())',
+    "assert.ok(x.startsWith('a', 1))",
+  ],
+
+  invalid: [
+    // ── RegExp.test() ─────────────────────────────────────────────────────
+    {
+      code: 'assert.ok(/foo/.test(x))',
+      output: 'assert.match(x, /foo/)',
+      errors: [{ messageId: 'preferMatch', data: { method: 'test' } }],
+    },
+    {
+      code: 'assert.ok(/foo/i.test(x.y))',
+      output: 'assert.match(x.y, /foo/i)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(/foo/.test(x), 'message')",
+      output: "assert.match(x, /foo/, 'message')",
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: 'assert.ok(!/foo/.test(x))',
+      output: 'assert.doesNotMatch(x, /foo/)',
+      errors: [{ messageId: 'preferDoesNotMatch', data: { method: 'test' } }],
+    },
+    {
+      code: "assert.ok(!/foo/.test(x), 'should not match')",
+      output: "assert.doesNotMatch(x, /foo/, 'should not match')",
+      errors: [{ messageId: 'preferDoesNotMatch' }],
+    },
+    // RegExp identifier (non-literal) is still fixable: just shuffles args.
+    {
+      code: 'assert.ok(re.test(x))',
+      output: 'assert.match(x, re)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+
+    // ── String.prototype.match() ──────────────────────────────────────────
+    {
+      code: 'assert.ok(x.match(/foo/))',
+      output: 'assert.match(x, /foo/)',
+      errors: [{ messageId: 'preferMatch', data: { method: 'match' } }],
+    },
+    {
+      code: 'assert.ok(!x.match(/foo/g))',
+      output: 'assert.doesNotMatch(x, /foo/g)',
+      errors: [{ messageId: 'preferDoesNotMatch' }],
+    },
+    // .match() with a non-regex-literal argument: report but don't auto-fix
+    // (string arg has different runtime semantics under assert.match).
+    {
+      code: 'assert.ok(x.match(pattern))',
+      output: null,
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(x.match('foo'))",
+      output: null,
+      errors: [{ messageId: 'preferMatch' }],
+    },
+
+    // ── String.prototype.startsWith() ─────────────────────────────────────
+    {
+      code: "assert.ok(x.startsWith('foo'))",
+      output: 'assert.match(x, /^foo/)',
+      errors: [{ messageId: 'preferMatch', data: { method: 'startsWith' } }],
+    },
+    // Regex metacharacters must be escaped inside the produced regex literal.
+    {
+      code: "assert.ok(x.startsWith('foo.bar'))",
+      output: 'assert.match(x, /^foo\\.bar/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(x.startsWith('a/b'))",
+      output: 'assert.match(x, /^a\\/b/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(x.startsWith('(a)*'))",
+      output: 'assert.match(x, /^\\(a\\)\\*/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(x.startsWith('foo'), 'starts with foo')",
+      output: "assert.match(x, /^foo/, 'starts with foo')",
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(!x.startsWith('foo'))",
+      output: 'assert.doesNotMatch(x, /^foo/)',
+      errors: [{ messageId: 'preferDoesNotMatch', data: { method: 'startsWith' } }],
+    },
+    // Non-literal arg: report only.
+    {
+      code: 'assert.ok(x.startsWith(prefix))',
+      output: null,
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    // Template literal arg: report only (interpolation values aren't known).
+    {
+      // eslint-disable-next-line no-template-curly-in-string
+      code: 'assert.ok(x.startsWith(`foo${bar}`))',
+      output: null,
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    // String containing a real newline can't be embedded in a regex literal.
+    {
+      code: "assert.ok(x.startsWith('foo\\nbar'))",
+      output: null,
+      errors: [{ messageId: 'preferMatch' }],
+    },
+
+    // ── String.prototype.endsWith() ───────────────────────────────────────
+    {
+      code: "assert.ok(x.endsWith('...'))",
+      output: 'assert.match(x, /\\.\\.\\.$/)',
+      errors: [{ messageId: 'preferMatch', data: { method: 'endsWith' } }],
+    },
+    {
+      code: "assert.ok(x.endsWith('.js'))",
+      output: 'assert.match(x, /\\.js$/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(!x.endsWith('foo'))",
+      output: 'assert.doesNotMatch(x, /foo$/)',
+      errors: [{ messageId: 'preferDoesNotMatch' }],
+    },
+
+    // ── Member chains on the string side ──────────────────────────────────
+    {
+      code: "assert.ok(obj.prop.startsWith('foo'))",
+      output: 'assert.match(obj.prop, /^foo/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: "assert.ok(obj?.prop?.endsWith('bar'))",
+      output: 'assert.match(obj?.prop, /bar$/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: 'assert.ok(getString().match(/foo/))',
+      output: 'assert.match(getString(), /foo/)',
+      errors: [{ messageId: 'preferMatch' }],
+    },
+  ],
+})

--- a/eslint-rules/eslint-prefer-assert-match.test.mjs
+++ b/eslint-rules/eslint-prefer-assert-match.test.mjs
@@ -71,11 +71,19 @@ ruleTester.run('eslint-prefer-assert-match', /** @type {import('eslint').Rule.Ru
       output: "assert.doesNotMatch(x, /foo/, 'should not match')",
       errors: [{ messageId: 'preferDoesNotMatch' }],
     },
-    // RegExp identifier (non-literal) is still fixable: just shuffles args.
+    // Non-regex-literal receivers of `.test()` are reported but not auto-fixed:
+    // the receiver might not be a RegExp (e.g. a Joi schema, AJV instance, or
+    // any other helper with a `.test()` method), so blindly rewriting to
+    // `assert.match(x, re)` could throw `TypeError: regexp must be a RegExp`.
     {
       code: 'assert.ok(re.test(x))',
-      output: 'assert.match(x, re)',
+      output: null,
       errors: [{ messageId: 'preferMatch' }],
+    },
+    {
+      code: 'assert.ok(predicate.test(value))',
+      output: null,
+      errors: [{ messageId: 'preferMatch', data: { method: 'test' } }],
     },
 
     // ── String.prototype.match() ──────────────────────────────────────────

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,7 @@ import eslintConfigNamesSync from './eslint-rules/eslint-config-names-sync.mjs'
 import eslintEnvAliases from './eslint-rules/eslint-env-aliases.mjs'
 import eslintLogPrintfStyle from './eslint-rules/eslint-log-printf-style.mjs'
 import eslintNonPrefixEnvNames from './eslint-rules/eslint-non-prefix-env-names.mjs'
+import eslintPreferAssertMatch from './eslint-rules/eslint-prefer-assert-match.mjs'
 import eslintProcessEnv from './eslint-rules/eslint-process-env.mjs'
 import eslintRequireExportExists from './eslint-rules/eslint-require-export-exists.mjs'
 import eslintSafeTypeOfObject from './eslint-rules/eslint-safe-typeof-object.mjs'
@@ -381,6 +382,7 @@ export default [
           'eslint-env-aliases': eslintEnvAliases,
           'eslint-config-names-sync': eslintConfigNamesSync,
           'eslint-non-prefix-env-names': eslintNonPrefixEnvNames,
+          'eslint-prefer-assert-match': eslintPreferAssertMatch,
           'eslint-safe-typeof-object': eslintSafeTypeOfObject,
           'eslint-log-printf-style': eslintLogPrintfStyle,
           'eslint-require-export-exists': eslintRequireExportExists,
@@ -734,6 +736,7 @@ export default [
       n: eslintPluginN,
     },
     rules: {
+      'eslint-rules/eslint-prefer-assert-match': 'error',
       'mocha/consistent-spacing-between-blocks': 'off',
       'mocha/max-top-level-suites': ['error', { limit: 1 }],
       'mocha/no-mocha-arrows': 'off',

--- a/integration-tests/code-origin.spec.js
+++ b/integration-tests/code-origin.spec.js
@@ -40,6 +40,10 @@ describe('Code Origin for Spans', function () {
       await Promise.all([
         agent.assertMessageReceived(({ payload }) => {
           const [span] = payload.flatMap(p => p.filter(span => span.name === 'fastify.request'))
+          // Switch to `assert.match(span.meta[...], new RegExp(`${RegExp.escape(cwd)}/code-origin/typescript\\.ts$`))`
+          // once the minimum supported Node.js version is 24. Until then, `RegExp.escape` is unavailable and
+          // hand-escaping every regex metacharacter in `cwd` would be more error-prone than this `endsWith` check.
+          // eslint-disable-next-line eslint-rules/eslint-prefer-assert-match
           assert.ok(span.meta['_dd.code_origin.frames.0.file'].endsWith(`${cwd}/code-origin/typescript.ts`))
           assertObjectContains(span, {
             meta: {

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -1283,9 +1283,10 @@ moduleTypes.forEach(({
                 11,
                 'should report the correct source line for it() test'
               )
-              assert.ok(
-                itTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
+              assert.match(
+                itTestEvent.content.meta[TEST_SOURCE_FILE],
+                /spec-source-line\.cy\.ts$/,
+                `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
               )
 
               // 'specify' with a template literal test name is defined at line 16.
@@ -1297,9 +1298,12 @@ moduleTypes.forEach(({
                 16,
                 'should report the correct source line for specify() with template literal name'
               )
-              assert.ok(
-                testTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
+              assert.match(
+                testTestEvent.content.meta[TEST_SOURCE_FILE],
+                /spec-source-line\.cy\.ts$/,
+                `TEST_SOURCE_FILE should point to TypeScript source, got: ${
+                  testTestEvent.content.meta[TEST_SOURCE_FILE]
+                }`
               )
             }, { hardTimeout: 60000 })
 
@@ -1413,9 +1417,12 @@ moduleTypes.forEach(({
                 7,
                 'should report TS source line resolved via declaration scanning fallback'
               )
-              assert.ok(
-                fallbackEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-fallback.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${fallbackEvent.content.meta[TEST_SOURCE_FILE]}`
+              assert.match(
+                fallbackEvent.content.meta[TEST_SOURCE_FILE],
+                /spec-source-line-fallback\.cy\.ts$/,
+                `TEST_SOURCE_FILE should point to TypeScript source, got: ${
+                  fallbackEvent.content.meta[TEST_SOURCE_FILE]
+                }`
               )
             }, { hardTimeout: 60000 })
 
@@ -1464,9 +1471,12 @@ moduleTypes.forEach(({
                 noMatchEvent.content.metrics[TEST_SOURCE_START]
               }`
               )
-              assert.ok(
-                noMatchEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-no-match.cy.ts'),
-              `TEST_SOURCE_FILE should point to TypeScript source, got: ${noMatchEvent.content.meta[TEST_SOURCE_FILE]}`
+              assert.match(
+                noMatchEvent.content.meta[TEST_SOURCE_FILE],
+                /spec-source-line-no-match\.cy\.ts$/,
+                `TEST_SOURCE_FILE should point to TypeScript source, got: ${
+                  noMatchEvent.content.meta[TEST_SOURCE_FILE]
+                }`
               )
             }, { hardTimeout: 60000 })
 
@@ -1508,11 +1518,12 @@ moduleTypes.forEach(({
               jsInvocationDetailsEvent.content.metrics[TEST_SOURCE_START] > 100,
               'should keep generated invocationDetails line directly for plain JS specs without source maps'
             )
-            assert.ok(
-              jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line-invocation.cy.js'),
-            `TEST_SOURCE_FILE should point to JS source, got: ${
-              jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE]
-            }`
+            assert.match(
+              jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE],
+              /spec-source-line-invocation\.cy\.js$/,
+              `TEST_SOURCE_FILE should point to JS source, got: ${
+                jsInvocationDetailsEvent.content.meta[TEST_SOURCE_FILE]
+              }`
             )
           }, { hardTimeout: 60000 })
 
@@ -1575,9 +1586,10 @@ moduleTypes.forEach(({
               11,
               'should report the correct source line for it() test'
             )
-            assert.ok(
-              itTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-            `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
+            assert.match(
+              itTestEvent.content.meta[TEST_SOURCE_FILE],
+              /spec-source-line\.cy\.ts$/,
+              `TEST_SOURCE_FILE should point to TypeScript source, got: ${itTestEvent.content.meta[TEST_SOURCE_FILE]}`
             )
 
             // 'specify' with a template literal test name is defined at line 16.
@@ -1587,9 +1599,10 @@ moduleTypes.forEach(({
             // contains interpolated variables), so the exact TS line cannot be recovered in this
             // mode. We verify the event exists and that TEST_SOURCE_FILE points to the TS source.
             assert.ok(testTestEvent, 'specify() with template literal name should exist')
-            assert.ok(
-              testTestEvent.content.meta[TEST_SOURCE_FILE].endsWith('spec-source-line.cy.ts'),
-            `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
+            assert.match(
+              testTestEvent.content.meta[TEST_SOURCE_FILE],
+              /spec-source-line\.cy\.ts$/,
+              `TEST_SOURCE_FILE should point to TypeScript source, got: ${testTestEvent.content.meta[TEST_SOURCE_FILE]}`
             )
           }, { hardTimeout: 60000 })
       childProcess.stdout?.on('data', chunk => {

--- a/integration-tests/debugger/capture-expressions.spec.js
+++ b/integration-tests/debugger/capture-expressions.spec.js
@@ -84,7 +84,7 @@ describe('Dynamic Instrumentation', function () {
         assert.strictEqual(snapshot.evaluationErrors.length, 1)
         assert.deepStrictEqual(Object.keys(snapshot.evaluationErrors[0]), ['expr', 'message'])
         assert.strictEqual(snapshot.evaluationErrors[0].expr, 'invalid')
-        assert.ok(snapshot.evaluationErrors[0].message.startsWith('ReferenceError: invalid is not defined'))
+        assert.match(snapshot.evaluationErrors[0].message, /^ReferenceError: invalid is not defined/)
 
         // Valid expression should still be captured
         assert.deepStrictEqual(snapshot.captures, {

--- a/integration-tests/debugger/template.spec.js
+++ b/integration-tests/debugger/template.spec.js
@@ -77,7 +77,7 @@ describe('Dynamic Instrumentation', function () {
           //   [Symbol(trigger_async_id_symbol)]: 204,
           //   [Symbol(kResourceStore)]: {}
           // }
-          assert.ok(messages.shift().startsWith('Promise { 42, '))
+          assert.match(messages.shift(), /^Promise \{ 42, /)
         }
         assert.strictEqual(messages.shift(), '[Function: arrowFn]')
         assert.strictEqual(messages.shift(), '[Function: fn]')
@@ -96,7 +96,7 @@ describe('Dynamic Instrumentation', function () {
         assert.strictEqual(messages.shift(), 'WeakSet { <items unknown> }')
         assert.strictEqual(messages.shift(), 'WeakMap { <items unknown> }')
         assert.strictEqual(messages.shift(), 'Buffer(6) [Uint8Array] [ 102, 111, 111, ... 3 more items ]')
-        assert.ok(messages.shift().startsWith('Error: foo\n    at'))
+        assert.match(messages.shift(), /^Error: foo\n {4}at/)
         assert.strictEqual(
           messages.shift(),
           'ArrayBuffer { ' +

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -280,7 +280,7 @@ versions.forEach((version) => {
               if (testSuiteEvent.content.meta[TEST_STATUS] === 'fail') {
                 assert.ok(testSuiteEvent.content.meta[ERROR_MESSAGE])
               }
-              assert.ok(testSuiteEvent.content.meta[TEST_SOURCE_FILE].endsWith('-test.js'))
+              assert.match(testSuiteEvent.content.meta[TEST_SOURCE_FILE], /-test\.js$/)
               assert.strictEqual(testSuiteEvent.content.metrics[TEST_SOURCE_START], 1)
               assert.ok(testSuiteEvent.content.metrics[DD_HOST_CPU_COUNT])
             })

--- a/packages/datadog-plugin-prisma/test/integration-test/server-ts-v7-otel.mjs
+++ b/packages/datadog-plugin-prisma/test/integration-test/server-ts-v7-otel.mjs
@@ -60,7 +60,7 @@ await new Promise((resolve, reject) => {
       })
 
       assert.ok(observedTraceparent, 'Expected Prisma query to include traceparent comment')
-      assert.ok(observedTraceparent.startsWith(`00-${spanContext.traceId}-`))
+      assert.match(observedTraceparent, new RegExp(`^00-${spanContext.traceId}-`))
       assert.notStrictEqual(observedTraceparent, placeholderTraceparent)
       assert.notStrictEqual(observedTraceparent, zeroTraceparent)
       process.stdout.write(`TRACEPARENT_OK:${observedTraceparent}\n`)

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -128,8 +128,8 @@ describe('Plugin', () => {
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
             assert.strictEqual(rawCommand.length, 1000)
-            assert.ok(rawCommand.startsWith('MSET '))
-            assert.ok(rawCommand.endsWith('...'))
+            assert.match(rawCommand, /^MSET /)
+            assert.match(rawCommand, /\.\.\.$/)
           }, { spanResourceMatch: /^MSET$/ })
 
           await Promise.all([client.sendCommand(['MSET', ...args]), promise])

--- a/packages/datadog-webpack/test/plugin.spec.js
+++ b/packages/datadog-webpack/test/plugin.spec.js
@@ -63,6 +63,10 @@ describe('loader', () => {
 
     const result = loader.call(context, source)
 
+    // Switch to `assert.match(result, new RegExp(`^${RegExp.escape(source)}`), ...)` once the minimum supported
+    // Node.js version is 24. Until then, `RegExp.escape` is unavailable and hand-escaping every regex metacharacter
+    // in `source` would be more error-prone than this `startsWith` check.
+    // eslint-disable-next-line eslint-rules/eslint-prefer-assert-match
     assert.ok(result.startsWith(source), 'result should start with original source')
     assert.ok(result.includes("require('dc-polyfill')"), 'result should require dc-polyfill')
     assert.ok(result.includes("'dd-trace:bundler:load'"), 'result should use the bundler channel')

--- a/packages/dd-trace/test/debugger/devtools_client/send.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/send.spec.js
@@ -174,8 +174,9 @@ describe('input message http requests', function () {
     sinon.assert.calledOnce(request)
     const opts = getRequestOptions(request)
     assert.strictEqual(opts.method, 'POST')
-    assert.ok(
-      opts.path.startsWith('/debugger/v2/input?ddtags='),
+    assert.match(
+      opts.path,
+      /^\/debugger\/v2\/input\?ddtags=/,
       `Expected path to start with /debugger/v2/input?ddtags= but got ${opts.path}`
     )
 
@@ -212,12 +213,18 @@ describe('input message http requests', function () {
     sinon.assert.calledTwice(requestWith404)
 
     const firstCallOpts = requestWith404.getCall(0).args[1]
-    assert.ok(firstCallOpts.path.startsWith('/debugger/v2/input?ddtags='),
-      `First call should use v2 endpoint but got ${firstCallOpts.path}`)
+    assert.match(
+      firstCallOpts.path,
+      /^\/debugger\/v2\/input\?ddtags=/,
+      `First call should use v2 endpoint but got ${firstCallOpts.path}`
+    )
 
     const secondCallOpts = requestWith404.getCall(1).args[1]
-    assert.ok(secondCallOpts.path.startsWith('/debugger/v1/diagnostics?ddtags='),
-      `Second call should fallback to diagnostics endpoint but got ${secondCallOpts.path}`)
+    assert.match(
+      secondCallOpts.path,
+      /^\/debugger\/v1\/diagnostics\?ddtags=/,
+      `Second call should fallback to diagnostics endpoint but got ${secondCallOpts.path}`
+    )
 
     // Verify config was updated to diagnostics
     assert.strictEqual(configStub.inputPath, '/debugger/v1/diagnostics')
@@ -263,8 +270,11 @@ describe('input message http requests', function () {
     sinon.assert.calledThrice(requestWith404)
 
     const thirdCallOpts = requestWith404.getCall(2).args[1]
-    assert.ok(thirdCallOpts.path.startsWith('/debugger/v1/diagnostics?ddtags='),
-      `Third call should stick with diagnostics endpoint but got ${thirdCallOpts.path}`)
+    assert.match(
+      thirdCallOpts.path,
+      /^\/debugger\/v1\/diagnostics\?ddtags=/,
+      `Third call should stick with diagnostics endpoint but got ${thirdCallOpts.path}`
+    )
 
     done()
   })

--- a/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js
@@ -56,7 +56,7 @@ describe('coverage-ci-visibility', () => {
 
     const form = encoder.makePayload()
 
-    assert.ok(form._data[0].startsWith('--'))
+    assert.match(form._data[0], /^--/)
     assertObjectContains(
       form._data,
       [
@@ -117,7 +117,7 @@ describe('coverage-ci-visibility', () => {
 
     const form = encoder.makePayload()
 
-    assert.ok(form._data[0].startsWith('--'))
+    assert.match(form._data[0], /^--/)
     assertObjectContains(
       form._data,
       [

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -194,7 +194,7 @@ describe('spanFormat', () => {
 
       const serialized = trace.meta['_dd.span_links']
       assert.strictEqual(serialized.length, MAX_META_VALUE_LENGTH + 3)
-      assert.ok(serialized.endsWith('...'))
+      assert.match(serialized, /\.\.\.$/)
     })
 
     it('should always set a parent ID', () => {


### PR DESCRIPTION
### What does this PR do?

Adds a new custom ESLint rule, `eslint-prefer-assert-match`, that runs on test files and flags `assert.ok(...)` calls whose first argument is a plain string-matching expression — `String.prototype.startsWith`, `String.prototype.endsWith`, `String.prototype.match`, or `RegExp.prototype.test` (with optional `!` negation). The rule auto-fixes the cases it can do safely (regex literals, and string literals whose regex metacharacters can be escaped into a regex literal) and reports the rest without a fix. The auto-fix has also been applied across the existing test suite.

### Motivation

`assert.match(string, regexp)` produces much more informative failure messages than `assert.ok(string.startsWith('foo'))` — the latter fails with just `Expected value to be truthy: false`, while `assert.match` includes both the actual string and the regex it was tested against. Until now we relied on convention; this rule mechanically enforces it on new test code and converts the existing call sites in one pass.

### Additional Notes

- `.includes()` is **deliberately not handled**. Across this codebase it is used about equally on strings (`comment.includes("ddsh='...'")`) and arrays (`tags.includes('foo')`, `_traceBuffer.includes(...)`), and without runtime type information we'd produce a lot of false positives. Easy to extend later if we want it.
- Two call sites are intentionally left on `assert.ok` (with an inline `// eslint-disable-next-line eslint-rules/eslint-prefer-assert-match` comment that explains why): `packages/datadog-webpack/test/plugin.spec.js` and `integration-tests/code-origin.spec.js`. In both cases the search string is a runtime value (`source`, `cwd`) that can legitimately contain regex metacharacters, and safe escaping requires `RegExp.escape`, which is only available on Node.js 24+. The comments point at the rewrite we'll be able to do once our minimum supported Node version is 24.
