### PR TITLE
ci(benchmarks): bring up the in-repo image and tolerate candidate-only baseline failures

### DIFF
--- a/.gitlab/benchmarks/bp-runner.yml
+++ b/.gitlab/benchmarks/bp-runner.yml
@@ -23,7 +23,11 @@ experiments:
         how_to_run_benchmarks: |
           cd ./benchmark/sirun
           ./runall.sh
-          cp results.ndjson "$ARTIFACTS_DIR/$BASELINE_OR_CANDIDATE-v$MAJOR_VERSION-$GROUP.ndjson"
+          # analyze_microbenchmarks' default input_filter_pattern only matches
+          # "$ARTIFACTS_DIR/$BASELINE_OR_CANDIDATE*.json", so the result must end
+          # in .json (not .ndjson) or it is never converted and the downstream
+          # check-big-regressions job finds no baseline*/candidate*.converted.json.
+          cp results.ndjson "$ARTIFACTS_DIR/$BASELINE_OR_CANDIDATE-v$MAJOR_VERSION-$GROUP.json"
 
       - name: Analyze results
         run: analyze_microbenchmarks

--- a/.gitlab/benchmarks/container/install-base-deps.sh
+++ b/.gitlab/benchmarks/container/install-base-deps.sh
@@ -18,7 +18,9 @@ echo "9038680028e006d13ea1ff68fdcab0a5494d2026cdd2dbdfb067c5b80b6272f1  /tmp/pyt
 tar -xzf /tmp/python.tar.gz -C /opt
 rm /tmp/python.tar.gz
 
-pip3 install awscli==1.45.21 virtualenv==21.4.2 setuptools==82.0.1
+# awscli 1.45+ dropped Python 3.9 (requires >=3.10); hold at the last 1.44.x until
+# the CPython pin above moves to 3.10+, or pip can't resolve awscli on this image.
+pip3 install awscli==1.44.87 virtualenv==21.4.2 setuptools==82.0.1
 curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version 2.4.1
 
 # Bootstrap bp-install so the Dockerfile can install the Benchmarking Platform

--- a/.gitlab/benchmarks/container/install-base-deps.sh
+++ b/.gitlab/benchmarks/container/install-base-deps.sh
@@ -18,6 +18,15 @@ echo "9038680028e006d13ea1ff68fdcab0a5494d2026cdd2dbdfb067c5b80b6272f1  /tmp/pyt
 tar -xzf /tmp/python.tar.gz -C /opt
 rm /tmp/python.tar.gz
 
+# bp-install's install.sh runs `pyenv local 3.9` before `python3 -m venv`. CPython
+# 3.9 from python-build-standalone is already first on PATH, so selection is a no-op;
+# stub pyenv rather than compiling the full pyenv the fleet uses.
+cat > /usr/local/bin/pyenv <<'PYENV_STUB'
+#!/usr/bin/env bash
+exit 0
+PYENV_STUB
+chmod +x /usr/local/bin/pyenv
+
 # awscli 1.45+ dropped Python 3.9 (requires >=3.10); hold at the last 1.44.x until
 # the CPython pin above moves to 3.10+, or pip can't resolve awscli on this image.
 pip3 install awscli==1.44.87 virtualenv==21.4.2 setuptools==82.0.1

--- a/.gitlab/benchmarks/container/install-base-deps.sh
+++ b/.gitlab/benchmarks/container/install-base-deps.sh
@@ -21,7 +21,8 @@ rm /tmp/python.tar.gz
 # awscli 1.45+ dropped Python 3.9 (requires >=3.10); hold at the last 1.44.x until
 # the CPython pin above moves to 3.10+, or pip can't resolve awscli on this image.
 pip3 install awscli==1.44.87 virtualenv==21.4.2 setuptools==82.0.1
-curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version 2.4.1
+# Poetry 2.3+ also requires Python >=3.10; 2.2.1 is the last 3.9-compatible release.
+curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version 2.2.1
 
 # Bootstrap bp-install so the Dockerfile can install the Benchmarking Platform
 # packages (bp-runner, benchmark-analyzer, github-tools) the same way the rest of

--- a/.gitlab/benchmarks/gitlab-ci.yml
+++ b/.gitlab/benchmarks/gitlab-ci.yml
@@ -27,8 +27,6 @@ variables:
   # Benchmark's env variables. Modify to tweak benchmark parameters.
   UNCONFIDENCE_THRESHOLD: "2.0"
   MD_REPORT_ONLY_CHANGES: "1"
-  # Set to the dd-trace-js benchmarks dashboard URL to add a link in the PR comment.
-  BENCHMARK_DASHBOARD_URL: ""
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/gitlab-ci.yml
+++ b/.gitlab/benchmarks/gitlab-ci.yml
@@ -25,8 +25,10 @@ variables:
   SLS_CI_BRANCH: main
 
   # Benchmark's env variables. Modify to tweak benchmark parameters.
-  UNCONFIDENCE_THRESHOLD: "5.0"
+  UNCONFIDENCE_THRESHOLD: "2.0"
   MD_REPORT_ONLY_CHANGES: "1"
