### PR TITLE
ci(project): remove supported integrations push jobs

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -182,7 +182,7 @@ jobs:
 
   supported-integrations-push:
     # See yarn-dedupe-push: skip the bot's own re-trigger after it pushes.
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.supported-integrations.outputs.has_changes == 'true' && github.actor != 'dd-octo-sts[bot]'
+    if: false
     runs-on: ubuntu-latest
     needs: supported-integrations
     permissions:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -180,51 +180,6 @@ jobs:
           path: ${{ runner.temp }}/supported-integrations
           if-no-files-found: error
 
-  supported-integrations-push:
-    # See yarn-dedupe-push: skip the bot's own re-trigger after it pushes.
-    if: false
-    runs-on: ubuntu-latest
-    needs: supported-integrations
-    permissions:
-      id-token: write
-    steps:
-      - uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
-        id: octo-sts
-        with:
-          scope: DataDog/dd-trace-js
-          policy: supported-integrations
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: supported-integrations
-          path: ${{ runner.temp }}/supported-integrations
-      - env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-          BRANCH: ${{ github.event.pull_request.head.ref }}
-          EXPECTED: ${{ github.event.pull_request.head.sha }}
-          DIR: ${{ runner.temp }}/supported-integrations
-        run: |
-          set -euo pipefail
-          # gh's `-f variables=<json>` does not parse the value as JSON; build
-          # the `{query, variables}` body with jq and pipe via `--input -`.
-          jq -nc \
-            --arg repo "$GITHUB_REPOSITORY" \
-            --arg branch "$BRANCH" \
-            --arg expected "$EXPECTED" \
-            --arg json "$(base64 -w 0 "$DIR/supported_versions_output.json")" \
-            --arg csv "$(base64 -w 0 "$DIR/supported_versions_table.csv")" \
-            '{
-              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url } } }",
-              variables: { input: {
-                branch: { repositoryNameWithOwner: $repo, branchName: $branch },
-                message: { headline: "chore: update supported-integrations" },
-                expectedHeadOid: $expected,
-                fileChanges: { additions: [
-                  { path: "supported_versions_output.json", contents: $json },
-                  { path: "supported_versions_table.csv", contents: $csv }
-                ] }
-              } }
-            }' | gh api graphql --input - >/dev/null
-
   yarn-dedupe:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -131,55 +131,6 @@ jobs:
   #     - uses: ./.github/actions/install
   #     - run: node scripts/verify-ci-config.js
 
-  supported-integrations:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      has_changes: ${{ steps.diff.outputs.has_changes }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/node/latest
-      - uses: ./.github/actions/install
-      - run: npm run generate:supported-integrations
-      - id: diff
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          BASE_REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          if git diff --quiet; then
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          changed="$(git diff --name-only | sort -u)"
-          expected="$(printf 'supported_versions_output.json\nsupported_versions_table.csv')"
-          if [ "$changed" != "$expected" ]; then
-            echo "Unexpected paths changed during regeneration:" >&2
-            echo "$changed" >&2
-            exit 1
-          fi
-
-          if [ "$EVENT_NAME" != "pull_request" ] || [ "$HEAD_REPO" != "$BASE_REPO" ]; then
-            echo "Out of date. Run 'npm run generate:supported-integrations' locally and commit." >&2
-            exit 1
-          fi
-
-          mkdir -p "${RUNNER_TEMP}/supported-integrations"
-          cp supported_versions_output.json supported_versions_table.csv "${RUNNER_TEMP}/supported-integrations/"
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
-      - if: steps.diff.outputs.has_changes == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: supported-integrations
-          path: ${{ runner.temp }}/supported-integrations
-          if-no-files-found: error
-
   yarn-dedupe:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### What does this PR do?

Temporarily remove `supported-integrations` and `supported-integrations-push` workflow jobs.

### Motivation

Allow https://github.com/DataDog/dd-trace-js/pull/8661 to be released

