### PR TITLE
ci: fix node version cache path on Windows

### DIFF
--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -33,14 +33,14 @@ runs:
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: node-version-cache
       with:
-        path: /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
+        path: ${{ runner.temp }}/.node-resolved-version-${{ steps.node-version.outputs.version }}
         key: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-${{ steps.cache-key.outputs.block }}
     - name: Read cached version
       id: cached
       shell: bash
       run: |
-        if [ -f /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }} ]; then
-          echo "version=$(cat /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }})" >> "$GITHUB_OUTPUT"
+        if [ -f "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}" ]; then
+          echo "version=$(cat "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}")" >> "$GITHUB_OUTPUT"
         fi
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -55,7 +55,7 @@ runs:
     - name: Save resolved version
       if: steps.node-version-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: node -v | tr -d 'v' > /tmp/.node-resolved-version-${{ steps.node-version.outputs.version }}
+      run: node -v | tr -d 'v' > "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}"
     - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
         bun-version: 1.3.1


### PR DESCRIPTION
## Summary

- On Windows, `actions/cache` (a JavaScript action) and Git Bash resolve `/tmp` to different directories, so the cached Node.js version file written by one is never found by the other
- This causes `check-latest: true` to always fire on Windows, which makes a manifest API call that can fail intermittently
- Replace `/tmp` with `${{ runner.temp }}` / `$RUNNER_TEMP`, which GitHub Actions sets consistently for both JS actions and shell steps on all platforms

## Test plan

- [ ] Verify that Windows CI jobs in the Profiling workflow no longer fail at the "Attempt to resolve the latest version from manifest" step

> Generated by [Claude Code](https://claude.ai/claude-code)