### PR TITLE
fix(dbm): rename _dd.dbm.propagation_hash to _dd.propagated_hash

### DIFF
--- a/packages/dd-trace/src/plugins/database.js
+++ b/packages/dd-trace/src/plugins/database.js
@@ -103,7 +103,7 @@ class DatabasePlugin extends StoragePlugin {
       if (hashBase64) {
         dbmComment += `,ddsh='${hashBase64}'`
         // Add hash to span meta as a tag
-        span.setTag('_dd.dbm.propagation_hash', hashBase64)
+        span.setTag('_dd.propagated_hash', hashBase64)
       }
     }
 

--- a/packages/dd-trace/test/plugins/database-dbm-hash.spec.js
+++ b/packages/dd-trace/test/plugins/database-dbm-hash.spec.js
@@ -76,10 +76,10 @@ describe('DatabasePlugin DBM Hash', () => {
       assert.ok(comment.includes("ddsh='AQIDBAUG'"), 'Comment should include base64 hash')
     })
 
-    it('should set _dd.dbm.propagation_hash tag on span', () => {
+    it('should set _dd.propagated_hash tag on span', () => {
       plugin.createDbmComment(span, 'test-service')
 
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], 'AQIDBAUG',
+      assert.strictEqual(span._tags['_dd.propagated_hash'], 'AQIDBAUG',
         'Span should have propagation hash tag')
     })
 
@@ -96,7 +96,7 @@ describe('DatabasePlugin DBM Hash', () => {
       plugin.config.dbmPropagationMode = 'full'
       const fullComment = plugin.createDbmComment(span, 'test-service')
       assert.ok(fullComment.includes("ddsh='AQIDBAUG'"), 'Full mode should include hash')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], 'AQIDBAUG',
+      assert.strictEqual(span._tags['_dd.propagated_hash'], 'AQIDBAUG',
         'Full mode should set span tag')
     })
 
@@ -107,7 +107,7 @@ describe('DatabasePlugin DBM Hash', () => {
 
       assert.ok(comment, 'Comment should still be created')
       assert.ok(!comment.includes('ddsh='), 'Comment should not include hash')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], undefined,
+      assert.strictEqual(span._tags['_dd.propagated_hash'], undefined,
         'Span should not have hash tag')
     })
 
@@ -127,7 +127,7 @@ describe('DatabasePlugin DBM Hash', () => {
 
       assert.ok(comment, 'Comment should still be created')
       assert.ok(!comment.includes('ddsh='), 'Comment should not include hash when config is disabled')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], undefined,
+      assert.strictEqual(span._tags['_dd.propagated_hash'], undefined,
         'Span should not have hash tag when config is disabled')
     })
 
@@ -159,7 +159,7 @@ describe('DatabasePlugin DBM Hash', () => {
       const query = 'SELECT * FROM users'
       plugin.injectDbmQuery(span, query, 'test-service')
 
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], 'AQIDBAUG',
+      assert.strictEqual(span._tags['_dd.propagated_hash'], 'AQIDBAUG',
         'Span should have hash tag after query injection')
     })
   })
@@ -174,7 +174,7 @@ describe('DatabasePlugin DBM Hash', () => {
 
       assert.ok(comment.includes("ddsh='AQIDBAUG'"), 'Should inject hash')
       assert.ok(comment.includes('dddbs='), 'Should inject service tags')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], 'AQIDBAUG',
+      assert.strictEqual(span._tags['_dd.propagated_hash'], 'AQIDBAUG',
         'Should set hash tag on span')
     })
 
@@ -188,7 +188,7 @@ describe('DatabasePlugin DBM Hash', () => {
       assert.ok(comment, 'Should still create comment')
       assert.ok(comment.includes('dddbs='), 'Should inject service tags')
       assert.ok(!comment.includes('ddsh='), 'Should NOT inject hash')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], undefined,
+      assert.strictEqual(span._tags['_dd.propagated_hash'], undefined,
         'Should NOT set hash tag on span')
     })
 
@@ -201,7 +201,7 @@ describe('DatabasePlugin DBM Hash', () => {
 
       assert.ok(comment, 'Should still create comment with basic service info')
       assert.ok(!comment.includes('ddsh='), 'Should NOT inject hash')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], undefined,
+      assert.strictEqual(span._tags['_dd.propagated_hash'], undefined,
         'Should NOT set hash tag on span')
     })
 
@@ -214,7 +214,7 @@ describe('DatabasePlugin DBM Hash', () => {
 
       assert.ok(comment, 'Should still create comment')
       assert.ok(!comment.includes('ddsh='), 'Should NOT inject hash without process tags enabled')
-      assert.strictEqual(span._tags['_dd.dbm.propagation_hash'], undefined,
+      assert.strictEqual(span._tags['_dd.propagated_hash'], undefined,
         'Should NOT set hash tag on span')
     })
   })


### PR DESCRIPTION
## Summary
- Rename the span tag `_dd.dbm.propagation_hash` to `_dd.propagated_hash` to align with the process tags feature naming convention.
- Update unit tests in `database-dbm-hash.spec.js` accordingly.
- Fixes a typo introduced in #7212

## Test plan
- [x] `./node_modules/.bin/mocha packages/dd-trace/test/plugins/database-dbm-hash.spec.js` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)