### PR TITLE
ci(release): cap proposal at 100 commits and notify guild at 50

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -48,7 +48,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true
           payload: |
-            channel: ${{ secrets.SLACK_GUILD_CHANNEL_ID }}
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
             blocks:
               - type: "section"
                 text:

--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -34,6 +34,29 @@ jobs:
       - uses: ./.github/actions/install/branch-diff
         with:
           token: ${{ steps.octo-sts.outputs.token }}
-      - run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
+      - id: proposal
+        run: node scripts/release/proposal ${{ matrix.release-line }} -y ${{ github.event_name == 'workflow_dispatch' && '-f' || '' }}
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
+      - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v2.1.0
+        if: >
+          github.event_name == 'schedule' &&
+          steps.proposal.outputs.commit_count != '' &&
+          fromJSON(steps.proposal.outputs.commit_count) >= 50
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          payload: |
+            channel: ${{ secrets.SLACK_GUILD_CHANNEL_ID }}
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: >-
+                    :warning: *Release proposal
+                    <${{ steps.proposal.outputs.pr_url }}|${{ steps.proposal.outputs.version }}>*
+                    has ${{ steps.proposal.outputs.commit_count }} commits queued.
+                    GitHub's rebase limit is 100 — once reached, commits that don't fit
+                    will be deferred to a subsequent release.
+                    Consider cutting this release soon.

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -122,31 +122,48 @@ try {
   const proposalDiff = capture(`${cherryPickDiffCmd} --format=sha --reverse v${newVersion}-proposal ${main}`)
     .replaceAll('\n', ' ').trim()
 
+  // GitHub rebase limit is 100 commits; reserve one slot for the version bump.
+  const MAX_CHERRY_PICKS = 99
+  const branchCommitCount = Number.parseInt(capture(`git rev-list --count v${releaseLine}.x..HEAD`), 10)
+  const existingCherryPicked = lastCommit === `v${newVersion}` ? branchCommitCount - 1 : branchCommitCount
+  const proposalShas = proposalDiff ? proposalDiff.split(' ').filter(Boolean) : []
+  const remainingSlots = Math.max(0, MAX_CHERRY_PICKS - existingCherryPicked)
+  const shasToApply = proposalShas.slice(0, remainingSlots)
+  const limitedDiff = shasToApply.join(' ')
+  const totalCommits = existingCherryPicked + shasToApply.length + 1
+
   if (proposalDiff) {
     // Get new changes since last commit of the proposal branch.
     const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${main}`)
+    const truncated = shasToApply.length < proposalShas.length
+    const truncationNote = truncated
+      ? `\n\n⚠️  Applying ${shasToApply.length} of ${proposalShas.length} available commits` +
+        ` (GitHub limit: ${MAX_CHERRY_PICKS}). Remaining commits require a separate release.`
+      : ''
 
-    pass(`\n${newChanges}`)
+    pass(`\n${newChanges}${truncationNote}`)
 
-    start('Apply changes from the main branch')
+    if (limitedDiff) {
+      start('Apply changes from the main branch')
 
-    // We have new commits to add, so revert the version commit if it exists.
-    if (lastCommit === `v${newVersion}`) {
-      run('git reset --hard HEAD~1')
-    }
+      // We have new commits to add, so revert the version commit if it exists.
+      if (lastCommit === `v${newVersion}`) {
+        run('git reset --hard HEAD~1')
+      }
 
-    // Cherry pick all new commits to the proposal branch.
-    try {
-      run(`git cherry-pick ${proposalDiff}`)
+      // Cherry pick commits up to the GitHub rebase limit.
+      try {
+        run(`git cherry-pick ${limitedDiff}`)
 
-      pass()
-    } catch {
-      run('git cherry-pick --abort')
+        pass()
+      } catch {
+        run('git cherry-pick --abort')
 
-      fatal(
-        'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
-        'Please make sure the release branch contains all changes from the main branch.'
-      )
+        fatal(
+          'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
+          'Please make sure the release branch contains all changes from the main branch.'
+        )
+      }
     }
   } else {
     pass('none')
@@ -234,6 +251,14 @@ try {
 
   if (process.env.CI) {
     log(`\n\n::notice::${newVersion}: ${pullRequest.url}`)
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, [
+      `commit_count=${totalCommits}`,
+      `version=v${newVersion}`,
+      `pr_url=${pullRequest.url}`,
+    ].join('\n') + '\n')
   }
 } catch (e) {
   fail(e)

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -97,23 +97,11 @@ try {
     process.exit(0)
   }
 
-  // Only labeled commits (semver-patch/minor/major) warrant cutting a release;
-  // unlabeled commits (e.g. docs/chore) ride along but are not enough on their own.
-  // Use the capped range so deferred commits beyond the limit don't trigger a release.
-  const cappedDiff = capture(`${cherryPickDiffCmd} --format=markdown v${releaseLine}.x ${upperBoundSha}`)
-
-  if (
-    !cappedDiff.includes('SEMVER-MINOR') &&
-    !cappedDiff.includes('SEMVER-PATCH') &&
-    !cappedDiff.includes('SEMVER-MAJOR')
-  ) {
-    pass('none (already up to date)')
-    process.exit(0)
-  }
-
-  // notesDiff excludes semver-major (gated behind a flag, not user-visible) for release notes.
+  // notesDiff is scoped to upperBoundSha so isMinor and release notes only reflect
+  // the capped commits actually included in the proposal, not deferred ones.
+  // Excludes semver-major (gated behind a flag, not user-visible).
   const notesDiff = capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x ${upperBoundSha}`)
-  const isMinor = cappedDiff.includes('SEMVER-MINOR')
+  const isMinor = notesDiff.includes('SEMVER-MINOR')
   const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
   const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
   const newVersion = isMinor ? newMinor : newPatch

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -172,8 +172,14 @@ try {
 
   start('Save release notes draft')
 
+  // Use the last applied main SHA as the upper bound to ensure links point to
+  // commits on main rather than cherry-picks on the proposal branch.
+  const notesContent = capture(
+    `${notesDiffCmd} --format=markdown v${releaseLine}.x ${shasToApply.at(-1) ?? main}`
+  )
+
   fs.mkdirSync(notesDir, { recursive: true })
-  fs.writeFileSync(notesFile, capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x HEAD`))
+  fs.writeFileSync(notesFile, notesContent)
 
   pass(notesFile)
 

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -131,11 +131,11 @@ try {
   const shasToApply = proposalShas.slice(0, remainingSlots)
   const limitedDiff = shasToApply.join(' ')
   const totalCommits = existingCherryPicked + shasToApply.length + 1
+  const truncated = shasToApply.length < proposalShas.length
 
   if (proposalDiff) {
     // Get new changes since last commit of the proposal branch.
     const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${main}`)
-    const truncated = shasToApply.length < proposalShas.length
     const truncationNote = truncated
       ? `\n\n⚠️  Applying ${shasToApply.length} of ${proposalShas.length} available commits` +
         ` (GitHub limit: ${MAX_CHERRY_PICKS}). Remaining commits require a separate release.`
@@ -175,9 +175,14 @@ try {
 
   start('Save release notes draft')
 
-  // Write release notes to a file that can be copied to the GitHub release.
+  // When commits were capped, recompute notes from the actual proposal branch
+  // contents to exclude commits that were deferred to a subsequent release.
+  const notesContent = truncated
+    ? capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x HEAD`)
+    : lineDiff
+
   fs.mkdirSync(notesDir, { recursive: true })
-  fs.writeFileSync(notesFile, lineDiff)
+  fs.writeFileSync(notesFile, notesContent)
 
   pass(notesFile)
 

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -76,6 +76,15 @@ try {
   start('Determine version increment')
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
+
+  // GitHub rebase limit is 100 commits; reserve one slot for the version bump.
+  const MAX_CHERRY_PICKS = 99
+
+  // Get all applicable commits from the release branch to main.
+  // Used to derive the capped upper bound before checking out any branch,
+  // avoiding a circular dependency between isMinor and the proposal branch state.
+  const allMainShas = capture(`${cherryPickDiffCmd} --format=sha --reverse v${releaseLine}.x ${main}`)
+    .split('\n').filter(Boolean)
   const allDiff = capture(`${cherryPickDiffCmd} --format=markdown v${releaseLine}.x ${main}`)
 
   // Only labeled commits (semver-patch/minor/major) warrant cutting a release;
@@ -89,7 +98,16 @@ try {
     process.exit(0)
   }
 
-  const isMinor = allDiff.includes('SEMVER-MINOR')
+  // The upper bound is the last main SHA that will fit in the proposal across all
+  // runs. It equals allMainShas[min(length, MAX_CHERRY_PICKS) - 1] regardless of
+  // how many commits are already on the branch (proven by:
+  // existingCherryPicked + shasToApply.length = min(allMainShas.length, MAX_CHERRY_PICKS)).
+  const upperBoundSha = allMainShas.at(Math.min(allMainShas.length, MAX_CHERRY_PICKS) - 1)
+
+  // notesDiff serves two purposes: determining isMinor from capped commits only
+  // (not all of main), and as the release notes content.
+  const notesDiff = capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x ${upperBoundSha}`)
+  const isMinor = notesDiff.includes('SEMVER-MINOR')
   const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
   const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
   const newVersion = isMinor ? newMinor : newPatch
@@ -118,20 +136,16 @@ try {
 
   // Get the hashes of the last version and the commits to add.
   const lastCommit = capture('git log -1 --pretty=%B')
-  const proposalShas = capture(`${cherryPickDiffCmd} --format=sha --reverse v${newVersion}-proposal ${main}`)
-    .split('\n').filter(Boolean)
-
-  // GitHub rebase limit is 100 commits; reserve one slot for the version bump.
-  const MAX_CHERRY_PICKS = 99
   const branchCommitCount = Number.parseInt(capture(`git rev-list --count v${releaseLine}.x..HEAD`), 10)
   const existingCherryPicked = lastCommit === `v${newVersion}` ? branchCommitCount - 1 : branchCommitCount
+  const proposalShas = allMainShas.slice(existingCherryPicked)
   const shasToApply = proposalShas.slice(0, Math.max(0, MAX_CHERRY_PICKS - existingCherryPicked))
   const truncated = shasToApply.length < proposalShas.length
   const totalCommits = existingCherryPicked + shasToApply.length + 1
 
   if (shasToApply.length > 0) {
-    // Show only commits being applied; shasToApply.at(-1) is the upper bound.
-    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${shasToApply.at(-1)}`)
+    // Show only commits being applied; upperBoundSha is the last main SHA that fits.
+    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${upperBoundSha}`)
     const truncationNote = truncated
       ? `\n\n⚠️  Applying ${shasToApply.length} of ${proposalShas.length} available commits` +
         ` (GitHub limit: ${MAX_CHERRY_PICKS}). Remaining commits require a separate release.`
@@ -172,14 +186,8 @@ try {
 
   start('Save release notes draft')
 
-  // Use the last applied main SHA as the upper bound to ensure links point to
-  // commits on main rather than cherry-picks on the proposal branch.
-  const notesContent = capture(
-    `${notesDiffCmd} --format=markdown v${releaseLine}.x ${shasToApply.at(-1) ?? main}`
-  )
-
   fs.mkdirSync(notesDir, { recursive: true })
-  fs.writeFileSync(notesFile, notesContent)
+  fs.writeFileSync(notesFile, notesDiff)
 
   pass(notesFile)
 

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -85,18 +85,6 @@ try {
   // avoiding a circular dependency between isMinor and the proposal branch state.
   const allMainShas = capture(`${cherryPickDiffCmd} --format=sha --reverse v${releaseLine}.x ${main}`)
     .split('\n').filter(Boolean)
-  const allDiff = capture(`${cherryPickDiffCmd} --format=markdown v${releaseLine}.x ${main}`)
-
-  // Only labeled commits (semver-patch/minor/major) warrant cutting a release;
-  // unlabeled commits (e.g. docs/chore) ride along but are not enough on their own.
-  if (
-    !allDiff.includes('SEMVER-MINOR') &&
-    !allDiff.includes('SEMVER-PATCH') &&
-    !allDiff.includes('SEMVER-MAJOR')
-  ) {
-    pass('none (already up to date)')
-    process.exit(0)
-  }
 
   // The upper bound is the last main SHA that will fit in the proposal across all
   // runs. It equals allMainShas[min(length, MAX_CHERRY_PICKS) - 1] regardless of
@@ -104,10 +92,28 @@ try {
   // existingCherryPicked + shasToApply.length = min(allMainShas.length, MAX_CHERRY_PICKS)).
   const upperBoundSha = allMainShas.at(Math.min(allMainShas.length, MAX_CHERRY_PICKS) - 1)
 
-  // notesDiff serves two purposes: determining isMinor from capped commits only
-  // (not all of main), and as the release notes content.
+  if (!upperBoundSha) {
+    pass('none (already up to date)')
+    process.exit(0)
+  }
+
+  // Only labeled commits (semver-patch/minor/major) warrant cutting a release;
+  // unlabeled commits (e.g. docs/chore) ride along but are not enough on their own.
+  // Use the capped range so deferred commits beyond the limit don't trigger a release.
+  const cappedDiff = capture(`${cherryPickDiffCmd} --format=markdown v${releaseLine}.x ${upperBoundSha}`)
+
+  if (
+    !cappedDiff.includes('SEMVER-MINOR') &&
+    !cappedDiff.includes('SEMVER-PATCH') &&
+    !cappedDiff.includes('SEMVER-MAJOR')
+  ) {
+    pass('none (already up to date)')
+    process.exit(0)
+  }
+
+  // notesDiff excludes semver-major (gated behind a flag, not user-visible) for release notes.
   const notesDiff = capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x ${upperBoundSha}`)
-  const isMinor = notesDiff.includes('SEMVER-MINOR')
+  const isMinor = cappedDiff.includes('SEMVER-MINOR')
   const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
   const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
   const newVersion = isMinor ? newMinor : newPatch

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -76,7 +76,6 @@ try {
   start('Determine version increment')
 
   const { DD_MAJOR, DD_MINOR, DD_PATCH } = require('../../version')
-  const lineDiff = capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x ${main}`)
   const allDiff = capture(`${cherryPickDiffCmd} --format=markdown v${releaseLine}.x ${main}`)
 
   // Only labeled commits (semver-patch/minor/major) warrant cutting a release;
@@ -90,7 +89,7 @@ try {
     process.exit(0)
   }
 
-  const isMinor = lineDiff.includes('SEMVER-MINOR')
+  const isMinor = allDiff.includes('SEMVER-MINOR')
   const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
   const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
   const newVersion = isMinor ? newMinor : newPatch
@@ -119,25 +118,20 @@ try {
 
   // Get the hashes of the last version and the commits to add.
   const lastCommit = capture('git log -1 --pretty=%B')
-  const proposalDiff = capture(`${cherryPickDiffCmd} --format=sha --reverse v${newVersion}-proposal ${main}`)
-    .replaceAll('\n', ' ').trim()
+  const proposalShas = capture(`${cherryPickDiffCmd} --format=sha --reverse v${newVersion}-proposal ${main}`)
+    .split('\n').filter(Boolean)
 
   // GitHub rebase limit is 100 commits; reserve one slot for the version bump.
   const MAX_CHERRY_PICKS = 99
   const branchCommitCount = Number.parseInt(capture(`git rev-list --count v${releaseLine}.x..HEAD`), 10)
   const existingCherryPicked = lastCommit === `v${newVersion}` ? branchCommitCount - 1 : branchCommitCount
-  const proposalShas = proposalDiff ? proposalDiff.split(' ').filter(Boolean) : []
-  const remainingSlots = Math.max(0, MAX_CHERRY_PICKS - existingCherryPicked)
-  const shasToApply = proposalShas.slice(0, remainingSlots)
-  const limitedDiff = shasToApply.join(' ')
-  const totalCommits = existingCherryPicked + shasToApply.length + 1
+  const shasToApply = proposalShas.slice(0, Math.max(0, MAX_CHERRY_PICKS - existingCherryPicked))
   const truncated = shasToApply.length < proposalShas.length
+  const totalCommits = existingCherryPicked + shasToApply.length + 1
 
-  if (proposalDiff) {
-    // Get new changes since last commit of the proposal branch.
-    // When truncated, compare up to the last applied SHA to exclude deferred commits.
-    const changesTarget = truncated ? shasToApply.at(-1) : main
-    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${changesTarget}`)
+  if (shasToApply.length > 0) {
+    // Show only commits being applied; shasToApply.at(-1) is the upper bound.
+    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${shasToApply.at(-1)}`)
     const truncationNote = truncated
       ? `\n\n⚠️  Applying ${shasToApply.length} of ${proposalShas.length} available commits` +
         ` (GitHub limit: ${MAX_CHERRY_PICKS}). Remaining commits require a separate release.`
@@ -145,28 +139,29 @@ try {
 
     pass(`\n${newChanges}${truncationNote}`)
 
-    if (limitedDiff) {
-      start('Apply changes from the main branch')
+    start('Apply changes from the main branch')
 
-      // We have new commits to add, so revert the version commit if it exists.
-      if (lastCommit === `v${newVersion}`) {
-        run('git reset --hard HEAD~1')
-      }
-
-      // Cherry pick commits up to the GitHub rebase limit.
-      try {
-        run(`git cherry-pick ${limitedDiff}`)
-
-        pass()
-      } catch {
-        run('git cherry-pick --abort')
-
-        fatal(
-          'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
-          'Please make sure the release branch contains all changes from the main branch.'
-        )
-      }
+    // We have new commits to add, so revert the version commit if it exists.
+    if (lastCommit === `v${newVersion}`) {
+      run('git reset --hard HEAD~1')
     }
+
+    // Cherry pick commits up to the GitHub rebase limit.
+    try {
+      run(`git cherry-pick ${shasToApply.join(' ')}`)
+
+      pass()
+    } catch {
+      run('git cherry-pick --abort')
+
+      fatal(
+        'Cherry-pick failed. This means that the release branch has deviated from the main branch.',
+        'Please make sure the release branch contains all changes from the main branch.'
+      )
+    }
+  } else if (proposalShas.length > 0) {
+    pass(`⚠️  Proposal is at the commit limit (${MAX_CHERRY_PICKS}/${MAX_CHERRY_PICKS}).` +
+      ` ${proposalShas.length} new commit(s) require a separate release.`)
   } else {
     pass('none')
   }
@@ -177,14 +172,8 @@ try {
 
   start('Save release notes draft')
 
-  // When commits were capped, recompute notes from the actual proposal branch
-  // contents to exclude commits that were deferred to a subsequent release.
-  const notesContent = truncated
-    ? capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x HEAD`)
-    : lineDiff
-
   fs.mkdirSync(notesDir, { recursive: true })
-  fs.writeFileSync(notesFile, notesContent)
+  fs.writeFileSync(notesFile, capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x HEAD`))
 
   pass(notesFile)
 

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -135,7 +135,9 @@ try {
 
   if (proposalDiff) {
     // Get new changes since last commit of the proposal branch.
-    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${main}`)
+    // When truncated, compare up to the last applied SHA to exclude deferred commits.
+    const changesTarget = truncated ? shasToApply.at(-1) : main
+    const newChanges = capture(`${cherryPickDiffCmd} v${newVersion}-proposal ${changesTarget}`)
     const truncationNote = truncated
       ? `\n\n⚠️  Applying ${shasToApply.length} of ${proposalShas.length} available commits` +
         ` (GitHub limit: ${MAX_CHERRY_PICKS}). Remaining commits require a separate release.`


### PR DESCRIPTION
## What

- Limits the release proposal cherry-pick to 99 commits + 1 version bump = 100 total, matching [GitHub's rebase limit](https://docs.github.com/en/enterprise-cloud@latest/repositories/creating-and-managing-repositories/repository-limits#rebase-limits). Commits beyond the limit are skipped and will require a subsequent release.
- Posts a Slack notification to the guild channel when a scheduled proposal reaches 50+ commits, prompting the team to cut a release before hitting the cap.

## How

**`scripts/release/proposal.js`**
- Counts existing cherry-picked commits on the proposal branch and calculates remaining slots (max 99).
- Slices the SHA list to fit within the budget before passing it to `git cherry-pick`.
- Displays a truncation note in the output when available commits exceed the limit.
- Writes `commit_count`, `version`, and `pr_url` to `$GITHUB_OUTPUT` for use by the workflow.

**`.github/workflows/release-proposal.yml`**
- Adds `id: proposal` to the proposal step to expose its outputs.
- Adds a `slackapi/slack-github-action` step that fires on scheduled runs when `commit_count >= 50`, reusing the existing `SLACK_CHANNEL_ID` and `SLACK_BOT_TOKEN` secrets.

---
*Generated by [Claude Code](https://github.com/anthropics/claude-code)*