### PR TITLE
perf(span): drop per-span throwaway allocations in the constructor

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -79,12 +79,6 @@ class DatadogSpan {
 
     const operationName = fields.operationName
     const parent = fields.parent || null
-    // Stay on `Object.assign({}, src)` for backportability: V8 12+ (Node 22 /
-    // 24) inlines `{ ...src }` and beats `Object.assign` here, but on V8 10.2
-    // / 11.3 (Node 18 / 20) the spread takes a generic runtime path and slows
-    // `spans-finish-*` by ~140%. Revisit once those LTS lines drop.
-    // eslint-disable-next-line prefer-object-spread
-    const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
 
     this.#parentTracer = tracer
@@ -106,7 +100,7 @@ class DatadogSpan {
 
     this._spanContext = this._createContext(parent, fields)
     this._spanContext._name = operationName
-    Object.assign(this._spanContext.getTags(), tags)
+    Object.assign(this._spanContext.getTags(), fields.tags)
     this._spanContext._hostname = hostname
 
     this._spanContext._trace.started.push(this)
@@ -389,7 +383,7 @@ class DatadogSpan {
     let spanContext
     let startTime
 
-    let baggage = {}
+    let baggage
     const propagationBehavior = this.#parentTracer._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
     if (parent && parent._isRemote && propagationBehavior !== 'continue') {
       baggage = parent._baggageItems
@@ -431,7 +425,7 @@ class DatadogSpan {
       }
 
       if (propagationBehavior === 'restart') {
-        spanContext._baggageItems = baggage
+        spanContext._baggageItems = baggage ?? {}
       }
     }
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -614,6 +614,12 @@ describe('Span', () => {
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar' })
       })
+
+      it('should start with empty baggage on restart when there is no parent to inherit from', () => {
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
+        span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+        assert.deepStrictEqual(span._spanContext._baggageItems, {})
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

Every span paid for two allocations it never used. The constructor copied the caller's `fields.tags` into a throwaway object only to merge that copy into the context tag bag one line later; the merge already copies values into the context's own object, so the intermediate protected nothing. `_createContext` likewise allocated a `baggage` object on every span when only the `propagation_behavior_extract=restart` path reads it.

Merging `fields.tags` directly and deferring the baggage object to the restart branch removes both allocations from the hottest tracer operation (it runs on every span, not only finished ones). Express-root-shaped span constructor, n=2M x 7 trials, drop best+worst, Node 24.15 / V8 13.6: tag merge 39.0 -> 30.2 ns; full create path 264 -> 251 ns.