### PR TITLE
test(playwright): reuse browser server across integration tests

### DIFF
--- a/integration-tests/helpers/playwright.js
+++ b/integration-tests/helpers/playwright.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const path = require('node:path')
+const { sandboxCwd } = require('./index')
+
+/**
+ * Registers before/after hooks that launch a shared Playwright browser server
+ * for the enclosing describe block, so each exec'd `playwright test` subprocess
+ * connects to an existing browser instead of launching a new one.
+ *
+ * Must be called after the before() hook that installs Chromium, so that
+ * playwright-core and the browser binary are ready.
+ *
+ * The endpoint is written to process.env.BROWSER_WS_ENDPOINT, which is picked
+ * up automatically by getCiVisAgentlessConfig/getCiVisEvpProxyConfig (both
+ * spread process.env) and read by integration-tests/playwright.config.js.
+ */
+function useBrowserServer () {
+  let browserServer
+
+  before(async function () {
+    const { chromium } = require(path.join(sandboxCwd(), 'node_modules', 'playwright-core'))
+    browserServer = await chromium.launchServer()
+    process.env.BROWSER_WS_ENDPOINT = browserServer.wsEndpoint()
+  })
+
+  after(async function () {
+    await browserServer?.close()
+    delete process.env.BROWSER_WS_ENDPOINT
+  })
+}
+
+module.exports = { useBrowserServer }

--- a/integration-tests/playwright.config.js
+++ b/integration-tests/playwright.config.js
@@ -48,4 +48,8 @@ if (process.env.MAX_FAILURES) {
   config.maxFailures = Number(process.env.MAX_FAILURES)
 }
 
+if (process.env.BROWSER_WS_ENDPOINT) {
+  config.use = { browserWSEndpoint: process.env.BROWSER_WS_ENDPOINT }
+}
+
 module.exports = config

--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -13,6 +13,7 @@ const {
   getCiVisEvpProxyConfig,
   assertObjectContains,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const { createWebAppServerWithRedirect } = require('../ci-visibility/web-app-server-with-redirect')
@@ -87,6 +88,8 @@ versions.forEach((version) => {
       await new Promise(resolve => webAppServer.close(resolve))
       await new Promise(resolve => webAppServerWithRedirect.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()

--- a/integration-tests/playwright/playwright-atr.spec.js
+++ b/integration-tests/playwright/playwright-atr.spec.js
@@ -11,6 +11,7 @@ const {
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -72,6 +73,8 @@ versions.forEach((version) => {
     after(async () => {
       await new Promise(resolve => webAppServer.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()

--- a/integration-tests/playwright/playwright-efd.spec.js
+++ b/integration-tests/playwright/playwright-efd.spec.js
@@ -11,6 +11,7 @@ const {
   getCiVisAgentlessConfig,
   assertObjectContains,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -80,6 +81,8 @@ versions.forEach((version) => {
     after(async () => {
       await new Promise(resolve => webAppServer.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -10,6 +10,7 @@ const {
   useSandbox,
   getCiVisAgentlessConfig,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -77,6 +78,8 @@ versions.forEach((version) => {
     after(async () => {
       await new Promise(resolve => webAppServer.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()

--- a/integration-tests/playwright/playwright-impacted-tests.spec.js
+++ b/integration-tests/playwright/playwright-impacted-tests.spec.js
@@ -13,6 +13,7 @@ const {
   getCiVisAgentlessConfig,
   assertObjectContains,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -78,6 +79,8 @@ versions.forEach((version) => {
     after(async () => {
       await new Promise(resolve => webAppServer.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -13,6 +13,7 @@ const {
   getCiVisEvpProxyConfig,
   assertObjectContains,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -94,6 +95,8 @@ versions.forEach((version) => {
     after(async () => {
       await new Promise(resolve => webAppServer.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -12,6 +12,7 @@ const {
   getCiVisAgentlessConfig,
   assertObjectContains,
 } = require('../helpers')
+const { useBrowserServer } = require('../helpers/playwright')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const { createWebAppServer } = require('../ci-visibility/web-app-server')
 const {
@@ -84,6 +85,8 @@ versions.forEach((version) => {
     after(async () => {
       await new Promise(resolve => webAppServer.close(resolve))
     })
+
+    useBrowserServer()
 
     beforeEach(async function () {
       receiver = await new FakeCiVisIntake().start()


### PR DESCRIPTION
### What does this PR do?

Adds a `useBrowserServer()` hook helper to `integration-tests/helpers/playwright.js` that launches a Playwright browser server once per spec file (in `before()`/`after()`) instead of letting each `playwright test` subprocess launch its own Chromium instance.

All 7 Playwright integration spec files are updated to call `useBrowserServer()`, and `playwright.config.js` is updated to connect to the shared server via `browserWSEndpoint` when `BROWSER_WS_ENDPOINT` is set.

### Motivation

Each `it()` test spawns a fresh `playwright test` subprocess which previously launched a new Chromium browser, adding ~1–2s of startup overhead per test. Since `getCiVisAgentlessConfig`/`getCiVisEvpProxyConfig` both spread `process.env`, setting the endpoint there propagates to all subprocesses automatically — no exec call sites needed changing.

### Additional Notes

- The helper is Playwright-specific and lives in its own file (`helpers/playwright.js`) rather than the generic `helpers/index.js`.
- Each subprocess still gets a fresh `BrowserContext` per test, so there is no state leakage between `it()` tests.
- The browser binary is required from the sandbox path, ensuring version fidelity with the Playwright version under test.

> Generated by [Claude Code](https://github.com/anthropics/claude-code)