### PR TITLE
bench(plugin-mongodb-core): sirun coverage for the per-op bindStart sanitiser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,7 @@
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-q/ @DataDog/apm-idm-js
 

--- a/benchmark/sirun/plugin-mongodb-core/README.md
+++ b/benchmark/sirun/plugin-mongodb-core/README.md
@@ -1,0 +1,45 @@
+This benchmark measures the per-mongo-op work in
+`packages/datadog-plugin-mongodb-core/src/index.js` `bindStart`. Every traced
+mongo op walks `bindStart` -> `getQuery` -> `sanitiseAndStringify`, builds the
+meta literal, then calls `serviceName` / `startSpan` (the DBM-comment chain
+is stubbed off so the signal is the sanitiser, not the DBM concat).
+
+The bench instantiates a real `MongodbCorePlugin` subclass that overrides
+`addTraceSubs` (skip diagnostic-channel wiring) and `serviceName` /
+`startSpan` / `getPeerService` / `injectDbmComment` (skip tracer plumbing
+and DBM construction), so the loop measures the per-op work end to end while
+keeping the production `bindStart` shape intact. Subclassing instead of
+`Object.create` is required because the parent `DatabasePlugin` uses private
+methods that need a real instance.
+
+Variants:
+
+- `plain-find` (control) -- a flat `{ filter: { user_id, status, region },
+  limit }`. Goes through the `canStringifyDirect` fast path and exits via the
+  native `JSON.stringify`. Pins the per-op baseline cost; should not regress.
+- `deep-aggregate` (`baseline: plain-find`) -- a 5-stage aggregation
+  pipeline (`$match` / `$lookup` / `$group` / `$sort` / `$limit`) with
+  nested operators. Still on the fast path, but exercises the deeper
+  walk in `canStringifyDirect` and the longer `JSON.stringify` output.
+  Catches regressions in either the fast-path probe or any future
+  per-pipeline caching.
+- `bigint-id` (`baseline: plain-find`) -- a sharded read whose `_id`
+  overflows `Number.MAX_SAFE_INTEGER` and arrives as a native bigint.
+  Disqualifies the fast path and forces the manual walker on every call.
+  Every customer that shards on 64-bit ids hits this shape on every read.
+- `binary-hash` (`baseline: plain-find`) -- a Buffer-typed query field
+  (32-byte SHA-256 hash, content-addressable lookup, idempotency key,
+  etc.). The driver accepts Buffer in place of `BSON.Binary` for
+  binary columns; binary fields are common in production mongodb
+  workloads (hash indexes, blob references, idempotency keys). This
+  shape disqualifies the fast path, pinning the slow path's cost on a
+  realistic per-op shape.
+- `mixed-ops` (`baseline: plain-find`) -- eight realistic shapes
+  (`find` / `insert` / `update` / `delete` / `aggregate` / `count` /
+  `findAndModify` / `ping`) interleaved. Megamorphic input, closest to
+  what a busy customer's process actually feeds the plugin.
+
+Expected noise budget: `wall.time.stddev_pct` ≤ ~3 % overall (control
+variant ≤ ~1 % since it is fully synchronous);
+`instructions.stddev_pct` ≤ ~0.5 % on every variant. Total wall-clock
+per variant ≈ 1 min at 30 iterations.

