### PR TITLE
bench(pg): real-world pg query instrumentation bench

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-pino/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-q/ @DataDog/apm-idm-js
 /benchmark/sirun/url/ @DataDog/apm-idm-js

--- a/benchmark/sirun/plugin-pg/README.md
+++ b/benchmark/sirun/plugin-pg/README.md
@@ -1,0 +1,5 @@
+Measures the per-query DBM comment injection for postgres: `injectDbmQuery` ->
+`createDbmComment` builds the Datadog Block Monitoring SQL comment and splices it
+onto the query. The `service` variant is the common cached-prefix mode; `full`
+adds sampling and a real traceparent per query. Drives the real plugin and span
+context so encode/getTags/toTraceparent run as in production.

--- a/benchmark/sirun/plugin-pg/index.js
+++ b/benchmark/sirun/plugin-pg/index.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const PGPlugin = require('../../../packages/datadog-plugin-pg/src/index')
+const DatadogSpanContext = require('../../../packages/dd-trace/src/opentracing/span_context')
+const id = require('../../../packages/dd-trace/src/id')
+const { AUTO_KEEP } = require('../../../ext/priority')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 6_000_000
+
+// Every traced pg query reaches injectDbmQuery -> createDbmComment, which builds
+// the Datadog Block Monitoring SQL comment and splices it onto the query. This
+// is the dbm hot path. Subclass the real plugin so configure() bakes the
+// dde/ddps/ddpv fragments and the prefix cache exactly as in production, then
+// drive createDbmComment / injectDbmQuery directly with a real span context.
+class BenchedPGPlugin extends PGPlugin {
+  addTraceSubs () { /* skip diagnostic-channel subscriptions */ }
+  serviceName () { return 'pg-prod' }
+  getPeerService () {}
+}
+
+const tracer = {
+  _env: 'production',
+  _service: 'web-app',
+  _version: '1.2.3',
+}
+const tracerConfig = { spanComputePeerService: false }
+const plugin = new BenchedPGPlugin(tracer, tracerConfig)
+plugin.configure({
+  enabled: true,
+  service: 'pg-prod',
+  dbmPropagationMode: VARIANT === 'disabled' ? 'disabled' : (VARIANT === 'full' ? 'full' : 'service'),
+  appendComment: false,
+  truncate: 5000,
+})
+
+// A real span context so createDbmComment runs the production getTags / encode /
+// (full mode) toTraceparent path. A minimal span wrapper exposes the surface the
+// DBM code touches: context(), setTag(), _spanContext, _processor.sample().
+const spanContext = new DatadogSpanContext({
+  traceId: id('1234567890abcdef', 16),
+  spanId: id('abcdef1234567890', 16),
+  tags: { 'db.name': 'orders', 'out.host': 'pg-primary.internal' },
+})
+spanContext._sampling.priority = AUTO_KEEP
+spanContext._trace.tags['_dd.p.tid'] = '640cfd8d00000000'
+
+const span = {
+  _spanContext: spanContext,
+  _processor: { sample () {} },
+  context () { return spanContext },
+  setTag (key, value) { spanContext.setTag(key, value) },
+}
+
+const QUERY = 'SELECT id, user_id, total, status FROM orders WHERE user_id = $1 AND status = $2'
+
+function injectOnce () {
+  return plugin.injectDbmQuery(span, QUERY, 'pg-prod', false)
+}
+
+// Preflight: confirm the comment was actually spliced (or, for disabled, that
+// the query is returned untouched), so a refactor cannot silently no-op it.
+const sample = injectOnce()
+if (VARIANT === 'disabled') {
+  assert.equal(sample, QUERY, 'disabled mode should return the query untouched')
+} else {
+  assert.ok(sample.includes("dddb='orders'") && sample.length > QUERY.length,
+    'injectDbmQuery did not splice the dbm comment')
+}
+
+guard.loopStart()
+let sink = 0
+if (VARIANT === 'full') {
+  // Production builds a new span per query, so toTraceparent() formats freshly
+  // generated identifiers each time. Swapping in new ids per iteration keeps the
+  // hex computation unwarmed; a single reused context would memoize toString(16)
+  // after the first call and measure cached lookups instead of the real cost.
+  for (let i = 0; i < ITERATIONS; i++) {
+    spanContext._traceId = id()
+    spanContext._spanId = id()
+    sink += injectOnce().length
+  }
+} else {
+  for (let i = 0; i < ITERATIONS; i++) {
+    sink += injectOnce().length
+  }
+}
+guard.done()
+
+if (sink === 0) throw new Error('unreachable')

--- a/benchmark/sirun/plugin-pg/meta.json
+++ b/benchmark/sirun/plugin-pg/meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "plugin-pg",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 10,
+  "instructions": true,
+  "variants": {
+    "service": {
+      "env": { "VARIANT": "service", "ITERATIONS": "6000000" }
+    },
+    "full": {
+      "env": { "VARIANT": "full", "ITERATIONS": "6000000" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

New sirun bench for the pg plugin's per-query tracer overhead (start hook: query normalization, statement tagging, DBM propagation).

## Test plan

- [ ] The microbenchmark shard containing this bench runs green.