### PR TITLE
ci(playwright): install libatomic for Node 26

### DIFF
--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -10,19 +10,10 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 RUN apt-get update && apt-get install -y curl git gpg libatomic1 unzip && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
-    && echo "playwright npm install finished"
-
-RUN /tmp/pw/node_modules/.bin/playwright install-deps chromium \
-    && echo "playwright chromium dependency install finished"
-
-RUN DEBUG=pw:install /tmp/pw/node_modules/.bin/playwright install chromium \
-    && echo "playwright chromium install finished"
-
-RUN rm -rf /tmp/pw \
-    && echo "playwright temp cleanup finished" \
+    && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
+    && rm -rf /tmp/pw \
     # Remove node in the same RUN so it is invisible to the container at runtime.
     # Deletions in a later layer would still bloat the image with the unreachable binary.
     # setup-node is the sole provider of node at runtime.
     && rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
-    && rm -rf /usr/local/lib/node_modules /usr/local/include/node \
-    && echo "node runtime cleanup finished"
+    && rm -rf /usr/local/lib/node_modules /usr/local/include/node

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -10,10 +10,14 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 RUN apt-get update && apt-get install -y curl git gpg libatomic1 && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
+    && echo "playwright npm install finished" \
     && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
+    && echo "playwright chromium install finished" \
     && rm -rf /tmp/pw \
+    && echo "playwright temp cleanup finished" \
     # Remove node in the same RUN so it is invisible to the container at runtime.
     # Deletions in a later layer would still bloat the image with the unreachable binary.
     # setup-node is the sole provider of node at runtime.
     && rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
-    && rm -rf /usr/local/lib/node_modules /usr/local/include/node
+    && rm -rf /usr/local/lib/node_modules /usr/local/include/node \
+    && echo "node runtime cleanup finished"

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -7,7 +7,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
-RUN apt-get update && apt-get install -y curl git gpg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y curl git gpg libatomic1 && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
     && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -10,10 +10,15 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 RUN apt-get update && apt-get install -y curl git gpg libatomic1 && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
-    && echo "playwright npm install finished" \
-    && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
-    && echo "playwright chromium install finished" \
-    && rm -rf /tmp/pw \
+    && echo "playwright npm install finished"
+
+RUN /tmp/pw/node_modules/.bin/playwright install-deps chromium \
+    && echo "playwright chromium dependency install finished"
+
+RUN DEBUG=pw:install /tmp/pw/node_modules/.bin/playwright install chromium \
+    && echo "playwright chromium install finished"
+
+RUN rm -rf /tmp/pw \
     && echo "playwright temp cleanup finished" \
     # Remove node in the same RUN so it is invisible to the container at runtime.
     # Deletions in a later layer would still bloat the image with the unreachable binary.

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -1,5 +1,7 @@
 FROM oven/bun:1.3.1 AS bun
-FROM node:24-bookworm-slim
+# This Node version only runs Playwright's browser installer during image build.
+# setup-node provides the test runtime version after this binary is removed below.
+FROM node:20-bookworm-slim
 ARG PLAYWRIGHT_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -115,16 +115,12 @@ jobs:
           IMAGE_TAG: ${{ steps.versions.outputs.image-tag }}
         run: |
           IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${IMAGE_TAG}"
-          echo "Checking for ${IMAGE}"
           if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
             echo "Image ${IMAGE} already exists, skipping build"
           else
-            echo "Building ${IMAGE} for Playwright ${PW_VERSION}"
-            docker build --progress=plain --build-arg PLAYWRIGHT_VERSION="${PW_VERSION}" \
+            docker build --build-arg PLAYWRIGHT_VERSION="${PW_VERSION}" \
               -t "${IMAGE}" .github/playwright
-            echo "Built ${IMAGE}, pushing"
             docker push "${IMAGE}"
-            echo "Pushed ${IMAGE}"
           fi
 
   integration-playwright:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -115,12 +115,16 @@ jobs:
           IMAGE_TAG: ${{ steps.versions.outputs.image-tag }}
         run: |
           IMAGE="ghcr.io/datadog/dd-trace-js/playwright-tools:${IMAGE_TAG}"
