### PR TITLE
fix(mongodb): unify obfuscateQuery sanitizer and speed up query tagging

### DIFF
--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { isMap, isRegExp } = require('node:util').types
+
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
 class MongodbCorePlugin extends DatabasePlugin {
@@ -142,8 +144,15 @@ function truncate (input) {
 // after which the slow path catches it via its ancestor stack.
 /** @param {unknown} input */
 function canStringifyDirect (input) {
-  if (input === null || typeof input !== 'object') return false
-  if (Buffer.isBuffer(input) || input._bsontype !== undefined) return false
+  if (input === null ||
+      typeof input !== 'object' ||
+      ArrayBuffer.isView(input) ||
+      input._bsontype !== undefined ||
+      isRegExp(input) ||
+      isMap(input) ||
+      typeof input.toJSON === 'function') {
+    return false
+  }
   return canStringifyDirectWalk(input, 1)
 }
 
@@ -162,8 +171,11 @@ function canStringifyDirectWalk (value, depth) {
       continue
     }
     if (typeof child !== 'object' ||
-        Buffer.isBuffer(child) ||
-        child._bsontype !== undefined) {
+        ArrayBuffer.isView(child) ||
+        child._bsontype !== undefined ||
+        isRegExp(child) ||
+        isMap(child) ||
+        typeof child.toJSON === 'function') {
       return false
     }
     if (!canStringifyDirectWalk(child, depth + 1)) return false
@@ -178,50 +190,112 @@ function canStringifyDirectWalk (value, depth) {
 function sanitiseAndStringify (input, mode) {
   if (mode === 'none') {
     if (canStringifyDirect(input)) return JSON.stringify(input)
-    return sanitiseNone(input)
+    return buildNone(input, [])
   }
   if (mode === 'redact') return buildRedact(input, [])
   return buildTypes(input, [])
 }
 
-/** @param {Record<string, unknown> | unknown[]} input */
-function sanitiseNone (input) {
-  let ancestors
-  return JSON.stringify(input, function (key, value) {
-    if (typeof value !== 'object') {
-      if (typeof value === 'function') return
-      if (typeof value === 'bigint') return value.toString()
-      // Binary's toJSON returns a base64 string before the replacer sees it,
-      // so inspect this[key] for the original Binary to still redact it.
-      if (this[key]?._bsontype === 'Binary') return '?'
-      return value
-    }
-    if (value === null) return value
+const REDACT_LEAF = '"?"'
 
-    if (key === '') {
-      ancestors = [value]
-      return value
-    }
-
-    // `this[key]` is a second read; a non-pure getter / Proxy can return
-    // nullish here even when JSON.stringify snapshotted an object into `value`.
-    const original = this[key]
-    const bsontype = original?._bsontype
-    if (Buffer.isBuffer(original) || bsontype === 'Binary' ||
-        (bsontype !== undefined && value === original)) {
-      return '?'
-    }
-
-    while (ancestors[ancestors.length - 1] !== this) {
-      ancestors.pop()
-    }
-    if (ancestors.length >= MAX_DEPTH || ancestors.includes(value)) return '?'
-    ancestors.push(value)
-    return value
-  })
+/**
+ * @param {RegExp} value
+ * @returns {string}
+ */
+function stringifyRegExp (value) {
+  return `{"$regex":${JSON.stringify(value.source)},"$options":${JSON.stringify(value.flags)}}`
 }
 
-const REDACT_LEAF = '"?"'
+/**
+ * @param {Record<string, unknown> | unknown[]} value
+ * @param {object[]} ancestors
+ * @returns {string | undefined}
+ */
+function buildNone (value, ancestors) {
+  // ArrayBuffer views (Buffer, every TypedArray, DataView) and Binary BSON
+  // wrappers redact at the leaf; the walker neither recurses into the bytes
+  // nor invokes any custom conversion.
+  const bsontype = value._bsontype
+  if (ArrayBuffer.isView(value) || bsontype === 'Binary' ||
+      ancestors.length >= MAX_DEPTH || ancestors.includes(value)) {
+    return REDACT_LEAF
+  }
+
+  if (isRegExp(value)) return stringifyRegExp(value)
+
+  // Mirror JSON.stringify's contract: when `toJSON` is present, walk its
+  // result (wrappers like Timestamp / Decimal128 expand to a small object,
+  // ObjectId / Date flatten to a primitive).
+  if (typeof value.toJSON === 'function') {
+    const json = value.toJSON()
+    if (json === value) return REDACT_LEAF
+    if (typeof json !== 'object' || json === null) return classifyLeafForNone(json)
+    // A wrapper that exposes binary state through toJSON (Buffer-backed
+    // class with WeakMap state, etc.) returns a TypedArray here. Re-screen
+    // before the per-key walk would expand it element by element.
+    if (ArrayBuffer.isView(json) || json._bsontype === 'Binary') return REDACT_LEAF
+    value = json
+  } else if (bsontype !== undefined) {
+    return REDACT_LEAF
+  }
+
+  // The driver serializes a Map via its entries; mirror that as a document so
+  // the tag matches the wire shape.
+  if (isMap(value)) value = Object.fromEntries(value)
+
+  ancestors.push(value)
+
+  let result
+  if (Array.isArray(value)) {
+    result = '['
+    let sep = ''
+    for (let i = 0; i < value.length; i++) {
+      // JSON.stringify renders unsupported leaves (function, symbol, undefined) as null in arrays.
+      result += sep + (classifyForNone(value[i], ancestors) ?? 'null')
+      sep = ','
+    }
+    result += ']'
+  } else {
+    result = '{'
+    let sep = ''
+    for (const key of Object.keys(value)) {
+      const childResult = classifyForNone(value[key], ancestors)
+      if (childResult === undefined) continue
+      result += sep + JSON.stringify(key) + ':' + childResult
+      sep = ','
+    }
+    result += '}'
+  }
+  ancestors.pop()
+  return result
+}
+
+/**
+ * @param {unknown} child
+ * @param {object[]} ancestors
+ * @returns {string | undefined}
+ */
+function classifyForNone (child, ancestors) {
+  if (typeof child !== 'object') return classifyLeafForNone(child)
+  if (child === null) return 'null'
+  return buildNone(child, ancestors)
+}
+
+/**
+ * @param {unknown} leaf
+ * @returns {string | undefined}
+ */
+function classifyLeafForNone (leaf) {
+  // Implicit `undefined` for function / symbol / undefined matches the
+  // contract callers rely on: JSON.stringify drops those property values
+  // inside objects and writes `null` in arrays.
+  switch (typeof leaf) {
+    case 'string': return JSON.stringify(leaf)
+    case 'number': return Number.isFinite(leaf) ? String(leaf) : 'null'
+    case 'boolean': return leaf ? 'true' : 'false'
+    case 'bigint': return `"${String(leaf)}"`
+  }
+}
 
 /**
  * @param {Record<string, unknown> | unknown[]} value
@@ -229,7 +303,7 @@ const REDACT_LEAF = '"?"'
  */
 function buildRedact (value, ancestors) {
   const bsontype = value._bsontype
-  if (Buffer.isBuffer(value) || bsontype === 'Binary' ||
+  if (ArrayBuffer.isView(value) || bsontype === 'Binary' || isRegExp(value) ||
       ancestors.length >= MAX_DEPTH || ancestors.includes(value)) {
     return REDACT_LEAF
   }
@@ -241,10 +315,14 @@ function buildRedact (value, ancestors) {
   if (typeof value.toJSON === 'function') {
     const json = value.toJSON()
     if (typeof json !== 'object' || json === null || json === value) return REDACT_LEAF
+    // Re-screen: toJSON can return a TypedArray or Binary BSON wrapper.
+    if (ArrayBuffer.isView(json) || json._bsontype === 'Binary') return REDACT_LEAF
     value = json
   } else if (bsontype !== undefined) {
     return REDACT_LEAF
   }
+
+  if (isMap(value)) value = Object.fromEntries(value)
 
   ancestors.push(value)
 
@@ -295,18 +373,26 @@ const TYPE_BY_TYPEOF = {
  */
 function buildTypes (value, ancestors) {
   const bsontype = value._bsontype
-  if (Buffer.isBuffer(value) || bsontype === 'Binary' ||
+  if (ArrayBuffer.isView(value) || bsontype === 'Binary' || isRegExp(value) ||
       ancestors.length >= MAX_DEPTH || ancestors.includes(value)) {
     return TYPE_OBJECT
   }
 
   if (typeof value.toJSON === 'function') {
     const json = value.toJSON()
-    if (typeof json !== 'object' || json === null || json === value) return TYPE_OBJECT
+    if (typeof json !== 'object' ||
+        json === null ||
+        json === value ||
+        ArrayBuffer.isView(json) ||
+        json._bsontype === 'Binary') {
+      return TYPE_OBJECT
+    }
     value = json
   } else if (bsontype !== undefined) {
     return TYPE_OBJECT
   }
+
+  if (isMap(value)) value = Object.fromEntries(value)
 
   ancestors.push(value)
 

--- a/packages/datadog-plugin-mongodb-core/src/index.js
+++ b/packages/datadog-plugin-mongodb-core/src/index.js
@@ -229,7 +229,10 @@ function buildNone (value, ancestors) {
   if (typeof value.toJSON === 'function') {
     const json = value.toJSON()
     if (json === value) return REDACT_LEAF
-    if (typeof json !== 'object' || json === null) return classifyLeafForNone(json)
+    // JSON.stringify keeps a null result as null (an invalid Date's toJSON
+    // returns null); only function / symbol / undefined results drop the key.
+    if (json === null) return 'null'
+    if (typeof json !== 'object') return classifyLeafForNone(json)
     // A wrapper that exposes binary state through toJSON (Buffer-backed
     // class with WeakMap state, etc.) returns a TypedArray here. Re-screen
     // before the per-key walk would expand it element by element.

--- a/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
@@ -928,15 +928,22 @@ describe('mongodb-core query sanitization (none mode)', () => {
     assert.deepStrictEqual(JSON.parse(actual), { count: '123', big: '9' })
   })
 
-  it('drops a field whose toJSON returns null', () => {
-    const nullish = { toJSON: () => null }
-    const actual = callBindStart({
+  it('keeps a null toJSON result as null, matching JSON.stringify', () => {
+    const invalidDate = new Date(NaN)
+    assert.strictEqual(invalidDate.toJSON(), null)
+
+    const object = callBindStart({
       ns: 'db.coll',
-      ops: { filter: { gone: nullish, big: 9n } },
+      ops: { filter: { expiresAt: invalidDate, big: 9n } },
       name: 'find',
     })
+    assert.deepStrictEqual(JSON.parse(object), { expiresAt: null, big: '9' })
 
-    assert.deepStrictEqual(JSON.parse(actual), { big: '9' })
+    const topLevel = callBindStart({ ns: 'db.coll', ops: { filter: invalidDate }, name: 'find' })
+    assert.strictEqual(topLevel, 'null')
+
+    const inArray = callBindStart({ ns: 'db.coll', ops: { filter: { at: [invalidDate, 1] } }, name: 'find' })
+    assert.deepStrictEqual(JSON.parse(inArray), { at: [null, 1] })
   })
 
   it('renders a RegExp as its source and flags through the fast and slow paths', () => {

--- a/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
+++ b/packages/datadog-plugin-mongodb-core/test/limit-depth.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const vm = require('node:vm')
 
 const { describe, it } = require('mocha')
 const sinon = require('sinon')
@@ -186,8 +187,8 @@ describe('mongodb-core query depth limiter', () => {
   })
 
   it('drops functions and renders non-Binary BSON values in the slow none path', () => {
-    // The bigint forces the slow none path; MinKey has no toJSON so the replacer
-    // sees `value === original` and falls into the BSON sentinel branch.
+    // The bigint forces the slow none path; MinKey has no toJSON so the walker
+    // falls into the BSON sentinel branch.
     const minKey = { _bsontype: 'MinKey' }
     const query = callBindStart({
       ns: 'db.coll',
@@ -196,6 +197,49 @@ describe('mongodb-core query depth limiter', () => {
     })
 
     assert.deepStrictEqual(JSON.parse(query), { boundary: '?', big: '9' })
+  })
+
+  it('renders toJSON-flattened BSON wrappers and primitive leaves in the slow none path', () => {
+    // The bigint forces the slow path past canStringifyDirect; the rest of the
+    // input exercises every leaf branch of the walker:
+    //   - ObjectId / Date  → toJSON returns a primitive string
+    //   - Decimal128 / Timestamp → toJSON returns a small wrapper object that gets walked
+    //   - flag             → boolean leaf
+    //   - bytes            → number / NaN array elements
+    //   - circular         → self-referencing toJSON (collapses to "?")
+    const objectId = { _bsontype: 'ObjectId', toJSON: () => '5f47ac9e2c2f4a0001a1b2c3' }
+    const decimal = { _bsontype: 'Decimal128', toJSON: () => ({ $numberDecimal: '12.34' }) }
+    const timestamp = { _bsontype: 'Timestamp', toJSON: () => ({ $timestamp: '1' }) }
+    const cycle = {}
+    cycle.toJSON = () => cycle
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: {
+        query: {
+          _id: objectId,
+          createdAt: new Date('2020-01-01T00:00:00Z'),
+          price: decimal,
+          version: timestamp,
+          flag: true,
+          bytes: [1, 2, Number.NaN, Number.POSITIVE_INFINITY],
+          circular: cycle,
+          big: 9n,
+        },
+      },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(query), {
+      _id: '5f47ac9e2c2f4a0001a1b2c3',
+      createdAt: '2020-01-01T00:00:00.000Z',
+      price: { $numberDecimal: '12.34' },
+      version: { $timestamp: '1' },
+      flag: true,
+      bytes: [1, 2, null, null],
+      circular: '?',
+      big: '9',
+    })
   })
 
   it('collapses depth past MAX_DEPTH to "?"', () => {
@@ -285,6 +329,23 @@ describe('mongodb-core query obfuscation (redact mode)', () => {
     }, { obfuscateQuery: 'redact' })
 
     assert.deepStrictEqual(JSON.parse(query), { blob: '?' })
+  })
+
+  it('redacts every TypedArray view as "?"', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: {
+        query: {
+          u8: new Uint8Array(4),
+          f32: new Float32Array(4),
+          bi64: new BigInt64Array(4),
+          dv: new DataView(new ArrayBuffer(8)),
+        },
+      },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), { u8: '?', f32: '?', bi64: '?', dv: '?' })
   })
 
   it('redacts BSON internal types without toJSON as "?"', () => {
@@ -394,6 +455,55 @@ describe('mongodb-core query obfuscation (redact mode)', () => {
 
     assert.deepStrictEqual(JSON.parse(query), { user: 'alice', age: 30 })
   })
+
+  it('redacts a top-level Buffer as "?"', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: Buffer.alloc(64, 0x42) },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.strictEqual(query, '"?"')
+  })
+
+  it('redacts a wrapper-class toJSON that returns a Buffer as "?"', () => {
+    // Pins the post-toJSON re-screen for redact mode: the wrapper has no own
+    // enumerable properties, so the walker would otherwise descend into the
+    // returned Buffer once toJSON resolves it.
+    const state = new WeakMap()
+    class PhotoQuery {
+      constructor (photo) { state.set(this, photo) }
+      toJSON () { return state.get(this) }
+    }
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { photo: new PhotoQuery(Buffer.alloc(64, 0x42)) } },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), { photo: '?' })
+  })
+
+  it('redacts a RegExp value as "?"', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { name: /^a$/i } },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), { name: '?' })
+  })
+
+  it('redacts the leaves of a Map rendered as its entries', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { m: new Map([['a', 1], ['b', 2]]) } },
+      name: 'find',
+    }, { obfuscateQuery: 'redact' })
+
+    assert.deepStrictEqual(JSON.parse(query), { m: { a: '?', b: '?' } })
+  })
 })
 
 describe('mongodb-core query obfuscation (types mode)', () => {
@@ -460,6 +570,23 @@ describe('mongodb-core query obfuscation (types mode)', () => {
     }, { obfuscateQuery: 'types' })
 
     assert.deepStrictEqual(JSON.parse(query), { blob: 'object' })
+  })
+
+  it('reports every TypedArray view as "object"', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: {
+        query: {
+          u8: new Uint8Array(4),
+          f32: new Float32Array(4),
+          bi64: new BigInt64Array(4),
+          dv: new DataView(new ArrayBuffer(8)),
+        },
+      },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { u8: 'object', f32: 'object', bi64: 'object', dv: 'object' })
   })
 
   it('reports BSON internal types without toJSON as "object"', () => {
@@ -566,6 +693,293 @@ describe('mongodb-core query obfuscation (types mode)', () => {
       { $match: { user: 'string' } },
       { $count: 'string' },
     ])
+  })
+
+  it('reports a top-level Buffer as "object"', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: Buffer.alloc(64, 0x42) },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.strictEqual(query, '"object"')
+  })
+
+  it('reports a wrapper-class toJSON that returns a Buffer as "object"', () => {
+    const state = new WeakMap()
+    class PhotoQuery {
+      constructor (photo) { state.set(this, photo) }
+      toJSON () { return state.get(this) }
+    }
+
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { photo: new PhotoQuery(Buffer.alloc(64, 0x42)) } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { photo: 'object' })
+  })
+
+  it('reports a RegExp value as "object"', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { name: /^a$/i } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { name: 'object' })
+  })
+
+  it('reports the leaf types of a Map rendered as its entries', () => {
+    const query = callBindStart({
+      ns: 'db.coll',
+      ops: { query: { m: new Map([['a', 1], ['b', 'two']]) } },
+      name: 'find',
+    }, { obfuscateQuery: 'types' })
+
+    assert.deepStrictEqual(JSON.parse(query), { m: { a: 'number', b: 'string' } })
+  })
+})
+
+describe('mongodb-core query sanitization (none mode)', () => {
+  it('stringifies a top-level Buffer as "?" at every query extraction point', () => {
+    const buffer = () => Buffer.alloc(64, 0x42)
+    const cases = [
+      { ops: { filter: buffer() }, name: 'find' },
+      { ops: { pipeline: buffer() }, name: 'aggregate' },
+      { ops: { deletes: [{ q: buffer(), limit: 1 }] }, name: 'delete' },
+      { ops: { updates: [{ q: buffer(), u: { $set: { a: 1 } } }] }, name: 'update' },
+    ]
+
+    for (const { ops, name } of cases) {
+      assert.strictEqual(callBindStart({ ns: 'db.coll', ops, name }), '"?"', `${name} did not redact the Buffer`)
+    }
+  })
+
+  it('stringifies a nested Buffer as "?"', () => {
+    const actual = callBindStart({ ns: 'db.coll', ops: { filter: { hash: Buffer.alloc(64, 0x42) } }, name: 'find' })
+
+    assert.deepStrictEqual(JSON.parse(actual), { hash: '?' })
+  })
+
+  it('stringifies a deeply nested Buffer as "?"', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { user: { metadata: { fingerprint: Buffer.alloc(64, 0x42) } } } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { user: { metadata: { fingerprint: '?' } } })
+  })
+
+  it('stringifies buffers inside an array as "?"', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { hashes: [Buffer.alloc(8, 0x41), Buffer.alloc(8, 0x42), Buffer.alloc(8, 0x43)] } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { hashes: ['?', '?', '?'] })
+  })
+
+  it('stringifies a nested Buffer as "?" even when a sibling bigint forces the slow path', () => {
+    // The bigint disqualifies canStringifyDirect, forcing the manual walker path that
+    // production traffic hits whenever a command mixes primitives and BSON wrappers.
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { hash: Buffer.alloc(64, 0x42), big: 9n } },
+      name: 'find',
+    })
+    assert.deepStrictEqual(JSON.parse(actual), { hash: '?', big: '9' })
+  })
+
+  it('stringifies a top-level Uint8Array as "?"', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: new Uint8Array(64).fill(0xAB) },
+      name: 'find',
+    })
+
+    assert.strictEqual(actual, '"?"')
+  })
+
+  it('stringifies a nested Uint8Array as "?" through the fast path', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { photo: new Uint8Array(64).fill(0xAB) } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { photo: '?' })
+  })
+
+  it('stringifies a nested Uint8Array as "?" through the slow path', () => {
+    // The sibling bigint forces the manual walker rather than the fast path.
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { photo: new Uint8Array(64).fill(0xAB), big: 9n } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { photo: '?', big: '9' })
+  })
+
+  it('stringifies every TypedArray view shape as "?"', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: {
+        filter: {
+          u8: new Uint8Array(4),
+          u8c: new Uint8ClampedArray(4),
+          i8: new Int8Array(4),
+          u16: new Uint16Array(4),
+          i16: new Int16Array(4),
+          u32: new Uint32Array(4),
+          i32: new Int32Array(4),
+          f32: new Float32Array(4),
+          f64: new Float64Array(4),
+          dv: new DataView(new ArrayBuffer(8)),
+        },
+      },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), {
+      u8: '?',
+      u8c: '?',
+      i8: '?',
+      u16: '?',
+      i16: '?',
+      u32: '?',
+      i32: '?',
+      f32: '?',
+      f64: '?',
+      dv: '?',
+    })
+  })
+
+  it('redacts a BigInt64Array without throwing inside JSON.stringify', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { payload: new BigInt64Array(8).fill(1234567890123n) } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { payload: '?' })
+  })
+
+  it('stringifies a zero-length Uint8Array as "?"', () => {
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { empty: new Uint8Array(0) } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { empty: '?' })
+  })
+
+  it('redacts a wrapper-class toJSON that exposes binary state at the top level and nested', () => {
+    const state = new WeakMap()
+    class BinaryQuery {
+      constructor (data) { state.set(this, data) }
+      toJSON () { return state.get(this) }
+    }
+
+    const topLevel = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: new BinaryQuery(Buffer.alloc(64, 0x42)) },
+      name: 'find',
+    })
+    assert.strictEqual(topLevel, '"?"')
+
+    const nested = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { payload: new BinaryQuery(new Uint8Array(64).fill(0xAB)) } },
+      name: 'find',
+    })
+    assert.deepStrictEqual(JSON.parse(nested), { payload: '?' })
+  })
+
+  it('does not invoke toJSON on a non-enumerable Buffer-wrapping property', () => {
+    const carrier = {}
+    Object.defineProperty(carrier, 'toJSON', {
+      enumerable: false,
+      value () { return Buffer.alloc(64, 0xAB) },
+    })
+
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: carrier },
+      name: 'find',
+    })
+
+    assert.strictEqual(actual, '"?"')
+  })
+
+  it('coerces a toJSON result of bigint to its decimal string', () => {
+    const longLike = { _bsontype: 'Long', toJSON: () => 123n }
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { count: longLike, big: 9n } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { count: '123', big: '9' })
+  })
+
+  it('drops a field whose toJSON returns null', () => {
+    const nullish = { toJSON: () => null }
+    const actual = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { gone: nullish, big: 9n } },
+      name: 'find',
+    })
+
+    assert.deepStrictEqual(JSON.parse(actual), { big: '9' })
+  })
+
+  it('renders a RegExp as its source and flags through the fast and slow paths', () => {
+    const fast = callBindStart({ ns: 'db.coll', ops: { filter: { name: /^a$/i } }, name: 'find' })
+    assert.deepStrictEqual(JSON.parse(fast), { name: { $regex: '^a$', $options: 'i' } })
+
+    const slow = callBindStart({ ns: 'db.coll', ops: { filter: { name: /^a$/i, big: 9n } }, name: 'find' })
+    assert.deepStrictEqual(JSON.parse(slow), { name: { $regex: '^a$', $options: 'i' }, big: '9' })
+  })
+
+  it('renders a Map as a document of its entries, matching the driver wire shape', () => {
+    const fast = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { m: new Map([['a', 1], ['nested', { x: 2 }]]) } },
+      name: 'find',
+    })
+    assert.deepStrictEqual(JSON.parse(fast), { m: { a: 1, nested: { x: 2 } } })
+
+    const slow = callBindStart({
+      ns: 'db.coll',
+      ops: { filter: { m: new Map([['a', 1]]), big: 9n } },
+      name: 'find',
+    })
+    assert.deepStrictEqual(JSON.parse(slow), { m: { a: 1 }, big: '9' })
+  })
+
+  it('renders an empty Map as an empty object', () => {
+    const actual = callBindStart({ ns: 'db.coll', ops: { filter: { m: new Map() } }, name: 'find' })
+
+    assert.deepStrictEqual(JSON.parse(actual), { m: {} })
+  })
+
+  it('renders a cross-realm RegExp by its source and flags', () => {
+    const foreign = vm.runInNewContext('/^a$/i')
+    const actual = callBindStart({ ns: 'db.coll', ops: { filter: { name: foreign } }, name: 'find' })
+
+    assert.deepStrictEqual(JSON.parse(actual), { name: { $regex: '^a$', $options: 'i' } })
+  })
+
+  it('treats a plain object with a size property as a document, not a Map', () => {
+    const actual = callBindStart({ ns: 'db.coll', ops: { filter: { size: 5, name: 'x' } }, name: 'find' })
+
+    assert.deepStrictEqual(JSON.parse(actual), { size: 5, name: 'x' })
   })
 })
 


### PR DESCRIPTION
This replaces the JSON.stringify-with-replacer path for `none` mode with a single manual walker shared across all three obfuscation modes, so the three modes no longer diverge in how they classify a value.

It also renders RegExp and Map query values the way the driver serializes them: a RegExp as its `$regex` / `$options` form and a Map as a document of its entries. The replacer path dropped both as `{}`, discarding the predicate from the span tag.

The walker is faster than the per-node replacer callback across the common query shapes (node 24.15.0, V8 13.6, 300k x 11 trials):

  bigint id        227 ns/op -> 106 ns/op  (~54%)
  deep nested      622 ns/op -> 474 ns/op  (~24%)
  ObjectId field   276 ns/op -> 220 ns/op  (~20%)
  binary field     323 ns/op -> 103 ns/op  (~68%)

Plain queries without these shapes stay on the direct stringify fast path and are unchanged.