### PR TITLE
fix(google-cloud-pubsub): poll for GC collection instead of fixed retry count

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/test/pubsub-push-subscription.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/pubsub-push-subscription.spec.js
@@ -273,13 +273,15 @@ describe('Push Subscription Plugin', () => {
             await sendPushRequest(port)
             await wait(100)
 
-            // Force garbage collection multiple times
-            gc()
-            await wait(100)
-            gc()
-            await wait(100)
-            gc()
-            await wait(500)
+            // FinalizationRegistry callbacks are scheduled as microtasks after GC and
+            // V8 may need multiple passes to collect an object. Poll until collected
+            // or the test timeout is reached to avoid flakiness from GC timing variance.
+            const deadline = Date.now() + 8000
+            while (Date.now() < deadline) {
+              gc()
+              await wait(100)
+              if (requestWasCollected) break
+            }
 
             assert.strictEqual(requestWasCollected, true)
             done()


### PR DESCRIPTION
## Summary

The `should clean up receiveSpans WeakMap when request is garbage collected` test used 3 fixed `gc()` calls with 800ms total wait to check that a `FinalizationRegistry` callback fires. On slow CI runners V8 needs more passes before it collects the object, causing the assertion to fail intermittently.

Replace the fixed retry count with a polling loop that calls `gc()` every 100ms and exits as soon as the finalizer fires, up to a maximum of 8s. In the common case the request is collected on the first or second pass (~100–200ms); the 8s bound is only hit on exceptionally slow runners.

## Test plan

- [ ] Verify `google-cloud-pubsub` CI job passes consistently

_Generated with [Claude Code](https://claude.com/claude-code)_