### PR TITLE
fix(ci): fix azure-functions cosmosdb test regressions

### DIFF
--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -216,7 +216,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Cosmos emulator to be ready
-        run: timeout 120 bash -c 'until curl -s -o /dev/null --max-time 5 http://127.0.0.1:8080/ready; do sleep 3; done'
+        run: timeout 120 bash -c 'until curl -sf -o /dev/null --max-time 5 http://127.0.0.1:8080/ready; do sleep 3; done'
       - name: Copy emulator config files
         run: |
           docker cp \
@@ -320,7 +320,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Cosmos emulator to be ready
-        run: timeout 120 bash -c 'until curl -s -o /dev/null --max-time 5 http://127.0.0.1:8080/ready; do sleep 3; done'
+        run: timeout 120 bash -c 'until curl -sf -o /dev/null --max-time 5 http://127.0.0.1:8080/ready; do sleep 3; done'
       - uses: ./.github/actions/plugins/test
 
 

--- a/.github/workflows/serverless.yml
+++ b/.github/workflows/serverless.yml
@@ -215,6 +215,8 @@ jobs:
       SPEC: ${{ matrix.spec }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Wait for Cosmos emulator to be ready
+        run: timeout 120 bash -c 'until curl -s -o /dev/null --max-time 5 http://127.0.0.1:8080/ready; do sleep 3; done'
       - name: Copy emulator config files
         run: |
           docker cp \
@@ -318,7 +320,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Wait for Cosmos emulator to be ready
-        run: timeout 120 bash -c 'until nc -z 127.0.0.1 8081; do sleep 3; done'
+        run: timeout 120 bash -c 'until curl -s -o /dev/null --max-time 5 http://127.0.0.1:8080/ready; do sleep 3; done'
       - uses: ./.github/actions/plugins/test
 
 

--- a/packages/datadog-plugin-azure-functions/test/integration-test/cosmosdb-test/cosmosdb.spec.js
+++ b/packages/datadog-plugin-azure-functions/test/integration-test/cosmosdb-test/cosmosdb.spec.js
@@ -10,7 +10,7 @@ const {
   hookFile,
   sandboxCwd,
   useSandbox,
-  curlAndAssertMessage,
+  curl,
   assertObjectContains,
   stopProc,
 } = require('../../../../../integration-tests/helpers')
@@ -55,37 +55,38 @@ describe('esm', () => {
     })
 
     it('propagates cosmosdb writes to azure function trigger', async () => {
-      return curlAndAssertMessage(agent, 'http://127.0.0.1:7071/api/writeToCosmos', ({ headers, payload }) => {
-        assert.ok(Array.isArray(payload), 'trace payload should be an array of traces')
+      const isHttpInvokeGroup = group =>
+        group.some(s => s?.name === 'azure.functions.invoke' && s.resource === 'GET /api/writeToCosmos')
+      const isTriggerGroup = group =>
+        group.some(s => s?.name === 'azure.functions.invoke' && s.resource === 'CosmosDB cosmosDBTrigger1')
 
-        const allSpans = payload.filter(Array.isArray).flat()
+      const groups = await agent.collectGroups({
+        trigger: () => curl('http://127.0.0.1:7071/api/writeToCosmos'),
+        predicate: group => isHttpInvokeGroup(group) || isTriggerGroup(group),
+        expectedCount: 2,
+        timeout: 120000,
+      })
 
-        const httpWriteInvoke = allSpans.find(
-          s =>
-            s?.name === 'azure.functions.invoke' &&
-            (typeof s.resource === 'string' && s.resource === 'GET /api/writeToCosmos')
-        )
-        assert.ok(httpWriteInvoke, 'expected writeToCosmos HTTP invoke span')
+      const httpGroup = groups.find(isHttpInvokeGroup)
+      const triggerGroup = groups.find(isTriggerGroup)
 
-        const cosmosQueryCount = allSpans.filter(s => s?.name === 'cosmosdb.query').length
-        assert.ok(cosmosQueryCount >= 2, `expected cosmosdb.query spans; found ${cosmosQueryCount}`)
+      assert.ok(httpGroup, 'expected writeToCosmos HTTP invoke span')
+      assert.ok(triggerGroup, 'expected CosmosDB trigger invoke span')
 
-        const triggerInvoke = allSpans.find(
-          s =>
-            s?.name === 'azure.functions.invoke' &&
-            (typeof s.resource === 'string' && s.resource === 'CosmosDB cosmosDBTrigger1')
-        )
-        assert.ok(triggerInvoke, 'expected CosmosDB trigger invoke span')
+      const cosmosQueryCount = httpGroup.filter(s => s?.name === 'cosmosdb.query').length
+      assert.ok(cosmosQueryCount >= 2, `expected cosmosdb.query spans; found ${cosmosQueryCount}`)
 
-        assertObjectContains(triggerInvoke, {
-          name: 'azure.functions.invoke',
-          resource: 'CosmosDB cosmosDBTrigger1',
-          type: 'serverless',
-          meta: {
-            'aas.function.trigger': 'CosmosDB',
-            'aas.function.name': 'cosmosDBTrigger1',
-          },
-        })
+      const triggerSpan = triggerGroup.find(
+        s => s?.name === 'azure.functions.invoke' && s.resource === 'CosmosDB cosmosDBTrigger1'
+      )
+      assertObjectContains(triggerSpan, {
+        name: 'azure.functions.invoke',
+        resource: 'CosmosDB cosmosDBTrigger1',
+        type: 'serverless',
+        meta: {
+          'aas.function.trigger': 'CosmosDB',
+          'aas.function.name': 'cosmosDBTrigger1',
+        },
       })
     }).timeout(120000)
   })


### PR DESCRIPTION
### What does this PR do?

Fixes three `azure-functions` test regressions introduced by the CosmosDB PR (#7943).

**CI fix — missing readiness wait (`serverless.yml`):**
The CosmosDB PR added `azurecosmosemulator` as a service container to the `azure-functions` matrix job but omitted the "Wait for Cosmos emulator to be ready" step that already existed on the `azure-cosmos` job. The Azure Functions host reads `MyCosmosDB` from `local.settings.json` on startup and attempts to connect to `http://127.0.0.1:8081/`; without the wait, it hits the emulator while PostgreSQL is still initializing internally, causing a ~57s hang in `func start` that exceeds the 60s `before`-hook timeout. This caused the `eventhubs` and `client` specs to fail with either a timeout or `Port 7071 is unavailable` (the first hung `func` process still holding the port when the second spec tried to start).

Also upgrades both wait steps (here and on `azure-cosmos`) from `nc -z` (TCP-only — passes as soon as the port opens, well before the HTTP server is ready) to `curl http://127.0.0.1:8080/ready`, the dedicated readiness probe endpoint exposed by the vnext-preview emulator on port 8080.

**Test fix — span collection across separate traces (`cosmosdb.spec.js`):**
`curlAndAssertMessage` evaluates each incoming trace message independently. The HTTP invoke span (`GET /api/writeToCosmos`) and the CosmosDB trigger span (`CosmosDB cosmosDBTrigger1`) arrive in separate trace messages because they come from two different function invocations. The original assertion required both spans in a single message, which never happened. Replaced with `agent.collectGroups()` (the same API used by the `eventhubs` spec) which accumulates matching span groups across multiple messages.

### Motivation

Flakiness report flagged `azure-functions` as failing across multiple unrelated branches after the CosmosDB PR landed.

### Additional Notes

The `curl http://127.0.0.1:8080/ready` endpoint is officially documented by Microsoft for the vnext-preview emulator. It returns 200 when all internal components (PostgreSQL, gateway) are ready and 503 otherwise.

> Generated by [Claude Code](https://claude.ai/claude-code)