### PR TITLE
test(kafkajs): poll fetchTopicMetadata after createTopics to fix CI flakes

### DIFF
--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -6,8 +6,6 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const semver = require('semver')
 const sinon = require('sinon')
 
-const { createAndAwaitTopics } = require('./helpers')
-
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 
@@ -16,6 +14,8 @@ const { computePathwayHash } = require('../../dd-trace/src/datastreams/pathway')
 const { ENTRY_PARENT_HASH, DataStreamsProcessor } = require('../../dd-trace/src/datastreams/processor')
 const propagationHash = require('../../dd-trace/src/propagation-hash')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+
+const { createAndAwaitTopics } = require('./helpers')
 
 const testKafkaClusterId = '5L6g3nShT-eMCtK--X86sw'
 

--- a/packages/datadog-plugin-kafkajs/test/dsm.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/dsm.spec.js
@@ -6,6 +6,8 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const semver = require('semver')
 const sinon = require('sinon')
 
+const { createAndAwaitTopics } = require('./helpers')
+
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 
@@ -70,14 +72,14 @@ describe('Plugin', () => {
           topicBIn = `topic-b-in-${randomUUID()}`
           topicBOut = `topic-b-out-${randomUUID()}`
           admin = kafka.admin()
-          await admin.createTopics({
-            waitForLeaders: true,
-            topics: [testTopic, topicAIn, topicAOut, topicBIn, topicBOut].map(topic => ({
+          await createAndAwaitTopics(
+            admin,
+            [testTopic, topicAIn, topicAOut, topicBIn, topicBOut].map(topic => ({
               topic,
               numPartitions: 1,
               replicationFactor: 1,
-            })),
-          })
+            }))
+          )
           expectedProducerHash = getDsmPathwayHash(testTopic, true, ENTRY_PARENT_HASH)
           expectedConsumerHash = getDsmPathwayHash(testTopic, false, expectedProducerHash)
         })

