### PR TITLE
fix(aws-sdk): extract EventBridge trace context on the SQS consumer

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -5,6 +5,38 @@ const BaseAwsSdkPlugin = require('../base')
 const { DsmPathwayCodec, getHeadersSize } = require('../../../dd-trace/src/datastreams')
 const { extractQueueMetadata, isEmpty } = require('../util')
 
+/**
+ * Resolve the EventBridge `_datadog` text map from a parsed SQS message body.
+ *
+ * Handles two delivery shapes, both recognised by the `detail-type` marker
+ * that is always present on EventBridge `PutEvents` deliveries:
+ *   - EventBridge -> SQS: the envelope is the message body itself, so the
+ *     context is at `body.detail._datadog`.
+ *   - EventBridge -> SNS -> SQS: the envelope is a JSON string in the SNS
+ *     `Notification` body's `Message` field, so the context is at
+ *     `JSON.parse(body.Message).detail._datadog`.
+ *
+ * @param {object} [parsedBody] - The JSON-parsed SQS message body.
+ * @returns {object | undefined} The EventBridge `_datadog` text map, if any.
+ */
+function getEventBridgeContext (parsedBody) {
+  if (parsedBody?.['detail-type'] !== undefined) {
+    return parsedBody.detail?._datadog
+  }
+  if (parsedBody?.Type === 'Notification' && typeof parsedBody.Message === 'string') {
+    let innerEnvelope
+    try {
+      innerEnvelope = JSON.parse(parsedBody.Message)
+    } catch {
+      // SNS `Message` is not JSON — not an EventBridge envelope.
+      return
+    }
+    if (innerEnvelope?.['detail-type'] !== undefined) {
+      return innerEnvelope.detail?._datadog
+    }
+  }
+}
+
 class Sqs extends BaseAwsSdkPlugin {
   static id = 'sqs'
   static peerServicePrecursors = ['queuename']
@@ -149,6 +181,21 @@ class Sqs extends BaseAwsSdkPlugin {
       }
     }
 
+    // EventBridge to SQS (optionally via SNS): `_datadog` is embedded in the
+    // EventBridge envelope's `detail`, not in MessageAttributes. The producer
+    // plugin injects via `Entries[i].Detail`, which AWS delivers to SQS at
+    // `body.detail._datadog`, or — when fanned out through SNS — inside the
+    // SNS `Notification` body's stringified `Message`.
+    const eventBridgeContext = getEventBridgeContext(parsedBody)
+    if (eventBridgeContext) {
+      return {
+        datadogContext: this.tracer.extract('text_map', eventBridgeContext),
+        parsedAttributes: eventBridgeContext,
+        parsedBody,
+        bodyChecked: true,
+      }
+    }
+
     if (!message.MessageAttributes || !message.MessageAttributes._datadog) {
       return { parsedBody, bodyChecked: true }
     }
