### PR TITLE
fix(core): redact the whole query-parameter value, not just the matched span

### DIFF
--- a/packages/datadog-plugin-http2/test/server.spec.js
+++ b/packages/datadog-plugin-http2/test/server.spec.js
@@ -371,7 +371,7 @@ describe('Plugin', () => {
                 resource: 'GET',
                 meta: {
                   'span.kind': 'server',
-                  'http.url': `http://localhost:${port}/user?<redacted>foo=bar`,
+                  'http.url': `http://localhost:${port}/user?secret=<redacted>&foo=bar`,
                   'http.method': 'GET',
                   'http.status_code': '200',
                   component: 'http2',

--- a/packages/dd-trace/src/plugins/util/url.js
+++ b/packages/dd-trace/src/plugins/util/url.js
@@ -38,7 +38,13 @@ function getProtocol (req) {
 /**
  * Obfuscate query string
  *
- * @param {object} config
+ * When the regex matches inside a parameter, the parameter's entire value is
+ * redacted (not only the matched span). Matching a prefix and leaving the tail
+ * both leaks the sensitive remainder and explodes `http.url` cardinality, since
+ * the tail is the high-cardinality part (timestamps, UUIDs, free-text search).
+ * Parameters with no value (no `=`) are redacted whole.
+ *
+ * @param {{ queryStringObfuscation: boolean | RegExp }} config
  * @param {string} url
  * @returns {string} obfuscated URL
  */
@@ -53,11 +59,26 @@ function obfuscateQs (config, url) {
   const path = url.slice(0, i)
   if (queryStringObfuscation === true) return path
 
-  let qs = url.slice(i + 1)
+  const qs = url.slice(i + 1)
 
-  qs = qs.replace(queryStringObfuscation, '<redacted>')
+  // Fast path: most requests carry no sensitive parameter, so a single scan
+  // over the whole query string short-circuits before paying the per-parameter
+  // split / rebuild below. The shared RegExp carries the global flag, so reset
+  // `lastIndex` before relying on `test`.
+  queryStringObfuscation.lastIndex = 0
+  if (!queryStringObfuscation.test(qs)) return url
 
-  return `${path}?${qs}`
+  const params = qs.split('&')
+  for (let p = 0; p < params.length; p++) {
+    const param = params[p]
+    queryStringObfuscation.lastIndex = 0
+    if (!queryStringObfuscation.test(param)) continue
+
+    const eq = param.indexOf('=')
+    params[p] = eq === -1 ? '<redacted>' : `${param.slice(0, eq)}=<redacted>`
+  }
+
+  return `${path}?${params.join('&')}`
 }
 
 /**

--- a/packages/dd-trace/test/plugins/util/url.spec.js
+++ b/packages/dd-trace/test/plugins/util/url.spec.js
@@ -136,6 +136,68 @@ describe('plugins/util/url', () => {
 
       assert.strictEqual(result, urlPath + 'secret/?data=<redacted>')
     })
+
+    it('should redact the whole value when the regex matches only a prefix of it', () => {
+      // A regex that matches the start of a value but not through to `&` used to
+      // leave the high-cardinality, often-sensitive tail in the tag. Redact the
+      // entire value of the matched parameter instead.
+      config.queryStringObfuscation = /campaign_id=[a-z0-9]+/gi
+
+      const result = url.obfuscateQs(
+        config,
+        urlPath + '?campaign_id=12345678-a7ea-47d9-8c62-b42f4618c5bf&limit=20'
+      )
+
+      assert.strictEqual(result, urlPath + '?campaign_id=<redacted>&limit=20')
+    })
+
+    it('should redact every matched parameter value while leaving the rest intact', () => {
+      config.queryStringObfuscation = /(?:search|min_timestamp_created)=[a-z0-9]+/gi
+
+      const result = url.obfuscateQs(
+        config,
+        urlPath + '?limit=50&min_timestamp_created=2024-02-10T14:57:32.697Z&search=abc-mN4DDcb&mode=focused'
+      )
+
+      assert.strictEqual(
+        result,
+        urlPath + '?limit=50&min_timestamp_created=<redacted>&search=<redacted>&mode=focused'
+      )
+    })
+
+    it('should redact the value but keep the key when the regex matches the key=value pair', () => {
+      // The default secrets regex matches `<key>=<value>` as a whole; the key is
+      // low-cardinality and safe to keep, so only the value is redacted.
+      config.queryStringObfuscation = /token=[a-z0-9]+/gi
+
+      const result = url.obfuscateQs(config, urlPath + '?token=supersecret123&user=alice')
+
+      assert.strictEqual(result, urlPath + '?token=<redacted>&user=alice')
+    })
+
+    it('should redact the trailing parameter value through the end of the query string', () => {
+      config.queryStringObfuscation = /before_id=[a-z0-9]+/gi
+
+      const result = url.obfuscateQs(config, urlPath + '?limit=20&before_id=98765-ab46-7309')
+
+      assert.strictEqual(result, urlPath + '?limit=20&before_id=<redacted>')
+    })
+
+    it('should leave the query string untouched when nothing matches', () => {
+      config.queryStringObfuscation = /password=[a-z0-9]+/gi
+
+      const result = url.obfuscateQs(config, urlPath + '?limit=50&search=abc&mode=focused')
+
+      assert.strictEqual(result, urlPath + '?limit=50&search=abc&mode=focused')
+    })
+
+    it('should redact a value-less parameter whole when it matches', () => {
+      config.queryStringObfuscation = /token/gi
+
+      const result = url.obfuscateQs(config, urlPath + '?debug&token&limit=50')
+
+      assert.strictEqual(result, urlPath + '?debug&<redacted>&limit=50')
+    })
   })
 
   describe('extractPathFromUrl', () => {


### PR DESCRIPTION
## Summary

`obfuscateQs` (`packages/dd-trace/src/plugins/util/url.js`) replaced only the
regex's matched span in the query string. A pattern that matched a prefix of a
value but not through to the next `&` left the unmatched tail in `http.url` —
the high-cardinality, often-sensitive part (ISO timestamps, UUIDs, free-text
search). This both leaked the remainder and exploded `http.url` cardinality,
since every distinct tail is a distinct tag value. It surfaced on outbound
client `http.url` once query-string retention reached the client (#8407), but
the flaw lived in the shared server/client helper.

The fix redacts the entire value of any parameter the regex matches (key kept,
value replaced with `<redacted>`); value-less flags are redacted whole. The
default secrets regex now yields `token=<redacted>` instead of dropping the key
with the value — the key is low-cardinality and safe to keep.

## Why

The previous contract ("redact exactly the regex match span") made redaction
correctness depend on every user/default regex matching through to the `&`. A
regex that matched only a value prefix silently leaked the tail and uncapped
cardinality. Redacting the whole matched parameter's value removes that footgun
regardless of how the regex is written.

This changes observable output for the default secrets regex: previously
`<redacted>` (key dropped), now `key=<redacted>` (key kept). The three existing
http/http2 obfuscation specs are updated to the new shape.

The common no-match request short-circuits on a single scan and is
equal-or-faster (66 vs 70 ns/op on a 7-parameter query string); the split /
rebuild only runs once a parameter actually matches.

## Test plan

- `obfuscateQs` unit permutations in `packages/dd-trace/test/plugins/util/url.spec.js`
  (prefix-match, multi-param, key-kept, trailing param, no-match, value-less flag).
- http/http2 client + http2 server obfuscation specs reflect `key=<redacted>`.