### PR TITLE
ci: simplify pr-title workflow triggers and condition

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: Pull Request Title
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened]
     branches:
       - "master"
 
@@ -23,10 +23,7 @@ jobs:
       PR_TITLE_PATTERN: '^(revert(!)?: )?(feat|fix|docs|style|refactor|perf|test|bench|build|ci|chore)(\(([^)]+)\))?(!)?: .+'
     steps:
       - name: Validate PR title against Conventional Commits
-        if: >-
-          github.event.action == 'opened' ||
-          github.event.action == 'reopened' ||
-          (github.event.action == 'edited' && github.event.changes.title != null)
+        if: github.event.action != 'edited' || github.event.changes.title != null
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |


### PR DESCRIPTION
## Summary

- Remove `labeled` and `unlabeled` from `pull_request_target` trigger types — the workflow only validates/syncs based on the PR title, so label events are unnecessary and prevent manual label overrides
- Simplify the title-validation step's `if:` condition to a single line: since `labeled`/`unlabeled` are gone, the only case to guard against is an `edited` event where the title didn't change

## Test Plan

- [ ] Open a PR and verify title validation runs
- [ ] Edit a PR title and verify validation re-runs
- [ ] Edit a PR body (no title change) and verify validation is skipped
- [ ] Manually add/remove a label and verify the workflow no longer triggers

> Generated by Claude Code