### PR TITLE
ci(verify-tests): flag specs no CI invocation reaches

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -158,6 +158,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/plugins/upstream
+      # `plugins/upstream` only runs `test:plugins:upstream`, which is a non-glob suite runner;
+      # the in-tree `test/integration-test/*.spec.js` files would otherwise have no CI invocation
+      # whose glob expands to reach them.
+      - uses: ./.github/actions/plugins/integration-test
 
   body-parser:
     runs-on: ubuntu-latest
@@ -168,6 +172,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/plugins/upstream
+      - uses: ./.github/actions/plugins/integration-test
 
   bullmq:
     runs-on: ubuntu-latest

--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -118,17 +118,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
 
-  # The couchbase native binding ships libcouchbase; the 3.x line only builds
-  # on Node 18 and the 4.2+ line only builds on Node 20+. Pin one Node version
-  # per range instead of using the composite action that runs both oldest+latest.
+  # The couchbase native binding ships libcouchbase: the 3.x line has no
+  # prebuilt binary for Node 18+ and its bundled sources do not compile under
+  # modern gcc (missing <cstdint> for std::uint8_t). Pin one Node version per
+  # range instead of using the composite action that runs both oldest+latest,
+  # mirroring the existing plugin job's matrix.
   instrumentation-couchbase:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - node-version: 18
+          - node-version: eol
             range: "^3.0.7"
-          - node-version: 20
+          - node-version: 18
             range: ">=4.2.0"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -58,6 +58,26 @@ jobs:
           flags: platform-webpack
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
+  instrumentation-ai:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: ai
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
+  instrumentation-aws-sdk:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: aws-sdk
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-bluebird:
     runs-on: ubuntu-latest
     permissions:
@@ -98,6 +118,53 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
 
+  # The couchbase native binding ships libcouchbase; the 3.x line only builds
+  # on Node 18 and the 4.2+ line only builds on Node 20+. Pin one Node version
+  # per range instead of using the composite action that runs both oldest+latest.
+  instrumentation-couchbase:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - node-version: 18
+            range: "^3.0.7"
+          - node-version: 20
+            range: ">=4.2.0"
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: couchbase
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
+      - uses: ./.github/actions/node
+        with:
+          version: ${{ matrix.node-version }}
+      - uses: ./.github/actions/install
+      - run: yarn config set ignore-engines true
+      - run: yarn test:instrumentations:ci --ignore-engines
+      - uses: ./.github/actions/coverage
+        with:
+          flags: instrumentations-${{ github.job }}-${{ matrix.node-version }}
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+
+  instrumentation-crypto:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: crypto
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-express-mongo-sanitize:
     runs-on: ubuntu-latest
     permissions:
@@ -134,6 +201,26 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-express-multi-version:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: express-multi-version
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
+  instrumentation-fetch:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: fetch
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-fs:
     runs-on: ubuntu-latest
     permissions:
@@ -150,6 +237,16 @@ jobs:
       id-token: write
     env:
       PLUGINS: generic-pool
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
+  instrumentation-hono:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: hono
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
@@ -191,6 +288,16 @@ jobs:
         if: "!cancelled()"
         with:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
+
+  instrumentation-http-client-options:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: http-client-options
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
 
   instrumentation-knex:
     runs-on: ubuntu-latest
@@ -253,6 +360,16 @@ jobs:
     env:
       PLUGINS: mysql2
       SERVICES: mysql2
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
+  instrumentation-otel-sdk-trace:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: otel-sdk-trace
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
@@ -336,6 +453,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-stripe:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: stripe
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-url:
     runs-on: ubuntu-latest
     permissions:
