### PR TITLE
ci(release): fix validation workflow never triggering on proposal branches

### DIFF
--- a/.github/workflows/release-validate.yml
+++ b/.github/workflows/release-validate.yml
@@ -1,20 +1,16 @@
 name: "Release Validation"
 
 on:
-  pull_request:
+  push:
     branches:
       - v[0-9]+.[0-9]+.[0-9]+-proposal
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_id || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   validate-proposal:
-    strategy:
-      fail-fast: false
-      matrix:
-        release-line: ["5"]
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- The `pull_request` trigger's `branches` filter matches the **base** branch, not the head. Since release proposal PRs are always opened against `v*.x`, the validation workflow never ran for any release proposal.
- Switch to a `push` trigger on `v[0-9]+.[0-9]+.[0-9]+-proposal` branches so validation fires on every push to any proposal branch, for any release line.
- Remove the unused `release-line` matrix — `validate.js` already derives the release line from the branch name itself, so the matrix variable was never referenced.

## Test plan

- [ ] Push to a `v*.*.* -proposal` branch and verify the "Release Validation" workflow runs
- [ ] Confirm the workflow passes on a valid proposal and fails on one with an extra commit

> Generated by [Claude Code](https://claude.ai/code)