### PR TITLE
perf(format,encode): reduce per-span format and encode overhead

### DIFF
--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -3,7 +3,7 @@
 const getConfig = require('../config')
 const { MsgpackChunk } = require('../msgpack')
 const log = require('../log')
-const { normalizeSpan } = require('./tags-processors')
+const { normalizeSpan, eventTimeNano } = require('./tags-processors')
 
 const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
 // Values longer than this byte threshold skip the `_stringMap` lookup and
@@ -114,8 +114,10 @@ const ATTR_PAYLOAD_BOOL_FALSE = Buffer.concat([ATTR_PREFIX_BOOL, Buffer.from([0x
 function formatSpanWithLegacyEvents (span) {
   span = normalizeSpan(span)
   if (span.span_events) {
-    // TODO: this is currently a main cost driver. By unifying it with the formatter
-    // it should be possible to improve performance significantly overall.
+    // Reads the raw `_events` array directly (no formatter pre-reshape) and
+    // serializes to the legacy meta.events JSON string. The serialization is
+    // still the main cost on the legacy path; the native span_events slot
+    // (`#encodeSpanEvents`) avoids it entirely.
     span.meta.events = stringifySpanEvents(span.span_events)
     // `= undefined` over `delete` to keep the span's hidden class — `delete`
     // would push every event-bearing span into V8 dictionary mode.
@@ -125,14 +127,15 @@ function formatSpanWithLegacyEvents (span) {
 }
 
 /**
- * Hand-written stringifier for `span.span_events`. The shape is fixed by
- * `extractSpanEvents` (`{ name, time_unix_nano, attributes? }`) and attribute
- * values are pre-sanitized to primitives or arrays of primitives, so we can
- * skip everything `JSON.stringify` does for the generic case (toJSON probing,
- * key iteration over the prototype chain, replacer hooks). Output matches
- * `JSON.stringify(spanEvents)` byte-for-byte for the post-sanitization shape.
+ * Hand-written stringifier for `span.span_events`. Events arrive in their raw
+ * `{ name, startTime, attributes? }` shape; `time_unix_nano` is derived per
+ * event via `eventTimeNano` and empty attribute objects are dropped, matching
+ * what the formatter used to precompute. Attribute values are pre-sanitized to
+ * primitives or arrays of primitives, so we skip everything `JSON.stringify`
+ * does for the generic case (toJSON probing, prototype-chain key iteration,
+ * replacer hooks).
  *
- * @param {Array<{ name: string, time_unix_nano: number, attributes?: object }>} spanEvents
+ * @param {Array<{ name: unknown, startTime: number, attributes?: object }>} spanEvents
  * @returns {string}
  */
 function stringifySpanEvents (spanEvents) {
@@ -140,17 +143,21 @@ function stringifySpanEvents (spanEvents) {
   for (let index = 0; index < spanEvents.length; index++) {
     if (index > 0) result += ','
     const event = spanEvents[index]
+    // `_sanitizeEventAttributes` leaves `attributes` undefined when empty, so a
+    // present value always has entries — no emptiness probe here.
+    const attributes = event.attributes
     // `addEvent` does not type-check `name`; defer the unusual cases to
-    // `JSON.stringify` so non-string names match the prior behaviour
-    // instead of throwing in `escapeJsonString`.
+    // `JSON.stringify` so non-string names match the prior behaviour instead
+    // of throwing in `escapeJsonString`. Build the wire-shaped object so the
+    // emitted key stays `time_unix_nano`, not the raw `startTime`.
     if (typeof event.name !== 'string') {
-      result += JSON.stringify(event)
+      result += JSON.stringify({ name: event.name, time_unix_nano: eventTimeNano(event), attributes })
       continue
     }
     result += '{"name":' + escapeJsonString(event.name) +
-      ',"time_unix_nano":' + jsonNumber(event.time_unix_nano)
-    if (event.attributes) {
-      result += ',"attributes":' + stringifyAttributes(event.attributes)
+      ',"time_unix_nano":' + jsonNumber(eventTimeNano(event))
+    if (attributes) {
+      result += ',"attributes":' + stringifyAttributes(attributes)
     }
     result += '}'
   }
@@ -241,8 +248,8 @@ class AgentEncoder {
     this.#config = getConfig()
     this.#debugEncoding = this.#config.DD_TRACE_ENCODING_DEBUG
     // Pick the per-span formatter once so the hot loop pays no per-span
-    // config check. The native path doesn't need to reshape `span_events`
-    // because `#encodeSpanEvents` works directly on the raw attributes.
+    // config check. The native path keeps the raw `span_events` slot for
+    // `#encodeSpanEvents`; the legacy path serializes it into meta.events.
     this.#formatSpan = this.#config.DD_TRACE_NATIVE_SPAN_EVENTS
       ? normalizeSpan
       : formatSpanWithLegacyEvents
@@ -764,7 +771,7 @@ class AgentEncoder {
    * values — no `formatSpanEvents` pre-pass and no recursive generic walk.
    *
    * @param {MsgpackChunk} bytes
-   * @param {Array<{ name: string, time_unix_nano: number, attributes?: object }>} spanEvents
+   * @param {Array<{ name: unknown, startTime: number, attributes?: object }>} spanEvents
    */
   #encodeSpanEvents (bytes, spanEvents) {
     const offset = bytes.length
@@ -785,7 +792,7 @@ class AgentEncoder {
       bytes.set(KEY_NAME)
       this._encodeString(bytes, event.name)
       bytes.set(KEY_EVENT_TIME)
-      bytes.writeFloat(event.time_unix_nano)
+      bytes.writeFloat(eventTimeNano(event))
 
       const attributes = event.attributes
       if (attributes !== null && typeof attributes === 'object') {

--- a/packages/dd-trace/src/encode/0.4.js
+++ b/packages/dd-trace/src/encode/0.4.js
@@ -320,16 +320,18 @@ class AgentEncoder {
       const resourceLen = resourceEntry.length
       const serviceLen = serviceEntry.length
 
-      // Almost every span carries `error: 0` or `error: 1` AND a nanosecond
-      // `start` timestamp ≥ 2³² (so `start` always encodes as a u64). When
-      // both hold, the block fuses error key+value, the start key + 0xCF
-      // type byte + 8-byte timestamp, and the duration key into the per-span
-      // reserve. The fallback path covers synthetic/test inputs with small
-      // starts and rare non-binary error flags by keeping per-field emits so
-      // each integer picks the shortest msgpack encoding.
-      const errorIsFixint = span.error === 0 || span.error === 1
-      const startFitsU64 = span.start >= 0x1_00_00_00_00
-      const fuseTail = errorIsFixint && startFitsU64
+      // `error` is `0` or `1` on nearly every span, and `start` is a
+      // nanosecond timestamp ≥ 2³² (always a msgpack u64). Decide the fused
+      // error key+value up front (`KEY_ERROR_0` / `KEY_ERROR_1`, or `undefined`
+      // for the rare non-binary flag) so the tail fuses without re-deciding the
+      // error shape twice. The fused tail also needs `start` as a u64; when
+      // either misses (synthetic small `start`, non-binary error) the tail
+      // routes each integer through `writeIntOrFloat` for the shortest
+      // encoding.
+      const errorEntry = span.error === 0
+        ? KEY_ERROR_0
+        : span.error === 1 ? KEY_ERROR_1 : undefined
+      const fuseTail = errorEntry !== undefined && span.start >= 0x1_00_00_00_00
 
       let blockSize = 1 +
         KEY_TRACE_ID_PREFIX.length + 8 +
@@ -340,7 +342,7 @@ class AgentEncoder {
         KEY_SERVICE.length + serviceLen
       if (typeEntry) blockSize += KEY_TYPE.length + typeEntry.length
       if (fuseTail) {
-        blockSize += KEY_ERROR_0.length + KEY_START_PREFIX.length + 8 + KEY_DURATION.length
+        blockSize += errorEntry.length + KEY_START_PREFIX.length + 8 + KEY_DURATION.length
       }
 
       const blockOffset = bytes.length
@@ -377,8 +379,8 @@ class AgentEncoder {
       cursor += serviceLen
 
       if (fuseTail) {
-        target.set(span.error === 0 ? KEY_ERROR_0 : KEY_ERROR_1, cursor)
-        cursor += KEY_ERROR_0.length
+        target.set(errorEntry, cursor)
+        cursor += errorEntry.length
 
         target.set(KEY_START_PREFIX, cursor)
         cursor += KEY_START_PREFIX.length
@@ -389,15 +391,14 @@ class AgentEncoder {
         cursor += 8
 
         target.set(KEY_DURATION, cursor)
+      } else if (errorEntry) {
+        bytes.set(errorEntry)
+        bytes.set(KEY_START)
+        bytes.writeIntOrFloat(span.start)
+        bytes.set(KEY_DURATION)
       } else {
-        if (span.error === 0) {
-          bytes.set(KEY_ERROR_0)
-        } else if (span.error === 1) {
-          bytes.set(KEY_ERROR_1)
-        } else {
-          bytes.set(KEY_ERROR)
-          bytes.writeIntOrFloat(span.error)
-        }
+        bytes.set(KEY_ERROR)
+        bytes.writeIntOrFloat(span.error)
         bytes.set(KEY_START)
         bytes.writeIntOrFloat(span.start)
         bytes.set(KEY_DURATION)

--- a/packages/dd-trace/src/encode/agentless-json.js
+++ b/packages/dd-trace/src/encode/agentless-json.js
@@ -3,6 +3,7 @@
 const log = require('../log')
 const { TOP_LEVEL_KEY } = require('../constants')
 const { normalizeSpan } = require('./tags-processors')
+const { stringifySpanEvents } = require('./0.4')
 
 // Soft limit for estimated payload size. Triggers an early flush to stay under intake request size limits.
 const SOFT_LIMIT = 8 * 1024 * 1024 // 8MB
@@ -20,7 +21,10 @@ function formatSpan (span, isFirstSpan) {
   delete span.meta['_dd.p.tid']
 
   if (span.span_events) {
-    span.meta.events = JSON.stringify(span.span_events)
+    // Events arrive raw (`{ name, startTime, attributes? }`); stringifySpanEvents
+    // derives `time_unix_nano` and drops empty attributes, matching the JSON the
+    // reshaped array used to produce.
+    span.meta.events = stringifySpanEvents(span.span_events)
     delete span.span_events
   }
 

--- a/packages/dd-trace/src/encode/tags-processors.js
+++ b/packages/dd-trace/src/encode/tags-processors.js
@@ -46,6 +46,19 @@ function truncateSpanTestOpt (span) {
   return span
 }
 
+/**
+ * Convert a raw span event's `startTime` (milliseconds, sub-millisecond
+ * precision) to the wire `time_unix_nano`. Single source of truth for the
+ * formula so the four encoders that consume `span_events` stay in lockstep;
+ * the formatter no longer reshapes events, it hands the raw array through.
+ *
+ * @param {{ startTime: number }} event
+ * @returns {number}
+ */
+function eventTimeNano (event) {
+  return Math.round(event.startTime * 1e6)
+}
+
 function normalizeSpan (span) {
   span.service = span.service || DEFAULT_SERVICE_NAME
   if (span.service.length > MAX_SERVICE_LENGTH) {
@@ -69,6 +82,7 @@ module.exports = {
   truncateSpan,
   truncateSpanTestOpt,
   normalizeSpan,
+  eventTimeNano,
   MAX_META_KEY_LENGTH,
   MAX_META_VALUE_LENGTH,
   MAX_META_VALUE_LENGTH_TEST_OPTIMIZATION,

--- a/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
+++ b/packages/dd-trace/src/opentelemetry/trace/otlp_transformer.js
@@ -4,6 +4,7 @@ const OtlpTransformerBase = require('../otlp/otlp_transformer_base')
 const { getProtobufTypes } = require('../otlp/protobuf_loader')
 const { VERSION } = require('../../../../../version')
 const id = require('../../id')
+const { eventTimeNano } = require('../../encode/tags-processors')
 
 const { protoSpanKind } = getProtobufTypes()
 const SPAN_KIND_UNSPECIFIED = protoSpanKind.values.SPAN_KIND_UNSPECIFIED
@@ -33,7 +34,7 @@ const TRACE_ID_128 = '_dd.p.tid'
  *
  * @typedef {object} DDSpanEvent
  * @property {string} name - Event name
- * @property {number} time_unix_nano - Event time in nanoseconds since epoch
+ * @property {number} startTime - Event start time in milliseconds (sub-ms precision)
  * @property {Record<string, string | number | boolean>} [attributes] - Event attributes
  *
  * @typedef {object} DDFormattedSpan
@@ -274,7 +275,7 @@ class OtlpTraceTransformer extends OtlpTransformerBase {
    */
   #transformEvent (event) {
     return {
-      timeUnixNano: event.time_unix_nano,
+      timeUnixNano: eventTimeNano(event),
       name: event.name || '',
       attributes: this.transformAttributes(event.attributes ?? {}),
       droppedAttributesCount: 0,

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -38,20 +38,26 @@ const tagsUpdateCh = channel('dd-trace:span:tags:update')
 // Module-scope so we don't allocate a fresh recursive closure on every
 // `addLink` / `addEvent`.
 /**
- * @param {Record<string, string>} out
+ * @param {Record<string, string> | undefined} out Accumulator, created lazily
+ * on the first surviving entry so an all-dropped set stays `undefined`.
  * @param {string} key
  * @param {unknown} value
+ * @returns {Record<string, string> | undefined}
  */
 function addArrayOrScalarAttribute (out, key, value) {
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      addArrayOrScalarAttribute(out, `${key}.${i}`, value[i])
+      out = addArrayOrScalarAttribute(out, `${key}.${i}`, value[i])
     }
-  } else if (ALLOWED.has(typeof value)) {
-    out[key] = typeof value === 'string' ? value : String(value)
-  } else {
-    log.warn('Dropping span link attribute. It is not of an allowed type')
+    return out
   }
+  if (ALLOWED.has(typeof value)) {
+    out ??= {}
+    out[key] = typeof value === 'string' ? value : String(value)
+    return out
+  }
+  log.warn('Dropping span link attribute. It is not of an allowed type')
+  return out
 }
 
 function getIntegrationCounter (event, integration) {
@@ -348,21 +354,24 @@ class DatadogSpan {
 
   /**
    * @param {Record<string, unknown>} [attributes]
+   * @returns {Record<string, string> | undefined} `undefined` when nothing
+   * survives, so `extractSpanLinks` omits the slot without an emptiness probe.
    */
   _sanitizeAttributes (attributes = {}) {
-    /** @type {Record<string, string>} */
-    const out = {}
+    let out
     for (const key of Object.keys(attributes)) {
-      addArrayOrScalarAttribute(out, key, attributes[key])
+      out = addArrayOrScalarAttribute(out, key, attributes[key])
     }
     return out
   }
 
   /**
    * @param {Record<string, unknown>} [attributes]
+   * @returns {Record<string, unknown> | undefined} `undefined` when nothing
+   * survives, so the encoders skip the slot without an emptiness probe.
    */
   _sanitizeEventAttributes (attributes = {}) {
-    const sanitizedAttributes = {}
+    let sanitizedAttributes
 
     for (const key of Object.keys(attributes)) {
       const value = attributes[key]
@@ -375,8 +384,10 @@ class DatadogSpan {
             log.warn('Dropping span event attribute. It is not of an allowed type')
           }
         }
+        sanitizedAttributes ??= {}
         sanitizedAttributes[key] = newArray
       } else if (ALLOWED.has(typeof value)) {
+        sanitizedAttributes ??= {}
         sanitizedAttributes[key] = value
       } else {
         log.warn('Dropping span event attribute. It is not of an allowed type')

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -23,6 +23,8 @@ class DatadogTracer {
   constructor (config, prioritySampler) {
     this._config = config
     this._service = config.service
+    // Lowercased once for span_format's per-span base-service comparison.
+    this.serviceLower = typeof config.service === 'string' ? config.service.toLowerCase() : ''
     this._version = config.version
     this._env = config.env
     this._logInjection = config.logInjection

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -168,7 +168,7 @@ function extractTags (formattedSpan, span) {
     metrics[MEASURED] = 1
   }
 
-  const tracerService = span.tracer()._service.toLowerCase()
+  const tracerService = span.tracer().serviceLower
   if (tags['service.name']?.toLowerCase() !== tracerService) {
     span.setTag(BASE_SERVICE, tracerService)
 

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -48,9 +48,10 @@ const { IGNORE_OTEL_ERROR } = constants
  * @property {Array} links
  * @property {Array<SpanEvent> | undefined} span_events
  *
- * @typedef {object} SpanEvent
+ * @typedef {object} SpanEvent Raw span event as stored on the span; the encoder
+ *   layer derives `time_unix_nano` from `startTime` via `eventTimeNano`.
  * @property {string} name
- * @property {number} time_unix_nano
+ * @property {number} startTime Milliseconds with sub-millisecond precision.
  * @property {Record<string, string>} [attributes]
  */
 
@@ -137,6 +138,12 @@ function extractSpanLinks (formattedSpan, span) {
 }
 
 /**
+ * Hand the raw `_events` array to the encoder layer instead of copying it into
+ * reshaped `{ name, time_unix_nano, attributes }` objects. Each encoder derives
+ * `time_unix_nano` from `event.startTime` via `eventTimeNano` and drops empty
+ * attribute objects itself, so the per-event allocation here is pure waste on
+ * every event-bearing span.
+ *
  * @param {FormattedSpan} formattedSpan
  * @param {import('./opentracing/span')} span
  */
@@ -144,13 +151,7 @@ function extractSpanEvents (formattedSpan, span) {
   if (!span._events?.length) {
     return
   }
-  formattedSpan.span_events = span._events.map(event => {
-    return {
-      name: event.name,
-      time_unix_nano: Math.round(event.startTime * 1e6),
-      attributes: event.attributes && Object.keys(event.attributes).length > 0 ? event.attributes : undefined,
-    }
-  })
+  formattedSpan.span_events = span._events
 }
 
 function extractTags (formattedSpan, span) {

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -121,7 +121,9 @@ function extractSpanLinks (formattedSpan, span) {
       span_id: context.toSpanId(true),
     }
 
-    if (attributes && Object.keys(attributes).length > 0) {
+    // `_sanitizeAttributes` (addLink) leaves `attributes` undefined when empty,
+    // so a present value always has entries — no emptiness probe here.
+    if (attributes) {
       formattedLink.attributes = attributes
     }
     if (context?._sampling?.priority >= 0) formattedLink.flags = context._sampling.priority > 0 ? 1 : 0

--- a/packages/dd-trace/src/span_format.js
+++ b/packages/dd-trace/src/span_format.js
@@ -89,7 +89,6 @@ function formatSpan (span) {
     metrics: {},
     start: Math.round(span._startTime * 1e6),
     duration: Math.round(span._duration * 1e6),
-    links: [],
     span_events: undefined,
   }
 }

--- a/packages/dd-trace/test/encode/0.4.spec.js
+++ b/packages/dd-trace/test/encode/0.4.spec.js
@@ -236,11 +236,12 @@ describe('encode', () => {
     })
 
     it('should encode span events within tags as a fallback to encoding as a top level field', () => {
+      // Events arrive raw: the encoder derives time_unix_nano = round(startTime * 1e6).
       const topLevelEvents = [
-        { name: 'Something went so wrong', time_unix_nano: 1000000 },
+        { name: 'Something went so wrong', startTime: 1 },
         {
           name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
-          time_unix_nano: 1633023102000000,
+          startTime: 1633023102,
           attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false },
         },
       ]
@@ -263,6 +264,19 @@ describe('encode', () => {
       // `addEvent` does not type-check `name`. The legacy stringifier must
       // tolerate the same inputs `JSON.stringify` did before the rewrite.
       const events = [
+        { name: undefined, startTime: 1 },
+        { name: null, startTime: 2, attributes: { ok: true } },
+        { name: 42, startTime: 3 },
+        { name: true, startTime: 4 },
+        { name: ['array', 'name'], startTime: 5 },
+        { name: { nested: 'object' }, startTime: 6 },
+        { name: Symbol('event'), startTime: 7 },
+        { name: 'plain', startTime: 8 },
+      ]
+
+      // The wire shape uses time_unix_nano = round(startTime * 1e6) and drops
+      // undefined attributes, matching the old formatter output.
+      const expected = JSON.stringify([
         { name: undefined, time_unix_nano: 1000000 },
         { name: null, time_unix_nano: 2000000, attributes: { ok: true } },
         { name: 42, time_unix_nano: 3000000 },
@@ -271,7 +285,7 @@ describe('encode', () => {
         { name: { nested: 'object' }, time_unix_nano: 6000000 },
         { name: Symbol('event'), time_unix_nano: 7000000 },
         { name: 'plain', time_unix_nano: 8000000 },
-      ]
+      ])
 
       data[0].span_events = events
 
@@ -279,7 +293,7 @@ describe('encode', () => {
 
       const buffer = encoder.makePayload()
       const decoded = msgpack.decode(buffer, { useBigInt64: true })
-      assert.strictEqual(decoded[0][0].meta.events, JSON.stringify(events))
+      assert.strictEqual(decoded[0][0].meta.events, expected)
     })
 
     it('should encode spanLinks', () => {
@@ -594,11 +608,12 @@ describe('encode', () => {
     })
 
     it('should encode span events as a top-level field when the agent version supports this', () => {
+      // Raw events carry startTime; the encoder derives time_unix_nano = round(startTime * 1e6).
       const topLevelEvents = [
-        { name: 'Something went so wrong', time_unix_nano: 1000000 },
+        { name: 'Something went so wrong', startTime: 1 },
         {
           name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
-          time_unix_nano: 1633023102000000,
+          startTime: 1633023102,
           attributes: { emotion: 'happy', happiness: 10, rating: 9.8, other: ['hi', false, 1, 1.2], idol: false },
         },
       ]
@@ -645,12 +660,12 @@ describe('encode', () => {
       const topLevelEvents = [
         {
           name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
-          time_unix_nano: 1633023102000000,
+          startTime: 1633023102,
           attributes: { emotion: { unsupportedNestedObject: 'happiness' }, array: [['nested_array']] },
         },
         {
           name: 'I can sing!!!',
-          time_unix_nano: 1633023102000000,
+          startTime: 1633023102,
           attributes: { emotion: { unsupportedNestedObject: 'happiness' }, array: [['nested_array'], 'valid_value'] },
         },
       ]
@@ -683,22 +698,22 @@ describe('encode', () => {
       const topLevelEvents = [
         {
           name: 'Event 1',
-          time_unix_nano: 1000000,
+          startTime: 1,
           attributes: { unsupported_key: { some: 'object' }, other_key: 'valid' },
         },
         {
           name: 'Event 2',
-          time_unix_nano: 2000000,
+          startTime: 2,
           attributes: { unsupported_key: { another: 'object' } },
         },
         {
           name: 'Event 3',
-          time_unix_nano: 3000000,
+          startTime: 3,
           attributes: { unsupported_key: { yet: 'another object' } },
         },
         {
           name: 'Event 4',
-          time_unix_nano: 4000000,
+          startTime: 4,
           attributes: { unsupported_key: { different: 'structure' } },
         },
       ]
@@ -719,17 +734,17 @@ describe('encode', () => {
       const topLevelEvents = [
         {
           name: 'Event 1',
-          time_unix_nano: 1000000,
+          startTime: 1,
           attributes: { unsupported_key1: { some: 'object' }, unsupported_key2: { another: 'object' } },
         },
         {
           name: 'Event 2',
-          time_unix_nano: 2000000,
+          startTime: 2,
           attributes: { unsupported_key1: { different: 'structure' }, unsupported_key3: { more: 'objects' } },
         },
         {
           name: 'Event 3',
-          time_unix_nano: 3000000,
+          startTime: 3,
           attributes: { unsupported_key2: { yet: 'another object' }, unsupported_key3: { extra: 'data' } },
         },
       ]
@@ -751,11 +766,11 @@ describe('encode', () => {
       // and would have aborted the entire trace. Bad entries are dropped
       // silently; the rest of the trace must still encode.
       const topLevelEvents = [
-        { name: null, time_unix_nano: 1000000, attributes: { ok: true } },
-        { name: 42, time_unix_nano: 2000000 },
-        { name: Symbol('event'), time_unix_nano: 3000000 },
-        { name: undefined, time_unix_nano: 4000000 },
-        { name: 'kept', time_unix_nano: 5000000, attributes: { mood: 'happy' } },
+        { name: null, startTime: 1, attributes: { ok: true } },
+        { name: 42, startTime: 2 },
+        { name: Symbol('event'), startTime: 3 },
+        { name: undefined, startTime: 4 },
+        { name: 'kept', startTime: 5, attributes: { mood: 'happy' } },
       ]
 
       data[0].span_events = topLevelEvents

--- a/packages/dd-trace/test/encode/0.5.spec.js
+++ b/packages/dd-trace/test/encode/0.5.spec.js
@@ -70,11 +70,12 @@ describe('encode 0.5', () => {
   })
 
   it('should encode span events', () => {
+    // Raw events carry startTime; the encoder derives time_unix_nano = round(startTime * 1e6).
     const topLevelEvents = [
-      { name: 'Something went so wrong', time_unix_nano: 1000000 },
+      { name: 'Something went so wrong', startTime: 1 },
       {
         name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
-        time_unix_nano: 1633023102000000,
+        startTime: 1633023102,
         attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false },
       },
     ]

--- a/packages/dd-trace/test/encode/agentless-json.spec.js
+++ b/packages/dd-trace/test/encode/agentless-json.spec.js
@@ -178,7 +178,8 @@ describe('AgentlessJSONEncoder', () => {
     })
 
     it('should convert span_events to meta.events JSON string', () => {
-      data[0].span_events = [{ name: 'exception', attributes: { message: 'error' } }]
+      // Raw events carry startTime; the encoder derives time_unix_nano = round(startTime * 1e6).
+      data[0].span_events = [{ name: 'exception', startTime: 1, attributes: { message: 'error' } }]
 
       encoder.encode(data)
 
@@ -188,7 +189,10 @@ describe('AgentlessJSONEncoder', () => {
 
       assert.strictEqual(span.span_events, undefined)
       assert.strictEqual(typeof span.meta.events, 'string')
-      assert.deepStrictEqual(JSON.parse(span.meta.events), [{ name: 'exception', attributes: { message: 'error' } }])
+      assert.deepStrictEqual(
+        JSON.parse(span.meta.events),
+        [{ name: 'exception', time_unix_nano: 1000000, attributes: { message: 'error' } }]
+      )
     })
 
     it('should include meta_struct when present', () => {

--- a/packages/dd-trace/test/opentelemetry/traces.spec.js
+++ b/packages/dd-trace/test/opentelemetry/traces.spec.js
@@ -369,10 +369,11 @@ describe('OpenTelemetry Traces', () => {
 
     it('transforms span events', () => {
       const transformer = new OtlpTraceTransformer({})
+      // Raw events carry startTime; the transformer derives timeUnixNano = round(startTime * 1e6).
       const span = createMockSpan({
         span_events: [{
           name: 'exception',
-          time_unix_nano: 1700000000010000000,
+          startTime: 1700000000010,
           attributes: {
             'exception.message': 'test error',
             'exception.type': 'Error',
@@ -385,6 +386,7 @@ describe('OpenTelemetry Traces', () => {
 
       assert.strictEqual(otlpSpan.events.length, 1)
       assert.strictEqual(otlpSpan.events[0].name, 'exception')
+      assert.strictEqual(Number(otlpSpan.events[0].timeUnixNano), 1700000000010000000)
 
       const eventAttrs = extractAttrs(otlpSpan.events[0].attributes)
       assert.deepStrictEqual(

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -333,7 +333,7 @@ describe('Span', () => {
         'extras.0': '1',
         'extras.1': '2',
       })
-      assert.deepStrictEqual(span._links[1].attributes, {})
+      assert.strictEqual(span._links[1].attributes, undefined)
     })
   })
 
@@ -403,6 +403,63 @@ describe('Span', () => {
       ]
       assert.deepStrictEqual(events, expectedEvents)
     })
+  })
+
+  describe('empty event and link attributes (end to end)', () => {
+    // addEvent / addLink sanitize empty (and all-dropped) attribute sets to
+    // `undefined` at the source, so format() and every 0.4 encoder path omit
+    // the slot instead of emitting `"attributes":{}`. The encoders trust that
+    // contract and skip the per-entry emptiness probe, so this guards the wire.
+    const msgpack = require('@msgpack/msgpack')
+    const format = require('../../src/span_format')
+    // Real id (not the suite's string stub) so span-link contexts serialize.
+    const RealSpan = require('../../src/opentracing/span')
+
+    function buildSpan () {
+      const span = new RealSpan(tracer, processor, prioritySampler, { operationName: 'operation' })
+      span.addEvent('empty', {})
+      span.addEvent('all dropped', { nested: { not: 'allowed' } })
+      span.addEvent('kept', { rating: 9 })
+      span.addLink({ context: span.context(), attributes: {} })
+      span.addLink({ context: span.context(), attributes: { nested: { not: 'allowed' } } })
+      span.addLink({ context: span.context(), attributes: { color: 'blue' } })
+      span.finish()
+      return span
+    }
+
+    it('sanitizes empty and all-dropped attributes to undefined on the span', () => {
+      const span = buildSpan()
+
+      assert.strictEqual(span._events[0].attributes, undefined)
+      assert.strictEqual(span._events[1].attributes, undefined)
+      assert.deepStrictEqual(span._events[2].attributes, { rating: 9 })
+
+      assert.strictEqual(span._links[0].attributes, undefined)
+      assert.strictEqual(span._links[1].attributes, undefined)
+      assert.deepStrictEqual(span._links[2].attributes, { color: 'blue' })
+    })
+
+    for (const nativeSpanEvents of [false, true]) {
+      it(`omits empty attributes through format() + 0.4 encode (native span events: ${nativeSpanEvents})`, () => {
+        const { AgentEncoder } = proxyquire('../../src/encode/0.4', {
+          '../config': () => ({ DD_TRACE_NATIVE_SPAN_EVENTS: nativeSpanEvents }),
+        })
+        const encoder = new AgentEncoder({ flush () {} })
+
+        encoder.encode([format(buildSpan())])
+        const encoded = msgpack.decode(encoder.makePayload(), { useBigInt64: true })[0][0]
+
+        const links = JSON.parse(encoded.meta['_dd.span_links'])
+        assert.ok(!('attributes' in links[0]), 'empty link attributes must be omitted')
+        assert.ok(!('attributes' in links[1]), 'all-dropped link attributes must be omitted')
+        assert.deepStrictEqual(links[2].attributes, { color: 'blue' })
+
+        const events = nativeSpanEvents ? encoded.span_events : JSON.parse(encoded.meta.events)
+        assert.ok(!('attributes' in events[0]), 'empty event attributes must be omitted')
+        assert.ok(!('attributes' in events[1]), 'all-dropped event attributes must be omitted')
+        assert.ok('attributes' in events[2], 'kept event attributes must be present')
+      })
+    }
   })
 
   describe('getBaggageItem', () => {

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -99,7 +99,10 @@ describe('spanFormat', () => {
   })
 
   describe('spanFormat', () => {
-    it('should format span events', () => {
+    it('should pass span events through to the encoder as the raw _events array', () => {
+      // The formatter no longer reshapes events; each encoder derives
+      // time_unix_nano from startTime via eventTimeNano. extractSpanEvents
+      // must hand the raw array straight through without copying.
       span._events = [
         { name: 'Something went so wrong', startTime: 1 },
         {
@@ -110,16 +113,8 @@ describe('spanFormat', () => {
       ]
 
       trace = spanFormat(span)
-      const spanEvents = trace.span_events
-      assert.deepStrictEqual(spanEvents, [{
-        name: 'Something went so wrong',
-        time_unix_nano: 1000000,
-        attributes: undefined,
-      }, {
-        name: 'I can sing!!! acbdefggnmdfsdv k 2e2ev;!|=xxx',
-        time_unix_nano: 1633023102000000,
-        attributes: { emotion: 'happy', rating: 9.8, other: [1, 9.5, 1], idol: false },
-      }])
+
+      assert.strictEqual(trace.span_events, span._events)
     })
 
     it('should convert a span to the correct trace format', () => {

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -196,7 +196,6 @@ describe('spanFormat', () => {
         },
         start: Math.round(1_500_000_000_000.123 * 1e6),
         duration: Math.round(1.234 * 1e6),
-        links: [],
         span_events: undefined,
       })
     })

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -69,6 +69,7 @@ describe('spanFormat', () => {
       context: sinon.stub().returns(spanContext),
       tracer: sinon.stub().returns({
         _service: 'test',
+        serviceLower: 'test',
       }),
       setTag: sinon.stub(),
       _startTime: 1500000000000.123,
@@ -344,6 +345,14 @@ describe('spanFormat', () => {
 
       it('should infer the tag when no changes occur', () => {
         span.context()._tags['service.name'] = 'test'
+
+        trace = spanFormat(span)
+
+        sinon.assert.notCalled(span.setTag)
+      })
+
+      it('should treat a case-only service difference as no change', () => {
+        span.context()._tags['service.name'] = 'TEST'
 
         trace = spanFormat(span)
 


### PR DESCRIPTION
## Summary

Six independent per-span micro-optimizations in the format → encode path, each byte-identical on the wire:

1. The tracer service is lowercased once on the tracer (`serviceLower`) instead of on every span, so `extractTags`' case-insensitive `_dd.base_service` comparison is a property read.
2. The fused error key is decided once in the span tail, collapsing a double-emit.
3. `addEvent` / `addLink` sanitize empty (and all-dropped) attribute sets to `undefined` at the source instead of materializing `{}`. Empty sets were already kept off the wire one layer later, so this is wire-neutral on its own — but it lets the formatter and encoders omit the slot on a truthiness check, with no per-entry `Object.keys` probe (items 4 and 6).
4. Raw span events are handed to the encoders by reference instead of reshaped into throwaway `{ name, time_unix_nano, attributes }` objects; each encoder derives `time_unix_nano` through a shared `eventTimeNano`.
5. `formatSpan` no longer initializes `links: []` on every span — span links are routed into `meta['_dd.span_links']` and the slot is never written (the agentless-json guard is null-safe and the msgpack encoders ignore the slot).
6. `extractSpanLinks` drops its per-link `Object.keys` emptiness probe — link attributes are `undefined` when empty after item 3, so a presence check suffices.

End-to-end `span.spec.js` cases pin that empty and all-dropped event/link attributes stay off the wire across the legacy `meta.events` and native `span_events` paths, so the probe removals can't silently start emitting `"attributes":{}`.