### PR TITLE
test(playwright): pin flaky retry count in ATR test for 1.18.0 determinism

### DIFF
--- a/integration-tests/playwright/playwright-atr.spec.js
+++ b/integration-tests/playwright/playwright-atr.spec.js
@@ -119,6 +119,9 @@ versions.forEach((version) => {
               ...getCiVisAgentlessConfig(receiver.port),
               PW_BASE_URL: `http://localhost:${webAppPort}`,
               TEST_DIR: './ci-visibility/playwright-tests-automatic-retry',
+              // Playwright 1.18.0 runs all retries even after a pass (doesn't stop on first pass),
+              // so pin the count to match the fixture's pass threshold (retry < 2) for determinism.
+              DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '2',
             },
           }
         )


### PR DESCRIPTION
## Summary

- Playwright 1.18.0 runs all `project.retries + 1` attempts regardless of pass/fail (doesn't stop at first pass)
- The default `DD_CIVISIBILITY_FLAKY_RETRY_COUNT=5` causes `project.retries=5` → 6 total runs → `tests.length=6` instead of 3
- Pins `DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '2'` so the retry count matches the fixture's pass threshold (`retry < 2`), giving exactly 3 runs (fail, fail, pass) on any Node version or Docker environment

The other ATR tests already set this explicitly (`DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1'`) and were passing for the same reason.

This only manifests on v5 release proposals (not master) because master runs `DD_MAJOR=6` where `oldest='1.38.0'`, so the 1.18.0 code path is never exercised. The `if (DD_MAJOR < 6)` block is dead code on master.

> Generated by [Claude Code](https://claude.ai/claude-code)