### PR TITLE
ci: work around actions/cache windows flakiness

### DIFF
--- a/.github/actions/datadog-ci/action.yml
+++ b/.github/actions/datadog-ci/action.yml
@@ -4,11 +4,6 @@ description: Install @datadog/datadog-ci from npm and add it to PATH.
 runs:
   using: composite
   steps:
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: ${{ github.workspace }}/.github/actions/datadog-ci/node_modules
-        key: datadog-ci-${{ hashFiles('.github/actions/datadog-ci/yarn.lock') }}
-
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -8,54 +8,16 @@ inputs:
 runs:
   using: composite
   steps:
-    # Resolve the version from the input alias so we can use it in cache keys.
-    - name: Resolve Node.js version
-      id: node-version
-      env:
-        NODE_VERSION: ${{
-          inputs.version == 'eol' && '16' ||
-          inputs.version == 'oldest' && '18' ||
-          inputs.version == 'maintenance' && '20' ||
-          inputs.version == 'active' && '22' ||
-          inputs.version == 'latest' && (env.LATEST_VERSION || '24') ||
-          inputs.version }}
-      shell: bash
-      run: echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
-
-    # Cache a tiny file containing the exact Node.js version resolved by a previous run.
-    # Key rotates every 60 minutes (epoch / 3600), capping setup-node manifest API
-    # calls at one per (os, arch, major) per hour. On cache hit, install the cached
-    # patch directly and skip the manifest lookup.
-    - name: Compute cache key
-      id: cache-key
-      shell: bash
-      run: echo "block=$(( $(date -u +%s) / 3600 ))" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      id: node-version-cache
+    # Retry once on failure to work around actions/cache#1754, an open bug where
+    # @actions/cache silently exits non-zero on Windows during cache restore (no
+    # error output), failing whichever step triggered the restore — setup-node,
+    # setup-bun, or our node-version-cache.
+    - id: attempt
+      uses: ./.github/actions/node/setup
+      continue-on-error: true
       with:
-        path: ${{ runner.temp }}/.node-resolved-version-${{ steps.node-version.outputs.version }}
-        key: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-${{ steps.cache-key.outputs.block }}
-    - name: Read cached version
-      id: cached
-      shell: bash
-      run: |
-        if [ -f "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}" ]; then
-          echo "version=$(cat "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}")" >> "$GITHUB_OUTPUT"
-        fi
-
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        version: ${{ inputs.version }}
+    - if: steps.attempt.outcome == 'failure'
+      uses: ./.github/actions/node/setup
       with:
-        # Cache hit installs the cached patch directly. Otherwise pass the major; the cached
-        # patch is a semver-exact spec, so check-latest would not upgrade it.
-        node-version: ${{ steps.cached.outputs.version || steps.node-version.outputs.version }}
-        check-latest: ${{ steps.cached.outputs.version == '' }}
-        registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}
-
-    # Persist the resolved version so subsequent runs within this 60-minute window can reuse it.
-    - name: Save resolved version
-      if: steps.node-version-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: node -v | tr -d 'v' > "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}"
-    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-      with:
-        bun-version: 1.3.1
+        version: ${{ inputs.version }}

