### PR TITLE
chore(ci): update dd-sts-action to v1.0.3

### DIFF
--- a/.github/actions/dd-sts-api-key/action.yml
+++ b/.github/actions/dd-sts-api-key/action.yml
@@ -11,6 +11,6 @@ runs:
   steps:
     - name: Get Datadog API key
       id: dd-sts
-      uses: DataDog/dd-sts-action@cf22dd37b6a6355fd2dcd4b7a1634ef5f837e6fc # v1.0.1
+      uses: DataDog/dd-sts-action@1f350ca511be980515cf08b0bd64182b9c6e5d32 # v1.0.3
       with:
         policy: dd-trace-js-api-key

--- a/.github/actions/dd-sts-app-key/action.yml
+++ b/.github/actions/dd-sts-app-key/action.yml
@@ -11,6 +11,6 @@ runs:
   steps:
     - name: Get Datadog App key
       id: dd-sts
-      uses: DataDog/dd-sts-action@cf22dd37b6a6355fd2dcd4b7a1634ef5f837e6fc # v1.0.1
+      uses: DataDog/dd-sts-action@1f350ca511be980515cf08b0bd64182b9c6e5d32 # v1.0.3
       with:
         policy: dd-trace-js


### PR DESCRIPTION
### What does this PR do?

Bumps `DataDog/dd-sts-action` from v1.0.1 to v1.0.3 in both composite actions:

- `.github/actions/dd-sts-api-key/action.yml`
- `.github/actions/dd-sts-app-key/action.yml`

### Motivation

v1.0.3 contains a fix for a race condition that can cause the API key to never be outputted.

### Additional Notes

Generated by Claude Code.