### PR TITLE
bench(kafkajs): kafkajs and data-streams checkpoint benches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-pino/ @DataDog/apm-idm-js

--- a/benchmark/sirun/datastreams/index.js
+++ b/benchmark/sirun/datastreams/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
 
 // `DataStreamsProcessor` registers a `beforeExit` handler on the dd-trace global,
 // which the tracer normally provides at init. Stub the minimal shape so the bench
@@ -104,6 +105,7 @@ for (let carrierIndex = 0; carrierIndex < 50; carrierIndex++) {
 assert.ok(processor.buckets.size > 0, 'no DSM bucket created')
 assert.ok(CONSUME_CARRIERS[0]['dd-pathway-ctx-base64'], 'codec did not inject pathway header')
 
+guard.loopStart()
 if (VARIANT === 'consume') {
   for (let iteration = 0; iteration < ITERATIONS; iteration++) {
     const carrier = CONSUME_CARRIERS[iteration % CONSUME_CARRIERS.length]
@@ -152,3 +154,4 @@ if (VARIANT === 'consume') {
     DsmPathwayCodec.encode(ctx, {})
   }
 }
+guard.done()

--- a/benchmark/sirun/datastreams/meta.json
+++ b/benchmark/sirun/datastreams/meta.json
@@ -3,13 +3,13 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 30,
+  "iterations": 20,
   "instructions": true,
   "variants": {
     "produce": { "env": { "VARIANT": "produce" } },
     "consume": { "env": { "VARIANT": "consume" } },
-    "produce-with-message-size": { "baseline": "produce", "env": { "VARIANT": "produce-with-message-size" } },
-    "produce-manual-checkpoint": { "baseline": "produce", "env": { "VARIANT": "produce-manual-checkpoint" } },
-    "produce-high-cardinality": { "baseline": "produce", "env": { "VARIANT": "produce-high-cardinality" } }
+    "produce-with-message-size": { "env": { "VARIANT": "produce-with-message-size" } },
+    "produce-manual-checkpoint": { "env": { "VARIANT": "produce-manual-checkpoint" } },
+    "produce-high-cardinality": { "env": { "VARIANT": "produce-high-cardinality" } }
   }
 }

--- a/benchmark/sirun/plugin-kafkajs/README.md
+++ b/benchmark/sirun/plugin-kafkajs/README.md
@@ -1,0 +1,6 @@
+Measures the per-message Data Streams Monitoring hot path for the kafkajs
+producer: `getMessageSize` plus `DsmPathwayCodec.encode`, which varint-encodes
+the pathway context into a reused scratch buffer and base64s it into the message
+headers. Variants cover a small keyed message, a larger message with user
+headers, and a mixed batch. Header trace-context injection is covered by the
+propagation bench and is not duplicated here.

--- a/benchmark/sirun/plugin-kafkajs/index.js
+++ b/benchmark/sirun/plugin-kafkajs/index.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const { DsmPathwayCodec, getMessageSize } = require('../../../packages/dd-trace/src/datastreams')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 8_000_000
+
+// With Data Streams Monitoring enabled, every produced kafka message runs
+// getMessageSize then DsmPathwayCodec.encode, which varint-encodes the pathway
+// context into a reused scratch buffer and base64s it into the message headers.
+// This is the per-message DSM hot path. The header trace-context injection is
+// already covered by the propagation bench, so it is not duplicated here.
+const dataStreamsContext = {
+  hash: Buffer.from('0123456789abcdef', 'hex'),
+  pathwayStartNs: 1_716_950_000_000_000_000,
+  edgeStartNs: 1_716_950_000_500_000_000,
+}
+
+// Representative produced messages: a small JSON value with a key (the common
+// case) and a larger value with a couple of user headers.
+const SMALL = {
+  key: 'user-1234567',
+  value: '{"event":"order_created","order_id":987654,"total":42.5}',
+  headers: {},
+}
+const LARGE = {
+  key: 'session-abcdef0123456789',
+  value: JSON.stringify({ event: 'page_view', path: '/api/v2/products', meta: 'x'.repeat(400) }),
+  headers: { 'correlation-id': 'c-12345', source: 'web' },
+}
+
+const FIXTURES = {
+  small: [SMALL],
+  large: [LARGE],
+  mixed: [SMALL, LARGE, SMALL],
+}
+
+const messages = FIXTURES[VARIANT]
+assert.ok(messages, `unknown VARIANT: ${VARIANT}`)
+
+// Fresh headers per message each iteration: encode writes a key into the carrier,
+// matching the per-produce carrier the plugin hands it.
+function encodeOnce (message) {
+  const carrier = {}
+  const size = getMessageSize(message)
+  DsmPathwayCodec.encode(dataStreamsContext, carrier)
+  return size + Object.keys(carrier).length
+}
+
+// Preflight: confirm encode actually wrote the pathway key.
+const probe = {}
+DsmPathwayCodec.encode(dataStreamsContext, probe)
+assert.ok(Object.keys(probe).length === 1, 'DsmPathwayCodec.encode did not write the carrier')
+
+guard.loopStart()
+let sink = 0
+const len = messages.length
+for (let i = 0; i < ITERATIONS; i++) {
+  sink += encodeOnce(messages[i % len])
+}
+guard.done()
+
+if (sink === 0) throw new Error('unreachable')

--- a/benchmark/sirun/plugin-kafkajs/meta.json
+++ b/benchmark/sirun/plugin-kafkajs/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "plugin-kafkajs",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 15,
+  "instructions": true,
+  "variants": {
+    "small": {
+      "env": { "VARIANT": "small", "ITERATIONS": "8500000" }
+    },
+    "large": {
+      "env": { "VARIANT": "large", "ITERATIONS": "5500000" }
+    },
+    "mixed": {
+      "env": { "VARIANT": "mixed", "ITERATIONS": "7000000" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

New kafkajs producer/consumer bench plus data-streams (DSM) checkpoint tuning -- the per-message pathway-hash and checkpoint overhead.

## Test plan

- [ ] The microbenchmark shard(s) containing these benches run green.