### PR TITLE
ci(test-optimization): build versioned Playwright Docker image in GHCR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -238,6 +238,7 @@
 /.github/actions/dd-sts-app-key/action.yml @Datadog/lang-platform-js
 /.github/actions/dd-sts-api-key/action.yml @Datadog/lang-platform-js
 /.github/actions/push_to_test_optimization/ @DataDog/ci-app-libraries
+/.github/playwright/ @DataDog/ci-app-libraries
 /.github/actions/upload-node-reports/action.yml @Datadog/lang-platform-js
 /.github/chainguard @DataDog/sdlc-security
 /.github/codeql_config.yml @DataDog/sdlc-security

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1.3.1 AS bun
+FROM node:26-bookworm-slim
+ARG PLAYWRIGHT_VERSION
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+
+RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
+    && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
+    && rm -rf /tmp/pw \
+    # Remove node in the same RUN so it is invisible to the container at runtime.
+    # Deletions in a later layer would still bloat the image with the unreachable binary.
+    # setup-node is the sole provider of node at runtime.
+    && rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    && rm -rf /usr/local/lib/node_modules /usr/local/include/node

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -1,5 +1,5 @@
 FROM oven/bun:1.3.1 AS bun
-FROM node:26-bookworm-slim
+FROM node:24-bookworm-slim
 ARG PLAYWRIGHT_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -7,6 +7,8 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
     && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
     && rm -rf /tmp/pw \

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -7,7 +7,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl git gpg && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
     && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -98,9 +98,11 @@ jobs:
           OLDEST_TAG="${OLDEST}-${DOCKER_HASH}"
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
           IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST_TAG" "$BASE" "$OLDEST_TAG")
-          VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST_TAG" || echo "$OLDEST_TAG")
+          PW_VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST" || echo "$OLDEST")
+          IMAGE_TAG=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST_TAG" || echo "$OLDEST_TAG")
           echo "images=$IMAGES" >> $GITHUB_OUTPUT
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "pw-version=$PW_VERSION" >> $GITHUB_OUTPUT
+          echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -109,13 +111,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Ensure image
         env:
-          VERSION: ${{ steps.versions.outputs.version }}
+          PW_VERSION: ${{ steps.versions.outputs.pw-version }}
+          IMAGE_TAG: ${{ steps.versions.outputs.image-tag }}
         run: |
-          IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${VERSION}"
+          IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${IMAGE_TAG}"
           if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
             echo "Image ${IMAGE} already exists, skipping build"
           else
-            docker build --build-arg PLAYWRIGHT_VERSION="${VERSION}" \
+            docker build --build-arg PLAYWRIGHT_VERSION="${PW_VERSION}" \
               -t "${IMAGE}" .github/playwright
             docker push "${IMAGE}"
           fi

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -91,8 +91,8 @@ jobs:
       - name: Determine versions
         id: versions
         run: |
-          LATEST=$(node -p "require('./integration-tests/playwright/versions').latest")
-          OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
+          LATEST=$(node -p "require('./integration-tests/playwright/versions').tag(require('./integration-tests/playwright/versions').latest)")
+          OLDEST=$(node -p "require('./integration-tests/playwright/versions').tag(require('./integration-tests/playwright/versions').oldest)")
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
           IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST" "$BASE" "$OLDEST")
           VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST" || echo "$OLDEST")

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -94,9 +94,11 @@ jobs:
           LATEST=$(node -p "require('./integration-tests/playwright/versions').latest")
           OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
           DOCKER_HASH=$(sha256sum .github/playwright/Dockerfile | cut -c1-8)
+          LATEST_TAG="${LATEST}-${DOCKER_HASH}"
+          OLDEST_TAG="${OLDEST}-${DOCKER_HASH}"
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
-          IMAGES=$(printf '{"latest":"%s:%s-%s","oldest":"%s:%s-%s"}' "$BASE" "$LATEST" "$DOCKER_HASH" "$BASE" "$OLDEST" "$DOCKER_HASH")
-          VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST" || echo "$OLDEST")
+          IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST_TAG" "$BASE" "$OLDEST_TAG")
+          VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST_TAG" || echo "$OLDEST_TAG")
           echo "images=$IMAGES" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Log in to GHCR

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -91,10 +91,11 @@ jobs:
       - name: Determine versions
         id: versions
         run: |
