### PR TITLE
feat(redis): use built-in dc for ioredis@5.11.0 and @redis/client@5.12.0

### DIFF
--- a/packages/datadog-instrumentations/src/ioredis.js
+++ b/packages/datadog-instrumentations/src/ioredis.js
@@ -56,6 +56,7 @@ addHook({ name: 'ioredis', versions: ['>=5 <5.11.0'] }, wrapRedis)
 // subscribes directly to those channels and no shimmer is needed. Fall back to the
 // shimmer approach on older Node.js runtimes.
 addHook({ name: 'ioredis', versions: ['>=5.11.0'] }, (Redis) => {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   if (typeof require('node:diagnostics_channel').tracingChannel === 'function') {
     return Redis
   }

--- a/packages/datadog-instrumentations/src/ioredis.js
+++ b/packages/datadog-instrumentations/src/ioredis.js
@@ -52,16 +52,7 @@ addHook({ name: 'ioredis', versions: ['>=4.11.0 <5'], file: 'built/redis/index.j
 addHook({ name: 'ioredis', versions: ['>=5 <5.11.0'] }, wrapRedis)
 
 // ioredis >= 5.11.0 exposes a built-in TracingChannel (tracing:ioredis:command).
-// On Node.js versions that support dc.tracingChannel (>= 19.9 / 20.2), the plugin
-// subscribes directly to those channels and no shimmer is needed. Fall back to the
-// shimmer approach on older Node.js runtimes.
-addHook({ name: 'ioredis', versions: ['>=5.11.0'] }, (Redis) => {
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  if (typeof require('node:diagnostics_channel').tracingChannel === 'function') {
-    return Redis
-  }
-  return wrapRedis(Redis)
-})
+// dc-polyfill ensures tracingChannel is always available, so no shimmer is needed.
 
 function finish (finishCh, errorCh, ctx, error) {
   if (error) {

--- a/packages/datadog-instrumentations/src/ioredis.js
+++ b/packages/datadog-instrumentations/src/ioredis.js
@@ -49,7 +49,18 @@ addHook({ name: 'ioredis', versions: ['>=4.11.0 <5'], file: 'built/redis/index.j
   return exports
 })
 
-addHook({ name: 'ioredis', versions: ['>=5'] }, wrapRedis)
+addHook({ name: 'ioredis', versions: ['>=5 <5.11.0'] }, wrapRedis)
+
+// ioredis >= 5.11.0 exposes a built-in TracingChannel (tracing:ioredis:command).
+// On Node.js versions that support dc.tracingChannel (>= 19.9 / 20.2), the plugin
+// subscribes directly to those channels and no shimmer is needed. Fall back to the
+// shimmer approach on older Node.js runtimes.
+addHook({ name: 'ioredis', versions: ['>=5.11.0'] }, (Redis) => {
+  if (typeof require('node:diagnostics_channel').tracingChannel === 'function') {
+    return Redis
+  }
+  return wrapRedis(Redis)
+})
 
 function finish (finishCh, errorCh, ctx, error) {
   if (error) {

--- a/packages/datadog-instrumentations/src/ioredis.js
+++ b/packages/datadog-instrumentations/src/ioredis.js
@@ -52,7 +52,15 @@ addHook({ name: 'ioredis', versions: ['>=4.11.0 <5'], file: 'built/redis/index.j
 addHook({ name: 'ioredis', versions: ['>=5 <5.11.0'] }, wrapRedis)
 
 // ioredis >= 5.11.0 exposes a built-in TracingChannel (tracing:ioredis:command).
-// dc-polyfill ensures tracingChannel is always available, so no shimmer is needed.
+// On Node.js >= 19.9 / 20.2 the plugin subscribes directly; on Node.js 18 the native
+// diagnostics_channel lacks tracingChannel so ioredis skips it — fall back to the shimmer.
+addHook({ name: 'ioredis', versions: ['>=5.11.0'] }, (Redis) => {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  if (typeof require('node:diagnostics_channel').tracingChannel !== 'function') {
+    return wrapRedis(Redis)
+  }
+  return Redis
+})
 
 function finish (finishCh, errorCh, ctx, error) {
   if (error) {

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
-const satisfies = require('../../../vendor/dist/semifies')
 const {
   channel,
   addHook,
@@ -74,22 +73,13 @@ addHook({ name: '@node-redis/client', file: 'dist/lib/client/index.js', versions
 })
 
 // @redis/client >= 5.12.0 emits built-in TracingChannel events (tracing:node-redis:command).
-// On Node.js versions that support dc.tracingChannel (>= 19.9 / 20.2), skip the shimmer to
-// avoid double-tracing. Fall back to the shimmer approach on older Node.js runtimes.
-addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=1.1'] }, (redis, version) => {
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  if (satisfies(version, '>=5.12.0') && typeof require('node:diagnostics_channel').tracingChannel === 'function') {
-    return redis
-  }
+// dc-polyfill ensures tracingChannel is always available, so no shimmer is needed for >= 5.12.0.
+addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=1.1 <5.12.0'] }, (redis) => {
   shimmer.wrap(redis.default, 'create', wrapCreateClient)
   return redis
 })
 
-addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=1.1'] }, (redis, version) => {
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  if (satisfies(version, '>=5.12.0') && typeof require('node:diagnostics_channel').tracingChannel === 'function') {
-    return redis
-  }
+addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=1.1 <5.12.0'] }, (redis) => {
   redis.default = wrapCommandQueueClass(redis.default)
   shimmer.wrap(redis.default.prototype, 'addCommand', wrapAddCommand)
   return redis

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -77,6 +77,7 @@ addHook({ name: '@node-redis/client', file: 'dist/lib/client/index.js', versions
 // On Node.js versions that support dc.tracingChannel (>= 19.9 / 20.2), skip the shimmer to
 // avoid double-tracing. Fall back to the shimmer approach on older Node.js runtimes.
 addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=1.1'] }, (redis, version) => {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   if (satisfies(version, '>=5.12.0') && typeof require('node:diagnostics_channel').tracingChannel === 'function') {
     return redis
   }
@@ -85,6 +86,7 @@ addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>
 })
 
 addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=1.1'] }, (redis, version) => {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   if (satisfies(version, '>=5.12.0') && typeof require('node:diagnostics_channel').tracingChannel === 'function') {
     return redis
   }

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -72,8 +72,6 @@ addHook({ name: '@node-redis/client', file: 'dist/lib/client/index.js', versions
   return redis
 })
 
-// @redis/client >= 5.12.0 emits built-in TracingChannel events (tracing:node-redis:command).
-// dc-polyfill ensures tracingChannel is always available, so no shimmer is needed for >= 5.12.0.
 addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=1.1 <5.12.0'] }, (redis) => {
   shimmer.wrap(redis.default, 'create', wrapCreateClient)
   return redis
@@ -82,6 +80,26 @@ addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>
 addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=1.1 <5.12.0'] }, (redis) => {
   redis.default = wrapCommandQueueClass(redis.default)
   shimmer.wrap(redis.default.prototype, 'addCommand', wrapAddCommand)
+  return redis
+})
+
+// @redis/client >= 5.12.0 emits built-in TracingChannel events (tracing:node-redis:command).
+// On Node.js >= 19.9 / 20.2 the plugin subscribes directly; on Node.js 18 the native
+// diagnostics_channel lacks tracingChannel so @redis/client skips it — fall back to the shimmer.
+addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=5.12.0'] }, (redis) => {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  if (typeof require('node:diagnostics_channel').tracingChannel !== 'function') {
+    shimmer.wrap(redis.default, 'create', wrapCreateClient)
+  }
+  return redis
+})
+
+addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=5.12.0'] }, (redis) => {
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  if (typeof require('node:diagnostics_channel').tracingChannel !== 'function') {
+    redis.default = wrapCommandQueueClass(redis.default)
+    shimmer.wrap(redis.default.prototype, 'addCommand', wrapAddCommand)
+  }
   return redis
 })
 

--- a/packages/datadog-instrumentations/src/redis.js
+++ b/packages/datadog-instrumentations/src/redis.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const shimmer = require('../../datadog-shimmer')
+const satisfies = require('../../../vendor/dist/semifies')
 const {
   channel,
   addHook,
@@ -72,12 +73,21 @@ addHook({ name: '@node-redis/client', file: 'dist/lib/client/index.js', versions
   return redis
 })
 
-addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=1.1'] }, redis => {
+// @redis/client >= 5.12.0 emits built-in TracingChannel events (tracing:node-redis:command).
+// On Node.js versions that support dc.tracingChannel (>= 19.9 / 20.2), skip the shimmer to
+// avoid double-tracing. Fall back to the shimmer approach on older Node.js runtimes.
+addHook({ name: '@redis/client', file: 'dist/lib/client/index.js', versions: ['>=1.1'] }, (redis, version) => {
+  if (satisfies(version, '>=5.12.0') && typeof require('node:diagnostics_channel').tracingChannel === 'function') {
+    return redis
+  }
   shimmer.wrap(redis.default, 'create', wrapCreateClient)
   return redis
 })
 
-addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=1.1'] }, redis => {
+addHook({ name: '@redis/client', file: 'dist/lib/client/commands-queue.js', versions: ['>=1.1'] }, (redis, version) => {
+  if (satisfies(version, '>=5.12.0') && typeof require('node:diagnostics_channel').tracingChannel === 'function') {
+    return redis
+  }
   redis.default = wrapCommandQueueClass(redis.default)
   shimmer.wrap(redis.default.prototype, 'addCommand', wrapAddCommand)
   return redis

--- a/packages/datadog-plugin-ioredis/src/index.js
+++ b/packages/datadog-plugin-ioredis/src/index.js
@@ -19,7 +19,7 @@ class IORedisPlugin extends RedisPlugin {
    * Normalizes the ioredis built-in TracingChannel context to the format
    * expected by RedisPlugin.bindStart.
    *
-   * Built-in context: { command, args (sanitized, no command name), database, serverAddress, serverPort }
+   * Built-in context: { command, args (no command name), database, serverAddress, serverPort }
    *
    * @param {{ command: string, args: string[], database: number,
    *   serverAddress: string, serverPort: number | undefined }} builtinCtx

--- a/packages/datadog-plugin-ioredis/src/index.js
+++ b/packages/datadog-plugin-ioredis/src/index.js
@@ -21,7 +21,8 @@ class IORedisPlugin extends RedisPlugin {
    *
    * Built-in context: { command, args (sanitized, no command name), database, serverAddress, serverPort }
    *
-   * @param {{ command: string, args: string[], database: number, serverAddress: string, serverPort: number | undefined }} builtinCtx
+   * @param {{ command: string, args: string[], database: number,
+   *   serverAddress: string, serverPort: number | undefined }} builtinCtx
    * @returns {object}
    */
   #bindBuiltinStart (builtinCtx) {

--- a/packages/datadog-plugin-ioredis/src/index.js
+++ b/packages/datadog-plugin-ioredis/src/index.js
@@ -4,6 +4,38 @@ const RedisPlugin = require('../../datadog-plugin-redis/src')
 
 class IORedisPlugin extends RedisPlugin {
   static id = 'ioredis'
+
+  constructor (...args) {
+    super(...args)
+    // ioredis >= 5.11.0 emits built-in TracingChannel events on Node.js >= 19.9 / 20.2.
+    // Subscribe directly so no shimmer is needed for those version combinations.
+    this.addBind('tracing:ioredis:command:start', ctx => this.#bindBuiltinStart(ctx))
+    // Use asyncEnd (not end) because tracePromise fires end before error.
+    this.addSub('tracing:ioredis:command:asyncEnd', ctx => this.finish(ctx))
+    this.addSub('tracing:ioredis:command:error', ctx => this.error(ctx))
+  }
+
+  /**
+   * Normalizes the ioredis built-in TracingChannel context to the format
+   * expected by RedisPlugin.bindStart.
+   *
+   * Built-in context: { command, args (sanitized, no command name), database, serverAddress, serverPort }
+   *
+   * @param {{ command: string, args: string[], database: number, serverAddress: string, serverPort: number | undefined }} builtinCtx
+   * @returns {object}
+   */
+  #bindBuiltinStart (builtinCtx) {
+    const ctx = {
+      db: builtinCtx.database,
+      command: builtinCtx.command,
+      args: builtinCtx.args,
+      connectionOptions: {
+        host: builtinCtx.serverAddress,
+        port: builtinCtx.serverPort,
+      },
+    }
+    return this.bindStart(ctx)
+  }
 }
 
 module.exports = IORedisPlugin

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -11,10 +11,8 @@ const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers'
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
-// ioredis >= 5.11.0 uses built-in TracingChannel on Node.js >= 19.9 / 20.2, which
-// does not expose the connection name, so splitByInstance has no effect.
-// eslint-disable-next-line n/no-unsupported-features/node-builtins
-const hasDcTracingChannel = typeof require('node:diagnostics_channel').tracingChannel === 'function'
+// ioredis >= 5.11.0 uses built-in TracingChannel (dc-polyfill ensures it's always available),
+// which does not expose the connection name, so splitByInstance has no effect for those versions.
 
 describe('Plugin', () => {
   let Redis
@@ -162,7 +160,7 @@ describe('Plugin', () => {
           // ioredis >= 5.11.0 on Node.js >= 20.2 uses built-in TracingChannel which does not
           // expose connectionName, so splitByInstance has no effect and the service is 'custom'.
           // `version` may be a range string like '>=5.11.0', so coerce before comparing.
-          const expectedService = hasDcTracingChannel && semver.satisfies(semver.coerce(version), '>=5.11.0')
+          const expectedService = semver.satisfies(semver.coerce(version), '>=5.11.0')
             ? 'custom'
             : 'custom-test'
 
@@ -184,10 +182,10 @@ describe('Plugin', () => {
           {
             v0: {
               opName: 'redis.command',
-              // ioredis >= 5.11.0 on Node.js >= 20.2 uses built-in TracingChannel which does not
-              // expose connectionName, so splitByInstance has no effect and the service is 'custom'.
+              // ioredis >= 5.11.0 uses built-in TracingChannel which does not expose connectionName,
+              // so splitByInstance has no effect and the service is 'custom'.
               // `version` may be a range string like '>=5.11.0', so coerce before comparing.
-              serviceName: hasDcTracingChannel && semver.satisfies(semver.coerce(version), '>=5.11.0')
+              serviceName: semver.satisfies(semver.coerce(version), '>=5.11.0')
                 ? 'custom'
                 : 'custom-test',
             },

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -213,5 +213,46 @@ describe('Plugin', () => {
         })
       })
     })
+
+    // Covers the ioredis >=5.11.0 shimmer fallback branch that only runs on Node 18,
+    // where diagnostics_channel.tracingChannel is absent. We simulate that here by temporarily
+    // removing tracingChannel so the conditional shimmer-wrap path executes on all Node versions.
+    describe('ioredis >=5.11.0 Node 18 shimmer fallback', () => {
+      let dc, origTracingChannel
+
+      before(() => {
+        // Load the instrumentation to register hooks in the global instrumentations map.
+        require('../../datadog-instrumentations/src/ioredis')
+        dc = require('node:diagnostics_channel')
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        origTracingChannel = dc.tracingChannel
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        delete dc.tracingChannel
+      })
+
+      after(() => {
+        if (origTracingChannel !== undefined) {
+          // eslint-disable-next-line n/no-unsupported-features/node-builtins
+          dc.tracingChannel = origTracingChannel
+        }
+      })
+
+      it('shimmer-wraps sendCommand when tracingChannel is absent', () => {
+        const instrumentations = globalThis[Symbol.for('_ddtrace_instrumentations')]
+        const hooks = instrumentations.ioredis
+        const ioredisHook = hooks.find(h => h.versions && h.versions.includes('>=5.11.0') && !h.file)
+
+        assert(ioredisHook, 'should find hook for ioredis >=5.11.0')
+
+        class MockRedis {
+          sendCommand (command, stream) { return command }
+        }
+        const origSendCommand = MockRedis.prototype.sendCommand
+        const result = ioredisHook.hook(MockRedis)
+
+        assert.strictEqual(result, MockRedis)
+        assert.notStrictEqual(MockRedis.prototype.sendCommand, origSendCommand)
+      })
+    })
   })
 })

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const semver = require('semver')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 
@@ -9,6 +10,10 @@ const agent = require('../../dd-trace/test/plugins/agent')
 const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers')
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
+
+// ioredis >= 5.11.0 uses built-in TracingChannel on Node.js >= 19.9 / 20.2, which
+// does not expose the connection name, so splitByInstance has no effect.
+const hasDcTracingChannel = typeof require('node:diagnostics_channel').tracingChannel === 'function'
 
 describe('Plugin', () => {
   let Redis
@@ -153,8 +158,15 @@ describe('Plugin', () => {
         it('should be configured with the correct values', async () => {
           await redis.get('foo')
 
+          // ioredis >= 5.11.0 on Node.js >= 20.2 uses built-in TracingChannel which does not
+          // expose connectionName, so splitByInstance has no effect and the service is 'custom'.
+          // `version` may be a range string like '>=5.11.0', so coerce before comparing.
+          const expectedService = hasDcTracingChannel && semver.satisfies(semver.coerce(version), '>=5.11.0')
+            ? 'custom'
+            : 'custom-test'
+
           await agent.assertFirstTraceSpan({
-            service: 'custom-test',
+            service: expectedService,
           })
         })
 
@@ -171,7 +183,10 @@ describe('Plugin', () => {
           {
             v0: {
               opName: 'redis.command',
-              serviceName: 'custom-test',
+              // ioredis >= 5.11.0 on Node.js >= 20.2 uses built-in TracingChannel which does not
+              // expose connectionName, so splitByInstance has no effect and the service is 'custom'.
+              // `version` may be a range string like '>=5.11.0', so coerce before comparing.
+              serviceName: hasDcTracingChannel && semver.satisfies(semver.coerce(version), '>=5.11.0') ? 'custom' : 'custom-test',
             },
             v1: {
               opName: 'redis.command',

--- a/packages/datadog-plugin-ioredis/test/index.spec.js
+++ b/packages/datadog-plugin-ioredis/test/index.spec.js
@@ -13,6 +13,7 @@ const { expectedSchema, rawExpectedSchema } = require('./naming')
 
 // ioredis >= 5.11.0 uses built-in TracingChannel on Node.js >= 19.9 / 20.2, which
 // does not expose the connection name, so splitByInstance has no effect.
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
 const hasDcTracingChannel = typeof require('node:diagnostics_channel').tracingChannel === 'function'
 
 describe('Plugin', () => {
@@ -186,7 +187,9 @@ describe('Plugin', () => {
               // ioredis >= 5.11.0 on Node.js >= 20.2 uses built-in TracingChannel which does not
               // expose connectionName, so splitByInstance has no effect and the service is 'custom'.
               // `version` may be a range string like '>=5.11.0', so coerce before comparing.
-              serviceName: hasDcTracingChannel && semver.satisfies(semver.coerce(version), '>=5.11.0') ? 'custom' : 'custom-test',
+              serviceName: hasDcTracingChannel && semver.satisfies(semver.coerce(version), '>=5.11.0')
+                ? 'custom'
+                : 'custom-test',
             },
             v1: {
               opName: 'redis.command',

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -37,7 +37,7 @@ class RedisPlugin extends CachePlugin {
    * Normalizes the `@redis/client` built-in TracingChannel context to the format
    * expected by RedisPlugin.bindStart.
    *
-   * Built-in context: { command (uppercase), args (sanitized, includes command name at [0]),
+   * Built-in context: { command (uppercase), args (includes command name at [0]),
    *   database, clientId, serverAddress, serverPort }
    *
    * @param {{ command: string, args: string[], database: number,
@@ -111,15 +111,43 @@ class RedisPlugin extends CachePlugin {
   }
 }
 
+// How many positional args after the command are safe to emit verbatim.
+// -1 = all args safe; 0 = all args redacted (default for unknown commands).
+// Rules adapted from @opentelemetry/redis-common (Apache 2.0), which ioredis also uses.
+const REDIS_SAFE_ARG_PATTERNS = [
+  [/^ECHO/i, 0],
+  [/^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i, 1],
+  [/^(HSET|HMSET|LSET|LINSERT)/i, 2],
+  [/^(ACL|BIT|B[LRZ]|CLIENT|CLUSTER|CONFIG|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i, -1],
+]
+
+function safeArgCount (command) {
+  for (const [pattern, count] of REDIS_SAFE_ARG_PATTERNS) {
+    if (pattern.test(command)) return count
+  }
+  return 0
+}
+
 function formatCommand (command, args, argsStartIndex = 0) {
   if (!args || command === 'AUTH') return command
 
+  const safeCount = safeArgCount(command)
   let result = command
+  let safeLeft = safeCount
+
   for (let i = argsStartIndex, l = args.length; i < l; i++) {
     const arg = args[i]
     if (typeof arg === 'function') continue
 
-    result = `${result} ${formatArg(arg)}`
+    let formatted
+    if (safeCount === -1 || safeLeft > 0) {
+      formatted = formatArg(arg)
+      if (safeCount !== -1) safeLeft--
+    } else {
+      formatted = '?'
+    }
+
+    result = `${result} ${formatted}`
     if (result.length > MAX_COMMAND_LENGTH) return result.slice(0, MAX_COMMAND_LENGTH - 3) + '...'
   }
 

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -25,6 +25,36 @@ class RedisPlugin extends CachePlugin {
   constructor (...args) {
     super(...args)
     this._spanType = 'redis'
+    // @redis/client >= 5.12.0 emits built-in TracingChannel events on Node.js >= 19.9 / 20.2.
+    // Subscribe directly so no shimmer is needed for those version combinations.
+    this.addBind('tracing:node-redis:command:start', ctx => this.#bindBuiltinRedisStart(ctx))
+    // Use asyncEnd (not end) because tracePromise fires end before error.
+    this.addSub('tracing:node-redis:command:asyncEnd', ctx => this.finish(ctx))
+    this.addSub('tracing:node-redis:command:error', ctx => this.error(ctx))
+  }
+
+  /**
+   * Normalizes the @redis/client built-in TracingChannel context to the format
+   * expected by RedisPlugin.bindStart.
+   *
+   * Built-in context: { command (uppercase), args (sanitized, includes command name at [0]),
+   *   database, clientId, serverAddress, serverPort }
+   *
+   * @param {{ command: string, args: string[], database: number, serverAddress: string, serverPort: number | undefined }} builtinCtx
+   * @returns {object}
+   */
+  #bindBuiltinRedisStart (builtinCtx) {
+    const ctx = {
+      db: builtinCtx.database,
+      command: builtinCtx.command,
+      args: builtinCtx.args,
+      argsStartIndex: 1, // args[0] is the command name; skip it in formatting
+      connectionOptions: {
+        host: builtinCtx.serverAddress,
+        port: builtinCtx.serverPort,
+      },
+    }
+    return this.bindStart(ctx)
   }
 
   bindStart (ctx) {

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -111,43 +111,15 @@ class RedisPlugin extends CachePlugin {
   }
 }
 
-// How many positional args after the command are safe to emit verbatim.
-// -1 = all args safe; 0 = all args redacted (default for unknown commands).
-// Rules adapted from @opentelemetry/redis-common (Apache 2.0), which ioredis also uses.
-const REDIS_SAFE_ARG_PATTERNS = [
-  [/^ECHO/i, 0],
-  [/^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i, 1],
-  [/^(HSET|HMSET|LSET|LINSERT)/i, 2],
-  [/^(ACL|BIT|B[LRZ]|CLIENT|CLUSTER|CONFIG|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i, -1],
-]
-
-function safeArgCount (command) {
-  for (const [pattern, count] of REDIS_SAFE_ARG_PATTERNS) {
-    if (pattern.test(command)) return count
-  }
-  return 0
-}
-
 function formatCommand (command, args, argsStartIndex = 0) {
   if (!args || command === 'AUTH') return command
 
-  const safeCount = safeArgCount(command)
   let result = command
-  let safeLeft = safeCount
-
   for (let i = argsStartIndex, l = args.length; i < l; i++) {
     const arg = args[i]
     if (typeof arg === 'function') continue
 
-    let formatted
-    if (safeCount === -1 || safeLeft > 0) {
-      formatted = formatArg(arg)
-      if (safeCount !== -1) safeLeft--
-    } else {
-      formatted = '?'
-    }
-
-    result = `${result} ${formatted}`
+    result = `${result} ${formatArg(arg)}`
     if (result.length > MAX_COMMAND_LENGTH) return result.slice(0, MAX_COMMAND_LENGTH - 3) + '...'
   }
 

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -34,13 +34,14 @@ class RedisPlugin extends CachePlugin {
   }
 
   /**
-   * Normalizes the @redis/client built-in TracingChannel context to the format
+   * Normalizes the `@redis/client` built-in TracingChannel context to the format
    * expected by RedisPlugin.bindStart.
    *
    * Built-in context: { command (uppercase), args (sanitized, includes command name at [0]),
    *   database, clientId, serverAddress, serverPort }
    *
-   * @param {{ command: string, args: string[], database: number, serverAddress: string, serverPort: number | undefined }} builtinCtx
+   * @param {{ command: string, args: string[], database: number,
+   *   serverAddress: string, serverPort: number | undefined }} builtinCtx
    * @returns {object}
    */
   #bindBuiltinRedisStart (builtinCtx) {

--- a/packages/datadog-plugin-redis/src/index.js
+++ b/packages/datadog-plugin-redis/src/index.js
@@ -25,12 +25,18 @@ class RedisPlugin extends CachePlugin {
   constructor (...args) {
     super(...args)
     this._spanType = 'redis'
-    // @redis/client >= 5.12.0 emits built-in TracingChannel events on Node.js >= 19.9 / 20.2.
-    // Subscribe directly so no shimmer is needed for those version combinations.
-    this.addBind('tracing:node-redis:command:start', ctx => this.#bindBuiltinRedisStart(ctx))
-    // Use asyncEnd (not end) because tracePromise fires end before error.
-    this.addSub('tracing:node-redis:command:asyncEnd', ctx => this.finish(ctx))
-    this.addSub('tracing:node-redis:command:error', ctx => this.error(ctx))
+    // Only bind node-redis built-in channels for the redis plugin itself, not subclasses
+    // (e.g. ioredis, iovalkey). When both @redis/client and a subclass are loaded, the
+    // base-class constructor runs for each plugin instance; without this guard the subclass
+    // would also handle @redis/client spans and tag them with the wrong component/integration.
+    if (this.constructor === RedisPlugin) {
+      // @redis/client >= 5.12.0 emits built-in TracingChannel events on Node.js >= 19.9 / 20.2.
+      // Subscribe directly so no shimmer is needed for those version combinations.
+      this.addBind('tracing:node-redis:command:start', ctx => this.#bindBuiltinRedisStart(ctx))
+      // Use asyncEnd (not end) because tracePromise fires end before error.
+      this.addSub('tracing:node-redis:command:asyncEnd', ctx => this.finish(ctx))
+      this.addSub('tracing:node-redis:command:error', ctx => this.error(ctx))
+    }
   }
 
   /**

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -390,5 +390,66 @@ describe('Plugin', () => {
         })
       })
     })
+
+    // Covers the @redis/client >=5.12.0 shimmer fallback branches that only run on Node 18,
+    // where diagnostics_channel.tracingChannel is absent. We simulate that here by temporarily
+    // removing tracingChannel so the conditional shimmer-wrap paths execute on all Node versions.
+    describe('@redis/client >=5.12.0 Node 18 shimmer fallback', () => {
+      let dc, origTracingChannel
+
+      before(() => {
+        // Load the instrumentation to register hooks in the global instrumentations map.
+        require('../../datadog-instrumentations/src/redis')
+        dc = require('node:diagnostics_channel')
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        origTracingChannel = dc.tracingChannel
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        delete dc.tracingChannel
+      })
+
+      after(() => {
+        if (origTracingChannel !== undefined) {
+          // eslint-disable-next-line n/no-unsupported-features/node-builtins
+          dc.tracingChannel = origTracingChannel
+        }
+      })
+
+      it('shimmer-wraps create on dist/lib/client/index.js', () => {
+        const instrumentations = globalThis[Symbol.for('_ddtrace_instrumentations')]
+        const hooks = instrumentations['@redis/client']
+        const indexHook = hooks.find(h =>
+          h.versions && h.versions.includes('>=5.12.0') &&
+          h.file === 'dist/lib/client/index.js')
+
+        assert(indexHook, 'should find hook for @redis/client >=5.12.0 index.js')
+
+        const mockCreate = function create () {}
+        const mockRedis = { default: { create: mockCreate } }
+        const result = indexHook.hook(mockRedis)
+
+        assert.strictEqual(result, mockRedis)
+        assert.notStrictEqual(mockRedis.default.create, mockCreate)
+      })
+
+      it('shimmer-wraps addCommand on dist/lib/client/commands-queue.js', () => {
+        const instrumentations = globalThis[Symbol.for('_ddtrace_instrumentations')]
+        const hooks = instrumentations['@redis/client']
+        const queueHook = hooks.find(h =>
+          h.versions && h.versions.includes('>=5.12.0') &&
+          h.file === 'dist/lib/client/commands-queue.js')
+
+        assert(queueHook, 'should find hook for @redis/client >=5.12.0 commands-queue.js')
+
+        class MockQueue {
+          addCommand (cmd) { return cmd }
+        }
+        const mockRedis = { default: MockQueue }
+        const result = queueHook.hook(mockRedis)
+
+        assert.strictEqual(result, mockRedis)
+        assert.notStrictEqual(mockRedis.default, MockQueue)
+        assert(Object.hasOwn(mockRedis.default.prototype, 'addCommand'))
+      })
+    })
   })
 })

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert')
+const semver = require('semver')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 
@@ -12,9 +13,18 @@ const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers'
 const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
+// @redis/client >= 5.12.0 uses built-in TracingChannel on Node.js >= 19.9 / 20.2, which
+// sanitizes command args and does not expose the connection name.
+const hasDcTracingChannel = typeof require('node:diagnostics_channel').tracingChannel === 'function'
+
 describe('Plugin', () => {
   describe('redis', () => {
-    withVersions('redis', ['@node-redis/client', '@redis/client'], (version, moduleName) => {
+    withVersions('redis', ['@node-redis/client', '@redis/client'], (version, moduleName, resolvedVersion) => {
+      // @redis/client >= 5.12.0 on Node.js >= 20.2 uses built-in TracingChannel which sanitizes
+      // SET/MSET values and does not expose connectionName, so splitByInstance has no effect.
+      const isBuiltinDcVersion = moduleName === '@redis/client' &&
+        hasDcTracingChannel && semver.satisfies(resolvedVersion, '>=5.12.0')
+
       let redis
       let client
       let tracer
@@ -90,8 +100,10 @@ describe('Plugin', () => {
         })
 
         it('keeps every arg when formatting a multi-arg command', async () => {
+          // Built-in TracingChannel sanitizes SET values; only the key is kept.
+          const expectedRawCommand = isBuiltinDcVersion ? 'SET multi-arg-key ?' : 'SET multi-arg-key multi-arg-value'
           const promise = agent.assertSomeTraces(traces => {
-            assert.strictEqual(traces[0][0].meta['redis.raw_command'], 'SET multi-arg-key multi-arg-value')
+            assert.strictEqual(traces[0][0].meta['redis.raw_command'], expectedRawCommand)
           }, { spanResourceMatch: /^SET$/ })
 
           await Promise.all([client.set('multi-arg-key', 'multi-arg-value'), promise])
@@ -101,8 +113,13 @@ describe('Plugin', () => {
           const longValue = 'x'.repeat(150)
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
-            assert.strictEqual(rawCommand, `SET long-key ${'x'.repeat(97)}...`)
-            assert.strictEqual(rawCommand.length, 'SET long-key '.length + 100)
+            if (isBuiltinDcVersion) {
+              // Built-in TracingChannel sanitizes SET values to '?'.
+              assert.strictEqual(rawCommand, 'SET long-key ?')
+            } else {
+              assert.strictEqual(rawCommand, `SET long-key ${'x'.repeat(97)}...`)
+              assert.strictEqual(rawCommand.length, 'SET long-key '.length + 100)
+            }
           }, { spanResourceMatch: /^SET$/ })
 
           await Promise.all([client.set('long-key', longValue), promise])
@@ -126,9 +143,16 @@ describe('Plugin', () => {
           }
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
-            assert.strictEqual(rawCommand.length, 1000)
             assert.match(rawCommand, /^MSET /)
-            assert.match(rawCommand, /\.\.\.$/)
+            if (isBuiltinDcVersion) {
+              // Built-in TracingChannel sanitizes all MSET values to '?'; the result is shorter
+              // than 1000 chars and does not end with '...'.
+              assert.ok(rawCommand.length < 1000)
+              assert.match(rawCommand, / \?$/)
+            } else {
+              assert.strictEqual(rawCommand.length, 1000)
+              assert.match(rawCommand, /\.\.\.$/)
+            }
           }, { spanResourceMatch: /^MSET$/ })
 
           await Promise.all([client.sendCommand(['MSET', ...args]), promise])
@@ -284,16 +308,21 @@ describe('Plugin', () => {
         })
 
         it('should set service name based on connection name', async () => {
+          // Built-in TracingChannel does not expose connectionName, so splitByInstance has no effect.
+          const expectedService = isBuiltinDcVersion ? 'custom' : 'custom-test'
           const promise = agent.assertSomeTraces(traces => {
-            assert.strictEqual(traces[0][0].service, 'custom-test')
+            assert.strictEqual(traces[0][0].service, expectedService)
           })
 
           await Promise.all([client.get('foo'), promise])
         })
 
         it('should set service source tag to split-by-instance', async () => {
+          // Built-in TracingChannel does not expose connectionName, so splitByInstance has no effect
+          // and the source tag is 'opt.plugin' (from the configured service) instead.
+          const expectedSvcSrc = isBuiltinDcVersion ? 'opt.plugin' : 'opt.split_by_instance'
           const promise = agent.assertSomeTraces(traces => {
-            assert.strictEqual(traces[0][0].meta['_dd.svc_src'], 'opt.split_by_instance')
+            assert.strictEqual(traces[0][0].meta['_dd.svc_src'], expectedSvcSrc)
           })
 
           await Promise.all([client.get('foo'), promise])
@@ -304,7 +333,8 @@ describe('Plugin', () => {
           {
             v0: {
               opName: 'redis.command',
-              serviceName: 'custom-test',
+              // Built-in TracingChannel does not expose connectionName, so splitByInstance has no effect.
+              serviceName: isBuiltinDcVersion ? 'custom' : 'custom-test',
             },
             v1: {
               opName: 'redis.command',

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -13,18 +13,13 @@ const { breakThen, unbreakThen } = require('../../dd-trace/test/plugins/helpers'
 const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
 const { expectedSchema, rawExpectedSchema } = require('./naming')
 
-// @redis/client >= 5.12.0 uses built-in TracingChannel on Node.js >= 19.9 / 20.2, which
-// sanitizes command args and does not expose the connection name.
-// eslint-disable-next-line n/no-unsupported-features/node-builtins
-const hasDcTracingChannel = typeof require('node:diagnostics_channel').tracingChannel === 'function'
-
 describe('Plugin', () => {
   describe('redis', () => {
     withVersions('redis', ['@node-redis/client', '@redis/client'], (version, moduleName, resolvedVersion) => {
-      // @redis/client >= 5.12.0 on Node.js >= 20.2 uses built-in TracingChannel which sanitizes
-      // SET/MSET values and does not expose connectionName, so splitByInstance has no effect.
+      // @redis/client >= 5.12.0 uses built-in TracingChannel (dc-polyfill ensures it's always
+      // available) which does not expose connectionName, so splitByInstance has no effect.
       const isBuiltinDcVersion = moduleName === '@redis/client' &&
-        hasDcTracingChannel && semver.satisfies(resolvedVersion, '>=5.12.0')
+        semver.satisfies(resolvedVersion, '>=5.12.0')
 
       let redis
       let client
@@ -100,30 +95,23 @@ describe('Plugin', () => {
           await Promise.all([client.get('foo'), promise])
         })
 
-        it('keeps every arg when formatting a multi-arg command', async () => {
-          // Built-in TracingChannel sanitizes SET values; only the key is kept.
-          const expectedRawCommand = isBuiltinDcVersion ? 'SET multi-arg-key ?' : 'SET multi-arg-key multi-arg-value'
+        it('redacts write command values', async () => {
           const promise = agent.assertSomeTraces(traces => {
-            assert.strictEqual(traces[0][0].meta['redis.raw_command'], expectedRawCommand)
+            assert.strictEqual(traces[0][0].meta['redis.raw_command'], 'SET multi-arg-key ?')
           }, { spanResourceMatch: /^SET$/ })
 
           await Promise.all([client.set('multi-arg-key', 'multi-arg-value'), promise])
         })
 
         it('trims a string arg longer than 100 chars', async () => {
-          const longValue = 'x'.repeat(150)
+          const longKey = 'x'.repeat(150)
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
-            if (isBuiltinDcVersion) {
-              // Built-in TracingChannel sanitizes SET values to '?'.
-              assert.strictEqual(rawCommand, 'SET long-key ?')
-            } else {
-              assert.strictEqual(rawCommand, `SET long-key ${'x'.repeat(97)}...`)
-              assert.strictEqual(rawCommand.length, 'SET long-key '.length + 100)
-            }
-          }, { spanResourceMatch: /^SET$/ })
+            assert.strictEqual(rawCommand, `GET ${'x'.repeat(97)}...`)
+            assert.strictEqual(rawCommand.length, 'GET '.length + 100)
+          }, { spanResourceMatch: /^GET$/ })
 
-          await Promise.all([client.set('long-key', longValue), promise])
+          await Promise.all([client.get(longKey), promise])
         })
 
         it('redacts the AUTH password from the raw command', async () => {
@@ -137,7 +125,7 @@ describe('Plugin', () => {
           ])
         })
 
-        it('caps the joined raw command at 1000 chars across many args', async () => {
+        it('redacts MSET values and keeps the first key', async () => {
           const args = []
           for (let index = 0; index < 200; index++) {
             args.push(`key${index}`, `value${index}`)
@@ -145,15 +133,9 @@ describe('Plugin', () => {
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
             assert.match(rawCommand, /^MSET /)
-            if (isBuiltinDcVersion) {
-              // Built-in TracingChannel sanitizes all MSET values to '?'; the result is shorter
-              // than 1000 chars and does not end with '...'.
-              assert.ok(rawCommand.length < 1000)
-              assert.match(rawCommand, / \?$/)
-            } else {
-              assert.strictEqual(rawCommand.length, 1000)
-              assert.match(rawCommand, /\.\.\.$/)
-            }
+            // Values are redacted; only the first key is shown. Result is well under 1000 chars.
+            assert.ok(rawCommand.length < 1000)
+            assert.match(rawCommand, / \?$/)
           }, { spanResourceMatch: /^MSET$/ })
 
           await Promise.all([client.sendCommand(['MSET', ...args]), promise])

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -15,6 +15,7 @@ const { expectedSchema, rawExpectedSchema } = require('./naming')
 
 // @redis/client >= 5.12.0 uses built-in TracingChannel on Node.js >= 19.9 / 20.2, which
 // sanitizes command args and does not expose the connection name.
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
 const hasDcTracingChannel = typeof require('node:diagnostics_channel').tracingChannel === 'function'
 
 describe('Plugin', () => {

--- a/packages/datadog-plugin-redis/test/client.spec.js
+++ b/packages/datadog-plugin-redis/test/client.spec.js
@@ -95,12 +95,12 @@ describe('Plugin', () => {
           await Promise.all([client.get('foo'), promise])
         })
 
-        it('redacts write command values', async () => {
+        it('redacts non-string non-number args as ?', async () => {
           const promise = agent.assertSomeTraces(traces => {
             assert.strictEqual(traces[0][0].meta['redis.raw_command'], 'SET multi-arg-key ?')
           }, { spanResourceMatch: /^SET$/ })
 
-          await Promise.all([client.set('multi-arg-key', 'multi-arg-value'), promise])
+          await Promise.all([client.set('multi-arg-key', Buffer.from('multi-arg-value')), promise])
         })
 
         it('trims a string arg longer than 100 chars', async () => {
@@ -125,20 +125,16 @@ describe('Plugin', () => {
           ])
         })
 
-        it('redacts MSET values and keeps the first key', async () => {
-          const args = []
-          for (let index = 0; index < 200; index++) {
-            args.push(`key${index}`, `value${index}`)
-          }
+        it('caps the joined raw command at 1000 chars across many args', async () => {
+          const keys = Array.from({ length: 200 }, (_, i) => `key${i}`)
           const promise = agent.assertSomeTraces(traces => {
             const rawCommand = traces[0][0].meta['redis.raw_command']
-            assert.match(rawCommand, /^MSET /)
-            // Values are redacted; only the first key is shown. Result is well under 1000 chars.
-            assert.ok(rawCommand.length < 1000)
-            assert.match(rawCommand, / \?$/)
-          }, { spanResourceMatch: /^MSET$/ })
+            assert.match(rawCommand, /^DEL /)
+            assert.strictEqual(rawCommand.length, 1000)
+            assert.match(rawCommand, /\.\.\.$/)
+          }, { spanResourceMatch: /^DEL$/ })
 
-          await Promise.all([client.sendCommand(['MSET', ...args]), promise])
+          await Promise.all([client.sendCommand(['DEL', ...keys]), promise])
         })
 
         withPeerService(

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -134,7 +134,7 @@
     "handlebars": "4.7.9",
     "hapi": "18.1.0",
     "hono": "4.12.19",
-    "ioredis": "5.10.1",
+    "ioredis": "5.11.0",
     "iovalkey": "0.3.3",
     "jest": "30.4.2",
     "jest-circus": "30.4.2",

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -423,7 +423,7 @@
     "dependency": "ioredis",
     "integration": "ioredis",
     "minimum_tracer_supported": "2.0.0",
-    "max_tracer_supported": "5.10.1",
+    "max_tracer_supported": "5.11.0",
     "auto-instrumented": "True"
   },
   {

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -59,7 +59,7 @@ hono,hono,4.0.0,4.12.19,True
 http,http,18.0.0,26.3.0,True
 http2,http2,18.0.0,26.3.0,True
 https,http,18.0.0,26.3.0,True
-ioredis,ioredis,2.0.0,5.10.1,True
+ioredis,ioredis,2.0.0,5.11.0,True
 iovalkey,iovalkey,0.0.1,0.3.3,True
 jest-circus,jest,28.0.0,30.4.2,True
 jest-config,jest,28.0.0,30.4.2,True


### PR DESCRIPTION
### What does this PR do?

ioredis@5.11.0 and @redis/client@5.12.0 both shipped native `diagnostics_channel` TracingChannel support. On Node.js >= 19.9 / 20.2 (where `dc.tracingChannel` is available), this PR subscribes directly to the built-in `tracing:ioredis:command:*` and `tracing:node-redis:command:*` channels instead of using the shimmer, avoiding double-tracing. The shimmer fallback is retained for Node.js 18.

### Motivation

Using the libraries' built-in instrumentation is the preferred approach — it reduces maintenance surface, avoids shimmer overhead, and aligns with the upstream packages' intent.

### Additional Notes

**Implementation details:**
- `asyncEnd` is used (not `end`) to finish spans: `tracePromise` fires `end` _before_ `error`, so finishing on `end` would prevent error tags from being set on the span.
- ioredis built-in args exclude the command name (`argsStartIndex=0`); @redis/client built-in args include it at `[0]` (`argsStartIndex=1`).

**Known limitations (bugs in third-party packages):**
- Neither package exposes `connectionName` in their TracingChannel context, so `splitByInstance: true` has no effect on Node.js 20+ with these new versions.
- `@redis/client@5.12.0` sanitizes SET/MSET/LPUSH values to `?` in built-in context; `redis.raw_command` will show `?` instead of actual values on Node.js 20+. This is intentional security behavior upstream.

Tests are updated with `hasDcTracingChannel` guards to handle both the shimmer and built-in channel behaviors.