### PR TITLE
ci: add retry with 60s delay to coverage, dd-sts-api-key, and node actions

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -16,45 +16,21 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Verify coverage output
-      shell: bash
-      run: node scripts/verify-coverage.js --flags "${{ inputs.flags }}"
-
-    # `master-coverage` is the flag .codecov.yml gates codecov/patch on. Attach
-    # it only on PRs targeting master so release-branch PRs auto-pass.
-    - name: Compute Codecov flags
-      id: codecov-flags
-      shell: bash
-      env:
-        JOB_FLAGS: ${{ inputs.flags }}
-        EVENT_NAME: ${{ github.event_name }}
-        BASE_REF: ${{ github.base_ref }}
-      run: |
-        flags="$JOB_FLAGS"
-        if [ "$EVENT_NAME" = "pull_request" ] && [ "$BASE_REF" = "master" ]; then
-          flags="${flags:+$flags,}master-coverage"
-        fi
-        echo "value=$flags" >> "$GITHUB_OUTPUT"
-
-    - name: Install gpg for Codecov validation
-      if: runner.os == 'Linux'
-      shell: bash
-      run: command -v gpg || sudo apt-get install -y gpg
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
-      with:
-        flags: ${{ steps.codecov-flags.outputs.value }}
-
-    - name: Install datadog-ci
-      if: always()
-      uses: ./.github/actions/datadog-ci
-
-    - name: Upload coverage to Datadog
-      if: always()
+    # Retry once on failure to work around transient issues (e.g. flaky
+    # Codecov upload network calls).
+    - id: attempt
+      uses: ./.github/actions/coverage/upload
       continue-on-error: true
+      with:
+        flags: ${{ inputs.flags }}
+        report-dir: ${{ inputs.report-dir }}
+        dd_api_key: ${{ inputs.dd_api_key }}
+    - if: steps.attempt.outcome == 'failure'
       shell: bash
-      run: datadog-ci coverage upload ${FLAGS:+--flags "$FLAGS"} .
-      env:
-        DD_API_KEY: ${{ inputs.dd_api_key }}
-        FLAGS: ${{ inputs.flags }}
+      run: sleep 60
+    - if: steps.attempt.outcome == 'failure'
+      uses: ./.github/actions/coverage/upload
+      with:
+        flags: ${{ inputs.flags }}
+        report-dir: ${{ inputs.report-dir }}
+        dd_api_key: ${{ inputs.dd_api_key }}

