### PR TITLE
test-optimization(feat): Tag playwright test events where a screenshot was taken

### DIFF
--- a/integration-tests/ci-visibility/playwright-tests-screenshot/screenshot-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-screenshot/screenshot-test.js
@@ -1,0 +1,11 @@
+'use strict'
+const { test, expect } = require('@playwright/test')
+
+test('fails and triggers a screenshot', async ({ page }) => {
+  await page.goto('/')
+  expect(true).toBe(false)
+})
+
+test('passes without a screenshot', async () => {
+  // intentionally passes
+})

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -48,4 +48,8 @@ if (process.env.MAX_FAILURES) {
   config.maxFailures = Number(process.env.MAX_FAILURES)
 }
 
+if (process.env.PW_SCREENSHOT) {
+  config.use = { screenshot: process.env.PW_SCREENSHOT }
+}
+
 module.exports = config

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -38,6 +38,7 @@ const {
   DD_CI_LIBRARY_CONFIGURATION_ERROR_SETTINGS,
   DD_CI_LIBRARY_CONFIGURATION_ERROR_KNOWN_TESTS,
   DD_CI_LIBRARY_CONFIGURATION_ERROR_TEST_MANAGEMENT_TESTS,
+  TEST_HAS_IMAGES,
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
@@ -705,6 +706,54 @@ versions.forEach((version) => {
           ])
         })
       })
+    })
+
+    const itWithScreenshots = version === 'latest' ? it : it.skip
+    itWithScreenshots('tags test spans with test.has_images when a failure screenshot is taken', async () => {
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const testEvents = payloads
+            .flatMap(({ payload }) => payload.events)
+            .filter(event => event.type === 'test')
+
+          const failedTest = testEvents.find(event =>
+            event.content.meta[TEST_NAME] === 'fails and triggers a screenshot'
+          )
+          const passedTest = testEvents.find(event =>
+            event.content.meta[TEST_NAME] === 'passes without a screenshot'
+          )
+
+          assert.ok(failedTest, 'failed test span should exist')
+          assert.strictEqual(
+            failedTest.content.meta[TEST_HAS_IMAGES],
+            'true',
+            'failed test with screenshot should be tagged with test.has_images'
+          )
+
+          assert.ok(passedTest, 'passed test span should exist')
+          assert.ok(
+            !passedTest.content.meta[TEST_HAS_IMAGES],
+            'passed test without screenshot should not have test.has_images tag'
+          )
+        })
+
+      childProcess = exec(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            TEST_DIR: './ci-visibility/playwright-tests-screenshot',
+            PW_SCREENSHOT: 'only-on-failure',
+          },
+        }
+      )
+
+      await Promise.all([
+        eventsPromise,
+        once(childProcess, 'exit'),
+      ])
     })
   })
 })

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1691,7 +1691,8 @@ addHook({
     })
     await res
 
-    const { status, error, annotations, retry, testId } = testInfo
+    const { status, error, annotations, retry, testId, attachments } = testInfo
+    const hasImages = attachments?.some(a => a.contentType?.startsWith('image/')) ?? false
     const testEfdKey = getTestEfdKey(test)
     const isEfdManagedTest = isTestEfdManaged(test)
     if (isEfdManagedTest && !test._ddIsEfdRetry && !efdRetryCountByTestKey.has(testEfdKey)) {
@@ -1777,6 +1778,7 @@ addHook({
       onDone,
       finalStatus,
       earlyFlakeAbortReason: test._ddEarlyFlakeAbortReason,
+      hasImages,
       ...testCtx.currentStore,
     })
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -16,6 +16,7 @@ const {
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_EARLY_FLAKE_ENABLED,
   TEST_HAS_FAILED_ALL_RETRIES,
+  TEST_HAS_IMAGES,
   TEST_IS_MODIFIED,
   TEST_IS_NEW,
   TEST_IS_RETRY,
@@ -323,6 +324,7 @@ class PlaywrightPlugin extends CiPlugin {
       finalStatus,
       earlyFlakeAbortReason,
       onDone,
+      hasImages,
     }) => {
       if (!span) return
 
@@ -387,6 +389,9 @@ class PlaywrightPlugin extends CiPlugin {
       }
       if (earlyFlakeAbortReason) {
         span.setTag(TEST_EARLY_FLAKE_ABORT_REASON, earlyFlakeAbortReason)
+      }
+      if (hasImages) {
+        span.setTag(TEST_HAS_IMAGES, 'true')
       }
       for (const step of steps) {
         const stepStartTime = step.startTime.getTime()

--- a/packages/dd-trace/src/plugins/util/test.js
+++ b/packages/dd-trace/src/plugins/util/test.js
@@ -87,6 +87,7 @@ const TEST_EARLY_FLAKE_ENABLED = 'test.early_flake.enabled'
 const TEST_EARLY_FLAKE_ABORT_REASON = 'test.early_flake.abort_reason'
 const TEST_RETRY_REASON = 'test.retry_reason'
 const TEST_HAS_FAILED_ALL_RETRIES = 'test.has_failed_all_retries'
+const TEST_HAS_IMAGES = 'test.has_images'
 const TEST_IS_MODIFIED = 'test.is_modified'
 const TEST_HAS_DYNAMIC_NAME = '_dd.has_dynamic_name'
 const CI_APP_ORIGIN = 'ciapp-test'
@@ -388,6 +389,7 @@ module.exports = {
   TEST_EARLY_FLAKE_ABORT_REASON,
   TEST_RETRY_REASON,
   TEST_HAS_FAILED_ALL_RETRIES,
+  TEST_HAS_IMAGES,
   TEST_IS_MODIFIED,
   TEST_HAS_DYNAMIC_NAME,
   getTestEnvironmentMetadata,


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
Adds a new `test.has_images` tag to cypress test events that triggered a screenshot.

### Motivation
Cypress has the ability to take screenshots of end-to-end tests either when triggered with `cy.screenshot()` or on failure. Tests events that triggered a screenshot are now tagged with the tag `test.has_images`.

