### PR TITLE
test(aws-sdk): fix flaky stepfunctions startExecution span assertion

### DIFF
--- a/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/stepfunctions.spec.js
@@ -115,7 +115,7 @@ describe('Sfn', () => {
             assert.ok(span, 'expected startExecution span')
             assert.strictEqual(span.resource, 'startExecution')
             assert.strictEqual(span.meta.statemachinearn, stateMachineArn)
-          })
+          }, { spanResourceMatch: /startExecution/ })
 
           const resp = await client.startExecution(startExecInput)
 


### PR DESCRIPTION
## Summary

- `agent.assertSomeTraces` in the stepfunctions test had no `spanResourceMatch` filter, causing the callback to fire on any incoming trace payload
- The `createStateMachine` span from `beforeEach` is flushed asynchronously and frequently arrives during the test, triggering the assertion before the `startExecution` span is received
- Adding `{ spanResourceMatch: /startExecution/ }` ensures the callback is only invoked when a payload containing a `startExecution` span arrives, eliminating the race condition
- Root-caused from 4 out of 6 flaky `aws-sdk (oldest, stepfunctions)` CI failures seen on 2026-05-29

## Test plan

- [ ] Verify the `aws-sdk (oldest, stepfunctions)` job passes consistently in CI

> Generated by [Claude Code](https://claude.ai/claude-code)