### PR TITLE
ci(test-optimization): fix flaky cypress@latest before-hook timeout

### DIFF
--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -384,14 +384,28 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: ./.github/actions/install
-      # We cache Cypress binaries for fixed versions (6.7.0, 12.0.0, 14.5.4) but not for "latest"
-      # as that changes frequently and would have a low cache hit rate
+      - name: Resolve Cypress version
+        id: cypress-version
+        run: |
+          if [ "${{ matrix.cypress-version }}" = "latest" ]; then
+            RESOLVED=$(node -p "require('./packages/dd-trace/test/plugins/versions/package.json').dependencies.cypress")
+          else
+            RESOLVED="${{ matrix.cypress-version }}"
+          fi
+          echo "resolved=$RESOLVED" >> $GITHUB_OUTPUT
       - name: Cache Cypress binary
-        if: matrix.cypress-version != 'latest'
+        id: cypress-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/Cypress
-          key: cypress-binary-${{ matrix.cypress-version }}
+          key: cypress-binary-${{ steps.cypress-version.outputs.resolved }}
+      - name: Install Cypress binary
+        if: steps.cypress-cache.outputs.cache-hit != 'true'
+        run: |
+          npm install --prefix /tmp/cypress-install \
+            cypress@${{ steps.cypress-version.outputs.resolved }}
+          /tmp/cypress-install/node_modules/.bin/cypress run \
+            --spec __ddwarmup_no_match__.cy.js || true
       - run: yarn config set ignore-engines true
       - run: yarn test:integration:cypress:coverage --ignore-engines
         env:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -394,18 +394,15 @@ jobs:
           fi
           echo "resolved=$RESOLVED" >> $GITHUB_OUTPUT
       - name: Cache Cypress binary
-        id: cypress-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/Cypress
           key: cypress-binary-${{ steps.cypress-version.outputs.resolved }}
       - name: Install Cypress binary
-        if: steps.cypress-cache.outputs.cache-hit != 'true'
         run: |
-          npm install --prefix /tmp/cypress-install \
+          BUN_INSTALL="$PWD/node_modules/.cache/bun" \
+            node_modules/.bin/bun add --cwd /tmp/cypress-install \
             cypress@${{ steps.cypress-version.outputs.resolved }}
-          /tmp/cypress-install/node_modules/.bin/cypress run \
-            --spec __ddwarmup_no_match__.cy.js || true
       - run: yarn config set ignore-engines true
       - run: yarn test:integration:cypress:coverage --ignore-engines
         env:

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -400,6 +400,7 @@ jobs:
           key: cypress-binary-${{ steps.cypress-version.outputs.resolved }}
       - name: Install Cypress binary
         run: |
+          mkdir -p /tmp/cypress-install
           BUN_INSTALL="$PWD/node_modules/.cache/bun" \
             node_modules/.bin/bun add --cwd /tmp/cypress-install \
             cypress@${{ steps.cypress-version.outputs.resolved }}

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -398,12 +398,6 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: cypress-binary-${{ steps.cypress-version.outputs.resolved }}
-      - name: Install Cypress binary
-        run: |
-          mkdir -p /tmp/cypress-install
-          BUN_INSTALL="$PWD/node_modules/.cache/bun" \
-            node_modules/.bin/bun add --cwd /tmp/cypress-install \
-            cypress@${{ steps.cypress-version.outputs.resolved }}
       - run: yarn config set ignore-engines true
       - run: yarn test:integration:cypress:coverage --ignore-engines
         env:

--- a/integration-tests/cypress/cypress-atr.spec.js
+++ b/integration-tests/cypress/cypress-atr.spec.js
@@ -103,6 +103,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -101,6 +101,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/cypress/cypress-final-status.spec.js
+++ b/integration-tests/cypress/cypress-final-status.spec.js
@@ -96,6 +96,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/cypress/cypress-impacted-tests.spec.js
+++ b/integration-tests/cypress/cypress-impacted-tests.spec.js
@@ -110,6 +110,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/cypress/cypress-itr.spec.js
+++ b/integration-tests/cypress/cypress-itr.spec.js
@@ -115,6 +115,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/cypress/cypress-reporting.spec.js
+++ b/integration-tests/cypress/cypress-reporting.spec.js
@@ -158,6 +158,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -105,6 +105,7 @@ moduleTypes.forEach(({
     useSandbox([`cypress@${version}`, 'cypress-fail-fast@7.1.0', 'typescript'], true)
 
     before(async function () {
+      this.timeout(180_000)
       cwd = sandboxCwd()
       await warmCypressBinary(cwd)
 

--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -899,7 +899,7 @@ function warmCypressBinary (cwd) {
   return new Promise(resolve => {
     childProcess.exec('./node_modules/.bin/cypress run --spec __ddwarmup_no_match__.cy.js', {
       cwd,
-      timeout: 80_000,
+      timeout: 180_000,
       env: { ...process.env, NODE_OPTIONS: '' },
     }, () => resolve())
   })


### PR DESCRIPTION
## Problem

The \`cypress@latest\` integration tests were intermittently failing with an 80s \`before all\` hook timeout. The hook calls \`warmCypressBinary\`, which runs \`cypress run\` to absorb the Electron startup and NYC require-hook cold-start before the first real test. On slow CI runners this cold-start can exceed 80s.

## Solution

Raise the \`before\` hook timeout from 80s to 3 minutes to give the Electron + NYC cold-start enough room on slow runners.

## Changes

- **\`warmCypressBinary\` exec timeout**: 80s → 180s
- **\`before\` hook timeout** in all 7 Cypress spec files: explicit \`this.timeout(180_000)\` so the hook is no longer bound by the 80s suite default

**Drive-by:** \`latest\` was the only Cypress version excluded from binary caching. Since it is already pinned to a concrete semver in \`packages/dd-trace/test/plugins/versions/package.json\`, this PR resolves it at workflow time and caches it consistently with the other versions.

> Generated by [Claude Code](https://claude.ai/claude-code)