### PR TITLE
chore(cypress): bump latest test version

### DIFF
--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -108,7 +108,7 @@
     "cookie": "1.1.1",
     "cookie-parser": "1.4.7",
     "couchbase": "4.7.0",
-    "cypress": "15.15.0",
+    "cypress": "15.16.0",
     "cypress-fail-fast": "8.1.0",
     "dd-trace-api": "1.0.1",
     "ejs": "5.0.2",

--- a/supported_versions_output.json
+++ b/supported_versions_output.json
@@ -318,7 +318,7 @@
     "dependency": "cypress",
     "integration": "cypress",
     "minimum_tracer_supported": "12.0.0",
-    "max_tracer_supported": "15.15.0",
+    "max_tracer_supported": "15.16.0",
     "auto-instrumented": "True"
   },
   {

--- a/supported_versions_table.csv
+++ b/supported_versions_table.csv
@@ -44,7 +44,7 @@ cassandra-driver,cassandra-driver,3.0.0,4.9.0,True
 child_process,child_process,18.0.0,26.2.0,True
 connect,connect,2.2.2,3.7.0,True
 couchbase,couchbase,3.0.7,4.7.0,True
-cypress,cypress,12.0.0,15.15.0,True
+cypress,cypress,12.0.0,15.16.0,True
 dns,dns,18.0.0,26.2.0,True
 durable-functions,azure-durable-functions,3.0.0,3.3.1,True
 elasticsearch,elasticsearch,10.0.0,16.7.3,True


### PR DESCRIPTION
### What does this PR do?
Bumps the Cypress latest-version pin used by the plugin test version matrix from `15.15.0` to `15.16.0` and regenerates the supported integrations JSON/CSV metadata.

### Motivation
Keep the Cypress integration test sandbox aligned with the current npm `latest` release.

