### PR TITLE
fix: stop using url.parse in http

### DIFF
--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -292,12 +292,7 @@ function patch (http, methodName) {
 
   function normalizeOptions (inputURL) {
     if (typeof inputURL === 'string') {
-      try {
-        return urlToOptions(new url.URL(inputURL))
-      } catch {
-        // eslint-disable-next-line n/no-deprecated-api
-        return url.parse(inputURL)
-      }
+      return urlToOptions(new url.URL(inputURL))
     } else if (inputURL instanceof url.URL) {
       return urlToOptions(inputURL)
     } else {

--- a/packages/datadog-instrumentations/src/http/client.js
+++ b/packages/datadog-instrumentations/src/http/client.js
@@ -293,11 +293,11 @@ function patch (http, methodName) {
   function normalizeOptions (inputURL) {
     if (typeof inputURL === 'string') {
       return urlToOptions(new url.URL(inputURL))
-    } else if (inputURL instanceof url.URL) {
-      return urlToOptions(inputURL)
-    } else {
-      return inputURL
     }
+    if (inputURL instanceof url.URL) {
+      return urlToOptions(inputURL)
+    }
+    return inputURL
   }
 
   function urlToOptions (url) {


### PR DESCRIPTION
The url.parse method is long deprecated and not used in any supported Node.js versions.

Removing it prevents a deprecation notice for modern Node.js versions.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8713

I did not include a regression test since we only remove this. I think for the particular case it should be fine as an exception.