### PR TITLE
ci(test-optimization): install Chrome in Docker image for Selenium tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,6 +240,7 @@
 /.github/actions/dd-sts-api-key/action.yml @Datadog/lang-platform-js
 /.github/actions/push_to_test_optimization/ @DataDog/ci-app-libraries
 /.github/playwright/ @DataDog/ci-app-libraries
+/.github/selenium/ @DataDog/ci-app-libraries
 /.github/actions/upload-node-reports/action.yml @Datadog/lang-platform-js
 /.github/chainguard @DataDog/sdlc-security
 /.github/codeql_config.yml @DataDog/sdlc-security

--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -1,5 +1,5 @@
-FROM oven/bun:1.3.1 AS bun
-FROM node:24.14.1-bookworm-slim
+FROM oven/bun:1.3.1@sha256:c1526bc496336087e5bdfaf519746c12ac4d5ebdda6d8a99d27ebd5d9ad7304c AS bun
+FROM node:24.14.1-bookworm-slim@sha256:e484ae3f1e3c378021c967fd42254f343c302a9263e412280eac32bf5bca7008
 ARG PLAYWRIGHT_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/selenium/Dockerfile
+++ b/.github/selenium/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24.14.1-bookworm-slim@sha256:e484ae3f1e3c378021c967fd42254f343c302a926
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y curl wget gnupg libatomic1 unzip \
+RUN apt-get update && apt-get install -y curl git gnupg libatomic1 unzip wget \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Google Chrome stable

--- a/.github/selenium/Dockerfile
+++ b/.github/selenium/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:24.14.1-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y curl wget gnupg unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Google Chrome stable
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
+    | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+       > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install ChromeDriver matching the installed Chrome version
+RUN CHROME_VER=$(google-chrome --version | awk '{print $3}' | cut -d. -f1-3) \
+    && curl -sf https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json \
+       > /tmp/chrome-versions.json \
+    && DRIVER_URL=$(CHROME_VER="$CHROME_VER" node -e " \
+        const d = JSON.parse(require('fs').readFileSync('/tmp/chrome-versions.json', 'utf8')); \
+        const prefix = process.env.CHROME_VER; \
+        const matches = d.versions.filter(v => v.version.startsWith(prefix)); \
+        const latest = matches[matches.length - 1]; \
+        const entry = latest.downloads.chromedriver.find(e => e.platform === 'linux64'); \
+        console.log(entry.url);") \
+    && wget -q "$DRIVER_URL" -O /tmp/chromedriver.zip \
+    && unzip /tmp/chromedriver.zip -d /tmp/chromedriver-dir \
+    && mv /tmp/chromedriver-dir/chromedriver-linux64/chromedriver /usr/bin/chromedriver \
+    && chmod +x /usr/bin/chromedriver \
+    && rm -rf /tmp/chrome-versions.json /tmp/chromedriver.zip /tmp/chromedriver-dir
+
+# Remove node since it will be injected at runtime by setup-node
+RUN rm -f /usr/local/bin/node /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/corepack \
+    && rm -rf /usr/local/lib/node_modules /usr/local/include/node

--- a/.github/selenium/Dockerfile
+++ b/.github/selenium/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:24.14.1-bookworm-slim
+FROM node:24.14.1-bookworm-slim@sha256:e484ae3f1e3c378021c967fd42254f343c302a9263e412280eac32bf5bca7008
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y curl wget gnupg unzip \
+RUN apt-get update && apt-get install -y curl wget gnupg libatomic1 unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Google Chrome stable

