### PR TITLE
fix(llmobs): fan array-valued user tags out into one wire entry per element

### DIFF
--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -338,11 +338,12 @@ class LLMObsSpanProcessor {
   #objectTagsToStringArrayTags (tags) {
     const out = []
     for (const [key, value] of Object.entries(tags)) {
-      // Fan arrays out: comma is the inter-tag delimiter at intake, so a
-      // single `"key:v1,v2,v3"` entry gets split there and leaves every
-      // value after the first orphaned. One entry per element keeps each
-      // value addressable as its own facet.
-      if (Array.isArray(value)) {
+      // Comma is the intake-side tag delimiter, so a single `"key:v1,v2"`
+      // entry fans into two orphan tags. One-per-element keeps each value
+      // addressable; empty arrays fall through to the scalar branch and
+      // still emit `key:` so `_dd.cost_tags` references keep finding a
+      // wire entry.
+      if (Array.isArray(value) && value.length > 0) {
         for (const item of value) out.push(`${key}:${item ?? ''}`)
       } else {
         out.push(`${key}:${value ?? ''}`)

--- a/packages/dd-trace/src/llmobs/span_processor.js
+++ b/packages/dd-trace/src/llmobs/span_processor.js
@@ -332,8 +332,23 @@ class LLMObsSpanProcessor {
     return tags
   }
 
+  /**
+   * @param {Record<string, unknown>} tags
+   */
   #objectTagsToStringArrayTags (tags) {
-    return Object.entries(tags).map(([key, value]) => `${key}:${value ?? ''}`)
+    const out = []
+    for (const [key, value] of Object.entries(tags)) {
+      // Fan arrays out: comma is the inter-tag delimiter at intake, so a
+      // single `"key:v1,v2,v3"` entry gets split there and leaves every
+      // value after the first orphaned. One entry per element keeps each
+      // value addressable as its own facet.
+      if (Array.isArray(value)) {
+        for (const item of value) out.push(`${key}:${item ?? ''}`)
+      } else {
+        out.push(`${key}:${value ?? ''}`)
+      }
+    }
+    return out
   }
 
   /**

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -528,6 +528,57 @@ describe('span processor', () => {
       assertObjectContains(payload.tags, ['source:mySource', 'hostname:localhost', 'foo:bar'])
     })
 
+    it('fans out array-valued user tags into one wire entry per element', () => {
+      // Regression for https://github.com/DataDog/dd-trace-js/issues/8662 — a single
+      // `"key:v1,v2"` entry on the wire gets comma-split at intake, leaving every
+      // value after the first orphaned (UI shows a bare `v2` token, `@key:v2` filter
+      // does not match). One `key:value` per element preserves each value as its
+      // own facet.
+      span = {
+        context () {
+          return {
+            _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
+            toTraceId () { return '123' },
+            toSpanId () { return '456' },
+          }
+        },
+      }
+
+      LLMObsTagger.tagMap.set(span, {
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.tags': {
+          'tool.shell.bin': ['grep', 'head'],
+          'tool.shell.cmd': ['git log'],
+          'tool.shell.argv': [],
+          'tool.shell.flags': [null, 'verbose'],
+          'tool.shell.name': 'bash',
+        },
+      })
+
+      processor.process(span)
+      const payload = writer.append.getCall(0).firstArg
+
+      assertObjectContains(payload.tags, [
+        'tool.shell.bin:grep',
+        'tool.shell.bin:head',
+        'tool.shell.cmd:git log',
+        'tool.shell.flags:',
+        'tool.shell.flags:verbose',
+        'tool.shell.name:bash',
+      ])
+      assert.ok(
+        !payload.tags.some(tag => tag.startsWith('tool.shell.argv')),
+        'empty arrays should not produce a tag entry',
+      )
+      assert.ok(
+        !payload.tags.includes('tool.shell.bin:grep,head'),
+        'array values must not collapse into a single comma-joined entry',
+      )
+    })
+
     it('marks the apm span with _dd.llmobs.submitted=1 for sdk-tagged spans', () => {
       const apmTags = {}
       span = {

--- a/packages/dd-trace/test/llmobs/span_processor.spec.js
+++ b/packages/dd-trace/test/llmobs/span_processor.spec.js
@@ -533,7 +533,8 @@ describe('span processor', () => {
       // `"key:v1,v2"` entry on the wire gets comma-split at intake, leaving every
       // value after the first orphaned (UI shows a bare `v2` token, `@key:v2` filter
       // does not match). One `key:value` per element preserves each value as its
-      // own facet.
+      // own facet. Empty arrays still emit `key:` so `_dd.cost_tags` references
+      // keep finding a wire entry.
       span = {
         context () {
           return {
@@ -565,18 +566,48 @@ describe('span processor', () => {
         'tool.shell.bin:grep',
         'tool.shell.bin:head',
         'tool.shell.cmd:git log',
+        'tool.shell.argv:',
         'tool.shell.flags:',
         'tool.shell.flags:verbose',
         'tool.shell.name:bash',
       ])
       assert.ok(
-        !payload.tags.some(tag => tag.startsWith('tool.shell.argv')),
-        'empty arrays should not produce a tag entry',
-      )
-      assert.ok(
         !payload.tags.includes('tool.shell.bin:grep,head'),
         'array values must not collapse into a single comma-joined entry',
       )
+    })
+
+    it('keeps cost-tag references and their wire entries consistent for empty arrays', () => {
+      // The cost-tag validator only checks that the referenced key is present in the
+      // tag object, not that it produces a wire entry. Dropping empty arrays from
+      // the wire would leave `_dd.cost_tags: ['team']` pointing at a key with no
+      // matching `team:*` tag, so dd-go would drop or misattribute the cost
+      // dimension. Empty arrays therefore stay on the wire as `key:`, matching the
+      // pre-fan-out shape.
+      span = {
+        context () {
+          return {
+            _tags: {},
+            getTags () { return this._tags },
+            getTag (key) { return this._tags[key] },
+            setTag (key, value) { this._tags[key] = value },
+            toTraceId () { return '123' },
+            toSpanId () { return '456' },
+          }
+        },
+      }
+
+      LLMObsTagger.tagMap.set(span, {
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.tags': { team: [] },
+        '_ml_obs.meta.metadata._dd.cost_tags': ['team'],
+      })
+
+      processor.process(span)
+      const payload = writer.append.getCall(0).firstArg
+
+      assertObjectContains(payload.tags, ['team:'])
+      assert.deepStrictEqual(payload.meta.metadata._dd.cost_tags, ['team'])
     })
 
     it('marks the apm span with _dd.llmobs.submitted=1 for sdk-tagged spans', () => {


### PR DESCRIPTION
## Summary

`tracer.llmobs.annotate({ tags: { 'tool.shell.bin': ['grep', 'head'] } })`
produced a single `"tool.shell.bin:grep,head"` wire entry, which intake
then comma-split — leaving `head` as a bare orphan in the LLMObs tag
panel and breaking `@tool.shell.bin:head` facet filters. One `key:value`
entry per array element keeps each value addressable as its own facet,
matching the APM tagger's contract for `string[]` tag values.

As a side effect, an empty array now emits zero entries instead of a
`"key:"` placeholder — the previous output was a no-value tag the user
never asked for.

## Test plan

- [x] Regression test in `packages/dd-trace/test/llmobs/span_processor.spec.js` covering the reported case plus four sibling permutations (single-element, empty, `null` element, mixed scalar+array on the same span); fails on master, passes after the fix.
- [x] Full `span_processor.spec.js` (23 tests) green.
- [x] `nyc` on `packages/dd-trace/src/llmobs/span_processor.js` confirms both branches of the new `Array.isArray` arm exercised.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8662