### PR TITLE
ci: test system-tests mssql GHCR mirror

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -46,7 +46,7 @@ jobs:
     needs:
       - build-artifacts
       - get-credentials
-    uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
+    uses: DataDog/system-tests/.github/workflows/system-tests.yml@rochdev/mssql-ghcr-mirror
     secrets:
       TEST_OPTIMIZATION_API_KEY: ${{ needs.get-credentials.outputs.api_key }}
       DD_API_KEY: ${{ needs.get-credentials.outputs.api_key }}


### PR DESCRIPTION
## Summary

- Temporarily points the system-tests workflow to the `rochdev/mssql-ghcr-mirror` branch (DataDog/system-tests#7000)
- This validates that replacing `mcr.microsoft.com/mssql/server:2022-latest` with the GHCR mirror works before merging to `main`

## Test plan

- [ ] Verify mssql-dependent system tests pass in CI

> Generated by [Claude Code](https://claude.com/claude-code)