### PR TITLE
fix(aiguard): Use abortController instead of promise resolve/reject

### DIFF
--- a/packages/datadog-instrumentations/src/ai.js
+++ b/packages/datadog-instrumentations/src/ai.js
@@ -2,8 +2,8 @@
 
 const { channel, tracingChannel } = require('dc-polyfill')
 const shimmer = require('../../datadog-shimmer')
-const { addHook, getHooks } = require('./helpers/instrument')
 const { convertVercelPromptToMessages, buildOutputMessages } = require('./helpers/ai-messages')
+const { addHook, getHooks } = require('./helpers/instrument')
 
 const vercelAiTracingChannel = tracingChannel('dd-trace:vercel-ai')
 const vercelAiSpanSetAttributesChannel = channel('dd-trace:vercel-ai:span:setAttributes')
@@ -15,12 +15,21 @@ const wrappedModels = new WeakSet()
 /**
  * Publishes already-converted AI-style messages to the AI Guard evaluation channel.
  *
+ * Subscribers push async work into `pending` and abort `abortController` to block.
+ *
  * @param {Array<object>} messages - AI-style messages to evaluate.
  * @returns {Promise<void>}
  */
 function publishEvaluation (messages) {
-  return new Promise((resolve, reject) => {
-    aiguardChannel.publish({ messages, integration: 'ai', resolve, reject })
+  const abortController = new AbortController()
+  const ctx = { messages, integration: 'ai', abortController, pending: [] }
+
+  aiguardChannel.publish(ctx)
+
+  return Promise.all(ctx.pending).then(() => {
+    if (abortController.signal.aborted) {
+      throw abortController.signal.reason
+    }
   })
 }
 

--- a/packages/datadog-instrumentations/src/helpers/openai-ai-guard.js
+++ b/packages/datadog-instrumentations/src/helpers/openai-ai-guard.js
@@ -29,12 +29,21 @@ const aiguardChannel = dc.channel('dd-trace:ai:aiguard')
 /**
  * Publishes already-converted AI-style messages to the AI Guard evaluation channel.
  *
+ * Subscribers push async work into `pending` and abort `abortController` to block.
+ *
  * @param {Array<object>} messages - AI-style messages to evaluate.
  * @returns {Promise<void>}
  */
 function publishEvaluation (messages) {
-  return new Promise((resolve, reject) => {
-    aiguardChannel.publish({ messages, integration: 'openai', resolve, reject })
+  const abortController = new AbortController()
+  const ctx = { messages, integration: 'openai', abortController, pending: [] }
+
+  aiguardChannel.publish(ctx)
+
+  return Promise.all(ctx.pending).then(() => {
+    if (abortController.signal.aborted) {
+      throw abortController.signal.reason
+    }
   })
 }
 

--- a/packages/datadog-instrumentations/test/ai.spec.js
+++ b/packages/datadog-instrumentations/test/ai.spec.js
@@ -36,8 +36,8 @@ function readStream (stream) {
 function subscribeAutoResolve () {
   const calls = []
   const handler = ctx => {
-    calls.push({ messages: ctx.messages })
-    ctx.resolve()
+    calls.push(ctx)
+    ctx.pending.push(Promise.resolve())
   }
   evaluateChannel.subscribe(handler)
   return { calls, unsubscribe: () => evaluateChannel.unsubscribe(handler) }
@@ -45,9 +45,23 @@ function subscribeAutoResolve () {
 
 function subscribeAutoReject () {
   const err = Object.assign(new Error(), { name: 'AIGuardAbortError', reason: 'blocked' })
-  const handler = ctx => ctx.reject(err)
+  const handler = ctx => {
+    ctx.abortController.abort(err)
+    ctx.pending.push(Promise.resolve())
+  }
   evaluateChannel.subscribe(handler)
   return { err, unsubscribe: () => evaluateChannel.unsubscribe(handler) }
+}
+
+function subscribeAbortOnCall (abortOnCall, err) {
+  let callCount = 0
+  const handler = ctx => {
+    callCount++
+    if (callCount === abortOnCall) ctx.abortController.abort(err)
+    ctx.pending.push(Promise.resolve())
+  }
+  evaluateChannel.subscribe(handler)
+  return () => evaluateChannel.unsubscribe(handler)
 }
 
 describe('wrapModelWithAIGuard', () => {
@@ -110,6 +124,10 @@ describe('wrapModelWithAIGuard', () => {
         .then(() => {
           assert.strictEqual(calls.length, 1)
           assert.deepStrictEqual(calls[0].messages, [{ role: 'user', content: 'Hello' }])
+          assert.ok(calls[0].abortController instanceof AbortController)
+          assert.ok(Array.isArray(calls[0].pending))
+          assert.strictEqual(Object.hasOwn(calls[0], 'resolve'), false)
+          assert.strictEqual(Object.hasOwn(calls[0], 'reject'), false)
           assert.strictEqual(llmCalledBeforeGuardResolves, true)
           sinon.assert.calledOnce(original)
         })
@@ -139,6 +157,7 @@ describe('wrapModelWithAIGuard', () => {
             { role: 'user', content: 'Hello' },
             { role: 'assistant', content: 'Hello!' },
           ])
+          assert.strictEqual(calls[1].abortController.signal.aborted, false)
         })
         .finally(unsubscribe)
     })
@@ -199,18 +218,13 @@ describe('wrapModelWithAIGuard', () => {
     })
 
     it('rejects when output evaluation rejects', () => {
-      let callCount = 0
       const err = Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' })
-      const handler = ctx => {
-        callCount++
-        callCount === 1 ? ctx.resolve() : ctx.reject(err)
-      }
-      evaluateChannel.subscribe(handler)
+      const unsubscribe = subscribeAbortOnCall(2, err)
       model.doGenerate = sinon.stub().resolves({ content: [{ type: 'text', text: 'bad' }] })
       wrapModelWithAIGuard(model)
 
       return assert.rejects(() => model.doGenerate({ prompt }), e => e === err)
-        .finally(() => evaluateChannel.unsubscribe(handler))
+        .finally(unsubscribe)
     })
 
     it('does not wrap already wrapped model', () => {
@@ -358,19 +372,14 @@ describe('wrapModelWithAIGuard', () => {
     })
 
     it('rejects when output evaluation rejects', () => {
-      let callCount = 0
       const err = Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' })
-      const handler = ctx => {
-        callCount++
-        callCount === 1 ? ctx.resolve() : ctx.reject(err)
-      }
-      evaluateChannel.subscribe(handler)
+      const unsubscribe = subscribeAbortOnCall(2, err)
       const chunks = [{ type: 'text-delta', textDelta: 'bad response' }, { type: 'finish' }]
       model.doStream = sinon.stub().resolves({ stream: makeStream(chunks) })
       wrapModelWithAIGuard(model)
 
       return assert.rejects(() => model.doStream({ prompt }), e => e === err)
-        .finally(() => evaluateChannel.unsubscribe(handler))
+        .finally(unsubscribe)
     })
   })
 })

--- a/packages/datadog-instrumentations/test/helpers/openai-ai-guard.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/openai-ai-guard.spec.js
@@ -15,8 +15,8 @@ describe('openai-ai-guard helper', () => {
   beforeEach(() => {
     calls = []
     handler = ctx => {
-      calls.push({ messages: ctx.messages, integration: ctx.integration })
-      ctx.resolve()
+      calls.push(ctx)
+      ctx.pending.push(Promise.resolve())
     }
     evaluateChannel.subscribe(handler)
   })
@@ -225,6 +225,8 @@ describe('openai-ai-guard helper', () => {
       assert.strictEqual(calls.length, 2)
       assert.deepStrictEqual(calls[0].messages.at(-1), { role: 'assistant', content: 'one' })
       assert.deepStrictEqual(calls[1].messages.at(-1), { role: 'assistant', content: 'two' })
+      assert.strictEqual(calls[0].abortController.signal.aborted, false)
+      assert.strictEqual(calls[1].abortController.signal.aborted, false)
     })
 
     it('publishes one combined evaluation for responses output items', async () => {
@@ -257,7 +259,10 @@ describe('openai-ai-guard helper', () => {
 
     it('rejects when Before Model evaluation rejects', () => {
       evaluateChannel.unsubscribe(handler)
-      const rejectHandler = ctx => ctx.reject(Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' }))
+      const rejectHandler = ctx => {
+        ctx.abortController.abort(Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' }))
+        ctx.pending.push(Promise.resolve())
+      }
       evaluateChannel.subscribe(rejectHandler)
       const guard = aiGuard.createGuard(
         'chat.completions',
@@ -302,7 +307,10 @@ describe('openai-ai-guard helper', () => {
 
     it('propagates Before Model rejection through asResponse', () => {
       evaluateChannel.unsubscribe(handler)
-      const rejectHandler = ctx => ctx.reject(Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' }))
+      const rejectHandler = ctx => {
+        ctx.abortController.abort(Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' }))
+        ctx.pending.push(Promise.resolve())
+      }
       evaluateChannel.subscribe(rejectHandler)
       const guard = aiGuard.createGuard(
         'chat.completions',

--- a/packages/datadog-instrumentations/test/openai-aiguard.spec.js
+++ b/packages/datadog-instrumentations/test/openai-aiguard.spec.js
@@ -58,8 +58,8 @@ class FakeResponses {
 function subscribeAutoResolve () {
   const calls = []
   const handler = ctx => {
-    calls.push({ messages: ctx.messages })
-    ctx.resolve()
+    calls.push(ctx)
+    ctx.pending.push(Promise.resolve())
   }
   evaluateChannel.subscribe(handler)
   return { calls, unsubscribe: () => evaluateChannel.unsubscribe(handler) }
@@ -72,6 +72,15 @@ function subscribeWithHandler (handler) {
 
 function aiGuardAbortError (message = 'blocked') {
   return Object.assign(new Error(message), { name: 'AIGuardAbortError' })
+}
+
+function allowEvaluation (ctx) {
+  ctx.pending.push(Promise.resolve())
+}
+
+function blockEvaluation (ctx, err) {
+  ctx.abortController.abort(err)
+  ctx.pending.push(Promise.resolve())
 }
 
 /**
@@ -163,6 +172,10 @@ describe('openai AI Guard instrumentation', () => {
           // Before Model + After Model (assistant responded)
           assert.strictEqual(calls.length, 2)
           assert.deepStrictEqual(calls[0].messages, messages)
+          assert.ok(calls[0].abortController instanceof AbortController)
+          assert.ok(Array.isArray(calls[0].pending))
+          assert.strictEqual(Object.hasOwn(calls[0], 'resolve'), false)
+          assert.strictEqual(Object.hasOwn(calls[0], 'reject'), false)
         })
         .finally(unsubscribe)
     })
@@ -181,6 +194,7 @@ describe('openai AI Guard instrumentation', () => {
             { role: 'user', content: 'Hi' },
             { role: 'assistant', content: 'Hello!' },
           ])
+          assert.strictEqual(calls[1].abortController.signal.aborted, false)
         })
         .finally(unsubscribe)
     })
@@ -212,7 +226,7 @@ describe('openai AI Guard instrumentation', () => {
 
     it('rejects with the AI Guard error when Before Model denies', () => {
       const err = aiGuardAbortError()
-      const unsubscribe = subscribeWithHandler(ctx => ctx.reject(err))
+      const unsubscribe = subscribeWithHandler(ctx => blockEvaluation(ctx, err))
       const completions = new Completions()
       completions._nextApiPromise = new FakeAPIPromise({ choices: [{ message: { role: 'assistant', content: 'x' } }] })
 
@@ -227,7 +241,7 @@ describe('openai AI Guard instrumentation', () => {
       const err = aiGuardAbortError()
       const unsubscribe = subscribeWithHandler(ctx => {
         count++
-        count === 1 ? ctx.resolve() : ctx.reject(err)
+        count === 1 ? allowEvaluation(ctx) : blockEvaluation(ctx, err)
       })
       const completions = new Completions()
       completions._nextApiPromise = new FakeAPIPromise({ choices: [{ message: { role: 'assistant', content: 'x' } }] })
@@ -245,7 +259,7 @@ describe('openai AI Guard instrumentation', () => {
       const observed = { llmCalledBeforeGuard: false }
       const unsubscribe = subscribeWithHandler(ctx => {
         observed.llmCalledBeforeGuard = llmCalled
-        ctx.resolve()
+        allowEvaluation(ctx)
       })
 
       let llmCalled = false
@@ -301,7 +315,7 @@ describe('openai AI Guard instrumentation', () => {
       const unsubscribe = subscribeWithHandler(ctx => {
         count++
         // Before Model passes; first choice passes; second choice rejects
-        count === 3 ? ctx.reject(err) : ctx.resolve()
+        count === 3 ? blockEvaluation(ctx, err) : allowEvaluation(ctx)
       })
       const completions = new Completions()
       completions._nextApiPromise = new FakeAPIPromise({
@@ -319,7 +333,7 @@ describe('openai AI Guard instrumentation', () => {
 
     it('propagates Before Model rejection through asResponse()', () => {
       const err = aiGuardAbortError()
-      const unsubscribe = subscribeWithHandler(ctx => ctx.reject(err))
+      const unsubscribe = subscribeWithHandler(ctx => blockEvaluation(ctx, err))
       const completions = new Completions()
       completions._nextApiPromise = new FakeAPIPromise({ choices: [{ message: { role: 'assistant', content: 'x' } }] })
 
@@ -488,7 +502,7 @@ describe('openai AI Guard instrumentation', () => {
 
     it('does not emit unhandled rejection when apiProm is discarded and Before Model would deny', async () => {
       const err = aiGuardAbortError()
-      const unsubscribe = subscribeWithHandler(ctx => ctx.reject(err))
+      const unsubscribe = subscribeWithHandler(ctx => blockEvaluation(ctx, err))
 
       const observed = []
       const onUnhandled = reason => observed.push(reason)
@@ -590,7 +604,7 @@ describe('openai AI Guard instrumentation', () => {
 
     it('rejects with AI Guard error when Before Model denies on the unwrapped promise', () => {
       const err = aiGuardAbortError()
-      const unsubscribe = subscribeWithHandler(ctx => ctx.reject(err))
+      const unsubscribe = subscribeWithHandler(ctx => blockEvaluation(ctx, err))
       const completions = new Completions()
       const body = { choices: [{ message: { role: 'assistant', content: 'x' } }] }
       completions._nextApiPromise = new FakeUnwrappableAPIPromise(body)
@@ -607,7 +621,7 @@ describe('openai AI Guard instrumentation', () => {
       const err = aiGuardAbortError()
       const unsubscribe = subscribeWithHandler(ctx => {
         count++
-        count === 1 ? ctx.resolve() : ctx.reject(err)
+        count === 1 ? allowEvaluation(ctx) : blockEvaluation(ctx, err)
       })
       const completions = new Completions()
       const body = { choices: [{ message: { role: 'assistant', content: 'leaked pii' } }] }
@@ -720,7 +734,7 @@ describe('openai AI Guard instrumentation', () => {
 
     it('rejects with AI Guard error when Before Model denies', () => {
       const err = aiGuardAbortError()
-      const unsubscribe = subscribeWithHandler(ctx => ctx.reject(err))
+      const unsubscribe = subscribeWithHandler(ctx => blockEvaluation(ctx, err))
       const responses = new Responses()
       responses._nextApiPromise = new FakeAPIPromise({
         output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'x' }] }],
@@ -737,7 +751,7 @@ describe('openai AI Guard instrumentation', () => {
       const err = aiGuardAbortError()
       const unsubscribe = subscribeWithHandler(ctx => {
         count++
-        count === 1 ? ctx.resolve() : ctx.reject(err)
+        count === 1 ? allowEvaluation(ctx) : blockEvaluation(ctx, err)
       })
       const responses = new Responses()
       responses._nextApiPromise = new FakeAPIPromise({

--- a/packages/dd-trace/src/aiguard/index.js
+++ b/packages/dd-trace/src/aiguard/index.js
@@ -44,27 +44,40 @@ function disable () {
 /**
  * Handles channel messages with pre-converted messages.
  *
- * @param {{messages: Array<object>, integration?: string, resolve: Function, reject: Function}} ctx
+ * @param {object} ctx
+ * @param {Array<object>} ctx.messages
+ * @param {string} [ctx.integration]
+ * @param {AbortController} ctx.abortController
+ * @param {Array<Promise<void>>} ctx.pending - Subscribers push only when they evaluate.
  */
 function onEvaluate (ctx) {
+  // Decline to evaluate empty payloads by not pushing to pending.
   if (!ctx.messages?.length) {
-    ctx.resolve()
     return
   }
 
   const opts = { block, source: SOURCE_AUTO, integration: ctx.integration || INTEGRATION_NONE }
-  aiguard.evaluate(ctx.messages, opts)
-    .then(() => {
-      ctx.resolve()
-    })
-    .catch(err => {
-      if (err.name === 'AIGuardAbortError') {
-        ctx.reject(err)
-      } else {
-        log.error('AIGuard: unexpected error during evaluation: %s', err.message)
-        ctx.resolve()
-      }
-    })
+
+  try {
+    ctx.pending.push(aiguard.evaluate(ctx.messages, opts).catch(handleEvaluationError.bind(null, ctx)))
+  } catch (err) {
+    ctx.pending.push(Promise.resolve().then(() => handleEvaluationError(ctx, err)))
+  }
+}
+
+/**
+ * Handles an AI Guard evaluation failure.
+ *
+ * @param {object} ctx
+ * @param {AbortController} ctx.abortController
+ * @param {Error} err
+ */
+function handleEvaluationError (ctx, err) {
+  if (err.name === 'AIGuardAbortError') {
+    ctx.abortController.abort(err)
+  } else {
+    log.error('AIGuard: unexpected error during evaluation: %s', err.message)
+  }
 }
 
 module.exports = { enable, disable }

--- a/packages/dd-trace/test/aiguard/index.spec.js
+++ b/packages/dd-trace/test/aiguard/index.spec.js
@@ -4,8 +4,10 @@ const assert = require('node:assert/strict')
 const { rejects } = require('node:assert/strict')
 const { inspect } = require('node:util')
 
+const { channel } = require('dc-polyfill')
 const msgpack = require('@msgpack/msgpack')
 const { afterEach, beforeEach, describe, it } = require('mocha')
+const proxyquire = require('proxyquire').noPreserveCache()
 const sinon = require('sinon')
 
 const NoopAIGuard = require('../../src/aiguard/noop')
@@ -20,12 +22,130 @@ const { USER_KEEP } = require('../../../../ext/priority')
 const { SAMPLING_MECHANISM_AI_GUARD, DECISION_MAKER_KEY } = require('../../src/constants')
 const {
   EVENT_TAG_KEY,
+  SOURCE_AUTO,
   SOURCE_SDK,
   INTEGRATION_NONE,
   ERROR_TYPE_CLIENT,
   ERROR_TYPE_STATUS,
   ERROR_TYPE_RESPONSE,
 } = require('../../src/aiguard/tags')
+
+describe('AIGuard auto instrumentation channel', () => {
+  const aiguardChannel = channel('dd-trace:ai:aiguard')
+  const messages = [{ role: 'user', content: 'Hello' }]
+  const config = { experimental: { aiguard: { block: true } } }
+  let evaluate
+  let log
+  let aiguard
+
+  beforeEach(() => {
+    evaluate = sinon.stub().resolves()
+    log = { error: sinon.stub() }
+
+    function MockAIGuard () {
+      return { evaluate }
+    }
+
+    aiguard = proxyquire('../../src/aiguard/index', {
+      '../log': log,
+      './sdk': MockAIGuard,
+    })
+    aiguard.enable({}, config)
+  })
+
+  afterEach(() => {
+    aiguard.disable()
+    sinon.restore()
+  })
+
+  function publish (publishedMessages = messages, integration = 'openai') {
+    const abortController = new AbortController()
+    const ctx = { messages: publishedMessages, integration, abortController, pending: [] }
+    aiguardChannel.publish(ctx)
+    return ctx
+  }
+
+  it('returns without pushing to pending for empty messages', () => {
+    const ctx = publish([])
+
+    assert.strictEqual(ctx.pending.length, 0)
+    assert.strictEqual(ctx.abortController.signal.aborted, false)
+    sinon.assert.notCalled(evaluate)
+  })
+
+  it('pushes an allowed evaluation promise without aborting', async () => {
+    const ctx = publish()
+
+    assert.strictEqual(ctx.pending.length, 1)
+    await Promise.all(ctx.pending)
+
+    assert.strictEqual(ctx.abortController.signal.aborted, false)
+    sinon.assert.calledOnceWithExactly(evaluate, messages, {
+      block: true,
+      source: SOURCE_AUTO,
+      integration: 'openai',
+    })
+  })
+
+  it('aborts with the original AIGuardAbortError', async () => {
+    const err = Object.assign(new Error('blocked'), { name: 'AIGuardAbortError', reason: 'blocked' })
+    evaluate.rejects(err)
+
+    const ctx = publish()
+    await Promise.all(ctx.pending)
+
+    assert.strictEqual(ctx.abortController.signal.aborted, true)
+    assert.strictEqual(ctx.abortController.signal.reason, err)
+  })
+
+  it('fails open for unexpected evaluation errors', async () => {
+    const err = new Error('network failed')
+    evaluate.rejects(err)
+
+    const ctx = publish()
+    await Promise.all(ctx.pending)
+
+    assert.strictEqual(ctx.abortController.signal.aborted, false)
+    sinon.assert.calledOnceWithExactly(log.error, 'AIGuard: unexpected error during evaluation: %s', err.message)
+  })
+
+  it('fails open when evaluation throws synchronously', async () => {
+    const err = new Error('sync failure')
+    evaluate.throws(err)
+
+    const ctx = publish()
+    assert.strictEqual(ctx.pending.length, 1)
+    await Promise.all(ctx.pending)
+
+    assert.strictEqual(ctx.abortController.signal.aborted, false)
+    sinon.assert.calledOnceWithExactly(log.error, 'AIGuard: unexpected error during evaluation: %s', err.message)
+  })
+
+  it('waits for every subscriber promise and blocks if any subscriber aborts', async () => {
+    let secondSubscriberResolved = false
+    const err = Object.assign(new Error('blocked'), { name: 'AIGuardAbortError' })
+    const extraSubscriber = ctx => {
+      ctx.pending.push(new Promise(resolve => {
+        setImmediate(() => {
+          secondSubscriberResolved = true
+          ctx.abortController.abort(err)
+          resolve()
+        })
+      }))
+    }
+    aiguardChannel.subscribe(extraSubscriber)
+
+    try {
+      const ctx = publish()
+      await Promise.all(ctx.pending)
+
+      assert.strictEqual(secondSubscriberResolved, true)
+      assert.strictEqual(ctx.abortController.signal.reason, err)
+    } finally {
+      aiguardChannel.unsubscribe(extraSubscriber)
+    }
+  })
+})
 
 describe('AIGuard SDK', () => {
   const config = {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?

Use abortController instead of promise resolve/reject

### Motivation

We usually use abortController to block operation instead of Promise reject/resolve, It's actually correct in this particular situation since we do an http call to AI Guard (async)

### Additional Notes

[APPSEC-68180](https://datadoghq.atlassian.net/browse/APPSEC-68180)




[APPSEC-68180]: https://datadoghq.atlassian.net/browse/APPSEC-68180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