### PR TITLE
fix(jest): gate coverage backfill by jest version

### DIFF
--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -65,6 +65,7 @@ const oldestJestVersion = DD_MAJOR >= 6 ? '28.0.0' : '24.8.0'
 const JEST_VERSION = requestedJestVersion === 'oldest' ? oldestJestVersion : requestedJestVersion
 const onlyLatestIt = JEST_VERSION === 'latest' ? it : it.skip
 const shouldInstallJestEnvironmentJsdom = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
+const isJestCoverageBackfillSupported = JEST_VERSION === 'latest' || Number(JEST_VERSION.split('.')[0]) >= 28
 
 function assertItrSkippingEnabledTags (events, expected) {
   const testSuite = events.find(event => event.type === 'test_suite_end').content
@@ -207,18 +208,26 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
 
         assertObjectContains(allCoverageFiles.sort(), expectedCoverageFiles.sort())
         assert.ok(coveredSourceFile.bitmap, 'covered source files should report line coverage bitmaps')
-        assert.ok(sessionCoverage, 'session executable line coverage should be reported')
-        assert.ok(
-          sessionCoverage.files.every(file => file.bitmap),
-          'session executable line coverage files should report bitmaps'
-        )
+        if (isJestCoverageBackfillSupported) {
+          assert.ok(sessionCoverage, 'session executable line coverage should be reported')
+          assert.ok(
+            sessionCoverage.files.every(file => file.bitmap),
+            'session executable line coverage files should report bitmaps'
+          )
+        } else {
+          assert.strictEqual(sessionCoverage, undefined)
+        }
 
         const [coveragePayload] = codeCovRequest.payload
         assert.ok(coveragePayload.content.coverages[0].test_session_id)
         assert.ok(coveragePayload.content.coverages[0].test_suite_id)
 
         const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-        assert.ok(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
+        if (isJestCoverageBackfillSupported) {
+          assert.ok(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
+        } else {
+          assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], undefined)
+        }
 
         const eventTypes = eventsRequest.payload.events.map(event => event.type)
         assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])
@@ -839,7 +848,11 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           // Jest still adds untested files to total coverage, including unused-dependency.js from the skipped
           // suite. The result stays at 100% because backend meta.coverage backfills those skipped lines before the
           // test session total is published.
-          assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], 100)
+          if (isJestCoverageBackfillSupported) {
+            assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], 100)
+          } else {
+            assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], undefined)
+          }
         })
 
       childProcess = exec(
@@ -940,7 +953,11 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
           assert.strictEqual(skippedSuite.meta[TEST_STATUS], 'skip')
           assert.strictEqual(skippedSuite.meta[TEST_SKIPPED_BY_ITR], 'true')
           assert.strictEqual(testSession.meta[TEST_ITR_TESTS_SKIPPED], 'true')
-          assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], 100)
+          if (isJestCoverageBackfillSupported) {
+            assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], 100)
+          } else {
+            assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], undefined)
+          }
         })
 
       childProcess = exec(

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -162,8 +162,10 @@ const MINIMUM_JEST_VERSION_BEFORE_30 = DD_MAJOR >= 6 ? '>=28.0.0 <30.0.0' : '>=2
 const MINIMUM_JEST_WORKER_VERSION_BEFORE_30 = DD_MAJOR >= 6 ? '>=28.0.0 <30.0.0' : '>=24.9.0 <30.0.0'
 const MINIMUM_JEST_CONFIG_ASYNC_VERSION = DD_MAJOR >= 6 ? '>=28.0.0' : '>=25.1.0'
 const MINIMUM_JEST_TEST_SCHEDULER_VERSION = DD_MAJOR >= 6 ? '>=28.0.0' : '>=27.0.0'
+const MINIMUM_JEST_COVERAGE_BACKFILL_VERSION = '>=28.0.0'
 const atrSuppressedErrors = new Map()
 let hasWarnedDeprecatedJestVersion = false
+let isJestCoverageBackfillSupported = false
 
 // Track quarantined tests whose errors were suppressed, keyed by "suite › testName"
 const quarantinedFailingTests = new Set()
@@ -1169,7 +1171,8 @@ function hasSkippableSuitesCoverage () {
 }
 
 function shouldCollectJestCoverageForTia () {
-  return shouldReportJestSuiteCoverageForTia() || (isItrEnabled && isCoverageReportUploadEnabled)
+  return shouldReportJestSuiteCoverageForTia() ||
+    (isJestCoverageBackfillSupported && isItrEnabled && isCoverageReportUploadEnabled)
 }
 
 function shouldReportJestSuiteCoverageForTia () {
@@ -1182,7 +1185,7 @@ function hasJestCoverageMap () {
 
 // TIA coverage backfill is part of Datadog Code Coverage, not the per-suite TIA coverage upload.
 function isTiaCoverageBackfillEnabled () {
-  return isItrEnabled && isCoverageReportUploadEnabled && hasJestCoverageMap()
+  return isJestCoverageBackfillSupported && isItrEnabled && isCoverageReportUploadEnabled && hasJestCoverageMap()
 }
 
 // Non-TIA Jest coverage keeps the legacy metric. TIA only reports it from the backfill-capable path.
@@ -1441,6 +1444,8 @@ function searchSourceWrapper (searchSourcePackage, frameworkVersion) {
 function getCliWrapper (isNewJestVersion) {
   return function cliWrapper (cli, jestVersion) {
     warnDeprecatedJestVersion(jestVersion)
+    isJestCoverageBackfillSupported = !!jestVersion &&
+      satisfies(jestVersion, MINIMUM_JEST_COVERAGE_BACKFILL_VERSION)
 
     if (isNewJestVersion) {
       cli = shimmer.wrap(


### PR DESCRIPTION
### What does this PR do?

Gates Jest TIA coverage backfill and session executable coverage reporting by the resolved Jest framework version.

Backfill runs only for Jest versions that support the required coverage hooks. Older supported Jest versions keep TIA suite skipping and suite-level CITESTCOV uploads, but do not apply backfill or report session executable coverage.

### Motivation

Coverage backfill depends on Jest coverage APIs that are only available in newer Jest versions. The runtime gate should follow the actual Jest version in use, so newer Jest versions get backfill regardless of dd-trace major version, and older Jest versions avoid the unsupported backfill path.

### Additional Notes

The dedicated TIA code coverage integration test already uses supported Jest versions.
