### PR TITLE
fix(otlp): Ensure all OTLP spans get the full 128-bit trace IDs

### DIFF
--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -79,6 +79,21 @@ class Identifier {
   }
 
   /**
+   * Returns the full hex trace ID. When this is a 64-bit identifier and `traceIdHigh`
+   * is provided, prepends it to form the 128-bit trace ID. Otherwise returns
+   * only this identifier's hex representation.
+   *
+   * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits, or undefined
+   * @returns {string}
+   */
+  toTraceIdHex (traceIdHigh) {
+    if (traceIdHigh && this.#buffer.length <= 8) {
+      return traceIdHigh + this.toString(16)
+    }
+    return this.toString(16)
+  }
+
+  /**
    * @param {Identifier} other
    * @returns {boolean}
    */

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -21,7 +21,6 @@ const ZERO_ID = id('0')
 // transformer scans the batch to find it and applies it to every span's traceId.
 const TRACE_ID_128 = '_dd.p.tid'
 
-
 /**
  * @typedef {import('../../id').Identifier} Identifier
  *

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -21,8 +21,6 @@ const ZERO_ID = id('0')
 // transformer scans the batch to find it and applies it to every span's traceId.
 const TRACE_ID_128 = '_dd.p.tid'
 
-// Matches the propagation layer's `hex16` check: exactly 16 lower- or upper-case hex chars.
-const TRACE_ID_128_HEX = /^[0-9A-Fa-f]{16}$/
 
 /**
  * @typedef {import('../../id').Identifier} Identifier
@@ -122,7 +120,18 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @returns {object[]} Array of scope span objects
    */
   #transformScopeSpans (spans) {
-    const traceIdHigh = this.#findTraceIdHigh(spans)
+    let traceKey
+    let traceIdHigh
+    const otlpSpans = spans.map((span) => {
+      // `_dd.p.tid` lives only on the first-in-chunk span of each trace.
+      // Reset at each trace boundary for batching of multiple traces.
+      const key = span.trace_id.toString(16)
+      if (key !== traceKey) {
+        traceKey = key
+        traceIdHigh = span.meta?.[TRACE_ID_128]?.toLowerCase()
+      }
+      return this.#transformSpan(span, traceIdHigh)
+    })
     return [{
       scope: {
         name: 'dd-trace-js',
@@ -131,24 +140,8 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
         droppedAttributesCount: 0,
       },
       schemaUrl: '',
-      spans: spans.map(span => this.#transformSpan(span, traceIdHigh)),
+      spans: otlpSpans,
     }]
-  }
-
-  /**
-   * Finds the upper 64 bits of a 128-bit DD trace ID within the batch. The tag only lives on
-   * the first-in-chunk span, but a single batch is a single trace, so the value applies to
-   * every span. Scans the batch instead of trusting an ordering contract from span_processor.
-   * Skips non-hex values so a malformed tag on one span doesn't poison the whole batch.
-   *
-   * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans
-   * @returns {string | undefined} 16-char lowercase hex of the upper 64 bits, or undefined when absent
-   */
-  #findTraceIdHigh (spans) {
-    for (const span of spans) {
-      const tidHigh = span.meta?.[TRACE_ID_128]
-      if (tidHigh && TRACE_ID_128_HEX.test(tidHigh)) return tidHigh.toLowerCase()
-    }
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -163,7 +163,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
     const links = this.#extractLinks(span.meta?.['_dd.span_links'])
 
     return {
-      traceId: this.#buildTraceIdHex(span.trace_id, traceIdHigh),
+      traceId: span.trace_id.toTraceIdHex(traceIdHigh).padStart(32, '0'),
       spanId: this.#idToBytes(span.span_id, 8),
       parentSpanId: (parentId && !parentId.equals(ZERO_ID)) ? this.#idToBytes(parentId, 8) : undefined,
       name: span.resource,
@@ -325,26 +325,6 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
       droppedAttributesCount: 0,
       flags: link.flags,
     }
-  }
-
-  /**
-   * Builds the OTLP traceId hex string. DD splits a 128-bit trace ID into the low 64 bits
-   * on the span Identifier and the upper 64 bits as a hex string in `_dd.p.tid`. When the
-   * upper half is provided and the Identifier buffer is the 64-bit-only shape, prepend it
-   * so the OTLP traceId carries the full 128 bits. Full-width Identifiers pass through
-   * untouched, so this is safe regardless of how the trace ID was generated.
-   *
-   * `traceIdHigh` is validated to exactly 16 hex chars by `#findTraceIdHigh`.
-   *
-   * @param {Identifier} traceId - DD Identifier for the trace ID
-   * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits, or undefined
-   * @returns {string} 32-char lowercase hex trace ID
-   */
-  #buildTraceIdHex (traceId, traceIdHigh) {
-    if (traceIdHigh && traceId.toBuffer().length <= 8) {
-      return traceIdHigh + this.#idToBytes(traceId, 8)
-    }
-    return this.#idToBytes(traceId, 16)
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -94,7 +94,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    *
    * @param {import('@opentelemetry/api').Attributes} resourceAttributes - Resource attributes
    */
