### PR TITLE
fix(http2): avoid port reuse in server tests

### DIFF
--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -218,7 +218,10 @@ describe('Plugin', () => {
         beforeEach(done => {
           const server = http2.createServer(listener)
           appListener = server
-            .listen(port, 'localhost', () => done())
+            .listen(0, 'localhost', () => {
+              port = appListener.address().port
+              done()
+            })
         })
 
         const spanProducerFn = (done) => {
@@ -313,7 +316,10 @@ describe('Plugin', () => {
         beforeEach(done => {
           const server = http2.createServer(listener)
           appListener = server
-            .listen(port, 'localhost', () => done())
+            .listen(0, 'localhost', () => {
+              port = appListener.address().port
+              done()
+            })
         })
 
         it('should drop traces for blocklist route', done => {


### PR DESCRIPTION
## Summary

- Two `beforeEach` blocks in the http2 server tests were calling `.listen(port, 'localhost', ...)`, reusing whatever port a previous test had bound to
- This caused intermittent `EADDRINUSE` errors when the OS hadn't released the port yet
- Fixed by switching to `.listen(0, ...)` and capturing the dynamically assigned port via `appListener.address().port`, matching the pattern already used by other setup blocks in the same file

## Test Plan

- [x] Run `./node_modules/.bin/mocha packages/datadog-plugin-http2/test/server.spec.js` — 25/26 tests pass (the 1 failure is a pre-existing flaky timeout in the `cancelled request` test unrelated to this change)

> Generated by [Claude Code](https://claude.com/claude-code)