--- a/.github/actions/coverage/upload/action.yml
+++ b/.github/actions/coverage/upload/action.yml
@@ -1,0 +1,60 @@
+name: Coverage Upload
+description: Internal implementation; verify and upload coverage. Use `./.github/actions/coverage` instead.
+
+inputs:
+  flags:
+    description: "Codecov flags value"
+    required: false
+  report-dir:
+    description: "Coverage report directory (defaults to 'coverage')"
+    required: false
+    default: coverage
+  dd_api_key:
+    description: "Datadog API key for coverage upload"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Verify coverage output
+      shell: bash
+      run: node scripts/verify-coverage.js --flags "${{ inputs.flags }}"
+
+    # `master-coverage` is the flag .codecov.yml gates codecov/patch on. Attach
+    # it only on PRs targeting master so release-branch PRs auto-pass.
+    - name: Compute Codecov flags
+      id: codecov-flags
+      shell: bash
+      env:
+        JOB_FLAGS: ${{ inputs.flags }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        flags="$JOB_FLAGS"
+        if [ "$EVENT_NAME" = "pull_request" ] && [ "$BASE_REF" = "master" ]; then
+          flags="${flags:+$flags,}master-coverage"
+        fi
+        echo "value=$flags" >> "$GITHUB_OUTPUT"
+
+    - name: Install gpg for Codecov validation
+      if: runner.os == 'Linux'
+      shell: bash
+      run: command -v gpg || sudo apt-get install -y gpg
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      with:
+        flags: ${{ steps.codecov-flags.outputs.value }}
+
+    - name: Install datadog-ci
+      if: always()
+      uses: ./.github/actions/datadog-ci
+
+    - name: Upload coverage to Datadog
+      if: always()
+      continue-on-error: true
+      shell: bash
+      run: datadog-ci coverage upload ${FLAGS:+--flags "$FLAGS"} .
+      env:
+        DD_API_KEY: ${{ inputs.dd_api_key }}
+        FLAGS: ${{ inputs.flags }}

--- a/.github/actions/dd-sts-api-key/action.yml
+++ b/.github/actions/dd-sts-api-key/action.yml
@@ -4,13 +4,18 @@ description: Exchange GitHub OIDC token for a Datadog API key via dd-sts.
 outputs:
   api_key:
     description: "Datadog API key"
-    value: ${{ steps.dd-sts.outputs.api_key }}
+    value: ${{ steps.attempt.outputs.api_key || steps.retry.outputs.api_key }}
 
 runs:
   using: composite
   steps:
-    - name: Get Datadog API key
-      id: dd-sts
-      uses: DataDog/dd-sts-action@1f350ca511be980515cf08b0bd64182b9c6e5d32 # v1.0.3
-      with:
-        policy: dd-trace-js-api-key
+    # Retry once on failure to work around transient dd-sts exchange errors.
+    - id: attempt
+      uses: ./.github/actions/dd-sts-api-key/exchange
+      continue-on-error: true
+    - if: steps.attempt.outcome == 'failure'
+      shell: bash
+      run: sleep 60
+    - if: steps.attempt.outcome == 'failure'
+      id: retry
+      uses: ./.github/actions/dd-sts-api-key/exchange

--- a/.github/actions/dd-sts-api-key/exchange/action.yml
+++ b/.github/actions/dd-sts-api-key/exchange/action.yml
@@ -1,0 +1,25 @@
+name: Get Datadog API key (exchange)
+description: Internal implementation; exchange OIDC token for API key. Use `./.github/actions/dd-sts-api-key` instead.
+
+outputs:
+  api_key:
+    description: "Datadog API key"
+    value: ${{ steps.dd-sts.outputs.api_key }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get Datadog API key
+      id: dd-sts
+      uses: DataDog/dd-sts-action@1f350ca511be980515cf08b0bd64182b9c6e5d32 # v1.0.3
+      with:
+        policy: dd-trace-js-api-key
+    - name: Verify API key was returned
+      shell: bash
+      env:
+        API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+      run: |
+        if [ -z "$API_KEY" ]; then
+          echo "dd-sts succeeded but returned no API key"
+          exit 1
+        fi

--- a/.github/actions/node/action.yml
+++ b/.github/actions/node/action.yml
@@ -16,6 +16,9 @@ runs:
       with:
         version: ${{ inputs.version }}
     - if: steps.attempt.outcome == 'failure'
+      shell: bash
+      run: sleep 60
+    - if: steps.attempt.outcome == 'failure'
       uses: ./.github/actions/node/setup
       with:
         version: ${{ inputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ lib-cov
 coverage/
 !integration-tests/coverage/
 !integration-tests/coverage/**
+!.github/actions/coverage/
+!.github/actions/coverage/**
 *.lcov
 
 # nyc test coverage


### PR DESCRIPTION
## Summary

- Adds a retry pattern (with a 60s wait) to the `coverage` and `dd-sts-api-key` actions, which fail transiently often enough to warrant it
- Applies the same 60s wait to the existing retry in the `node` action
- `dd-sts-api-key` also now validates the returned key is non-empty before considering the exchange successful, so a silent empty-key failure also triggers the retry

Each wrapper tries the inner action once (`continue-on-error: true`), sleeps 60s on failure, then retries once. The inner implementations are extracted into `coverage/upload/` and `dd-sts-api-key/exchange/` sub-actions, mirroring the existing `node/setup/` pattern.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Manually confirm the `coverage`, `dd-sts-api-key`, and `node` actions still work as expected

> Generated by Claude Code