### PR TITLE
fix(ci): cancel running workflows on all-green timeout, reduce retries and initial delay

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -39,4 +39,4 @@ jobs:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           POLLING_INTERVAL: 1
-          RETRIES: 30
+          RETRIES: 20

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -34,7 +34,7 @@ jobs:
       - run: yarn add @actions/core @actions/github octokit
       - run: node scripts/all-green.mjs
         env:
-          DELAY: ${{ github.run_attempt == 1 && '5' || '0' }} # 5 minutes on first attempt, no delay on reruns
+          DELAY: ${{ github.run_attempt == 1 && '1' || '0' }} # 1 minute on first attempt, no delay on reruns
           RUN_ATTEMPT: ${{ github.run_attempt }}
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -112,18 +112,18 @@ async function pollUntilDone () {
     !retriedRunIds.has(r.id)
   )
 
-  if (toRetry.length > 0) {
-    await rerunFailedWorkflows(toRetry)
-    for (const run of toRetry) retriedRunIds.add(run.id)
-    runsCache = undefined
-  }
-
   const pending = runs.filter(r => r.status !== 'completed').length
   if (pending === 0 && toRetry.length === 0) return { runs, done: true }
 
   retries++
 
   if (RETRIES && retries > RETRIES) return { runs, done: false }
+
+  if (toRetry.length > 0) {
+    await rerunFailedWorkflows(toRetry)
+    for (const run of toRetry) retriedRunIds.add(run.id)
+    runsCache = undefined
+  }
 
   console.log(`Status is still pending, waiting for ${POLLING_INTERVAL} minutes before retrying.`)
   await setTimeout(POLLING_INTERVAL * 60_000)

--- a/scripts/all-green.mjs
+++ b/scripts/all-green.mjs
@@ -160,6 +160,18 @@ async function rerunOnStartup () {
   }
 }
 
+async function cancelRunningWorkflows (runs) {
+  const running = runs.filter(r => r.status !== 'completed')
+  if (running.length === 0) return
+  console.log(`Cancelling ${running.length} still-running workflow(s).`)
+  await Promise.all(
+    running.map(run => {
+      console.log(`Cancelling workflow run ${run.id} (${run.name}).`)
+      return octokit.rest.actions.cancelWorkflowRun({ owner, repo, run_id: run.id })
+    })
+  )
+}
+
 async function checkAllGreen () {
   await rerunOnStartup()
 
@@ -169,6 +181,7 @@ async function checkAllGreen () {
 
   if (!done) {
     console.log(`State is still pending after ${RETRIES} retries.`)
+    await cancelRunningWorkflows(runs)
     process.exitCode = 1
     return
   }


### PR DESCRIPTION
## Summary

- Cancels all still-running workflow runs when the all-green polling limit is reached, preventing stuck workflows (e.g. blocked on \`apt install\`) from lingering indefinitely
- Reduces the \`RETRIES\` ceiling from 30 to 20
- Reduces the initial delay from 5 minutes to 1 minute to allow retries to complete more quickly

## Test Plan

- [ ] Verify all-green workflow behaves correctly on a PR with passing workflows
- [ ] Verify stuck/timeout scenarios result in cancellation of running workflows

> Generated by Claude Code