### PR TITLE
chore: deactivate eslint-require-boolean-assert-message

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -739,7 +739,8 @@ export default [
     },
     rules: {
       'eslint-rules/eslint-prefer-assert-match': 'error',
-      'eslint-rules/eslint-require-boolean-assert-message': 'error',
+      // TODO: Re-enable this rule once we have a way to fix the false positives or have Node.js report better errors.
+      'eslint-rules/eslint-require-boolean-assert-message': 'off',
       'mocha/consistent-spacing-between-blocks': 'off',
       'mocha/max-top-level-suites': ['error', { limit: 1 }],
       'mocha/no-mocha-arrows': 'off',


### PR DESCRIPTION
The rule is currently matching a couple of situations where using a message would not provide additional information. Using messages also has the downside of potentially providing a less ideal message than is generated by default.

The rule should be reworked to detect definit non-ideal parts only before being activated again.
Ideally, Node.js will provide that information by default (this is possible by using the V8 debugger).