### PR TITLE
test(profiling): stabilize Poisson sampling filter spec

### DIFF
--- a/packages/dd-trace/test/profiling/profilers/poisson.spec.js
+++ b/packages/dd-trace/test/profiling/profilers/poisson.spec.js
@@ -131,7 +131,11 @@ describe('PoissonProcessSamplingFilter', () => {
       now,
     })
     const prevNextSamplingInstant = filter.nextSamplingInstant
-    nowValue = 1000
+    // nowValue must comfortably exceed the initial nextSamplingInstant, which is an
+    // exponential RV with mean = samplingInterval = 100. P(initial > 100000) = e^-1000,
+    // so the first assertion below is effectively never flaky. The resetInterval still
+    // bounds the while loop in filter() to ~2 iterations, keeping the other assertions tight.
+    nowValue = 100000
     const event = { startTime: 0, duration: 1e6 }
     filter.filter(event)
     assert.ok(


### PR DESCRIPTION
## Summary

The `should cap endTime to now() if event endTime is in the future` test in `packages/dd-trace/test/profiling/profilers/poisson.spec.js` is rarely but reproducibly flaky. Example failure: [Profiling / macos run 26454619398](https://github.com/DataDog/dd-trace-js/actions/runs/26454619398/job/77884890728).

```
AssertionError [ERR_ASSERTION]: Expected 0 >= 1019.6941980837971
  at packages/dd-trace/test/profiling/profilers/poisson.spec.js:137
```

### Root cause

The test sets `nowValue = 1000`, which caps `endTime` inside `filter()` to 1000. But after the constructor runs, `nextSamplingInstant` is an exponentially distributed random variable with rate `1 / samplingInterval = 1 / 100`, i.e. mean 100. The first assertion (`currentSamplingInstant >= prevNextSamplingInstant`) only holds if the while loop in `poisson.js` advances at least once, which requires `cappedEndTime >= nextSamplingInstant` — i.e. the initial sample is `≤ 1000`.

P(exp(mean=100) > 1000) = e⁻¹⁰ ≈ 4.5 × 10⁻⁵ per run. Across the CI matrix that surfaces as a flake every ~22k invocations.

### Fix

Bump `nowValue` to `100000`, so the cap sits 1000× the mean of the initial random sample. New failure probability is e⁻¹⁰⁰⁰ ≈ 0.

The other assertions remain tight:
- `nextSamplingInstant < 500000`: after the while loop, `nextSamplingInstant ≈ nowValue + exp(100)` ≈ 100100. ✓
- `samplingInstantCount < 30`: the reset on line 73 in `poisson.js` clamps `nextSamplingInstant` to `cappedEndTime - resetInterval = 99800`, so the while loop runs `~resetInterval / samplingInterval ≈ 2` iterations. Total count ≈ 3. ✓

## Test plan

- [x] Ran `packages/dd-trace/test/profiling/profilers/poisson.spec.js` 50× locally — 50/50 pass
- [x] Verified other assertions stay well within bounds under the new `nowValue`