-          LATEST=$(node -p "require('./integration-tests/playwright/versions').tag(require('./integration-tests/playwright/versions').latest)")
-          OLDEST=$(node -p "require('./integration-tests/playwright/versions').tag(require('./integration-tests/playwright/versions').oldest)")
+          LATEST=$(node -p "require('./integration-tests/playwright/versions').latest")
+          OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
+          DOCKER_HASH=$(sha256sum .github/playwright/Dockerfile | cut -c1-8)
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
-          IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST" "$BASE" "$OLDEST")
+          IMAGES=$(printf '{"latest":"%s:%s-%s","oldest":"%s:%s-%s"}' "$BASE" "$LATEST" "$DOCKER_HASH" "$BASE" "$OLDEST" "$DOCKER_HASH")
           VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST" || echo "$OLDEST")
           echo "images=$IMAGES" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -79,8 +79,9 @@ jobs:
       contents: read
       packages: write
     outputs:
-      latest-version: ${{ steps.versions.outputs.latest }}
-      oldest-version: ${{ steps.versions.outputs.oldest }}
+      images: ${{ steps.versions.outputs.images }}
+      latest: ${{ steps.versions.outputs.latest }}
+      oldest: ${{ steps.versions.outputs.oldest }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Determine versions
@@ -88,6 +89,9 @@ jobs:
         run: |
           LATEST=$(node -p "require('./integration-tests/playwright/versions').latest")
           OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
+          BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
+          IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST" "$BASE" "$OLDEST")
+          echo "images=$IMAGES" >> $GITHUB_OUTPUT
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
           echo "oldest=$OLDEST" >> $GITHUB_OUTPUT
       - name: Log in to GHCR
@@ -141,11 +145,7 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: >-
-        ghcr.io/datadog/dd-trace-js/playwright-tools:${{
-          matrix.playwright-version == 'latest'
-          && needs.playwright-image.outputs.latest-version
-          || needs.playwright-image.outputs.oldest-version }}
+      image: ${{ fromJson(needs.playwright-image.outputs.images)[matrix.playwright-version] }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -73,15 +73,19 @@ jobs:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
   playwright-image:
-    name: Ensure Playwright Docker images
+    strategy:
+      fail-fast: false
+      matrix:
+        playwright-version: [oldest, latest]
+    name: Ensure Playwright Docker image (${{ matrix.playwright-version }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
+      # Both matrix jobs set this to the same value, so the last-writer-wins
+      # behaviour of matrix outputs is safe here.
       images: ${{ steps.versions.outputs.images }}
-      latest: ${{ steps.versions.outputs.latest }}
-      oldest: ${{ steps.versions.outputs.oldest }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Determine versions
@@ -91,30 +95,18 @@ jobs:
           OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
           BASE="ghcr.io/datadog/dd-trace-js/playwright-tools"
           IMAGES=$(printf '{"latest":"%s:%s","oldest":"%s:%s"}' "$BASE" "$LATEST" "$BASE" "$OLDEST")
+          VERSION=$([ "${{ matrix.playwright-version }}" = "latest" ] && echo "$LATEST" || echo "$OLDEST")
           echo "images=$IMAGES" >> $GITHUB_OUTPUT
-          echo "latest=$LATEST" >> $GITHUB_OUTPUT
-          echo "oldest=$OLDEST" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Ensure latest image
+      - name: Ensure image
         env:
-          VERSION: ${{ steps.versions.outputs.latest }}
-        run: |
-          IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${VERSION}"
-          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
-            echo "Image ${IMAGE} already exists, skipping build"
-          else
-            docker build --build-arg PLAYWRIGHT_VERSION="${VERSION}" \
-              -t "${IMAGE}" .github/playwright
-            docker push "${IMAGE}"
-          fi
-      - name: Ensure oldest image
-        env:
-          VERSION: ${{ steps.versions.outputs.oldest }}
+          VERSION: ${{ steps.versions.outputs.version }}
         run: |
           IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${VERSION}"
           if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -72,7 +72,57 @@ jobs:
           flags: test-optimization-testopt-${{ matrix.version }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
+  playwright-image:
+    name: Ensure Playwright Docker images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      latest-version: ${{ steps.versions.outputs.latest }}
+      oldest-version: ${{ steps.versions.outputs.oldest }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Determine versions
+        id: versions
+        run: |
+          LATEST=$(node -p "require('./integration-tests/playwright/versions').latest")
+          OLDEST=$(node -p "require('./integration-tests/playwright/versions').oldest")
+          echo "latest=$LATEST" >> $GITHUB_OUTPUT
+          echo "oldest=$OLDEST" >> $GITHUB_OUTPUT
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Ensure latest image
+        env:
+          VERSION: ${{ steps.versions.outputs.latest }}
+        run: |
+          IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${VERSION}"
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "Image ${IMAGE} already exists, skipping build"
+          else
+            docker build --build-arg PLAYWRIGHT_VERSION="${VERSION}" \
+              -t "${IMAGE}" .github/playwright
+            docker push "${IMAGE}"
+          fi
+      - name: Ensure oldest image
+        env:
+          VERSION: ${{ steps.versions.outputs.oldest }}
+        run: |
+          IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${VERSION}"
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "Image ${IMAGE} already exists, skipping build"
+          else
+            docker build --build-arg PLAYWRIGHT_VERSION="${VERSION}" \
+              -t "${IMAGE}" .github/playwright
+            docker push "${IMAGE}"
+          fi
+
   integration-playwright:
+    needs: playwright-image
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +141,14 @@ jobs:
     permissions:
       id-token: write
     container:
-      image: ghcr.io/rochdev/playwright-tools@sha256:65b8161e23ede2354d04c8a242032d9ee8ca275359eac1764c027f073d38217c # 1.54.1-5
+      image: >-
+        ghcr.io/datadog/dd-trace-js/playwright-tools:${{
+          matrix.playwright-version == 'latest'
+          && needs.playwright-image.outputs.latest-version
+          || needs.playwright-image.outputs.oldest-version }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
@@ -105,25 +162,6 @@ jobs:
         with:
           version: ${{ matrix.node-version }}
       - uses: ./.github/actions/install
-      # We need this because the "oldest" playwright version depends on the major version of dd-trace
-      # For v5 it's 1.18.0 and for v6 it's 1.38.0
-      # We don't cache "latest" because it changes based on playwright releases.
-      # We could do it, but we'd have to request GitHub API to get the latest version,
-      # and the cache hit rate would be way lower than for "oldest", which should be 100%.
-      - name: Get dd-trace major version
-        if: matrix.playwright-version == 'oldest'
-        id: dd-version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          echo "major=$MAJOR" >> $GITHUB_OUTPUT
-          echo "dd-trace major version: $MAJOR"
-      - name: Cache Playwright browsers
-        if: matrix.playwright-version == 'oldest'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /github/home/.cache/ms-playwright
-          key: playwright-browsers-oldest-dd${{ steps.dd-version.outputs.major }}
       - name: Configure Git safe directory
         # The Playwright job runs in a container where the checkout can be owned by a different UID.
         # Git rejects metadata commands in that checkout unless the workspace is marked as safe.

--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -24,14 +24,13 @@ const {
   TEST_IS_RUM_ACTIVE,
   TEST_BROWSER_VERSION,
 } = require('../../packages/dd-trace/src/plugins/util/test')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
 const NUM_RETRIES_EFD = 3
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-atr.spec.js
+++ b/integration-tests/playwright/playwright-atr.spec.js
@@ -20,12 +20,11 @@ const {
   TEST_HAS_FAILED_ALL_RETRIES,
   TEST_RETRY_REASON_TYPES,
 } = require('../../packages/dd-trace/src/plugins/util/test')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-efd.spec.js
+++ b/integration-tests/playwright/playwright-efd.spec.js
@@ -25,7 +25,6 @@ const {
   TEST_BROWSER_NAME,
   TEST_RETRY_REASON_TYPES,
 } = require('../../packages/dd-trace/src/plugins/util/test')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
@@ -33,7 +32,7 @@ const NUM_RETRIES_EFD = 3
 const PLAYWRIGHT_EFD_GATHER_TIMEOUT = 60000
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -20,14 +20,13 @@ const {
   TEST_MANAGEMENT_IS_DISABLED,
   TEST_MANAGEMENT_IS_QUARANTINED,
 } = require('../../packages/dd-trace/src/plugins/util/test')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
 const NUM_RETRIES_EFD = 3
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-impacted-tests.spec.js
+++ b/integration-tests/playwright/playwright-impacted-tests.spec.js
@@ -24,14 +24,13 @@ const {
   TEST_RETRY_REASON_TYPES,
   TEST_IS_MODIFIED,
 } = require('../../packages/dd-trace/src/plugins/util/test')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
 const NUM_RETRIES_EFD = 3
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -42,12 +42,11 @@ const {
 } = require('../../packages/dd-trace/src/plugins/util/test')
 const { DD_HOST_CPU_COUNT } = require('../../packages/dd-trace/src/plugins/util/env')
 const { ERROR_MESSAGE } = require('../../packages/dd-trace/src/constants')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -30,14 +30,13 @@ const {
   TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED,
   TEST_RETRY_REASON_TYPES,
 } = require('../../packages/dd-trace/src/plugins/util/test')
-const { DD_MAJOR } = require('../../version')
 
 const { PLAYWRIGHT_VERSION } = process.env
 
 const PLAYWRIGHT_TEST_MANAGEMENT_GATHER_TIMEOUT = 60000
 
 const latest = 'latest'
-const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const { oldest } = require('./versions')
 const versions = [oldest, latest]
 
 versions.forEach((version) => {

--- a/integration-tests/playwright/versions.js
+++ b/integration-tests/playwright/versions.js
@@ -2,8 +2,13 @@
 
 const { DD_MAJOR } = require('../../version')
 
+// Increment when the Dockerfile changes to force a fresh image build in GHCR.
+const dockerBuild = 2
+
 const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
 const latest = require('../../packages/dd-trace/test/plugins/versions/package.json')
   .dependencies['@playwright/test']
 
-module.exports = { oldest, latest }
+const tag = (version) => `${version}-${dockerBuild}`
+
+module.exports = { oldest, latest, tag }

--- a/integration-tests/playwright/versions.js
+++ b/integration-tests/playwright/versions.js
@@ -2,13 +2,8 @@
 
 const { DD_MAJOR } = require('../../version')
 
-// Increment when the Dockerfile changes to force a fresh image build in GHCR.
-const dockerBuild = 2
-
 const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
 const latest = require('../../packages/dd-trace/test/plugins/versions/package.json')
   .dependencies['@playwright/test']
 
-const tag = (version) => `${version}-${dockerBuild}`
-
-module.exports = { oldest, latest, tag }
+module.exports = { oldest, latest }

--- a/integration-tests/playwright/versions.js
+++ b/integration-tests/playwright/versions.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { DD_MAJOR } = require('../../version')
+
+const oldest = DD_MAJOR >= 6 ? '1.38.0' : '1.18.0'
+const latest = require('../../packages/dd-trace/test/plugins/versions/package.json')
+  .dependencies['@playwright/test']
+
+module.exports = { oldest, latest }


### PR DESCRIPTION
### What does this PR do?

Adds a versioned Docker image for Playwright tests, built on demand in GHCR, so Playwright, Chromium and system dependencies are no longer reinstalled on every CI run.

### Motivation

The `integration-playwright` job runs 28 matrix jobs. Each called `npx playwright install chromium` in the test `before()` hook with a 120-second timeout. The `latest` Playwright variant had no cache at all, meaning Chromium was downloaded from scratch on every run, causing slowdowns and intermittent failures.

### Changes

- **`.github/playwright/Dockerfile`** — new image based on `node:26-bookworm-slim` (ensures all Node 26 runtime deps including `libatomic1` are present). Installs Playwright + Chromium + system deps, then removes node so `setup-node` is the sole provider at runtime. Bun is copied from `oven/bun:1.3.1`.
- **`test-optimization.yml`** — new `playwright-image` job that checks GHCR for `ghcr.io/datadog/dd-trace-js/playwright-tools:<version>` and only builds if missing. `integration-playwright` gains a `needs: playwright-image` dependency and uses the versioned image tag selected by matrix. The browser cache steps are removed.
- **`integration-tests/playwright/versions.js`** — single source of truth for oldest/latest Playwright version constants, shared between the seven spec files and the workflow (previously duplicated in all of them).

### Additional Notes

The `execSync('npx playwright install chromium')` calls in the spec files are intentionally kept — they are a fast no-op in CI (browser already at `PLAYWRIGHT_BROWSERS_PATH`) and remain necessary for local development.

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)