### PR TITLE
fix(mongoose): make PeerCat model registration idempotent

### DIFF
--- a/packages/datadog-plugin-mongoose/test/index.spec.js
+++ b/packages/datadog-plugin-mongoose/test/index.spec.js
@@ -66,7 +66,10 @@ describe('Plugin', () => {
         () => tracer,
         'mongodb-core',
         () => {
-          const PeerCat = mongoose.model('PeerCat', { name: String })
+          // Use existing model if already compiled: on master, --retries 1 reruns failed tests on
+          // the same Mongoose instance, and calling model() with a schema a second time throws
+          // OverwriteModelError.
+          const PeerCat = mongoose.models.PeerCat || mongoose.model('PeerCat', { name: String })
           return new PeerCat({ name: 'PeerCat' }).save()
         },
         () => dbName,


### PR DESCRIPTION
## Summary

`mongoose.model('PeerCat', schema)` throws `OverwriteModelError` when called twice on the same Mongoose instance. This surfaces specifically on `master` because `MOCHA_OPTIONS=--retries 1` automatically reruns any failing test once.

The failure sequence:
1. `should compute peer service` fails transiently (e.g. MongoDB hiccup)
2. `PeerCat` is now registered in Mongoose's global model registry
3. Mocha retries the test — `mongoose.model('PeerCat', schema)` throws `OverwriteModelError`

The fix uses `mongoose.models.PeerCat || mongoose.model(...)` — the idiomatic Mongoose pattern for safe get-or-create — so retries reuse the already-compiled model instead of trying to reregister it.

## Test plan

- [ ] Verify `mongoose` CI job passes consistently

_Generated with [Claude Code](https://claude.com/claude-code)_