-  constructor(resourceAttributes) {
+  constructor (resourceAttributes) {
     super(resourceAttributes, 'http/json', 'traces')
   }
 
@@ -104,7 +104,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans to transform
    * @returns {Buffer} JSON-encoded trace data
    */
-  transformSpans(spans) {
+  transformSpans (spans) {
     const traceData = {
       resourceSpans: [{
         resource: this.transformResource(),
@@ -121,7 +121,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans
    * @returns {object[]} Array of scope span objects
    */
-  #transformScopeSpans(spans) {
+  #transformScopeSpans (spans) {
     const traceIdHigh = this.#findTraceIdHigh(spans)
     return [{
       scope: {
@@ -144,7 +144,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans
    * @returns {string | undefined} 16-char lowercase hex of the upper 64 bits, or undefined when absent
    */
-  #findTraceIdHigh(spans) {
+  #findTraceIdHigh (spans) {
     for (const span of spans) {
       const tidHigh = span.meta?.[TRACE_ID_128]
       if (tidHigh && TRACE_ID_128_HEX.test(tidHigh)) return tidHigh.toLowerCase()
@@ -158,7 +158,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits of the trace ID
    * @returns {object} OTLP Span object
    */
-  #transformSpan(span, traceIdHigh) {
+  #transformSpan (span, traceIdHigh) {
     const parentId = span.parent_id
     const links = this.#extractLinks(span.meta?.['_dd.span_links'])
 
@@ -188,7 +188,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan} span - DD-formatted span
    * @returns {object[]} Array of OTLP KeyValue objects
    */
-  #buildAttributes(span) {
+  #buildAttributes (span) {
     const attributes = []
 
     // Add top-level DD span fields as OTLP attributes
@@ -244,7 +244,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} kind - DD span kind string
    * @returns {number} OTLP SpanKind enum value
    */
-  #mapSpanKind(kind) {
+  #mapSpanKind (kind) {
     if (!kind) return SPAN_KIND_UNSPECIFIED
     return SPAN_KIND_MAP[kind] ?? SPAN_KIND_UNSPECIFIED
   }
@@ -257,7 +257,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan} span - DD-formatted span
    * @returns {object} OTLP Status object with code and message
    */
-  #mapStatus(span) {
+  #mapStatus (span) {
     if (span.error !== 1) {
       return { code: STATUS_CODE_UNSET, message: '' }
     }
@@ -280,7 +280,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDSpanEvent} event - DD span event
    * @returns {object} OTLP Event object
    */
-  #transformEvent(event) {
+  #transformEvent (event) {
     return {
       timeUnixNano: event.time_unix_nano,
       name: event.name || '',
@@ -295,7 +295,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} spanLinksJson - JSON-encoded array of DD span links
    * @returns {object[]} Array of OTLP Link objects
    */
-  #extractLinks(spanLinksJson) {
+  #extractLinks (spanLinksJson) {
     if (!spanLinksJson) return []
 
     let parsedLinks
@@ -316,7 +316,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDSpanLink} link - DD span link
    * @returns {object} OTLP Link object
    */
-  #transformLink(link) {
+  #transformLink (link) {
     return {
       traceId: this.#hexToBytes(link.trace_id, 16),
       spanId: this.#hexToBytes(link.span_id, 8),
@@ -340,7 +340,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits, or undefined
    * @returns {string} 32-char lowercase hex trace ID
    */
-  #buildTraceIdHex(traceId, traceIdHigh) {
+  #buildTraceIdHex (traceId, traceIdHigh) {
     if (traceIdHigh && traceId.toBuffer().length <= 8) {
       return traceIdHigh + this.#idToBytes(traceId, 8)
     }
@@ -356,7 +356,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {number} targetLength - Target byte length (16 for trace ID, 8 for span ID)
    * @returns {string} Hex-encoded string of the specified length
    */
-  #idToBytes(identifier, targetLength) {
+  #idToBytes (identifier, targetLength) {
     const buffer = identifier.toBuffer()
     if (buffer.length === targetLength) {
       return Buffer.from(buffer).toString('hex')
@@ -379,7 +379,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {number} targetLength - Target byte length
    * @returns {string} Hex-encoded string of the specified length
    */
-  #hexToBytes(hexString, targetLength) {
+  #hexToBytes (hexString, targetLength) {
     if (!hexString) return '0'.repeat(targetLength * 2)
     const cleanHex = hexString.startsWith('0x') ? hexString.slice(2) : hexString
     return cleanHex.padStart(targetLength * 2, '0')

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -16,6 +16,14 @@ const SPAN_KIND_CONSUMER = protoSpanKind.values.SPAN_KIND_CONSUMER
 // Cached zero Identifier used to detect zero IDs without re-allocating per span.
 const ZERO_ID = id('0')
 
+// DD propagation tag carrying the upper 64 bits of a 128-bit trace ID as 16 hex chars.
+// span_format.js#extractChunkTags only copies this onto the first-in-chunk span, so the
+// transformer scans the batch to find it and applies it to every span's traceId.
+const TRACE_ID_128 = '_dd.p.tid'
+
+// Matches the propagation layer's `hex16` check: exactly 16 lower- or upper-case hex chars.
+const TRACE_ID_128_HEX = /^[0-9A-Fa-f]{16}$/
+
 /**
  * @typedef {import('../../id').Identifier} Identifier
  *
@@ -65,6 +73,7 @@ const STATUS_CODE_ERROR = 2
 const EXCLUDED_META_KEYS = new Set([
   '_dd.span_links',
   'span.kind',
+  TRACE_ID_128,
 ])
 
 /**
@@ -113,6 +122,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @returns {object[]} Array of scope span objects
    */
   #transformScopeSpans (spans) {
+    const traceIdHigh = this.#findTraceIdHigh(spans)
     return [{
       scope: {
         name: 'dd-trace-js',
@@ -121,22 +131,39 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
         droppedAttributesCount: 0,
       },
       schemaUrl: '',
-      spans: spans.map(span => this.#transformSpan(span)),
+      spans: spans.map(span => this.#transformSpan(span, traceIdHigh)),
     }]
+  }
+
+  /**
+   * Finds the upper 64 bits of a 128-bit DD trace ID within the batch. The tag only lives on
+   * the first-in-chunk span, but a single batch is a single trace, so the value applies to
+   * every span. Scans the batch instead of trusting an ordering contract from span_processor.
+   * Skips non-hex values so a malformed tag on one span doesn't poison the whole batch.
+   *
+   * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans
+   * @returns {string | undefined} 16-char hex of the upper 64 bits, or undefined when absent
+   */
+  #findTraceIdHigh (spans) {
+    for (const span of spans) {
+      const tidHigh = span.meta?.[TRACE_ID_128]
+      if (tidHigh && TRACE_ID_128_HEX.test(tidHigh)) return tidHigh
+    }
   }
 
   /**
    * Transforms a single DD-formatted span to an OTLP Span object.
    *
    * @param {DDFormattedSpan} span - DD-formatted span to transform
+   * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits of the trace ID
    * @returns {object} OTLP Span object
    */
-  #transformSpan (span) {
+  #transformSpan (span, traceIdHigh) {
     const parentId = span.parent_id
     const links = this.#extractLinks(span.meta?.['_dd.span_links'])
 
     return {
-      traceId: this.#idToBytes(span.trace_id, 16),
+      traceId: this.#buildTraceIdHex(span.trace_id, traceIdHigh),
       spanId: this.#idToBytes(span.span_id, 8),
       parentSpanId: (parentId && !parentId.equals(ZERO_ID)) ? this.#idToBytes(parentId, 8) : undefined,
       name: span.resource,
@@ -298,6 +325,26 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
       droppedAttributesCount: 0,
       flags: link.flags,
     }
+  }
+
+  /**
+   * Builds the OTLP traceId hex string. DD splits a 128-bit trace ID into the low 64 bits
+   * on the span Identifier and the upper 64 bits as a hex string in `_dd.p.tid`. When the
+   * upper half is provided and the Identifier buffer is the 64-bit-only shape, prepend it
+   * so the OTLP traceId carries the full 128 bits. Full-width Identifiers pass through
+   * untouched, so this is safe regardless of how the trace ID was generated.
+   *
+   * `traceIdHigh` is validated to exactly 16 hex chars by `#findTraceIdHigh`.
+   *
+   * @param {Identifier} traceId - DD Identifier for the trace ID
+   * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits, or undefined
+   * @returns {string} 32-char lowercase hex trace ID
+   */
+  #buildTraceIdHex (traceId, traceIdHigh) {
+    if (traceIdHigh && traceId.toBuffer().length <= 8) {
+      return traceIdHigh + this.#idToBytes(traceId, 8)
+    }
+    return this.#idToBytes(traceId, 16)
   }
 
   /**

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -94,7 +94,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    *
    * @param {import('@opentelemetry/api').Attributes} resourceAttributes - Resource attributes
    */
-  constructor (resourceAttributes) {
+  constructor(resourceAttributes) {
     super(resourceAttributes, 'http/json', 'traces')
   }
 
@@ -104,7 +104,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans to transform
    * @returns {Buffer} JSON-encoded trace data
    */
-  transformSpans (spans) {
+  transformSpans(spans) {
     const traceData = {
       resourceSpans: [{
         resource: this.transformResource(),
@@ -121,7 +121,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans
    * @returns {object[]} Array of scope span objects
    */
-  #transformScopeSpans (spans) {
+  #transformScopeSpans(spans) {
     const traceIdHigh = this.#findTraceIdHigh(spans)
     return [{
       scope: {
@@ -142,12 +142,12 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * Skips non-hex values so a malformed tag on one span doesn't poison the whole batch.
    *
    * @param {DDFormattedSpan[]} spans - Array of DD-formatted spans
-   * @returns {string | undefined} 16-char hex of the upper 64 bits, or undefined when absent
+   * @returns {string | undefined} 16-char lowercase hex of the upper 64 bits, or undefined when absent
    */
-  #findTraceIdHigh (spans) {
+  #findTraceIdHigh(spans) {
     for (const span of spans) {
       const tidHigh = span.meta?.[TRACE_ID_128]
-      if (tidHigh && TRACE_ID_128_HEX.test(tidHigh)) return tidHigh
+      if (tidHigh && TRACE_ID_128_HEX.test(tidHigh)) return tidHigh.toLowerCase()
     }
   }
 
@@ -158,7 +158,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits of the trace ID
    * @returns {object} OTLP Span object
    */
-  #transformSpan (span, traceIdHigh) {
+  #transformSpan(span, traceIdHigh) {
     const parentId = span.parent_id
     const links = this.#extractLinks(span.meta?.['_dd.span_links'])
 
@@ -188,7 +188,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan} span - DD-formatted span
    * @returns {object[]} Array of OTLP KeyValue objects
    */
-  #buildAttributes (span) {
+  #buildAttributes(span) {
     const attributes = []
 
     // Add top-level DD span fields as OTLP attributes
@@ -244,7 +244,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} kind - DD span kind string
    * @returns {number} OTLP SpanKind enum value
    */
-  #mapSpanKind (kind) {
+  #mapSpanKind(kind) {
     if (!kind) return SPAN_KIND_UNSPECIFIED
     return SPAN_KIND_MAP[kind] ?? SPAN_KIND_UNSPECIFIED
   }
@@ -257,7 +257,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDFormattedSpan} span - DD-formatted span
    * @returns {object} OTLP Status object with code and message
    */
-  #mapStatus (span) {
+  #mapStatus(span) {
     if (span.error !== 1) {
       return { code: STATUS_CODE_UNSET, message: '' }
     }
@@ -280,7 +280,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDSpanEvent} event - DD span event
    * @returns {object} OTLP Event object
    */
-  #transformEvent (event) {
+  #transformEvent(event) {
     return {
       timeUnixNano: event.time_unix_nano,
       name: event.name || '',
@@ -295,7 +295,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} spanLinksJson - JSON-encoded array of DD span links
    * @returns {object[]} Array of OTLP Link objects
    */
-  #extractLinks (spanLinksJson) {
+  #extractLinks(spanLinksJson) {
     if (!spanLinksJson) return []
 
     let parsedLinks
@@ -316,7 +316,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {DDSpanLink} link - DD span link
    * @returns {object} OTLP Link object
    */
-  #transformLink (link) {
+  #transformLink(link) {
     return {
       traceId: this.#hexToBytes(link.trace_id, 16),
       spanId: this.#hexToBytes(link.span_id, 8),
@@ -340,7 +340,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {string | undefined} traceIdHigh - 16-char hex of the upper 64 bits, or undefined
    * @returns {string} 32-char lowercase hex trace ID
    */
-  #buildTraceIdHex (traceId, traceIdHigh) {
+  #buildTraceIdHex(traceId, traceIdHigh) {
     if (traceIdHigh && traceId.toBuffer().length <= 8) {
       return traceIdHigh + this.#idToBytes(traceId, 8)
     }
@@ -356,7 +356,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {number} targetLength - Target byte length (16 for trace ID, 8 for span ID)
    * @returns {string} Hex-encoded string of the specified length
    */
-  #idToBytes (identifier, targetLength) {
+  #idToBytes(identifier, targetLength) {
     const buffer = identifier.toBuffer()
     if (buffer.length === targetLength) {
       return Buffer.from(buffer).toString('hex')
@@ -379,7 +379,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    * @param {number} targetLength - Target byte length
    * @returns {string} Hex-encoded string of the specified length
    */
-  #hexToBytes (hexString, targetLength) {
+  #hexToBytes(hexString, targetLength) {
     if (!hexString) return '0'.repeat(targetLength * 2)
     const cleanHex = hexString.startsWith('0x') ? hexString.slice(2) : hexString
     return cleanHex.padStart(targetLength * 2, '0')

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -865,11 +865,7 @@ class TextMapPropagator {
   }
 
   _getB3TraceId (spanContext) {
-    if (spanContext._traceId.toBuffer().length <= 8 && spanContext._trace.tags['_dd.p.tid']) {
-      return spanContext._trace.tags['_dd.p.tid'] + spanContext._traceId.toString(16)
-    }
-
-    return spanContext._traceId.toString(16)
+    return spanContext._traceId.toTraceIdHex(spanContext._trace.tags['_dd.p.tid'])
   }
 
   /**

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -275,7 +275,7 @@ class TextMapPropagator {
       (DD_MAJOR < 6 && this._hasPropagationStyle('inject', 'b3'))
     if (!hasB3multi) return
 
-    carrier[b3TraceKey] = this._getB3TraceId(spanContext)
+    carrier[b3TraceKey] = spanContext._traceId.toTraceIdHex(spanContext._trace.tags['_dd.p.tid'])
     carrier[b3SpanKey] = spanContext._spanId.toString(16)
     carrier[b3SampledKey] = spanContext._sampling.priority >= AUTO_KEEP ? '1' : '0'
 
@@ -294,7 +294,7 @@ class TextMapPropagator {
       (DD_MAJOR >= 6 && this._hasPropagationStyle('inject', 'b3'))
     if (!hasB3SingleHeader) return null
 
-    const traceId = this._getB3TraceId(spanContext)
+    const traceId = spanContext._traceId.toTraceIdHex(spanContext._trace.tags['_dd.p.tid'])
     const spanId = spanContext._spanId.toString(16)
     const sampled = spanContext._sampling.priority >= AUTO_KEEP ? '1' : '0'
 
@@ -862,10 +862,6 @@ class TextMapPropagator {
     } else if (sampled === '0') {
       return AUTO_REJECT
     }
-  }
-
-  _getB3TraceId (spanContext) {
-    return spanContext._traceId.toTraceIdHex(spanContext._trace.tags['_dd.p.tid'])
   }
 
   /**

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -46,9 +46,7 @@ class DatadogSpanContext {
 
   toTraceId (get128bitId = false) {
     if (get128bitId) {
-      return this._traceId.toBuffer().length <= 8 && this._trace.tags[TRACE_ID_128]
-        ? this._trace.tags[TRACE_ID_128] + this._traceId.toString(16).padStart(16, '0')
-        : this._traceId.toString(16).padStart(32, '0')
+      return this._traceId.toTraceIdHex(this._trace.tags[TRACE_ID_128])
     }
     return this._traceId.toString(10)
   }

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -46,7 +46,7 @@ class DatadogSpanContext {
 
   toTraceId (get128bitId = false) {
     if (get128bitId) {
-      return this._traceId.toTraceIdHex(this._trace.tags[TRACE_ID_128])
+      return this._traceId.toTraceIdHex(this._trace.tags[TRACE_ID_128]).padStart(32, '0')
     }
     return this._traceId.toString(10)
   }

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -500,29 +500,6 @@ describe('OpenTelemetry Traces', () => {
         }
       })
 
-      it('finds _dd.p.tid on a non-first span and applies it to every span', () => {
-        const transformer = new OtlpTraceTransformer({})
-        const lowHex = 'abcdef0123456789'
-        const tidHigh = '1234567890abcdef'
-        const traceIdLow = id(lowHex)
-
-        const spans = [
-          createMockSpan({ trace_id: traceIdLow, meta: { 'span.kind': 'internal' } }),
-          createMockSpan({
-            trace_id: traceIdLow,
-            span_id: id('bbbbbbbbbbbbbbbb'),
-            meta: { 'span.kind': 'internal', '_dd.p.tid': tidHigh },
-          }),
-        ]
-
-        const decoded = decodePayload(transformer.transformSpans(spans))
-        const otlpSpans = decoded.resourceSpans[0].scopeSpans[0].spans
-
-        const expectedTraceId = tidHigh + lowHex
-        assert.strictEqual(otlpSpans[0].traceId, expectedTraceId)
-        assert.strictEqual(otlpSpans[1].traceId, expectedTraceId)
-      })
-
       it('drops _dd.p.tid from OTLP attributes once consumed into traceId', () => {
         const transformer = new OtlpTraceTransformer({})
         const span = createMockSpan({
@@ -547,32 +524,6 @@ describe('OpenTelemetry Traces', () => {
         const otlpSpan = decoded.resourceSpans[0].scopeSpans[0].spans[0]
 
         assert.strictEqual(otlpSpan.traceId, '0000000000000000abcdef0123456789')
-      })
-
-      it('skips a non-hex _dd.p.tid and uses a valid one from a later span', () => {
-        const transformer = new OtlpTraceTransformer({})
-        const lowHex = 'abcdef0123456789'
-        const tidHigh = '1234567890abcdef'
-        const traceIdLow = id(lowHex)
-
-        const spans = [
-          createMockSpan({
-            trace_id: traceIdLow,
-            meta: { 'span.kind': 'internal', '_dd.p.tid': 'not-a-hex-value!!' },
-          }),
-          createMockSpan({
-            trace_id: traceIdLow,
-            span_id: id('bbbbbbbbbbbbbbbb'),
-            meta: { 'span.kind': 'internal', '_dd.p.tid': tidHigh },
-          }),
-        ]
-
-        const decoded = decodePayload(transformer.transformSpans(spans))
-        const otlpSpans = decoded.resourceSpans[0].scopeSpans[0].spans
-
-        const expectedTraceId = tidHigh + lowHex
-        assert.strictEqual(otlpSpans[0].traceId, expectedTraceId)
-        assert.strictEqual(otlpSpans[1].traceId, expectedTraceId)
       })
 
       it('lowercases an uppercase _dd.p.tid so the OTLP traceId is canonical lowercase hex', () => {

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -34,7 +34,7 @@ describe('OpenTelemetry Traces', () => {
    * @param {object} [overrides] - Optional field overrides
    * @returns {object} A mock DD-formatted span
    */
-  function createMockSpan(overrides = {}) {
+  function createMockSpan (overrides = {}) {
     return {
       trace_id: id('1234567890abcdef1234567890abcdef'),
       span_id: id('abcdef1234567890'),
@@ -58,7 +58,7 @@ describe('OpenTelemetry Traces', () => {
     }
   }
 
-  function mockOtlpExport(validator) {
+  function mockOtlpExport (validator) {
     let capturedPayload, capturedHeaders
     let validatorCalled = false
 
@@ -72,21 +72,21 @@ describe('OpenTelemetry Traces', () => {
             validator(decoded, capturedHeaders)
             validatorCalled = true
           },
-          on: () => { },
-          once: () => { },
-          setTimeout: () => { },
+          on: () => {},
+          once: () => {},
+          setTimeout: () => {},
         }
-        callback({ statusCode: 200, on: () => { }, once: () => { }, setTimeout: () => { } })
+        callback({ statusCode: 200, on: () => {}, once: () => {}, setTimeout: () => {} })
         return mockReq
       }
       const mockReq = {
-        write: () => { },
-        end: () => { },
-        on: () => { },
-        once: () => { },
-        setTimeout: () => { },
+        write: () => {},
+        end: () => {},
+        on: () => {},
+        once: () => {},
+        setTimeout: () => {},
       }
-      callback({ statusCode: 200, on: () => { }, once: () => { }, setTimeout: () => { } })
+      callback({ statusCode: 200, on: () => {}, once: () => {}, setTimeout: () => {} })
       return mockReq
     })
 
@@ -105,7 +105,7 @@ describe('OpenTelemetry Traces', () => {
    * @param {object} [extraEnv] - Extra environment variables for this one build
    * @returns {OtlpHttpTraceExporter}
    */
-  function buildExporter(extraEnv) {
+  function buildExporter (extraEnv) {
     if (extraEnv) Object.assign(process.env, extraEnv)
     return createOtlpTraceExporter(getConfigFresh())
   }
@@ -140,7 +140,7 @@ describe('OpenTelemetry Traces', () => {
      * @param {Buffer} payload - The JSON-encoded payload
      * @returns {object} Decoded JSON object
      */
-    function decodePayload(payload) {
+    function decodePayload (payload) {
       return JSON.parse(payload.toString())
     }
 
@@ -150,7 +150,7 @@ describe('OpenTelemetry Traces', () => {
      * @param {object[]} attributes - Array of OTLP KeyValue objects
      * @returns {Record<string, string|number>} Flat key-value map
      */
-    function extractAttrs(attributes) {
+    function extractAttrs (attributes) {
       const attrs = {}
       for (const attr of attributes) {
         if (attr.value.stringValue !== undefined) {
@@ -687,7 +687,7 @@ describe('OpenTelemetry Traces', () => {
       let exportCalled = false
       sinon.stub(http, 'request').callsFake(() => {
         exportCalled = true
-        return { write: () => { }, end: () => { }, on: () => { }, once: () => { }, setTimeout: () => { } }
+        return { write: () => {}, end: () => {}, on: () => {}, once: () => {}, setTimeout: () => {} }
       })
 
       const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', {}, 1000, {})
@@ -700,7 +700,7 @@ describe('OpenTelemetry Traces', () => {
       let exportCalled = false
       sinon.stub(http, 'request').callsFake(() => {
         exportCalled = true
-        return { write: () => { }, end: () => { }, on: () => { }, once: () => { }, setTimeout: () => { } }
+        return { write: () => {}, end: () => {}, on: () => {}, once: () => {}, setTimeout: () => {} }
       })
 
       const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', {}, 1000, {})
@@ -713,7 +713,7 @@ describe('OpenTelemetry Traces', () => {
       let exportCalled = false
       sinon.stub(http, 'request').callsFake(() => {
         exportCalled = true
-        return { write: () => { }, end: () => { }, on: () => { }, once: () => { }, setTimeout: () => { } }
+        return { write: () => {}, end: () => {}, on: () => {}, once: () => {}, setTimeout: () => {} }
       })
 
       const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', {}, 1000, {})

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -575,6 +575,20 @@ describe('OpenTelemetry Traces', () => {
         assert.strictEqual(otlpSpans[1].traceId, expectedTraceId)
       })
 
+      it('lowercases an uppercase _dd.p.tid so the OTLP traceId is canonical lowercase hex', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const lowHex = 'abcdef0123456789'
+        const span = createMockSpan({
+          trace_id: id(lowHex),
+          meta: { 'span.kind': 'internal', '_dd.p.tid': '1234567890ABCDEF' },
+        })
+
+        const decoded = decodePayload(transformer.transformSpans([span]))
+        const otlpSpan = decoded.resourceSpans[0].scopeSpans[0].spans[0]
+
+        assert.strictEqual(otlpSpan.traceId, '1234567890abcdef' + lowHex)
+      })
+
       it('uses a full 16-byte trace_id buffer directly without consulting _dd.p.tid', () => {
         const transformer = new OtlpTraceTransformer({})
         const unusedTidHigh = '1000000000000000'

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -34,7 +34,7 @@ describe('OpenTelemetry Traces', () => {
    * @param {object} [overrides] - Optional field overrides
    * @returns {object} A mock DD-formatted span
    */
-  function createMockSpan (overrides = {}) {
+  function createMockSpan(overrides = {}) {
     return {
       trace_id: id('1234567890abcdef1234567890abcdef'),
       span_id: id('abcdef1234567890'),
@@ -58,7 +58,7 @@ describe('OpenTelemetry Traces', () => {
     }
   }
 
-  function mockOtlpExport (validator) {
+  function mockOtlpExport(validator) {
     let capturedPayload, capturedHeaders
     let validatorCalled = false
 
@@ -72,21 +72,21 @@ describe('OpenTelemetry Traces', () => {
             validator(decoded, capturedHeaders)
             validatorCalled = true
           },
-          on: () => {},
-          once: () => {},
-          setTimeout: () => {},
+          on: () => { },
+          once: () => { },
+          setTimeout: () => { },
         }
-        callback({ statusCode: 200, on: () => {}, once: () => {}, setTimeout: () => {} })
+        callback({ statusCode: 200, on: () => { }, once: () => { }, setTimeout: () => { } })
         return mockReq
       }
       const mockReq = {
-        write: () => {},
-        end: () => {},
-        on: () => {},
-        once: () => {},
-        setTimeout: () => {},
+        write: () => { },
+        end: () => { },
+        on: () => { },
+        once: () => { },
+        setTimeout: () => { },
       }
-      callback({ statusCode: 200, on: () => {}, once: () => {}, setTimeout: () => {} })
+      callback({ statusCode: 200, on: () => { }, once: () => { }, setTimeout: () => { } })
       return mockReq
     })
 
@@ -105,7 +105,7 @@ describe('OpenTelemetry Traces', () => {
    * @param {object} [extraEnv] - Extra environment variables for this one build
    * @returns {OtlpHttpTraceExporter}
    */
-  function buildExporter (extraEnv) {
+  function buildExporter(extraEnv) {
     if (extraEnv) Object.assign(process.env, extraEnv)
     return createOtlpTraceExporter(getConfigFresh())
   }
@@ -140,7 +140,7 @@ describe('OpenTelemetry Traces', () => {
      * @param {Buffer} payload - The JSON-encoded payload
      * @returns {object} Decoded JSON object
      */
-    function decodePayload (payload) {
+    function decodePayload(payload) {
       return JSON.parse(payload.toString())
     }
 
@@ -150,7 +150,7 @@ describe('OpenTelemetry Traces', () => {
      * @param {object[]} attributes - Array of OTLP KeyValue objects
      * @returns {Record<string, string|number>} Flat key-value map
      */
-    function extractAttrs (attributes) {
+    function extractAttrs(attributes) {
       const attrs = {}
       for (const attr of attributes) {
         if (attr.value.stringValue !== undefined) {
@@ -462,6 +462,133 @@ describe('OpenTelemetry Traces', () => {
         ['/api/first', '/api/second']
       )
     })
+
+    describe('128-bit trace ID handling', () => {
+      // DD splits 128-bit trace IDs: low 64 bits live on the span Identifier,
+      // upper 64 bits live in trace-level tags as `_dd.p.tid` (16 hex chars).
+      // span_format.js#extractChunkTags only copies trace-level tags onto the
+      // first-in-chunk span, so the transformer has to look across the batch
+      // to find `_dd.p.tid` and then apply it to every span.
+
+      it('reconstructs the full 128-bit traceId for every span in a batch from _dd.p.tid', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const lowHex = 'abcdef0123456789'
+        const tidHigh = '1234567890abcdef'
+        const traceIdLow = id(lowHex)
+
+        const firstSpan = createMockSpan({
+          trace_id: traceIdLow,
+          meta: { 'span.kind': 'internal', '_dd.p.tid': tidHigh },
+        })
+        const secondSpan = createMockSpan({
+          trace_id: traceIdLow,
+          span_id: id('bbbbbbbbbbbbbbbb'),
+          meta: { 'span.kind': 'internal' },
+        })
+        const thirdSpan = createMockSpan({
+          trace_id: traceIdLow,
+          span_id: id('cccccccccccccccc'),
+          meta: { 'span.kind': 'internal' },
+        })
+
+        const decoded = decodePayload(transformer.transformSpans([firstSpan, secondSpan, thirdSpan]))
+        const otlpSpans = decoded.resourceSpans[0].scopeSpans[0].spans
+
+        const expectedTraceId = tidHigh + lowHex
+        for (const otlpSpan of otlpSpans) {
+          assert.strictEqual(otlpSpan.traceId, expectedTraceId)
+        }
+      })
+
+      it('finds _dd.p.tid on a non-first span and applies it to every span', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const lowHex = 'abcdef0123456789'
+        const tidHigh = '1234567890abcdef'
+        const traceIdLow = id(lowHex)
+
+        const spans = [
+          createMockSpan({ trace_id: traceIdLow, meta: { 'span.kind': 'internal' } }),
+          createMockSpan({
+            trace_id: traceIdLow,
+            span_id: id('bbbbbbbbbbbbbbbb'),
+            meta: { 'span.kind': 'internal', '_dd.p.tid': tidHigh },
+          }),
+        ]
+
+        const decoded = decodePayload(transformer.transformSpans(spans))
+        const otlpSpans = decoded.resourceSpans[0].scopeSpans[0].spans
+
+        const expectedTraceId = tidHigh + lowHex
+        assert.strictEqual(otlpSpans[0].traceId, expectedTraceId)
+        assert.strictEqual(otlpSpans[1].traceId, expectedTraceId)
+      })
+
+      it('drops _dd.p.tid from OTLP attributes once consumed into traceId', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const span = createMockSpan({
+          trace_id: id('abcdef0123456789'),
+          meta: { 'span.kind': 'internal', '_dd.p.tid': '1234567890abcdef' },
+        })
+
+        const decoded = decodePayload(transformer.transformSpans([span]))
+        const attrs = extractAttrs(decoded.resourceSpans[0].scopeSpans[0].spans[0].attributes)
+
+        assert.strictEqual(attrs['_dd.p.tid'], undefined)
+      })
+
+      it('zero-pads traceId to 32 hex chars when no _dd.p.tid is present', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const span = createMockSpan({
+          trace_id: id('abcdef0123456789'),
+          meta: { 'span.kind': 'internal' },
+        })
+
+        const decoded = decodePayload(transformer.transformSpans([span]))
+        const otlpSpan = decoded.resourceSpans[0].scopeSpans[0].spans[0]
+
+        assert.strictEqual(otlpSpan.traceId, '0000000000000000abcdef0123456789')
+      })
+
+      it('skips a non-hex _dd.p.tid and uses a valid one from a later span', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const lowHex = 'abcdef0123456789'
+        const tidHigh = '1234567890abcdef'
+        const traceIdLow = id(lowHex)
+
+        const spans = [
+          createMockSpan({
+            trace_id: traceIdLow,
+            meta: { 'span.kind': 'internal', '_dd.p.tid': 'not-a-hex-value!!' },
+          }),
+          createMockSpan({
+            trace_id: traceIdLow,
+            span_id: id('bbbbbbbbbbbbbbbb'),
+            meta: { 'span.kind': 'internal', '_dd.p.tid': tidHigh },
+          }),
+        ]
+
+        const decoded = decodePayload(transformer.transformSpans(spans))
+        const otlpSpans = decoded.resourceSpans[0].scopeSpans[0].spans
+
+        const expectedTraceId = tidHigh + lowHex
+        assert.strictEqual(otlpSpans[0].traceId, expectedTraceId)
+        assert.strictEqual(otlpSpans[1].traceId, expectedTraceId)
+      })
+
+      it('uses a full 16-byte trace_id buffer directly without consulting _dd.p.tid', () => {
+        const transformer = new OtlpTraceTransformer({})
+        const unusedTidHigh = '1000000000000000'
+        const span = createMockSpan({
+          trace_id: id('1234567890abcdef1234567890abcdef'),
+          meta: { 'span.kind': 'internal', '_dd.p.tid': unusedTidHigh },
+        })
+
+        const decoded = decodePayload(transformer.transformSpans([span]))
+        const otlpSpan = decoded.resourceSpans[0].scopeSpans[0].spans[0]
+
+        assert.strictEqual(otlpSpan.traceId, '1234567890abcdef1234567890abcdef')
+      })
+    })
   })
 
   describe('Exporter', () => {
@@ -546,7 +673,7 @@ describe('OpenTelemetry Traces', () => {
       let exportCalled = false
       sinon.stub(http, 'request').callsFake(() => {
         exportCalled = true
-        return { write: () => {}, end: () => {}, on: () => {}, once: () => {}, setTimeout: () => {} }
+        return { write: () => { }, end: () => { }, on: () => { }, once: () => { }, setTimeout: () => { } }
       })
 
       const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', {}, 1000, {})
@@ -559,7 +686,7 @@ describe('OpenTelemetry Traces', () => {
       let exportCalled = false
       sinon.stub(http, 'request').callsFake(() => {
         exportCalled = true
-        return { write: () => {}, end: () => {}, on: () => {}, once: () => {}, setTimeout: () => {} }
+        return { write: () => { }, end: () => { }, on: () => { }, once: () => { }, setTimeout: () => { } }
       })
 
       const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', {}, 1000, {})
@@ -572,7 +699,7 @@ describe('OpenTelemetry Traces', () => {
       let exportCalled = false
       sinon.stub(http, 'request').callsFake(() => {
         exportCalled = true
-        return { write: () => {}, end: () => {}, on: () => {}, once: () => {}, setTimeout: () => {} }
+        return { write: () => { }, end: () => { }, on: () => { }, once: () => { }, setTimeout: () => { } }
       })
 
       const exporter = new OtlpHttpTraceExporter('http://localhost:4318/v1/traces', {}, 1000, {})


### PR DESCRIPTION
### What does this PR do?
When transforming the chunk of formatted spans to OTLP spans, extract the upper 64 bits of the full 128-bit trace ID and pass it into the transformation for all spans for that chunk. The extraction logic will iterate the chunk and find the first valid `_dd.p.tid` value (16 hex chars) or return `undefined` if not found.

### Motivation
End-to-end tests discovered that the upper 64 bits of the 128-bit trace ID (present in the '_dd.p.tid' tag) were only copied onto the first span of the trace chunk, but not the rest. This resulted in the first span of the chunk having the full 128-bit trace ID but the remaining spans having `0000000000000000` for the upper 64-bits (but the lower 64 bits were identical). This fix ensures that all spans in the trace have the same, 128-bit trace ID.

### Additional Notes
Unit tests have been added in `packages/dd-trace/test/opentelemetry/traces.spec.js`