### PR TITLE
test(profiler): fix flaky poisson test by injecting random dependency

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/poisson.js
+++ b/packages/dd-trace/src/profiling/profilers/poisson.js
@@ -6,10 +6,11 @@ class PoissonProcessSamplingFilter {
   #samplingInterval
   #resetInterval
   #now
+  #random
   #lastNow = Number.NEGATIVE_INFINITY
   #samplingInstantCount = 0
 
-  constructor ({ samplingInterval, now, resetInterval }) {
+  constructor ({ samplingInterval, now, resetInterval, random = Math.random }) {
     if (samplingInterval <= 0) {
       throw new RangeError(`samplingInterval (${samplingInterval}) must be greater than 0`)
     }
@@ -24,6 +25,7 @@ class PoissonProcessSamplingFilter {
     this.#samplingInterval = samplingInterval
     this.#resetInterval = resetInterval
     this.#now = now
+    this.#random = random
     this.#nextSamplingInstant = this.#callNow()
     this.#setNextSamplingInstant()
   }
@@ -97,7 +99,7 @@ class PoissonProcessSamplingFilter {
 
   #setNextSamplingInstant () {
     this.#currentSamplingInstant = this.#nextSamplingInstant
-    this.#nextSamplingInstant -= Math.log(1 - Math.random()) * this.#samplingInterval
+    this.#nextSamplingInstant -= Math.log(1 - this.#random()) * this.#samplingInterval
     this.#samplingInstantCount++
   }
 }

--- a/packages/dd-trace/test/profiling/profilers/poisson.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/poisson.spec.js
@@ -15,6 +15,18 @@ describe('PoissonProcessSamplingFilter', () => {
     nowValue = 0
   })
 
+  it('should use provided random function instead of Math.random', () => {
+    const random = () => 0.5
+    const filter = new PoissonProcessSamplingFilter({
+      samplingInterval: 100,
+      resetInterval: 200,
+      now,
+      random,
+    })
+    const expected = -Math.log(1 - 0.5) * 100
+    assert.strictEqual(filter.nextSamplingInstant, expected)
+  })
+
   it('should throw if resetInterval < samplingInterval', () => {
     assert.throws(() => new PoissonProcessSamplingFilter({
       samplingInterval: 100,
@@ -129,6 +141,7 @@ describe('PoissonProcessSamplingFilter', () => {
       samplingInterval: 100,
       resetInterval: 200,
       now,
+      random: () => 0.5,
     })
     const prevNextSamplingInstant = filter.nextSamplingInstant
     nowValue = 1000


### PR DESCRIPTION
### What does this PR do?

Adds an injectable `random` parameter (defaulting to `Math.random`) to `PoissonProcessSamplingFilter`, and uses it to make a long-standing flaky test deterministic.

### Motivation

The test `should cap endTime to now() if event endTime is in the future` relied on `Math.random()` placing the initial sampling instant within `[0, 1000ms]`. With `samplingInterval=100`, the probability of failure was `e^(-10) ≈ 0.005%` per run — rare, but the test has been patched 3 times already ([#6229](https://github.com/DataDog/dd-trace-js/pull/6229), [#6341](https://github.com/DataDog/dd-trace-js/pull/6341), [#6382](https://github.com/DataDog/dd-trace-js/pull/6382)) without addressing the root cause: the `currentSamplingInstant >= prevNextSamplingInstant` assertion fails whenever the initial Poisson draw exceeds `cappedEndTime`. This was observed in CI run [#26454619398](https://github.com/DataDog/dd-trace-js/actions/runs/26454619398/job/77884890728).

The fix injects randomness as a constructor dependency (matching the existing `now` injection pattern), allowing tests to pass `random: () => 0.5` for deterministic sampling instants.

### Additional Notes

The `random` parameter has no impact on production behavior — `Math.random` remains the default.

> This PR was generated with [Claude Code](https://claude.ai/claude-code)