### PR TITLE
[test optimization] normalize seed suffix in test names in `jest`

### DIFF
--- a/integration-tests/ci-visibility/jest-fast-check/jest-fast-check.js
+++ b/integration-tests/ci-visibility/jest-fast-check/jest-fast-check.js
@@ -1,9 +1,0 @@
-'use strict'
-
-const { test, fc } = require('@fast-check/jest')
-
-describe('fast check', () => {
-  test.prop([fc.string(), fc.string(), fc.string()])('will not include seed', (a, b, c) => {
-    expect([a, b, c]).toContain(b)
-  })
-})

--- a/integration-tests/ci-visibility/jest-seed-suffix/jest-describe-seed-suffix.js
+++ b/integration-tests/ci-visibility/jest-seed-suffix/jest-describe-seed-suffix.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const assert = require('assert')
+
+describe('seed suffix (with seed=12)', () => {
+  it('should preserve describe seed suffix', () => {
+    assert.deepStrictEqual(1 + 2, 3)
+  })
+})

--- a/integration-tests/ci-visibility/jest-seed-suffix/jest-seed-suffix.js
+++ b/integration-tests/ci-visibility/jest-seed-suffix/jest-seed-suffix.js
@@ -2,8 +2,8 @@
 
 const assert = require('assert')
 
-describe('fast check with seed', () => {
-  it('should include seed (with seed=12)', () => {
+describe('seed suffix', () => {
+  it('should strip seed (with seed=12)', () => {
     assert.deepStrictEqual(1 + 2, 3)
   })
 })

--- a/integration-tests/jest/jest.core.spec.js
+++ b/integration-tests/jest/jest.core.spec.js
@@ -88,7 +88,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     'office-addin-mock',
     'winston',
     'jest-image-snapshot',
-    '@fast-check/jest',
   ].filter(Boolean), true)
 
   before(function () {

--- a/integration-tests/jest/jest.itr-efd.spec.js
+++ b/integration-tests/jest/jest.itr-efd.spec.js
@@ -93,7 +93,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     'office-addin-mock',
     'winston',
     'jest-image-snapshot',
-    '@fast-check/jest',
   ].filter(Boolean), true)
 
   before(function () {

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -78,7 +78,6 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     'office-addin-mock',
     'winston',
     'jest-image-snapshot',
-    '@fast-check/jest',
   ].filter(Boolean), true)
 
   before(function () {
@@ -2545,14 +2544,14 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
     })
   })
 
-  context('fast-check', () => {
-    onlyLatestIt('should remove seed from the test name if @fast-check/jest is used in the test', async () => {
+  context('seed suffix normalization', () => {
+    onlyLatestIt('should remove seed suffix from reported test names', async () => {
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
           const events = payloads.flatMap(({ payload }) => payload.events)
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
           assert.strictEqual(tests.length, 1)
-          assert.strictEqual(tests[0].meta[TEST_NAME], 'fast check will not include seed')
+          assert.strictEqual(tests[0].meta[TEST_NAME], 'seed suffix should strip seed')
         })
 
       childProcess = exec(
@@ -2561,7 +2560,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           cwd,
           env: {
             ...getCiVisAgentlessConfig(receiver.port),
-            TESTS_TO_RUN: 'jest-fast-check/jest-fast-check',
+            TESTS_TO_RUN: 'jest-seed-suffix/jest-seed-suffix',
           },
         }
       )
@@ -2572,13 +2571,32 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
       ])
     })
 
-    onlyLatestIt('should not remove seed if @fast-check/jest is not used', async () => {
+    onlyLatestIt('does not mark seed-suffixed tests as new when known tests use the stripped name', async () => {
+      receiver.setKnownTests({
+        jest: {
+          'ci-visibility/jest-seed-suffix/jest-seed-suffix.js': [
+            'seed suffix should strip seed',
+          ],
+        },
+      })
+      receiver.setSettings({
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': 2,
+          },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
+      })
+
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
           const events = payloads.flatMap(({ payload }) => payload.events)
           const tests = events.filter(event => event.type === 'test').map(event => event.content)
           assert.strictEqual(tests.length, 1)
-          assert.strictEqual(tests[0].meta[TEST_NAME], 'fast check with seed should include seed (with seed=12)')
+          assert.strictEqual(tests[0].meta[TEST_NAME], 'seed suffix should strip seed')
+          assert.ok(!(TEST_IS_NEW in tests[0].meta))
         })
 
       childProcess = exec(
@@ -2587,7 +2605,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           cwd,
           env: {
             ...getCiVisAgentlessConfig(receiver.port),
-            TESTS_TO_RUN: 'jest-fast-check/jest-no-fast-check',
+            TESTS_TO_RUN: 'jest-seed-suffix/jest-seed-suffix',
           },
         }
       )

--- a/integration-tests/jest/jest.test-management.spec.js
+++ b/integration-tests/jest/jest.test-management.spec.js
@@ -2615,6 +2615,66 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         eventsPromise,
       ])
     })