--- a/benchmark/sirun/plugin-mongodb-core/README.md
+++ b/benchmark/sirun/plugin-mongodb-core/README.md
@@ -1,45 +1,4 @@
-This benchmark measures the per-mongo-op work in
-`packages/datadog-plugin-mongodb-core/src/index.js` `bindStart`. Every traced
-mongo op walks `bindStart` -> `getQuery` -> `sanitiseAndStringify`, builds the
-meta literal, then calls `serviceName` / `startSpan` (the DBM-comment chain
-is stubbed off so the signal is the sanitiser, not the DBM concat).
-
-The bench instantiates a real `MongodbCorePlugin` subclass that overrides
-`addTraceSubs` (skip diagnostic-channel wiring) and `serviceName` /
-`startSpan` / `getPeerService` / `injectDbmComment` (skip tracer plumbing
-and DBM construction), so the loop measures the per-op work end to end while
-keeping the production `bindStart` shape intact. Subclassing instead of
-`Object.create` is required because the parent `DatabasePlugin` uses private
-methods that need a real instance.
-
-Variants:
-
-- `plain-find` (control) -- a flat `{ filter: { user_id, status, region },
-  limit }`. Goes through the `canStringifyDirect` fast path and exits via the
-  native `JSON.stringify`. Pins the per-op baseline cost; should not regress.
-- `deep-aggregate` (`baseline: plain-find`) -- a 5-stage aggregation
-  pipeline (`$match` / `$lookup` / `$group` / `$sort` / `$limit`) with
-  nested operators. Still on the fast path, but exercises the deeper
-  walk in `canStringifyDirect` and the longer `JSON.stringify` output.
-  Catches regressions in either the fast-path probe or any future
-  per-pipeline caching.
-- `bigint-id` (`baseline: plain-find`) -- a sharded read whose `_id`
-  overflows `Number.MAX_SAFE_INTEGER` and arrives as a native bigint.
-  Disqualifies the fast path and forces the manual walker on every call.
-  Every customer that shards on 64-bit ids hits this shape on every read.
-- `binary-hash` (`baseline: plain-find`) -- a Buffer-typed query field
-  (32-byte SHA-256 hash, content-addressable lookup, idempotency key,
-  etc.). The driver accepts Buffer in place of `BSON.Binary` for
-  binary columns; binary fields are common in production mongodb
-  workloads (hash indexes, blob references, idempotency keys). This
-  shape disqualifies the fast path, pinning the slow path's cost on a
-  realistic per-op shape.
-- `mixed-ops` (`baseline: plain-find`) -- eight realistic shapes
-  (`find` / `insert` / `update` / `delete` / `aggregate` / `count` /
-  `findAndModify` / `ping`) interleaved. Megamorphic input, closest to
-  what a busy customer's process actually feeds the plugin.
-
-Expected noise budget: `wall.time.stddev_pct` ≤ ~3 % overall (control
-variant ≤ ~1 % since it is fully synchronous);
-`instructions.stddev_pct` ≤ ~0.5 % on every variant. Total wall-clock
-per variant ≈ 1 min at 30 iterations.
+sirun coverage for `packages/datadog-plugin-mongodb-core/src/index.js` `bindStart`.
+Every traced mongo op walks `bindStart` -> `getQuery` -> `sanitiseAndStringify` ->
+meta literal -> `startSpan`; per-op savings on this chain compound across mongo
+throughput. Variants live in `meta.json`; the workload lives in `index.js`.

