### PR TITLE
feat(aws-sdk): EventBridge producer batch propagation + DSM checkpoints

### DIFF
--- a/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
@@ -1,4 +1,5 @@
 'use strict'
+const { DsmPathwayCodec, getSizeOrZero } = require('../../../dd-trace/src/datastreams')
 const log = require('../../../dd-trace/src/log')
 const BaseAwsSdkPlugin = require('../base')
 
@@ -26,16 +27,40 @@ class EventBridge extends BaseAwsSdkPlugin {
    * We cannot use the traceHeader field as that's reserved for X-Ray.
    * Detail must be a valid JSON string
    * Max size per event is 256kb (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
+   *
+   * By default only the first entry receives the trace context, mirroring
+   * SQS `sendMessageBatch`. Set `batchPropagationEnabled` (plugin config or
+   * `DD_TRACE_AWS_SDK_EVENTBRIDGE_BATCH_PROPAGATION_ENABLED`) to inject into
+   * every entry in the batch.
+   *
+   * Each entry is a distinct message: it carries the same trace context but,
+   * when DSM is enabled, its own Data Streams pathway checkpoint, so the
+   * `_datadog` payload is built per entry rather than shared.
    */
   requestInject (span, request) {
-    const operation = request.operation
-    if (operation === 'putEvents' &&
-      request.params &&
-      request.params.Entries &&
-      request.params.Entries.length > 0 &&
-      request.params.Entries[0].Detail) {
-      const injected = {}
-      this.tracer.inject(span, 'text_map', injected)
+    if (request.operation !== 'putEvents' || !request.params?.Entries?.length) {
+      return
+    }
+
+    const batchPropagationEnabled = this.config?.batchPropagationEnabled
+
+    for (let i = 0; i < request.params.Entries.length; i++) {
+      // Inject only into the first entry by default; opt in to the rest of
+      // the batch via `batchPropagationEnabled`.
+      if (i > 0 && !batchPropagationEnabled) break
+
+      const entry = request.params.Entries[i]
+      if (!entry?.Detail) continue
+
+      const ddInfo = {}
+      this.tracer.inject(span, 'text_map', ddInfo)
+
+      if (this.config?.dsmEnabled) {
+        const dataStreamsContext = this.setDSMCheckpoint(span, entry)
+        if (dataStreamsContext) {
+          DsmPathwayCodec.encode(dataStreamsContext, ddInfo)
+        }
+      }
 
       // Only `injectFieldIntoJsonObject` can throw (the slow path
       // `JSON.parse` for non-`{...}` payloads). Tighten the catch around
@@ -43,19 +68,35 @@ class EventBridge extends BaseAwsSdkPlugin {
       let finalData
       try {
         finalData = BaseAwsSdkPlugin.injectFieldIntoJsonObject(
-          request.params.Entries[0].Detail, '_datadog', injected
+          entry.Detail, '_datadog', ddInfo
         )
       } catch (error) {
         log.error('EventBridge error injecting request', error)
-        return
+        continue
       }
 
       if (Buffer.byteLength(finalData) >= 1024 * 256) {
         log.info('Payload size too large to pass context')
-        return
+        continue
       }
-      request.params.Entries[0].Detail = finalData
+      entry.Detail = finalData
     }
+  }
+
+  /**
+   * Record a Data Streams `direction:out` checkpoint for a single PutEvents
+   * entry. The DSM "topic" is the target event bus (the routing destination),
+   * defaulting to `default` when the entry omits `EventBusName`.
+   *
+   * @param {import('../../../..').Span} span
+   * @param {{ Detail?: string, EventBusName?: string }} entry
+   * @returns {object | undefined} The pathway context to encode, if any.
+   */
+  setDSMCheckpoint (span, entry) {
+    const eventBusName = entry.EventBusName ?? 'default'
+    const payloadSize = getSizeOrZero(entry.Detail)
+    return this.tracer
+      .setCheckpoint(['direction:out', `topic:${eventBusName}`, 'type:eventbridge'], span, payloadSize)
   }
 }
 module.exports = EventBridge

--- a/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/eventbridge.js
@@ -28,14 +28,10 @@ class EventBridge extends BaseAwsSdkPlugin {
    * Detail must be a valid JSON string
    * Max size per event is 256kb (https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-putevent-size.html)
    *
-   * By default only the first entry receives the trace context, mirroring
-   * SQS `sendMessageBatch`. Set `batchPropagationEnabled` (plugin config or
-   * `DD_TRACE_AWS_SDK_EVENTBRIDGE_BATCH_PROPAGATION_ENABLED`) to inject into
-   * every entry in the batch.
-   *
-   * Each entry is a distinct message: it carries the same trace context but,
-   * when DSM is enabled, its own Data Streams pathway checkpoint, so the
-   * `_datadog` payload is built per entry rather than shared.
+   * Injects only the first entry by default (like SQS `sendMessageBatch`); set
+   * `batchPropagationEnabled` (or `DD_TRACE_AWS_SDK_EVENTBRIDGE_BATCH_PROPAGATION_ENABLED`)
+   * for the whole batch. `_datadog` is built per entry since each carries its own
+   * DSM pathway when DSM is enabled.
    */
   requestInject (span, request) {
     if (request.operation !== 'putEvents' || !request.params?.Entries?.length) {
@@ -45,8 +41,7 @@ class EventBridge extends BaseAwsSdkPlugin {
     const batchPropagationEnabled = this.config?.batchPropagationEnabled
 
     for (let i = 0; i < request.params.Entries.length; i++) {
-      // Inject only into the first entry by default; opt in to the rest of
-      // the batch via `batchPropagationEnabled`.
+      // First entry only by default; the rest require batchPropagationEnabled.
       if (i > 0 && !batchPropagationEnabled) break
 
       const entry = request.params.Entries[i]
@@ -84,13 +79,12 @@ class EventBridge extends BaseAwsSdkPlugin {
   }
 
   /**
-   * Record a Data Streams `direction:out` checkpoint for a single PutEvents
-   * entry. The DSM "topic" is the target event bus (the routing destination),
-   * defaulting to `default` when the entry omits `EventBusName`.
+   * Records a Data Streams `direction:out` checkpoint for one PutEvents entry.
+   * The DSM topic is the target event bus (`EventBusName`, default `default`).
    *
    * @param {import('../../../..').Span} span
    * @param {{ Detail?: string, EventBusName?: string }} entry
-   * @returns {object | undefined} The pathway context to encode, if any.
+   * @returns {object | undefined}
    */
   setDSMCheckpoint (span, entry) {
     const eventBusName = entry.EventBusName ?? 'default'

--- a/packages/datadog-plugin-aws-sdk/test/eventbridge.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/eventbridge.dsm.spec.js
@@ -1,0 +1,135 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { after, afterEach, before, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+const { computePathwayHash } = require('../../dd-trace/src/datastreams/pathway')
+const { ENTRY_PARENT_HASH } = require('../../dd-trace/src/datastreams/processor')
+const propagationHash = require('../../dd-trace/src/propagation-hash')
+const agent = require('../../dd-trace/test/plugins/agent')
+const { setup, withAwsSdkVersions } = require('./spec_helpers')
+
+describe('EventBridge', function () {
+  setup()
+  this.timeout(20000)
+
+  withAwsSdkVersions((version, moduleName) => {
+    let eventbridge
+    let tracer
+
+    const ebClientName = moduleName === '@aws-sdk/smithy-client' ? '@aws-sdk/client-eventbridge' : 'aws-sdk'
+
+    const putEntry = (overrides = {}) => ({
+      Source: 'dd.test',
+      DetailType: 'dsmTest',
+      Detail: JSON.stringify({ hello: 'world' }),
+      EventBusName: 'default',
+      ...overrides,
+    })
+
+    describe('Data Streams Monitoring', () => {
+      let expectedProducerHash
+      let nowStub
+
+      before(() => {
+        return agent.load('aws-sdk', { eventbridge: { dsmEnabled: true } }, { dsmEnabled: true })
+      })
+
+      before(() => {
+        process.env.DD_DATA_STREAMS_ENABLED = 'true'
+        tracer = require('../../dd-trace')
+        tracer.use('aws-sdk', { eventbridge: { dsmEnabled: true } })
+
+        const { EventBridge } = require(`../../../versions/${ebClientName}@${version}`).get()
+        eventbridge = new EventBridge({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1' })
+
+        // The DSM "topic" is the target event bus; the default bus is `default`.
+        const phash = propagationHash.getHash()
+        expectedProducerHash = computePathwayHash(
+          'test', 'tester',
+          ['direction:out', 'topic:default', 'type:eventbridge'],
+          ENTRY_PARENT_HASH,
+          phash
+        ).readBigUInt64LE(0).toString()
+      })
+
+      afterEach(() => {
+        try {
+          nowStub.restore()
+        } catch {
+          // pass
+        }
+      })
+
+      after(() => {
+        return agent.close()
+      })
+
+      it('emits a producer pathway hash to the putEvents span', done => {
+        agent.assertSomeTraces(traces => {
+          const span = traces[0][0]
+
+          if (span.meta?.['pathway.hash']) {
+            assert.strictEqual(span.meta['pathway.hash'], expectedProducerHash)
+          }
+        }).then(done, done)
+
+        eventbridge.putEvents({ Entries: [putEntry()] }, () => {})
+      })
+
+      it('outputs DSM stats to the agent when putting events', done => {
+        agent.expectPipelineStats(dsmStats => {
+          let statsPointsReceived = 0
+          dsmStats.forEach((timeStatsBucket) => {
+            if (timeStatsBucket && timeStatsBucket.Stats) {
+              timeStatsBucket.Stats.forEach((statsBuckets) => {
+                statsPointsReceived += statsBuckets.Stats.length
+              })
+            }
+          })
+          assert.ok(statsPointsReceived >= 1, `Expected ${statsPointsReceived} >= 1`)
+          assert.strictEqual(agent.dsmStatsExist(agent, expectedProducerHash), true)
+        }).then(done, done)
+
+        eventbridge.putEvents({ Entries: [putEntry()] }, () => {})
+      })
+
+      it('outputs a DSM stats point for every entry when batchPropagationEnabled', done => {
+        // Stub Date.now() so each checkpoint lands in its own stats bucket
+        // instead of being merged into one point.
+        let now = Date.now()
+        nowStub = sinon.stub(Date, 'now')
+        nowStub.callsFake(() => {
+          now += 1_000_000
+          return now
+        })
+
+        agent.expectPipelineStats(dsmStats => {
+          let statsPointsReceived = 0
+          dsmStats.forEach((timeStatsBucket) => {
+            if (timeStatsBucket && timeStatsBucket.Stats) {
+              timeStatsBucket.Stats.forEach((statsBuckets) => {
+                statsPointsReceived += statsBuckets.Stats.length
+              })
+            }
+          })
+          assert.ok(statsPointsReceived >= 3, `Expected ${statsPointsReceived} >= 3`)
+          assert.strictEqual(agent.dsmStatsExist(agent, expectedProducerHash), true)
+        }, { timeoutMs: 2000 }).then(done, done)
+
+        tracer.use('aws-sdk', { eventbridge: { dsmEnabled: true, batchPropagationEnabled: true } })
+        eventbridge.putEvents({
+          Entries: [
+            putEntry({ Detail: JSON.stringify({ order: 1 }) }),
+            putEntry({ Detail: JSON.stringify({ order: 2 }) }),
+            putEntry({ Detail: JSON.stringify({ order: 3 }) }),
+          ],
+        }, () => {
+          nowStub.restore()
+        })
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const { Buffer } = require('node:buffer')
 const { randomBytes } = require('node:crypto')
 
 const { before, describe, it } = require('mocha')
@@ -179,5 +180,281 @@ describe('EventBridge', () => {
         rulename: 'my-rule-name',
       })
     })
+  })
+})
+
+/**
+ * Bypass the plugin/diagnostic-channel wiring in `BaseAwsSdkPlugin`'s
+ * constructor. `requestInject` reads `this.tracer.inject`,
+ * `this.tracer.setCheckpoint`, `this.config`, and the static
+ * `BaseAwsSdkPlugin.injectFieldIntoJsonObject`, so a hand-rolled stub is
+ * enough to exercise the multi-entry and DSM behavior.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.batchPropagationEnabled]
+ * @param {boolean} [options.dsmEnabled]
+ * @param {(span: unknown, format: string, info: object) => void} [options.inject]
+ * @param {(tags: string[], span: unknown, payloadSize: number) => unknown} [options.setCheckpoint]
+ *        Stand-in for `tracer.setCheckpoint`; returns the pathway context the
+ *        test wants `DsmPathwayCodec.encode` to consume.
+ * @returns {EventBridge}
+ */
+function buildPluginUnit ({
+  batchPropagationEnabled = false,
+  dsmEnabled = false,
+  inject = (span, format, info) => { info['x-datadog-trace-id'] = '123' },
+  setCheckpoint = () => null,
+} = {}) {
+  const plugin = Object.create(EventBridge.prototype)
+  plugin._tracer = { inject, setCheckpoint }
+  plugin.config = { batchPropagationEnabled, dsmEnabled }
+  return plugin
+}
+
+describe('EventBridge requestInject batch propagation', () => {
+  it('injects only into the first entry by default', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: false })
+    const request = {
+      operation: 'putEvents',
+      params: {
+        Entries: [
+          { Detail: JSON.stringify({ order: 1 }) },
+          { Detail: JSON.stringify({ order: 2 }) },
+          { Detail: JSON.stringify({ order: 3 }) },
+        ],
+      },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.deepStrictEqual(
+      JSON.parse(request.params.Entries[0].Detail),
+      { order: 1, _datadog: { 'x-datadog-trace-id': '123' } }
+    )
+    assert.deepStrictEqual(JSON.parse(request.params.Entries[1].Detail), { order: 2 })
+    assert.deepStrictEqual(JSON.parse(request.params.Entries[2].Detail), { order: 3 })
+  })
+
+  it('injects into every entry when batchPropagationEnabled is true', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: true })
+    const request = {
+      operation: 'putEvents',
+      params: {
+        Entries: [
+          { Detail: JSON.stringify({ order: 1 }) },
+          { Detail: JSON.stringify({ order: 2 }) },
+          { Detail: JSON.stringify({ order: 3 }) },
+        ],
+      },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.deepStrictEqual(
+      request.params.Entries.map((entry) => JSON.parse(entry.Detail)),
+      [
+        { order: 1, _datadog: { 'x-datadog-trace-id': '123' } },
+        { order: 2, _datadog: { 'x-datadog-trace-id': '123' } },
+        { order: 3, _datadog: { 'x-datadog-trace-id': '123' } },
+      ]
+    )
+  })
+
+  it('skips entries without a Detail field and continues the batch', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: true })
+    const request = {
+      operation: 'putEvents',
+      params: {
+        Entries: [
+          { Detail: JSON.stringify({ order: 1 }) },
+          {},
+          { Detail: JSON.stringify({ order: 3 }) },
+        ],
+      },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.deepStrictEqual(
+      JSON.parse(request.params.Entries[0].Detail),
+      { order: 1, _datadog: { 'x-datadog-trace-id': '123' } }
+    )
+    assert.deepStrictEqual(request.params.Entries[1], {})
+    assert.deepStrictEqual(
+      JSON.parse(request.params.Entries[2].Detail),
+      { order: 3, _datadog: { 'x-datadog-trace-id': '123' } }
+    )
+  })
+
+  it('skips entries whose detail exceeds the 256kb size cap and keeps going', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: true })
+    const huge = JSON.stringify({ blob: 'x'.repeat(256 * 1024) })
+    const request = {
+      operation: 'putEvents',
+      params: {
+        Entries: [
+          { Detail: huge },
+          { Detail: JSON.stringify({ order: 2 }) },
+        ],
+      },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    // First entry is untouched: post-inject size would be over the 256kb cap.
+    assert.strictEqual(request.params.Entries[0].Detail, huge)
+    assert.deepStrictEqual(
+      JSON.parse(request.params.Entries[1].Detail),
+      { order: 2, _datadog: { 'x-datadog-trace-id': '123' } }
+    )
+  })
+
+  it('skips entries whose Detail is not valid JSON and keeps going', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: true })
+    const request = {
+      operation: 'putEvents',
+      params: {
+        Entries: [
+          // Not a `{...}` payload, so `injectFieldIntoJsonObject` takes the
+          // slow path and `JSON.parse` throws — the entry is left untouched.
+          { Detail: 'not valid json' },
+          { Detail: JSON.stringify({ order: 2 }) },
+        ],
+      },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.strictEqual(request.params.Entries[0].Detail, 'not valid json')
+    assert.deepStrictEqual(
+      JSON.parse(request.params.Entries[1].Detail),
+      { order: 2, _datadog: { 'x-datadog-trace-id': '123' } }
+    )
+  })
+
+  it('no-ops for non-putEvents operations', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: true })
+    const request = {
+      operation: 'describeRule',
+      params: { Entries: [{ Detail: JSON.stringify({ order: 1 }) }] },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.deepStrictEqual(JSON.parse(request.params.Entries[0].Detail), { order: 1 })
+  })
+
+  it('no-ops on putEvents with an empty Entries array', () => {
+    const eventbridge = buildPluginUnit({ batchPropagationEnabled: true })
+    const request = { operation: 'putEvents', params: { Entries: [] } }
+
+    eventbridge.requestInject(null, request)
+
+    assert.deepStrictEqual(request.params, { Entries: [] })
+  })
+})
+
+describe('EventBridge requestInject DSM', () => {
+  // Shape consumed by DsmPathwayCodec.encode: a hash buffer plus start times.
+  const dataStreamsContext = { hash: Buffer.alloc(8), pathwayStartNs: 0, edgeStartNs: 0 }
+
+  it('sets a direction:out checkpoint and encodes the pathway into _datadog', () => {
+    const checkpointCalls = []
+    const eventbridge = buildPluginUnit({
+      dsmEnabled: true,
+      setCheckpoint: (tags, span, payloadSize) => {
+        checkpointCalls.push({ tags, span, payloadSize })
+        return dataStreamsContext
+      },
+    })
+    const request = {
+      operation: 'putEvents',
+      params: { Entries: [{ Detail: JSON.stringify({ order: 1 }) }] },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.strictEqual(checkpointCalls.length, 1)
+    assert.deepStrictEqual(checkpointCalls[0].tags, ['direction:out', 'topic:default', 'type:eventbridge'])
+
+    const ddInfo = JSON.parse(request.params.Entries[0].Detail)._datadog
+    assert.strictEqual(ddInfo['x-datadog-trace-id'], '123')
+    assert.ok(
+      typeof ddInfo['dd-pathway-ctx-base64'] === 'string' && ddInfo['dd-pathway-ctx-base64'].length > 0,
+      `expected an encoded pathway, got: ${JSON.stringify(ddInfo)}`
+    )
+  })
+
+  it('uses the entry EventBusName as the DSM topic', () => {
+    const checkpointCalls = []
+    const eventbridge = buildPluginUnit({
+      dsmEnabled: true,
+      setCheckpoint: (tags) => {
+        checkpointCalls.push(tags)
+        return dataStreamsContext
+      },
+    })
+    const request = {
+      operation: 'putEvents',
+      params: { Entries: [{ Detail: JSON.stringify({ order: 1 }), EventBusName: 'my-bus' }] },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.deepStrictEqual(checkpointCalls[0], ['direction:out', 'topic:my-bus', 'type:eventbridge'])
+  })
+
+  it('does not checkpoint or encode a pathway when dsmEnabled is false', () => {
+    let checkpointCalled = false
+    const eventbridge = buildPluginUnit({
+      dsmEnabled: false,
+      setCheckpoint: () => {
+        checkpointCalled = true
+        return dataStreamsContext
+      },
+    })
+    const request = {
+      operation: 'putEvents',
+      params: { Entries: [{ Detail: JSON.stringify({ order: 1 }) }] },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.strictEqual(checkpointCalled, false)
+    assert.deepStrictEqual(
+      JSON.parse(request.params.Entries[0].Detail)._datadog,
+      { 'x-datadog-trace-id': '123' }
+    )
+  })
+
+  it('checkpoints every entry in a batch when batchPropagationEnabled', () => {
+    const checkpointCalls = []
+    const eventbridge = buildPluginUnit({
+      dsmEnabled: true,
+      batchPropagationEnabled: true,
+      setCheckpoint: (tags) => {
+        checkpointCalls.push(tags)
+        return dataStreamsContext
+      },
+    })
+    const request = {
+      operation: 'putEvents',
+      params: {
+        Entries: [
+          { Detail: JSON.stringify({ order: 1 }) },
+          { Detail: JSON.stringify({ order: 2 }), EventBusName: 'bus-2' },
+        ],
+      },
+    }
+
+    eventbridge.requestInject(null, request)
+
+    assert.strictEqual(checkpointCalls.length, 2)
+    assert.deepStrictEqual(checkpointCalls[0], ['direction:out', 'topic:default', 'type:eventbridge'])
+    assert.deepStrictEqual(checkpointCalls[1], ['direction:out', 'topic:bus-2', 'type:eventbridge'])
+    for (let i = 0; i < 2; i++) {
+      const ddInfo = JSON.parse(request.params.Entries[i].Detail)._datadog
+      assert.ok(ddInfo['dd-pathway-ctx-base64'], `entry ${i} missing encoded pathway`)
+    }
   })
 })

--- a/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/eventbridge.spec.js
@@ -184,19 +184,15 @@ describe('EventBridge', () => {
 })
 
 /**
- * Bypass the plugin/diagnostic-channel wiring in `BaseAwsSdkPlugin`'s
- * constructor. `requestInject` reads `this.tracer.inject`,
- * `this.tracer.setCheckpoint`, `this.config`, and the static
- * `BaseAwsSdkPlugin.injectFieldIntoJsonObject`, so a hand-rolled stub is
- * enough to exercise the multi-entry and DSM behavior.
+ * `Object.create(EventBridge.prototype)` skips the heavy constructor wiring;
+ * `requestInject` only touches `this.tracer`, `this.config`, and the static
+ * `injectFieldIntoJsonObject`, so a hand-rolled stub suffices.
  *
  * @param {object} [options]
  * @param {boolean} [options.batchPropagationEnabled]
  * @param {boolean} [options.dsmEnabled]
  * @param {(span: unknown, format: string, info: object) => void} [options.inject]
  * @param {(tags: string[], span: unknown, payloadSize: number) => unknown} [options.setCheckpoint]
- *        Stand-in for `tracer.setCheckpoint`; returns the pathway context the
- *        test wants `DsmPathwayCodec.encode` to consume.
  * @returns {EventBridge}
  */
 function buildPluginUnit ({
@@ -315,8 +311,7 @@ describe('EventBridge requestInject batch propagation', () => {
       operation: 'putEvents',
       params: {
         Entries: [
-          // Not a `{...}` payload, so `injectFieldIntoJsonObject` takes the
-          // slow path and `JSON.parse` throws — the entry is left untouched.
+          // Non-`{...}` Detail: the parse throws, so the entry is left untouched.
           { Detail: 'not valid json' },
           { Detail: JSON.stringify({ order: 2 }) },
         ],


### PR DESCRIPTION
## Summary

Producer-side EventBridge enhancements, following #8698 (the consumer-extraction `semver-patch`, now merged to `master`).

1. **Multi-entry batch propagation** — `PutEvents` previously injected `_datadog` into only `Entries[0]`. Now injects entry 0 always, and the rest when `batchPropagationEnabled` (`DD_TRACE_AWS_SDK_EVENTBRIDGE_BATCH_PROPAGATION_ENABLED`) — same knob as SQS/SNS/Kinesis.
2. **Producer-side DSM checkpoints** — EventBridge now emits a `direction:out` Data Streams checkpoint per entry and encodes the pathway into `_datadog`, mirroring Kinesis/SNS. Combined with the merged consumer decode (#8698), an EventBridge → SQS (and → SNS → SQS) flow now forms a connected Data Streams pathway end to end.

## What changed

`packages/datadog-plugin-aws-sdk/src/services/eventbridge.js`:
- `requestInject` iterates all `Entries`; per-entry errors `continue` rather than aborting the batch.
- Per entry, when `dsmEnabled`: `setCheckpoint(['direction:out', 'topic:<EventBusName|default>', 'type:eventbridge'], span, getSizeOrZero(Detail))` then `DsmPathwayCodec.encode(...)` into that entry's `_datadog`.
- `_datadog` is built per entry (each is a distinct message with its own pathway hash).

## Reviewer notes / open questions

- **`type:eventbridge` is a new DSM node type** — no prior `type:eventbridge` exists in the tracer. Emitting it is correct/forward-looking, but whether the DSM backend models an EventBridge hop in the topology (and how `topic:default` renders) needs a **DSM-savvy reviewer**. Pathway stitching to the SQS consumer relies on the encoded `dd-pathway-ctx-base64` hash, not tag matching, so APM-style linkage is unaffected.
- **DSM topic semantics** — chose `EventBusName` (default `default`) as the topic, consistent with the destination-channel convention (SQS queue / SNS topic ARN / Kinesis stream). Confirm that's the intended identifier vs. event source.
- **Payload-size measurement** — `getSizeOrZero(entry.Detail)` measures the pre-injection `Detail`, matching **Kinesis** (the nearest body-injection analog, which measures `params.Data` pre-injection). This differs from SQS, which attaches a `_datadog` placeholder before measuring; the divergence is SQS-vs-the-body-injection-family and pre-existing.
- **`eventbridge.dsm.spec.js` validation** — I could not run LocalStack locally (no `eslint-plugin-sonarjs`/services in my env), so this integration test is modeled closely on the proven `sns.dsm.spec.js` but is **CI-validated, not locally validated**. It is producer-focused; full EventBridge → SQS *delivery* stitching needs greenfield bus/rule/target/queue-policy wiring and is deferred.
- **Sequential `setCheckpoint`** chains each entry's pathway off the previous one (mirrors SQS `sendMessageBatch`). If "all entries branch from one parent" is the intended DSM model, that's a shared question for both services — out of scope here.