+
+    onlyLatestIt('keeps seed-like describe suffixes when matching test management tests', async () => {
+      const testName = 'seed suffix (with seed=12) should preserve describe seed suffix'
+      receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 2 } })
+      receiver.setTestManagementTests({
+        jest: {
+          suites: {
+            'ci-visibility/jest-seed-suffix/jest-describe-seed-suffix.js': {
+              tests: {
+                [testName]: {
+                  properties: {
+                    attempt_to_fix: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), payloads => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+          const retriedTests = tests.filter(test => test.meta[TEST_NAME] === testName)
+
+          assert.strictEqual(retriedTests.length, 3)
+          assert.ok(!(TEST_IS_RETRY in retriedTests[0].meta))
+          assert.deepStrictEqual(
+            retriedTests.map(test => test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX]),
+            ['true', 'true', 'true']
+          )
+          assert.deepStrictEqual(
+            retriedTests.slice(1).map(test => ({
+              reason: test.meta[TEST_RETRY_REASON],
+              retry: test.meta[TEST_IS_RETRY],
+            })),
+            [
+              { reason: TEST_RETRY_REASON_TYPES.atf, retry: 'true' },
+              { reason: TEST_RETRY_REASON_TYPES.atf, retry: 'true' },
+            ]
+          )
+        })
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: 'jest-seed-suffix/jest-describe-seed-suffix',
+          },
+        }
+      )
+
+      await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+    })
   })
 
   it('does not crash with mocks that are not dependencies', async () => {

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -33,10 +33,10 @@ const {
   getTestOptimizationRequestResults,
 } = require('../../dd-trace/src/plugins/util/test')
 const {
-  SEED_SUFFIX_RE,
   getFormattedJestTestParameters,
   getJestTestName,
   getJestSuitesToRun,
+  removeSeedSuffixFromTestName,
 } = require('../../datadog-plugin-jest/src/util')
 const { addHook, channel } = require('./helpers/instrument')
 
@@ -130,8 +130,6 @@ const efdSlowAbortedTests = new Set()
 const efdNewTestCandidates = new Set()
 // Tests that are genuinely new (not in known tests list).
 const newTests = new Set()
-const testSuiteAbsolutePathsWithFastCheck = new Set()
-const testSuiteFastCheckUsage = new Map()
 const testSuiteJestObjects = new Map()
 const wrappedJestGlobals = new WeakSet()
 const wrappedJestObjects = new WeakSet()
@@ -293,9 +291,7 @@ function getAttemptToFixExecutionsFromJestResults (result) {
     if (!testManagementTestsForSuite) continue
 
     for (const { fullName, status } of testResults) {
-      const testName = testSuiteAbsolutePathsWithFastCheck.has(testFilePath)
-        ? fullName.replace(SEED_SUFFIX_RE, '')
-        : fullName
+      const testName = removeSeedSuffixFromTestName(fullName)
       const testStatus = getTestStatusFromJestResult(status)
       if (!testStatus) continue
 
@@ -542,14 +538,11 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
       }
     }
 
-    getShouldStripSeedFromTestName () {
-      return doesTestSuiteUseFastCheck(this.testSuiteAbsolutePath)
-    }
-
     // At the `add_test` event we don't have the test object yet, so we can't use it
     getTestNameFromAddTestEvent (event, state) {
-      const describeSuffix = getJestTestName(state.currentDescribeBlock, this.getShouldStripSeedFromTestName())
-      return describeSuffix ? `${describeSuffix} ${event.testName}` : event.testName
+      const describeSuffix = getJestTestName(state.currentDescribeBlock)
+      const testName = describeSuffix ? `${describeSuffix} ${event.testName}` : event.testName
+      return removeSeedSuffixFromTestName(testName)
     }
 
     async handleTestEvent (event, state) {
@@ -571,7 +564,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         })
       }
       if (event.name === 'test_start') {
-        const testName = getJestTestName(event.test, this.getShouldStripSeedFromTestName())
+        const testName = getJestTestName(event.test)
         if (testsToBeRetried.has(testName)) {
           // This is needed because we're retrying tests with the same name
           this.resetSnapshotState()
@@ -775,7 +768,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         let attemptToFixFailed = false
         let failedAllTests = false
         let isAttemptToFix = false
-        const testName = getJestTestName(event.test, this.getShouldStripSeedFromTestName())
+        const testName = getJestTestName(event.test)
         if (this.isTestManagementTestsEnabled) {
           isAttemptToFix = this.testManagementTestsForThisSuite?.attemptToFix?.includes(testName)
           if (isAttemptToFix) {
@@ -955,7 +948,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
           // so Jest doesn't see the failure (prevents --bail from stopping the run).
           const ctx = testContexts.get(test)
           if (ctx?.isQuarantined && !ctx.isAttemptToFix) {
-            const testName = getJestTestName(test, this.getShouldStripSeedFromTestName())
+            const testName = getJestTestName(test)
             quarantinedFailingTests.add(`${ctx.suite} › ${testName}`)
           } else {
             test.errors = errors
@@ -979,7 +972,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
         testsToBeRetried.clear()
       }
       if (event.name === 'test_skip' || event.name === 'test_todo') {
-        const testName = getJestTestName(event.test, this.getShouldStripSeedFromTestName())
+        const testName = getJestTestName(event.test)
         testSkippedCh.publish({
           test: {
             name: testName,
@@ -1383,9 +1376,7 @@ function getCliWrapper (isNewJestVersion) {
       for (const { testResults, testFilePath } of result.results.testResults) {
         const suite = getTestSuitePath(testFilePath, result.globalConfig.rootDir)
         for (const { fullName } of testResults) {
-          const name = testSuiteAbsolutePathsWithFastCheck.has(testFilePath)
-            ? fullName.replace(SEED_SUFFIX_RE, '')
-            : fullName
+          const name = removeSeedSuffixFromTestName(fullName)
           fullNameToSuite.set(name, suite)
         }
       }
@@ -1424,10 +1415,8 @@ function getCliWrapper (isNewJestVersion) {
           .testResults.flatMap(({ testResults, testFilePath: testSuiteAbsolutePath }) => (
             testResults.map(({ fullName: testName, status }) => (
               {
-                // Strip @fast-check/jest seed suffix so the name matches what was reported via TEST_NAME
-                testName: testSuiteAbsolutePathsWithFastCheck.has(testSuiteAbsolutePath)
-                  ? testName.replace(SEED_SUFFIX_RE, '')
-                  : testName,
+                // Strip seed suffix so the name matches what was reported via TEST_NAME.
+                testName: removeSeedSuffixFromTestName(testName),
                 testSuiteAbsolutePath,
                 status,
               }
@@ -1626,7 +1615,6 @@ function publishTestSuiteFinish (payload, waitForFinish) {
 
 function cleanupTestSuiteState (testSuiteAbsolutePath) {
   testSuiteMockedFiles.delete(testSuiteAbsolutePath)
-  testSuiteFastCheckUsage.delete(testSuiteAbsolutePath)
   testSuiteJestObjects.delete(testSuiteAbsolutePath)
 }
 
@@ -2080,38 +2068,6 @@ function wrapJestGlobalsForRuntime (runtime) {
   })
 }
 
-function recordFastCheckUsage (runtime, from, moduleName) {
-  if (moduleName !== '@fast-check/jest') return
-
-  if (from) {
-    testSuiteAbsolutePathsWithFastCheck.add(from)
-    testSuiteFastCheckUsage.set(from, true)
-  }
-  if (runtime?._testPath) {
-    testSuiteAbsolutePathsWithFastCheck.add(runtime._testPath)
-    testSuiteFastCheckUsage.set(runtime._testPath, true)
-  }
-}
-
-function doesTestSuiteUseFastCheck (testSuiteAbsolutePath) {
-  if (!testSuiteAbsolutePath) return false
-  if (testSuiteFastCheckUsage.has(testSuiteAbsolutePath)) {
-    return testSuiteFastCheckUsage.get(testSuiteAbsolutePath)
-  }
-
-  try {
-    const usesFastCheck = readFileSync(testSuiteAbsolutePath, 'utf8').includes('@fast-check/jest')
-    testSuiteFastCheckUsage.set(testSuiteAbsolutePath, usesFastCheck)
-    if (usesFastCheck) {
-      testSuiteAbsolutePathsWithFastCheck.add(testSuiteAbsolutePath)
-    }
-    return usesFastCheck
-  } catch {
-    testSuiteFastCheckUsage.set(testSuiteAbsolutePath, false)
-    return false
-  }
-}
-
 function getLastLoggedReferenceError (runtime) {
   const loggedReferenceErrors = runtime?.loggedReferenceErrors
   if (!loggedReferenceErrors?.size) return
@@ -2220,8 +2176,6 @@ addHook({
         // To bypass jest's own require engine
         return requireOutsideJestRequireEngine(this, moduleName)
       }
-      // This means that `@fast-check/jest` is used in the test file.
-      recordFastCheckUsage(this, from, moduleName)
       let returnedValue
       try {
         returnedValue = requireModuleOrMock.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -35,6 +35,7 @@ const {
 const {
   getFormattedJestTestParameters,
   getJestTestName,
+  getRawJestTestName,
   getJestSuitesToRun,
   removeSeedSuffixFromTestName,
 } = require('../../datadog-plugin-jest/src/util')
@@ -540,7 +541,7 @@ function getWrappedEnvironment (BaseEnvironment, jestVersion) {
 
     // At the `add_test` event we don't have the test object yet, so we can't use it
     getTestNameFromAddTestEvent (event, state) {
-      const describeSuffix = getJestTestName(state.currentDescribeBlock)
+      const describeSuffix = getRawJestTestName(state.currentDescribeBlock)
       const testName = describeSuffix ? `${describeSuffix} ${event.testName}` : event.testName
       return removeSeedSuffixFromTestName(testName)
     }

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -41,11 +41,16 @@ function getFormattedJestTestParameters (testParameters) {
   return formattedParameters
 }
 
-// Support for `@fast-check/jest`: this library modifies the test name to include the seed
-// A test name that keeps changing breaks some Test Optimization's features.
+// @fast-check/jest appends a random seed to the reported test name. A test name that keeps changing
+// breaks some Test Optimization features, so normalize this narrow suffix regardless of import style.
 const SEED_SUFFIX_RE = /\s*\(with seed=-?\d+\)\s*$/i
+
+function removeSeedSuffixFromTestName (testName) {
+  return testName.replace(SEED_SUFFIX_RE, '')
+}
+
 // https://github.com/facebook/jest/blob/3e38157ad5f23fb7d24669d24fae8ded06a7ab75/packages/jest-circus/src/utils.ts#L396
-function getJestTestName (test, shouldStripSeed = false) {
+function getJestTestName (test) {
   const titles = []
   let parent = test
   do {
@@ -55,10 +60,7 @@ function getJestTestName (test, shouldStripSeed = false) {
   titles.shift() // remove TOP_DESCRIBE_BLOCK_NAME
 
   const testName = titles.join(' ')
-  if (shouldStripSeed) {
-    return testName.replace(SEED_SUFFIX_RE, '')
-  }
-  return testName
+  return removeSeedSuffixFromTestName(testName)
 }
 
 const globalDocblockRegExp = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/
@@ -172,4 +174,5 @@ module.exports = {
   getJestTestName,
   getJestSuitesToRun,
   isMarkedAsUnskippable,
+  removeSeedSuffixFromTestName,
 }

--- a/packages/datadog-plugin-jest/src/util.js
+++ b/packages/datadog-plugin-jest/src/util.js
@@ -50,7 +50,7 @@ function removeSeedSuffixFromTestName (testName) {
 }
 
 // https://github.com/facebook/jest/blob/3e38157ad5f23fb7d24669d24fae8ded06a7ab75/packages/jest-circus/src/utils.ts#L396
-function getJestTestName (test) {
+function getRawJestTestName (test) {
   const titles = []
   let parent = test
   do {
@@ -59,8 +59,11 @@ function getJestTestName (test) {
 
   titles.shift() // remove TOP_DESCRIBE_BLOCK_NAME
 
-  const testName = titles.join(' ')
-  return removeSeedSuffixFromTestName(testName)
+  return titles.join(' ')
+}
+
+function getJestTestName (test) {
+  return removeSeedSuffixFromTestName(getRawJestTestName(test))
 }
 
 const globalDocblockRegExp = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/
@@ -172,6 +175,7 @@ module.exports = {
   SEED_SUFFIX_RE,
   getFormattedJestTestParameters,
   getJestTestName,
+  getRawJestTestName,
   getJestSuitesToRun,
   isMarkedAsUnskippable,
   removeSeedSuffixFromTestName,

--- a/packages/datadog-plugin-jest/test/util.spec.js
+++ b/packages/datadog-plugin-jest/test/util.spec.js
@@ -5,7 +5,36 @@ const path = require('node:path')
 
 const { describe, it } = require('mocha')
 
-const { getFormattedJestTestParameters, getJestSuitesToRun } = require('../src/util')
+const {
+  getFormattedJestTestParameters,
+  getJestSuitesToRun,
+  removeSeedSuffixFromTestName,
+} = require('../src/util')
+
+describe('removeSeedSuffixFromTestName', () => {
+  it('removes seed suffixes', () => {
+    assert.strictEqual(
+      removeSeedSuffixFromTestName('property passes (with seed=1234)'),
+      'property passes'
+    )
+    assert.strictEqual(
+      removeSeedSuffixFromTestName('property passes (with seed=-1234)'),
+      'property passes'
+    )
+    assert.strictEqual(
+      removeSeedSuffixFromTestName('property passes (with seed=1234) '),
+      'property passes'
+    )
+  })
+
+  it('only removes the seed suffix at the end of the name', () => {
+    assert.strictEqual(
+      removeSeedSuffixFromTestName('property (with seed=1234) keeps running'),
+      'property (with seed=1234) keeps running'
+    )
+  })
+})
+
 describe('getFormattedJestTestParameters', () => {
   it('returns formatted parameters for arrays', () => {
     const result = getFormattedJestTestParameters([[[1, 2], [3, 4]]])

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -32,7 +32,6 @@
     "@elastic/elasticsearch": "9.4.0",
     "@elastic/transport": "9.3.5",
     "@electron/packager": "20.0.0",
-    "@fast-check/jest": "2.2.0",
     "@fastify/cookie": "11.0.2",
     "@fastify/multipart": "10.0.0",
     "@google-cloud/pubsub": "5.3.0",


### PR DESCRIPTION
### What does this PR do?
Always normalizes Jest test names by stripping a narrow trailing `(with seed=<integer>)` suffix before reporting and before known-tests/new-tests comparisons. This also removes the fragile `@fast-check/jest` import detection and the dedicated integration dependency, since the suffix is normalized generically.

### Motivation
Property tests from `@fast-check/jest` append a random seed to the test name, for example `(with seed=1234)`. When that suffix is kept, the same test can be reported under many names and can be marked as new even when known tests contain the stable name.

