### PR TITLE
test(aerospike,couchbase): fix hook timeouts and couchbase service readiness

### DIFF
--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -48,7 +48,8 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => {
+        before(function () {
+          this.timeout(10_000)
           return agent.load('aerospike')
         })
 
@@ -303,7 +304,8 @@ describe('Plugin', () => {
       })
 
       describe('with configuration', () => {
-        before(() => {
+        before(function () {
+          this.timeout(10_000)
           return agent.load('aerospike', { service: 'custom' })
         })
 

--- a/packages/datadog-plugin-couchbase/test/index.spec.js
+++ b/packages/datadog-plugin-couchbase/test/index.spec.js
@@ -22,7 +22,8 @@ describe('Plugin', () => {
 
     withVersions('couchbase', 'couchbase', '>=3.0.0', version => {
       describe('without configuration', () => {
-        beforeEach(async () => {
+        beforeEach(async function () {
+          this.timeout(10_000)
           tracer = global.tracer = await agent.load('couchbase')
           couchbase = proxyquire(`../../../versions/couchbase@${version}`, {}).get()
           cluster = await couchbase.connect('couchbase://localhost', {

--- a/packages/dd-trace/test/setup/services/couchbase.js
+++ b/packages/dd-trace/test/setup/services/couchbase.js
@@ -20,7 +20,8 @@ function waitForCouchbase () {
       })
         .then(response => {
           if (!response.data.results?.length) {
-            operation.retry(new Error('datadog-test keyspace not ready'))
+            const err = new Error('datadog-test keyspace not ready')
+            if (!operation.retry(err)) reject(err)
           } else {
             resolve()
           }

--- a/packages/dd-trace/test/setup/services/couchbase.js
+++ b/packages/dd-trace/test/setup/services/couchbase.js
@@ -6,19 +6,25 @@ const RetryOperation = require('../operation')
 function waitForCouchbase () {
   return new Promise((resolve, reject) => {
     const operation = new RetryOperation('couchbase')
-    const cbasEndpoint = 'http://127.0.0.1:8095/query/service'
+    const n1qlEndpoint = 'http://127.0.0.1:8093/query/service'
 
     operation.attempt(currentAttempt => {
       axios({
         method: 'POST',
-        url: cbasEndpoint,
-        data: { statement: 'SELECT * FROM datatest', timeout: '75000000us' },
+        url: n1qlEndpoint,
+        data: { statement: 'SELECT * FROM system:keyspaces WHERE name="datadog-test"' },
         auth: {
           username: 'Administrator',
           password: 'password',
         },
       })
-        .then(() => resolve())
+        .then(response => {
+          if (!response.data.results?.length) {
+            operation.retry(new Error('datadog-test keyspace not ready'))
+          } else {
+            resolve()
+          }
+        })
         .catch(err => {
           if (operation.retry(err)) return
           reject(err)


### PR DESCRIPTION
## Summary

**Aerospike (2 failures):**
Both \`before\` hooks inside arrow-function \`describe\` blocks don't inherit the parent suite's timeout — they fall back to the 5000ms default. Converted to regular functions with \`this.timeout(10_000)\`.

**Couchbase (3/3 failures):**

*beforeEach hook timeout (2 failures):*
The \`beforeEach\` arrow function calling \`couchbase.connect()\` couldn't override the 5000ms default. Converted to a regular function with \`this.timeout(10_000)\`.

*ambiguous_timeout on queries (1 failure):*
The \`waitForCouchbase\` service readiness check was polling the Analytics service (port 8095) instead of the N1QL service (port 8093) used by the tests. Even when Analytics was ready, N1QL and the \`datadog-test\` bucket could still be unavailable, causing \`ambiguous_timeout (13)\` errors. Fixed to poll port 8093 and wait until \`system:keyspaces\` confirms \`datadog-test\` is accessible.

## Test plan

- [ ] Verify \`aerospike\` CI job passes consistently
- [ ] Verify \`couchbase\` CI job passes consistently (all 3 failure modes addressed)

_Generated with [Claude Code](https://claude.com/claude-code)_