--- a/benchmark/sirun/plugin-mongodb-core/index.js
+++ b/benchmark/sirun/plugin-mongodb-core/index.js
@@ -1,0 +1,150 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const MongodbCorePlugin = require('../../../packages/datadog-plugin-mongodb-core/src/index')
+
+const { VARIANT } = process.env
+
+const ITERATIONS = 2_000_000
+
+// Every traced mongo op walks `bindStart` -> `getQuery` ->
+// `sanitiseAndStringify`, builds the meta literal, calls `serviceName` /
+// `startSpan`, and would otherwise reach `injectDbmComment`. Subclassing the
+// real `MongodbCorePlugin` and overriding only the four hooks that reach for
+// tracer / diagnostic-channel / DBM plumbing keeps the production `bindStart`
+// shape intact while pulling the loop's measured surface back to the
+// per-op sanitiser + meta construction. Subclassing (rather than
+// `Object.create`) is required because `DatabasePlugin` uses private methods
+// that demand a real instance.
+let lastMeta
+const FAKE_SPAN = { finish () {} }
+const SERVICE_RESULT = { name: 'mongo-prod', source: 'mongodb' }
+class BenchedMongoPlugin extends MongodbCorePlugin {
+  addTraceSubs () { /* skip diagnostic-channel subscriptions */ }
+  serviceName () { return SERVICE_RESULT }
+  startSpan (name, opts) { lastMeta = opts.meta; return FAKE_SPAN }
+  getPeerService () {}
+  injectDbmComment () { /* DBM concat is a separate per-op concern */ }
+}
+
+const tracer = {
+  _env: 'production',
+  _service: 'web-app',
+  _version: '1.2.3',
+  _nomenclature: { opName: () => 'mongodb.query' },
+}
+const tracerConfig = { spanComputePeerService: false }
+const plugin = new BenchedMongoPlugin(tracer, tracerConfig)
+plugin.config = {
+  heartbeatEnabled: true,
+  dbmPropagationMode: 'service',
+  appendComment: false,
+  truncate: 5000,
+  queryInResourceName: false,
+  obfuscateQuery: 'none',
+}
+
+const OPTIONS = { host: 'mongo-primary.internal', port: 27017 }
+
+// Pre-built per-variant ops fixtures. The hot loop never allocates a new
+// `ops` object; pre-allocation pins the V8 hidden class V8 sees on every
+// `bindStart` call and keeps the loop measuring the plugin's own work rather
+// than fixture construction.
+const PLAIN_FIND = {
+  find: 'orders',
+  filter: { user_id: 1234567, status: 'active', region: 'us-east-1' },
+  limit: 100,
+}
+
+const DEEP_AGGREGATE = {
+  aggregate: 'orders',
+  pipeline: [
+    { $match: { status: 'paid', region: { $in: ['us-east-1', 'us-west-2'] } } },
+    { $lookup: { from: 'users', localField: 'user_id', foreignField: '_id', as: 'user' } },
+    { $group: { _id: '$user_id', total: { $sum: '$total' }, items: { $sum: '$qty' } } },
+    { $sort: { total: -1 } },
+    { $limit: 100 },
+  ],
+}
+
+// 64-bit shard IDs overflow `Number.MAX_SAFE_INTEGER`, so the driver passes
+// them as native bigints. That disqualifies the `canStringifyDirect` fast
+// path and forces the manual walker -- every customer that shards on a
+// 64-bit id hits this shape on every read.
+const BIGINT_ID = {
+  find: 'shards',
+  filter: { _id: 9_999_999_999_999_999_999n, region: 'us-east-1', tier: 'gold' },
+}
+
+// A 32-byte binary field (SHA-256 hash, content-addressable key,
+// idempotency key, UUID stored as binary) passed as a Node Buffer. The
+// driver accepts Buffer in place of `BSON.Binary` for binary-typed
+// columns. Binary fields are common in production mongodb workloads
+// (hash indexes, blob references, idempotency keys), and this shape
+// disqualifies the fast path, so this variant pins the slow path's
+// cost on a realistic per-op shape.
+const BINARY_HASH = {
+  find: 'documents',
+  filter: { sha256: Buffer.alloc(32, 0x42), tenant: 'acme', deleted: false },
+}
+
+const MIXED_OPS = [
+  PLAIN_FIND,
+  { insert: 'orders', documents: [{ user_id: 1, total: 99.99, items: [{ sku: 'A', qty: 2 }] }] },
+  { update: 'orders', updates: [{ q: { _id: 1 }, u: { $set: { status: 'shipped' } } }] },
+  { delete: 'sessions', deletes: [{ q: { expires_at: { $lt: new Date(0) } }, limit: 0 }] },
+  DEEP_AGGREGATE,
+  { count: 'users', query: { active: true } },
+  { findAndModify: 'sessions', query: { id: 'abc' }, update: { $set: { last_seen: new Date(0) } } },
+  { ping: 1 },
+]
+
+function makeCtx (ops) {
+  return { ns: 'shop.orders', ops, options: OPTIONS, name: 'find' }
+}
+
+// Pre-flight: confirm `bindStart` reached the meta literal and routed
+// through the sanitiser. Without this, a refactor that renames a hook or
+// skips a branch can quietly turn the bench into a near no-op and ship a
+// fake speedup. Cost: one extra `bindStart` call per variant at module
+// load, then zero per iteration. `ping` legitimately produces no query
+// (no `.filter` / `.pipeline` / etc.), so verify the meta literal was
+// built rather than asserting on the query string.
+function preflight (ctx) {
+  lastMeta = undefined
+  plugin.bindStart(ctx)
+  assert.ok(lastMeta && lastMeta['db.name'] === ctx.ns && 'mongodb.query' in lastMeta,
+    'bindStart did not build the meta literal')
+}
+
+const FIXTURES = {
+  'plain-find': PLAIN_FIND,
+  'deep-aggregate': DEEP_AGGREGATE,
+  'bigint-id': BIGINT_ID,
+  'binary-hash': BINARY_HASH,
+}
+
+if (VARIANT === 'mixed-ops') {
+  const ctxs = MIXED_OPS.map(makeCtx)
+  for (const ctx of ctxs) preflight(ctx)
+  lastMeta = undefined
+  const len = ctxs.length
+  for (let i = 0; i < ITERATIONS; i++) {
+    plugin.bindStart(ctxs[i % len])
+  }
+} else {
+  const ops = FIXTURES[VARIANT]
+  assert.ok(ops, `unknown VARIANT: ${VARIANT}`)
+  const ctx = makeCtx(ops)
+  preflight(ctx)
+  lastMeta = undefined
+  for (let i = 0; i < ITERATIONS; i++) {
+    plugin.bindStart(ctx)
+  }
+}
+
+// Post-loop read of `lastMeta` keeps V8 from dead-code-eliminating the
+// per-iter `startSpan` stub side effect, which is the only thing pinning
+// the meta-literal construction inside the loop.
+assert.ok(lastMeta, 'startSpan stub was never reached inside the hot loop')