--- a/packages/datadog-plugin-kafkajs/test/helpers.js
+++ b/packages/datadog-plugin-kafkajs/test/helpers.js
@@ -31,6 +31,11 @@ async function createAndAwaitTopics (admin, topicSpecs, { timeoutMs = 8000, poll
   }
   if (lastError) throw lastError
 
+  // `fetchTopicMetadata` was added to admin in kafkajs 1.5; on 1.4.0 the
+  // create-with-retry above is the only knob we have. The consumer/producer
+  // will refresh its own metadata on first use.
+  if (typeof admin.fetchTopicMetadata !== 'function') return
+
   while (Date.now() < deadline) {
     try {
       const { topics } = await admin.fetchTopicMetadata({ topics: topicNames })

--- a/packages/datadog-plugin-kafkajs/test/helpers.js
+++ b/packages/datadog-plugin-kafkajs/test/helpers.js
@@ -1,0 +1,53 @@
+'use strict'
+
+// `admin.createTopics({ waitForLeaders: true })` can still throw
+// UNKNOWN_TOPIC_OR_PARTITION (errorCode 3) while the broker propagates
+// metadata internally — kafkajs's retryOnLeaderNotAvailable only covers
+// LEADER_NOT_AVAILABLE (5). Single-broker dev Kafka makes the lag window
+// very visible in CI. Drive create-and-verify until the topic is reachable
+// from the client's broker pool.
+//
+// Two phases, because kafkajs 1.4.0 (unlike >=2.x) throws
+// TOPIC_ALREADY_EXISTS rather than returning false, so we can only call
+// createTopics safely once and have to retry the metadata fetch separately.
+async function createAndAwaitTopics (admin, topicSpecs, { timeoutMs = 8000, pollIntervalMs = 100 } = {}) {
+  const topicNames = topicSpecs.map(t => t.topic)
+  const deadline = Date.now() + timeoutMs
+  let lastError
+
+  while (Date.now() < deadline) {
+    try {
+      await admin.createTopics({ waitForLeaders: true, topics: topicSpecs })
+      lastError = undefined
+      break
+    } catch (e) {
+      if (e.type === 'TOPIC_ALREADY_EXISTS' || /already exists/i.test(e.message ?? '')) {
+        lastError = undefined
+        break
+      }
+      lastError = e
+      await sleep(pollIntervalMs)
+    }
+  }
+  if (lastError) throw lastError
+
+  while (Date.now() < deadline) {
+    try {
+      const { topics } = await admin.fetchTopicMetadata({ topics: topicNames })
+      const allReady = topics.length === topicNames.length &&
+        topics.every(t => t.partitions.length > 0 && t.partitions.every(p => p.leader >= 0))
+      if (allReady) return
+    } catch (e) {
+      lastError = e
+    }
+    await sleep(pollIntervalMs)
+  }
+
+  throw lastError ?? new Error(`Topics never became ready: ${topicNames.join(', ')}`)
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+module.exports = { createAndAwaitTopics }

--- a/packages/datadog-plugin-kafkajs/test/index.spec.js
+++ b/packages/datadog-plugin-kafkajs/test/index.spec.js
@@ -15,6 +15,7 @@ const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/c
 const { clientToCluster } = require('../../datadog-instrumentations/src/helpers/kafka')
 const { assertObjectContains, deepFreeze } = require('../../../integration-tests/helpers')
 
+const { createAndAwaitTopics } = require('./helpers')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
 const testKafkaClusterId = '5L6g3nShT-eMCtK--X86sw'
@@ -50,14 +51,11 @@ describe('Plugin', () => {
           })
           testTopic = `test-topic-${randomUUID()}`
           admin = kafka.admin()
-          await admin.createTopics({
-            waitForLeaders: true,
-            topics: [{
-              topic: testTopic,
-              numPartitions: 1,
-              replicationFactor: 1,
-            }],
-          })
+          await createAndAwaitTopics(admin, [{
+            topic: testTopic,
+            numPartitions: 1,
+            replicationFactor: 1,
+          }])
         })
 
         describe('producer', () => {


### PR DESCRIPTION
### What does this PR do?

Adds a `createAndAwaitTopics` helper for `packages/datadog-plugin-kafkajs/test/` that:

1. Calls `admin.createTopics({ waitForLeaders: true, topics })` with a bounded retry, catching `TOPIC_ALREADY_EXISTS` so a retried call (or a leftover from a previous run on the same broker) is a no-op.
2. On kafkajs >=1.5, polls `admin.fetchTopicMetadata({ topics })` until every partition reports `leader >= 0`, so the next `consumer.subscribe` / `producer.send` finds the topic in the client's broker pool. (Feature-detected — `fetchTopicMetadata` was added in 1.5; 1.4.0 relies on the create-with-retry alone, which is what was actually leaking on that path.)

Both flaking `beforeEach` setups — `index.spec.js` (single-topic) and `dsm.spec.js` (five-topic DSM) — now route through it.

### Motivation

Three kafkajs CI runs in a row failed with `KafkaJSProtocolError: This server does not host this topic-partition` inside `beforeEach`:

- `"before each" hook for "Should set a checkpoint on consume (eachMessage)"` (`dsm.spec.js`, kafkajs >=1.4 path / 2.2.4)
- `"before each" hook for "should compute peer service"` (`index.spec.js`, 1.4.0)
- `"before each" hook for "should be instrumented"` (`index.spec.js`, >=1.4 / 2.2.4)

All three traced into `Broker.metadata` → `retryOnLeaderNotAvailable.delay` called from inside `admin.createTopics`. The race: the broker accepts the create, then the verification metadata call returns `UNKNOWN_TOPIC_OR_PARTITION` (errorCode 3) before metadata has propagated through the broker's own pool. kafkajs's `retryOnLeaderNotAvailable` only retries `LEADER_NOT_AVAILABLE` (errorCode 5), so `waitForLeaders: true` alone is not enough — the bare-create call still bubbles errorCode 3 to the caller.

Single-broker dev Kafka makes the lag window especially visible in CI's shared runners, which is why this lit up now even though the code paths are old.

### Additional Notes

- The two-phase structure of the helper (create-once, then poll metadata) is required because kafkajs 1.4.0 throws `TOPIC_ALREADY_EXISTS` where >=2.x returns `false`. Wrapping `createTopics` in a tight retry loop directly will deadlock the 1.4.0 paths under the suite's `this.timeout(10000)`.
- The metadata probe is feature-detected: `admin.fetchTopicMetadata` was added in kafkajs 1.5, so on 1.4.0 it would throw `TypeError`. On that path the create-with-retry alone is what closes the leak (it catches the bubbled errorCode 3 and retries) and the producer/consumer's own metadata fetch warms the broker pool on first use.
- The noisy `AssertionError ... 'span.kind': 'producer' ... -name: 'kafka.consume'` log spam in the same CI runs is `agent.assertSomeTraces` evaluating its predicate against every received trace and logging the misses. Every one of those tests still reports `✔ passing`; that noise is unrelated to this fix and out of scope.

### Local verification

```
PLUGINS=kafkajs npm run test:plugins
# → 83 passing
```

Plus 5/5 clean runs of the targeted mocha suites against a freshly-restarted broker (the highest-lag window):

```
docker compose restart kafka
for i in 1 2 3 4 5; do
  ./node_modules/.bin/mocha --timeout 60000 \
    packages/datadog-plugin-kafkajs/test/{dsm,index}.spec.js
done
```

Drafted while a CI incident is open on flaky tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)