### PR TITLE
fix(electron): fix flaky IPC tests and Xvfb startup race

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -461,11 +461,14 @@ jobs:
           sudo apt-get update
           # Xvfb provides a virtual X display so Electron (a GUI app) can start
           # on the headless CI runner without a physical screen.
-          sudo apt-get install -y xvfb
+          sudo apt-get install -y xvfb x11-utils
           # Launch the virtual display on screen :99 with a 24-bit 1024×768
           # framebuffer. Output is discarded; the & backgrounds it so the step
           # does not block.
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          # Wait until the display is ready before proceeding, otherwise Electron
+          # can fail to connect to the display and the test beforeEach times out.
+          until xdpyinfo -display :99 >/dev/null 2>&1; do sleep 0.1; done
       # Point Electron at the virtual display started above.
       - run: DISPLAY=:99 yarn test:plugins:ci
       - uses: ./.github/actions/push_to_test_optimization

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -468,7 +468,8 @@ jobs:
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           # Wait until the display is ready before proceeding, otherwise Electron
           # can fail to connect to the display and the test beforeEach times out.
-          until xdpyinfo -display :99 >/dev/null 2>&1; do sleep 0.1; done
+          # Bounded at 30s so an Xvfb crash fails fast instead of hanging.
+          timeout 30 bash -c 'until xdpyinfo -display :99 >/dev/null 2>&1; do sleep 0.1; done'
       # Point Electron at the virtual display started above.
       - run: DISPLAY=:99 yarn test:plugins:ci
       - uses: ./.github/actions/push_to_test_optimization

--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -112,7 +112,7 @@ describe('Plugin', () => {
         it('should do automatic instrumentation for main IPC when receiving', done => {
           agent
             .assertSomeTraces(traces => {
-              const span = traces[0][0]
+              const span = traces.flat().find(s => s.name === 'electron.main.receive')
               const { meta } = span
 
               assert.strictEqual(span.type, 'worker')
@@ -155,7 +155,7 @@ describe('Plugin', () => {
         it('should do automatic instrumentation for main IPC when sending', done => {
           agent
             .assertSomeTraces(traces => {
-              const span = traces[0][0]
+              const span = traces.flat().find(s => s.name === 'electron.main.send')
               const { meta } = span
 
               assert.strictEqual(span.name, 'electron.main.send')
@@ -175,7 +175,7 @@ describe('Plugin', () => {
         it('should do automatic instrumentation for renderer IPC when receiving', done => {
           agent
             .assertSomeTraces(traces => {
-              const span = traces[0][0]
+              const span = traces.flat().find(s => s.name === 'electron.renderer.receive')
               const { meta } = span
 
               assert.strictEqual(span.type, 'worker')
@@ -197,7 +197,7 @@ describe('Plugin', () => {
         it('should do automatic instrumentation for renderer IPC when sending', done => {
           agent
             .assertSomeTraces(traces => {
-              const span = traces[0][0]
+              const span = traces.flat().find(s => s.name === 'electron.renderer.send')
               const { meta } = span
 
               assert.strictEqual(span.name, 'electron.renderer.send')


### PR DESCRIPTION
## Summary

- **Test race condition**: IPC tests that trigger spans across two processes (main + renderer) were using `traces[0][0]`, which assumes a fixed span arrival order. When the "other" process span arrived first, the assertion on the wrong span caused non-deterministic failures. Fixed all 4 affected IPC tests to use `.find()` by span name, consistent with the existing `electron.main.handle` test.
- **Xvfb startup race**: The CI step started Xvfb in the background then immediately ran tests with no readiness check. If Electron tried to connect before the display was initialized, the `beforeEach` hook would time out. Added `until xdpyinfo -display :99 >/dev/null 2>&1; do sleep 0.1; done` after starting Xvfb and installed `x11-utils` (which provides `xdpyinfo`).

These two issues account for the 37 flaky `electron` job failures recorded in the flakiness report over the past 2 days (~58% of all flaky CI runs).

## Test plan

- [ ] Verify the `electron` CI job passes consistently after this change
- [ ] Confirm no other tests in `packages/datadog-plugin-electron/test/index.spec.js` are affected

## Semver

`semver-patch` — test and CI-only changes, no production code modified.

_Generated with [Claude Code](https://claude.com/claude-code)_