--- a/benchmark/sirun/plugin-mongodb-core/meta.json
+++ b/benchmark/sirun/plugin-mongodb-core/meta.json
@@ -1,0 +1,29 @@
+{
+  "name": "plugin-mongodb-core",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 30,
+  "instructions": true,
+  "variants": {
+    "plain-find": {
+      "env": { "VARIANT": "plain-find" }
+    },
+    "deep-aggregate": {
+      "baseline": "plain-find",
+      "env": { "VARIANT": "deep-aggregate" }
+    },
+    "bigint-id": {
+      "baseline": "plain-find",
+      "env": { "VARIANT": "bigint-id" }
+    },
+    "binary-hash": {
+      "baseline": "plain-find",
+      "env": { "VARIANT": "binary-hash" }
+    },
+    "mixed-ops": {
+      "baseline": "plain-find",
+      "env": { "VARIANT": "mixed-ops" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the first sirun benchmark for `plugin-mongodb-core`. Every traced mongo op walks `bindStart` -> `getQuery` -> `sanitiseAndStringify` -> meta literal -> `startSpan`, so per-op savings on this chain compound across mongo throughput. The dir had no sirun coverage at all; regressions would only surface through a customer report.
- The bench instantiates a real `MongodbCorePlugin` subclass with the four tracer / diagnostic-channel / DBM hooks stubbed off, keeping the production `bindStart` shape intact while pulling the measured surface to the plugin's own per-op work. A pre-flight assertion confirms `bindStart` reached the meta literal, so a future rename or branch skip can't quietly turn the bench into a near no-op and ship a fake speedup.
- Five variants cover the realistic input distribution: `plain-find` (control, fast path), `deep-aggregate` (fast path with a deeper walk), `bigint-id` (slow path via 64-bit sharded id), `binary-hash` (slow path on a Buffer-typed field — hash indexes, blob references, idempotency keys are common production shapes), and `mixed-ops` (megamorphic interleave of eight realistic shapes).

## Smoke numbers on Node 24.15.0 / V8 13.6, single iteration each

| variant          | wall-clock per process | scope                                                  |
|------------------|-----------------------:|--------------------------------------------------------|
| `plain-find`     |                ~350 ms | fast path baseline                                     |
| `deep-aggregate` |                ~2.3 s  | fast path, deeper walk                                 |
| `bigint-id`      |                ~750 ms | slow path on a native bigint shard id                  |
| `binary-hash`    |                ~800 ms | slow path with 32-byte Buffer field                    |
| `mixed-ops`      |                ~700 ms | eight-shape interleave                                 |

(`iterations: 2_000_000` per process, `iterations: 30` sirun runs.)

## Test plan

- [ ] CI: `benchmark.yml` workflow picks up the new `plugin-mongodb-core` dir and emits `wall.time.stddev_pct` <= ~3 % overall (<= ~1 % on `plain-find`) and `instructions.stddev_pct` <= ~0.5 % on every variant.
- [ ] Re-run on the same SHA twice; per-variant means should land within ~1 % of each other (skill noise budget for sirun benches).
- [ ] Local pre-flight: `VARIANT=<each> node benchmark/sirun/plugin-mongodb-core/index.js` exits 0 and the post-loop `assert.ok(lastMeta, ...)` confirms the hot loop actually reached the stub.

## Depends on

- https://github.com/DataDog/dd-trace-js/pull/8683 (allow `bench` as a Conventional Commits type) — without it the `conventional-commit` check on this PR can't go green.