+  # Set to the dd-trace-js benchmarks dashboard URL to add a link in the PR comment.
+  BENCHMARK_DASHBOARD_URL: ""
 
 .benchmarks:
   stage: benchmarks

--- a/.gitlab/benchmarks/gitlab-ci.yml
+++ b/.gitlab/benchmarks/gitlab-ci.yml
@@ -6,11 +6,11 @@ include:
     file: 'images/templates/gitlab/build-ci-images.template.yml'
 
 variables:
-  # Consumed by the benchmark jobs below. After the first `build-benchmark-ci-images`
-  # run, repin this to the registry.ddbuild.io/ci/benchmarking-platform:dd-trace-js-<pipeline-id>
-  # tag it pushes (dd-trace-go pins the same way).
-  # TODO(BridgeAR): repin to the registry.ddbuild.io tag once the in-repo image is built.
-  MICROBENCHMARKS_CI_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dd-trace-js
+  # Consumed by the benchmark jobs below. Repin after a `build-benchmark-ci-images`
+  # run to the tag it pushes; the @sha256 digest is what image-integrity verifies, so
+  # the pull can't be shifted by a tag rewrite.
+  # Built here: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-js/-/jobs/1755904623
+  MICROBENCHMARKS_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:dd-trace-js-117825597@sha256:23a63e17211bb712a07494ccbbed86edb8f4a3c1c301310c217938dbe1b7284d
 
   # Image build, consumed by the included build-ci-images template. The per-pipeline
   # suffix pins each build to a unique tag so a rebuild can't shift what older

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -94,7 +94,9 @@ GROUP=${GROUP:-1}
 # broken benchmark. The candidate run records its passing variants below.
 SKIP_BASELINE_FAILURES=""
 RECORD_CANDIDATE_PASS=""
-CANDIDATE_PASSED_FILE="${ARTIFACTS_DIR:-/tmp}/candidate-passed-variants.txt"
+# In /tmp, not ARTIFACTS_DIR: analyze_microbenchmarks ingests that dir as sirun
+# results and fails on this plain-text list; /tmp survives both runs.
+CANDIDATE_PASSED_FILE="/tmp/candidate-passed-variants.txt"
 if [[ "${TOLERATE_NEW_BENCHMARK_FAILURES:-}" == "1" ]]; then
   if [[ "${BASELINE_OR_CANDIDATE:-}" == "candidate" ]]; then
     RECORD_CANDIDATE_PASS="1"

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -8,12 +8,15 @@ CWD=$(pwd)
 # Background subshells can't share a bash variable, so failed variants
 # write their dir/variant name here and the parent counts lines after `wait`.
 FAILURES_FILE=$(mktemp)
+# Variants whose latest definition failed against the older baseline source;
+# tolerated there unless this PR also changes non-benchmark source (see below).
+SKIPPED_FILE=$(mktemp)
 
 function cleanup {
   for D in "${DIRS[@]}"; do
     rm -f "${CWD}/${D}/meta-temp.json"
   done
-  rm -f "$FAILURES_FILE"
+  rm -f "$FAILURES_FILE" "$SKIPPED_FILE"
 }
 
 trap cleanup EXIT
@@ -85,6 +88,22 @@ CPU_AFFINITY="${CPUSET_START}" # reset for each node.js version
 SPLITS=${SPLITS:-1}
 GROUP=${GROUP:-1}
 
+# With BENCHMARKS_FROM=candidate the baseline runs this PR's benchmark code on
+# the older source. Skip a baseline failure only when the same variant passed on
+# the candidate run -- proof the failure is specific to the older source, not a
+# broken benchmark. The candidate run records its passing variants below.
+SKIP_BASELINE_FAILURES=""
+RECORD_CANDIDATE_PASS=""
+CANDIDATE_PASSED_FILE="${ARTIFACTS_DIR:-/tmp}/candidate-passed-variants.txt"
+if [[ "${TOLERATE_NEW_BENCHMARK_FAILURES:-}" == "1" ]]; then
+  if [[ "${BASELINE_OR_CANDIDATE:-}" == "candidate" ]]; then
+    RECORD_CANDIDATE_PASS="1"
+    : > "$CANDIDATE_PASSED_FILE"
+  elif [[ "${BASELINE_OR_CANDIDATE:-}" == "baseline" ]]; then
+    SKIP_BASELINE_FAILURES="1"
+  fi
+fi
+
 BENCH_COUNT=0
 for D in "${DIRS[@]}"; do
   cd "${D}"
@@ -126,10 +145,14 @@ for D in "${DIRS[@]}"; do
       (
         if time node ../run-one-variant.js >> ../results.ndjson; then
           echo "${D}/${V} finished."
-        else
-          echo "${D}/${V} FAILED on core ${CPU_AFFINITY}" >&2
+          if [[ -n "${RECORD_CANDIDATE_PASS}" ]]; then echo "${D}/${V}" >> "$CANDIDATE_PASSED_FILE"; fi
+        elif [[ -n "${SKIP_BASELINE_FAILURES}" ]] && grep -Fqx "${D}/${V}" "$CANDIDATE_PASSED_FILE" 2>/dev/null; then
+          echo "${D}/${V} skipped: passed on the candidate but failed on the older baseline source." >&2
           # Append-only writes to a single tempfile from parallel subshells are
           # atomic on Linux below PIPE_BUF (4 KiB); each line here is ~30 bytes.
+          echo "${D}/${V}" >> "$SKIPPED_FILE"
+        else
+          echo "${D}/${V} FAILED on core ${CPU_AFFINITY}" >&2
           echo "${D}/${V}" >> "$FAILURES_FILE"
         fi
       ) &
