### PR TITLE
test(http2): fix flaky cancelled-request span assertion

### DIFF
--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -138,9 +138,13 @@ describe('Plugin', () => {
           app = sinon.stub()
 
           const tracesPromise = agent.assertSomeTraces(traces => {
+            // The batch may also contain the client-side http.request span; find the server span.
+            const serverTrace = traces.find(t => t[0]?.name === 'web.request')
+            if (!serverTrace) throw new Error('No web.request span found in batch yet')
+
             sinon.assert.notCalled(app) // request should be cancelled before call to app
 
-            assertObjectContains(traces[0][0], {
+            assertObjectContains(serverTrace[0], {
               name: 'web.request',
               service: 'test',
               type: 'web',


### PR DESCRIPTION
## Summary

- The `assertSomeTraces` callback in the cancelled-request test was checking `traces[0][0]`, but both the http2 client span (`http.request`) and server span (`web.request`) can arrive in the same batch with the client span appearing first
- This caused a sporadic `AssertionError: 'http.request' !== 'web.request'` since no further batches would arrive
- Fix: filter the batch for a trace whose first span has `name === 'web.request'` before asserting, making the assertion resilient to span ordering and mixed-span batches

## Test Plan

- [x] `PLUGINS="http2" npm run test:plugins` — all 145 tests pass, 8 pending

> Generated by Claude Code