### PR TITLE
fix(jest): report coverage metric without skipped suites

### DIFF
--- a/integration-tests/jest/jest.tia-efd.spec.js
+++ b/integration-tests/jest/jest.tia-efd.spec.js
@@ -223,11 +223,7 @@ describe(`jest@${JEST_VERSION} commonJS`, () => {
         assert.ok(coveragePayload.content.coverages[0].test_suite_id)
 
         const testSession = eventsRequest.payload.events.find(event => event.type === 'test_session_end').content
-        if (isJestCoverageBackfillSupported) {
-          assert.ok(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
-        } else {
-          assert.strictEqual(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT], undefined)
-        }
+        assert.ok(testSession.metrics[TEST_CODE_COVERAGE_LINES_PCT])
 
         const eventTypes = eventsRequest.payload.events.map(event => event.type)
         assertObjectContains(eventTypes, ['test', 'test_suite_end', 'test_session_end', 'test_module_end'])

--- a/packages/datadog-instrumentations/src/jest.js
+++ b/packages/datadog-instrumentations/src/jest.js
@@ -1188,9 +1188,15 @@ function isTiaCoverageBackfillEnabled () {
   return isJestCoverageBackfillSupported && isItrEnabled && isCoverageReportUploadEnabled && hasJestCoverageMap()
 }
 
-// Non-TIA Jest coverage keeps the legacy metric. TIA only reports it from the backfill-capable path.
+// Non-TIA Jest coverage keeps the legacy metric. TIA only reports it when Datadog Code Coverage is enabled and
+// either the run is complete locally or the skipped suites can be backfilled.
 function shouldReportCodeCoverageLinesPct () {
-  return hasJestCoverageMap() && (!isItrEnabled || isTiaCoverageBackfillEnabled())
+  if (!hasJestCoverageMap()) return false
+  if (!isItrEnabled) return true
+  if (!isCoverageReportUploadEnabled) return false
+
+  // If no suites were actually skipped, the local Jest coverage map is complete and does not need backfill.
+  return !isSuitesSkipped || isTiaCoverageBackfillEnabled()
 }
 
 function getHookRequire (hookMeta) {


### PR DESCRIPTION
### What does this PR do?

Allows Jest TIA runs to publish the total code coverage percentage when no suites were actually skipped, even on older Jest versions where coverage backfill is unsupported.

Backfill and session executable coverage remain gated by supported Jest versions when suites are skipped. The Jest TIA/EFD integration expectation now reflects that session executable coverage and the line coverage percentage are separate behaviors.

### Motivation

Fixes a Jest 24 regression where TIA forced coverage collection but `test.code_coverage.lines_pct` was not reported because the metric gate required coverage backfill, even though no skipped suites needed backfill.

### Additional Notes

Validated locally under fake v5 with Jest 24.8.0 using the full Jest core, TIA/EFD, and test-management integration specs. Lint and syntax checks passed.