### PR TITLE
test(ci): harden sandbox cleanup

### DIFF
--- a/integration-tests/helpers/index.js
+++ b/integration-tests/helpers/index.js
@@ -629,6 +629,9 @@ async function createSandbox (
 
   if (isGitRepo) {
     execHelper('git init', { cwd: folder })
+    // These sandboxes are removed right after tests, so disable detached Git maintenance in them.
+    execHelper('git config gc.auto 0', { cwd: folder })
+    execHelper('git config maintenance.auto false', { cwd: folder })
     await fs.writeFile(path.join(folder, '.gitignore'), 'node_modules/', { flush: true })
     execHelper('git config user.email "john@doe.com"', { cwd: folder })
     execHelper('git config user.name "John Doe"', { cwd: folder })
@@ -638,6 +641,9 @@ async function createSandbox (
     const localRemotePath = path.join(folder, '..', `${path.basename(folder)}-remote.git`)
     if (!existsSync(localRemotePath)) {
       execHelper(`git init --bare ${localRemotePath}`)
+      // Keep the temporary bare remote from starting detached maintenance during local pushes.
+      execHelper(`git --git-dir=${localRemotePath} config gc.auto 0`)
+      execHelper(`git --git-dir=${localRemotePath} config maintenance.auto false`)
     }
 
     execHelper('git add -A', { cwd: folder })


### PR DESCRIPTION
### What does this PR do?

Disables Git auto-maintenance for integration-test sandbox Git repositories and their temporary bare remotes. The helper still removes sandboxes through the existing `execHelper` shell commands (`rm -rf` on Unix, `Remove-Item` on Windows), preserving older Node.js support for `integration-guardrails`.

### Motivation

Two Test Optimization integration jobs failed after the `git-cache` assertions had already passed, during the shared sandbox `after all` cleanup:

- [Test Optimization / integration (node-latest)](https://github.com/DataDog/dd-trace-js/actions/runs/26656430625/job/78567641050)
- [Test Optimization / integration (node-oldest)](https://github.com/DataDog/dd-trace-js/actions/runs/26512877771/job/78081712734)

Both failures happened while deleting a temporary Git repository and surfaced as transient `Directory not empty` errors under `.git`.

Git Trace2 reproduced the behavior locally: sandbox commits and local pushes can spawn detached `git maintenance run --auto --detach` work. That background process may still be touching `.git` when the shared `after all` hook removes the sandbox. Retrying deletion would hide the symptom, but the better fit for these tests is to prevent the throwaway repositories from starting background maintenance at all. The repositories are created only for the test, pushed to local temporary remotes, and deleted immediately, so automatic maintenance has no useful work to preserve here.

### Additional Notes

The change sets `gc.auto=0` and `maintenance.auto=false` on both the worktree repo and the bare remote as soon as they are initialized. This keeps teardown deterministic while leaving the existing `exec` cleanup path intact for older Node.js compatibility. A focused Trace2 run after the change shows those configs being applied and no remaining detached maintenance child process from the `git-cache` test.