### PR TITLE
fix(esbuild): drop ...arguments spread from CJS module wrap

### DIFF
--- a/integration-tests/esbuild/build-and-test-esm-minify-globals.mjs
+++ b/integration-tests/esbuild/build-and-test-esm-minify-globals.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// Regression for https://github.com/DataDog/dd-trace-js/issues/8681.
+
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import * as esbuild from 'esbuild'
+
+const PACKAGE = 'dd-esbuild-cjs-fixture'
+const installed = path.join('node_modules', PACKAGE)
+
+// The plugin only wraps packages it knows are instrumented, and it reads this
+// registry once when required. Copy the committed fixture into node_modules so
+// it resolves as a real package, flag it as instrumented, then load the plugin.
+await fs.rm(installed, { recursive: true, force: true })
+await fs.cp('./instrumented-cjs-fixture', installed, { recursive: true })
+
+const instrumentations = (globalThis[Symbol.for('_ddtrace_instrumentations')] ??= {})
+instrumentations[PACKAGE] = [{ name: PACKAGE }]
+
+const { default: ddPlugin } = await import('../../esbuild.js')
+
+const ENTRY = './esm-minify-globals-entry.mjs'
+const SCRIPT = './esm-minify-globals-out.mjs'
+
+try {
+  await fs.writeFile(ENTRY, `import fixture from '${PACKAGE}'\n\nprocess.stdout.write(JSON.stringify(fixture))\n`)
+
+  await esbuild.build({
+    entryPoints: [ENTRY],
+    bundle: true,
+    outfile: SCRIPT,
+    format: 'esm',
+    minify: true,
+    keepNames: true,
+    platform: 'node',
+    target: ['node18'],
+    plugins: [ddPlugin],
+  })
+
+  const { status, stdout, stderr } = spawnSync('node', [SCRIPT])
+  if (stderr.length) process.stderr.write(stderr)
+  assert.equal(status, 0, 'minified ESM bundle should run without crashing')
+
+  const result = JSON.parse(stdout.toString())
+  assert.equal(result.rel, 'bundled-relative-ok')
+  assert.match(result.filename, /\.mjs$/)
+  assert.ok(result.dirname.length > 0)
+  process.stdout.write('ok\n')
+} finally {
+  await fs.rm(SCRIPT, { force: true })
+  await fs.rm(ENTRY, { force: true })
+  await fs.rm(installed, { recursive: true, force: true })
+}

--- a/integration-tests/esbuild/build-and-test-esm-minify.mjs
+++ b/integration-tests/esbuild/build-and-test-esm-minify.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// Regression for https://github.com/DataDog/dd-trace-js/issues/8681.
+
+import fs from 'node:fs/promises'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+
+import * as esbuild from 'esbuild'
+
+import ddPlugin from '../../esbuild.js'
+
+const SCRIPT = './esm-minify-out.mjs'
+
+try {
+  await esbuild.build({
+    entryPoints: ['./esm-minify-entry.mjs'],
+    bundle: true,
+    outfile: SCRIPT,
+    format: 'esm',
+    minify: true,
+    keepNames: true,
+    platform: 'node',
+    target: ['node18'],
+    plugins: [ddPlugin],
+  })
+
+  const { status, stdout, stderr } = spawnSync('node', [SCRIPT])
+  if (stderr.length) process.stderr.write(stderr)
+  assert.equal(status, 0, 'minified ESM bundle should run without crashing')
+  assert.equal(stdout.toString(), 'ok')
+  process.stdout.write('ok\n')
+} finally {
+  await fs.rm(SCRIPT, { force: true })
+}

--- a/integration-tests/esbuild/esm-minify-entry.mjs
+++ b/integration-tests/esbuild/esm-minify-entry.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict'
+
+// @smithy/smithy-client is an instrumented CJS package (hooks.js), which
+// triggers the dd-trace onLoad wrapper that this regression test exercises.
+import { Client } from '@smithy/smithy-client'
+
+assert.equal(typeof Client, 'function')
+
+process.stdout.write('ok')

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -121,6 +121,12 @@ esbuildVersions.forEach((version) => {
         })
       })
 
