### PR TITLE
fix(electron): increase assertSomeTraces timeout for IPC window tests

### DIFF
--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -8,6 +8,8 @@ const { afterEach, beforeEach, describe, it } = require('mocha')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withVersions } = require('../../dd-trace/test/setup/mocha')
 
+const IPC_TIMEOUT_MS = 10_000
+
 describe('Plugin', () => {
   let child
   let listener
@@ -52,7 +54,8 @@ describe('Plugin', () => {
     }
 
     describe('electron', () => {
-      describe('without configuration', () => {
+      describe('without configuration', function () {
+        this.timeout(IPC_TIMEOUT_MS + 5_000)
         beforeEach(() => agent.load('electron'))
         beforeEach(function (done) {
           this.timeout(30_000)
@@ -129,7 +132,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'consumer')
-            })
+            }, { timeoutMs: IPC_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -151,7 +154,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'consumer')
-            })
+            }, { timeoutMs: IPC_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -172,7 +175,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'producer')
-            })
+            }, { timeoutMs: IPC_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -195,7 +198,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'consumer')
-            })
+            }, { timeoutMs: IPC_TIMEOUT_MS })
             .then(done)
             .catch(done)
 
@@ -216,7 +219,7 @@ describe('Plugin', () => {
 
               assert.strictEqual(meta.component, 'electron')
               assert.strictEqual(meta['span.kind'], 'producer')
-            })
+            }, { timeoutMs: IPC_TIMEOUT_MS })
             .then(done)
             .catch(done)
 


### PR DESCRIPTION
## Summary

- IPC tests that trigger `loadWindow()` create a full Chromium `BrowserWindow`, which can take 1–2+ seconds in CI
- The default `assertSomeTraces` timeout of 1000ms was too short: other traces would arrive first, the assertion would fail, and the 1000ms window would expire before the target span arrived
- Adds `IPC_TIMEOUT_MS = 10_000` constant and applies it as `{ timeoutMs: IPC_TIMEOUT_MS }` on all 5 IPC `assertSomeTraces` calls, with the `describe` block timeout set to `IPC_TIMEOUT_MS + 5_000` for headroom

## Test plan

- [ ] CI electron job passes without flakes on re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)