### PR TITLE
ci: skip implicit-else branches in istanbul line-coverage patch

### DIFF
--- a/integration-tests/coverage-child-process.spec.js
+++ b/integration-tests/coverage-child-process.spec.js
@@ -8,6 +8,8 @@ const os = require('node:os')
 const path = require('node:path')
 const { inspect } = require('node:util')
 
+const libCoverage = require('istanbul-lib-coverage')
+
 const { installPatch } = require('./coverage/patch-child-process')
 const { installLastExitHandler } = require('./coverage/pre-instrumented-writer')
 const finalizeSandboxCoverage = require('./coverage/finalize-sandbox')
@@ -537,5 +539,42 @@ describe('integration coverage last-exit handler', () => {
     process.removeAllListeners('beforeExit')
 
     assert.deepStrictEqual(fired, ['beforeExit'])
+  })
+})
+
+describe('istanbul-lib-coverage getLineCoverage patch', () => {
+  it('does not emit a line for an implicit else with no source location', () => {
+    // An `if` without an `else` still gets a branch location for the implicit
+    // else, and istanbul's `cloneLocation(undefined)` leaves its `start.line`
+    // undefined. The patch must skip it instead of recording a phantom line.
+    const fileCoverage = libCoverage.createFileCoverage({
+      path: '/fixture.js',
+      statementMap: {
+        0: { start: { line: 10, column: 0 }, end: { line: 12, column: 1 } },
+      },
+      s: { 0: 1 },
+      fnMap: {},
+      f: {},
+      branchMap: {
+        0: {
+          loc: { start: { line: 10, column: 0 }, end: { line: 12, column: 1 } },
+          type: 'if',
+          locations: [
+            { start: { line: 10, column: 0 }, end: { line: 12, column: 1 } },
+            { start: { line: undefined, column: undefined }, end: { line: undefined, column: undefined } },
+          ],
+          line: 10,
+        },
+      },
+      b: { 0: [1, 0] },
+    })
+
+    const lineCoverage = fileCoverage.getLineCoverage()
+
+    // The implicit-else location is skipped (its undefined line would surface as
+    // a NaN line); the consequent on line 10 is still recorded.
+    assert.deepStrictEqual(Object.keys(lineCoverage), ['10'],
+      `unexpected line keys in ${inspect(lineCoverage)}`)
+    assert.strictEqual(lineCoverage[10], 1)
   })
 })

--- a/scripts/patch-istanbul-lib-coverage.js
+++ b/scripts/patch-istanbul-lib-coverage.js
@@ -11,10 +11,11 @@
  * records straight from that map, so Codecov's patch view marks those lines
  * as missing on every PR until upstream lands the fix.
  *
- * Idempotent — applies the change once, then no-ops while the sentinel
- * comment is present in the file. Fails loudly if the locked upstream code
- * shape changes so a future yarn upgrade can't silently leave the patch
- * unapplied.
+ * Idempotent — no-ops while the current sentinel is present. When the patch
+ * body changes, the bumped sentinel makes it replace a stale dd-trace-js patch
+ * in place, so existing installs self-heal on the next `prepare` instead of
+ * keeping the old body. Fails loudly only if the upstream `getLineCoverage()`
+ * shape changes, so a future yarn upgrade can't silently leave it unapplied.
  *
  * Wired to the `prepare` lifecycle so the script never fires on consumer
  * installs of the published tarball — the script itself is not in the
@@ -30,7 +31,12 @@ const path = require('node:path')
 
 // Inline marker so the script can detect a previous run without parsing the
 // whole replacement body. Bump the version suffix when the patch body changes.
-const SENTINEL = '// dd-trace-js patch v1: fold fnMap/branchMap into getLineCoverage'
+const SENTINEL = '// dd-trace-js patch v2: fold fnMap/branchMap into getLineCoverage'
+
+// Version-agnostic prefix shared by every SENTINEL. Lets the script recognise a
+// stale patch from an earlier version and replace it, rather than mistaking it
+// for an upstream shape change.
+const PATCH_MARKER = '// dd-trace-js patch'
 
 const ORIGINAL = `    getLineCoverage() {
         const statementMap = this.data.statementMap;
@@ -85,8 +91,10 @@ const REPLACEMENT = `    getLineCoverage() {
             /* istanbul ignore if: is this even possible? */
             if (!entry || !Array.isArray(entry.locations)) return;
             entry.locations.forEach((branchLoc, i) => {
-                /* istanbul ignore else: is this even possible? */
-                if (branchLoc && branchLoc.start) {
+                // An \`if\` without an \`else\` still records a location for the
+                // implicit else; istanbul leaves its start.line undefined, which
+                // would otherwise land as a NaN line in the lcov report.
+                if (typeof branchLoc?.start?.line === 'number') {
                     record(branchLoc.start.line, counts[i] | 0);
                 }
             });
@@ -94,6 +102,11 @@ const REPLACEMENT = `    getLineCoverage() {
 
         return lineMap;
     }`
+
+// Matches the whole `getLineCoverage()` method, pristine or already patched, so
+// a body change can be swapped in place. The closing `}` is the only one at the
+// method's 4-space indentation; inner blocks close deeper.
+const GET_LINE_COVERAGE_RE = /^ {4}getLineCoverage\(\) \{\n[\s\S]*?\n {4}\}/m
 
 /**
  * @param {string} message
@@ -144,7 +157,20 @@ if (source.includes(SENTINEL)) {
   return
 }
 
-if (!source.includes(ORIGINAL)) {
+const existing = source.match(GET_LINE_COVERAGE_RE)
+if (existing === null) {
+  fail(
+    `refusing to patch ${relativeTarget}: could not locate getLineCoverage(). ` +
+    'Re-verify the patch against the new upstream code before bumping istanbul-lib-coverage.'
+  )
+  return
+}
+
+// Pristine upstream must match byte-for-byte; anything else without our marker
+// means the upstream shape changed and the patch needs re-verifying. A body
+// carrying the marker is an earlier patch version and is replaced in place.
+const current = existing[0]
+if (current !== ORIGINAL && !current.includes(PATCH_MARKER)) {
   fail(
     `refusing to patch ${relativeTarget}: upstream getLineCoverage() shape has changed. ` +
     'Re-verify the patch against the new upstream code before bumping istanbul-lib-coverage.'
@@ -152,5 +178,5 @@ if (!source.includes(ORIGINAL)) {
   return
 }
 
-fs.writeFileSync(targetFile, source.replace(ORIGINAL, REPLACEMENT))
+fs.writeFileSync(targetFile, source.replace(current, REPLACEMENT))
 log(`patched ${relativeTarget}`)


### PR DESCRIPTION
## Summary

The patched `getLineCoverage()` recorded every branch location, but an `if` without an `else` carries an implicit-else location whose `start.line` is undefined. That landed an `undefined` line key in the map, which the lcov reporter wrote as `DA:undefined,0` and the text report rendered as `NaN` uncovered lines in the coverage overview. The branch loop now records a location only when its line is numeric.

Bumping the sentinel to v2 would otherwise fail loudly on installs still carrying the v1 body, so the script matches the whole `getLineCoverage()` method and replaces a stale dd-trace-js patch in place. Existing installs self-heal on the next `prepare`; a genuine upstream shape change still fails loudly.

## Test plan

- New regression in `integration-tests/coverage-child-process.spec.js` builds a `FileCoverage` with an implicit-else branch and asserts the patched `getLineCoverage()` emits only the real source line. Fails on `master`, passes here.

Refs: https://github.com/istanbuljs/istanbuljs/issues/809