@@ -352,6 +479,16 @@ jobs:
       id-token: write
     env:
       PLUGINS: when
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/instrumentations/test
+
+  instrumentation-zlib:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: zlib
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/instrumentations/test

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -206,6 +206,19 @@ jobs:
           flags: test-optimization-jest-${{ matrix.version }}-${{ matrix.jest-version }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
+  # Unit tests for `packages/datadog-plugin-jest`. The `integration-jest` matrix above only runs
+  # `integration-tests/jest/*.spec.js`, so this is the only CI invocation whose glob expands to
+  # cover `packages/datadog-plugin-jest/test/util.spec.js`.
+  jest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: jest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/plugins/test
+
   integration-cucumber:
     strategy:
       fail-fast: false

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -803,6 +803,15 @@ export default [
     },
   },
   {
+    // jest-docblock's `@datadog {"unskippable": true}` tag reads as a malformed
+    // JSDoc type to `jsdoc/valid-types`. The shape is required by the plugin.
+    name: 'dd-trace/datadog-plugin-jest/fixtures',
+    files: ['packages/datadog-plugin-jest/test/fixtures/**/*.js'],
+    rules: {
+      'jsdoc/valid-types': 'off',
+    },
+  },
+  {
     // CI-visibility retry fixtures intentionally call `this.retries(N)` to
     // exercise the dd-trace test-optimization retry code paths. The fixtures
     // ARE the flaky tests that the plugin watches.

--- a/packages/datadog-instrumentations/test/http-client-options.spec.js
+++ b/packages/datadog-instrumentations/test/http-client-options.spec.js
@@ -20,7 +20,9 @@ describe('http client option ownership', () => {
     // `request`/`get` on the module instance the test uses.
     http = require('node:http')
 
-    server = http.createServer((req, res) => res.end()).listen(0, '127.0.0.1')
+    // Bind to all interfaces so requests via `localhost` reach the server
+    // regardless of whether Node DNS resolves IPv4 or IPv6 first.
+    server = http.createServer((req, res) => res.end()).listen(0)
     await new Promise(resolve => server.once('listening', resolve))
     port = server.address().port
   })

--- a/packages/datadog-plugin-axios/test/integration-test/server.mjs
+++ b/packages/datadog-plugin-axios/test/integration-test/server.mjs
@@ -1,7 +1,8 @@
 import 'dd-trace/init.js'
 import axios from 'axios'
 
-axios.get('/foo')
+// An arbitrary port is used here as we just need a request even if it fails.
+axios.get('http://localhost:55555/foo')
   .then(() => {})
   .catch(() => {})
   .finally(() => {})

--- a/packages/datadog-plugin-jest/test/fixtures/test-to-run.js
+++ b/packages/datadog-plugin-jest/test/fixtures/test-to-run.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// Fixture for util.spec.js. `getJestSuitesToRun` reads this file to scan for
+// a `@datadog` docblock; the body of the suite is never executed.
+
+describe('test-to-run', () => {
+  it('is a placeholder fixture', () => {})
+})

--- a/packages/datadog-plugin-jest/test/fixtures/test-to-skip.js
+++ b/packages/datadog-plugin-jest/test/fixtures/test-to-skip.js
@@ -1,0 +1,8 @@
+'use strict'
+
+// Fixture for util.spec.js. `getJestSuitesToRun` reads this file to scan for
+// a `@datadog` docblock; the body of the suite is never executed.
+
+describe('test-to-skip', () => {
+  it('is a placeholder fixture', () => {})
+})

--- a/packages/datadog-plugin-jest/test/fixtures/test-unskippable.js
+++ b/packages/datadog-plugin-jest/test/fixtures/test-unskippable.js
@@ -1,0 +1,11 @@
+/**
+ * @datadog {"unskippable": true}
+ */
+'use strict'
+
+// Fixture for util.spec.js. `getJestSuitesToRun` reads this file to scan for
+// the `@datadog` docblock above; the body of the suite is never executed.
+
+describe('test-unskippable', () => {
+  it('is a placeholder fixture', () => {})
+})

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -153,7 +153,15 @@ function normalizeScriptGlob (raw, opts = {}) {
 
   // For global analysis we treat env vars as wildcards, but when evaluating a specific CI run
   // we need to preserve them so they can be expanded with the provided env.
-  if (!preserveEnv) {
+  if (preserveEnv) {
+    // Unwrap extglob constructs that wrap a single env var so the env-aware expansion
+    // below still sees the variable. Without this, every glob of the form
+    // `@(${PLUGINS}).spec.js` would degrade to `*.spec.js` and a single-plugin CI job
+    // (e.g. `PLUGINS=bluebird`) would falsely appear to exercise every spec in the
+    // same directory.
+    p = p.replaceAll(/@\((\$\{[^}]+\})\)/g, '$1')
+    p = p.replaceAll(/@\((\$[A-Za-z_][A-Za-z0-9_]*)\)/g, '$1')
+  } else {
     // Replace shell variable expansion with a wildcard for our analysis.
     // Examples:
     // - ${PLUGINS} -> *
@@ -163,8 +171,8 @@ function normalizeScriptGlob (raw, opts = {}) {
     p = p.replaceAll(/\$[A-Za-z_][A-Za-z0-9_]*/g, '*')
   }
 
-  // Replace bash extglob constructs with a conservative wildcard to avoid parsing issues.
-  // Examples: @(...), +(...), ?(...), !(...)
+  // Replace remaining bash extglob constructs with a conservative wildcard to avoid
+  // parsing issues. Examples: @(...), +(...), ?(...), !(...).
   p = p.replaceAll(/[@+?!]\([^)]*\)/g, '*')
 
   // Normalize leading './' which appears sometimes in scripts.
@@ -749,6 +757,28 @@ function collectWorkflowRuns (repoRoot) {
             out.push({ workflowFile: wf, jobId, run: e.run, env: e.env })
           }
         }
+
+        // Third-party retry wrappers run their `with.command` like an inline `run:`.
+        // Without unwrapping it, the joint check below cannot see that `instrumentation-http`
+        // exercises `test:instrumentations:ci` with `PLUGINS=http`.
+        if (typeof step.uses === 'string' && /^nick-fields\/retry@/.test(step.uses)) {
+          const command = isPlainObject(step.with) && typeof step.with.command === 'string'
+            ? step.with.command
+            : null
+          if (command) {
+            const stepEnv = { ...env }
+            const exports = parseExportAssignments(command)
+            for (const [k, v] of Object.entries(exports)) stepEnv[k] = v
+            const idxYarn = command.indexOf('yarn ')
+            const idxNpm = command.indexOf('npm ')
+            const idx = idxYarn === -1 ? idxNpm : (idxNpm === -1 ? idxYarn : Math.min(idxYarn, idxNpm))
+            if (idx > 0) {
+              const assigns = parseInlineAssignments(command.slice(0, idx))
+              for (const [k, v] of Object.entries(assigns)) stepEnv[k] = v
+            }
+            out.push({ workflowFile: wf, jobId, run: command, env: stepEnv })
+          }
+        }
       }
     }
   }
