### PR TITLE
chore(log): drop the orphaned StructuredLogPlugin subclass

### DIFF
--- a/packages/dd-trace/src/plugins/structured_log_plugin.js
+++ b/packages/dd-trace/src/plugins/structured_log_plugin.js
@@ -1,9 +1,0 @@
-'use strict'
-
-const LogPlugin = require('./log_plugin')
-
-module.exports = class StructuredLogPlugin extends LogPlugin {
-  _isEnabled (config) {
-    return super._isEnabled(config) || (config.enabled && config.logInjection === 'structured')
-  }
-}


### PR DESCRIPTION
## Summary

`StructuredLogPlugin` was introduced in #5859 so pino, bunyan, and winston could extend it and opt into log injection via `logInjection: 'structured'`. #6174 then made `logInjection: true` the default and moved the three subclasses back to extending `LogPlugin` directly, leaving the subclass with no consumers in production code, tests, or benchmarks. The file has been an unused export for ten months; this PR deletes it.

Verification (master, 2026-05-20):

\`\`\`
$ rg -i 'Structured.?Log|structured_log_plugin|structured-log-plugin' packages/ integration-tests/ benchmark/
packages/dd-trace/src/plugins/structured_log_plugin.js:5:module.exports = class StructuredLogPlugin extends LogPlugin {
\`\`\`

The only match is the self-definition line.

## Test plan

CI alone is sufficient; the diff is a single file deletion and the class is unreferenced.

Refs: https://github.com/DataDog/dd-trace-js/pull/5859
Refs: https://github.com/DataDog/dd-trace-js/pull/6174