### PR TITLE
ci(benchmark): reduce iterations to keep jobs under 1 minute

### DIFF
--- a/benchmark/sirun/appsec/meta.json
+++ b/benchmark/sirun/appsec/meta.json
@@ -2,7 +2,7 @@
   "name": "appsec",
   "cachegrind": false,
   "instructions": true,
-  "iterations": 100,
+  "iterations": 70,
   "variants": {
     "control": {
       "setup": "bash -c \"nohup node client.js >/dev/null 2>&1 &\"",

--- a/benchmark/sirun/datastreams/meta.json
+++ b/benchmark/sirun/datastreams/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 30,
+  "iterations": 20,
   "instructions": true,
   "variants": {
     "produce": { "env": { "VARIANT": "produce" } },

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "debugger",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 3,
   "instructions": true,
   "variants": {
     "control": {

--- a/benchmark/sirun/llmobs/meta.json
+++ b/benchmark/sirun/llmobs/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 5,
+  "iterations": 3,
   "instructions": true,
   "variants": {
     "encode-unicode-ascii": {

--- a/benchmark/sirun/log/meta.json
+++ b/benchmark/sirun/log/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 8,
   "instructions": true,
   "variants": {
     "without-log": { "env": { "DD_TRACE_DEBUG": "false" } },

--- a/benchmark/sirun/plugin-dns/meta.json
+++ b/benchmark/sirun/plugin-dns/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 40,
+  "iterations": 25,
   "instructions": true,
   "variants": {
     "control": {

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -3,7 +3,7 @@
   "run": "node spans.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node spans.js\"",
   "cachegrind": false,
-  "iterations": 80,
+  "iterations": 70,
   "instructions": true,
   "variants": {
     "finish-immediately": {


### PR DESCRIPTION
### What does this PR do?

Reduces the iteration counts in several benchmark `meta.json` files so that all variants complete in under 1 minute.

### Motivation

Multiple benchmark jobs were exceeding 1 minute per run. The new iteration counts are scaled proportionally from observed run times, targeting ~55s to leave a safety margin.

| Benchmark | Old iterations | New iterations |
|---|---|---|
| appsec | 100 | 70 |
| datastreams | 30 | 20 |
| debugger | 10 | 3 |
| llmobs | 5 | 3 |
| log | 10 | 8 |
| plugin-dns | 40 | 25 |
| spans | 80 | 70 |

### Additional Notes

Generated by [Claude Code](https://claude.ai/code).