### PR TITLE
ci(profiling): capture Windows crash dumps via WER LocalDumps

### DIFF
--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -99,7 +99,7 @@ jobs:
           $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\node.exe'
           New-Item -Path $key -Force | Out-Null
           Set-ItemProperty -Path $key -Name DumpFolder -Type ExpandString -Value $dumpDir
-          Set-ItemProperty -Path $key -Name DumpType   -Type DWord        -Value 2   # MiniDumpWithFullMemory
+          Set-ItemProperty -Path $key -Name DumpType   -Type DWord        -Value 1   # 1 = minidump (small; full dump = 2 would risk runner disk pressure with DumpCount=20)
           Set-ItemProperty -Path $key -Name DumpCount  -Type DWord        -Value 20
           "WER_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - run: yarn test:profiler:ci

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -98,9 +98,16 @@ jobs:
           New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
           $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\node.exe'
           New-Item -Path $key -Force | Out-Null
-          Set-ItemProperty -Path $key -Name DumpFolder -Type ExpandString -Value $dumpDir
-          Set-ItemProperty -Path $key -Name DumpType   -Type DWord        -Value 1   # 1 = minidump (small; full dump = 2 would risk runner disk pressure with DumpCount=20)
-          Set-ItemProperty -Path $key -Name DumpCount  -Type DWord        -Value 20
+          Set-ItemProperty -Path $key -Name DumpFolder      -Type ExpandString -Value $dumpDir
+          # DumpType=0 means "use CustomDumpFlags". Flags chosen for diagnosing native-binding
+          # teardown crashes (PROF-14469) without including heap memory:
+          #   0x0001 MiniDumpWithDataSegs        — module .data segments (V8/libc globals)
+          #   0x0004 MiniDumpWithHandleData      — process handle table
+          #   0x0020 MiniDumpWithUnloadedModules — modules unloaded before the crash
+          #   0x1000 MiniDumpWithThreadInfo      — per-thread CPU/start-address/affinity
+          Set-ItemProperty -Path $key -Name DumpType        -Type DWord        -Value 0
+          Set-ItemProperty -Path $key -Name CustomDumpFlags -Type DWord        -Value 0x1025
+          Set-ItemProperty -Path $key -Name DumpCount       -Type DWord        -Value 20
           "WER_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler:coverage

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -109,6 +109,21 @@ jobs:
           Set-ItemProperty -Path $key -Name CustomDumpFlags -Type DWord        -Value 0x1025
           Set-ItemProperty -Path $key -Name DumpCount       -Type DWord        -Value 20
           "WER_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+      # Defense-in-depth: blank known-sensitive env vars before tests so that
+      # if any of them ever do end up in the test process env (today they
+      # don't, but it's one workflow edit away), they cannot reach a published
+      # minidump artifact via module data segments or static state.
+      - name: Scrub sensitive env before tests
+        shell: pwsh
+        run: |
+          @(
+            'DD_API_KEY',
+            'DD_APP_KEY',
+            'DD_APPLICATION_KEY',
+            'GITHUB_TOKEN',
+            'NODE_AUTH_TOKEN',
+            'NPM_TOKEN'
+          ) | ForEach-Object { "$_=" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8 }
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler:coverage
       - uses: ./.github/actions/node-crash-report

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -87,10 +87,36 @@ jobs:
         with:
           version: 24.14.1 # TODO: remove pin when https://github.com/nodejs/node/issues/62991 is fixed
       - uses: ./.github/actions/install
+      # Enable Windows Error Reporting LocalDumps for node.exe so __fastfail /
+      # RaiseFailFastException crashes (e.g. STATUS_STACK_BUFFER_OVERRUN /
+      # 0xC0000409) — which bypass V8 and process.report — still produce a
+      # minidump. See PROF-14469.
+      - name: Enable WER LocalDumps for node.exe
+        shell: pwsh
+        run: |
+          $dumpDir = Join-Path $env:RUNNER_TEMP 'windows-crash-dumps'
+          New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
+          $key = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\node.exe'
+          New-Item -Path $key -Force | Out-Null
+          Set-ItemProperty -Path $key -Name DumpFolder -Type ExpandString -Value $dumpDir
+          Set-ItemProperty -Path $key -Name DumpType   -Type DWord        -Value 2   # MiniDumpWithFullMemory
+          Set-ItemProperty -Path $key -Name DumpCount  -Type DWord        -Value 20
+          "WER_DUMP_DIR=$dumpDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       - run: yarn test:profiler:ci
       - run: yarn test:integration:profiler:coverage
       - uses: ./.github/actions/node-crash-report
         if: failure()
+      # Upload any WER minidumps that landed during this job, even on
+      # mocha-retry-recovered success — those are exactly the flake signatures
+      # we want to inspect.
+      - name: Upload Windows crash dumps
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-crash-dumps-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.WER_DUMP_DIR }}/*.dmp
+          if-no-files-found: ignore
+          retention-days: 14
       - uses: ./.github/actions/coverage
         with:
           flags: profiling-windows


### PR DESCRIPTION
### What does this PR do?

Configures Windows Error Reporting (WER) LocalDumps for `node.exe` on the Profiling Windows job before tests run, and uploads any resulting minidumps as a job artifact.

Two new steps in the `windows` job in `.github/workflows/profiling.yml`:

1. **Enable WER LocalDumps for `node.exe`** (PowerShell, runs after `./.github/actions/install`, before the tests). Sets the registry key `HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\node.exe` with `DumpFolder = $RUNNER_TEMP\windows-crash-dumps`, `DumpType = 2` (`MiniDumpWithFullMemory`), `DumpCount = 20`. Path is exported as `WER_DUMP_DIR` for the upload step.
2. **Upload Windows crash dumps** (runs after `node-crash-report`, before `coverage`/`push_to_test_optimization`). Uses `actions/upload-artifact@v7.0.1`, `if: always()` so flake-retried runs that surface as "green" still capture their dump, `if-no-files-found: ignore`, 14-day retention. Artifact name includes `run_id` + `run_attempt`.

### Motivation

The dominant Profiling flake on Windows (see PROF-14469) is a worker exiting with `STATUS_STACK_BUFFER_OVERRUN` (`0xC0000409`) after the test summary prints — a `__fastfail` / `RaiseFailFastException` deep inside the native profiler bindings during teardown.

The existing `node-crash-report` action prints `process.report` JSON, which is V8's fatal-error path. `__fastfail` is specifically designed to bypass V8, SEH, VEH, and every user-mode handler and go straight to WER — so `process.report` produces nothing for this crash class. The dd-trace-js crashtracker is also a silent no-op on Windows (no `@datadog/libdatadog` Windows prebuild yet). That leaves WER LocalDumps as the only mechanism that captures these crashes.

Here's a successful run for Profiling target on Windows showing execution of this change: https://github.com/DataDog/dd-trace-js/actions/runs/26225608877/job/77171704955

### Additional Notes

- The minidumps will be downloadable from each Windows job's "Artifacts" panel as `windows-crash-dumps-<run-id>-<attempt>`. Inspect locally with WinDbg / Visual Studio against `node.exe` symbols.
- Retention is 14 days; bump if you want a longer window for investigations.
- No effect on Linux or macOS jobs; no effect on dd-trace runtime behavior.

### Related

Jira: [PROF-14469](https://datadoghq.atlassian.net/browse/PROF-14469)

[PROF-14469]: https://datadoghq.atlassian.net/browse/PROF-14469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