### PR TITLE
ci(test): repro AppSec/mongoose on Node 20 (not for merge)

### DIFF
--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -321,10 +321,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/oldest-maintenance-lts
+      - uses: ./.github/actions/node/newest-maintenance-lts
       - uses: ./.github/actions/install
-      - run: yarn test:appsec:plugins:ci
-      - uses: ./.github/actions/node/latest
       - run: yarn test:appsec:plugins:ci
       - uses: ./.github/actions/coverage
         with:


### PR DESCRIPTION
Repro probe. Tests whether AppSec/mongoose on master passes with Node 20 instead of Node 18. **Do not merge.**