### PR TITLE
fix(undici): unfinished CONNECT span

### DIFF
--- a/packages/datadog-plugin-undici/src/index.js
+++ b/packages/datadog-plugin-undici/src/index.js
@@ -27,6 +27,7 @@ class UndiciPlugin extends HttpClientPlugin {
     // Subscribe to native undici diagnostic channels for undici >= 4.7.0
     // These channels fire for ALL undici requests (fetch, request, stream, etc.)
     this.addSub('undici:request:create', this.#onNativeRequestCreate.bind(this))
+    this.addSub('undici:request:bodySent', this.#onNativeRequestBodySent.bind(this))
     this.addSub('undici:request:headers', this.#onNativeRequestHeaders.bind(this))
     this.addSub('undici:request:trailers', this.#onNativeRequestTrailers.bind(this))
     this.addSub('undici:request:error', this.#onNativeRequestError.bind(this))
@@ -109,10 +110,28 @@ class UndiciPlugin extends HttpClientPlugin {
       span,
       store,
       uri,
+      method,
     })
 
     // Enter the span context
     storage('legacy').enterWith({ ...store, span })
+  }
+
+  #onNativeRequestBodySent ({ request }) {
+    const ctx = requestContexts.get(request)
+    if (!ctx || ctx.method !== 'CONNECT') return
+
+    const { span, store } = ctx
+
+    this.config.hooks.request(span, null, null)
+
+    span.finish()
+
+    requestContexts.delete(request)
+
+    if (store) {
+      storage('legacy').enterWith(store)
+    }
   }
 
   #onNativeRequestHeaders ({ request, response }) {

--- a/packages/datadog-plugin-undici/test/index.spec.js
+++ b/packages/datadog-plugin-undici/test/index.spec.js
@@ -730,6 +730,88 @@ describe('Plugin', () => {
           })
         })
       })
+
+      describe('with ProxyAgent', () => {
+        let proxyListener
+
+        beforeEach(() => {
+          return agent.load('undici', {
+            service: 'test',
+          })
+            .then(() => {
+              express = require('express')
+              fetch = require(`../../../versions/undici@${version}`, {}).get()
+            })
+        })
+
+        afterEach(() => {
+          if (proxyListener) {
+            proxyListener.close()
+            proxyListener = null
+          }
+          express = null
+        })
+
+        // Regression for the leaked CONNECT span: ProxyAgent emits :create + :bodySent for
+        // the tunnel-setup request, but never :headers/:trailers/:error. Before the fix the
+        // CONNECT span was started and never finished, which kept the parent trace pinned in
+        // span_processor and prevented the surrounding express.request span from exporting.
+        it('finishes the CONNECT tunnel span established via ProxyAgent', function (done) {
+          if (!satisfies(resolvedVersion, '>=5.1.0')) {
+            this.skip()
+            return
+          }
+
+          const http = require('node:http')
+          const net = require('node:net')
+
+          const app = express()
+          app.get('/data', (req, res) => res.status(200).send('OK'))
+
+          appListener = server(app, downstreamPort => {
+            const proxy = http.createServer((_req, res) => {
+              res.writeHead(405)
+              res.end()
+            })
+            proxy.on('connect', (req, clientSocket, head) => {
+              const [hostname, portStr] = req.url.split(':')
+              const upstream = net.connect(Number.parseInt(portStr, 10) || 80, hostname, () => {
+                clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
+                upstream.write(head)
+                upstream.pipe(clientSocket)
+                clientSocket.pipe(upstream)
+              })
+              upstream.on('error', () => clientSocket.end())
+              clientSocket.on('error', () => upstream.end())
+            })
+
+            proxy.listen(0, 'localhost', () => {
+              proxyListener = proxy
+              const proxyPort = (/** @type {import('net').AddressInfo} */ (proxy.address())).port
+
+              agent
+                .assertSomeTraces(traces => {
+                  const connectSpan = traces.flat().find(s => s.resource === 'CONNECT')
+                  assert.ok(connectSpan, 'expected a finished CONNECT span to be exported')
+                  assertObjectContains(connectSpan, {
+                    name: 'undici.request',
+                    service: 'test',
+                    type: 'http',
+                    resource: 'CONNECT',
+                    meta: { 'http.method': 'CONNECT' },
+                  })
+                }, { timeoutMs: 3000 })
+                .then(done)
+                .catch(done)
+
+              const dispatcher = new fetch.ProxyAgent(`http://localhost:${proxyPort}`)
+              fetch.request(`http://localhost:${downstreamPort}/data`, { dispatcher })
+                .then(({ body }) => body.text())
+                .catch(done)
+            })
+          })
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes a regression after #7206. When requests are issued through the ProxyAgent, the plugin subscribes to undici:request:bodySent and finishes the CONNECT span there.

Adds a regression test in packages/datadog-plugin-undici/test/index.spec.js that spins up a downstream server + minimal CONNECT proxy, issues undici.request(..., { dispatcher: new ProxyAgent(...) }), and asserts the CONNECT span is exported.
 
### Motivation
<!-- What inspired you to submit this pull request? -->
CONNECT request issued by the ProxyAgent where unfinished as consequence of not emitting any of the following events :headers, :trailers, and :error channels. The only terminal event undici emits for CONNECT is :bodySent, after the proxy returns 200 Connection Established.

Because span_processor.js only flushes a trace when started.length === finished.length, the entire trace, including any parent express.request span was held in memory and never exported.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


