### PR TITLE
fix(ci): handle stale failure conclusion in all-green retry

### DIFF
--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -47,6 +47,10 @@ const pollingRetryConclusions = new Set(['failure', 'timed_out'])
 
 let retries = 0
 const retriedRunIds = new Set()
+// Runs where reRunWorkflowFailedJobs returned 403 — GitHub says no failed jobs
+// exist, meaning the run's failure conclusion is stale (e.g. a job that failed
+// due to a GitHub infrastructure error auto-recovered). Treat them as passed.
+const staleFailureRunIds = new Set()
 
 // ETag cache for the workflow-runs poll. GitHub returns 304 Not Modified when
 // the response is unchanged, and 304 responses don't count against the rate
@@ -96,7 +100,8 @@ async function pollUntilDone () {
   const retryFailed = runs.filter(r =>
     r.status === 'completed' &&
     failureConclusions.has(r.conclusion) &&
-    retriedRunIds.has(r.id)
+    retriedRunIds.has(r.id) &&
+    !staleFailureRunIds.has(r.id)
   )
 
   if (retryFailed.length > 0) {
@@ -109,7 +114,8 @@ async function pollUntilDone () {
   const toRetry = runs.filter(r =>
     r.status === 'completed' &&
     pollingRetryConclusions.has(r.conclusion) &&
-    !retriedRunIds.has(r.id)
+    !retriedRunIds.has(r.id) &&
+    !staleFailureRunIds.has(r.id)
   )
 
   const pending = runs.filter(r => r.status !== 'completed').length
@@ -133,9 +139,18 @@ async function pollUntilDone () {
 
 async function rerunFailedWorkflows (workflowRuns) {
   await Promise.all(
-    workflowRuns.map(workflowRun => {
+    workflowRuns.map(async workflowRun => {
       console.log(`Rerunning ${workflowRun.conclusion} workflow run ${workflowRun.id} (${workflowRun.name}).`)
-      return octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
+      try {
+        await octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
+      } catch (err) {
+        if (err.status === 403) {
+          console.log(`Workflow run ${workflowRun.id} (${workflowRun.name}) has no failed jobs — stale failure conclusion, treating as passed.`)
+          staleFailureRunIds.add(workflowRun.id)
+          return
+        }
+        throw err
+      }
     })
   )
 }
@@ -183,7 +198,9 @@ async function checkAllGreen () {
     return
   }
 
-  const failedRuns = runs.filter(r => failureConclusions.has(r.conclusion))
+  const failedRuns = runs.filter(r =>
+    failureConclusions.has(r.conclusion) && !staleFailureRunIds.has(r.id)
+  )
 
   if (failedRuns.length === 0) {
     console.log('All jobs were successful.')

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -148,10 +148,16 @@ async function rerunFailedWorkflows (workflowRuns) {
         )
       } catch (err) {
         if (err.status === 403) {
-          const { id, name } = workflowRun
-          console.log(`Workflow run ${id} (${name}) has no failed jobs — stale conclusion, treating as passed.`)
-          staleFailureRunIds.add(workflowRun.id)
-          return
+          const jobs = await octokit.paginate(octokit.rest.actions.listJobsForWorkflowRun, {
+            owner, repo, run_id: workflowRun.id, filter: 'latest', per_page: 100,
+          })
+          const hasFailedJobs = jobs.some(j => failureConclusions.has(j.conclusion))
+          if (!hasFailedJobs) {
+            const { id, name } = workflowRun
+            console.log(`Workflow run ${id} (${name}) has no failed jobs — stale conclusion, treating as passed.`)
+            staleFailureRunIds.add(workflowRun.id)
+            return
+          }
         }
         throw err
       }

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -141,10 +141,7 @@ async function rerunFailedWorkflows (workflowRuns) {
     workflowRuns.map(async workflowRun => {
       console.log(`Rerunning ${workflowRun.conclusion} workflow run ${workflowRun.id} (${workflowRun.name}).`)
       try {
-        await (workflowRun.conclusion === 'cancelled'
-          ? octokit.rest.actions.reRunWorkflow({ owner, repo, run_id: workflowRun.id })
-          : octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
-        )
+        await octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
       } catch (err) {
         if (err.status === 403) {
           const jobs = await octokit.paginate(octokit.rest.actions.listJobsForWorkflowRun, {

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -142,10 +142,14 @@ async function rerunFailedWorkflows (workflowRuns) {
     workflowRuns.map(async workflowRun => {
       console.log(`Rerunning ${workflowRun.conclusion} workflow run ${workflowRun.id} (${workflowRun.name}).`)
       try {
-        await octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
+        await (workflowRun.conclusion === 'cancelled'
+          ? octokit.rest.actions.reRunWorkflow({ owner, repo, run_id: workflowRun.id })
+          : octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
+        )
       } catch (err) {
         if (err.status === 403) {
-          console.log(`Workflow run ${workflowRun.id} (${workflowRun.name}) has no failed jobs — stale failure conclusion, treating as passed.`)
+          const { id, name } = workflowRun
+          console.log(`Workflow run ${id} (${name}) has no failed jobs — stale conclusion, treating as passed.`)
           staleFailureRunIds.add(workflowRun.id)
           return
         }

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -114,8 +114,7 @@ async function pollUntilDone () {
   const toRetry = runs.filter(r =>
     r.status === 'completed' &&
     pollingRetryConclusions.has(r.conclusion) &&
-    !retriedRunIds.has(r.id) &&
-    !staleFailureRunIds.has(r.id)
+    !retriedRunIds.has(r.id)
   )
 
   const pending = runs.filter(r => r.status !== 'completed').length


### PR DESCRIPTION
### What does this PR do?

Catches the 403 returned by `reRunWorkflowFailedJobs` when a workflow run has a stale `failure` conclusion but no failed jobs remaining, and treats those runs as passed instead of crashing.

### Motivation

When a GitHub Actions job fails due to an infrastructure error (e.g. runner rate limit) and auto-recovers, the workflow run keeps `conclusion:failure` even though all its jobs end up passing. `all-green` saw the stale failure, called `reRunWorkflowFailedJobs`, received a 403 "This workflow run cannot be retried" (nothing to retry), and crashed with an unhandled exception — blocking the PR from merging.

Example failure: https://github.com/DataDog/dd-trace-js/actions/runs/26248439951/job/77252871454?pr=8584

### Additional Notes

The fix introduces `staleFailureRunIds` to track runs that returned 403 on retry. Those runs are excluded from the retry loop, the "failed after retry" check, and the final failure verdict.

> Generated by [Claude Code](https://claude.ai/claude-code)