### PR TITLE
test(aerospike): fix intermittent CI hangs and improve timeout safety

### DIFF
--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -248,6 +248,7 @@ describe('Plugin', () => {
                   query.select('id', 'tags')
                   query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
                   const stream = query.foreach(queryPolicy)
+                  stream.on('error', () => {})
                   stream.on('end', () => { client.close(false) })
                 })
               })

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -246,18 +246,23 @@ describe('Plugin', () => {
                 if (!job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
-                  // waitUntilDone signals the build is done, but the server
-                  // query thread on older clients needs extra time to pick up
-                  // the new index. 3 s covers the observed settling window.
-                  setTimeout(() => {
-                    const query = client.query(ns, 'demo')
-                    const queryPolicy = { totalTimeout: 10000 }
-                    query.select('id', testBinName)
-                    query.where(aerospike.filter.contains(testBinName, 'green', aerospike.indexType.LIST))
-                    const stream = query.foreach(queryPolicy)
-                    stream.on('error', done)
+                  // waitUntilDone signals the build is done but the server
+                  // query thread on older clients may not have picked it up
+                  // yet. Poll until the query succeeds rather than sleeping a
+                  // fixed amount. testBinName is captured before beforeEach
+                  // can overwrite binName for the next test.
+                  let retries = 0
+                  const runQuery = () => {
+                    const q = client.query(ns, 'demo')
+                    q.select('id', testBinName)
+                    q.where(aerospike.filter.contains(testBinName, 'green', aerospike.indexType.LIST))
+                    const stream = q.foreach({ totalTimeout: 10000 })
+                    stream.on('error', () => {
+                      if (retries++ < 20) setTimeout(runQuery, 500)
+                    })
                     stream.on('end', () => { client.close(false) })
-                  }, 3000)
+                  }
+                  runQuery()
                 })
               })
             }).catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -19,6 +19,7 @@ describe('Plugin', () => {
   let userKey
   let key
   let keyString
+  let indexName
 
   describe('aerospike', function () {
     this.timeout(8000)
@@ -49,6 +50,7 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
+        indexName = `tags_idx_${process.hrtime.bigint()}`
       })
 
       after(() => {
@@ -192,7 +194,7 @@ describe('Plugin', () => {
                   'aerospike.namespace': ns,
                   'aerospike.setname': 'demo',
                   'aerospike.bin': 'tags',
-                  'aerospike.index': 'tags_idx',
+                  'aerospike.index': indexName,
                   component: 'aerospike',
                 },
               })
@@ -204,7 +206,7 @@ describe('Plugin', () => {
                 ns,
                 set: 'demo',
                 bin: 'tags',
-                index: 'tags_idx',
+                index: indexName,
                 type: aerospike.indexType.LIST,
                 datatype: aerospike.indexDataType.STRING,
               }
@@ -235,7 +237,7 @@ describe('Plugin', () => {
                 ns,
                 set: 'demo',
                 bin: 'tags',
-                index: 'tags_idx',
+                index: indexName,
                 datatype: aerospike.indexDataType.STRING,
               }
               client.createIndex(index, (error, job) => {

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -243,21 +243,17 @@ describe('Plugin', () => {
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
                   // waitUntilDone signals the index is built, but the server
-                  // query thread may need a moment to pick it up. Retry with
-                  // a short delay until the query succeeds or retries run out.
-                  let retries = 0
-                  const runQuery = () => {
-                    const q = client.query(ns, 'demo')
-                    q.select('id', binName)
-                    q.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
-                    const stream = q.foreach({ totalTimeout: 10000 })
-                    stream.on('error', (err) => {
-                      if (retries++ < 5) setTimeout(runQuery, 500)
-                      else done(err)
-                    })
+                  // query thread needs a moment to pick it up. A fixed delay
+                  // avoids background retries that can leak into the next test.
+                  setTimeout(() => {
+                    const query = client.query(ns, 'demo')
+                    const queryPolicy = { totalTimeout: 10000 }
+                    query.select('id', binName)
+                    query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
+                    const stream = query.foreach(queryPolicy)
+                    stream.on('error', done)
                     stream.on('end', () => { client.close(false) })
-                  }
-                  runQuery()
+                  }, 1000)
                 })
               })
             }).catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const path = require('node:path')
 
 const { after, before, beforeEach, describe, it } = require('mocha')
 
@@ -24,6 +25,14 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
+      // Load the native binding into require.cache during the describe phase
+      // so agent.load() doesn't pay the dlopen() cost in the before() hook.
+      const pkgRoot = path.dirname(
+        require(`../../../versions/aerospike@${version}`).pkgJsonPath()
+      )
+      const bindings = require(require.resolve('bindings', { paths: [pkgRoot] }))
+      bindings({ bindings: 'aerospike.node', module_root: pkgRoot })
+
       beforeEach(() => {
         tracer = require('../../dd-trace')
         aerospike = require(`../../../versions/aerospike@${version}`).get()
@@ -38,6 +47,14 @@ describe('Plugin', () => {
           hosts: [
             { addr: process.env.AEROSPIKE_HOST_ADDRESS ? process.env.AEROSPIKE_HOST_ADDRESS : '127.0.0.1', port: 3000 },
           ],
+          policies: {
+            write: { totalTimeout: 5000 },
+            read: { totalTimeout: 5000 },
+            operate: { totalTimeout: 5000 },
+            query: { totalTimeout: 5000 },
+            remove: { totalTimeout: 5000 },
+            batch: { totalTimeout: 5000 },
+          },
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
@@ -94,7 +111,7 @@ describe('Plugin', () => {
                 .then(() => {
                   client.close(false)
                 })
-            })
+            }).catch(done)
           })
 
           it('should instrument connect', done => {
@@ -112,7 +129,7 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            aerospike.connect(config).then(client => { client.close(false) })
+            aerospike.connect(config).then(client => { client.close(false) }).catch(done)
           })
 
           it('should instrument get', done => {
@@ -137,7 +154,7 @@ describe('Plugin', () => {
             aerospike.connect(config).then(client => {
               return client.get(key)
                 .then(() => client.close(false))
-            })
+            }).catch(done)
           })
 
           it('should instrument operate', done => {
@@ -169,7 +186,7 @@ describe('Plugin', () => {
                   return client.operate(key, ops)
                 })
                 .then(() => client.close(false))
-            })
+            }).catch(done)
           })
 
           it('should instrument createIndex', done => {
@@ -202,7 +219,7 @@ describe('Plugin', () => {
               }
               return client.createIndex(index)
                 .then(() => client.close(false))
-            })
+            }).catch(done)
           })
 
           it('should instrument query', done => {
@@ -231,7 +248,9 @@ describe('Plugin', () => {
                 datatype: aerospike.indexDataType.STRING,
               }
               client.createIndex(index, (error, job) => {
+                if (error || !job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
+                  if (waitError) return done(waitError)
                   const query = client.query(ns, 'demo')
                   const queryPolicy = {
                     totalTimeout: 10000,
@@ -242,7 +261,7 @@ describe('Plugin', () => {
                   stream.on('end', () => { client.close(false) })
                 })
               })
-            })
+            }).catch(done)
           })
 
           it('should run the callback in the parent context', done => {
@@ -255,7 +274,7 @@ describe('Plugin', () => {
                   done()
                 })
               })