+      it('runs minified ESM bundles without ReferenceError on arguments', () => {
+        execSync('node ./build-and-test-esm-minify.mjs', {
+          timeout,
+        })
+      })
+
       it('should not override existing js banner', () => {
         execSync('node ./build-and-run.esm-unrelated-js-banner.mjs', {
           timeout,

--- a/integration-tests/esbuild/index.spec.js
+++ b/integration-tests/esbuild/index.spec.js
@@ -127,6 +127,12 @@ esbuildVersions.forEach((version) => {
         })
       })
 
+      it('keeps __filename, __dirname, and relative requires working in a minified instrumented module', () => {
+        execSync('node ./build-and-test-esm-minify-globals.mjs', {
+          timeout,
+        })
+      })
+
       it('should not override existing js banner', () => {
         execSync('node ./build-and-run.esm-unrelated-js-banner.mjs', {
           timeout,

--- a/integration-tests/esbuild/instrumented-cjs-fixture/index.js
+++ b/integration-tests/esbuild/instrumented-cjs-fixture/index.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const relative = require('./relative-module')
+
+module.exports = {
+  rel: relative.value,
+  filename: __filename,
+  dirname: __dirname,
+}

--- a/integration-tests/esbuild/instrumented-cjs-fixture/package.json
+++ b/integration-tests/esbuild/instrumented-cjs-fixture/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dd-esbuild-cjs-fixture",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/integration-tests/esbuild/instrumented-cjs-fixture/relative-module.js
+++ b/integration-tests/esbuild/instrumented-cjs-fixture/relative-module.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = { value: 'bundled-relative-ok' }

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -25,6 +25,7 @@
     "@smithy/smithy-client": "4.13.5",
     "aws-sdk": "2.1693.0",
     "axios": "1.16.1",
+    "esbuild": "^0.28.0",
     "express": "4.22.2",
     "knex": "3.2.10",
     "koa": "3.2.1",

--- a/integration-tests/esbuild/package.json
+++ b/integration-tests/esbuild/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@apollo/server": "5.5.1",
     "@koa/router": "15.5.0",
+    "@smithy/smithy-client": "4.13.5",
     "aws-sdk": "2.1693.0",
     "axios": "1.16.1",
     "express": "4.22.2",

--- a/packages/datadog-esbuild/index.js
+++ b/packages/datadog-esbuild/index.js
@@ -347,10 +347,15 @@ register(${JSON.stringify(toRegister)}, _, set, get, ${JSON.stringify(data.raw)}
         }
       } else {
         const fileCode = fs.readFileSync(args.path, 'utf8')
+        // Don't spread `...arguments`: esbuild's minifier can rewrite the surrounding
+        // `__commonJS` factory into an arrow function whose `arguments` resolves to the
+        // ESM top-level scope (see issue #8681). Pass `(module.exports, module)`
+        // explicitly; the IIFE declares no parameters so esbuild's static `require()`
+        // resolution inside `fileCode` is preserved through the factory's closure.
         contents = `
         (function() {
           ${fileCode}
-        })(...arguments);
+        })(module.exports, module);
         {
           const dc = require('dc-polyfill');
           const ch = dc.channel('${CHANNEL}');


### PR DESCRIPTION
## Summary

Bundling with `format: 'esm'` and `minifyIdentifiers: true` (which `minify: true`
enables) crashes at module load with `ReferenceError: arguments is not defined`.
esbuild's identifier minifier rewrites the surrounding `__commonJS` factory from
a `function` expression into an arrow, and arrows resolve `arguments` to the
enclosing scope -- which is ESM top-level, where the binding does not exist.

The IIFE around the instrumented module body now forwards `module.exports, module`
explicitly. It stays parameter-less so `require`, `module`, and `exports` inside
the wrapped code keep referring to the factory's closure -- preserving esbuild's
static `require()` resolution that aws-sdk and other CJS modules with relative
dynamic requires depend on.

## Test plan

- New regression test `integration-tests/esbuild/build-and-test-esm-minify.mjs`
  bundles `@smithy/smithy-client` (an instrumented CJS package) as ESM with
  `minify: true, keepNames: true` and runs the output. Fails on `master`
  (status 1, `ReferenceError: arguments is not defined`), passes with the fix.
- Existing `build-and-test-aws-sdk.js` still passes -- confirms static
  `require_node_loader()` resolution is preserved.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8681