### PR TITLE
chore(release): replace semver-major exclusion with only-land-on-next label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,9 +71,9 @@ In the event that some existing functionality _does_ need to change, as much as 
 
 ## Indicate intended release targets
 
-When writing major changes we use a series of labels in the form of `dont-land-on-vN.x` where N is the major release line which a PR should not land in. Every PR marked as semver-major should include these tags. These tags allow our [branch-diff](https://github.com/bengl/branch-diff) tooling to work smoothly as we can exclude PRs not intended for the release line we're preparing a release proposal for. The `semver-major` labels on their own are not sufficient as they don't encode any indication of from _which_ releases they are a major change.
+When writing changes that should only land on the next major release line (master) and not on any current stable release line, add the `only-land-on-next` label. This tells our [branch-diff](https://github.com/bengl/branch-diff) tooling to exclude those PRs when preparing a release proposal for a stable line.
 
-For outside contributions we will have the relevant team add these labels when they review and determine when they plan to release it.
+For outside contributions we will have the relevant team add this label when they review and determine the intended release target.
 
 ## Ensure all tests are green
 

--- a/scripts/check-proposal-labels.js
+++ b/scripts/check-proposal-labels.js
@@ -6,19 +6,16 @@ const childProcess = require('child_process')
 const ORIGIN = 'origin/'
 
 let releaseBranch = process.env.GITHUB_BASE_REF // 'origin/v3.x'
-let releaseVersion = releaseBranch
-if (releaseBranch.startsWith(ORIGIN)) {
-  releaseVersion = releaseBranch.slice(ORIGIN.length)
-} else {
+if (!releaseBranch.startsWith(ORIGIN)) {
   releaseBranch = ORIGIN + releaseBranch
 }
-let currentBranch = process.env.GITHUB_HEAD_REF // 'ugaitz/workflow-to-verify-dont-land-on-v3.x'
+let currentBranch = process.env.GITHUB_HEAD_REF
 if (!currentBranch.startsWith(ORIGIN)) {
   currentBranch = ORIGIN + currentBranch
 }
 
-const getHashesCommandWithExclusions = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major' +
-  ` --exclude-label=dont-land-on-${releaseVersion} ${releaseBranch} ${currentBranch}`
+const getHashesCommandWithExclusions =
+  `branch-diff --user DataDog --repo dd-trace-js --exclude-label=only-land-on-next ${releaseBranch} ${currentBranch}`
 const getHashesCommandWithoutExclusions =
   `branch-diff --user DataDog --repo dd-trace-js ${releaseBranch} ${currentBranch}`
 

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -66,17 +66,26 @@ try {
 
   pass(`v${releaseLine}.x`)
 
-  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major'
+  // Notes exclude semver-major (gated behind a flag, not user-visible).
+  // Cherry-pick includes semver-major; only only-land-on-next is fully excluded.
+  const notesDiffCmd = 'branch-diff --user DataDog --repo dd-trace-js' +
+    ' --exclude-label=semver-major --exclude-label=only-land-on-next'
+  const cherryPickDiffCmd = 'branch-diff --user DataDog --repo dd-trace-js' +
+    ' --exclude-label=only-land-on-next'
 
   start('Determine version increment')
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
-  const lineDiff = capture(`${diffCmd} --format=markdown v${releaseLine}.x ${main}`)
+  const lineDiff = capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x ${main}`)
+  const allDiff = capture(`${cherryPickDiffCmd} --format=markdown v${releaseLine}.x ${main}`)
 
-  // Only commits with a semver-patch/minor label warrant cutting a release;
-  // unlabeled commits (e.g. docs/chore) ride along in the notes and the
-  // cherry-pick, but are not enough on their own.
-  if (!lineDiff.includes('SEMVER-MINOR') && !lineDiff.includes('SEMVER-PATCH')) {
+  // Only labeled commits (semver-patch/minor/major) warrant cutting a release;
+  // unlabeled commits (e.g. docs/chore) ride along but are not enough on their own.
+  if (
+    !allDiff.includes('SEMVER-MINOR') &&
+    !allDiff.includes('SEMVER-PATCH') &&
+    !allDiff.includes('SEMVER-MAJOR')
+  ) {
     pass('none (already up to date)')
     process.exit(0)
   }
@@ -110,12 +119,12 @@ try {
 
   // Get the hashes of the last version and the commits to add.
   const lastCommit = capture('git log -1 --pretty=%B')
-  const proposalDiff = capture(`${diffCmd} --format=sha --reverse v${newVersion}-proposal ${main}`)
+  const proposalDiff = capture(`${cherryPickDiffCmd} --format=sha --reverse v${newVersion}-proposal ${main}`)
     .replaceAll('\n', ' ').trim()
 
   if (proposalDiff) {
     // Get new changes since last commit of the proposal branch.
-    const newChanges = capture(`${diffCmd} v${newVersion}-proposal ${main}`)
+    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${main}`)
 
     pass(`\n${newChanges}`)
 

--- a/scripts/release/validate.js
+++ b/scripts/release/validate.js
@@ -58,7 +58,7 @@ try {
 
   pass()
 
-  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=semver-major'
+  const diffCmd = 'branch-diff --user DataDog --repo dd-trace-js --exclude-label=only-land-on-next'
 
   start('Validate differences between proposal and main branch.')
 


### PR DESCRIPTION
### What does this PR do?

Updates the release tooling to replace the old `semver-major` / `dont-land-on-vN.x` label exclusion model with a single `only-land-on-next` label.

- `semver-major` commits are now **included** in stable release proposals (cherry-picked) and treated as patches, since they are gated behind a flag that is only enabled for the next major. They are excluded from the release notes.
- The per-version `dont-land-on-vN.x` labels are removed. A single `only-land-on-next` label replaces them to mark commits that should only land on master (the next major release line) and not on any current stable release line.

### Motivation

The previous model excluded `semver-major` commits from stable releases entirely, which meant flag-gated breaking changes never shipped to users on stable lines. The new model lets those commits ride along in patch releases while keeping them out of the changelog.

### Additional Notes

- `scripts/release/proposal.js`: split into `notesDiffCmd` (excludes `semver-major` + `only-land-on-next`) and `cherryPickDiffCmd` (excludes `only-land-on-next` only). Version bump is triggered by any labeled commit (SEMVER-MINOR/PATCH/MAJOR).
- `scripts/release/validate.js`: updated to exclude `only-land-on-next` so validation correctly reconstructs the branch including `semver-major` commits.
- `scripts/check-proposal-labels.js`: updated to enforce `only-land-on-next` as the forbidden label; removed the now-unused `releaseVersion` variable and `dont-land-on-*` exclusion.
- `CONTRIBUTING.md`: updated to document the new label.

> This PR was generated by Claude Code.