@@ -213,9 +260,11 @@ class Sqs extends BaseAwsSdkPlugin {
         if (body?.Type === 'Notification') {
           message = body
         }
-        if (message.MessageAttributes && message.MessageAttributes._datadog) {
-          parsedAttributes = this.parseDatadogAttributes(message.MessageAttributes._datadog)
-        }
+        // MessageAttributes carry the context for direct SQS and SNS; the
+        // EventBridge envelope (optionally via SNS) carries it inside `detail`.
+        parsedAttributes = message.MessageAttributes?._datadog
+          ? this.parseDatadogAttributes(message.MessageAttributes._datadog)
+          : getEventBridgeContext(body)
       }
       const payloadSize = getHeadersSize({
         Body: message.Body,

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -6,12 +6,6 @@ const { DsmPathwayCodec, getHeadersSize } = require('../../../dd-trace/src/datas
 const { extractQueueMetadata, isEmpty } = require('../util')
 
 /**
- * Shape of a JSON-parsed SQS message body across the delivery types the
- * consumer extracts from: `detail-type`/`detail` mark an EventBridge envelope
- * (the producer injects `_datadog` into `detail` via `Entries[i].Detail`);
- * `Type`/`Message` mark an SNS `Notification`, whose `Message` may itself be a
- * stringified EventBridge envelope.
- *
  * @typedef {{
  *   'detail-type'?: string,
  *   detail?: { _datadog?: Record<string, string> },
@@ -21,40 +15,28 @@ const { extractQueueMetadata, isEmpty } = require('../util')
  */
 
 /**
- * Resolve the EventBridge `_datadog` text map from a parsed SQS message body.
+ * Resolve the EventBridge `_datadog` text map from a parsed SQS body — for both
+ * EventBridge -> SQS (`body.detail._datadog`) and EventBridge -> SNS -> SQS (the
+ * envelope is the SNS `Notification`'s stringified `Message`). Keyed off
+ * `detail-type`, the marker AWS sets on every PutEvents delivery. Relies on the
+ * default SQS-target shape; a target InputTransformer can drop `detail`.
  *
- * Handles two delivery shapes, both recognised by the `detail-type` marker
- * that AWS always sets on EventBridge `PutEvents` deliveries:
- *   - EventBridge -> SQS: the envelope is the message body itself, so the
- *     context is at `body.detail._datadog`.
- *   - EventBridge -> SNS -> SQS: the envelope is a JSON string in the SNS
- *     `Notification` body's `Message` field, so the context is at
- *     `JSON.parse(body.Message).detail._datadog`.
- *
- * Envelope-shape contract: for an SQS target without an EventBridge
- * InputTransformer, AWS delivers the full event as the SQS message body and
- * parses the `PutEvents` `Detail` string into the `detail` object — so a
- * `_datadog` injected into `Detail` arrives at `body.detail._datadog`. A target
- * InputTransformer/InputPath can reshape or drop `detail`; that case is not
- * handled and simply yields no context.
- *
- * @param {ParsedSqsBody} [parsedBody] - The JSON-parsed SQS message body.
- * @returns {Record<string, string> | undefined} The EventBridge `_datadog` text map, if any.
+ * @param {ParsedSqsBody} [parsedBody]
+ * @returns {Record<string, string> | undefined}
  */
 function getEventBridgeContext (parsedBody) {
   let envelope
   if (parsedBody?.['detail-type'] !== undefined) {
-    // EventBridge -> SQS: the body is the envelope itself.
-    envelope = parsedBody
+    envelope = parsedBody // EventBridge -> SQS
   } else if (parsedBody?.Type === 'Notification' && typeof parsedBody.Message === 'string') {
-    // EventBridge -> SNS -> SQS: the envelope is the SNS `Message` string.
+    // EventBridge -> SNS -> SQS
     try {
       const innerEnvelope = JSON.parse(parsedBody.Message)
       if (innerEnvelope?.['detail-type'] !== undefined) {
         envelope = innerEnvelope
       }
     } catch {
-      // SNS `Message` is not JSON — not an EventBridge envelope.
+      // SNS `Message` not JSON
     }
   }
   return envelope?.detail?._datadog
@@ -204,10 +186,9 @@ class Sqs extends BaseAwsSdkPlugin {
       }
     }
 
-    // MessageAttributes carry the context for direct SQS and SNS deliveries.
-    // Check them first: it is the common path and avoids parsing the body
-    // payload (e.g. a large SNS `Message`) on every receive just to rule out an
-    // EventBridge envelope. Precedence matches responseExtractDSMContext.
+    // Check MessageAttributes first (common direct-SQS/SNS path): avoids parsing
+    // the body (e.g. a large SNS `Message`) just to rule out an EventBridge
+    // envelope. Precedence matches responseExtractDSMContext.
     const datadogAttribute = message.MessageAttributes?._datadog
     if (datadogAttribute) {
       const parsedAttributes = this.parseDatadogAttributes(datadogAttribute)
@@ -221,11 +202,7 @@ class Sqs extends BaseAwsSdkPlugin {
       }
     }
 
-    // EventBridge to SQS (optionally via SNS): `_datadog` is embedded in the
-    // EventBridge envelope's `detail`, not in MessageAttributes. The producer
-    // plugin injects via `Entries[i].Detail`, which AWS delivers to SQS at
-    // `body.detail._datadog`, or — when fanned out through SNS — inside the
-    // SNS `Notification` body's stringified `Message`.
+    // Then the EventBridge envelope (optionally via SNS); see getEventBridgeContext.
     const eventBridgeContext = getEventBridgeContext(parsedBody)
     if (eventBridgeContext) {
       return {
@@ -284,8 +261,7 @@ class Sqs extends BaseAwsSdkPlugin {
         if (body?.Type === 'Notification') {
           message = body
         }
-        // MessageAttributes carry the context for direct SQS and SNS; the
-        // EventBridge envelope (optionally via SNS) carries it inside `detail`.
+        // MessageAttributes for direct SQS/SNS; else the EventBridge envelope.
         parsedAttributes = message.MessageAttributes?._datadog
           ? this.parseDatadogAttributes(message.MessageAttributes._datadog)
           : getEventBridgeContext(body)
@@ -295,11 +271,8 @@ class Sqs extends BaseAwsSdkPlugin {
         MessageAttributes: message.MessageAttributes,
       })
       if (parsedAttributes) {
-        // For the EventBridge path this is inert until the EventBridge producer
-        // emits a DSM pathway (a separate, follow-up change): the EventBridge
-        // `_datadog` carries only trace context today, so there is no
-        // `dd-pathway-ctx-base64` to decode and this is a no-op. The direct SQS
-        // and SNS paths decode a real pathway here.
+        // Inert for EventBridge until its producer emits a pathway (separate
+        // change) — no `dd-pathway-ctx-base64` to decode yet; SQS/SNS decode now.
         this.tracer.decodeDataStreamsContext(parsedAttributes)
       }
       this.tracer

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -6,35 +6,55 @@ const { DsmPathwayCodec, getHeadersSize } = require('../../../dd-trace/src/datas
 const { extractQueueMetadata, isEmpty } = require('../util')
 
 /**
+ * @typedef {object} ParsedSqsBody
+ * @property {string} [detail-type] - EventBridge envelope marker; AWS sets it on
+ *   every `PutEvents` delivery, so it distinguishes an EventBridge event from an
+ *   arbitrary user payload.
+ * @property {{ _datadog?: Record<string, string> }} [detail] - EventBridge custom
+ *   event payload; the producer injects `_datadog` here via `Entries[i].Detail`.
+ * @property {string} [Type] - `'Notification'` for SNS -> SQS deliveries.
+ * @property {string} [Message] - SNS notification payload; may itself be a
+ *   stringified EventBridge envelope (EventBridge -> SNS -> SQS).
+ */
+
+/**
  * Resolve the EventBridge `_datadog` text map from a parsed SQS message body.
  *
  * Handles two delivery shapes, both recognised by the `detail-type` marker
- * that is always present on EventBridge `PutEvents` deliveries:
+ * that AWS always sets on EventBridge `PutEvents` deliveries:
  *   - EventBridge -> SQS: the envelope is the message body itself, so the
  *     context is at `body.detail._datadog`.
  *   - EventBridge -> SNS -> SQS: the envelope is a JSON string in the SNS
  *     `Notification` body's `Message` field, so the context is at
  *     `JSON.parse(body.Message).detail._datadog`.
  *
- * @param {object} [parsedBody] - The JSON-parsed SQS message body.
- * @returns {object | undefined} The EventBridge `_datadog` text map, if any.
+ * Envelope-shape contract: for an SQS target without an EventBridge
+ * InputTransformer, AWS delivers the full event as the SQS message body and
+ * parses the `PutEvents` `Detail` string into the `detail` object — so a
+ * `_datadog` injected into `Detail` arrives at `body.detail._datadog`. A target
+ * InputTransformer/InputPath can reshape or drop `detail`; that case is not
+ * handled and simply yields no context.
+ *
+ * @param {ParsedSqsBody} [parsedBody] - The JSON-parsed SQS message body.
+ * @returns {Record<string, string> | undefined} The EventBridge `_datadog` text map, if any.
  */
 function getEventBridgeContext (parsedBody) {
+  let envelope
   if (parsedBody?.['detail-type'] !== undefined) {
-    return parsedBody.detail?._datadog
-  }
-  if (parsedBody?.Type === 'Notification' && typeof parsedBody.Message === 'string') {
-    let innerEnvelope
+    // EventBridge -> SQS: the body is the envelope itself.
+    envelope = parsedBody
+  } else if (parsedBody?.Type === 'Notification' && typeof parsedBody.Message === 'string') {
+    // EventBridge -> SNS -> SQS: the envelope is the SNS `Message` string.
     try {
-      innerEnvelope = JSON.parse(parsedBody.Message)
+      const innerEnvelope = JSON.parse(parsedBody.Message)
+      if (innerEnvelope?.['detail-type'] !== undefined) {
+        envelope = innerEnvelope
+      }
     } catch {
       // SNS `Message` is not JSON — not an EventBridge envelope.
-      return
-    }
-    if (innerEnvelope?.['detail-type'] !== undefined) {
-      return innerEnvelope.detail?._datadog
     }
   }
+  return envelope?.detail?._datadog
 }
 
 class Sqs extends BaseAwsSdkPlugin {
@@ -181,6 +201,23 @@ class Sqs extends BaseAwsSdkPlugin {
       }
     }
 
+    // MessageAttributes carry the context for direct SQS and SNS deliveries.
+    // Check them first: it is the common path and avoids parsing the body
+    // payload (e.g. a large SNS `Message`) on every receive just to rule out an
+    // EventBridge envelope. Precedence matches responseExtractDSMContext.
+    const datadogAttribute = message.MessageAttributes?._datadog
+    if (datadogAttribute) {
+      const parsedAttributes = this.parseDatadogAttributes(datadogAttribute)
+      if (parsedAttributes) {
+        return {
+          datadogContext: this.tracer.extract('text_map', parsedAttributes),
+          parsedAttributes,
+          parsedBody,
+          bodyChecked: true,
+        }
+      }
+    }
+
     // EventBridge to SQS (optionally via SNS): `_datadog` is embedded in the
     // EventBridge envelope's `detail`, not in MessageAttributes. The producer
     // plugin injects via `Entries[i].Detail`, which AWS delivers to SQS at
@@ -191,22 +228,6 @@ class Sqs extends BaseAwsSdkPlugin {
       return {
         datadogContext: this.tracer.extract('text_map', eventBridgeContext),
         parsedAttributes: eventBridgeContext,
-        parsedBody,
-        bodyChecked: true,
-      }
-    }
-
-    if (!message.MessageAttributes || !message.MessageAttributes._datadog) {
-      return { parsedBody, bodyChecked: true }
-    }
-
-    const datadogAttribute = message.MessageAttributes._datadog
-
-    const parsedAttributes = this.parseDatadogAttributes(datadogAttribute)
-    if (parsedAttributes) {
-      return {
-        datadogContext: this.tracer.extract('text_map', parsedAttributes),
-        parsedAttributes,
         parsedBody,
         bodyChecked: true,
       }
@@ -271,6 +292,11 @@ class Sqs extends BaseAwsSdkPlugin {
         MessageAttributes: message.MessageAttributes,
       })
       if (parsedAttributes) {
+        // For the EventBridge path this is inert until the EventBridge producer
+        // emits a DSM pathway (a separate, follow-up change): the EventBridge
+        // `_datadog` carries only trace context today, so there is no
+        // `dd-pathway-ctx-base64` to decode and this is a no-op. The direct SQS
+        // and SNS paths decode a real pathway here.
         this.tracer.decodeDataStreamsContext(parsedAttributes)
       }
       this.tracer

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -6,15 +6,18 @@ const { DsmPathwayCodec, getHeadersSize } = require('../../../dd-trace/src/datas
 const { extractQueueMetadata, isEmpty } = require('../util')
 
 /**
- * @typedef {object} ParsedSqsBody
- * @property {string} [detail-type] - EventBridge envelope marker; AWS sets it on
- *   every `PutEvents` delivery, so it distinguishes an EventBridge event from an
- *   arbitrary user payload.
- * @property {{ _datadog?: Record<string, string> }} [detail] - EventBridge custom
- *   event payload; the producer injects `_datadog` here via `Entries[i].Detail`.
- * @property {string} [Type] - `'Notification'` for SNS -> SQS deliveries.
- * @property {string} [Message] - SNS notification payload; may itself be a
- *   stringified EventBridge envelope (EventBridge -> SNS -> SQS).
+ * Shape of a JSON-parsed SQS message body across the delivery types the
+ * consumer extracts from: `detail-type`/`detail` mark an EventBridge envelope
+ * (the producer injects `_datadog` into `detail` via `Entries[i].Detail`);
+ * `Type`/`Message` mark an SNS `Notification`, whose `Message` may itself be a
+ * stringified EventBridge envelope.
+ *
+ * @typedef {{
+ *   'detail-type'?: string,
+ *   detail?: { _datadog?: Record<string, string> },
+ *   Type?: string,
+ *   Message?: string
+ * }} ParsedSqsBody
  */
 
 /**

--- a/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
@@ -218,6 +218,21 @@ describe('Sqs plugin injectToMessage', () => {
   })
 })
 
+// Fixtures for the EventBridge extraction matrix. `ebEnvelope(datadog)` builds
+// a PutEvents-delivered envelope (omitting `_datadog` when none is passed);
+// `snsWrap(message)` wraps a payload as an SNS `Notification` body.
+const ebEnvelope = (datadog) => ({
+  version: '0',
+  'detail-type': 'orderPlaced',
+  source: 'my.app',
+  detail: { orderId: 'o-1', ...(datadog && { _datadog: datadog }) },
+})
+
+const snsWrap = (message) => ({
+  Type: 'Notification',
+  Message: typeof message === 'string' ? message : JSON.stringify(message),
+})
+
 describe('Sqs plugin responseExtract', () => {
   it('extracts trace context from MessageAttributes._datadog (direct SQS to SQS)', () => {
     let receivedAttributes
@@ -309,13 +324,9 @@ describe('Sqs plugin responseExtract', () => {
     assert.strictEqual(result.bodyChecked, true)
   })
 
-  // EventBridge -> SQS:
-  // When EventBridge's `PutEvents` is targeted at an SQS queue, the EventBridge
-  // producer plugin (packages/datadog-plugin-aws-sdk/src/services/eventbridge.js)
-  // injects `_datadog` into `Entries[i].Detail`. EventBridge delivers the event
-  // to SQS with the full envelope as the message body and `detail` parsed as an
-  // object — so the trace context lands at `body.detail._datadog`. The
-  // consumer recognises this via the EventBridge `detail-type` marker.
+  // EventBridge -> SQS: `PutEvents` to an SQS target delivers the full envelope
+  // as the body, so the producer's `_datadog` lands at `body.detail._datadog`.
+  // Recognised via the `detail-type` marker.
   it('extracts trace context from EventBridge body.detail._datadog (EventBridge to SQS)', () => {
     let receivedAttributes
     const plugin = buildPlugin({
@@ -325,36 +336,14 @@ describe('Sqs plugin responseExtract', () => {
       },
     })
 
-    const eventBridgeEnvelope = {
-      version: '0',
-      id: '00000000-0000-0000-0000-000000000000',
-      'detail-type': 'orderPlaced',
-      source: 'my.app',
-      account: '123456789012',
-      time: '2026-05-28T00:00:00Z',
-      region: 'us-east-1',
-      resources: [],
-      detail: {
-        orderId: 'o-1',
-        _datadog: {
-          'x-datadog-trace-id': '999',
-          'x-datadog-parent-id': '888',
-          'x-datadog-sampling-priority': '1',
-        },
-      },
-    }
-
+    const datadog = { 'x-datadog-trace-id': '999', 'x-datadog-parent-id': '888', 'x-datadog-sampling-priority': '1' }
     const result = plugin.responseExtract(
       { QueueUrl },
       'receiveMessage',
-      { Messages: [{ Body: JSON.stringify(eventBridgeEnvelope) }] }
+      { Messages: [{ Body: JSON.stringify(ebEnvelope(datadog)) }] }
     )
 
-    assert.deepStrictEqual(receivedAttributes, {
-      'x-datadog-trace-id': '999',
-      'x-datadog-parent-id': '888',
-      'x-datadog-sampling-priority': '1',
-    })
+    assert.deepStrictEqual(receivedAttributes, datadog)
     assert.strictEqual(result.datadogContext, 'eventbridge-context')
   })
 
@@ -367,17 +356,10 @@ describe('Sqs plugin responseExtract', () => {
       },
     })
 
-    const envelope = {
-      version: '0',
-      'detail-type': 'orderPlaced',
-      source: 'my.app',
-      detail: { orderId: 'o-1' },
-    }
-
     const result = plugin.responseExtract(
       { QueueUrl },
       'receiveMessage',
-      { Messages: [{ Body: JSON.stringify(envelope) }] }
+      { Messages: [{ Body: JSON.stringify(ebEnvelope()) }] }
     )
 
     assert.strictEqual(extractCalled, false)
@@ -385,9 +367,8 @@ describe('Sqs plugin responseExtract', () => {
     assert.strictEqual(result.bodyChecked, true)
   })
 
-  // EventBridge -> SNS -> SQS: when EventBridge fans out via an SNS topic, the
-  // SQS body is an SNS `Notification` whose `Message` field is the EventBridge
-  // envelope as a JSON string. The trace context is one level deeper, at
+  // EventBridge -> SNS -> SQS: fanned out via SNS, the envelope is a JSON string
+  // in the SNS `Notification`'s `Message`, so context is one level deeper at
   // `JSON.parse(body.Message).detail._datadog`.
   it('extracts trace context from an EventBridge envelope wrapped in an SNS Notification', () => {
     let receivedAttributes
@@ -398,35 +379,14 @@ describe('Sqs plugin responseExtract', () => {
       },
     })
 
-    const eventBridgeEnvelope = {
-      version: '0',
-      'detail-type': 'orderPlaced',
-      source: 'my.app',
-      detail: {
-        orderId: 'o-1',
-        _datadog: {
-          'x-datadog-trace-id': '555',
-          'x-datadog-parent-id': '444',
-        },
-      },
-    }
-    const snsBody = {
-      Type: 'Notification',
-      MessageId: 'msg-1',
-      TopicArn: 'arn:aws:sns:us-east-1:000000000000:topic',
-      Message: JSON.stringify(eventBridgeEnvelope),
-    }
-
+    const datadog = { 'x-datadog-trace-id': '555', 'x-datadog-parent-id': '444' }
     const result = plugin.responseExtract(
       { QueueUrl },
       'receiveMessage',
-      { Messages: [{ Body: JSON.stringify(snsBody) }] }
+      { Messages: [{ Body: JSON.stringify(snsWrap(ebEnvelope(datadog))) }] }
     )
 
-    assert.deepStrictEqual(receivedAttributes, {
-      'x-datadog-trace-id': '555',
-      'x-datadog-parent-id': '444',
-    })
+    assert.deepStrictEqual(receivedAttributes, datadog)
     assert.strictEqual(result.datadogContext, 'eventbridge-sns-context')
   })
 
@@ -439,15 +399,10 @@ describe('Sqs plugin responseExtract', () => {
       },
     })
 
-    const snsBody = {
-      Type: 'Notification',
-      Message: 'a plain string payload, not JSON',
-    }
-
     const result = plugin.responseExtract(
       { QueueUrl },
       'receiveMessage',
-      { Messages: [{ Body: JSON.stringify(snsBody) }] }
+      { Messages: [{ Body: JSON.stringify(snsWrap('a plain string payload, not JSON')) }] }
     )
 
     assert.strictEqual(extractCalled, false)
@@ -456,7 +411,7 @@ describe('Sqs plugin responseExtract', () => {
   })
 
   // Precedence: MessageAttributes are checked before the EventBridge body path.
-  // The body here is a syntactically valid EventBridge envelope, but because
+  // The body here is a valid EventBridge envelope, but because
   // `MessageAttributes._datadog` is present the body is never consulted — which
   // is also what avoids a wasted parse on the common SNS->SQS receive.
   it('prefers MessageAttributes over the EventBridge body when both are present', () => {
@@ -468,17 +423,12 @@ describe('Sqs plugin responseExtract', () => {
       },
     })
 
-    const eventBridgeEnvelope = {
-      'detail-type': 'orderPlaced',
-      detail: { _datadog: { 'x-datadog-trace-id': 'from-body' } },
-    }
-
     const result = plugin.responseExtract(
       { QueueUrl },
       'receiveMessage',
       {
         Messages: [{
-          Body: JSON.stringify(eventBridgeEnvelope),
+          Body: JSON.stringify(ebEnvelope({ 'x-datadog-trace-id': 'from-body' })),
           MessageAttributes: {
             _datadog: {
               DataType: 'String',
@@ -508,30 +458,15 @@ describe('Sqs plugin responseExtractDSMContext', () => {
       },
     })
 
-    const envelope = {
-      version: '0',
-      'detail-type': 'orderPlaced',
-      source: 'my.app',
-      detail: {
-        orderId: 'o-1',
-        _datadog: {
-          'x-datadog-trace-id': '777',
-          'x-datadog-parent-id': '666',
-        },
-      },
-    }
-
+    const datadog = { 'x-datadog-trace-id': '777', 'x-datadog-parent-id': '666' }
     plugin.responseExtractDSMContext(
       'receiveMessage',
       { QueueUrl },
-      { Messages: [{ Body: JSON.stringify(envelope) }] },
+      { Messages: [{ Body: JSON.stringify(ebEnvelope(datadog)) }] },
       null
     )
 
-    assert.deepStrictEqual(decodedCarrier, {
-      'x-datadog-trace-id': '777',
-      'x-datadog-parent-id': '666',
-    })
+    assert.deepStrictEqual(decodedCarrier, datadog)
     assert.strictEqual(setCheckpointCalls.length, 1)
     assert.deepStrictEqual(setCheckpointCalls[0].tags, [
       'direction:in',
@@ -547,31 +482,15 @@ describe('Sqs plugin responseExtractDSMContext', () => {
       decodeDataStreamsContext: (carrier) => { decodedCarrier = carrier },
     })
 
-    const eventBridgeEnvelope = {
-      'detail-type': 'orderPlaced',
-      detail: {
-        _datadog: {
-          'x-datadog-trace-id': '555',
-          'x-datadog-parent-id': '444',
-        },
-      },
-    }
-    const snsBody = {
-      Type: 'Notification',
-      Message: JSON.stringify(eventBridgeEnvelope),
-    }
-
+    const datadog = { 'x-datadog-trace-id': '555', 'x-datadog-parent-id': '444' }
     plugin.responseExtractDSMContext(
       'receiveMessage',
       { QueueUrl },
-      { Messages: [{ Body: JSON.stringify(snsBody) }] },
+      { Messages: [{ Body: JSON.stringify(snsWrap(ebEnvelope(datadog))) }] },
       null
     )
 
-    assert.deepStrictEqual(decodedCarrier, {
-      'x-datadog-trace-id': '555',
-      'x-datadog-parent-id': '444',
-    })
+    assert.deepStrictEqual(decodedCarrier, datadog)
   })
 
   it('does not decode anything when dsmEnabled is false', () => {
@@ -581,15 +500,10 @@ describe('Sqs plugin responseExtractDSMContext', () => {
       decodeDataStreamsContext: () => { decodeCalled = true },
     })
 
-    const envelope = {
-      'detail-type': 'orderPlaced',
-      detail: { _datadog: { 'x-datadog-trace-id': '777' } },
-    }
-
     plugin.responseExtractDSMContext(
       'receiveMessage',
       { QueueUrl },
-      { Messages: [{ Body: JSON.stringify(envelope) }] },
+      { Messages: [{ Body: JSON.stringify(ebEnvelope({ 'x-datadog-trace-id': '777' })) }] },
       null
     )
 

--- a/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
@@ -8,6 +8,8 @@ const { describe, it } = require('mocha')
 
 const Sqs = require('../src/services/sqs')
 
+const QueueUrl = 'http://127.0.0.1:4566/00000000000000000000/test-queue'
+
 /**
  * `Object.create(Sqs.prototype)` skips the heavy plugin/diagnostic-channel
  * wiring in `BaseAwsSdkPlugin`'s constructor. The methods under test only
@@ -19,14 +21,29 @@ const Sqs = require('../src/services/sqs')
  * @param {(span: unknown, format: string, info: object) => void} [options.inject]
  *        Stand-in for `tracer.inject` that may populate the trace context
  *        in `info`.
+ * @param {(format: string, attrs: object) => unknown} [options.extract]
+ *        Stand-in for `tracer.extract` used by `responseExtract`.
+ * @param {(carrier: object) => void} [options.decodeDataStreamsContext]
+ *        Stand-in for `tracer.decodeDataStreamsContext`, called by
+ *        `responseExtractDSMContext` when a context carrier is found.
+ * @param {(tags: string[], span: unknown, payloadSize: number) => unknown} [options.setCheckpoint]
+ *        Stand-in for `tracer.setCheckpoint`, called once per message in
+ *        `responseExtractDSMContext`.
  * @param {unknown} [options.dataStreamsContext]
  *        Value returned by the stubbed `setDSMCheckpoint`.
  * @returns {Sqs & { dsmCalls: Array<{ datadog: object | undefined }> }}
  */
-function buildPlugin ({ dsmEnabled = false, inject = () => {}, dataStreamsContext = null } = {}) {
+function buildPlugin ({
+  dsmEnabled = false,
+  inject = () => {},
+  extract = () => undefined,
+  decodeDataStreamsContext = () => {},
+  setCheckpoint = () => null,
+  dataStreamsContext = null,
+} = {}) {
   const plugin = Object.create(Sqs.prototype)
   // `tracer` is a getter on the base Plugin class that reads `_tracer`.
-  plugin._tracer = { inject }
+  plugin._tracer = { inject, extract, decodeDataStreamsContext, setCheckpoint }
   plugin.config = { dsmEnabled }
   plugin.dsmCalls = []
   plugin.setDSMCheckpoint = (span, params) => {
@@ -198,5 +215,345 @@ describe('Sqs plugin injectToMessage', () => {
       DataType: 'String',
       StringValue: '{"x-datadog-trace-id":"123"}',
     })
+  })
+})
+
+describe('Sqs plugin responseExtract', () => {
+  it('extracts trace context from MessageAttributes._datadog (direct SQS to SQS)', () => {
+    let receivedAttributes
+    const plugin = buildPlugin({
+      extract: (format, attrs) => {
+        receivedAttributes = attrs
+        return 'sqs-native-context'
+      },
+    })
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      {
+        Messages: [{
+          Body: 'opaque payload — body is not JSON',
+          MessageAttributes: {
+            _datadog: {
+              DataType: 'String',
+              StringValue: JSON.stringify({
+                'x-datadog-trace-id': '111',
+                'x-datadog-parent-id': '222',
+                'x-datadog-sampling-priority': '1',
+              }),
+            },
+          },
+        }],
+      }
+    )
+
+    assert.deepStrictEqual(receivedAttributes, {
+      'x-datadog-trace-id': '111',
+      'x-datadog-parent-id': '222',
+      'x-datadog-sampling-priority': '1',
+    })
+    assert.strictEqual(result.datadogContext, 'sqs-native-context')
+  })
+
+  it('extracts trace context from the SNS Notification body wrapper (SNS to SQS)', () => {
+    let receivedAttributes
+    const plugin = buildPlugin({
+      extract: (format, attrs) => {
+        receivedAttributes = attrs
+        return 'sns-context'
+      },
+    })
+
+    const snsBody = {
+      Type: 'Notification',
+      MessageId: 'msg-1',
+      TopicArn: 'arn:aws:sns:us-east-1:000000000000:topic',
+      Message: 'inner sns payload',
+      MessageAttributes: {
+        _datadog: {
+          Type: 'Binary',
+          Value: Buffer.from(JSON.stringify({
+            'x-datadog-trace-id': '333',
+            'x-datadog-parent-id': '444',
+          })).toString('base64'),
+        },
+      },
+    }
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      { Messages: [{ Body: JSON.stringify(snsBody) }] }
+    )
+
+    assert.deepStrictEqual(receivedAttributes, {
+      'x-datadog-trace-id': '333',
+      'x-datadog-parent-id': '444',
+    })
+    assert.strictEqual(result.datadogContext, 'sns-context')
+  })
+
+  it('returns no datadogContext when neither MessageAttributes nor SNS body carry _datadog', () => {
+    let extractCalled = false
+    const plugin = buildPlugin({ extract: () => { extractCalled = true } })
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      { Messages: [{ Body: 'plain text', MessageAttributes: {} }] }
+    )
+
+    assert.strictEqual(extractCalled, false)
+    assert.strictEqual(result.datadogContext, undefined)
+    assert.strictEqual(result.bodyChecked, true)
+  })
+
+  // EventBridge -> SQS:
+  // When EventBridge's `PutEvents` is targeted at an SQS queue, the EventBridge
+  // producer plugin (packages/datadog-plugin-aws-sdk/src/services/eventbridge.js)
+  // injects `_datadog` into `Entries[i].Detail`. EventBridge delivers the event
+  // to SQS with the full envelope as the message body and `detail` parsed as an
+  // object — so the trace context lands at `body.detail._datadog`. The
+  // consumer recognises this via the EventBridge `detail-type` marker.
+  it('extracts trace context from EventBridge body.detail._datadog (EventBridge to SQS)', () => {
+    let receivedAttributes
+    const plugin = buildPlugin({
+      extract: (format, attrs) => {
+        receivedAttributes = attrs
+        return 'eventbridge-context'
+      },
+    })
+
+    const eventBridgeEnvelope = {
+      version: '0',
+      id: '00000000-0000-0000-0000-000000000000',
+      'detail-type': 'orderPlaced',
+      source: 'my.app',
+      account: '123456789012',
+      time: '2026-05-28T00:00:00Z',
+      region: 'us-east-1',
+      resources: [],
+      detail: {
+        orderId: 'o-1',
+        _datadog: {
+          'x-datadog-trace-id': '999',
+          'x-datadog-parent-id': '888',
+          'x-datadog-sampling-priority': '1',
+        },
+      },
+    }
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      { Messages: [{ Body: JSON.stringify(eventBridgeEnvelope) }] }
+    )
+
+    assert.deepStrictEqual(receivedAttributes, {
+      'x-datadog-trace-id': '999',
+      'x-datadog-parent-id': '888',
+      'x-datadog-sampling-priority': '1',
+    })
+    assert.strictEqual(result.datadogContext, 'eventbridge-context')
+  })
+
+  it('falls through cleanly when an EventBridge envelope has no `_datadog` in detail', () => {
+    let extractCalled = false
+    const plugin = buildPlugin({
+      extract: () => {
+        extractCalled = true
+        return 'should-not-happen'
+      },
+    })
+
+    const envelope = {
+      version: '0',
+      'detail-type': 'orderPlaced',
+      source: 'my.app',
+      detail: { orderId: 'o-1' },
+    }
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      { Messages: [{ Body: JSON.stringify(envelope) }] }
+    )
+
+    assert.strictEqual(extractCalled, false)
+    assert.strictEqual(result.datadogContext, undefined)
+    assert.strictEqual(result.bodyChecked, true)
+  })
+
+  // EventBridge -> SNS -> SQS: when EventBridge fans out via an SNS topic, the
+  // SQS body is an SNS `Notification` whose `Message` field is the EventBridge
+  // envelope as a JSON string. The trace context is one level deeper, at
+  // `JSON.parse(body.Message).detail._datadog`.
+  it('extracts trace context from an EventBridge envelope wrapped in an SNS Notification', () => {
+    let receivedAttributes
+    const plugin = buildPlugin({
+      extract: (format, attrs) => {
+        receivedAttributes = attrs
+        return 'eventbridge-sns-context'
+      },
+    })
+
+    const eventBridgeEnvelope = {
+      version: '0',
+      'detail-type': 'orderPlaced',
+      source: 'my.app',
+      detail: {
+        orderId: 'o-1',
+        _datadog: {
+          'x-datadog-trace-id': '555',
+          'x-datadog-parent-id': '444',
+        },
+      },
+    }
+    const snsBody = {
+      Type: 'Notification',
+      MessageId: 'msg-1',
+      TopicArn: 'arn:aws:sns:us-east-1:000000000000:topic',
+      Message: JSON.stringify(eventBridgeEnvelope),
+    }
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      { Messages: [{ Body: JSON.stringify(snsBody) }] }
+    )
+
+    assert.deepStrictEqual(receivedAttributes, {
+      'x-datadog-trace-id': '555',
+      'x-datadog-parent-id': '444',
+    })
+    assert.strictEqual(result.datadogContext, 'eventbridge-sns-context')
+  })
+
+  it('falls through when an SNS Notification Message is not an EventBridge envelope', () => {
+    let extractCalled = false
+    const plugin = buildPlugin({
+      extract: () => {
+        extractCalled = true
+        return 'should-not-happen'
+      },
+    })
+
+    const snsBody = {
+      Type: 'Notification',
+      Message: 'a plain string payload, not JSON',
+    }
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      { Messages: [{ Body: JSON.stringify(snsBody) }] }
+    )
+
+    assert.strictEqual(extractCalled, false)
+    assert.strictEqual(result.datadogContext, undefined)
+    assert.strictEqual(result.bodyChecked, true)
+  })
+})
+
+describe('Sqs plugin responseExtractDSMContext', () => {
+  it('decodes DSM context from EventBridge body.detail._datadog when dsmEnabled', () => {
+    let decodedCarrier
+    const setCheckpointCalls = []
+    const plugin = buildPlugin({
+      dsmEnabled: true,
+      decodeDataStreamsContext: (carrier) => { decodedCarrier = carrier },
+      setCheckpoint: (tags, span, payloadSize) => {
+        setCheckpointCalls.push({ tags, span, payloadSize })
+        return null
+      },
+    })
+
+    const envelope = {
+      version: '0',
+      'detail-type': 'orderPlaced',
+      source: 'my.app',
+      detail: {
+        orderId: 'o-1',
+        _datadog: {
+          'x-datadog-trace-id': '777',
+          'x-datadog-parent-id': '666',
+        },
+      },
+    }
+
+    plugin.responseExtractDSMContext(
+      'receiveMessage',
+      { QueueUrl },
+      { Messages: [{ Body: JSON.stringify(envelope) }] },
+      null
+    )
+
+    assert.deepStrictEqual(decodedCarrier, {
+      'x-datadog-trace-id': '777',
+      'x-datadog-parent-id': '666',
+    })
+    assert.strictEqual(setCheckpointCalls.length, 1)
+    assert.deepStrictEqual(setCheckpointCalls[0].tags, [
+      'direction:in',
+      'topic:test-queue',
+      'type:sqs',
+    ])
+  })
+
+  it('decodes DSM context from an EventBridge envelope wrapped in an SNS Notification', () => {
+    let decodedCarrier
+    const plugin = buildPlugin({
+      dsmEnabled: true,
+      decodeDataStreamsContext: (carrier) => { decodedCarrier = carrier },
+    })
+
+    const eventBridgeEnvelope = {
+      'detail-type': 'orderPlaced',
+      detail: {
+        _datadog: {
+          'x-datadog-trace-id': '555',
+          'x-datadog-parent-id': '444',
+        },
+      },
+    }
+    const snsBody = {
+      Type: 'Notification',
+      Message: JSON.stringify(eventBridgeEnvelope),
+    }
+
+    plugin.responseExtractDSMContext(
+      'receiveMessage',
+      { QueueUrl },
+      { Messages: [{ Body: JSON.stringify(snsBody) }] },
+      null
+    )
+
+    assert.deepStrictEqual(decodedCarrier, {
+      'x-datadog-trace-id': '555',
+      'x-datadog-parent-id': '444',
+    })
+  })
+
+  it('does not decode anything when dsmEnabled is false', () => {
+    let decodeCalled = false
+    const plugin = buildPlugin({
+      dsmEnabled: false,
+      decodeDataStreamsContext: () => { decodeCalled = true },
+    })
+
+    const envelope = {
+      'detail-type': 'orderPlaced',
+      detail: { _datadog: { 'x-datadog-trace-id': '777' } },
+    }
+
+    plugin.responseExtractDSMContext(
+      'receiveMessage',
+      { QueueUrl },
+      { Messages: [{ Body: JSON.stringify(envelope) }] },
+      null
+    )
+
+    assert.strictEqual(decodeCalled, false)
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
@@ -11,26 +11,18 @@ const Sqs = require('../src/services/sqs')
 const QueueUrl = 'http://127.0.0.1:4566/00000000000000000000/test-queue'
 
 /**
- * `Object.create(Sqs.prototype)` skips the heavy plugin/diagnostic-channel
- * wiring in `BaseAwsSdkPlugin`'s constructor. The methods under test only
- * read `this.tracer` and `this.config` and call `this.setDSMCheckpoint`, so
- * a hand-rolled stub is enough to exercise the inject-time ordering.
+ * `Object.create(Sqs.prototype)` skips the heavy constructor wiring in
+ * `BaseAwsSdkPlugin`; the methods under test only touch `this.tracer`,
+ * `this.config`, and `this.setDSMCheckpoint`, so a hand-rolled stub suffices.
+ * The options stub the corresponding `tracer` methods.
  *
  * @param {object} options
  * @param {boolean} [options.dsmEnabled]
  * @param {(span: unknown, format: string, info: object) => void} [options.inject]
- *        Stand-in for `tracer.inject` that may populate the trace context
- *        in `info`.
  * @param {(format: string, attrs: object) => unknown} [options.extract]
- *        Stand-in for `tracer.extract` used by `responseExtract`.
  * @param {(carrier: object) => void} [options.decodeDataStreamsContext]
- *        Stand-in for `tracer.decodeDataStreamsContext`, called by
- *        `responseExtractDSMContext` when a context carrier is found.
  * @param {(tags: string[], span: unknown, payloadSize: number) => unknown} [options.setCheckpoint]
- *        Stand-in for `tracer.setCheckpoint`, called once per message in
- *        `responseExtractDSMContext`.
- * @param {unknown} [options.dataStreamsContext]
- *        Value returned by the stubbed `setDSMCheckpoint`.
+ * @param {unknown} [options.dataStreamsContext] Value returned by stubbed `setDSMCheckpoint`.
  * @returns {Sqs & { dsmCalls: Array<{ datadog: object | undefined }> }}
  */
 function buildPlugin ({
@@ -324,9 +316,6 @@ describe('Sqs plugin responseExtract', () => {
     assert.strictEqual(result.bodyChecked, true)
   })
 
-  // EventBridge -> SQS: `PutEvents` to an SQS target delivers the full envelope
-  // as the body, so the producer's `_datadog` lands at `body.detail._datadog`.
-  // Recognised via the `detail-type` marker.
   it('extracts trace context from EventBridge body.detail._datadog (EventBridge to SQS)', () => {
     let receivedAttributes
     const plugin = buildPlugin({
@@ -367,9 +356,6 @@ describe('Sqs plugin responseExtract', () => {
     assert.strictEqual(result.bodyChecked, true)
   })
 
-  // EventBridge -> SNS -> SQS: fanned out via SNS, the envelope is a JSON string
-  // in the SNS `Notification`'s `Message`, so context is one level deeper at
-  // `JSON.parse(body.Message).detail._datadog`.
   it('extracts trace context from an EventBridge envelope wrapped in an SNS Notification', () => {
     let receivedAttributes
     const plugin = buildPlugin({
@@ -410,10 +396,7 @@ describe('Sqs plugin responseExtract', () => {
     assert.strictEqual(result.bodyChecked, true)
   })
 
-  // Precedence: MessageAttributes are checked before the EventBridge body path.
-  // The body here is a valid EventBridge envelope, but because
-  // `MessageAttributes._datadog` is present the body is never consulted — which
-  // is also what avoids a wasted parse on the common SNS->SQS receive.
+  // Both carriers present: MessageAttributes must win and the body is never consulted.
   it('prefers MessageAttributes over the EventBridge body when both are present', () => {
     const extractCalls = []
     const plugin = buildPlugin({

--- a/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs-inject-to-message.spec.js
@@ -454,6 +454,45 @@ describe('Sqs plugin responseExtract', () => {
     assert.strictEqual(result.datadogContext, undefined)
     assert.strictEqual(result.bodyChecked, true)
   })
+
+  // Precedence: MessageAttributes are checked before the EventBridge body path.
+  // The body here is a syntactically valid EventBridge envelope, but because
+  // `MessageAttributes._datadog` is present the body is never consulted — which
+  // is also what avoids a wasted parse on the common SNS->SQS receive.
+  it('prefers MessageAttributes over the EventBridge body when both are present', () => {
+    const extractCalls = []
+    const plugin = buildPlugin({
+      extract: (format, attrs) => {
+        extractCalls.push(attrs)
+        return 'message-attribute-context'
+      },
+    })
+
+    const eventBridgeEnvelope = {
+      'detail-type': 'orderPlaced',
+      detail: { _datadog: { 'x-datadog-trace-id': 'from-body' } },
+    }
+
+    const result = plugin.responseExtract(
+      { QueueUrl },
+      'receiveMessage',
+      {
+        Messages: [{
+          Body: JSON.stringify(eventBridgeEnvelope),
+          MessageAttributes: {
+            _datadog: {
+              DataType: 'String',
+              StringValue: JSON.stringify({ 'x-datadog-trace-id': 'from-attrs' }),
+            },
+          },
+        }],
+      }
+    )
+
+    assert.strictEqual(result.datadogContext, 'message-attribute-context')
+    // extract is called exactly once, with the MessageAttributes context only.
+    assert.deepStrictEqual(extractCalls, [{ 'x-datadog-trace-id': 'from-attrs' }])
+  })
 })
 
 describe('Sqs plugin responseExtractDSMContext', () => {


### PR DESCRIPTION
## Summary

Fixes the reported ECS → EventBridge → SQS → ECS trace-propagation gap. Consumer-side extraction only — a clean `semver-patch`: no new API/config, works with the existing producer injection.

EventBridge puts its trace context in the event envelope's `detail._datadog`, but the SQS consumer only read `MessageAttributes._datadog` (direct SQS) and the SNS `Notification` wrapper (SNS → SQS), so it missed EventBridge deliveries and started a new trace.

Producer-side enhancements (multi-entry batch propagation, DSM checkpoint emission) are `semver-minor`, in stacked follow-up #8745 — which also adds the LocalStack `eventbridge.dsm.spec.js` every DSM-emitting sibling has.

## What changed

`packages/datadog-plugin-aws-sdk/src/services/sqs.js` — a shared `getEventBridgeContext(parsedBody)` helper, keyed off the `detail-type` marker (present on every `PutEvents` delivery), resolves context from:

- **EventBridge → SQS**: `body.detail._datadog`
- **EventBridge → SNS → SQS**: `JSON.parse(body.Message).detail._datadog` (envelope is a JSON string in the SNS `Notification`'s `Message`)

Both `responseExtract` (APM) and `responseExtractDSMContext` (DSM decode) route through it; EventBridge writes a plain text-map, so `parseDatadogAttributes` isn't needed.

## Tests

`sqs-inject-to-message.spec.js` — `responseExtract`: direct SQS, SNS Notification, no-context fallback, EventBridge → SQS (with/without `_datadog`), EventBridge → SNS → SQS (and non-envelope `Message`), MessageAttributes-first precedence. `responseExtractDSMContext`: both EventBridge paths + DSM-disabled short-circuit. **21 passing locally.**

## Inherited behavior

`responseExtract` short-circuits when `MaxNumberOfMessages !== 1`: single-message receives propagate APM context, batch receives don't. Pre-existing, unchanged.