### PR TITLE
feat(cypress): upload failure screenshots

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -211,6 +211,18 @@ class FakeCiVisIntake extends FakeAgent {
       })
     })
 
+    app.post('/api/unstable/ci/test-runs/:traceId/media', express.raw({ limit: Infinity, type: '*/*' }), (req, res) => {
+      res.status(201).send()
+      this.emit('message', {
+        headers: req.headers,
+        media: {
+          traceId: req.params.traceId,
+          content: req.body,
+        },
+        url: req.url,
+      })
+    })
+
     app.post([
       '/api/v2/libraries/tests/services/setting',
       '/evp_proxy/:version/api/v2/libraries/tests/services/setting',

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -20,7 +20,7 @@ async function runCypress () {
         specPattern: process.env.SPEC_PATTERN || 'cypress/e2e/**/*.cy.js',
       },
       video: false,
-      screenshotOnRunFailure: false,
+      screenshotOnRunFailure: process.env.CYPRESS_SCREENSHOT_ON_RUN_FAILURE === 'true',
     },
   })
 

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -2117,6 +2117,7 @@ moduleTypes.forEach(({
           assertObjectContains(screenshotPayload, {
             headers: {
               'dd-api-key': '1',
+              'test-drive-test-failure-media-bucket': '1',
             },
             media: {
               traceId: expectedTraceId,

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -2074,5 +2074,69 @@ moduleTypes.forEach(({
         receiverPromise,
       ])
     })
+
+    it('uploads screenshots for failed tests using the test trace id', async function () {
+      const envVars = getCiVisAgentlessConfig(receiver.port)
+      const command = version === '6.7.0'
+        ? './node_modules/.bin/cypress run ' +
+          '--config-file cypress-config.json ' +
+          '--config screenshotOnRunFailure=true --spec "cypress/e2e/basic-fail.js"'
+        : `${testCommand} --config screenshotOnRunFailure=true`
+      let testOutput = ''
+
+      childProcess = exec(
+        command,
+        {
+          cwd,
+          env: {
+            ...envVars,
+            CYPRESS_BASE_URL: webAppBaseUrl,
+            CYPRESS_SCREENSHOT_ON_RUN_FAILURE: 'true',
+            SPEC_PATTERN: 'cypress/e2e/basic-fail.js',
+          },
+        }
+      )
+      childProcess.stdout.on('data', data => { testOutput += data.toString() })
+      childProcess.stderr.on('data', data => { testOutput += data.toString() })
+
+      const receiverPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url.startsWith('/api/unstable/ci/test-runs/') || url === '/api/v2/citestcycle',
+        payloads => {
+          const screenshotPayload = payloads.find(({ url }) => url.startsWith('/api/unstable/ci/test-runs/'))
+          const events = payloads
+            .filter(({ url }) => url === '/api/v2/citestcycle')
+            .flatMap(({ payload }) => payload.events)
+          const failedTest = events.find(event =>
+            event.content.resource === 'cypress/e2e/basic-fail.js.basic fail suite can fail'
+          )
+          assert.ok(screenshotPayload)
+          assert.ok(failedTest)
+          const expectedTraceId = failedTest.content.trace_id.toString()
+
+          assertObjectContains(screenshotPayload, {
+            headers: {
+              'dd-api-key': '1',
+            },
+            media: {
+              traceId: expectedTraceId,
+            },
+            url: `/api/unstable/ci/test-runs/${expectedTraceId}/media`,
+          })
+          assert.deepStrictEqual(
+            [...screenshotPayload.media.content.subarray(0, 8)],
+            [137, 80, 78, 71, 13, 10, 26, 10]
+          )
+        }, { hardTimeout: 60000 })
+        .catch(error => {
+          error.message += `\nCypress output:\n${testOutput}`
+          throw error
+        })
+
+      await Promise.all([
+        once(childProcess, 'exit'),
+        receiverPromise,
+      ])
+    })
   })
 })

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -443,6 +443,7 @@ class CypressPlugin {
   loggedAttemptToFixTests = new Set()
   uploadedScreenshotPaths = new Set()
   lastFinishedTest = null
+  pendingScreenshotUploads = []
 
   constructor () {
     const {
@@ -525,6 +526,7 @@ class CypressPlugin {
     this.loggedAttemptToFixTests = new Set()
     this.uploadedScreenshotPaths = new Set()
     this.lastFinishedTest = null
+    this.pendingScreenshotUploads = []
     this.activeTestSpan = null
     this.testSuiteSpan = null
     this.testModuleSpan = null
@@ -1095,7 +1097,7 @@ class CypressPlugin {
    * Uploads failure screenshots as soon as Cypress creates them.
    *
    * @param {object} details - Cypress screenshot details
-   * @returns {Promise<void>|undefined}
+   * @returns {void}
    */
   afterScreenshot (details) {
     const lastFailedTestSpan = this.lastFinishedTest?.testStatus === 'fail'
@@ -1111,10 +1113,13 @@ class CypressPlugin {
       return
     }
 
-    return this.uploadTestScreenshots({
+    const screenshotUploadPromise = this.uploadTestScreenshots({
       screenshots: [details],
       traceId: testSpan.context().toTraceId(),
     })
+    if (screenshotUploadPromise) {
+      this.pendingScreenshotUploads.push(screenshotUploadPromise)
+    }
   }
 
   afterSpec (spec, results) {
@@ -1313,8 +1318,10 @@ class CypressPlugin {
       this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
     }
 
-    if (screenshotUploadPromises.length > 0) {
-      return Promise.all(screenshotUploadPromises).then(() => null)
+    if (screenshotUploadPromises.length > 0 || this.pendingScreenshotUploads.length > 0) {
+      const pendingScreenshotUploads = this.pendingScreenshotUploads
+      this.pendingScreenshotUploads = []
+      return Promise.all([...pendingScreenshotUploads, ...screenshotUploadPromises]).then(() => null)
     }
   }
 

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -134,6 +134,11 @@ function getScreenshotFilePath (screenshot) {
   return typeof screenshot === 'string' ? screenshot : screenshot?.path
 }
 
+function isFailureScreenshotForUpload (screenshot) {
+  const screenshotFilePath = getScreenshotFilePath(screenshot)
+  return !!screenshotFilePath && (screenshot?.testFailure === true || screenshotFilePath.includes('(failed)'))
+}
+
 function isFailureScreenshot (screenshot) {
   return !!getScreenshotFilePath(screenshot) && screenshot?.testFailure !== false
 }
@@ -436,6 +441,8 @@ class CypressPlugin {
   newTestsWithDynamicNames = new Set()
   attemptToFixExecutions = new Map()
   loggedAttemptToFixTests = new Set()
+  uploadedScreenshotPaths = new Set()
+  lastFinishedTest = null
 
   constructor () {
     const {
@@ -516,6 +523,8 @@ class CypressPlugin {
     this.modifiedFiles = []
     this.attemptToFixExecutions = new Map()
     this.loggedAttemptToFixTests = new Set()
+    this.uploadedScreenshotPaths = new Set()
+    this.lastFinishedTest = null
     this.activeTestSpan = null
     this.testSuiteSpan = null
     this.testModuleSpan = null
@@ -1082,6 +1091,32 @@ class CypressPlugin {
     })
   }
 
+  /**
+   * Uploads failure screenshots as soon as Cypress creates them.
+   *
+   * @param {object} details - Cypress screenshot details
+   * @returns {Promise<void>|undefined}
+   */
+  afterScreenshot (details) {
+    const lastFailedTestSpan = this.lastFinishedTest?.testStatus === 'fail'
+      ? this.lastFinishedTest.testSpan
+      : undefined
+    const testSpan = this.activeTestSpan || lastFailedTestSpan
+
+    if (!testSpan) {
+      return
+    }
+
+    if (!isFailureScreenshotForUpload(details)) {
+      return
+    }
+
+    return this.uploadTestScreenshots({
+      screenshots: [details],
+      traceId: testSpan.context().toTraceId(),
+    })
+  }
+
   afterSpec (spec, results) {
     const { tests, stats, screenshots } = results || {}
     const cypressTests = tests || []
@@ -1299,15 +1334,14 @@ class CypressPlugin {
       return
     }
 
-    const uploadedFilePaths = new Set()
     const uploadPromises = []
 
     for (const screenshot of screenshots) {
       const filePath = getScreenshotFilePath(screenshot)
-      if (!filePath || uploadedFilePaths.has(filePath)) {
+      if (!filePath || this.uploadedScreenshotPaths.has(filePath)) {
         continue
       }
-      uploadedFilePaths.add(filePath)
+      this.uploadedScreenshotPaths.add(filePath)
       uploadPromises.push(new Promise(resolve => {
         exporter.uploadTestScreenshot({
           filePath,
@@ -1565,6 +1599,7 @@ class CypressPlugin {
         } else {
           this.finishedTestsByFile[testSuite] = [finishedTest]
         }
+        this.lastFinishedTest = finishedTest
         // test spans are finished at after:spec
         this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'test', {
           hasCodeOwners: !!activeSpanTags[TEST_CODE_OWNERS],

--- a/packages/datadog-plugin-cypress/src/cypress-plugin.js
+++ b/packages/datadog-plugin-cypress/src/cypress-plugin.js
@@ -128,6 +128,55 @@ const CYPRESS_STATUS_TO_TEST_STATUS = {
   skipped: 'skip',
 }
 
+const SCREENSHOT_ATTEMPT_RE = /\(attempt \d+\)/
+
+function getScreenshotFilePath (screenshot) {
+  return typeof screenshot === 'string' ? screenshot : screenshot?.path
+}
+
+function isFailureScreenshot (screenshot) {
+  return !!getScreenshotFilePath(screenshot) && screenshot?.testFailure !== false
+}
+
+function getAttemptScreenshots (cypressTest, attemptIndex) {
+  if (!Array.isArray(cypressTest.attempts)) {
+    return []
+  }
+  const attempt = cypressTest.attempts[attemptIndex]
+  if (!Array.isArray(attempt?.screenshots)) {
+    return []
+  }
+  return attempt.screenshots.filter(isFailureScreenshot)
+}
+
+function isScreenshotForTestAttempt (screenshot, titleParts, attemptIndex) {
+  const screenshotFilePath = getScreenshotFilePath(screenshot)
+  if (!screenshotFilePath || !isFailureScreenshot(screenshot)) {
+    return false
+  }
+  for (const titlePart of titleParts) {
+    if (!screenshotFilePath.includes(titlePart)) {
+      return false
+    }
+  }
+  if (attemptIndex === 0) {
+    return !SCREENSHOT_ATTEMPT_RE.test(screenshotFilePath)
+  }
+  return screenshotFilePath.includes(`(attempt ${attemptIndex + 1})`)
+}
+
+function getTestScreenshots (cypressTest, attemptIndex, specScreenshots) {
+  const attemptScreenshots = getAttemptScreenshots(cypressTest, attemptIndex)
+  if (attemptScreenshots.length > 0) {
+    return attemptScreenshots
+  }
+  if (!Array.isArray(specScreenshots)) {
+    return []
+  }
+  const titleParts = Array.isArray(cypressTest.title) ? cypressTest.title : []
+  return specScreenshots.filter(screenshot => isScreenshotForTestAttempt(screenshot, titleParts, attemptIndex))
+}
+
 function getSessionStatus (summary) {
   if (summary.totalFailed !== undefined && summary.totalFailed > 0) {
     return 'fail'
@@ -1034,9 +1083,11 @@ class CypressPlugin {
   }
 
   afterSpec (spec, results) {
-    const { tests, stats } = results || {}
+    const { tests, stats, screenshots } = results || {}
     const cypressTests = tests || []
+    const specScreenshots = screenshots || []
     const finishedTests = this.finishedTestsByFile[spec.relative] || []
+    const screenshotUploadPromises = []
 
     if (!this.testSuiteSpan) {
       // dd:testSuiteStart hasn't been triggered for whatever reason
@@ -1143,6 +1194,18 @@ class CypressPlugin {
         if (cypressTest.displayError) {
           latestError = new Error(cypressTest.displayError)
         }
+
+        if (cypressTestStatus === 'fail' || finishedTest.testStatus === 'fail' || cypressTest.displayError) {
+          const testScreenshots = getTestScreenshots(cypressTest, attemptIndex, specScreenshots)
+          const screenshotUploadPromise = this.uploadTestScreenshots({
+            screenshots: testScreenshots,
+            traceId: finishedTest.testSpan.context().toTraceId(),
+          })
+          if (screenshotUploadPromise) {
+            screenshotUploadPromises.push(screenshotUploadPromise)
+          }
+        }
+
         // Update test status - but NOT for non-ATF quarantined tests where we intentionally
         // report 'fail' to Datadog even though Cypress sees it as 'pass'
         const isQuarantinedTest = finishedTest.testSpan?.context()?._tags?.[TEST_MANAGEMENT_IS_QUARANTINED] === 'true'
@@ -1213,6 +1276,50 @@ class CypressPlugin {
       this.testSuiteSpan.finish()
       this.testSuiteSpan = null
       this.ciVisEvent(TELEMETRY_EVENT_FINISHED, 'suite')
+    }
+
+    if (screenshotUploadPromises.length > 0) {
+      return Promise.all(screenshotUploadPromises).then(() => null)
+    }
+  }
+
+  /**
+   * Uploads failure screenshots for a Cypress test attempt.
+   *
+   * @param {object} options - Upload options
+   * @param {Array<object|string>} options.screenshots - Cypress screenshot objects or screenshot paths
+   * @param {string} options.traceId - Test trace id used as the screenshot key
+   * @returns {Promise<void>|undefined}
+   */
+  uploadTestScreenshots ({ screenshots, traceId }) {
+    const exporter = this.tracer?._tracer?._exporter
+    if (!screenshots.length ||
+      !exporter?.canUploadTestScreenshots?.() ||
+      !exporter.uploadTestScreenshot) {
+      return
+    }
+
+    const uploadedFilePaths = new Set()
+    const uploadPromises = []
+
+    for (const screenshot of screenshots) {
+      const filePath = getScreenshotFilePath(screenshot)
+      if (!filePath || uploadedFilePaths.has(filePath)) {
+        continue
+      }
+      uploadedFilePaths.add(filePath)
+      uploadPromises.push(new Promise(resolve => {
+        exporter.uploadTestScreenshot({
+          filePath,
+          traceId,
+        }, () => {
+          resolve()
+        })
+      }))
+    }
+
+    if (uploadPromises.length > 0) {
+      return Promise.all(uploadPromises).then(() => {})
     }
   }
 

--- a/packages/datadog-plugin-cypress/src/index.js
+++ b/packages/datadog-plugin-cypress/src/index.js
@@ -44,6 +44,7 @@ class CypressPlugin extends Plugin {
       }
 
       on('before:run', cypressPlugin.beforeRun.bind(cypressPlugin))
+      on('after:screenshot', cypressPlugin.afterScreenshot.bind(cypressPlugin))
 
       on('after:spec', (spec, results) => {
         const chain = userAfterSpecHandlers.reduce(

--- a/packages/datadog-plugin-cypress/src/plugin.js
+++ b/packages/datadog-plugin-cypress/src/plugin.js
@@ -40,6 +40,7 @@ module.exports = function CypressPlugin (on, config) {
   }
 
   on('before:run', cypressPlugin.beforeRun.bind(cypressPlugin))
+  on('after:screenshot', cypressPlugin.afterScreenshot.bind(cypressPlugin))
   on('after:spec', cypressPlugin.afterSpec.bind(cypressPlugin))
   on('after:run', cypressPlugin.afterRun.bind(cypressPlugin))
   on('task', cypressPlugin.getTasks())

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const URL = require('url').URL
+
 const AgentWriter = require('../../../exporters/agent/writer')
 const AgentlessWriter = require('../agentless/writer')
 const CoverageWriter = require('../agentless/coverage-writer')
 const CiVisibilityExporter = require('../ci-visibility-exporter')
 const { fetchAgentInfo } = require('../../../agent/info')
 const { DEBUGGER_INPUT_V1 } = require('../../../debugger/constants')
+const { getEnvironmentVariable } = require('../../../config/helper')
 
 const AGENT_EVP_PROXY_PATH_PREFIX = '/evp_proxy/v'
 const AGENT_EVP_PROXY_PATH_REGEX = /\/evp_proxy\/v(\d+)\/?/
@@ -30,9 +33,15 @@ function getCanForwardDebuggerLogs (err, agentInfo) {
   return !err && agentInfo.endpoints.includes(DEBUGGER_INPUT_V1)
 }
 
+function getTestScreenshotUploadUrl () {
+  const pocSite = getEnvironmentVariable('DD_POC_SITE')
+  return pocSite ? new URL(`https://api.${pocSite}`) : undefined
+}
+
 class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
     super(config)
+    this._testScreenshotUploadUrl = getTestScreenshotUploadUrl()
 
     const {
       tags,

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -2,9 +2,15 @@
 
 const URL = require('url').URL
 const CiVisibilityExporter = require('../ci-visibility-exporter')
+const { getEnvironmentVariable } = require('../../../config/helper')
 const log = require('../../../log')
 const Writer = require('./writer')
 const CoverageWriter = require('./coverage-writer')
+
+function getTestScreenshotUploadUrl () {
+  const pocSite = getEnvironmentVariable('DD_POC_SITE')
+  return pocSite ? new URL(`https://api.${pocSite}`) : undefined
+}
 
 class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
   constructor (config) {
@@ -30,6 +36,7 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     }
 
     this._apiUrl = url || new URL(`https://api.${site}`)
+    this._testScreenshotUploadUrl = url || getTestScreenshotUploadUrl()
     // Agentless is always gzip compatible
     this._isGzipCompatible = true
   }
@@ -39,6 +46,7 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     try {
       apiUrl = new URL(apiUrl)
       this._apiUrl = apiUrl
+      this._testScreenshotUploadUrl = apiUrl
     } catch (e) {
       log.error('Error setting CI exporter api url', e)
     }

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -8,6 +8,7 @@ const { getKnownTests: getKnownTestsRequest } = require('../early-flake-detectio
 const { getTestManagementTests: getTestManagementTestsRequest } =
   require('../test-management/get-test-management-tests')
 const { uploadCoverageReport: uploadCoverageReportRequest } = require('../requests/upload-coverage-report')
+const { uploadTestScreenshot: uploadTestScreenshotRequest } = require('../requests/upload-test-screenshot')
 const log = require('../../log')
 const BufferingExporter = require('../../exporters/common/buffering-exporter')
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../../plugins/util/tags')
@@ -415,6 +416,35 @@ class CiVisibilityExporter extends BufferingExporter {
       url: this._codeCoverageReportUrl,
       isEvpProxy: !!this._isUsingEvpProxy,
       evpProxyPrefix: this.evpProxyPrefix,
+    }, callback)
+  }
+
+  /**
+   * Returns whether the exporter can upload test screenshots.
+   *
+   * @returns {boolean}
+   */
+  canUploadTestScreenshots () {
+    return !!this._testScreenshotUploadUrl
+  }
+
+  /**
+   * Uploads a single test screenshot to the CI intake.
+   *
+   * @param {object} options - Upload options
+   * @param {string} options.filePath - Path to the screenshot file
+   * @param {string} options.traceId - Test trace id used as the screenshot key
+   * @param {Function} callback - Callback function (err)
+   */
+  uploadTestScreenshot ({ filePath, traceId }, callback) {
+    if (!this._testScreenshotUploadUrl) {
+      return callback(new Error('Test screenshot upload URL not configured'))
+    }
+
+    uploadTestScreenshotRequest({
+      filePath,
+      traceId,
+      url: this._testScreenshotUploadUrl,
     }, callback)
   }
 }

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -66,11 +66,14 @@ function uploadTestScreenshot (
     return callback(new Error(`Screenshot at ${filePath} is empty`))
   }
 
+  const contentType = getContentType(filePath)
   const options = {
     method: 'POST',
     headers: {
-      'Content-Type': getContentType(filePath),
+      'Content-Type': contentType,
       'DD-API-KEY': apiKey,
+      // Required by the temporary test-drive media endpoint during the PoC.
+      'test-drive-test-failure-media-bucket': '1',
     },
     path: `${TEST_SCREENSHOT_ENDPOINT_PREFIX}${traceId}${TEST_SCREENSHOT_ENDPOINT_SUFFIX}`,
     timeout: UPLOAD_TIMEOUT_MS,

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const { readFileSync } = require('node:fs')
+const { extname } = require('node:path')
+
+const getConfig = require('../../config')
+const request = require('../../exporters/common/request')
+const log = require('../../log')
+
+const UPLOAD_TIMEOUT_MS = 30_000
+const TEST_SCREENSHOT_ENDPOINT_PREFIX = '/api/unstable/ci/test-runs/'
+const TEST_SCREENSHOT_ENDPOINT_SUFFIX = '/media'
+const UINT64_MAX = 18_446_744_073_709_551_615n
+
+function getContentType (filePath) {
+  const extension = extname(filePath).toLowerCase()
+  if (extension === '.gif') {
+    return 'image/gif'
+  }
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return 'image/jpeg'
+  }
+  if (extension === '.webp') {
+    return 'image/webp'
+  }
+  return 'image/png'
+}
+
+function isValidTraceId (traceId) {
+  if (!/^[1-9]\d*$/.test(traceId)) {
+    return false
+  }
+  return BigInt(traceId) <= UINT64_MAX
+}
+
+/**
+ * Uploads a single test screenshot to the Datadog CI intake.
+ * The trace id is included in the request path and the body is the raw image bytes.
+ *
+ * @param {object} options - Upload options
+ * @param {string} options.filePath - Path to the screenshot file
+ * @param {string} options.traceId - Test trace id used as the screenshot key
+ * @param {URL} options.url - The base URL for the screenshot upload
+ * @param {Function} callback - Callback function (err)
+ */
+function uploadTestScreenshot (
+  { filePath, traceId, url },
+  callback
+) {
+  const apiKey = getConfig().apiKey
+
+  if (!isValidTraceId(traceId)) {
+    return callback(new Error('A non-zero decimal uint64 trace_id is required for test screenshot upload'))
+  }
+  if (!apiKey) {
+    return callback(new Error('DD_API_KEY is required for test screenshot upload'))
+  }
+
+  let screenshotContent
+  try {
+    screenshotContent = readFileSync(filePath)
+  } catch (err) {
+    return callback(new Error(`Failed to read screenshot at ${filePath}: ${err.message}`))
+  }
+  if (screenshotContent.length === 0) {
+    return callback(new Error(`Screenshot at ${filePath} is empty`))
+  }
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': getContentType(filePath),
+      'DD-API-KEY': apiKey,
+    },
+    path: `${TEST_SCREENSHOT_ENDPOINT_PREFIX}${traceId}${TEST_SCREENSHOT_ENDPOINT_SUFFIX}`,
+    timeout: UPLOAD_TIMEOUT_MS,
+    url,
+  }
+
+  log.debug('Uploading test screenshot %s to %s%s', filePath, url, options.path)
+
+  request(screenshotContent, options, (err, res, statusCode) => {
+    if (err) {
+      log.error('Error uploading test screenshot: %s', err.message)
+      return callback(err)
+    }
+    log.debug('Test screenshot uploaded successfully (status: %d)', statusCode)
+    callback(null)
+  })
+}
+
+module.exports = { TEST_SCREENSHOT_ENDPOINT_PREFIX, TEST_SCREENSHOT_ENDPOINT_SUFFIX, uploadTestScreenshot }

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -130,6 +130,7 @@ export interface GeneratedConfig {
   DD_MINI_AGENT_PATH: string | undefined;
   DD_PIPELINE_EXECUTION_ID: string | undefined;
   DD_PLAYWRIGHT_WORKER: string | undefined;
+  DD_POC_SITE: string | undefined;
   DD_PROFILING_ASYNC_CONTEXT_FRAME_ENABLED: boolean;
   DD_PROFILING_CODEHOTSPOTS_ENABLED: boolean;
   DD_PROFILING_CPU_ENABLED: boolean;

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1293,6 +1293,13 @@
         "default": null
       }
     ],
+    "DD_POC_SITE": [
+      {
+        "implementation": "A",
+        "type": "string",
+        "default": null
+      }
+    ],
     "DD_PROFILING_ASYNC_CONTEXT_FRAME_ENABLED": [
       {
         "implementation": "A",


### PR DESCRIPTION
### What does this PR do?
Adds Cypress failure screenshot discovery and upload support for CI Visibility. When a Cypress test attempt fails and Cypress generated a screenshot, the plugin uploads the raw image bytes to `/api/unstable/ci/test-runs/{trace_id}/media`, using the failed test span decimal `trace_id` as the path key.

For this PoC, screenshots are uploaded whenever they are present. The media API host is selected with `DD_POC_SITE`, for example `DD_POC_SITE=us1.staging.dog` resolves to `https://api.us1.staging.dog`. The mock CI Visibility intake still uses the test URL override for integration coverage.

### Motivation
Cypress already captures screenshots for failed runs. CI Visibility can use those screenshots as failure media artifacts, associated by trace id with the failing test event.

### Additional Notes
Validation run:

- `CYPRESS_VERSION=14.5.4 CYPRESS_MODULE_TYPE=commonJS ./node_modules/.bin/mocha --timeout 900000 integration-tests/cypress/cypress-reporting.spec.js --grep "uploads screenshots"`
- `CYPRESS_VERSION=14.5.4 CYPRESS_MODULE_TYPE=esm ./node_modules/.bin/mocha --timeout 900000 integration-tests/cypress/cypress-reporting.spec.js --grep "uploads screenshots"`
- Targeted `eslint` on changed files
- `git diff --check`

The commit is signed.