### PR TITLE
bench(sirun): add startup-share guard for loop benchmarks

### DIFF
--- a/benchmark/sirun/startup-guard.js
+++ b/benchmark/sirun/startup-guard.js
@@ -1,0 +1,51 @@
+'use strict'
+
+// Startup-share guard. Require this FIRST in a loop benchmark so START captures
+// the file's load time (the heavy requires that follow, especially the tracer).
+// Call loopStart() right before the measured loop and done() right after it (for
+// async loops, call done() from the completion callback). done() fails the run
+// if load+setup grew past the allowed share of the total, which is the recurring
+// way a bench rots into measuring startup instead of its hot path.
+//
+//   const guard = require('../startup-guard')
+//   // ...requires, setup...
+//   guard.loopStart()
+//   for (...) { ... }
+//   guard.done()            // default 10% ceiling
+//   guard.done(0.15)        // relaxed ceiling when the loop legitimately can't dominate further
+
+const assert = require('node:assert/strict')
+
+const START = process.hrtime.bigint()
+let loopStartedAt
+
+function loopStart () {
+  loopStartedAt = process.hrtime.bigint()
+}
+
+function done (maxShare = 0.10) {
+  const end = process.hrtime.bigint()
+  assert.ok(loopStartedAt !== undefined, 'startup-guard: loopStart() was never called')
+  const total = Number(end - START)
+  const startup = Number(loopStartedAt - START)
+  const share = total === 0 ? 1 : startup / total
+
+  // Report mode (used by the overview collector): write the share to the given
+  // file and skip the assertion, so a high-startup variant still reports instead
+  // of crashing the data run. Off in normal/CI runs, where the assertion gates.
+  const reportPath = process.env.STARTUP_GUARD_REPORT
+  if (reportPath) {
+    try {
+      require('fs').writeFileSync(reportPath, share.toFixed(4))
+    } catch {}
+    return
+  }
+
+  assert.ok(
+    share <= maxShare,
+    `startup-guard: load+setup was ${(share * 100).toFixed(1)}% of the run ` +
+    `(max ${(maxShare * 100).toFixed(0)}%); grow the loop or load fewer modules up front`
+  )
+}
+
+module.exports = { loopStart, done }


### PR DESCRIPTION
## Summary

Adds the startup-share guard the loop benchmarks require: it captures load time at require, the loop boundary at `loopStart()`, and fails a run when load+setup exceeds the allowed share of the total run — the recurring way a loop bench rots into measuring startup instead of its hot path.

The per-benchmark PRs stack on this branch.