### PR TITLE
ci: structured retry and longer network-timeout for CI installs

### DIFF
--- a/.github/actions/datadog-ci/action.yml
+++ b/.github/actions/datadog-ci/action.yml
@@ -13,8 +13,14 @@ runs:
       with:
         node-version: '20'
 
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: 3
+        timeout_minutes: 5
+        retry_wait_seconds: 30
+        command: |
+          cd ${{ github.workspace }}/.github/actions/datadog-ci
+          yarn install --frozen-lockfile
+
     - shell: bash
-      run: |
-        yarn install --frozen-lockfile || (sleep 30 && yarn install --frozen-lockfile)
-        echo "$(pwd)/node_modules/.bin" >> $GITHUB_PATH
-      working-directory: ${{ github.workspace }}/.github/actions/datadog-ci
+      run: echo "${{ github.workspace }}/.github/actions/datadog-ci/node_modules/.bin" >> $GITHUB_PATH

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -3,9 +3,11 @@ description: Install dependencies
 runs:
   using: composite
   steps:
-      # Retry in case of server error from registry.
-      # Wait 60 seconds to give the registry server time to heal.
-    - run: bun install --linker=hoisted --trust --network-concurrency 8 || (sleep 60 && bun install --linker=hoisted --trust --network-concurrency 8)
-      shell: bash
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       env:
         _DD_IGNORE_ENGINES: 'true'
+      with:
+        max_attempts: 3
+        timeout_minutes: 5
+        retry_wait_seconds: 30
+        command: bun install --linker=hoisted --trust --network-concurrency 8

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
 ignore-engines true
+network-timeout 60000


### PR DESCRIPTION
## Summary

This widens the install retry envelope so CI yarn / bun installs
survive more shapes of transient registry failure:

1. `network-timeout 60000` in the repo-root `.yarnrc` doubles yarn's
   per-request timeout from the default 30s; yarn 1.x walks `.yarnrc`
   upward, so the single root entry covers every yarn install in the
   repo tree.

2. Composite install actions use `nick-fields/retry` (pinned in
   `instrumentation.yml`) instead of `|| (sleep N && cmd)`: three
   attempts with a 30s wait between, plus a per-attempt
   `timeout_minutes` cap that bounds a hung install.