### PR TITLE
fix(lint): add proper assert.ok after new lint rule

### DIFF
--- a/packages/datadog-plugin-azure-cosmos/test/index.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/index.spec.js
@@ -79,8 +79,11 @@ describe('Plugin', () => {
               })
 
               assert(span.meta['http.useragent'].includes('azure-cosmos-js/'), 'expected http.useragent in span meta')
-              assert(parseInt(span.meta['db.response.status_code']) >= 200 &&
-                parseInt(span.meta['db.response.status_code']) < 300)
+              assert(
+                parseInt(span.meta['db.response.status_code']) >= 200 &&
+                parseInt(span.meta['db.response.status_code']) < 300,
+                `expected 2xx db.response.status_code, got ${span.meta['db.response.status_code']}`
+              )
 
               validatedResources.add(resource)
             }
@@ -184,7 +187,10 @@ describe('Plugin', () => {
               },
             })
 
-            assert(conflictCreate.meta['http.useragent'].includes('azure-cosmos-js/'))
+            assert(
+              conflictCreate.meta['http.useragent'].includes('azure-cosmos-js/'),
+              `expected http.useragent to include azure-cosmos-js/, got ${conflictCreate.meta['http.useragent']}`
+            )
           }
         )
 

--- a/packages/datadog-plugin-azure-cosmos/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-azure-cosmos/test/integration-test/client.spec.js
@@ -41,7 +41,7 @@ describe('esm', () => {
       it(`is instrumented ${variant}`, async () => {
         const res = agent.assertMessageReceived(({ headers, payload }) => {
           assert.strictEqual(headers.host, `127.0.0.1:${agent.port}`)
-          assert.ok(Array.isArray(payload))
+          assert.ok(Array.isArray(payload), `expected payload to be an array, got ${typeof payload}`)
           assert.strictEqual(checkSpansForServiceName(payload, 'cosmosdb.query'), true)
         })
 


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds proper assert.ok after the newly added eslint rule. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


