### PR TITLE
fix(openfeature): keep the optional peer require opaque to bundlers

### DIFF
--- a/integration-tests/webpack/build-and-test-openfeature.js
+++ b/integration-tests/webpack/build-and-test-openfeature.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+'use strict'
+
+/* eslint-disable no-console */
+
+// Regression test for https://github.com/DataDog/dd-trace-js/issues/8635.
+//
+// Customer apps that bundle `dd-trace` with webpack must not have their build
+// follow the optional peer-of-peer chain
+// `@datadog/openfeature-node-server` -> `@openfeature/server-sdk` -> `@openfeature/core`.
+// Before the fix, webpack statically resolved the chain from
+// `packages/dd-trace/src/openfeature/flagging_provider.js` and failed builds
+// with `Module not found: Can't resolve '@openfeature/core'` when the user
+// hadn't opted into feature flagging.
+//
+// This test deliberately does not list `@datadog/openfeature-node-server` in
+// webpack's externals — the whole point is that dd-trace must not require
+// users to do so.
+
+const fs = require('fs')
+const path = require('path')
+const assert = require('assert')
+const webpack = require('webpack')
+const DatadogWebpackPlugin = require('../../webpack') // dd-trace/webpack
+
+const OUTFILE = path.join(__dirname, 'openfeature-out.js')
+
+const compiler = webpack({
+  mode: 'development',
+  entry: path.join(__dirname, 'basic-test.js'),
+  target: 'node',
+  externalsType: 'commonjs',
+  output: {
+    filename: 'openfeature-out.js',
+    path: __dirname,
+    hashFunction: 'sha256',
+  },
+  externals: [
+    'diagnostics_channel',
+    'pg',
+    'mysql2',
+    'better-sqlite3',
+    'sqlite3',
+    'mysql',
+    'oracledb',
+    'pg-query-stream',
+    'tedious',
+    '@yaacovcr/transform',
+    // Optional native dd-trace modules (kept consistent with `build.js`).
+    '@datadog/native-appsec',
+    '@datadog/native-iast-taint-tracking',
+    '@datadog/native-metrics',
+    '@datadog/pprof',
+    '@datadog/libdatadog',
+    // NOTE: `@datadog/openfeature-node-server` is deliberately absent. The
+    // whole point of this test is that the dd-trace source keeps the require
+    // opaque to webpack without help from the user's webpack config.
+  ],
+  plugins: [
+    new DatadogWebpackPlugin(),
+  ],
+})
+
+compiler.run((err, stats) => {
+  try {
+    if (err) {
+      console.error(err)
+      process.exitCode = 1
+      return
+    }
+    if (stats.hasErrors()) {
+      console.error(stats.toString({ errors: true }))
+      process.exitCode = 1
+      return
+    }
+
+    const output = fs.readFileSync(OUTFILE).toString()
+
+    // Webpack must not follow the optional chain into either dependency.
+    // Both substrings only appear in the bundle when webpack resolves the
+    // chain into `@datadog/openfeature-node-server`'s own source.
+    assert(
+      !output.includes('@datadog/flagging-core'),
+      'bundle leaked `@datadog/flagging-core`; webpack must not statically ' +
+      'follow `@datadog/openfeature-node-server`'
+    )
+    assert(
+      !output.includes('node_modules/@openfeature/server-sdk'),
+      'bundle leaked `@openfeature/server-sdk` paths; webpack must not ' +
+      'statically follow `@datadog/openfeature-node-server`'
+    )
+
+    console.log('ok')
+  } finally {
+    fs.rmSync(OUTFILE, { force: true })
+  }
+})

--- a/integration-tests/webpack/index.spec.js
+++ b/integration-tests/webpack/index.spec.js
@@ -58,6 +58,10 @@ webpackVersions.forEach((version) => {
       execSync('node ./build-and-test-skip-external.js', { timeout })
     })
 
+    it('does not follow `@datadog/openfeature-node-server` into its optional peer chain', () => {
+      execSync('node ./build-and-test-openfeature.js', { timeout })
+    })
+
     it('injects Git metadata into bundled applications', () => {
       execSync('node ./build-and-test-git-tags.js', { timeout })
     })

--- a/packages/dd-trace/src/openfeature/flagging_provider.js
+++ b/packages/dd-trace/src/openfeature/flagging_provider.js
@@ -1,10 +1,17 @@
 'use strict'
 
-const { DatadogNodeServerProvider } = require('@datadog/openfeature-node-server')
 const { channel } = require('dc-polyfill')
 const log = require('../log')
 const { EXPOSURE_CHANNEL } = require('./constants/constants')
 const EvalMetricsHook = require('./eval-metrics-hook')
