### PR TITLE
fix(ci): rerun only failed jobs for cancelled workflows in all-green

### DIFF
--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -135,9 +135,6 @@ async function rerunFailedWorkflows (workflowRuns) {
   await Promise.all(
     workflowRuns.map(workflowRun => {
       console.log(`Rerunning ${workflowRun.conclusion} workflow run ${workflowRun.id} (${workflowRun.name}).`)
-      if (workflowRun.conclusion === 'cancelled') {
-        return octokit.rest.actions.reRunWorkflow({ owner, repo, run_id: workflowRun.id })
-      }
       return octokit.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: workflowRun.id })
     })
   )


### PR DESCRIPTION
## Summary

- The GitHub API's `reRunWorkflowFailedJobs` handles cancelled workflows the same way the GitHub UI does — "Re-run failed jobs" is available for cancelled runs
- Removes the special case that re-ran **all** jobs for cancelled workflows, which wasted CI time for jobs that had already succeeded before cancellation

## Test plan

- [ ] Trigger a cancellation (e.g. push a new commit while CI is running) and verify All Green only re-runs the jobs that didn't complete

> Generated by [Claude Code](https://claude.ai/claude-code)