### PR TITLE
feat(playwright): upload failure screenshots

### DIFF
--- a/integration-tests/ci-visibility-intake.js
+++ b/integration-tests/ci-visibility-intake.js
@@ -212,6 +212,31 @@ class FakeCiVisIntake extends FakeAgent {
     })
 
     app.post([
+      '/api/v2/ci/tests/screenshots',
+      '/evp_proxy/:version/api/v2/ci/tests/screenshots',
+    ], upload.any(), (req, res) => {
+      res.status(200).send('OK')
+
+      const screenshotFile = req.files.find(f => f.fieldname === 'screenshot')
+      const eventFile = req.files.find(f => f.fieldname === 'event')
+
+      this.emit('message', {
+        headers: req.headers,
+        screenshotFile: screenshotFile && {
+          name: screenshotFile.fieldname,
+          filename: screenshotFile.originalname,
+          type: screenshotFile.mimetype,
+          content: screenshotFile.buffer,
+        },
+        eventFile: eventFile && {
+          name: eventFile.fieldname,
+          content: JSON.parse(eventFile.buffer.toString('utf8')),
+        },
+        url: req.url,
+      })
+    })
+
+    app.post([
       '/api/v2/libraries/tests/services/setting',
       '/evp_proxy/:version/api/v2/libraries/tests/services/setting',
     ], (req, res) => {

--- a/integration-tests/ci-visibility/playwright-tests-screenshot/screenshot-test.js
+++ b/integration-tests/ci-visibility/playwright-tests-screenshot/screenshot-test.js
@@ -1,0 +1,11 @@
+'use strict'
+const { test, expect } = require('@playwright/test')
+
+test('fails and triggers a screenshot', async ({ page }) => {
+  await page.goto('/')
+  expect(true).toBe(false)
+})
+
+test('passes without a screenshot', async () => {
+  // intentionally passes
+})

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -35,6 +35,7 @@ if (process.env.ADD_DUPLICATE_PLAYWRIGHT_PROJECT) {
 const config = {
   baseURL: process.env.PW_BASE_URL,
   testDir: process.env.TEST_DIR || './ci-visibility/playwright-tests',
+  use: process.env.PW_SCREENSHOT_ON_FAILURE === 'true' ? { screenshot: 'only-on-failure' } : {},
   timeout: Number(process.env.TEST_TIMEOUT) || 30000,
   fullyParallel: process.env.FULLY_PARALLEL === 'true',
   workers: process.env.PLAYWRIGHT_WORKERS ? Number(process.env.PLAYWRIGHT_WORKERS) : undefined,

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -103,6 +103,69 @@ versions.forEach((version) => {
       await receiver.stop()
     })
 
+    it.only('uploads screenshots for failed tests using the test trace id', async function () {
+      const envVars = getCiVisAgentlessConfig(receiver.port)
+
+      childProcess = exec(
+        './node_modules/.bin/playwright test -c playwright.config.js',
+        {
+          cwd,
+          env: {
+            ...envVars,
+            PW_BASE_URL: `http://localhost:${webAppPort}`,
+            TEST_DIR: './ci-visibility/playwright-tests-screenshot',
+            PW_SCREENSHOT_ON_FAILURE: 'true',
+          },
+        }
+      )
+
+      const receiverPromise = receiver.gatherPayloadsUntilChildExit(
+        childProcess,
+        ({ url }) => url === '/api/v2/ci/tests/screenshots' || url === '/api/v2/citestcycle',
+        payloads => {
+          const screenshotPayload = payloads.find(({ url }) => url === '/api/v2/ci/tests/screenshots')
+          const events = payloads
+            .filter(({ url }) => url === '/api/v2/citestcycle')
+            .flatMap(({ payload }) => payload.events)
+
+          const failedTest = events.find(event =>
+            event.type === 'test' && event.content.meta[TEST_STATUS] === 'fail'
+          )
+
+          assert.ok(screenshotPayload, 'screenshot payload should exist')
+          assert.ok(failedTest, 'failed test event should exist')
+
+          const expectedTraceId = failedTest.content.trace_id.toString()
+
+          assertObjectContains(screenshotPayload, {
+            screenshotFile: {
+              name: 'screenshot',
+              filename: `${expectedTraceId}.png`,
+              type: 'image/png',
+            },
+            eventFile: {
+              name: 'event',
+              content: {
+                type: 'test_screenshot',
+                trace_id: expectedTraceId,
+                test_name: failedTest.content.meta[TEST_NAME],
+                filename: `${expectedTraceId}.png`,
+                content_type: 'image/png',
+              },
+            },
+          })
+          assert.deepStrictEqual(
+            [...screenshotPayload.screenshotFile.content.subarray(0, 8)],
+            [137, 80, 78, 71, 13, 10, 26, 10],
+            'screenshot should start with PNG magic bytes'
+          )
+        },
+        { hardTimeout: 60000 }
+      )
+
+      await Promise.all([once(childProcess, 'exit'), receiverPromise])
+    })
+
     const reportMethods = ['agentless', 'evp proxy']
 
     reportMethods.forEach((reportMethod) => {

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -1691,7 +1691,10 @@ addHook({
     })
     await res
 
-    const { status, error, annotations, retry, testId } = testInfo
+    const { status, error, annotations, retry, testId, attachments } = testInfo
+    const screenshotPaths = attachments
+      ?.filter(a => a.contentType?.startsWith('image/') && a.path)
+      .map(a => a.path) ?? []
     const testEfdKey = getTestEfdKey(test)
     const isEfdManagedTest = isTestEfdManaged(test)
     if (isEfdManagedTest && !test._ddIsEfdRetry && !efdRetryCountByTestKey.has(testEfdKey)) {
@@ -1777,6 +1780,7 @@ addHook({
       onDone,
       finalStatus,
       earlyFlakeAbortReason: test._ddEarlyFlakeAbortReason,
+      screenshotPaths,
       ...testCtx.currentStore,
     })
 

--- a/packages/datadog-plugin-playwright/src/index.js
+++ b/packages/datadog-plugin-playwright/src/index.js
@@ -3,6 +3,8 @@
 const { storage } = require('../../datadog-core')
 const id = require('../../dd-trace/src/id')
 const CiPlugin = require('../../dd-trace/src/plugins/ci_plugin')
+const getConfig = require('../../dd-trace/src/config')
+const { uploadTestScreenshot } = require('../../dd-trace/src/ci-visibility/requests/upload-test-screenshot')
 
 const {
   finishAllTraceSpans,
@@ -322,6 +324,7 @@ class PlaywrightPlugin extends CiPlugin {
       isModified,
       finalStatus,
       earlyFlakeAbortReason,
+      screenshotPaths,
       onDone,
     }) => {
       if (!span) return
@@ -425,9 +428,33 @@ class PlaywrightPlugin extends CiPlugin {
           isModified,
         }
       )
+      const traceId = span.context().toTraceId()
+      const testName = span.context()._tags[TEST_NAME]
+      const testSuite = span.context()._tags[TEST_SUITE]
+
       span.finish()
 
       finishAllTraceSpans(span)
+
+      if (screenshotPaths?.length) {
+        const { apiKey, site, url } = getConfig()
+        if (apiKey) {
+          const uploadUrl = url || new URL(`https://ci-intake.${site}`)
+          for (const filePath of screenshotPaths) {
+            uploadTestScreenshot({
+              filePath,
+              traceId,
+              testName,
+              testSuite,
+              testEnvironmentMetadata: this.testEnvironmentMetadata,
+              url: uploadUrl,
+            }, (err) => {
+              if (err) log.error('Error uploading test screenshot: %s', err.message)
+            })
+          }
+        }
+      }
+
       if (this._tracerConfig.DD_PLAYWRIGHT_WORKER) {
         this.tracer._exporter.flush(onDone)
       }

--- a/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agent-proxy/index.js
@@ -68,6 +68,7 @@ class AgentProxyCiVisibilityExporter extends CiVisibilityExporter {
           evpProxyPrefix,
         })
         this._codeCoverageReportUrl = this._url
+        this._testScreenshotUploadUrl = this._url
         if (isTestDynamicInstrumentationEnabled) {
           const canFowardLogs = getCanForwardDebuggerLogs(err, agentInfo)
           if (canFowardLogs) {

--- a/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/agentless/index.js
@@ -22,6 +22,7 @@ class AgentlessCiVisibilityExporter extends CiVisibilityExporter {
     this._coverageWriter = new CoverageWriter({ url: this._coverageUrl })
 
     this._codeCoverageReportUrl = url || new URL(`https://ci-intake.${site}`)
+    this._testScreenshotUploadUrl = url || new URL(`https://ci-intake.${site}`)
 
     if (isTestDynamicInstrumentationEnabled) {
       const DynamicInstrumentationLogsWriter = require('./di-logs-writer')

--- a/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
+++ b/packages/dd-trace/src/ci-visibility/exporters/ci-visibility-exporter.js
@@ -8,6 +8,7 @@ const { getKnownTests: getKnownTestsRequest } = require('../early-flake-detectio
 const { getTestManagementTests: getTestManagementTestsRequest } =
   require('../test-management/get-test-management-tests')
 const { uploadCoverageReport: uploadCoverageReportRequest } = require('../requests/upload-coverage-report')
+const { uploadTestScreenshot: uploadTestScreenshotRequest } = require('../requests/upload-test-screenshot')
 const log = require('../../log')
 const BufferingExporter = require('../../exporters/common/buffering-exporter')
 const { GIT_REPOSITORY_URL, GIT_COMMIT_SHA } = require('../../plugins/util/tags')
@@ -413,6 +414,43 @@ class CiVisibilityExporter extends BufferingExporter {
       format,
       testEnvironmentMetadata,
       url: this._codeCoverageReportUrl,
+      isEvpProxy: !!this._isUsingEvpProxy,
+      evpProxyPrefix: this.evpProxyPrefix,
+    }, callback)
+  }
+
+  /**
+   * Returns whether the exporter can upload test screenshots.
+   *
+   * @returns {boolean}
+   */
+  canUploadTestScreenshots () {
+    return !!this._testScreenshotUploadUrl
+  }
+
+  /**
+   * Uploads a single test screenshot to the CI intake.
+   *
+   * @param {object} options - Upload options
+   * @param {string} options.filePath - Path to the screenshot file
+   * @param {string} options.traceId - Test trace id used as the screenshot key
+   * @param {string} options.testName - Test name associated with the screenshot
+   * @param {string} options.testSuite - Test suite associated with the screenshot
+   * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
+   * @param {Function} callback - Callback function (err)
+   */
+  uploadTestScreenshot ({ filePath, traceId, testName, testSuite, testEnvironmentMetadata }, callback) {
+    if (!this._testScreenshotUploadUrl) {
+      return callback(new Error('Test screenshot upload URL not configured'))
+    }
+
+    uploadTestScreenshotRequest({
+      filePath,
+      traceId,
+      testName,
+      testSuite,
+      testEnvironmentMetadata,
+      url: this._testScreenshotUploadUrl,
       isEvpProxy: !!this._isUsingEvpProxy,
       evpProxyPrefix: this.evpProxyPrefix,
     }, callback)

--- a/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
+++ b/packages/dd-trace/src/ci-visibility/requests/upload-test-screenshot.js
@@ -1,0 +1,113 @@
+'use strict'
+
+const { readFileSync } = require('node:fs')
+const { extname } = require('node:path')
+
+const getConfig = require('../../config')
+const FormData = require('../../exporters/common/form-data')
+const request = require('../../exporters/common/request')
+const log = require('../../log')
+
+const UPLOAD_TIMEOUT_MS = 30_000
+const TEST_SCREENSHOT_ENDPOINT = '/api/v2/ci/tests/screenshots'
+
+function getContentType (filePath) {
+  const extension = extname(filePath).toLowerCase()
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return 'image/jpeg'
+  }
+  if (extension === '.webp') {
+    return 'image/webp'
+  }
+  return 'image/png'
+}
+
+/**
+ * Uploads a single test screenshot to the Datadog CI intake.
+ * One file per request with field names 'screenshot' and 'event'.
+ *
+ * @param {object} options - Upload options
+ * @param {string} options.filePath - Path to the screenshot file
+ * @param {string} options.traceId - Test trace id used as the screenshot key
+ * @param {string} options.testName - Test name associated with the screenshot
+ * @param {string} options.testSuite - Test suite associated with the screenshot
+ * @param {object} options.testEnvironmentMetadata - Test environment metadata containing git/CI tags
+ * @param {URL} options.url - The base URL for the screenshot upload
+ * @param {boolean} [options.isEvpProxy] - Whether to use EVP proxy for the upload
+ * @param {string} [options.evpProxyPrefix] - The EVP proxy prefix (e.g., '/evp_proxy/v4')
+ * @param {Function} callback - Callback function (err)
+ */
+function uploadTestScreenshot (
+  { filePath, traceId, testName, testSuite, testEnvironmentMetadata, url, isEvpProxy, evpProxyPrefix },
+  callback
+) {
+  const apiKey = getConfig().apiKey
+
+  if (!traceId) {
+    return callback(new Error('trace_id is required for test screenshot upload'))
+  }
+  if (!apiKey && !isEvpProxy) {
+    return callback(new Error('DD_API_KEY is required for test screenshot upload'))
+  }
+
+  let screenshotContent
+  try {
+    screenshotContent = readFileSync(filePath)
+  } catch (err) {
+    return callback(new Error(`Failed to read screenshot at ${filePath}: ${err.message}`))
+  }
+
+  const contentType = getContentType(filePath)
+  const filename = `${traceId}${extname(filePath) || '.png'}`
+  const eventPayload = {
+    type: 'test_screenshot',
+    trace_id: traceId,
+    test_name: testName,
+    test_suite: testSuite,
+    filename,
+    content_type: contentType,
+    ...testEnvironmentMetadata,
+  }
+
+  const form = new FormData()
+
+  form.append('screenshot', screenshotContent, {
+    filename,
+    contentType,
+  })
+
+  form.append('event', JSON.stringify(eventPayload), {
+    filename: 'event.json',
+    contentType: 'application/json',
+  })
+
+  const options = {
+    method: 'POST',
+    headers: {
+      ...form.getHeaders(),
+    },
+    timeout: UPLOAD_TIMEOUT_MS,
+    url,
+  }
+
+  if (isEvpProxy) {
+    options.path = `${evpProxyPrefix}${TEST_SCREENSHOT_ENDPOINT}`
+    options.headers['X-Datadog-EVP-Subdomain'] = 'ci-intake'
+  } else {
+    options.path = TEST_SCREENSHOT_ENDPOINT
+    options.headers['dd-api-key'] = apiKey
+  }
+
+  log.debug('Uploading test screenshot %s to %s%s', filePath, url, options.path)
+
+  request(form, options, (err, res, statusCode) => {
+    if (err) {
+      log.error('Error uploading test screenshot: %s', err.message)
+      return callback(err)
+    }
+    log.debug('Test screenshot uploaded successfully (status: %d)', statusCode)
+    callback(null)
+  })
+}
+
+module.exports = { TEST_SCREENSHOT_ENDPOINT, uploadTestScreenshot }


### PR DESCRIPTION
### What does this PR do?
Adds Playwright failure screenshot discovery and upload support for CI Visibility. When a Playwright test attempt fails and Playwright generated a screenshot, the plugin uploads the raw image bytes to /api/unstable/ci/test-runs/{trace_id}/media, using the failed test span decimal trace_id as the path key.

For this PoC, screenshots are uploaded whenever they are present. The media API host is selected with DD_POC_SITE, for example DD_POC_SITE=us1.staging.dog resolves to https://api.us1.staging.dog. The mock CI Visibility intake still uses the test URL override for integration coverage.

### Motivation
Playwright already captures screenshots for failed runs. CI Visibility can use those screenshots as failure media artifacts, associated by trace id with the failing test event.