+          echo "Checking for ${IMAGE}"
           if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
             echo "Image ${IMAGE} already exists, skipping build"
           else
-            docker build --build-arg PLAYWRIGHT_VERSION="${PW_VERSION}" \
+            echo "Building ${IMAGE} for Playwright ${PW_VERSION}"
+            docker build --progress=plain --build-arg PLAYWRIGHT_VERSION="${PW_VERSION}" \
               -t "${IMAGE}" .github/playwright
+            echo "Built ${IMAGE}, pushing"
             docker push "${IMAGE}"
+            echo "Pushed ${IMAGE}"
           fi
 
   integration-playwright:

--- a/integration-tests/ci-visibility/automatic-log-submission.spec.js
+++ b/integration-tests/ci-visibility/automatic-log-submission.spec.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const assert = require('assert')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const { once } = require('events')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig,
   assertObjectContains,
@@ -29,11 +30,7 @@ describe('test optimization automatic log submission', () => {
 
   before(async () => {
     cwd = sandboxCwd()
-    const { NODE_OPTIONS, ...restOfEnv } = process.env
-    // Install chromium (configured in integration-tests/playwright.config.js)
-    // *Be advised*: this means that we'll only be using chromium for this test suite
-    // Must run in before hook: sandbox is created at test time so workflow can't install
-    execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+    installPlaywrightChromium(cwd)
     await new Promise((resolve, reject) => {
       webAppServer.listen(0, () => {
         const address = webAppServer.address()

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -1026,8 +1026,6 @@ function installPlaywrightChromium (cwd) {
     existsSync(PLAYWRIGHT_BROWSERS_PATH) &&
     readdirSync(PLAYWRIGHT_BROWSERS_PATH).length > 0
   ) {
-    // eslint-disable-next-line no-console
-    console.log(`Using preinstalled Playwright browsers from ${PLAYWRIGHT_BROWSERS_PATH}`)
     return
   }
 

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const childProcess = require('child_process')
 const { exec, execSync, fork, spawn } = childProcess
-const { existsSync, readFileSync, unlinkSync, writeFileSync } = require('fs')
+const { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } = require('fs')
 const fs = require('fs/promises')
 const http = require('http')
 const { builtinModules } = require('module')
@@ -1015,6 +1015,26 @@ function useEnv (env) {
 }
 
 /**
+ * @param {string} cwd
+ */
+function installPlaywrightChromium (cwd) {
+  const { NODE_OPTIONS, ...env } = process.env
+  const { PLAYWRIGHT_BROWSERS_PATH } = env
+
+  if (
+    PLAYWRIGHT_BROWSERS_PATH &&
+    existsSync(PLAYWRIGHT_BROWSERS_PATH) &&
+    readdirSync(PLAYWRIGHT_BROWSERS_PATH).length > 0
+  ) {
+    // eslint-disable-next-line no-console
+    console.log(`Using preinstalled Playwright browsers from ${PLAYWRIGHT_BROWSERS_PATH}`)
+    return
+  }
+
+  execSync('npx playwright install chromium', { cwd, env, stdio: 'inherit' })
+}
+
+/**
  * @param {Parameters<createSandbox>} args
  */
 function useSandbox (...args) {
@@ -1180,6 +1200,7 @@ module.exports = {
   spawnPluginIntegrationTestProcAndExpectExit,
   useEnv,
   setShouldKill,
+  installPlaywrightChromium,
   sandboxCwd,
   useSandbox,
   varySandbox,

--- a/integration-tests/playwright/playwright-active-test-span.spec.js
+++ b/integration-tests/playwright/playwright-active-test-span.spec.js
@@ -2,13 +2,14 @@
 
 const assert = require('node:assert')
 const { once } = require('node:events')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const { inspect } = require('node:util')
 const satisfies = require('semifies')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig,
   assertObjectContains,
@@ -56,11 +57,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instances to avoid issues with retries
       webAppServer = createWebAppServer()

--- a/integration-tests/playwright/playwright-atr.spec.js
+++ b/integration-tests/playwright/playwright-atr.spec.js
@@ -2,12 +2,13 @@
 
 const assert = require('node:assert')
 const { once } = require('node:events')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const satisfies = require('semifies')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig,
 } = require('../helpers')
@@ -50,11 +51,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instance to avoid issues with retries
       webAppServer = createWebAppServer()

--- a/integration-tests/playwright/playwright-efd.spec.js
+++ b/integration-tests/playwright/playwright-efd.spec.js
@@ -2,12 +2,13 @@
 
 const assert = require('node:assert')
 const { once } = require('node:events')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const satisfies = require('semifies')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   assertObjectContains,
 } = require('../helpers')
@@ -58,11 +59,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instance to avoid issues with retries
       webAppServer = createWebAppServer()

--- a/integration-tests/playwright/playwright-final-status.spec.js
+++ b/integration-tests/playwright/playwright-final-status.spec.js
@@ -2,12 +2,13 @@
 
 const assert = require('node:assert')
 const { once } = require('node:events')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const satisfies = require('semifies')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
@@ -56,11 +57,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instance to avoid issues with retries
       webAppServer = createWebAppServer()

--- a/integration-tests/playwright/playwright-impacted-tests.spec.js
+++ b/integration-tests/playwright/playwright-impacted-tests.spec.js
@@ -10,6 +10,7 @@ const satisfies = require('semifies')
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   assertObjectContains,
 } = require('../helpers')
@@ -56,11 +57,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instance to avoid issues with retries
       webAppServer = createWebAppServer()

--- a/integration-tests/playwright/playwright-reporting.spec.js
+++ b/integration-tests/playwright/playwright-reporting.spec.js
@@ -2,13 +2,14 @@
 
 const assert = require('node:assert')
 const { once } = require('node:events')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const { inspect } = require('node:util')
 const satisfies = require('semifies')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   getCiVisEvpProxyConfig,
   assertObjectContains,
@@ -73,11 +74,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instance to avoid issues with retries
       webAppServer = createWebAppServer()

--- a/integration-tests/playwright/playwright-test-management.spec.js
+++ b/integration-tests/playwright/playwright-test-management.spec.js
@@ -3,12 +3,13 @@
 const assert = require('node:assert')
 const { once } = require('node:events')
 const { inspect } = require('node:util')
-const { exec, execSync } = require('child_process')
+const { exec } = require('child_process')
 const satisfies = require('semifies')
 
 const {
   sandboxCwd,
   useSandbox,
+  installPlaywrightChromium,
   getCiVisAgentlessConfig,
   assertObjectContains,
 } = require('../helpers')
@@ -62,11 +63,7 @@ versions.forEach((version) => {
       this.timeout(120000)
 
       cwd = sandboxCwd()
-      const { NODE_OPTIONS, ...restOfEnv } = process.env
-      // Install chromium (configured in integration-tests/playwright.config.js)
-      // *Be advised*: this means that we'll only be using chromium for this test suite
-      // This will use cached browsers if available, otherwise download
-      execSync('npx playwright install chromium', { cwd, env: restOfEnv, stdio: 'inherit' })
+      installPlaywrightChromium(cwd)
 
       // Create fresh server instance to avoid issues with retries
       webAppServer = createWebAppServer()


### PR DESCRIPTION
### What does this PR do?
Adds `libatomic1` to the Playwright tools Docker image and makes Playwright integration specs reuse the Chromium browser already installed in that image when available.

### Motivation
Node 26 binaries from `actions/setup-node` require `libatomic.so.1`. The Playwright jobs run inside a custom image, so Node 26 failed before tests could start when that shared library was missing.

The oldest Playwright lane can also hang after the Chromium archive download completes when the browser installer runs under Node 26. Reusing the browser installed at image-build time avoids rerunning that installer during the test job.

### Additional Notes
Outside the prebuilt CI image, the helper still falls back to `npx playwright install chromium`.