### PR TITLE
ci(electron): push results to test optimization

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -442,10 +442,14 @@ jobs:
 
   electron:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       PLUGINS: electron
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
       - uses: ./.github/actions/testagent/start
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
@@ -464,6 +468,10 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
       # Point Electron at the virtual display started above.
       - run: DISPLAY=:99 yarn test:plugins:ci
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
   express:
     runs-on: ubuntu-latest

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -22,9 +22,15 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       - run: yarn test:integration:electron
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
   ubuntu:
     runs-on: ubuntu-latest
@@ -32,8 +38,14 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/dd-sts-api-key
+        id: dd-sts
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       # Electron needs a display even for headless (show: false) windows.
       # xvfb-run provides a virtual framebuffer so the test can run without a physical display.
       - run: xvfb-run --auto-servernum yarn test:integration:electron
+      - uses: ./.github/actions/push_to_test_optimization
+        if: "!cancelled()"
+        with:
+          dd_api_key: ${{ steps.dd-sts.outputs.api_key }}


### PR DESCRIPTION
## Summary

- Add `push_to_test_optimization` step to all three Electron CI jobs (`macos` and `ubuntu` in `electron.yml`, `electron` in `apm-integrations.yml`)
- Add `dd-sts-api-key` step and `permissions: id-token: write` where missing to support OIDC token exchange
- JUnit XML is already generated in CI by the existing mocha multi-reporter setup

## Test plan

- [ ] Verify CI passes on all three Electron jobs
- [ ] Confirm test results appear in Datadog Test Optimization after merge

> Generated by [Claude Code](https://claude.ai/claude-code)