### PR TITLE
fix(msgpack): cap MsgpackChunk growth at the agent intake limit

### DIFF
--- a/packages/dd-trace/src/datastreams/writer.js
+++ b/packages/dd-trace/src/datastreams/writer.js
@@ -4,7 +4,7 @@ const zlib = require('zlib')
 const pkg = require('../../../../package.json')
 const log = require('../log')
 const request = require('../exporters/common/request')
-const { encode: encodeMsgpack } = require('../msgpack')
+const { encode: encodeMsgpack, MAX_SIZE: MAX_CHUNK_SIZE } = require('../msgpack')
 
 function makeRequest (data, url, cb) {
   const options = {
@@ -36,7 +36,19 @@ class DataStreamsWriter {
       log.debug('Maximum number of active requests reached. Payload discarded: %j', payload)
       return
     }
-    const encodedPayload = encodeMsgpack(payload)
+
+    let encodedPayload
+    try {
+      encodedPayload = encodeMsgpack(payload)
+    } catch (error) {
+      if (error.code !== 'ERR_MSGPACK_CHUNK_OVERFLOW') throw error
+      // The msgpack-encoded pipeline-stats payload exceeded the agent
+      // intake cap. Dropping it locally is safer than letting the
+      // RangeError crash the host process; the agent would reject the
+      // oversized payload at the network boundary anyway.
+      log.error('DataStreamsWriter dropped a payload that exceeded the %d byte chunk cap', MAX_CHUNK_SIZE)
+      return
+    }
 
     zlib.gzip(encodedPayload, { level: 1 }, (err, compressedData) => {
       if (err) {

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const getConfig = require('../config')
-const { MsgpackChunk } = require('../msgpack')
+const { MsgpackChunk, MAX_SIZE: MAX_CHUNK_SIZE } = require('../msgpack')
 const log = require('../log')
 const { normalizeSpan, eventTimeNano } = require('./tags-processors')
 
@@ -265,7 +265,28 @@ class AgentEncoder {
 
     this._traceCount++
 
-    this._encode(bytes, trace)
+    try {
+      this._encode(bytes, trace)
+    } catch (error) {
+      if (error.code !== 'ERR_MSGPACK_CHUNK_OVERFLOW') throw error
+      // The trace, or the queued payload it joined, hit the chunk cap.
+      // Rolling back just the in-flight trace is unsafe: the string cache
+      // may already hold subarrays / indices pointing at bytes we'd
+      // discard, and the next encode would emit stale bytes against a
+      // smaller string table. Drop the whole queued payload so the next
+      // encode starts from a clean state. Emitting a partial buffer would
+      // corrupt the msgpack wire. The virtual `reset()` is called (not
+      // `_reset()`) so subclasses can clear their own per-payload state
+      // (e.g. `AgentlessCiVisibilityEncoder._eventCount`).
+      const dropped = this._traceCount
+      this.reset()
+      log.error(
+        'Trace encoder reset after exceeding the %d byte chunk cap; dropped %d trace(s)',
+        MAX_CHUNK_SIZE,
+        dropped
+      )
+      return
+    }
 
     if (this.#debugEncoding) {
       const end = bytes.length

--- a/packages/dd-trace/src/encode/0.5.js
+++ b/packages/dd-trace/src/encode/0.5.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { MAX_SIZE, OverflowError } = require('../msgpack')
 const { normalizeSpan } = require('./tags-processors')
 const { AgentEncoder: BaseEncoder, stringifySpanEvents } = require('./0.4')
 
@@ -30,7 +31,17 @@ class AgentEncoder extends BaseEncoder {
     const prefixSize = 1
     const stringSize = this._stringBytes.length + 5
     const traceSize = this._traceBytes.length + 5
-    const buffer = Buffer.allocUnsafe(prefixSize + stringSize + traceSize)
+    const payloadSize = prefixSize + stringSize + traceSize
+
+    // The string table and the trace bytes are capped independently, so both
+    // can sit just under the cap while their concatenation crosses it. `encode`
+    // never sees this overflow — it only exists once the two are summed here —
+    // so the writer's flush-time catch drops the payload.
+    if (payloadSize > MAX_SIZE) {
+      throw new OverflowError(payloadSize)
+    }
+
+    const buffer = Buffer.allocUnsafe(payloadSize)
 
     buffer[0] = ARRAY_OF_TWO
 

--- a/packages/dd-trace/src/encode/agentless-ci-visibility.js
+++ b/packages/dd-trace/src/encode/agentless-ci-visibility.js
@@ -7,7 +7,7 @@ const {
   TELEMETRY_ENDPOINT_PAYLOAD_SERIALIZATION_MS,
   TELEMETRY_ENDPOINT_PAYLOAD_EVENTS_COUNT,
 } = require('../ci-visibility/telemetry')
-const { MsgpackChunk } = require('../msgpack')
+const { MsgpackChunk, MAX_SIZE, OverflowError } = require('../msgpack')
 const { AgentEncoder } = require('./0.4')
 const {
   truncateSpanTestOpt,
@@ -371,6 +371,16 @@ class AgentlessCiVisibilityEncoder extends AgentEncoder {
 
     const eventsBytes = this._traceBytes
     const totalSize = prefixBytes.length + eventsBytes.length
+
+    // The metadata prefix (built here, not during `encode`) and the events are
+    // capped independently, so both can stay under the cap while the assembled
+    // payload crosses it. An oversized metadata tag also overflows the prefix
+    // chunk itself inside `_encodePayloadStart` above; either way the tagged
+    // error propagates to the writer's flush-time catch to drop the payload.
+    if (totalSize > MAX_SIZE) {
+      throw new OverflowError(totalSize)
+    }
+
     const buffer = Buffer.allocUnsafe(totalSize)
     prefixBytes.buffer.copy(buffer, 0, 0, prefixBytes.length)
     eventsBytes.buffer.copy(buffer, prefixBytes.length, 0, eventsBytes.length)

--- a/packages/dd-trace/src/encode/coverage-ci-visibility.js
+++ b/packages/dd-trace/src/encode/coverage-ci-visibility.js
@@ -1,11 +1,12 @@
 'use strict'
-const { MsgpackChunk } = require('../msgpack')
+const { MsgpackChunk, MAX_SIZE: MAX_CHUNK_SIZE } = require('../msgpack')
 
 const {
   distributionMetric,
   TELEMETRY_ENDPOINT_PAYLOAD_SERIALIZATION_MS,
   TELEMETRY_ENDPOINT_PAYLOAD_EVENTS_COUNT,
 } = require('../ci-visibility/telemetry')
+const log = require('../log')
 const FormData = require('../exporters/common/form-data')
 const { AgentEncoder } = require('./0.4')
 
@@ -40,7 +41,24 @@ class CoverageCIVisibilityEncoder extends AgentEncoder {
     const startTime = Date.now()
 
     this._coveragesCount++
-    this.encodeCodeCoverage(this._coverageBytes, coverage)
+    try {
+      this.encodeCodeCoverage(this._coverageBytes, coverage)
+    } catch (error) {
+      if (error.code !== 'ERR_MSGPACK_CHUNK_OVERFLOW') throw error
+      // The coverage payload hit the chunk cap. `_coverageBytes` may
+      // hold a partial entry and a stale `coverages` array prefix. Drop
+      // the whole queued payload so the next encode starts from a clean
+      // state; the parent `AgentEncoder` does the equivalent for its own
+      // bytes / string cache via the inherited `_reset()`.
+      const dropped = this._coveragesCount
+      this.reset()
+      log.error(
+        'Coverage encoder reset after exceeding the %d byte chunk cap; dropped %d coverage(s)',
+        MAX_CHUNK_SIZE,
+        dropped
+      )
+      return
+    }
 
     distributionMetric(
       TELEMETRY_ENDPOINT_PAYLOAD_SERIALIZATION_MS,

--- a/packages/dd-trace/src/exporters/common/writer.js
+++ b/packages/dd-trace/src/exporters/common/writer.js
@@ -3,6 +3,7 @@
 const { channel } = require('dc-polyfill')
 
 const log = require('../../log')
+const { MAX_SIZE: MAX_CHUNK_SIZE } = require('../../msgpack')
 const request = require('./request')
 const { safeJSONStringify } = require('./util')
 
@@ -27,7 +28,22 @@ class Writer {
         this.#isFirstFlush = false
         this._beforeFirstFlush()
       }
-      const payload = this._encoder.makePayload()
+      let payload
+      try {
+        payload = this._encoder.makePayload()
+      } catch (error) {
+        if (error.code !== 'ERR_MSGPACK_CHUNK_OVERFLOW') throw error
+        // Multi-chunk encoders (v0.5, CI Visibility) only learn the assembled
+        // payload exceeds the cap when `makePayload` stitches the chunks
+        // together, after `encode` already returned — so the encode-time catch
+        // never sees it. Drop the queued payload here instead of letting the
+        // RangeError escape into the host application; the agent would reject
+        // the oversized payload at the network boundary anyway.
+        this._encoder.reset()
+        log.error('Writer dropped %d trace(s) that exceeded the %d byte chunk cap', count, MAX_CHUNK_SIZE)
+        done()
+        return
+      }
       this._sendPayload(payload, count, done)
     } else {
       done()

--- a/packages/dd-trace/src/msgpack/chunk.js
+++ b/packages/dd-trace/src/msgpack/chunk.js
@@ -10,6 +10,33 @@ const SHRINK_AFTER_FLUSHES = 32
 // shape: after a halving step the post-shrink fill is the prior peak doubled,
 // still under 50 %.
 const SHRINK_USAGE_RATIO = 4
+// Hard cap on chunk growth. The agent's trace intake rejects payloads over
+// 50 MiB, so anything past that is dead on arrival anyway. A pathological
+// single trace (unsanitized meta tag the size of a media file, multi-MB
+// stack trace) used to grow the buffer without limit until either the
+// allocation failed or the process tripped its memory ceiling. `reserve`
+// now refuses the growth with a tagged `RangeError`; `AgentEncoder` catches
+// it, resets the in-flight payload, and logs.
+const MAX_SIZE = 50 * 1024 * 1024 // 50 MiB
+
+/**
+ * Thrown when a chunk — or an assembled payload stitched from several chunks —
+ * would cross `MAX_SIZE`. Shared so the `reserve` cap and the per-encoder
+ * assembled-size guards (`0.5`, agentless CI Visibility) raise the same `code`,
+ * which every writer's `flush` recognises to drop the payload instead of
+ * crashing the host.
+ */
+class OverflowError extends RangeError {
+  code = 'ERR_MSGPACK_CHUNK_OVERFLOW'
+
+  /**
+   * @param {number} needed Requested total byte size.
+   */
+  constructor (needed) {
+    super(`MsgpackChunk capped at ${MAX_SIZE} bytes; requested ${needed}`)
+    this.name = 'OverflowError'
+  }
+}
 
 /**
  * Resizable msgpack write buffer. Owns the byte-layout primitives the encoder
@@ -100,11 +127,14 @@ class MsgpackChunk {
     const needed = this.length + size
 
     if (needed > this.buffer.length) {
+      if (needed > MAX_SIZE) {
+        throw new OverflowError(needed)
+      }
       let newSize = this.buffer.length
       // `*= 2` instead of `<<= 1`: `1073741824 << 1` is negative as int32,
       // and msgpack values can legitimately reach the multi-GiB range.
       while (newSize < needed) newSize *= 2
-      this.#resize(newSize)
+      this.#resize(Math.min(newSize, MAX_SIZE))
     }
 
     this.length += size
@@ -454,3 +484,5 @@ class MsgpackChunk {
 }
 
 module.exports = MsgpackChunk
+module.exports.MAX_SIZE = MAX_SIZE
+module.exports.OverflowError = OverflowError

--- a/packages/dd-trace/src/msgpack/index.js
+++ b/packages/dd-trace/src/msgpack/index.js
@@ -97,4 +97,9 @@ function writeMap (bytes, value) {
   }
 }
 
-module.exports = { MsgpackChunk, encode }
+module.exports = {
+  MsgpackChunk,
+  encode,
+  MAX_SIZE: MsgpackChunk.MAX_SIZE,
+  OverflowError: MsgpackChunk.OverflowError,
+}

--- a/packages/dd-trace/test/datastreams/writer.spec.js
+++ b/packages/dd-trace/test/datastreams/writer.spec.js
@@ -9,6 +9,7 @@ const proxyquire = require('proxyquire')
 
 require('../setup/core')
 const pkg = require('../../../../package.json')
+const { MAX_SIZE, OverflowError } = require('../../src/msgpack')
 
 const stubRequest = sinon.stub()
 
@@ -55,5 +56,43 @@ describe('DataStreamWriter unix', () => {
       },
       url: unixConfig.url,
     })
+  })
+
+  it('drops the payload and logs when msgpack encoding hits the chunk cap', () => {
+    const localStubRequest = sinon.stub()
+    const errorLog = sinon.stub()
+    const overflow = new OverflowError(MAX_SIZE + 1)
+
+    const { DataStreamsWriter: GuardedWriter } = proxyquire(
+      '../../src/datastreams/writer', {
+        '../exporters/common/request': localStubRequest,
+        '../msgpack': {
+          encode () { throw overflow },
+          MAX_SIZE,
+        },
+        '../log': { error: errorLog, debug: sinon.stub() },
+        zlib: stubZlib,
+      })
+
+    const guarded = new GuardedWriter(unixConfig)
+    guarded.flush({ pathological: true })
+
+    sinon.assert.notCalled(localStubRequest)
+    sinon.assert.calledOnce(errorLog)
+  })
+
+  it('rethrows non-overflow encoding errors', () => {
+    const { DataStreamsWriter: ThrowingWriter } = proxyquire(
+      '../../src/datastreams/writer', {
+        '../exporters/common/request': sinon.stub(),
+        '../msgpack': {
+          encode () { throw new Error('not an overflow') },
+          MAX_SIZE: 50 * 1024 * 1024,
+        },
+        zlib: stubZlib,
+      })
+
+    const throwing = new ThrowingWriter(unixConfig)
+    assert.throws(() => throwing.flush({}), /not an overflow/)
   })
 })

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -11,6 +11,7 @@ const sinon = require('sinon')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 require('../setup/core')
 const id = require('../../src/id')
+const { MAX_SIZE, OverflowError } = require('../../src/msgpack')
 
 function randString (length) {
   return Array.from({ length }, () => {
@@ -113,6 +114,41 @@ describe('encode', () => {
       encoder.encode(data)
 
       sinon.assert.called(writer.flush)
+    })
+
+    it('should reset and log on ERR_MSGPACK_CHUNK_OVERFLOW instead of throwing', () => {
+      logger.error = sinon.stub()
+      // Queue a fine-shaped trace, then make the next encode hit the cap.
+      // The cap path has to drop the queued payload too — emitting a partial
+      // buffer afterwards would corrupt the wire because the per-trace
+      // string-cache entries point at offsets in `_stringBytes` we just
+      // discarded. The catch path routes through the virtual `reset()` so
+      // subclasses (e.g. `AgentlessCiVisibilityEncoder`) can clear their
+      // own per-payload counters; spying on `encoder.reset` pins that hook.
+      encoder.encode(data)
+      assert.strictEqual(encoder.count(), 1)
+
+      const resetSpy = sinon.spy(encoder, 'reset')
+      const originalReserve = encoder._traceBytes.reserve.bind(encoder._traceBytes)
+      let triggered = false
+      sinon.stub(encoder._traceBytes, 'reserve').callsFake(function (size) {
+        if (triggered) return originalReserve(size)
+        triggered = true
+        throw new OverflowError(MAX_SIZE + 1)
+      })
+
+      encoder.encode(data)
+      assert.strictEqual(encoder.count(), 0, 'encoder must reset, dropping the queued + in-flight traces')
+      sinon.assert.calledOnce(resetSpy)
+      sinon.assert.calledOnce(logger.error)
+      const [message] = logger.error.firstCall.args
+      assert.match(message, /chunk cap/)
+    })
+
+    it('should rethrow non-overflow encoder errors', () => {
+      sinon.stub(encoder._traceBytes, 'reserve').throws(new Error('something else'))
+
+      assert.throws(() => encoder.encode(data), /something else/)
     })
 
     it('should reset after making a payload', () => {

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 require('../setup/core')
 const id = require('../../src/id')
+const { MAX_SIZE, OverflowError } = require('../../src/msgpack')
 
 function randString (length) {
   return Array.from({ length }, () => {
@@ -298,5 +299,20 @@ describe('encode 0.5', () => {
     assert.strictEqual(stringMap[trace[0][11]], '') // unset
     // Everything works the same as without meta_struct, and nothing else is added
     assert.strictEqual(trace[0][12], undefined)
+  })
+
+  it('throws ERR_MSGPACK_CHUNK_OVERFLOW when the assembled payload exceeds the cap', () => {
+    // v0.5 concatenates the string table and the trace bytes into one wire
+    // buffer. Each chunk is capped independently at MAX_SIZE, so both can sit
+    // just under the cap while their sum blows past it. `reserve` never fires
+    // here — the overflow only exists once `makePayload` adds the two lengths,
+    // so the size guard lives there.
+    encoder.encode(data)
+
+    const half = Math.ceil(MAX_SIZE / 2)
+    encoder._stringBytes.length = half
+    encoder._traceBytes.length = half
+
+    assert.throws(() => encoder.makePayload(), OverflowError)
   })
 })

--- a/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js
@@ -10,6 +10,7 @@ const proxyquire = require('proxyquire')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 require('../setup/core')
 const id = require('../../src/id')
+const { MAX_SIZE, OverflowError } = require('../../src/msgpack')
 
 const {
   MAX_NAME_LENGTH,
@@ -128,6 +129,44 @@ describe('agentless-ci-visibility-encode', () => {
     encoder.makePayload()
 
     assert.strictEqual(encoder.count(), 0)
+  })
+
+  it('clears the subclass _eventCount when the chunk cap fires mid-encode', () => {
+    // Encode a fine trace so `_eventCount` is non-zero before the cap
+    // fires. The regression this pins is the inherited `AgentEncoder.encode`
+    // catch path calling `this._reset()` (base helper) instead of
+    // `this.reset()` (virtual): the base helper clears `_traceBytes` and the
+    // string cache but leaves `_eventCount` stale, so the next `makePayload`
+    // patches the `events` array prefix with a count larger than the bytes
+    // that actually made it through.
+    encoder.encode(trace)
+    assert.ok(encoder._eventCount > 0, 'precondition: _eventCount must be primed before the cap fires')
+
+    sinon.stub(encoder._traceBytes, 'reserve').callsFake(() => {
+      throw new OverflowError(MAX_SIZE + 1)
+    })
+
+    encoder.encode(trace)
+
+    assert.strictEqual(
+      encoder._eventCount, 0,
+      'overflow must route through the subclass reset() and clear _eventCount'
+    )
+  })
+
+  it('throws ERR_MSGPACK_CHUNK_OVERFLOW when the assembled payload exceeds the cap', () => {
+    // The events live in `_traceBytes` and the metadata prefix is encoded into
+    // a fresh chunk at flush time, then both are concatenated. Each chunk is
+    // capped on its own, so the metadata prefix and the events can both sit
+    // under MAX_SIZE while the assembled buffer blows past it. The metadata
+    // prefix is also built inside `makePayload`, so an oversized metadata tag
+    // overflows here and not during `encode` — both paths have to surface the
+    // tagged error so the writer can drop the payload instead of crashing.
+    encoder.encode(trace)
+
+    encoder._traceBytes.length = MAX_SIZE + 1
+
+    assert.throws(() => encoder.makePayload(), OverflowError)
   })
 
   it('should truncate name, service, type and resource when they are too long', () => {

--- a/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js
+++ b/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js
@@ -10,6 +10,7 @@ const proxyquire = require('proxyquire')
 const { assertObjectContains } = require('../../../../integration-tests/helpers')
 require('../setup/core')
 const id = require('../../src/id')
+const { MAX_SIZE, OverflowError } = require('../../src/msgpack')
 
 /**
  * @typedef {{
@@ -102,6 +103,36 @@ describe('coverage-ci-visibility', () => {
     encoder.makePayload()
 
     assert.strictEqual(encoder.count(), 0)
+  })
+
+  it('drops the queued payload and logs when the chunk cap fires mid-encode', () => {
+    logger.error = sinon.stub()
+    // Coverage uses its own `_coverageBytes` chunk rather than the parent's
+    // `_traceBytes`, so the cap throw skipped the `AgentEncoder.encode`
+    // catch path entirely and escaped to the host process. The regression
+    // pins that the local catch in `CoverageCIVisibilityEncoder.encode`
+    // drops the queued payload instead of throwing.
+    encoder.encode(formattedCoverage)
+    assert.strictEqual(encoder.count(), 1)
+
+    const originalReserve = encoder._coverageBytes.reserve.bind(encoder._coverageBytes)
+    let triggered = false
+    sinon.stub(encoder._coverageBytes, 'reserve').callsFake(function (size) {
+      if (triggered) return originalReserve(size)
+      triggered = true
+      throw new OverflowError(MAX_SIZE + 1)
+    })
+
+    encoder.encode(formattedCoverage2)
+
+    assert.strictEqual(encoder.count(), 0, 'queued payload must be dropped on overflow')
+    sinon.assert.calledOnce(logger.error)
+  })
+
+  it('rethrows non-overflow encode errors', () => {
+    sinon.stub(encoder._coverageBytes, 'reserve').throws(new Error('not an overflow'))
+
+    assert.throws(() => encoder.encode(formattedCoverage), /not an overflow/)
   })
 
   it('should be able to make multiple payloads', () => {

--- a/packages/dd-trace/test/exporters/common/writer.spec.js
+++ b/packages/dd-trace/test/exporters/common/writer.spec.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach } = require('mocha')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+require('../../setup/core')
+const { MAX_SIZE, OverflowError } = require('../../../src/msgpack')
+
+describe('common Writer', () => {
+  let Writer
+  let writer
+  let encoder
+  let request
+  let log
+
+  beforeEach(() => {
+    encoder = {
+      count: sinon.stub().returns(2),
+      makePayload: sinon.stub().returns(Buffer.from('payload')),
+      reset: sinon.stub(),
+    }
+
+    request = sinon.stub()
+    request.writable = true
+
+    log = { error: sinon.stub(), debug: sinon.stub() }
+
+    Writer = proxyquire('../../../src/exporters/common/writer', {
+      './request': request,
+      '../../log': log,
+    })
+
+    writer = new Writer({ url: 'http://localhost:8126' })
+    writer._encoder = encoder
+    writer._sendPayload = sinon.stub()
+  })
+
+  it('drops the payload and resets when makePayload hits the chunk cap', () => {
+    // The v0.5 encoder concatenates the string table and trace bytes, and the
+    // CI Visibility encoder builds its metadata prefix, only inside
+    // `makePayload` — after `encode` already returned. An assembled payload
+    // over the cap therefore overflows here, where the encode-time catch can
+    // never see it. Without this flush-time catch the RangeError escapes
+    // straight into the host application.
+    encoder.makePayload.throws(new OverflowError(MAX_SIZE + 1))
+    const done = sinon.stub()
+
+    writer.flush(done)
+
+    sinon.assert.calledOnce(encoder.reset)
+    sinon.assert.calledOnce(log.error)
+    sinon.assert.notCalled(writer._sendPayload)
+    sinon.assert.calledOnce(done)
+  })
+
+  it('rethrows non-overflow makePayload errors', () => {
+    encoder.makePayload.throws(new Error('not an overflow'))
+
+    assert.throws(() => writer.flush(), /not an overflow/)
+    sinon.assert.notCalled(writer._sendPayload)
+  })
+
+  it('sends the payload when makePayload succeeds', () => {
+    const payload = Buffer.from('payload')
+    encoder.makePayload.returns(payload)
+    const done = sinon.stub()
+
+    writer.flush(done)
+
+    sinon.assert.notCalled(encoder.reset)
+    sinon.assert.calledOnceWithExactly(writer._sendPayload, payload, 2, done)
+  })
+})

--- a/packages/dd-trace/test/msgpack/chunk.spec.js
+++ b/packages/dd-trace/test/msgpack/chunk.spec.js
@@ -51,6 +51,41 @@ describe('MsgpackChunk', () => {
       chunk.reserve(2049)
       assert.equal(chunk.buffer.length, 4096)
     })
+
+    it('throws ERR_MSGPACK_CHUNK_OVERFLOW past MAX_SIZE without growing the buffer', () => {
+      const chunk = new MsgpackChunk()
+      const before = chunk.buffer
+
+      assert.throws(() => chunk.reserve(MsgpackChunk.MAX_SIZE + 1), MsgpackChunk.OverflowError)
+      // The cap fires before the resize, so the chunk stays usable for the
+      // caller's recovery path (flush, reset, drop, etc.).
+      assert.equal(chunk.buffer, before)
+      assert.equal(chunk.length, 0)
+    })
+
+    it('tags OverflowError so writers can recognise the cap by code', () => {
+      const needed = MsgpackChunk.MAX_SIZE + 1
+      const error = new MsgpackChunk.OverflowError(needed)
+
+      assert.ok(error instanceof RangeError)
+      assert.equal(error.name, 'OverflowError')
+      // Writers branch on the `code` string, so it has to be an own instance
+      // property that survives crossing a module boundary, not a prototype-only
+      // tag.
+      assert.ok(Object.hasOwn(error, 'code'))
+      assert.equal(error.code, 'ERR_MSGPACK_CHUNK_OVERFLOW')
+      assert.ok(error.message.includes(String(needed)))
+    })
+
+    it('clamps the doubled capacity at MAX_SIZE when growth would otherwise overshoot', () => {
+      // Start the chunk just below MAX_SIZE so the doubling step would land
+      // at 2 * MAX_SIZE if it weren't clamped.
+      const chunk = new MsgpackChunk(MsgpackChunk.MAX_SIZE - 1024)
+
+      chunk.reserve(MsgpackChunk.MAX_SIZE - 512)
+
+      assert.equal(chunk.buffer.length, MsgpackChunk.MAX_SIZE)
+    })
   })
 
   describe('reset', () => {


### PR DESCRIPTION
## Summary

`MsgpackChunk.reserve` used to grow the backing buffer without bound. A
pathological span (multi-MB stack trace, unsanitized meta tag the size
of a media file) could grow the chunk until allocation failed and took
the host process with it. `reserve` now refuses growth past 50 MiB (the
agent's trace intake ceiling) with a tagged `RangeError`
(`code: 'ERR_MSGPACK_CHUNK_OVERFLOW'`).

Every direct `MsgpackChunk` consumer catches the tag and drops the queued
payload — rolling back just the in-flight entry is unsafe because the
string cache may already hold offsets pointing at bytes we'd invalidate:

1. `AgentEncoder.encode` calls the virtual `reset()` so subclasses can
   clear their own per-payload state (`AgentlessCiVisibilityEncoder.
   _eventCount` would otherwise stay primed and the next `makePayload`
   would patch the `events` array prefix with a count larger than the
   payload that survived).
2. `CoverageCIVisibilityEncoder` writes into its own `_coverageBytes`
   chunk and catches the tag locally; without the catch the parent
   `AgentEncoder.encode` catch path never sees it.
3. `DataStreamsWriter.flush` catches the tag from the standalone
   `msgpack.encode` and drops the pipeline-stats payload.

Stacked on top of #8504; merges into that branch.