### PR TITLE
fix(metrics): fix delta temporality not being applied to OTLP counter exports

### DIFF
--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -336,7 +336,7 @@ class MetricAggregator {
       }
     }
 
-    this.#applyDeltaTemporality(metricsMap, lastExportedState)
+    this.#applyDeltaTemporality(metricsMap.values(), lastExportedState)
     return metricsMap
   }
 

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -441,18 +441,31 @@ describe('OpenTelemetry Meter Provider', () => {
     })
 
     it('supports DELTA for counters', (done) => {
-      const validator = mockOtlpExport((decoded) => {
+      const exportedValues = []
+
+      mockOtlpExport((decoded) => {
         const counter = decoded.resourceMetrics[0].scopeMetrics[0].metrics[0]
         assert.strictEqual(counter.name, 'test')
         assert.strictEqual(counter.sum.aggregationTemporality, 1)
-        assert.strictEqual(counter.sum.dataPoints[0].asInt, 5)
+        exportedValues.push(counter.sum.dataPoints[0].asInt)
       })
 
       setupMetrics({ OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: 'delta' })
       const meter = metrics.getMeter('app')
-      meter.createCounter('test').add(5)
+      const counter = meter.createCounter('test')
 
-      setTimeout(() => { validator(); done() }, 150)
+      counter.add(5)
+
+      setTimeout(() => {
+        counter.add(3)
+
+        setTimeout(() => {
+          assert.strictEqual(exportedValues.length, 2, 'should have 2 exports')
+          assert.strictEqual(exportedValues[0], 5, 'first export should be 5')
+          assert.strictEqual(exportedValues[1], 3, 'second export should be 3 (delta), not 8 (cumulative)')
+          done()
+        }, 120)
+      }, 120)
     })
 
     it('LOWMEMORY uses DELTA for sync counters', (done) => {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where delta temporality was not being applied to counter metrics before OTLP export. The `#applyDeltaTemporality` method was receiving a `Map` but iterating over it directly with `for...of`, which yields entries `[key, value]` instead of values. This caused `metric.temporality` to always be `undefined`, so the delta conversion was skipped entirely.

The fix passes `metricsMap.values()` to `#applyDeltaTemporality`, consistent with how `otlp_http_metric_exporter.js` already calls `metrics.values()` when transforming metrics.

### Motivation

When using DELTA temporality for counters (the default), cumulative values were being exported instead of delta values. This caused receiving systems that assume delta semantics to over-count metrics by summing cumulative values.

For example, with evaluations happening at a steady rate:
- Expected DELTA exports: `[5, 5, 5, 5, ...]` (5 per interval)
- Actual (broken) exports: `[5, 10, 15, 20, ...]` (cumulative)
- When the receiver sums these: `5 + 10 + 15 + 20 = 50` instead of `5 + 5 + 5 + 5 = 20`

This resulted in overcounting in internal testing.

### Additional Notes

Added a regression test that verifies DELTA counters export only new values on subsequent exports (value should be 3, not 8, on the second export after adding 5 then 3).