### PR TITLE
fix(appsec): increase beforeEach timeout in rasp-metrics integration test

### DIFF
--- a/packages/dd-trace/test/appsec/rasp/rasp-metrics.integration.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/rasp-metrics.integration.spec.js
@@ -22,7 +22,8 @@ describe('RASP metrics', () => {
   describe('RASP error metric', () => {
     let agent, proc
 
-    beforeEach(async () => {
+    beforeEach(async function () {
+      this.timeout(10_000)
       agent = await new FakeAgent().start()
       proc = await spawnProc(appFile, {
         cwd,
@@ -79,7 +80,8 @@ describe('RASP metrics', () => {
   describe('RASP timeout metric', () => {
     let agent, proc
 
-    beforeEach(async () => {
+    beforeEach(async function () {
+      this.timeout(10_000)
       agent = await new FakeAgent().start()
       proc = await spawnProc(appFile, {
         cwd,


### PR DESCRIPTION
## Summary

- The `beforeEach` hooks in `rasp-metrics.integration.spec.js` used arrow functions, which means `this` is not the Mocha context and `this.timeout()` cannot be called. The default 5000ms Mocha timeout applied.
- On Windows, spawning a Node.js + Express process via `spawnProc` takes longer than 5000ms, causing intermittent `beforeEach` timeouts in the `AppSec / windows` CI job.
- Fix: convert both `beforeEach` hooks to regular functions and add `this.timeout(10_000)`, consistent with the pattern used in `useSandbox` elsewhere in the codebase.
- The `afterEach` hooks are left unchanged (arrow functions) as no `afterEach` timeouts have been observed — process teardown on Windows is fast.

This accounts for all 4 `AppSec` flaky job occurrences recorded in the last 2 days, all from the `AppSec / windows` runner.

## Test plan

- [ ] Verify `AppSec / windows` CI job passes consistently after this change

## Semver

`semver-patch` — test-only change, no production code modified.

_Generated with [Claude Code](https://claude.com/claude-code)_