### PR TITLE
fix(vitest): pin node 18 vitest 3 version

### DIFF
--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -48,7 +48,7 @@ const { NODE_MAJOR } = require('../../version')
 const NUM_RETRIES_EFD = 3
 
 // vitest@4.x requires Node.js >= 20
-const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3'] : ['1.6.0', 'latest']
+const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 
 versions.forEach((version) => {
   describe(`vitest@${version}`, () => {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -58,7 +58,7 @@ const FLAKY_UNNECESSARY_RETRY_RESOURCE =
 const linePctMatchRegex = /Lines\s+:\s+([\d.]+)%/
 
 // vitest@4.x requires Node.js >= 20
-const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3'] : ['1.6.0', 'latest']
+const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 
 versions.forEach((version) => {
   describe(`vitest@${version}`, () => {

--- a/integration-tests/vitest/vitest.test-management.spec.js
+++ b/integration-tests/vitest/vitest.test-management.spec.js
@@ -31,7 +31,7 @@ const {
 const { NODE_MAJOR } = require('../../version')
 
 // vitest@4.x requires Node.js >= 20
-const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3'] : ['1.6.0', 'latest']
+const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 
 versions.forEach((version) => {
   describe(`vitest@${version}`, () => {


### PR DESCRIPTION
### What does this PR do?
Pins the Node 18 Vitest 3 integration test leg to Vitest 3.2.6 instead of the floating 3 range.

### Motivation
Vitest 3.2.5 depended on vite-node 3.2.5, which is not published, causing bun sandbox installs to fail before the Vitest integration tests could run.

