### PR TITLE
ci: pin all Windows runners to windows-2022

### DIFF
--- a/.github/workflows/aiguard.yml
+++ b/.github/workflows/aiguard.yml
@@ -62,7 +62,7 @@ jobs:
 
   windows:
     name: ${{ github.workflow }} / windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/apm-capabilities.yml
+++ b/.github/workflows/apm-capabilities.yml
@@ -68,7 +68,7 @@ jobs:
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
 
   tracing-windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/appsec.yml
+++ b/.github/workflows/appsec.yml
@@ -71,7 +71,7 @@ jobs:
 
   windows:
     name: ${{ github.workflow }} / windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/openfeature.yml
+++ b/.github/workflows/openfeature.yml
@@ -89,7 +89,7 @@ jobs:
 
   windows:
     name: ${{ github.workflow }} / windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/profiling.yml
+++ b/.github/workflows/profiling.yml
@@ -76,7 +76,7 @@ jobs:
 
   windows:
     name: ${{ github.workflow }} / windows
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary

- Pin all `windows-latest` runners to `windows-2022` across 5 workflows: AppSec, AIGuard, profiling, openfeature, and apm-capabilities

## Motivation

`windows-latest` is being progressively redirected to `windows-2025-vs2026`. The new `windows-2025` image has an intermittent `bash.EXE` crash (exit code `-1073741502` / `STATUS_PIPE_NOT_AVAILABLE`) in the node version resolution step of `.github/actions/node/setup`, causing flaky failures across multiple workflows. Pinning to `windows-2022` avoids the unstable image until the upstream issue is resolved.

> Generated by [Claude Code](https://claude.ai/claude-code)