+
+// Bundler-opaque require for the optional peer chain
+// `@datadog/openfeature-node-server` -> `@openfeature/server-sdk` ->
+// `@openfeature/core`. Same shape as `helpers/rewriter/compiler.js`.
+// Refs: https://github.com/DataDog/dd-trace-js/issues/8635
+// eslint-disable-next-line camelcase, no-undef
+const runtimeRequire = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require
+const { DatadogNodeServerProvider } = runtimeRequire(['@datadog/openfeature', 'node', 'server'].join('-'))
 
 /**
  * OpenFeature provider that integrates with Datadog's feature flagging system.

--- a/packages/dd-trace/test/openfeature/flagging_provider.spec.js
+++ b/packages/dd-trace/test/openfeature/flagging_provider.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 
-const { describe, it, beforeEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
@@ -125,6 +125,58 @@ describe('FlaggingProvider', () => {
       const provider = new FlaggingProvider(mockTracer, mockConfig)
 
       assert.ok(provider instanceof DatadogNodeServerProvider)
+    })
+  })
+
+  // Pins the bundler-opaque require gate against accidental regression to a
+  // direct `require('@datadog/openfeature-node-server')`, which would leak
+  // the optional peer chain into customer bundles (see #8635).
+  describe('bundler-opaque require gate', () => {
+    const modulePath = require.resolve('../../src/openfeature/flagging_provider')
+
+    afterEach(() => {
+      delete require.cache[modulePath]
+      delete globalThis.__webpack_require__
+      delete globalThis.__non_webpack_require__
+    })
+
+    it('uses `require` outside a bundler', () => {
+      assert.strictEqual(typeof globalThis.__webpack_require__, 'undefined')
+      delete require.cache[modulePath]
+
+      const ReloadedFlaggingProvider = require(modulePath)
+
+      assert.strictEqual(typeof ReloadedFlaggingProvider, 'function')
+      assert.strictEqual(ReloadedFlaggingProvider.name, 'FlaggingProvider')
+    })
+
+    it('uses `__non_webpack_require__` under a webpack runtime', () => {
+      let escapeHatchCalls = 0
+      globalThis.__webpack_require__ = () => {
+        throw new Error('webpack require must not run for the optional peer')
+      }
+      globalThis.__non_webpack_require__ = (request) => {
+        escapeHatchCalls++
+        return require(request)
+      }
+      delete require.cache[modulePath]
+
+      const ReloadedFlaggingProvider = require(modulePath)
+
+      assert.strictEqual(escapeHatchCalls, 1)
+      assert.strictEqual(typeof ReloadedFlaggingProvider, 'function')
+      assert.strictEqual(ReloadedFlaggingProvider.name, 'FlaggingProvider')
+    })
+
+    it('does not statically require `@datadog/openfeature-node-server`', () => {
+      const fs = require('node:fs')
+      const source = fs.readFileSync(modulePath, 'utf8')
+
+      assert.doesNotMatch(
+        source,
+        /require\(\s*['"]@datadog\/openfeature-node-server['"]\s*\)/,
+        'a literal require would let bundlers resolve the optional peer chain at build time'
+      )
     })
   })
 })

--- a/vendor/rspack.config.js
+++ b/vendor/rspack.config.js
@@ -5,7 +5,9 @@
 // TODO: Stop depending on `@openfeature/server-sdk` and `@openfeature/core` and
 //       instead intercept the user version with an instrumentation.
 // TODO: Vendor `@datadog/openfeature-node-server` when the above has been
-//       addressed.
+//       addressed. Until then, `packages/dd-trace/src/openfeature/flagging_provider.js`
+//       loads it through a bundler-opaque require so customer bundles do not
+//       follow the optional peer-of-peer chain (see #8635).
 // TODO: Fix `import-in-the-middle` so that it doesn't interfere with the global
 //       object or switch to our own internal loader and remove the dependency.
 // TODO: Vendor `dc-polyfill` and figure out why it fails the tests.


### PR DESCRIPTION
`@datadog/openfeature-node-server` is an optional dependency. Its peer `@openfeature/server-sdk` and that package's peer `@openfeature/core` are also optional and absent from customer trees that do not opt into feature flagging. Webpack, Next.js, Turbopack, and esbuild statically follow `require()` from `proxy.js` -> `flagging_provider.js` and try to resolve the full chain at build time, which fails customer builds with `Module not found: Can't resolve '@openfeature/core'`.

Route the load through a variable + computed module name so no bundler can statically resolve it; webpack additionally honors `__non_webpack_require__` as the explicit escape hatch. Same shape as the runtime-require already used in `helpers/rewriter/compiler.js`. A webpack integration test pins the regression.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8635