### PR TITLE
perf(profiler): skip redundant setContext under AsyncContextFrame

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/wall.js
+++ b/packages/dd-trace/src/profiling/profilers/wall.js
@@ -247,6 +247,7 @@ class NativeWallProfiler {
     // context -- we simply can't tell which one it might've been across all
     // possible async context frames.
     if (this.#asyncContextFrameEnabled) {
+      const current = this.#pprof.time.getContext()
       if (this.#customLabelsActive) {
         // Custom labels may be active in this async context. The current CPED
         // context could be a 2-element array [profilingContext, customLabels].
@@ -254,7 +255,6 @@ class NativeWallProfiler {
         // This flag is monotonic (once set, stays true) because async
         // continuations from runWithLabels can fire at any time after the
         // synchronous runWithLabels call has returned.
-        const current = this.#pprof.time.getContext()
         if (Array.isArray(current)) {
           if (current[0] !== sampleContext) {
             this.#pprof.time.setContext([sampleContext, current[1]])
@@ -262,7 +262,13 @@ class NativeWallProfiler {
         } else if (current !== sampleContext) {
           this.#pprof.time.setContext(sampleContext)
         }
-      } else {
+      // Every setContext() call in ACF mode allocates a fresh contextHolder
+      // (a node::ObjectWrap with its own v8::Global<v8::Value>) in the native
+      // profiler. Skip the call if the CPED already holds this sampleContext,
+      // which is the common case when the same span is repeatedly activated:
+      // #getProfilingContext caches profilingContext on span[ProfilingContext],
+      // so identity comparison short-circuits.
+      } else if (current !== sampleContext) {
         this.#pprof.time.setContext(sampleContext)
       }
     } else {

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -24,6 +24,7 @@ describe('profilers/native/wall', () => {
         start: sinon.stub(),
         stop: sinon.stub().returns(profile0),
         setContext: sinon.stub(),
+        getContext: sinon.stub(),
         v8ProfilerStuckEventLoopDetected: sinon.stub().returns(false),
         constants: {
           kSampleCount: 0,
@@ -719,6 +720,7 @@ describe('profilers/native/wall', () => {
         time: {
           ...pprof.time,
           setContext: sinon.stub(),
+          getContext: sinon.stub(),
         },
       }
 
@@ -899,5 +901,35 @@ describe('profilers/native/wall', () => {
 
       profiler.stop()
     })
+
+    it('should skip setContext in ACF mode when current CPED context equals sampleContext', () => {
+      // Every native setContext in ACF mode allocates a fresh contextHolder
+      // (Object+Global), so repeated activations of the same span must short-
+      // circuit when the CPED already holds the cached profilingContext.
+      const { span: webSpan } = makeWebSpan()
+      const profiler = new WallProfiler({
+        endpointCollectionEnabled: true,
+        codeHotspotsEnabled: true,
+        asyncContextFrameEnabled: true,
+      })
+      profiler.start()
+
+      currentStore = { span: webSpan }
+      enterCh.publish()
+      sinon.assert.calledOnce(localPprof.time.setContext)
+      const ctx0 = localPprof.time.setContext.firstCall.args[0]
+
+      // Simulate the CPED now holding ctx0 (which the native side would have
+      // done in response to the previous setContext call).
+      localPprof.time.getContext.returns(ctx0)
+
+      // Re-activation with the same span returns the cached ctx0 from
+      // #getProfilingContext → #enter must skip the native setContext call.
+      enterCh.publish()
+      sinon.assert.calledOnce(localPprof.time.setContext)
+
+      profiler.stop()
+    })
+
   })
 })

--- a/packages/dd-trace/test/profiling/profilers/wall.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/wall.spec.js
@@ -930,6 +930,5 @@ describe('profilers/native/wall', () => {
 
       profiler.stop()
     })
-
   })
 })


### PR DESCRIPTION
### What does this PR do?

Cuts allocation churn in the wall profiler when AsyncContextFrame is enabled (default on Node.js 24+).

`NativeWallProfiler.#enter()` was calling the native `setContext()` on every legacy-storage `enterWith()`. In CPED mode, each native `setContext()` allocates a fresh contextHolder — `v8::Object` wrap, `v8::Global<v8::Value>`, and `PersistentContextPtr` — even when the value being written is identical to the entry already in the current AsyncContextFrame's CPED. Since `#getProfilingContext` caches the profilingContext on `span[ProfilingContext]`, repeated activations of the same span produce the same JS reference, so the call is redundant. We now skip it when `getContext() === sampleContext`. The native getter reads CPED via raw addresses without allocating, so the guard is cheap.

### Motivation

Customer reports of ~2× heap growth (e.g. 300 MB → 600 MB) for dd-trace-js processes with the profiler enabled on Node.js 24+. The increase isn't consistent with what the ACF profiling mode should structurally need (one profilingContext per active span: span id, local root span id, tags reference, plus modest native bookkeeping). Investigation pinned it to the unconditional `setContext` path producing one `PersistentContextPtr` + `Global<Value>` per `enterWith()` on busy hot paths.

The existing `profilers.wall.async_contexts_live` gauge (`liveContextPtrs_.size()` in pprof-nodejs's `wall.cc`) is a useful diagnostic for affected customers — if it sits in the tens or hundreds of thousands on a Node 24+ host, it confirms allocation churn rather than a structural leak.

### Additional Notes

- The `customLabelsActive` branch already had the equivalent identity check; this PR just lifts the `getContext()` call so the common (no custom labels) branch can use it too.
- Test added: verifies the `setContext` skip in ACF mode when the CPED already holds the sample context.
- No behavior change for the non-ACF path or for the `_generateLabels` output.

JIRA: [PROF-14782]