### PR TITLE
chore(ci): fold codeowners-audit and verify-exercised-tests into npm run lint

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -44,14 +44,6 @@ jobs:
       - uses: ./.github/actions/install
       - run: npm run lint
 
-  verify-exercised-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/node/latest
-      - uses: ./.github/actions/install
-      - run: npm run verify-exercised-tests
-
   generated-config-types:
     runs-on: ubuntu-latest
     name: Generated config types

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
-      - run: npm run lint && npm run lint:codeowners:ci
+      - run: npm run lint
 
   verify-exercised-tests:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type:check": "tsc --noEmit -p tsconfig.dev.json",
     "type:doc:build": "cd docs && yarn && yarn build",
     "type:doc:test": "cd docs && yarn && yarn test",
-    "lint": "node scripts/check_licenses.js && node scripts/check-no-coverage-artifacts.js && node scripts/check-no-mcr-images.js && node scripts/check-docker-image-shas.js && eslint . --concurrency=auto --max-warnings 0 && npm run lint:codeowners:ci",
+    "lint": "node scripts/check_licenses.js && node scripts/check-no-coverage-artifacts.js && node scripts/check-no-mcr-images.js && node scripts/check-docker-image-shas.js && eslint . --concurrency=auto --max-warnings 0 && npm run lint:codeowners:ci && npm run verify-exercised-tests",
     "lint:fix": "node scripts/check_licenses.js && node scripts/check-no-coverage-artifacts.js && node scripts/check-no-mcr-images.js && node scripts/check-docker-image-shas.js && eslint . --concurrency=auto --max-warnings 0 --fix",
     "lint:inspect": "npx @eslint/config-inspector@latest",
     "lint:codeowners": "codeowners-audit",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type:check": "tsc --noEmit -p tsconfig.dev.json",
     "type:doc:build": "cd docs && yarn && yarn build",
     "type:doc:test": "cd docs && yarn && yarn test",
-    "lint": "node scripts/check_licenses.js && node scripts/check-no-coverage-artifacts.js && node scripts/check-no-mcr-images.js && node scripts/check-docker-image-shas.js && eslint . --concurrency=auto --max-warnings 0",
+    "lint": "node scripts/check_licenses.js && node scripts/check-no-coverage-artifacts.js && node scripts/check-no-mcr-images.js && node scripts/check-docker-image-shas.js && eslint . --concurrency=auto --max-warnings 0 && npm run lint:codeowners:ci",
     "lint:fix": "node scripts/check_licenses.js && node scripts/check-no-coverage-artifacts.js && node scripts/check-no-mcr-images.js && node scripts/check-docker-image-shas.js && eslint . --concurrency=auto --max-warnings 0 --fix",
     "lint:inspect": "npx @eslint/config-inspector@latest",
     "lint:codeowners": "codeowners-audit",

--- a/scripts/verify-exercised-tests.js
+++ b/scripts/verify-exercised-tests.js
@@ -1070,7 +1070,24 @@ function main () {
     if (!uniqueErrors.has(msg)) uniqueErrors.add(msg)
   }
 
+  // Transitive closure: a script counts as "invoked" when CI either runs it directly or runs
+  // another script that calls it via `npm run X` / `yarn X`. Without this, chaining a `:ci`
+  // script into the body of a parent script (e.g. `lint` -> `npm run lint:codeowners:ci`)
+  // looks orphaned to the coverage check below even though the parent's CI step exercises it.
   const invokedScripts = new Set(invoked.map(i => i.script))
+  const closureQueue = [...invokedScripts]
+  while (closureQueue.length) {
+    const name = closureQueue.shift()
+    if (name === undefined) continue
+    const cmd = scripts[name]
+    if (typeof cmd !== 'string') continue
+    for (const inv of extractScriptInvocations(cmd, knownScripts)) {
+      if (!invokedScripts.has(inv.script)) {
+        invokedScripts.add(inv.script)
+        closureQueue.push(inv.script)
+      }
+    }
+  }
 
   /**
    * A script counts as "invoked" when either itself or its `:coverage` sibling (or base, if the


### PR DESCRIPTION
## What

Fold both static gates that previously lived as separate workflow
steps / jobs into `npm run lint` so they fire locally and as part of
the same CI job:

- `lint:codeowners:ci` now chains into `lint`. The workflow's
  `npm run lint && npm run lint:codeowners:ci` step simplifies to
  `npm run lint`.
- `verify-exercised-tests` chains into `lint` too. The dedicated
  `verify-exercised-tests` workflow job is dropped.
- `scripts/verify-exercised-tests.js` learns to follow transitive
  `npm run X` invocations when checking `:ci` script coverage.
  Without this, the codeowners chain above looks orphaned to the
  verifier; the same closure walker already powers the `test:`
  plugin coverage check (`expandInvokedScript`).

## Why

Both gates ran exclusively in CI, so contributors only learned about
CODEOWNERS gaps or unreachable `:ci` scripts after pushing. Both
checks cost <1s, so chaining them into `lint` is free locally and
removes a round-trip to CI for issues a fast static gate should
catch on save.

#8682's first lint run is the canonical CODEOWNERS case; this PR's
own first `verify-exercised-tests` run is the canonical transitive
case.