@@ -159,4 +182,29 @@ if [[ "${FAILED_COUNT}" -gt 0 ]]; then
   echo "${FAILED_COUNT} variant(s) failed:" >&2
   sed 's/^/  - /' "$FAILURES_FILE" >&2
   exit 1
+fi
+
+SKIPPED_COUNT=$(wc -l < "$SKIPPED_FILE" | tr -d ' ')
+if [[ "${SKIPPED_COUNT}" -gt 0 ]]; then
+  echo "" >&2
+  echo "${SKIPPED_COUNT} benchmark variant(s) failed on the baseline source and were skipped:" >&2
+  sed 's/^/  - /' "$SKIPPED_FILE" >&2
+
+  # A benchmark-only change is fine -- the skipped benchmark is the work. Any other
+  # source change leaves the A/B comparison incomplete, so fail and ask for the
+  # benchmark to land on its own first. Docs, CODEOWNERS, CI config and tests do
+  # not count as source here.
+  NON_BENCH_SOURCE_CHANGED=""
+  if [[ -d /app/candidate/.git && -n "${COMMIT_SHA:-}" && -n "${CI_COMMIT_SHA:-}" ]]; then
+    NON_BENCH_SOURCE_CHANGED="$(git -C /app/candidate diff --name-only "${COMMIT_SHA}..${CI_COMMIT_SHA}" \
+      | grep -vE '(^benchmark/|^docs/|^\.github/|^\.gitlab/|\.md$|(^|/)CODEOWNERS$|^test/|/test/|/__tests__/|\.spec\.[jt]s$|\.test\.[jt]s$)' || true)"
+  fi
+
+  if [[ -n "${NON_BENCH_SOURCE_CHANGED}" ]]; then
+    echo "" >&2
+    echo "This PR also changes non-benchmark source, so the A/B comparison is incomplete." >&2
+    echo "Land the benchmark change separately first, then rebase. Changed source files:" >&2
+    echo "${NON_BENCH_SOURCE_CHANGED}" | sed 's/^/  - /' >&2
+    exit 1
+  fi
 fi

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -190,10 +190,8 @@ if [[ "${SKIPPED_COUNT}" -gt 0 ]]; then
   echo "${SKIPPED_COUNT} benchmark variant(s) failed on the baseline source and were skipped:" >&2
   sed 's/^/  - /' "$SKIPPED_FILE" >&2
 
-  # A benchmark-only change is fine -- the skipped benchmark is the work. Any other
-  # source change leaves the A/B comparison incomplete, so fail and ask for the
-  # benchmark to land on its own first. Docs, CODEOWNERS, CI config and tests do
-  # not count as source here.
+  # We want to separate the source code change from a benchmark in case it is not
+  # possible to run the new benchmark on the baseline.
   NON_BENCH_SOURCE_CHANGED=""
   if [[ -d /app/candidate/.git && -n "${COMMIT_SHA:-}" && -n "${CI_COMMIT_SHA:-}" ]]; then
     NON_BENCH_SOURCE_CHANGED="$(git -C /app/candidate diff --name-only "${COMMIT_SHA}..${CI_COMMIT_SHA}" \


### PR DESCRIPTION
## Summary

1. `runall.sh` tolerates a new benchmark that fails on the older baseline source when the same variant passed on the candidate run, and still fails when the PR also changes non-benchmark source (an incomplete A/B comparison).
2. Lower `UNCONFIDENCE_THRESHOLD` from 5% to 2% so smaller changes are reported.
3. Keep the candidate-pass list in `/tmp`, not `ARTIFACTS_DIR`, so the analyzer doesn't read it as sirun results and abort with "Failed to collect even one benchmark result".
4. Pin `awscli` (1.44.87) and Poetry (2.2.1) to their last Python 3.9 releases; the image pins CPython 3.9.23 and the newer releases require 3.10+.
5. Stub `pyenv` so `bp-install` builds its venvs against the standalone CPython instead of failing with "pyenv: command not found".
6. Pin `MICROBENCHMARKS_CI_IMAGE` to the freshly built image by tag and `@sha256` digest.

## Why

#8809 added the in-repo image but never built it. This is its first build, which surfaced the Python 3.9 incompatibilities and the artifacts-dir collision above; items 1 and 2 are the harness change this PR started as.

## Test plan

- `build-benchmark-ci-images` builds green and `ddsign`-signs the image.
- The `benchmark` matrix runs on the pinned image and `Analyze results` passes.

Refs: https://github.com/DataDog/dd-trace-js/pull/8809