--- a/.github/workflows/test-optimization.yml
+++ b/.github/workflows/test-optimization.yml
@@ -285,7 +285,41 @@ jobs:
           flags: test-optimization-cucumber-${{ matrix.version }}-${{ matrix.cucumber-version }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
+  selenium-image:
+    name: Ensure Selenium Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Determine image tag
+        id: image
+        run: |
+          DOCKER_HASH=$(sha256sum .github/selenium/Dockerfile | cut -c1-8)
+          IMAGE="ghcr.io/datadog/dd-trace-js/selenium-tools:${DOCKER_HASH}"
+          echo "image=$IMAGE" >> $GITHUB_OUTPUT
+      - name: Log in to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Ensure image
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: |
+          if docker manifest inspect "${IMAGE}" > /dev/null 2>&1; then
+            echo "Image ${IMAGE} already exists, skipping build"
+          else
+            docker build -t "${IMAGE}" .github/selenium
+            docker push "${IMAGE}"
+          fi
+
   integration-selenium:
+    needs: selenium-image
     strategy:
       fail-fast: false
       matrix:
@@ -293,6 +327,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    container:
+      image: ${{ needs.selenium-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       DD_SERVICE: dd-trace-js-integration-tests
       DD_CIVISIBILITY_AGENTLESS_ENABLED: 1
@@ -304,24 +343,11 @@ jobs:
       - uses: ./.github/actions/node
         with:
           version: ${{ matrix.version }}
-      - name: Install Google Chrome
-        run: |
-          sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-          if [ $? -ne 0 ]; then echo "Failed to add Google key"; exit 1; fi
-          sudo apt-get update
-          sudo apt-get install -y google-chrome-stable
-          if [ $? -ne 0 ]; then echo "Failed to install Google Chrome"; exit 1; fi
-      - name: Install ChromeDriver
-        run: |
-          export CHROME_VERSION=$(google-chrome --version)
-          CHROME_DRIVER_DOWNLOAD_URL=$(node --experimental-fetch scripts/get-chrome-driver-download-url.js)
-          wget -q "$CHROME_DRIVER_DOWNLOAD_URL"
-          if [ $? -ne 0 ]; then echo "Failed to download ChromeDriver"; exit 1; fi
-          unzip chromedriver-linux64.zip
-          sudo mv chromedriver-linux64/chromedriver /usr/bin/chromedriver
-          sudo chmod +x /usr/bin/chromedriver
       - uses: ./.github/actions/install
+      - name: Configure Git safe directory
+        # The Selenium job runs in a container where the checkout can be owned by a different UID.
+        # Git rejects metadata commands in that checkout unless the workspace is marked as safe.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - run: yarn test:integration:selenium:coverage
         env:
           NODE_OPTIONS: "-r ./ci/init"

--- a/integration-tests/ci-visibility/features-selenium/support/steps.js
+++ b/integration-tests/ci-visibility/features-selenium/support/steps.js
@@ -10,7 +10,7 @@ let title
 let helloWorldText
 
 const options = new chrome.Options()
-options.addArguments('--headless')
+options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage')
 
 Before(async function () {
   const build = new Builder().forBrowser('chrome').setChromeOptions(options)

--- a/integration-tests/ci-visibility/test/selenium-no-framework.js
+++ b/integration-tests/ci-visibility/test/selenium-no-framework.js
@@ -5,7 +5,7 @@ const chrome = require('selenium-webdriver/chrome')
 
 async function run () {
   const options = new chrome.Options()
-  options.addArguments('--headless')
+  options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage')
   const build = new Builder().forBrowser('chrome').setChromeOptions(options)
   const driver = await build.build()
 

--- a/integration-tests/ci-visibility/test/selenium-test.js
+++ b/integration-tests/ci-visibility/test/selenium-test.js
@@ -5,7 +5,7 @@ const assert = require('assert')
 const { By, Builder } = require('selenium-webdriver')
 const chrome = require('selenium-webdriver/chrome')
 const options = new chrome.Options()
-options.addArguments('--headless')
+options.addArguments('--headless', '--no-sandbox', '--disable-dev-shm-usage')
 
 describe('selenium', function () {
   let driver


### PR DESCRIPTION
## Summary

- Add `.github/selenium/Dockerfile` that pre-installs Google Chrome stable and a matching ChromeDriver (using the Chrome for Testing JSON API to find the correct driver version)
- Add a `selenium-image` CI job that builds this image once, tags it by the Dockerfile SHA256 hash, and pushes to GHCR — skipping the build if the image already exists
- Replace the `integration-selenium` job's on-the-fly `apt-get install google-chrome-stable` + ChromeDriver download steps with a `container:` block pointing at the pre-built image, mirroring the existing `integration-playwright` pattern

## Motivation

Selenium integration tests were intermittently failing during Chrome and ChromeDriver download. Baking both into a Docker image makes the setup hermetic and eliminates that failure mode.

## Test plan

- [ ] `selenium-image` job builds and pushes the image on first run, skips on subsequent runs
- [ ] `integration-selenium` (oldest + latest Node) passes with Chrome and ChromeDriver pre-installed in the container

> Generated by [Claude Code](https://claude.ai/claude-code)