### PR TITLE
bench(encoders): tune the encoding and exporting-pipeline benches

### DIFF
--- a/benchmark/sirun/encoding/README.md
+++ b/benchmark/sirun/encoding/README.md
@@ -1,36 +1,9 @@
-This bench sends a single pre-formatted trace through the encoder many times
-with a null writer, so all I/O is excluded and the cost being measured is the
-encoder itself.
-
-The trace shape (`trace-fixture.js`) mirrors a typical Node.js HTTP-service
-request: one root Express server span plus a fan of internal middleware spans,
-Postgres / Redis client spans, a few outbound HTTP client spans, DNS lookups,
-and one error-bearing span with `error.message` / `error.stack`. The default
-trace has 30 spans; `TRACE_SPANS=<n>` scales the composition proportionally.
-
-Strings reuse the same keys (`span.kind`, `component`, `runtime-id`, …) and
-the same hot values (`GET`, `server`, `client`, `internal`, `javascript`, …)
-across spans, mirroring what the encoder's string cache sees in production.
-
-`tickTrace(trace, iteration)` runs before every encode and rewrites the
-per-request dynamic fields in place: `start` nanos and `duration`
-advance, the low half of every ID buffer is rewritten, `db.row_count`
-on the Postgres spans jitters, the root span rotates through eight
-coherent request shapes (route / URL / resource / status / client IP),
-and the error span rotates through four type/message/stack variants
-(each stack ~1.5 KB). Without that, every iteration encodes
-byte-identical data and V8 collapses the integer magnitude branches
-plus the stale-string cache hits the encoder is meant to exercise.
-`attachFreshEvents` does the same for `span_events` (legacy path).
-
-The `+ iteration * 4096` step on `span.start` is well above the
-IEEE-754 double's ULP at the ~1.7e18 nano-timestamp magnitude (256
-nanos); fixing that precision loss properly needs the span to carry
-`start` as a `BigInt` instead of a `Number`, which is a separate
-change on the tracer side, not here.
-
-Variants:
-
-- `0.4` / `0.5` — wire-format variants of the agent encoder.
-- `0.4-events-native` / `0.4-events-legacy` / `0.5-events-legacy` —
-  exercise the span-event encoding paths (`WITH_SPAN_EVENTS`).
+Measures the agent trace encoder in isolation: a pre-built trace is encoded many
+times through a null writer so only the encoder cost is measured. The fixture
+(`trace-fixture.js`) mirrors a typical Node.js HTTP-service request (~30 spans:
+an Express root, middleware, Postgres/Redis/HTTP-client/DNS spans, one error
+span) with reused keys and hot values to match the encoder's string cache.
+`tickTrace` rewrites the per-request dynamic fields before each encode so V8 does
+not collapse the magnitude branches and stale-cache hits the encoder must
+exercise. `TRACE_SPANS=<n>` scales the trace; variants `0.4`/`0.5` cover the wire
+formats and the `*-events-*` variants the span-event paths.

