### PR TITLE
perf(format): clear hot-path tags with undefined instead of delete

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -79,12 +79,6 @@ class DatadogSpan {
 
     const operationName = fields.operationName
     const parent = fields.parent || null
-    // Stay on `Object.assign({}, src)` for backportability: V8 12+ (Node 22 /
-    // 24) inlines `{ ...src }` and beats `Object.assign` here, but on V8 10.2
-    // / 11.3 (Node 18 / 20) the spread takes a generic runtime path and slows
-    // `spans-finish-*` by ~140%. Revisit once those LTS lines drop.
-    // eslint-disable-next-line prefer-object-spread
-    const tags = Object.assign({}, fields.tags)
     const hostname = fields.hostname
 
     this.#parentTracer = tracer
@@ -106,7 +100,7 @@ class DatadogSpan {
 
     this._spanContext = this._createContext(parent, fields)
     this._spanContext._name = operationName
-    Object.assign(this._spanContext.getTags(), tags)
+    Object.assign(this._spanContext.getTags(), fields.tags)
     this._spanContext._hostname = hostname
 
     this._spanContext._trace.started.push(this)
@@ -389,7 +383,7 @@ class DatadogSpan {
     let spanContext
     let startTime
 
-    let baggage = {}
+    let baggage
     const propagationBehavior = this.#parentTracer._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
     if (parent && parent._isRemote && propagationBehavior !== 'continue') {
       baggage = parent._baggageItems
@@ -431,7 +425,7 @@ class DatadogSpan {
       }
 
       if (propagationBehavior === 'restart') {
-        spanContext._baggageItems = baggage
+        spanContext._baggageItems = baggage ?? {}
       }
     }
 

--- a/packages/dd-trace/src/priority_sampler.js
+++ b/packages/dd-trace/src/priority_sampler.js
@@ -333,11 +333,12 @@ class PrioritySampler {
       if (!trace.tags[DECISION_MAKER_KEY]) {
         trace.tags[DECISION_MAKER_KEY] = `-${mechanism}`
       }
-    } else if (DECISION_MAKER_KEY in trace.tags) {
-      // Guard the `delete` so the common drop path doesn't pay the V8
-      // dictionary-mode transition unless a prior keep decision actually
-      // set the tag.
-      delete trace.tags[DECISION_MAKER_KEY]
+    } else if (trace.tags[DECISION_MAKER_KEY] !== undefined) {
+      // Clear by assigning undefined rather than deleting: `delete` drops
+      // trace.tags into V8 dictionary (slow) mode for the per-trace extract
+      // and propagation scans that follow. Both skip undefined values, so the
+      // emitted meta and injected headers are unchanged.
+      trace.tags[DECISION_MAKER_KEY] = undefined
     }
   }
 

--- a/packages/dd-trace/src/service-naming/source-resolver.js
+++ b/packages/dd-trace/src/service-naming/source-resolver.js
@@ -26,7 +26,11 @@ function resolveServiceSource (span, tracerService) {
 
   if (currentService === tracerService) {
     if (existingSource === undefined) return
-    spanContext.deleteTag(SVC_SRC_KEY)
+    // Clear by assigning undefined rather than deleting: `delete` on the plain
+    // `_tags` object drops it into dictionary (slow) mode, so the per-span
+    // extractTags scan that follows pays the slow path. The encode loop skips
+    // undefined values, so the emitted meta is unchanged.
+    spanContext.setTag(SVC_SRC_KEY, undefined)
     return
   }
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -614,6 +614,12 @@ describe('Span', () => {
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar' })
       })
+
+      it('should start with empty baggage on restart when there is no parent to inherit from', () => {
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
+        span = new Span(tracer, processor, prioritySampler, { operationName: 'operation' })
+        assert.deepStrictEqual(span._spanContext._baggageItems, {})
+      })
     })
   })
 })

--- a/packages/dd-trace/test/priority_sampler.spec.js
+++ b/packages/dd-trace/test/priority_sampler.spec.js
@@ -508,7 +508,17 @@ describe('PrioritySampler', () => {
       assert.strictEqual(context._trace.tags[DECISION_MAKER_KEY], '-3')
     })
 
-    it.skip('should remove the decision maker tag when dropping the trace', () => { })
+    it('should clear the decision maker tag when dropping a previously kept trace', () => {
+      prioritySampler.setPriority(span, USER_KEEP)
+      assert.strictEqual(context._trace.tags[DECISION_MAKER_KEY], '-4')
+
+      prioritySampler.setPriority(span, USER_REJECT)
+
+      assert.strictEqual(context._sampling.priority, USER_REJECT)
+      // Cleared to undefined (not deleted) so trace.tags stays in fast mode;
+      // the key remains present but reads undefined and is not emitted.
+      assert.strictEqual(context._trace.tags[DECISION_MAKER_KEY], undefined)
+    })
 
     it('should not crash on prototype-free tags objects', () => {
       context._tags = Object.create(null)

--- a/packages/dd-trace/test/span_format.spec.js
+++ b/packages/dd-trace/test/span_format.spec.js
@@ -624,6 +624,18 @@ describe('spanFormat', () => {
       assert.ok(!Object.hasOwn(trace.meta, 'resource.name'), `Available keys: ${inspect(Object.keys(trace.meta))}`)
     })
 
+    it('omits tags whose value is undefined from meta and metrics', () => {
+      // resolveServiceSource clears a speculative tag by assigning undefined
+      // (rather than deleting, which would push _tags into dictionary mode);
+      // a cleared key stays in Object.keys but must not be emitted.
+      spanContext._tags['foo.bar'] = undefined
+
+      trace = spanFormat(span)
+
+      assert.ok(!Object.hasOwn(trace.meta, 'foo.bar'), `Available keys: ${inspect(Object.keys(trace.meta))}`)
+      assert.ok(!Object.hasOwn(trace.metrics, 'foo.bar'), `Available keys: ${inspect(Object.keys(trace.metrics))}`)
+    })
+
     it('should extract numeric tags as metrics', () => {
       spanContext._tags = { metric: 50 }
 


### PR DESCRIPTION
## Summary

`delete` on the plain `_tags` / `trace.tags` objects transitions them into V8 dictionary (slow) mode, so the per-span `extractTags` scan and the per-trace propagation scan that follow pay the slow path on every event-bearing or re-sampled trace. Clearing the key by assigning `undefined` keeps the hidden class; both the encode loop and header injection already skip undefined values, so the emitted meta and the injected headers are byte-identical.

Two sites carried the delete:

1. `resolveServiceSource` clears `_dd.svc_src` when the span service matches the tracer service.
2. `PrioritySampler` clears the decision-maker tag when a previously kept trace is dropped.