--- a/.github/actions/node/setup/action.yml
+++ b/.github/actions/node/setup/action.yml
@@ -1,0 +1,61 @@
+name: Node.js Setup
+description: Internal implementation; install Node.js and Bun. Use `./.github/actions/node` instead.
+inputs:
+  version:
+    description: "Version identifier of the version to use."
+    required: false
+    default: 'latest'
+runs:
+  using: composite
+  steps:
+    # Resolve the version from the input alias so we can use it in cache keys.
+    - name: Resolve Node.js version
+      id: node-version
+      env:
+        NODE_VERSION: ${{
+          inputs.version == 'eol' && '16' ||
+          inputs.version == 'oldest' && '18' ||
+          inputs.version == 'maintenance' && '20' ||
+          inputs.version == 'active' && '22' ||
+          inputs.version == 'latest' && (env.LATEST_VERSION || '24') ||
+          inputs.version }}
+      shell: bash
+      run: echo "version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
+
+    # Cache a tiny file containing the exact Node.js version resolved by a previous run.
+    # Key rotates every 60 minutes (epoch / 3600), capping setup-node manifest API
+    # calls at one per (os, arch, major) per hour. On cache hit, install the cached
+    # patch directly and skip the manifest lookup.
+    - name: Compute cache key
+      id: cache-key
+      shell: bash
+      run: echo "block=$(( $(date -u +%s) / 3600 ))" >> "$GITHUB_OUTPUT"
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      id: node-version-cache
+      with:
+        path: ${{ runner.temp }}/.node-resolved-version-${{ steps.node-version.outputs.version }}
+        key: node-resolved-${{ runner.os }}-${{ runner.arch }}-v${{ steps.node-version.outputs.version }}-${{ steps.cache-key.outputs.block }}
+    - name: Read cached version
+      id: cached
+      shell: bash
+      run: |
+        if [ -f "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}" ]; then
+          echo "version=$(cat "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}")" >> "$GITHUB_OUTPUT"
+        fi
+
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        # Cache hit installs the cached patch directly. Otherwise pass the major; the cached
+        # patch is a semver-exact spec, so check-latest would not upgrade it.
+        node-version: ${{ steps.cached.outputs.version || steps.node-version.outputs.version }}
+        check-latest: ${{ steps.cached.outputs.version == '' }}
+        registry-url: ${{ inputs.registry-url || 'https://registry.npmjs.org' }}
+
+    # Persist the resolved version so subsequent runs within this 60-minute window can reuse it.
+    - name: Save resolved version
+      if: steps.node-version-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: node -v | tr -d 'v' > "$RUNNER_TEMP/.node-resolved-version-${{ steps.node-version.outputs.version }}"
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: 1.3.1


### PR DESCRIPTION
### What does this PR do?

Work around [actions/cache#1754](https://github.com/actions/cache/issues/1754), an open upstream bug where `@actions/cache` silently exits non-zero on Windows during cache restore — failing whichever step triggered the restore with no error output, ~0.6s in.

Two changes:

1. **`./.github/actions/node`** — split the implementation into `node/setup/` and turn `node/action.yml` into a thin wrapper that calls `setup` with `continue-on-error: true`, then retries once if it failed. Covers all three places we hit the bug inside the composite: `setup-node`'s tool cache, our `node-version-cache` step, and `setup-bun`'s internal cache restore. Public interface is unchanged, so every caller (including `node/latest`, `node/active-lts`, etc.) transparently gets the retry.

2. **`./.github/actions/datadog-ci`** — drop the `actions/cache` step entirely. `@datadog/datadog-ci` is a bundled package with no transitive deps; the install is fast enough that the cache wasn't pulling much weight, and it directly exposed us to the same bug. The existing `yarn install || (sleep 30 && yarn install)` retry remains.

### Motivation

`tracing-windows` (in APM Capabilities) and other Windows jobs have been failing intermittently for a while. The failure is silent — the job goes red with no actionable error in the log. Comparing a failing first attempt vs. a successful retry on the same PR confirmed the bug is the [upstream `actions/cache` Windows flakiness reported May 8](https://github.com/actions/cache/issues/1754), affecting multiple unrelated projects (RustPython, f3d-app, etc.). Until there's an upstream fix, retrying is the cleanest workaround.

### Additional Notes

- Retry runs immediately after the first failure. `actions/cache#1754` describes the failure as "randomly dies" rather than state-correlated, so an immediate retry should succeed almost always. If it doesn't, the `setup-bun` `existsSync(bunPath)` short-circuit means a second attempt skips its `restoreCache` entirely when bun was at least partially installed on the first pass.
- The runner agent itself stays alive across the failure — only the action's Node.js process exits. Subsequent steps with `if: failure()` / `if: always()` ran in the failing job, confirming the runner is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)