### PR TITLE
fix(eslint): skip autofix on ${} in string literal

### DIFF
--- a/eslint-rules/eslint-require-boolean-assert-message.mjs
+++ b/eslint-rules/eslint-require-boolean-assert-message.mjs
@@ -255,9 +255,16 @@ function buildAutofixMessage (firstArg, sourceCode) {
   const rhsText = sourceCode.getText(firstArg.right)
 
   // A backtick anywhere in an operand would break the template literal we're synthesising — bail
-  // rather than try to escape it. The same goes for backslashes that could fall just before a
-  // `${` boundary.
+  // rather than try to escape it.
   if (lhsText.includes('`') || rhsText.includes('`')) return null
+
+  // For literal operands, the source text is embedded verbatim into the template's static
+  // segments — so any `${` inside it (e.g. `'${expected}'` or `'foo\${x}'`) would turn into an
+  // unintended interpolation, which at best changes the message and at worst throws a
+  // `ReferenceError` before `assert.ok` runs. Non-literal operands are wrapped in `${...}` and
+  // are expression text, so they don't need this check.
+  if (firstArg.left.type === 'Literal' && lhsText.includes('${')) return null
+  if (firstArg.right.type === 'Literal' && rhsText.includes('${')) return null
 
   const lhsPart = firstArg.left.type === 'Literal' ? lhsText : '${' + lhsText + '}'
   const rhsPart = firstArg.right.type === 'Literal' ? rhsText : '${' + rhsText + '}'

--- a/eslint-rules/eslint-require-boolean-assert-message.test.mjs
+++ b/eslint-rules/eslint-require-boolean-assert-message.test.mjs
@@ -219,6 +219,31 @@ ruleTester.run('eslint-require-boolean-assert-message', /** @type {import('eslin
       errors: [{ messageId: 'missingMessage' }],
     },
 
+    // String literals containing `${...}` — copying them verbatim into the synthesised
+    // backtick template would turn the literal `${...}` into a real interpolation, silently
+    // changing the message (or throwing `ReferenceError` if the identifier isn't in scope).
+    // Bail rather than try to escape.
+    {
+      // eslint-disable-next-line no-template-curly-in-string
+      code: "assert.ok(value == '${expected}')",
+      output: null,
+      errors: [{ messageId: 'missingMessage' }],
+    },
+    {
+      // eslint-disable-next-line no-template-curly-in-string
+      code: "assert.ok(x > '${threshold}')",
+      output: null,
+      errors: [{ messageId: 'missingMessage' }],
+    },
+    {
+      // Escaped `${` inside the literal is just as dangerous — the synthesised template
+      // would still see `${...}` after the source backslash gets normalised by the parser.
+      // eslint-disable-next-line no-template-curly-in-string
+      code: "assert.ok(value == 'foo\\${expected}')",
+      output: null,
+      errors: [{ messageId: 'missingMessage' }],
+    },
+
     // Logical combinations — composite booleans hide which side was falsy, and there's no
     // mechanical message that's reliably better than what the author would write.
     {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the `eslint-require-boolean-assert-message` autofixer (introduced in #8537): when a boolean assertion has a string-literal operand that contains `${...}`, the autofixer silently produces a broken message — or, worse, code that throws `ReferenceError` before the assertion runs.

`buildAutofixMessage` embeds the source text of `Literal` operands verbatim into the static segments of the synthesised template literal (non-literal operands are wrapped in `${...}` and are expression text, so they're unaffected). For example:

```js
assert.ok(value == '${expected}')
```

was being autofixed to:

```js
assert.ok(value == '${expected}', `Expected ${value} == ${expected}`)
```

…where the literal's `${expected}` becomes a real interpolation against whatever `expected` happens to mean in scope. This PR adds an early bail-out (`return null`) when a `Literal` operand's source text contains `${`, leaving the violation flagged but unfixed so the author can write the message themselves. The companion comment about backslashes — now subsumed by the broader literal-level check — is dropped.

Three regression tests cover the cases that motivated the fix: `==` with an interpolation-shaped RHS, `>` with the same, and the escaped `\${...}` variant (the escape is normalised away by the parser, so the synthesised template still sees `${`).

### Motivation

The original autofixer in #8537 protected against one hazard — a literal backtick in an operand, which would terminate the synthesised template early — but missed the symmetric case of `${...}` syntax appearing inside a string literal. The window is narrow but real: any test asserting against a string that happens to contain template-literal syntax (error messages, snapshots, codegen output, fixture strings) would hit it on the first `--fix`.

### Additional Notes

#8620 proposes deactivating `eslint-require-boolean-assert-message` outright and reworking it before re-enabling. This PR is independent of that decision: the autofixer source still ships either way, the bug is real, and the fix is part of the hardening #8620 references. Happy to sequence behind it if reviewers prefer.
