### PR TITLE
ci: increase yarn install retry sleep from 30s to 60s

### DIFF
--- a/.github/actions/datadog-ci/action.yml
+++ b/.github/actions/datadog-ci/action.yml
@@ -15,6 +15,6 @@ runs:
 
     - shell: bash
       run: |
-        yarn install --frozen-lockfile || (sleep 30 && yarn install --frozen-lockfile)
+        yarn install --frozen-lockfile || (sleep 60 && yarn install --frozen-lockfile)
         echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
       working-directory: ${{ github.workspace }}/.github/actions/datadog-ci


### PR DESCRIPTION
## Changes

Bumps the sleep between retry attempts for `yarn install` in the `datadog-ci` action from 30s to 60s, matching the existing 60s sleep used in the `install` action for `bun install`.

The registry has been observed not recovering within 30s on failures, so the longer wait improves retry reliability.

## Checklist
- [x] No tests needed (CI config only)

---
*Generated by Claude Code*