### PR TITLE
fix(ci): restore azure-cosmos lint and fix electron packaging on Node 24.16+

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -455,7 +455,9 @@ jobs:
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
       - uses: ./.github/actions/testagent/start
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: '24.15'
       - uses: ./.github/actions/install
       # Ubuntu 24.04 tightened AppArmor defaults and now blocks unprivileged user
       # namespaces, which Electron's Chromium sandbox requires to run. Setting

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: '24.15'
       - uses: ./.github/actions/install
       - run: yarn test:integration:electron
       - uses: ./.github/actions/push_to_test_optimization
@@ -37,7 +39,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/dd-sts-api-key
         id: dd-sts
-      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/node
+        with:
+          version: '24.15'
       - uses: ./.github/actions/install
       # Electron needs a display even for headless (show: false) windows.
       # xvfb-run provides a virtual framebuffer so the test can run without a physical display.

--- a/integration-tests/electron/electron.spec.js
+++ b/integration-tests/electron/electron.spec.js
@@ -12,26 +12,25 @@ const { assertTraceReceived } = require('./helpers')
 describe('Electron integration', function () {
   let httpServer
   let httpPort
-  let binaryPath
+  let electronBin
+  let appDir
   let child
 
-  // Create a sandbox with electron and @electron/packager installed alongside dd-trace.
-  // The app source files are copied in; dd-trace is then installed into the app directory
-  // from the pre-packed sandbox tgz so electron-packager bundles it inside the binary.
-  useSandbox(['electron', '@electron/packager'], false, [path.join(__dirname, 'app')])
+  // Create a sandbox with electron installed alongside dd-trace.
+  // The app source files are copied in; dd-trace is installed into the app directory
+  // from the pre-packed sandbox tgz so it is available at runtime.
+  useSandbox(['electron'], false, [path.join(__dirname, 'app')])
 
   before(async function () {
     this.timeout(30_000)
 
     const sandboxFolder = sandboxCwd()
-    const appDir = path.join(sandboxFolder, 'app')
+    appDir = path.join(sandboxFolder, 'app')
 
     // createSandbox packs dd-trace into a .tgz one level above the sandbox folder.
     // We reference it with a file: URL so npm installs the exact local build.
     const ddTraceTgz = path.join(path.dirname(sandboxFolder), 'dd-trace.tgz')
 
-    // Write the app's package.json with dd-trace as a bundled dependency so that
-    // electron-packager includes it inside the binary together with the app source.
     fs.writeFileSync(
       path.join(appDir, 'package.json'),
       JSON.stringify({
@@ -45,43 +44,13 @@ describe('Electron integration', function () {
     // Install dd-trace and its transitive dependencies into the app directory.
     execFileSync('npm', ['install'], { cwd: appDir, stdio: 'pipe' })
 
-    // Use the electron version already installed in the sandbox so that
-    // electron-packager finds the cached binary and does not re-download it.
-    const electronVersion = require(
-      path.join(sandboxFolder, 'node_modules', 'electron', 'package.json')
-    ).version
-
-    // Build a real standalone Electron binary. Running a compiled binary rather
-    // than `electron <dir>` is a more faithful test of production behaviour.
-    const outDir = path.join(sandboxFolder, 'dist')
-    fs.mkdirSync(outDir, { recursive: true })
-
-    execFileSync(
-      path.join(sandboxFolder, 'node_modules', '.bin', 'electron-packager'),
-      [
-        appDir,
-        'ElectronTest',
-        `--platform=${process.platform}`,
-        `--arch=${process.arch}`,
-        `--electron-version=${electronVersion}`,
-        `--out=${outDir}`,
-        '--overwrite',
-      ],
-      { cwd: sandboxFolder, stdio: 'pipe' }
-    )
-
-    // The layout produced by electron-packager differs per platform:
-    //   macOS  → <out>/ElectronTest-darwin-<arch>/ElectronTest.app/Contents/MacOS/ElectronTest
-    //   Linux  → <out>/ElectronTest-linux-<arch>/ElectronTest
-    //   Windows→ <out>/ElectronTest-win32-<arch>/ElectronTest.exe
-    const packageDir = path.join(outDir, `ElectronTest-${process.platform}-${process.arch}`)
-    if (process.platform === 'darwin') {
-      binaryPath = path.join(packageDir, 'ElectronTest.app', 'Contents', 'MacOS', 'ElectronTest')
-    } else if (process.platform === 'win32') {
-      binaryPath = path.join(packageDir, 'ElectronTest.exe')
-    } else {
-      binaryPath = path.join(packageDir, 'ElectronTest')
-    }
+    // Use the electron binary already installed in the sandbox. Reading path.txt
+    // (written by electron's postinstall) avoids any per-platform path logic here.
+    const electronRelPath = fs.readFileSync(
+      path.join(sandboxFolder, 'node_modules', 'electron', 'path.txt'),
+      'utf-8'
+    ).trim()
+    electronBin = path.join(sandboxFolder, 'node_modules', 'electron', 'dist', electronRelPath)
 
     await new Promise(resolve => {
       httpServer = http.createServer((_req, res) => {
@@ -102,7 +71,8 @@ describe('Electron integration', function () {
   beforeEach(function (done) {
     this.timeout(30_000)
 
-    child = spawn(binaryPath, process.platform === 'linux' ? ['--no-sandbox'] : [], {
+    const args = [appDir, ...(process.platform === 'linux' ? ['--no-sandbox'] : [])]
+    child = spawn(electronBin, args, {
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
       windowsHide: true,
     })

--- a/integration-tests/electron/electron.spec.js
+++ b/integration-tests/electron/electron.spec.js
@@ -67,7 +67,7 @@ describe('Electron integration', function () {
         `--out=${outDir}`,
         '--overwrite',
       ],
-      { cwd: sandboxFolder, stdio: 'inherit', env: { ...process.env, DEBUG: '@electron/*' } }
+      { cwd: sandboxFolder, stdio: 'pipe' }
     )
 
     // The layout produced by electron-packager differs per platform:

--- a/integration-tests/electron/electron.spec.js
+++ b/integration-tests/electron/electron.spec.js
@@ -12,25 +12,26 @@ const { assertTraceReceived } = require('./helpers')
 describe('Electron integration', function () {
   let httpServer
   let httpPort
-  let electronBin
-  let appDir
+  let binaryPath
   let child
 
-  // Create a sandbox with electron installed alongside dd-trace.
-  // The app source files are copied in; dd-trace is installed into the app directory
-  // from the pre-packed sandbox tgz so it is available at runtime.
-  useSandbox(['electron'], false, [path.join(__dirname, 'app')])
+  // Create a sandbox with electron and @electron/packager installed alongside dd-trace.
+  // The app source files are copied in; dd-trace is then installed into the app directory
+  // from the pre-packed sandbox tgz so electron-packager bundles it inside the binary.
+  useSandbox(['electron', '@electron/packager'], false, [path.join(__dirname, 'app')])
 
   before(async function () {
     this.timeout(30_000)
 
     const sandboxFolder = sandboxCwd()
-    appDir = path.join(sandboxFolder, 'app')
+    const appDir = path.join(sandboxFolder, 'app')
 
     // createSandbox packs dd-trace into a .tgz one level above the sandbox folder.
     // We reference it with a file: URL so npm installs the exact local build.
     const ddTraceTgz = path.join(path.dirname(sandboxFolder), 'dd-trace.tgz')
 
+    // Write the app's package.json with dd-trace as a bundled dependency so that
+    // electron-packager includes it inside the binary together with the app source.
     fs.writeFileSync(
       path.join(appDir, 'package.json'),
       JSON.stringify({
@@ -44,13 +45,43 @@ describe('Electron integration', function () {
     // Install dd-trace and its transitive dependencies into the app directory.
     execFileSync('npm', ['install'], { cwd: appDir, stdio: 'pipe' })
 
-    // Use the electron binary already installed in the sandbox. Reading path.txt
-    // (written by electron's postinstall) avoids any per-platform path logic here.
-    const electronRelPath = fs.readFileSync(
-      path.join(sandboxFolder, 'node_modules', 'electron', 'path.txt'),
-      'utf-8'
-    ).trim()
-    electronBin = path.join(sandboxFolder, 'node_modules', 'electron', 'dist', electronRelPath)
+    // Use the electron version already installed in the sandbox so that
+    // electron-packager finds the cached binary and does not re-download it.
+    const electronVersion = require(
+      path.join(sandboxFolder, 'node_modules', 'electron', 'package.json')
+    ).version
+
+    // Build a real standalone Electron binary. Running a compiled binary rather
+    // than `electron <dir>` is a more faithful test of production behaviour.
+    const outDir = path.join(sandboxFolder, 'dist')
+    fs.mkdirSync(outDir, { recursive: true })
+
+    execFileSync(
+      path.join(sandboxFolder, 'node_modules', '.bin', 'electron-packager'),
+      [
+        appDir,
+        'ElectronTest',
+        `--platform=${process.platform}`,
+        `--arch=${process.arch}`,
+        `--electron-version=${electronVersion}`,
+        `--out=${outDir}`,
+        '--overwrite',
+      ],
+      { cwd: sandboxFolder, stdio: 'inherit', env: { ...process.env, DEBUG: '@electron/*' } }
+    )
+
+    // The layout produced by electron-packager differs per platform:
+    //   macOS  → <out>/ElectronTest-darwin-<arch>/ElectronTest.app/Contents/MacOS/ElectronTest
+    //   Linux  → <out>/ElectronTest-linux-<arch>/ElectronTest
+    //   Windows→ <out>/ElectronTest-win32-<arch>/ElectronTest.exe
+    const packageDir = path.join(outDir, `ElectronTest-${process.platform}-${process.arch}`)
+    if (process.platform === 'darwin') {
+      binaryPath = path.join(packageDir, 'ElectronTest.app', 'Contents', 'MacOS', 'ElectronTest')
+    } else if (process.platform === 'win32') {
+      binaryPath = path.join(packageDir, 'ElectronTest.exe')
+    } else {
+      binaryPath = path.join(packageDir, 'ElectronTest')
+    }
 
     await new Promise(resolve => {
       httpServer = http.createServer((_req, res) => {
@@ -71,8 +102,7 @@ describe('Electron integration', function () {
   beforeEach(function (done) {
     this.timeout(30_000)
 
-    const args = [appDir, ...(process.platform === 'linux' ? ['--no-sandbox'] : [])]
-    child = spawn(electronBin, args, {
+    child = spawn(binaryPath, process.platform === 'linux' ? ['--no-sandbox'] : [], {
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
       windowsHide: true,
     })

--- a/packages/datadog-plugin-azure-cosmos/test/index.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/index.spec.js
@@ -80,7 +80,8 @@ describe('Plugin', () => {
 
               assert(span.meta['http.useragent'].includes('azure-cosmos-js/'), 'expected http.useragent in span meta')
               assert(parseInt(span.meta['db.response.status_code']) >= 200 &&
-                parseInt(span.meta['db.response.status_code']) < 300)
+                parseInt(span.meta['db.response.status_code']) < 300,
+                `expected 2xx status code, got ${span.meta['db.response.status_code']}`)
 
               validatedResources.add(resource)
             }
@@ -184,7 +185,8 @@ describe('Plugin', () => {
               },
             })
 
-            assert(conflictCreate.meta['http.useragent'].includes('azure-cosmos-js/'))
+            assert(conflictCreate.meta['http.useragent'].includes('azure-cosmos-js/'),
+              `expected http.useragent to include 'azure-cosmos-js/', got ${conflictCreate.meta['http.useragent']}`)
           }
         )
 

--- a/packages/datadog-plugin-azure-cosmos/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/integration-test/client.spec.js
@@ -41,7 +41,7 @@ describe('esm', () => {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
-          assert.ok(Array.isArray(payload))
+          assert.ok(Array.isArray(payload), `expected payload to be an array, got ${typeof payload}`)
           assert.strictEqual(checkSpansForServiceName(payload, 'cosmosdb.query'), true)
         })
 


### PR DESCRIPTION
### What does this PR do?

Two unrelated CI fixes bundled together:

**1. Azure CosmosDB lint (`test(azure-cosmos)`):** Three `assert`/`assert.ok` calls in the azure-cosmos plugin tests were missing descriptive messages, violating the `eslint-require-boolean-assert-message` rule and causing `npm run lint` to fail on master.

**2. Electron workflow (`fix(electron)`):** `@electron/packager@20` silently exits without producing a binary on Node.js 24.16+. The process prints `Packaging app for platform X...` then exits ~40ms later with code 0 and no output — a regression introduced in Node.js 24.16.0. Pin the electron workflow to Node.js 24.15 until upstream (`@electron/packager` / its dependencies) is fixed.

### Motivation

Both issues were causing consistent CI failures across all PRs. The lint failure was pre-existing on master. The electron failure started on May 22 when Node.js 24.16.0 was released and `node/latest` began resolving to it.

### Additional Notes

Generated by Claude Code.