### PR TITLE
ci(pr-title): allow `bench` as a Conventional Commits type

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 
 <!-- PR title must follow Conventional Commits format: type(scope): description -->
-<!-- Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
+<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->
 
 ### What does this PR do?
 <!-- A brief description of the change being made with this pull request. -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,7 @@ jobs:
       # regex (no lookarounds, named groups, or other JS-only features).
       # Revert PRs nest the reverted commit's type, e.g. `revert: feat(api): undo X`,
       # so the semver label can track the magnitude of the original change.
-      PR_TITLE_PATTERN: '^(revert(!)?: )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(([^)]+)\))?(!)?: .+'
+      PR_TITLE_PATTERN: '^(revert(!)?: )?(feat|fix|docs|style|refactor|perf|test|bench|build|ci|chore)(\(([^)]+)\))?(!)?: .+'
     steps:
       - name: Validate PR title against Conventional Commits
         if: >-
@@ -35,7 +35,7 @@ jobs:
             echo "Got:      $PR_TITLE"
             echo "Expected: <type>(<scope>)?(!)?: <subject>"
             echo "          revert(!)?: <type>(<scope>)?(!)?: <subject>  (for reverts)"
-            echo "Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore"
+            echo "Allowed types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore"
             echo "Revert PRs must embed the original commit's type so the semver impact can"
             echo "be determined (e.g. 'revert: feat(scope): original title')."
             echo "Reverts of reverts re-apply the original change, so use the original"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ The `scope` is optional. Valid types are:
 | `refactor` | Code change that neither fixes a bug nor adds a feature |
 | `perf` | A code change that improves performance |
 | `test` | Adding or updating tests |
+| `bench` | Adding or updating benchmarks (e.g. under `benchmark/sirun/`) |
 | `build` | Changes to build system or external dependencies |
 | `ci` | Changes to CI configuration files and scripts |
 | `chore` | Other changes that don't modify src or test files |


### PR DESCRIPTION
## Summary

- Adds `bench` to the type allowlist in `.github/workflows/pr-title.yml`, the `CONTRIBUTING.md` type table, and the PR template's hint comment.
- The repo already has a top-level `benchmark/sirun/` tree with one dir per benchmarked surface (`encoding`, `spans`, `plugin-aws-sdk`, `plugin-http`, etc.). Changes scoped to that tree don't fit any of the existing allowed types cleanly — `test` is reserved for unit / integration tests, `chore` loses the perf-infrastructure signal, and `perf` carries a real semantic load ("a code change that improves performance") that a benchmark-only change doesn't.
- `bench` is a common convention for benchmark-only changes; it maps to `semver-patch` through the existing sync-labels fall-through and keeps the revert regex working without further changes.

## Test plan

- [ ] `Pull Request Title` workflow on this PR passes against its own `ci(pr-title): ...` title.
- [ ] A follow-up PR with a `bench(plugin-mongodb-core): ...` title (https://github.com/DataDog/dd-trace-js/pull/8682) goes from failing the conventional-commit check to passing once this lands.
- [ ] Sync-labels step assigns `semver-patch` (and `ci` if present) to this PR without falling through to `semver-major`.