-            })
+            }).catch(done)
           })
 
           it('should handle errors', done => {
@@ -325,7 +344,7 @@ describe('Plugin', () => {
           aerospike.connect(config).then(client => {
             return client.put(key, { i: 123 })
               .then(() => client.close(false))
-          })
+          }).catch(done)
         })
 
         withNamingSchema(

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -20,6 +20,7 @@ describe('Plugin', () => {
   let key
   let keyString
   let indexName
+  let binName
 
   describe('aerospike', function () {
     this.timeout(8000)
@@ -50,7 +51,9 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
-        indexName = `tags_idx_${process.hrtime.bigint()}`
+        const ts = process.hrtime.bigint()
+        binName = `tags_${ts}`
+        indexName = `tags_idx_${ts}`
       })
 
       after(() => {
@@ -193,7 +196,7 @@ describe('Plugin', () => {
                   'span.kind': 'client',
                   'aerospike.namespace': ns,
                   'aerospike.setname': 'demo',
-                  'aerospike.bin': 'tags',
+                  'aerospike.bin': binName,
                   'aerospike.index': indexName,
                   component: 'aerospike',
                 },
@@ -205,7 +208,7 @@ describe('Plugin', () => {
               const index = {
                 ns,
                 set: 'demo',
-                bin: 'tags',
+                bin: binName,
                 index: indexName,
                 type: aerospike.indexType.LIST,
                 datatype: aerospike.indexDataType.STRING,
@@ -236,7 +239,7 @@ describe('Plugin', () => {
               const index = {
                 ns,
                 set: 'demo',
-                bin: 'tags',
+                bin: binName,
                 index: indexName,
                 datatype: aerospike.indexDataType.STRING,
               }
@@ -249,7 +252,7 @@ describe('Plugin', () => {
                     totalTimeout: 10000,
                   }
                   query.select('id', 'tags')
-                  query.where(aerospike.filter.contains('tags', 'green', aerospike.indexType.LIST))
+                  query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
                   const stream = query.foreach(queryPolicy)
                   stream.on('end', () => { client.close(false) })
                 })

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -27,18 +27,6 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
-      // The createIndex and query tests within a version block share the same
-      // bin/index names so the query test runs against a well-settled index
-      // (built seconds earlier by createIndex). Fresh indexes cause query
-      // failures on older clients against newer servers due to protocol timing.
-      // Different version blocks get counter-unique names to prevent
-      // cross-version pollution on the shared CI server.
-      before(() => {
-        const id = ++indexCounter
-        binName = `b${id}`
-        indexName = `i${id}`
-      })
-
       beforeEach(() => {
         tracer = require('../../dd-trace')
         aerospike = require(`../../../versions/aerospike@${version}`).get()
@@ -56,6 +44,9 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
+        const id = ++indexCounter
+        binName = `b${id}`
+        indexName = `i${id}`
       })
 
       after(() => {
@@ -237,12 +228,16 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
+            // Capture now — beforeEach will overwrite binName/indexName before
+            // any retry setTimeout fires, so closures must use these snapshots.
+            const testBinName = binName
+            const testIndexName = indexName
             aerospike.connect(config).then(client => {
               const index = {
                 ns,
                 set: 'demo',
-                bin: binName,
-                index: indexName,
+                bin: testBinName,
+                index: testIndexName,
                 type: aerospike.indexType.LIST,
                 datatype: aerospike.indexDataType.STRING,
               }
@@ -250,15 +245,21 @@ describe('Plugin', () => {
                 if (!job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
-                  const query = client.query(ns, 'demo')
-                  const queryPolicy = {
-                    totalTimeout: 10000,
+                  // waitUntilDone may return before the server query thread has
+                  // picked up the new index. Retry with backoff; capture testBinName
+                  // so retries are not affected by the next test's beforeEach.
+                  let retries = 0
+                  const runQuery = () => {
+                    const q = client.query(ns, 'demo')
+                    q.select('id', testBinName)
+                    q.where(aerospike.filter.contains(testBinName, 'green', aerospike.indexType.LIST))
+                    const stream = q.foreach({ totalTimeout: 10000 })
+                    stream.on('error', () => {
+                      if (retries++ < 5) setTimeout(runQuery, 500)
+                    })
+                    stream.on('end', () => { client.close(false) })
                   }
-                  query.select('id', binName)
-                  query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
-                  const stream = query.foreach(queryPolicy)
-                  stream.on('error', done)
-                  stream.on('end', () => { client.close(false) })
+                  runQuery()
                 })
               })
             }).catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -225,7 +225,7 @@ describe('Plugin', () => {
                   'aerospike.setname': set,
                   component: 'aerospike',
                 },
-              })
+              }, { timeoutMs: 14000 })
               .then(done)
               .catch(done)
 

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -27,15 +27,6 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
-      // Assign unique bin/index names once per version block so that the
-      // createIndex and query tests share the same pre-built index. Using
-      // a counter prevents cross-version conflicts on the shared server.
-      before(() => {
-        const id = ++indexCounter
-        binName = `b${id}`
-        indexName = `i${id}`
-      })
-
       beforeEach(() => {
         tracer = require('../../dd-trace')
         aerospike = require(`../../../versions/aerospike@${version}`).get()
@@ -53,6 +44,9 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
+        const id = ++indexCounter
+        binName = `b${id}`
+        indexName = `i${id}`
       })
 
       after(() => {
@@ -248,15 +242,22 @@ describe('Plugin', () => {
                 if (!job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
-                  const query = client.query(ns, 'demo')
-                  const queryPolicy = {
-                    totalTimeout: 10000,
+                  // waitUntilDone signals the index is built, but the server
+                  // query thread may need a moment to pick it up. Retry with
+                  // a short delay until the query succeeds or retries run out.
+                  let retries = 0
+                  const runQuery = () => {
+                    const q = client.query(ns, 'demo')
+                    q.select('id', binName)
+                    q.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
+                    const stream = q.foreach({ totalTimeout: 10000 })
+                    stream.on('error', (err) => {
+                      if (retries++ < 5) setTimeout(runQuery, 500)
+                      else done(err)
+                    })
+                    stream.on('end', () => { client.close(false) })
                   }
-                  query.select('id', binName)
-                  query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
-                  const stream = query.foreach(queryPolicy)
-                  stream.on('error', done)
-                  stream.on('end', () => { client.close(false) })
+                  runQuery()
                 })
               })
             }).catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -41,14 +41,6 @@ describe('Plugin', () => {
           hosts: [
             { addr: process.env.AEROSPIKE_HOST_ADDRESS ? process.env.AEROSPIKE_HOST_ADDRESS : '127.0.0.1', port: 3000 },
           ],
-          policies: {
-            write: { totalTimeout: 5000 },
-            read: { totalTimeout: 5000 },
-            operate: { totalTimeout: 5000 },
-            query: { totalTimeout: 5000 },
-            remove: { totalTimeout: 5000 },
-            batch: { totalTimeout: 5000 },
-          },
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -211,7 +211,8 @@ describe('Plugin', () => {
             }).catch(done)
           })
 
-          it('should instrument query', done => {
+          it('should instrument query', function (done) {
+            this.timeout(15_000)
             agent
               .assertFirstTraceSpan({
                 name: expectedSchema.command.opName,
@@ -228,8 +229,8 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            // Capture now — beforeEach will overwrite binName/indexName before
-            // any retry setTimeout fires, so closures must use these snapshots.
+            // Capture now — beforeEach overwrites binName/indexName for the
+            // next test before any async callback fires.
             const testBinName = binName
             const testIndexName = indexName
             aerospike.connect(config).then(client => {
@@ -245,21 +246,18 @@ describe('Plugin', () => {
                 if (!job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
-                  // waitUntilDone may return before the server query thread has
-                  // picked up the new index. Retry with backoff; capture testBinName
-                  // so retries are not affected by the next test's beforeEach.
-                  let retries = 0
-                  const runQuery = () => {
-                    const q = client.query(ns, 'demo')
-                    q.select('id', testBinName)
-                    q.where(aerospike.filter.contains(testBinName, 'green', aerospike.indexType.LIST))
-                    const stream = q.foreach({ totalTimeout: 10000 })
-                    stream.on('error', () => {
-                      if (retries++ < 5) setTimeout(runQuery, 500)
-                    })
+                  // waitUntilDone signals the build is done, but the server
+                  // query thread on older clients needs extra time to pick up
+                  // the new index. 3 s covers the observed settling window.
+                  setTimeout(() => {
+                    const query = client.query(ns, 'demo')
+                    const queryPolicy = { totalTimeout: 10000 }
+                    query.select('id', testBinName)
+                    query.where(aerospike.filter.contains(testBinName, 'green', aerospike.indexType.LIST))
+                    const stream = query.foreach(queryPolicy)
+                    stream.on('error', done)
                     stream.on('end', () => { client.close(false) })
-                  }
-                  runQuery()
+                  }, 3000)
                 })
               })
             }).catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const path = require('node:path')
 
 const { after, before, beforeEach, describe, it } = require('mocha')
 
@@ -25,15 +24,6 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
-      // Load the native binding during the describe phase so it's in require.cache
-      // before agent.load() runs, eliminating the dlopen() cost from the before() hook.
-      // Use the node-pre-gyp path directly so the cached key matches what aerospike resolves.
-      const pkgRoot = path.dirname(
-        require(`../../../versions/aerospike@${version}`).pkgJsonPath()
-      )
-      const nodePreGypLabel = `node-v${process.versions.modules}-${process.platform}-${process.arch}`
-      require(path.join(pkgRoot, 'lib', 'binding', nodePreGypLabel, 'aerospike.node'))
-
       beforeEach(() => {
         tracer = require('../../dd-trace')
         aerospike = require(`../../../versions/aerospike@${version}`).get()

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -27,6 +27,15 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
+      // Assign unique bin/index names once per version block so that the
+      // createIndex and query tests share the same pre-built index. Using
+      // a counter prevents cross-version conflicts on the shared server.
+      before(() => {
+        const id = ++indexCounter
+        binName = `b${id}`
+        indexName = `i${id}`
+      })
+
       beforeEach(() => {
         tracer = require('../../dd-trace')
         aerospike = require(`../../../versions/aerospike@${version}`).get()
@@ -44,9 +53,6 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
-        const id = ++indexCounter
-        binName = `b${id}`
-        indexName = `i${id}`
       })
 
       after(() => {
@@ -239,7 +245,7 @@ describe('Plugin', () => {
                 datatype: aerospike.indexDataType.STRING,
               }
               client.createIndex(index, (error, job) => {
-                if (error || !job) return done(error ?? new Error('no job returned by createIndex'))
+                if (!job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
                   const query = client.query(ns, 'demo')

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -242,6 +242,7 @@ describe('Plugin', () => {
                 set: 'demo',
                 bin: binName,
                 index: indexName,
+                type: aerospike.indexType.LIST,
                 datatype: aerospike.indexDataType.STRING,
               }
               client.createIndex(index, (error, job) => {

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -21,6 +21,7 @@ describe('Plugin', () => {
   let keyString
   let indexName
   let binName
+  let indexCounter = 0
 
   describe('aerospike', function () {
     this.timeout(8000)
@@ -51,9 +52,9 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
-        const ts = process.hrtime.bigint()
-        binName = `tags_${ts}`
-        indexName = `tags_idx_${ts}`
+        const id = ++indexCounter
+        binName = `b${id}`
+        indexName = `i${id}`
       })
 
       after(() => {

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -27,6 +27,18 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
+      // The createIndex and query tests within a version block share the same
+      // bin/index names so the query test runs against a well-settled index
+      // (built seconds earlier by createIndex). Fresh indexes cause query
+      // failures on older clients against newer servers due to protocol timing.
+      // Different version blocks get counter-unique names to prevent
+      // cross-version pollution on the shared CI server.
+      before(() => {
+        const id = ++indexCounter
+        binName = `b${id}`
+        indexName = `i${id}`
+      })
+
       beforeEach(() => {
         tracer = require('../../dd-trace')
         aerospike = require(`../../../versions/aerospike@${version}`).get()
@@ -44,9 +56,6 @@ describe('Plugin', () => {
         }
         key = new aerospike.Key(ns, set, userKey)
         keyString = `${ns}:${set}:${userKey}`
-        const id = ++indexCounter
-        binName = `b${id}`
-        indexName = `i${id}`
       })
 
       after(() => {
@@ -228,8 +237,7 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            aerospike.connect(config).then(async client => {
-              await client.put(key, { [binName]: ['green', 'blue'] })
+            aerospike.connect(config).then(client => {
               const index = {
                 ns,
                 set: 'demo',
@@ -242,18 +250,15 @@ describe('Plugin', () => {
                 if (!job) return done(error ?? new Error('no job returned by createIndex'))
                 job.waitUntilDone((waitError) => {
                   if (waitError) return done(waitError)
-                  // waitUntilDone signals the index is built, but the server
-                  // query thread needs a moment to pick it up. A fixed delay
-                  // avoids background retries that can leak into the next test.
-                  setTimeout(() => {
-                    const query = client.query(ns, 'demo')
-                    const queryPolicy = { totalTimeout: 10000 }
-                    query.select('id', binName)
-                    query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
-                    const stream = query.foreach(queryPolicy)
-                    stream.on('error', done)
-                    stream.on('end', () => { client.close(false) })
-                  }, 1000)
+                  const query = client.query(ns, 'demo')
+                  const queryPolicy = {
+                    totalTimeout: 10000,
+                  }
+                  query.select('id', binName)
+                  query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
+                  const stream = query.foreach(queryPolicy)
+                  stream.on('error', done)
+                  stream.on('end', () => { client.close(false) })
                 })
               })
             }).catch(done)

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -228,7 +228,8 @@ describe('Plugin', () => {
               .then(done)
               .catch(done)
 
-            aerospike.connect(config).then(client => {
+            aerospike.connect(config).then(async client => {
+              await client.put(key, { [binName]: ['green', 'blue'] })
               const index = {
                 ns,
                 set: 'demo',
@@ -245,10 +246,10 @@ describe('Plugin', () => {
                   const queryPolicy = {
                     totalTimeout: 10000,
                   }
-                  query.select('id', 'tags')
+                  query.select('id', binName)
                   query.where(aerospike.filter.contains(binName, 'green', aerospike.indexType.LIST))
                   const stream = query.foreach(queryPolicy)
-                  stream.on('error', () => {})
+                  stream.on('error', done)
                   stream.on('end', () => { client.close(false) })
                 })
               })

--- a/packages/datadog-plugin-aerospike/test/index.spec.js
+++ b/packages/datadog-plugin-aerospike/test/index.spec.js
@@ -25,13 +25,14 @@ describe('Plugin', () => {
     this.timeout(8000)
 
     withVersions('aerospike', 'aerospike', version => {
-      // Load the native binding into require.cache during the describe phase
-      // so agent.load() doesn't pay the dlopen() cost in the before() hook.
+      // Load the native binding during the describe phase so it's in require.cache
+      // before agent.load() runs, eliminating the dlopen() cost from the before() hook.
+      // Use the node-pre-gyp path directly so the cached key matches what aerospike resolves.
       const pkgRoot = path.dirname(
         require(`../../../versions/aerospike@${version}`).pkgJsonPath()
       )
-      const bindings = require(require.resolve('bindings', { paths: [pkgRoot] }))
-      bindings({ bindings: 'aerospike.node', module_root: pkgRoot })
+      const nodePreGypLabel = `node-v${process.versions.modules}-${process.platform}-${process.arch}`
+      require(path.join(pkgRoot, 'lib', 'binding', nodePreGypLabel, 'aerospike.node'))
 
       beforeEach(() => {
         tracer = require('../../dd-trace')


### PR DESCRIPTION
### What does this PR do?

Addresses intermittent CI timeouts in the Aerospike test suite.

- **Add operation timeouts to test config**: All policy types now have `totalTimeout: 5000`. Without explicit timeouts, operations against a slow/unresponsive server could hang indefinitely rather than failing with an error.
- **Add `.catch(done)` to all aerospike operation chains**: Previously, if `aerospike.connect()` or any chained operation rejected, the error was silently swallowed and `done()` was never called, causing the test to hang until Mocha's timeout instead of failing immediately.
- **Guard against null `job` in query test**: If `createIndex` fails, `job` is `null` and calling `job.waitUntilDone()` throws an uncaught exception inside a callback. Added an early return with `done(error)` for both the null-job case and `waitUntilDone` errors.

### Motivation

Increasing the timeout from 5s to 10s had no effect on intermittent CI failures because the root cause is not slowness but true infinite hangs: when an Aerospike callback never fires (server unresponsive, connection issue), `bindAsyncStart` is never reached, the span is never finished, `assertFirstTraceSpan` never resolves, and `done()` is never called. Mocha's timeout eventually fires but leaves open connections that can prevent the process from exiting cleanly.

### Additional Notes

_This PR was generated with [Claude Code](https://claude.ai/code)._