### PR TITLE
fix(ci): install Playwright browser dependencies

### DIFF
--- a/.github/playwright/Dockerfile
+++ b/.github/playwright/Dockerfile
@@ -7,10 +7,66 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 
-RUN apt-get update && apt-get install -y curl git gpg libatomic1 unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gpg \
+    libatomic1 \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
 
+# Playwright 1.18.x tries obsolete Ubuntu package names on Debian Bookworm
+# (`ttf-unifont`, `xfonts-cyrillic`, `ttf-ubuntu-font-family`) and exits 0
+# even though apt fails. Install Chromium's runtime dependencies directly.
 RUN npm install --prefix /tmp/pw @playwright/test@${PLAYWRIGHT_VERSION} \
-    && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
+    && case "$PLAYWRIGHT_VERSION" in \
+      1.18|1.18.*) \
+        echo "Installing Playwright 1.18 Chromium dependencies for Debian Bookworm" \
+        && apt-get update && apt-get install -y --no-install-recommends \
+          ca-certificates \
+          fonts-ipafont-gothic \
+          fonts-liberation \
+          fonts-noto-color-emoji \
+          fonts-tlwg-loma-otf \
+          fonts-unifont \
+          fonts-wqy-zenhei \
+          libasound2 \
+          libatk-bridge2.0-0 \
+          libatk1.0-0 \
+          libatspi2.0-0 \
+          libcairo2 \
+          libcups2 \
+          libdbus-1-3 \
+          libdrm2 \
+          libegl1 \
+          libfontconfig1 \
+          libfreetype6 \
+          libgbm1 \
+          libglib2.0-0 \
+          libgtk-3-0 \
+          libnspr4 \
+          libnss3 \
+          libpango-1.0-0 \
+          libx11-6 \
+          libx11-xcb1 \
+          libxcb1 \
+          libxcomposite1 \
+          libxdamage1 \
+          libxext6 \
+          libxfixes3 \
+          libxrandr2 \
+          libxshmfence1 \
+          xfonts-scalable \
+          xvfb \
+        && rm -rf /var/lib/apt/lists/* \
+        && /tmp/pw/node_modules/.bin/playwright install chromium \
+        ;; \
+      *) \
+        echo "Installing Chromium through Playwright dependency installer" \
+        && /tmp/pw/node_modules/.bin/playwright install --with-deps chromium \
+        ;; \
+    esac \
     && rm -rf /tmp/pw \
     # Remove node in the same RUN so it is invisible to the container at runtime.
     # Deletions in a later layer would still bloat the image with the unreachable binary.


### PR DESCRIPTION
### What does this PR do?

Updates the Playwright Docker image so Chromium runtime dependencies are installed correctly on Debian Bookworm.

The large Bookworm-compatible dependency list is only used for Playwright 1.18.x, where Playwright's own `--with-deps` installer still requests obsolete Ubuntu package names. All other Playwright versions keep using `playwright install --with-deps chromium`.

### Motivation

The `integration-playwright (oldest, node-latest, playwright-atr)` job can publish/use a Playwright 1.18 image without Chromium runtime dependencies. In that image, Playwright initializes and emits CI Visibility events, but Chromium fails to launch on every ATR attempt, which turns the expected retry event count into `6 !== 3`.

The bad dependency installation comes from `@playwright/test@1.18.0` trying package names such as `ttf-unifont`, `xfonts-cyrillic`, and `ttf-ubuntu-font-family` on a Bookworm-based image. Apt fails, but Playwright exits successfully.

### Additional Notes

Validation performed locally:

- Reproduced the failure in `ghcr.io/datadog/dd-trace-js/playwright-tools:1.18.0-80bb7325` with Node 26 and `PLAYWRIGHT_VERSION=oldest`.
- Built the final image with `PLAYWRIGHT_VERSION=1.18.0`; the build log shows `Installing Playwright 1.18 Chromium dependencies for Debian Bookworm`.
- Ran full `playwright-atr` in the final 1.18 image: `4 passing`.
- Built the final image with `PLAYWRIGHT_VERSION=1.60.0`; the build log shows `Installing Chromium through Playwright dependency installer`.