### PR TITLE
ci: refine semver label assignment in pr-title workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -63,12 +63,15 @@ jobs:
 
             // For reverts, the semver bump tracks the magnitude of the change
             // being undone, parsed from the nested type in the title.
+            // feat -> minor; fix/build/docs/refactor/perf -> patch;
+            // style/test/ci/chore don't affect users and get no label.
             const semverFor = ({ type, revertedType, breaking }) => {
               if (!type) return undefined
               if (breaking) return 'semver-major'
               const effective = type === 'revert' ? revertedType : type
               if (effective === 'feat') return 'semver-minor'
-              return 'semver-patch'
+              if (['fix', 'build', 'docs', 'refactor', 'perf'].includes(effective)) return 'semver-patch'
+              return undefined
             }
 
             const pr = context.payload.pull_request


### PR DESCRIPTION
## Summary

- `semver-patch` is now only assigned to types that affect users: `fix`, `build`, `docs`, `refactor`, `perf`
- `style`, `test`, `ci`, and `chore` no longer get a semver label since they don't impact users
- `feat` continues to map to `semver-minor`, breaking changes to `semver-major`

## Test plan

- [ ] Open a PR with type `fix` → verify `semver-patch` label is added
- [ ] Open a PR with type `chore` → verify no semver label is added
- [ ] Open a PR with type `ci` → verify no semver label is added
- [ ] Open a PR with type `feat` → verify `semver-minor` label is added

> Generated by Claude Code