### PR TITLE
feat(dogstatsd): enable client self-telemetry

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -15,6 +15,7 @@ const TYPE_COUNTER = 'c'
 const TYPE_GAUGE = 'g'
 const TYPE_DISTRIBUTION = 'd'
 const TYPE_HISTOGRAM = 'h'
+const TYPE_LABEL = { c: 'count', g: 'gauge', d: 'distribution', h: 'histogram' }
 
 /**
  * @import { DogStatsD } from "../../../index.d.ts"
@@ -23,6 +24,24 @@ const TYPE_HISTOGRAM = 'h'
 class DogStatsDClient {
   #lookup
   #tagsPrefix
+  #telemetryEnabled
+
+  #metricsSent = 0
+  #metricsByType = {
+    [TYPE_COUNTER]: 0,
+    [TYPE_GAUGE]: 0,
+    [TYPE_DISTRIBUTION]: 0,
+    [TYPE_HISTOGRAM]: 0,
+  }
+
+  #bytesSent = 0
+  #bytesDropped = 0
+  #packetsSent = 0
+  #packetsDropped = 0
+
+  #metrics = { buffer: '', offset: 0, queue: [] }
+  #telemetry = { buffer: '', offset: 0, queue: [] }
+
   constructor (options) {
     this.#lookup = options.lookup
     if (options.metricsProxyUrl) {
@@ -33,14 +52,14 @@ class DogStatsDClient {
       }
     }
 
+    // Disable self-telemetry by default
+    this.#telemetryEnabled = options?.telemetry ?? false
+
     this._host = options.host
     this._family = isIP(this._host)
     this._port = options.port
     this._tags = options.tags
     this.#tagsPrefix = this._tags?.length ? `|#${this._tags.join(',')}` : ''
-    this._queue = []
-    this._buffer = ''
-    this._offset = 0
     this._udp4 = this._socket('udp4')
     this._udp6 = this._socket('udp6')
   }
@@ -65,23 +84,94 @@ class DogStatsDClient {
     this._add(stat, value, TYPE_HISTOGRAM, tags)
   }
 
-  flush () {
-    const queue = this._enqueue()
+  /**
+   * Flushes the metrics to the agent
+   *
+   * @param {boolean} [telemetry] - whether the payload is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  flush (telemetry = false) {
+    this._enqueue(telemetry)
+    const state = telemetry ? this.#telemetry : this.#metrics
+    const queue = state.queue
 
     if (queue.length === 0) return
 
     log.debug('Flushing %s metrics via %s', queue.length, this._httpOptions ? 'HTTP' : 'UDP')
 
-    this._queue = []
+    state.queue = []
 
     if (this._httpOptions) {
-      this._sendHttp(queue)
+      this._sendHttp(queue, telemetry)
     } else {
-      this._sendUdp(queue)
+      this._sendUdp(queue, telemetry)
     }
   }
 
-  _sendHttp (queue) {
+  /**
+   * Send self-telemetry metrics to the agent and reset the counters
+   *
+   * @memberof DogStatsDClient
+   */
+  sendTelemetry () {
+    if (!this.#telemetryEnabled) return
+
+    // Snapshot for async I/O
+    const snapshot = {
+      metrics: this.#metricsSent,
+      metricsByType: this.#metricsByType,
+      bytesSent: this.#bytesSent,
+      bytesDropped: this.#bytesDropped,
+      packetsSent: this.#packetsSent,
+      packetsDropped: this.#packetsDropped,
+    }
+
+    this.#metricsSent = 0
+    this.#metricsByType = {
+      [TYPE_COUNTER]: 0,
+      [TYPE_GAUGE]: 0,
+      [TYPE_DISTRIBUTION]: 0,
+      [TYPE_HISTOGRAM]: 0,
+    }
+    this.#bytesSent = 0
+    this.#bytesDropped = 0
+    this.#packetsSent = 0
+    this.#packetsDropped = 0
+
+    this._add('datadog.dogstatsd.client.metrics', snapshot.metrics, TYPE_COUNTER, [], true)
+    for (const [type, value] of Object.entries(snapshot.metricsByType)) {
+      const label = TYPE_LABEL[type]
+      this._add('datadog.dogstatsd.client.metrics_by_type', value, TYPE_COUNTER, [`metrics_type:${label}`], true)
+    }
+    this._add('datadog.dogstatsd.client.bytes_sent', snapshot.bytesSent, TYPE_COUNTER, [], true)
+    this._add('datadog.dogstatsd.client.bytes_dropped', snapshot.bytesDropped, TYPE_COUNTER, [], true)
+    this._add('datadog.dogstatsd.client.packets_sent', snapshot.packetsSent, TYPE_COUNTER, [], true)
+    this._add('datadog.dogstatsd.client.packets_dropped', snapshot.packetsDropped, TYPE_COUNTER, [], true)
+
+    this.flush(true)
+  }
+
+  /**
+   * Update self-telemetry counters.
+   *
+   * @param {string} type - The type of metric to record
+   * @memberof DogStatsDClient
+   */
+  recordMetric (type) {
+    if (!this.#telemetryEnabled) return
+
+    this.#metricsSent++
+    this.#metricsByType[type]++
+  }
+
+  /**
+   * Send metrics to the agent via HTTP
+   *
+   * @param {Buffer[]} queue - The metrics to send
+   * @param {boolean} [telemetry] - Whether the payload is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  _sendHttp (queue, telemetry = false) {
     const buffer = Buffer.concat(queue)
     request(buffer, this._httpOptions, (err) => {
       if (err) {
@@ -93,32 +183,79 @@ class DogStatsDClient {
           // options. Either way, we can give UDP a try.
           this._httpOptions = undefined
         }
-        this._sendUdp(queue)
+        this._sendUdp(queue, telemetry)
+      } else if (this.#telemetryEnabled && !telemetry) {
+        this.#bytesSent += buffer.length
+        this.#packetsSent++
       }
     })
   }
 
-  _sendUdp (queue) {
+  /**
+   * Send metrics to the agent via UDP
+   *
+   * @param {Buffer[]} queue - The metrics to send
+   * @param {boolean} [telemetry] - Whether the payload is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  _sendUdp (queue, telemetry = false) {
     if (this._family === 0) {
       this.#lookup(this._host, (err, address, family) => {
-        if (err) return log.error('DogStatsDClient: Host not found', err)
-        this._sendUdpFromQueue(queue, address, family)
+        if (err) {
+          if (this.#telemetryEnabled && !telemetry) {
+            const bytes = queue.reduce((sum, buf) => sum + buf.length, 0)
+            this.#bytesDropped += bytes
+            this.#packetsDropped += queue.length
+          }
+          return log.error('DogStatsDClient: Host not found', err)
+        }
+        this._sendUdpFromQueue(queue, address, family, telemetry)
       })
     } else {
-      this._sendUdpFromQueue(queue, this._host, this._family)
+      this._sendUdpFromQueue(queue, this._host, this._family, telemetry)
     }
   }
 
-  _sendUdpFromQueue (queue, address, family) {
+  /**
+   * Send metrics to the agent via UDP from queue
+   *
+   * @param {Buffer[]} queue - The metrics to send
+   * @param {string} address - The address to send the metrics to
+   * @param {number} family - The family of the address
+   * @param {boolean} [telemetry] - Whether the payload is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  _sendUdpFromQueue (queue, address, family, telemetry = false) {
     const socket = family === 6 ? this._udp6 : this._udp4
 
     for (const buffer of queue) {
       log.debug('Sending to DogStatsD: %s', buffer)
-      socket.send(buffer, 0, buffer.length, this._port, address)
+      socket.send(buffer, 0, buffer.length, this._port, address, (err) => {
+        if (err) {
+          if (this.#telemetryEnabled && !telemetry) {
+            this.#bytesDropped += buffer.length
+            this.#packetsDropped++
+          }
+          log.error('DogStatsDClient: UDP error', err)
+        } else if (this.#telemetryEnabled && !telemetry) {
+          this.#bytesSent += buffer.length
+          this.#packetsSent++
+        }
+      })
     }
   }
 
-  _add (stat, value, type, tags) {
+  /**
+   * Add a metric to the queue
+   *
+   * @param {string} stat - The metric name
+   * @param {number} value - The metric value
+   * @param {string} type - The metric type
+   * @param {string[]} tags - The metric tags
+   * @param {boolean} [telemetry] - Whether the metric is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  _add (stat, value, type, tags, telemetry = false) {
     let message = `${stat}:${value}|${type}`
 
     if (tags?.length) {
@@ -133,28 +270,39 @@ class DogStatsDClient {
       message += `|c:${entityId}`
     }
 
-    this._write(`${message}\n`)
+    this._write(`${message}\n`, telemetry)
   }
 
-  _write (message) {
+  /**
+   * Write a message to the queue
+   *
+   * @param {string} message - The message to write
+   * @param {boolean} [telemetry] - Whether the message is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  _write (message, telemetry = false) {
     const offset = Buffer.byteLength(message)
-
-    if (this._offset + offset > MAX_BUFFER_SIZE) {
-      this._enqueue()
+    const state = telemetry ? this.#telemetry : this.#metrics
+    if (state.offset + offset > MAX_BUFFER_SIZE) {
+      this._enqueue(telemetry)
     }
-
-    this._offset += offset
-    this._buffer += message
+    state.offset += offset
+    state.buffer += message
   }
 
-  _enqueue () {
-    if (this._offset > 0) {
-      this._queue.push(Buffer.from(this._buffer))
-      this._buffer = ''
-      this._offset = 0
+  /**
+   * Enqueue a message to the queue
+   *
+   * @param {boolean} [telemetry] - Whether the message is self-telemetry or not
+   * @memberof DogStatsDClient
+   */
+  _enqueue (telemetry = false) {
+    const state = telemetry ? this.#telemetry : this.#metrics
+    if (state.offset > 0) {
+      state.queue.push(Buffer.from(state.buffer))
+      state.buffer = ''
+      state.offset = 0
     }
-
-    return this._queue
   }
 
   _socket (type) {
@@ -212,6 +360,7 @@ class MetricsAggregationClient {
     this._captureHistograms()
 
     this._client.flush()
+    this._client.sendTelemetry()
   }
 
   reset () {
@@ -223,6 +372,7 @@ class MetricsAggregationClient {
   // TODO: Aggregate with a histogram and send the buckets to the client.
   distribution (name, value, tags) {
     this._client.distribution(name, value, tags)
+    this._client.recordMetric(TYPE_DISTRIBUTION)
   }
 
   boolean (name, value, tags) {
@@ -237,6 +387,7 @@ class MetricsAggregationClient {
     }
 
     node.value.record(value)
+    this._client.recordMetric(TYPE_HISTOGRAM)
   }
 
   count (name, count, tags = [], monotonic = true) {
@@ -249,12 +400,14 @@ class MetricsAggregationClient {
     const node = this._ensureTree(container, name, tags, 0)
 
     node.value += count
+    this._client.recordMetric(TYPE_COUNTER)
   }
 
   gauge (name, value, tags) {
     const node = this._ensureTree(this._gauges, name, tags, 0)
 
     node.value = value
+    this._client.recordMetric(TYPE_GAUGE)
   }
 
   increment (name, count = 1, tags) {
@@ -356,7 +509,7 @@ class CustomMetrics {
   #client
   constructor (config) {
     const clientConfig = DogStatsDClient.generateClientConfig(config)
-    this.#client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
+    this.#client = new MetricsAggregationClient(new DogStatsDClient({ ...clientConfig, telemetry: true }))
 
     const flush = this.flush.bind(this)
 

--- a/packages/dd-trace/src/noop/dogstatsd.js
+++ b/packages/dd-trace/src/noop/dogstatsd.js
@@ -16,4 +16,8 @@ module.exports = class NoopDogStatsDClient {
   histogram () {}
 
   flush () {}
+
+  sendTelemetry () {}
+
+  recordMetric () {}
 }

--- a/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/runtime_metrics.js
@@ -48,7 +48,7 @@ module.exports = {
     const trackEventLoop = config.runtimeMetrics.eventLoop !== false
     const trackGc = config.runtimeMetrics.gc !== false
 
-    client = new MetricsAggregationClient(new DogStatsDClient(clientConfig))
+    client = new MetricsAggregationClient(new DogStatsDClient({ ...clientConfig, telemetry: true }))
 
     if (trackGc) {
       startGCObserver()

--- a/packages/dd-trace/test/custom-metrics.spec.js
+++ b/packages/dd-trace/test/custom-metrics.spec.js
@@ -13,11 +13,12 @@ require('./setup/core')
 describe('Custom Metrics', () => {
   let httpServer
   let httpPort
-  let metricsData
+  let metricsPayloads
   let sockets
 
   beforeEach((done) => {
     sockets = []
+    metricsPayloads = []
     httpServer = http.createServer((req, res) => {
       let httpData = ''
       req.on('data', d => { httpData += d.toString() })
@@ -25,7 +26,7 @@ describe('Custom Metrics', () => {
         res.statusCode = 200
         res.end()
         if (req.url === '/dogstatsd/v2/proxy') {
-          metricsData = httpData
+          metricsPayloads.push(httpData)
         }
       })
     }).listen(0, () => {
@@ -56,7 +57,13 @@ describe('Custom Metrics', () => {
       // eslint-disable-next-line no-console
       if (stderr) console.error(stderr)
 
-      assert.strictEqual(metricsData.split('#')[0], 'page.views.data:1|c|')
+      assert.strictEqual(metricsPayloads.length, 2)
+
+      const [userMetrics, telemetryMetrics] = metricsPayloads
+
+      assert.strictEqual(userMetrics.split('#')[0], 'page.views.data:1|c|')
+      assert.match(telemetryMetrics, /datadog\.dogstatsd\.client\.metrics:1\|c\|/)
+      assert.match(telemetryMetrics, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:count/)
 
       done()
     })

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -132,6 +132,7 @@ describe('dogstatsd', () => {
       lookup: dns.lookup,
       port: 8125,
       tags: [],
+      telemetry: true,
       ...options,
     })
   }
@@ -146,6 +147,313 @@ describe('dogstatsd', () => {
       runtimeMetricsRuntimeId: false,
     })
   }
+
+  function stubUdpSend (callback) {
+    udp4.send = sinon.stub().callsFake((buffer, offset, length, port, address, cb) => {
+      callback?.(undefined, buffer, cb)
+    })
+    udp6.send = sinon.stub().callsFake((buffer, offset, length, port, address, cb) => {
+      callback?.(undefined, buffer, cb)
+    })
+  }
+
+  describe('client telemetry', () => {
+    beforeEach(() => {
+      stubUdpSend((err, buffer, callback) => {
+        callback?.(err)
+      })
+    })
+
+    it('sendTelemetry() is a no-op when telemetry is disabled', () => {
+      client = createDogStatsDClient({ telemetry: false })
+
+      client.recordMetric('c')
+      client.gauge('test.avg', 1)
+      client.flush()
+      client.sendTelemetry()
+
+      sinon.assert.calledOnce(udp4.send)
+      assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:1|g\n')
+    })
+
+    it('sendTelemetry() emits client self-telemetry metrics over UDP', () => {
+      client = createDogStatsDClient()
+
+      client.recordMetric('c')
+      client.recordMetric('c')
+      client.recordMetric('g')
+      client.recordMetric('d')
+      client.recordMetric('h')
+      client.gauge('test.avg', 1)
+      client.flush()
+      client.sendTelemetry()
+
+      sinon.assert.calledTwice(udp4.send)
+      assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:1|g\n')
+
+      const telemetry = udp4.send.secondCall.args[0].toString()
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics:5\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:2\|c\|.*metrics_type:count/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:gauge/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:distribution/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:histogram/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_sent:13\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_dropped:0\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_sent:1\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_dropped:0\|c[|#\n]/)
+    })
+
+    it('sendTelemetry() resets counters after each flush', () => {
+      client = createDogStatsDClient()
+
+      client.recordMetric('c')
+      client.gauge('test.avg', 1)
+      client.flush()
+      client.sendTelemetry()
+      // Call again explicitly to check that we reset counters
+      client.sendTelemetry()
+
+      sinon.assert.calledThrice(udp4.send)
+
+      const thirdSend = udp4.send.thirdCall.args[0].toString()
+      assert.match(thirdSend, /datadog\.dogstatsd\.client\.metrics:0\|c[|#\n]/)
+      assert.match(thirdSend, /datadog\.dogstatsd\.client\.metrics_by_type:0\|c\|.*metrics_type:count/)
+      assert.match(thirdSend, /datadog\.dogstatsd\.client\.bytes_sent:0\|c[|#\n]/)
+      assert.match(thirdSend, /datadog\.dogstatsd\.client\.packets_sent:0\|c[|#\n]/)
+    })
+
+    it('sendTelemetry() reports UDP bytes_dropped and packets_dropped after send failure', () => {
+      stubUdpSend((err, buffer, callback) => {
+        callback?.(new Error('send failed'))
+      })
+
+      client = createDogStatsDClient()
+      client.gauge('test.avg', 1)
+      client.flush()
+      client.sendTelemetry()
+
+      sinon.assert.calledTwice(udp4.send)
+
+      const telemetry = udp4.send.secondCall.args[0].toString()
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_dropped:13\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_dropped:1\|c[|#\n]/)
+    })
+
+    it('sendTelemetry() reports dropped metrics when DNS lookup fails', () => {
+      client = createDogStatsDClient({ host: 'invalid' })
+      client.gauge('test.avg', 1)
+      client.flush()
+
+      sinon.assert.notCalled(udp4.send)
+
+      client._host = '127.0.0.1'
+      client._family = 4
+      client.sendTelemetry()
+
+      sinon.assert.calledOnce(udp4.send)
+
+      const telemetry = udp4.send.firstCall.args[0].toString()
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_dropped:13\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_dropped:1\|c[|#\n]/)
+    })
+
+    it('sendTelemetry() reports HTTP bytes_sent and packets_sent after a successful flush', (done) => {
+      const payloads = []
+
+      assertData = () => {
+        payloads.push(Buffer.concat(httpData).toString())
+        httpData.length = 0
+
+        if (payloads.length === 1) {
+          client.sendTelemetry()
+          return
+        }
+
+        try {
+          const telemetry = payloads[1]
+          assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_sent:13\|c[|#\n]/)
+          assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_sent:1\|c[|#\n]/)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
+
+      client = createDogStatsDClient({
+        metricsProxyUrl: `http://localhost:${httpPort}`,
+      })
+      client.gauge('test.avg', 1)
+      client.flush()
+    })
+
+    it('sendTelemetry() uses a separate buffer from user metrics over HTTP', (done) => {
+      const payloads = []
+
+      assertData = () => {
+        payloads.push(Buffer.concat(httpData).toString())
+        httpData.length = 0
+
+        if (payloads.length === 1) {
+          client.sendTelemetry()
+          return
+        }
+
+        try {
+          assert.strictEqual(payloads[0], 'test.avg:1|g\n')
+          assert.match(payloads[1], /datadog\.dogstatsd\.client\.metrics:/)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
+
+      client = createDogStatsDClient({
+        metricsProxyUrl: `http://localhost:${httpPort}`,
+      })
+      client.gauge('test.avg', 1)
+      client.flush()
+    })
+
+    it('sendTelemetry() does not count its own HTTP delivery in client counters', (done) => {
+      const payloads = []
+
+      assertData = () => {
+        payloads.push(Buffer.concat(httpData).toString())
+        httpData.length = 0
+
+        if (payloads.length === 1) {
+          client.sendTelemetry()
+          return
+        }
+
+        if (payloads.length === 2) {
+          client.sendTelemetry()
+          return
+        }
+
+        try {
+          assert.match(payloads[1], /datadog\.dogstatsd\.client\.bytes_sent:13\|c[|#\n]/)
+          assert.match(payloads[2], /datadog\.dogstatsd\.client\.bytes_sent:0\|c[|#\n]/)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }
+
+      client = createDogStatsDClient({
+        metricsProxyUrl: `http://localhost:${httpPort}`,
+      })
+      client.gauge('test.avg', 1)
+      client.flush()
+    })
+
+    it('sendTelemetry() does not count its own UDP delivery in client counters', () => {
+      client = createDogStatsDClient()
+
+      client.gauge('test.avg', 1)
+      client.flush()
+      client.sendTelemetry()
+      client.sendTelemetry()
+
+      sinon.assert.calledThrice(udp4.send)
+
+      const firstTelemetry = udp4.send.secondCall.args[0].toString()
+      const secondTelemetry = udp4.send.thirdCall.args[0].toString()
+      assert.match(firstTelemetry, /datadog\.dogstatsd\.client\.bytes_sent:13\|c[|#\n]/)
+      assert.match(secondTelemetry, /datadog\.dogstatsd\.client\.bytes_sent:0\|c[|#\n]/)
+    })
+
+    it('sendTelemetry() does not count telemetry lines in datadog.dogstatsd.client.metrics', () => {
+      client = createDogStatsDClient()
+
+      client.gauge('test.avg', 1)
+      client.flush()
+      client.sendTelemetry()
+
+      sinon.assert.calledTwice(udp4.send)
+
+      const telemetry = udp4.send.secondCall.args[0].toString()
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics:0\|c[|#\n]/)
+    })
+
+    it('sendTelemetry() reports bytes_sent after HTTP fails over to UDP', (done) => {
+      statusCode = 404
+
+      client = createDogStatsDClient({
+        metricsProxyUrl: `http://localhost:${httpPort}`,
+        host: '127.0.0.1',
+      })
+      client.gauge('test.avg', 1)
+      client.flush()
+
+      setTimeout(() => {
+        try {
+          sinon.assert.calledOnce(udp4.send)
+          assert.strictEqual(udp4.send.firstCall.args[0].toString(), 'test.avg:1|g\n')
+
+          client.sendTelemetry()
+
+          const telemetry = udp4.send.secondCall.args[0].toString()
+          assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_sent:13\|c[|#\n]/)
+          assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_sent:1\|c[|#\n]/)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }, 50)
+    })
+
+    it('sendTelemetry() reports bytes_dropped after HTTP fails over to UDP and send fails', (done) => {
+      stubUdpSend((err, buffer, callback) => {
+        callback?.(new Error('send failed'))
+      })
+
+      statusCode = 404
+
+      client = createDogStatsDClient({
+        metricsProxyUrl: `http://localhost:${httpPort}`,
+        host: '127.0.0.1',
+      })
+      client.gauge('test.avg', 1)
+      client.flush()
+
+      setTimeout(() => {
+        try {
+          sinon.assert.calledOnce(udp4.send)
+
+          client.sendTelemetry()
+
+          const telemetry = udp4.send.secondCall.args[0].toString()
+          assert.match(telemetry, /datadog\.dogstatsd\.client\.bytes_dropped:13\|c[|#\n]/)
+          assert.match(telemetry, /datadog\.dogstatsd\.client\.packets_dropped:1\|c[|#\n]/)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      }, 50)
+    })
+
+    it('MetricsAggregationClient flush emits telemetry with metric counts from aggregated APIs', () => {
+      client = createDogStatsDClient()
+      const aggregator = new MetricsAggregationClient(client)
+
+      aggregator.increment('test.count', 1)
+      aggregator.increment('test.count', 1)
+      aggregator.gauge('test.gauge', 5)
+      aggregator.distribution('test.dist', 3)
+      aggregator.histogram('test.hist', 7)
+      aggregator.flush()
+
+      sinon.assert.calledTwice(udp4.send)
+
+      const telemetry = udp4.send.secondCall.args[0].toString()
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics:5\|c[|#\n]/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:2\|c\|.*metrics_type:count/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:gauge/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:distribution/)
+      assert.match(telemetry, /datadog\.dogstatsd\.client\.metrics_by_type:1\|c\|.*metrics_type:histogram/)
+    })
+  })
 
   it('should send gauges', () => {
     client = createDogStatsDClient()
@@ -690,18 +998,44 @@ describe('dogstatsd', () => {
     let aggregator
     let gaugeCalls
     let incrementCalls
+    let sendTelemetry
+    let recordMetric
 
     beforeEach(() => {
       gaugeCalls = []
       incrementCalls = []
+      sendTelemetry = sinon.spy()
+      recordMetric = sinon.spy()
       const inner = {
         gauge: (name, value, tags) => gaugeCalls.push([name, value, tags?.slice()]),
         increment: (name, value, tags) => incrementCalls.push([name, value, tags?.slice()]),
-        distribution: () => {},
-        histogram: () => {},
-        flush: () => {},
+        distribution: () => { },
+        histogram: () => { },
+        flush: () => { },
+        sendTelemetry,
+        recordMetric,
       }
       aggregator = new MetricsAggregationClient(inner)
+    })
+
+    it('calls sendTelemetry on flush', () => {
+      aggregator.gauge('test.avg', 5)
+      aggregator.flush()
+
+      sinon.assert.calledOnce(sendTelemetry)
+    })
+
+    it('records metrics by type when APIs are used', () => {
+      aggregator.increment('test.count', 1)
+      aggregator.gauge('test.gauge', 2)
+      aggregator.distribution('test.dist', 3)
+      aggregator.histogram('test.hist', 4)
+
+      sinon.assert.callCount(recordMetric, 4)
+      sinon.assert.calledWith(recordMetric, 'c')
+      sinon.assert.calledWith(recordMetric, 'g')
+      sinon.assert.calledWith(recordMetric, 'd')
+      sinon.assert.calledWith(recordMetric, 'h')
     })
 
     it('emits a gauge once and then stays silent until it is set again', () => {

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -49,15 +49,15 @@ function createGarbage (count = 50) {
         }
 
         runtimeMetrics = sinon.spy({
-          start () {},
-          stop () {},
-          track () {},
-          boolean () {},
-          histogram () {},
-          count () {},
-          gauge () {},
-          increment () {},
-          decrement () {},
+          start () { },
+          stop () { },
+          track () { },
+          boolean () { },
+          histogram () { },
+          count () { },
+          gauge () { },
+          increment () { },
+          decrement () { },
         })
 
         proxy = proxyquire('../src/runtime_metrics', {
@@ -161,6 +161,8 @@ function createGarbage (count = 50) {
             increment: wrapSpy(client, client.increment),
             histogram: wrapSpy(client, client.histogram),
             flush: client.flush.bind(client),
+            sendTelemetry: client.sendTelemetry.bind(client),
+            recordMetric: client.recordMetric.bind(client),
           }
         })
 
@@ -171,6 +173,8 @@ function createGarbage (count = 50) {
           increment: sinon.spy(),
           histogram: sinon.spy(),
           flush: sinon.spy(),
+          sendTelemetry: sinon.spy(),
+          recordMetric: sinon.spy(),
         }
 
         const proxiedObject = {
@@ -487,6 +491,8 @@ function createGarbage (count = 50) {
             increment: sinon.spy(),
             histogram: sinon.spy(),
             flush: sinon.spy(),
+            sendTelemetry: sinon.spy(),
+            recordMetric: sinon.spy(),
           }
 
           const LocalClient = sinon.spy(function () {
@@ -495,6 +501,8 @@ function createGarbage (count = 50) {
               increment: localClient.increment,
               histogram: localClient.histogram,
               flush: localClient.flush,
+              sendTelemetry: localClient.sendTelemetry,
+              recordMetric: localClient.recordMetric,
             }
           })
           LocalClient.generateClientConfig = DogStatsDClient.generateClientConfig


### PR DESCRIPTION
### What does this PR do?
* Enables client self-telemetry according to the spec provided on [Sending large volumes of metrics](https://docs.datadoghq.com/extend/dogstatsd/high_throughput/?tab=python)
* Client metrics enabled follow the Python specs
* Client metrics are collected and flushed separately from standard metrics, ensuring there is no buffer competition on send
* Collecting client metrics requires an explicit opt-in such that existing plugin and instrumentation metrics are not affected

*  | Metric | Description |
|--------|-------------|
| `datadog.dogstatsd.client.metrics` | Total number of metrics sent |
| `datadog.dogstatsd.client.metrics_by_type` | Metrics broken down by type (gauge, count, set, timing, histogram, distribution) |
| `datadog.dogstatsd.client.bytes_sent` | Total bytes successfully sent |
| `datadog.dogstatsd.client.bytes_dropped` | Total bytes dropped |
| `datadog.dogstatsd.client.packets_sent` | Total packets successfully sent |
| `datadog.dogstatsd.client.packets_dropped` | Total packets dropped |

### Motivation
* Several other client libraries already report client metrics that provide important insight into client health
* While the js client library does have existing error logs, there are several locations where fails are dropped silently. The metrics not only match the official Datadog spec, but also provide critical insight into client health

### Additional Notes
* Self-telemetry is disabled by default for backwards compatibility and to ensure that internal metrics and plugins are unaffected
* Internal client metrics do not contribute to the self-telemetry counters
