### PR TITLE
fix(oracledb): keep caller SQL when tracing is suppressed

### DIFF
--- a/packages/datadog-instrumentations/src/oracledb.js
+++ b/packages/datadog-instrumentations/src/oracledb.js
@@ -72,7 +72,11 @@ addHook({ name: 'oracledb', versions: ['>=5'], file: 'lib/oracledb.js' }, oracle
       }
 
       return startChannel.runStores(ctx, () => {
-        arguments[0] = ctx.injected
+        // bindStart is skipped when tracing is suppressed (legacy store is `noop`),
+        // leaving ctx.injected unset — do not overwrite the caller's SQL argument.
+        if (ctx.injected !== undefined) {
+          arguments[0] = ctx.injected
+        }
         try {
           let result = execute.apply(this, arguments)
 

--- a/packages/datadog-plugin-oracledb/test/index.spec.js
+++ b/packages/datadog-plugin-oracledb/test/index.spec.js
@@ -7,6 +7,7 @@ const { after, before, beforeEach, describe, it } = require('mocha')
 const semver = require('semver')
 
 const ddpv = require('mocha/package.json').version
+const { storage } = require('../../datadog-core')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
@@ -474,6 +475,26 @@ describe('Plugin', () => {
         it('should not inject a comment when propagation is disabled', async () => {
           await connection.execute(dbQuery)
           assert.strictEqual(injected, dbQuery)
+        })
+      })
+
+      // When the legacy store handle is marked `noop` (the suppression mechanism used by the
+      // agent's own request loop), the plugin's bindStart is skipped and ctx.injected stays
+      // undefined; the instrumentation must not overwrite the caller's SQL with it.
+      describe('with tracing suppressed via the noop legacy store handle', () => {
+        before(async () => {
+          tracer = await agent.load('oracledb')
+          oracledb = require(`../../../versions/oracledb@${version}`).get()
+          connection = await oracledb.getConnection(config)
+        })
+
+        after(async () => {
+          await connection.close()
+          await agent.close()
+        })
+
+        it('passes the caller SQL through unchanged when bindStart is skipped', async () => {
+          await storage('legacy').run({ noop: true }, () => connection.execute(dbQuery))
         })
       })
 


### PR DESCRIPTION
## Summary

Calls to `Connection.prototype.execute` running while the legacy store handle is marked `noop` (the suppression mechanism for nested instrumentation) had their SQL argument silently replaced with `undefined`. The plugin's `bindStart` transform is skipped on the noop path, so `ctx.injected` stays undefined; the instrumentation's unconditional `arguments[0] = ctx.injected` then overwrote the user's SQL or `{ statement, values }` template, and the underlying driver call failed.

Guard the rewrite the way the pg instrumentation does, and pin the noop path with a regression test that executes a real query under `storage('legacy').run({ noop: true }, …)`.

Refs: https://github.com/DataDog/dd-trace-js/pull/8661#discussion_r3316120997