### PR TITLE
fix(aws-sdk): fix flaky SFN, SNS DSM, S3, and Bedrockruntime tests

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js
@@ -23,7 +23,8 @@ describe('Plugin', () => {
           return agent.load('aws-sdk')
         })
 
-        before(() => {
+        before(function () {
+          this.timeout(10_000)
           const requireVersion = version === '3.0.0' ? '3.422.0' : '>=3.422.0'
           AWS = require(`../../../versions/${bedrockRuntimeClientName}@${requireVersion}`).get()
           const NodeHttpHandler =

--- a/packages/datadog-plugin-aws-sdk/test/s3.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/s3.spec.js
@@ -40,7 +40,8 @@ describe('Plugin', () => {
           return agent.load('aws-sdk')
         })
 
-        before(done => {
+        before(function (done) {
+          this.timeout(10_000)
           AWS = require(`../../../versions/${s3ClientName}@${version}`).get()
           s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4566', s3ForcePathStyle: true, region: 'us-east-1' })
 

--- a/packages/datadog-plugin-aws-sdk/test/sns.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sns.dsm.spec.js
@@ -221,7 +221,7 @@ describe('Sns', function () {
           })
           assert.ok(statsPointsReceived >= 2)
           assert.strictEqual(agent.dsmStatsExist(agent, expectedConsumerHash), true)
-        }).then(done, done)
+        }, { timeoutMs: 2000 }).then(done, done)
 
         sns.subscribe(subParams, () => {
           sns.publish({ TopicArn, Message: 'message DSM' }, () => {

--- a/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
@@ -110,7 +110,8 @@ describe('Sfn', () => {
             input: JSON.stringify({ moduleName }),
           }
           const expectSpanPromise = agent.assertSomeTraces(traces => {
-            const span = traces[0][0]
+            const span = traces.flat().find(s => s.resource === 'startExecution')
+            assert.ok(span, 'expected startExecution span')
             assert.strictEqual(span.resource, 'startExecution')
             assert.strictEqual(span.meta.statemachinearn, stateMachineArn)
           })


### PR DESCRIPTION
## Summary

Fixes all 11 flaky `aws-sdk` job failures recorded in the last 2 days, across four distinct root causes:

**Step Functions — `is instrumented` (6 failures)**
`beforeEach` calls `createStateMachine`, generating a span that can arrive at the test agent before the `startExecution` span does. `traces[0][0]` non-deterministically picks the setup span. Fixed with `.find(s => s.resource === 'startExecution')`, consistent with the pattern used elsewhere.

**SNS DSM — `statsPointsReceived >= 2` (3 failures)**
`sqs.receiveMessage` uses `WaitTimeSeconds: 1` (long-poll), so the consumer DSM checkpoint arrives ~1 second after the SNS publish. The default `expectPipelineStats` timeout is also 1 second, causing a race where the rejection timeout fires just before the consumer stats arrive. Increased to `{ timeoutMs: 2000 }`, matching the existing batch test.

**S3 — `before all` hook timeout (1 failure)**
The `before` hook connecting to LocalStack and creating a bucket used an arrow function, preventing `this.timeout()` from overriding the default 5000ms. Converted to a regular function with `this.timeout(10_000)`.

**Bedrockruntime — `before all` hook timeout (1 failure)**
Same issue: arrow function in `before` hook requiring packages lazily. Converted to a regular function with `this.timeout(10_000)`.

## Test plan

- [ ] Verify `aws-sdk` CI job passes consistently after this change

_Generated with [Claude Code](https://claude.com/claude-code)_