--- a/benchmark/sirun/encoding/index.js
+++ b/benchmark/sirun/encoding/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
 
 const {
   ENCODER_VERSION,
@@ -8,11 +9,26 @@ const {
   TRACE_SPANS,
 } = process.env
 
+const WIDE_TAGS = Number(process.env.WIDE_TAGS) || 0
+const ENCODE_COUNT = Number(process.env.ENCODE_COUNT) || 5000
+
 const { AgentEncoder } = require(`../../../packages/dd-trace/src/encode/${ENCODER_VERSION}`)
 const { buildTrace, tickTrace, attachFreshEvents } = require('./trace-fixture')
 
 const writer = { flush: () => {} }
 const trace = buildTrace(TRACE_SPANS ? Number(TRACE_SPANS) : 30)
+
+// Wide-meta variant: append synthetic custom tags to every span so the encoder's
+// per-tag meta-map loop (key + value write, string-cache lookup) dominates over
+// the fixed ~15 production tags. Static values match the production cache-hit
+// pattern for repeated custom keys.
+if (WIDE_TAGS > 0) {
+  for (const span of trace) {
+    for (let i = 0; i < WIDE_TAGS; i++) {
+      span.meta[`custom.tag.${i.toString().padStart(2, '0')}`] = `value-${i}`
+    }
+  }
+}
 
 const encoder = new AgentEncoder(writer)
 
@@ -25,15 +41,17 @@ assert.equal(encoder.count(), 1)
 assert.ok(encoder._traceBytes.length > 0)
 encoder._reset()
 
+guard.loopStart()
 if (WITH_SPAN_EVENTS === 'none') {
-  for (let iteration = 0; iteration < 5000; iteration++) {
+  for (let iteration = 0; iteration < ENCODE_COUNT; iteration++) {
     tickTrace(trace, iteration)
     encoder.encode(trace)
   }
 } else {
-  for (let iteration = 0; iteration < 5000; iteration++) {
+  for (let iteration = 0; iteration < ENCODE_COUNT; iteration++) {
     tickTrace(trace, iteration)
     attachFreshEvents(trace, iteration)
     encoder.encode(trace)
   }
 }
+guard.done()

--- a/benchmark/sirun/encoding/meta.json
+++ b/benchmark/sirun/encoding/meta.json
@@ -4,41 +4,59 @@
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
   "instructions": true,
-  "iterations": 10,
+  "iterations": 20,
   "variants": {
     "0.4": {
       "env": {
         "ENCODER_VERSION": "0.4",
-        "WITH_SPAN_EVENTS": "none"
+        "WITH_SPAN_EVENTS": "none",
+        "ENCODE_COUNT": "31000"
       }
     },
     "0.5": {
       "env": {
         "ENCODER_VERSION": "0.5",
-        "WITH_SPAN_EVENTS": "none"
+        "WITH_SPAN_EVENTS": "none",
+        "ENCODE_COUNT": "60000"
       }
     },
     "0.4-events-native": {
-      "baseline": "0.4",
       "env": {
         "ENCODER_VERSION": "0.4",
         "WITH_SPAN_EVENTS": "native",
-        "DD_TRACE_NATIVE_SPAN_EVENTS": "true"
+        "DD_TRACE_NATIVE_SPAN_EVENTS": "true",
+        "ENCODE_COUNT": "13000"
       }
     },
     "0.4-events-legacy": {
-      "baseline": "0.4",
       "env": {
         "ENCODER_VERSION": "0.4",
         "WITH_SPAN_EVENTS": "legacy",
-        "DD_TRACE_NATIVE_SPAN_EVENTS": "false"
+        "DD_TRACE_NATIVE_SPAN_EVENTS": "false",
+        "ENCODE_COUNT": "10500"
       }
     },
     "0.5-events-legacy": {
-      "baseline": "0.5",
       "env": {
         "ENCODER_VERSION": "0.5",
-        "WITH_SPAN_EVENTS": "legacy"
+        "WITH_SPAN_EVENTS": "legacy",
+        "ENCODE_COUNT": "15000"
+      }
+    },
+    "0.4-wide-tags": {
+      "env": {
+        "ENCODER_VERSION": "0.4",
+        "WITH_SPAN_EVENTS": "none",
+        "WIDE_TAGS": "40",
+        "ENCODE_COUNT": "11000"
+      }
+    },
+    "0.5-wide-tags": {
+      "env": {
+        "ENCODER_VERSION": "0.5",
+        "WITH_SPAN_EVENTS": "none",
+        "WIDE_TAGS": "40",
+        "ENCODE_COUNT": "19000"
       }
     }
   }

--- a/benchmark/sirun/exporting-pipeline/README.md
+++ b/benchmark/sirun/exporting-pipeline/README.md
@@ -1,7 +1,9 @@
-This test creates a 30 span trace (of similar format to the encoding test).
-These spans are then passed through the formatting, encoding, and writing steps
-in our pipeline, and sent to a dummy agent. Once a span (i.e. a trace) is added
-to the exporter, we then proceed to the next iteration via `setImmediate`, and
-run for many iterations.
+Measures the front of the export pipeline: `SpanProcessor.process` runs priority
+and span sampling, then `spanFormat` turns each finished span into its wire
+shape. A no-op exporter receives the formatted chunk so the loop stays CPU-bound
+with flat memory.
 
-There's a variant for each of our encodings/endpoints.
+The encoder and the agent socket are out of scope on purpose: `encoding` covers
+the encoder, and the real flush is a deferred `unref`'d timer that barely fires
+in a short run. Variants toggle the stats (DSM) path and the span-links/events
+formatting path, both of which run in `process`.

--- a/benchmark/sirun/exporting-pipeline/index.js
+++ b/benchmark/sirun/exporting-pipeline/index.js
@@ -1,30 +1,48 @@
 'use strict'
 
-// TODO: Update setup script to not leave agent process running in background.
-
 const assert = require('node:assert/strict')
 
 // Entry point normally primes this; bench imports src directly.
 globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
 
 const hostname = require('os').hostname()
+const guard = require('../startup-guard')
 const SpanProcessor = require('../../../packages/dd-trace/src/span_processor')
-const Exporter = require('../../../packages/dd-trace/src/exporters/agent/index')
 const PrioritySampler = require('../../../packages/dd-trace/src/priority_sampler')
 const id = require('../../../packages/dd-trace/src/id')
-const { defaults } = require('../../../packages/dd-trace/src/config/defaults')
 
-const config = {
-  url: `http://${defaults.hostname}:${defaults.port}`,
-  flushInterval: 1000,
-  flushMinSpans: 100,
-  protocolVersion: process.env.ENCODER_VERSION,
-  stats: {
-    enabled: process.env.WITH_STATS === '1',
-  },
+// Measures the front of the export pipeline: SpanProcessor.process -> priority
+// and span sampling -> spanFormat (span -> wire shape). The encoder and the
+// agent socket are out of scope on purpose: encode is covered by the `encoding`
+// bench, and the real flush is a deferred unref'd timer that barely fires in a
+// short run. A no-op exporter keeps the loop CPU-bound, leaves memory flat (the
+// formatted chunk is discarded each pass) and drops the agent dependency.
+const COUNT = Number(process.env.COUNT) || 200_000
+const WITH_STATS = process.env.WITH_STATS === '1'
+const WITH_LINKS = process.env.WITH_LINKS === '1'
+
+// Span link + events fixture for the links-and-events variant. spanFormat
+// serializes links into meta['_dd.span_links'] and maps events onto span_events
+// for every formatted span -- otel-era paths the plain shape never hits.
+const LINK_CONTEXT = {
+  toTraceId: () => '1234567890abcdef1234567890abcdef',
+  toSpanId: () => 'abcdef1234567890',
+  _sampling: { priority: 1 },
 }
+const LINK_ATTRIBUTES = { 'link.kind': 'fork', priority: 1, ok: true }
+const SPAN_EVENTS = [
+  { name: 'http.attempt', startTime: 1_415_926.5, attributes: { attempt: 1, ok: true, code: 200 } },
+  { name: 'db.query', startTime: 1_415_927, attributes: { rows: 17 } },
+]
+
+let exported = 0
+let lastFormatted
+const exporter = { export (formatted) { exported += formatted.length; lastFormatted = formatted } }
 const prioritySampler = new PrioritySampler()
-const exporter = new Exporter(config, prioritySampler)
+const config = {
+  flushMinSpans: 100,
+  stats: { enabled: WITH_STATS },
+}
 const sp = new SpanProcessor(exporter, prioritySampler, config)
 
 const finished = []
@@ -58,6 +76,10 @@ function createSpan (parent) {
     _startTime: 1415926,
     _duration: 100,
   }
+  if (WITH_LINKS) {
+    span._links = [{ context: LINK_CONTEXT, attributes: LINK_ATTRIBUTES }]
+    span._events = SPAN_EVENTS
+  }
   finished.push(span)
   return span
 }
@@ -66,18 +88,26 @@ for (let i = 0, parent = null; i < 30; i++) {
   parent = createSpan(parent)
 }
 
-const writerCountBefore = exporter._writer?._encoder?.count?.() ?? 0
+// Pre-flight: one pass must format and hand the whole 30-span chunk to the
+// exporter; a broken format path would otherwise measure a near-empty loop.
+trace.started = finished
+trace.finished = finished
 sp.process(finished[0])
-const writerCountAfter = exporter._writer?._encoder?.count?.() ?? 0
-assert.ok(writerCountAfter > writerCountBefore, 'span processor did not advance encoder count')
-
-let iterations = 1
-function processSpans () {
-  sp.process(finished[0])
-  trace.finished = finished
-  trace.started = finished
-  if (++iterations < 250) {
-    setImmediate(processSpans)
-  }
+assert.equal(exported, 30, 'span processor did not format and export the chunk')
+if (WITH_LINKS) {
+  assert.ok(lastFormatted[0].meta['_dd.span_links'], 'span links were not formatted')
+  assert.ok(lastFormatted[0].span_events?.length, 'span events were not formatted')
 }
-processSpans()
+
+guard.loopStart()
+exported = 0
+for (let i = 0; i < COUNT; i++) {
+  // process() erases trace.finished each pass; restore the chunk so every
+  // iteration formats the full set.
+  trace.started = finished
+  trace.finished = finished
+  sp.process(finished[0])
+}
+
+assert.ok(exported > 0, 'export loop produced no formatted spans')
+guard.done()

--- a/benchmark/sirun/exporting-pipeline/meta.json
+++ b/benchmark/sirun/exporting-pipeline/meta.json
@@ -1,34 +1,28 @@
 {
   "name": "exporting-pipeline",
-  "setup": "bash -c \"nohup node ../../e2e/fake-agent.js >/dev/null 2>&1 &\"",
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
-  "iterations": 100,
+  "iterations": 20,
   "instructions": true,
   "cachegrind": false,
   "variants": {
-    "0.4": {
+    "format": {
       "env": {
-        "ENCODER_VERSION": "0.4",
-        "WITH_STATS": "0"
+        "WITH_STATS": "0",
+        "COUNT": "200000"
       }
     },
-    "0.5": {
+    "format-with-stats": {
       "env": {
-        "ENCODER_VERSION": "0.5",
-        "WITH_STATS": "0"
+        "WITH_STATS": "1",
+        "COUNT": "200000"
       }
     },
-    "0.4_with_stats": {
+    "format-with-links-events": {
       "env": {
-        "ENCODER_VERSION": "0.4",
-        "WITH_STATS": "1"
-      }
-    },
-    "0.5_with_stats": {
-      "env": {
-        "ENCODER_VERSION": "0.5",
-        "WITH_STATS": "1"
+        "WITH_STATS": "0",
+        "WITH_LINKS": "1",
+        "COUNT": "85000"
       }
     }
   }


### PR DESCRIPTION
## Summary

Two trace-serialization benches brought under the per-variant runtime budget:

- encoding: add the startup guard and scale per-variant `ENCODE_COUNT` so each variant targets ~1 minute while the encode loop stays dominant.
- exporting-pipeline: drop the fake-agent setup for a CPU-only guarded `COUNT` loop, replacing the 0.4/0.5 split with `format` / `format-with-stats`.