@@ -1099,6 +1129,13 @@ function main () {
 
   // Detect CI steps that will match no tests due to env/script mismatches.
   const testFileSet = new Set(testFiles)
+  // Spec files reached by at least one CI invocation. Paired with the per-step
+  // `matchedTestCount` check below to flag the inverse failure: a spec that is matched
+  // by some script glob but no workflow ever sets the env (typically PLUGINS) that
+  // would expand the glob to reach it. Without this, a new `<name>.spec.js` under
+  // `packages/datadog-instrumentations/test/` looks covered by `test:instrumentations`'
+  // glob and slips into the tree with no CI job actually running it.
+  const ciExercisedFiles = new Set()
   for (const i of invoked) {
     if (!i.script.startsWith('test:')) continue
 
@@ -1116,7 +1153,10 @@ function main () {
     if (invokedGlobs.length) {
       let matchedTestCount = 0
       for (const f of files) {
-        if (testFileSet.has(f)) matchedTestCount++
+        if (testFileSet.has(f)) {
+          matchedTestCount++
+          ciExercisedFiles.add(f)
+        }
       }
 
       if (matchedTestCount === 0) {
@@ -1204,6 +1244,21 @@ function main () {
             `which is single-plugin; use "${i.script}:multi" instead`
         )
       }
+    }
+  }
+
+  // Spec files that pass the "matched by some script glob" check but no CI invocation
+  // actually expands to reach them. Common cause: a `<name>.spec.js` added under
+  // `packages/datadog-instrumentations/test/` (or any other PLUGINS-templated location)
+  // without a matching `PLUGINS=<name>` job in the corresponding workflow.
+  /** @type {string[]} */
+  const ciOrphans = []
+  for (const file of testFiles) {
+    if (!ciExercisedFiles.has(file)) ciOrphans.push(file)
+  }
+  if (ciOrphans.length) {
+    for (const file of ciOrphans) {
+      pushError(`No CI workflow invocation expands a glob to exercise ${file}`)
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a joint-condition check to `scripts/verify-exercised-tests.js`: every spec file must be matched by *some* `package.json` script glob **and** reached by at least one workflow invocation that expands the glob with the right env. The existing check only enforced the first half.

Two prerequisites land alongside the joint check so it produces truthful results:
- `normalizeScriptGlob` no longer collapses `@(${PLUGINS})` to `*` in `preserveEnv` mode, so a single-plugin CI job no longer looks like it exercises every spec in the same directory.
- `collectWorkflowRuns` unwraps `nick-fields/retry@*`'s `command:` input like an inline `run:`, so `instrumentation-http`'s retry-wrapped `test:instrumentations:ci` invocation is visible.

The check would have caught the silent CI gap that motivated PR #8516: `packages/datadog-instrumentations/test/fastify.spec.js` matched `test:instrumentations`' glob, but no workflow set `PLUGINS=fastify` for `test:instrumentations:ci`, so codecov reported 8 new lines as patch misses despite the spec covering them locally.

## CI gaps closed in this PR

Running the verifier with the new check on `master` surfaced 14 pre-existing orphans. All are addressed by the follow-up commits:

| Spec | Workflow | Job added |
| --- | --- | --- |
| `packages/datadog-instrumentations/test/ai.spec.js` | `instrumentation.yml` | `instrumentation-ai` |
| `packages/datadog-instrumentations/test/aws-sdk.spec.js` | `instrumentation.yml` | `instrumentation-aws-sdk` |
| `packages/datadog-instrumentations/test/couchbase.spec.js` | `instrumentation.yml` | `instrumentation-couchbase` |
| `packages/datadog-instrumentations/test/crypto.spec.js` | `instrumentation.yml` | `instrumentation-crypto` |
| `packages/datadog-instrumentations/test/express-multi-version.spec.js` | `instrumentation.yml` | `instrumentation-express-multi-version` |
| `packages/datadog-instrumentations/test/fetch.spec.js` | `instrumentation.yml` | `instrumentation-fetch` |
| `packages/datadog-instrumentations/test/hono.spec.js` | `instrumentation.yml` | `instrumentation-hono` |
| `packages/datadog-instrumentations/test/http-client-options.spec.js` | `instrumentation.yml` | `instrumentation-http-client-options` |
| `packages/datadog-instrumentations/test/otel-sdk-trace.spec.js` | `instrumentation.yml` | `instrumentation-otel-sdk-trace` |
| `packages/datadog-instrumentations/test/stripe.spec.js` | `instrumentation.yml` | `instrumentation-stripe` |
| `packages/datadog-instrumentations/test/zlib.spec.js` | `instrumentation.yml` | `instrumentation-zlib` |
| `packages/datadog-plugin-axios/test/integration-test/client.spec.js` | `apm-integrations.yml` | `axios:` (added `plugins/integration-test` step) |
| `packages/datadog-plugin-body-parser/test/integration-test/client.spec.js` | `apm-integrations.yml` | `body-parser:` (added `plugins/integration-test` step) |
| `packages/datadog-plugin-jest/test/util.spec.js` | `test-optimization.yml` | `jest:` |

`fastify.spec.js` is intentionally absent from the list — PR #8516 closes it.

## Test plan

- [x] `node scripts/verify-exercised-tests.js` on this branch: zero errors.
- [x] Cherry-picked the unit spec from #8516 into the same worktree without its `instrumentation-fastify` workflow entry: verifier flagged it as expected; with the entry, it passed. Confirms the joint check is functional.
- [x] `npm run verify:workflow-job-names` clean.
- [x] `eslint scripts/verify-exercised-tests.js` clean.
- [ ] CI run on this PR exercises each newly added job and confirms the specs pass under the same harness they were designed for.