### PR TITLE
fix(stats): bucket spans by start instead of the missing startTime field

### DIFF
--- a/packages/dd-trace/src/span_stats.js
+++ b/packages/dd-trace/src/span_stats.js
@@ -190,7 +190,7 @@ class SpanStatsProcessor {
     if (!this.enabled) return
     if (!span.metrics[TOP_LEVEL_KEY] && !span.metrics[MEASURED]) return
 
-    const spanEndNs = span.startTime + span.duration
+    const spanEndNs = span.start + span.duration
     const bucketTime = spanEndNs - (spanEndNs % this.bucketSizeNs)
 
     this.buckets.forTime(bucketTime)

--- a/packages/dd-trace/test/span_stats.spec.js
+++ b/packages/dd-trace/test/span_stats.spec.js
@@ -26,9 +26,12 @@ const {
 } = require('../src/encode/tags-processors')
 const processTags = require('../src/process-tags')
 
-// Mock spans
+// Mock spans use the post-format field name `start` (nanoseconds), matching
+// what `SpanProcessor.process` hands to `onSpanFinished` via the formatted
+// span. The formatter never emits `startTime`, so reading that field bucketed
+// every span under a single NaN time key.
 const basicSpan = {
-  startTime: 12345 * 1e9,
+  start: 12345 * 1e9,
   duration: 1234,
   error: 0,
   name: 'basic-span',
@@ -377,6 +380,33 @@ describe('SpanStatsProcessor', () => {
       OkSummary: okDistribution.toProto(),
       ErrorSummary: errorDistribution.toProto(),
     })
+  })
+
+  it('should bucket by the formatted span start, not the missing startTime field', () => {
+    const localProcessor = new SpanStatsProcessor(config)
+    clearTimeout(localProcessor.timer)
+
+    localProcessor.onSpanFinished(topLevelSpan)
+
+    const bucketTime = localProcessor.buckets.keys().next().value
+    assert.ok(Number.isFinite(bucketTime), `bucket time should be finite, got ${bucketTime}`)
+    assert.strictEqual(bucketTime, 12340000000000)
+  })
+
+  it('should bucket spans by their containing interval boundary', () => {
+    const localProcessor = new SpanStatsProcessor(config)
+    clearTimeout(localProcessor.timer)
+
+    const bucketSizeNs = config.stats.interval * 1e9
+    // Last nanosecond of the first bucket and first nanosecond of the second.
+    const lastInFirstBucket = { ...topLevelSpan, start: bucketSizeNs - topLevelSpan.duration - 1 }
+    const firstInSecondBucket = { ...topLevelSpan, start: bucketSizeNs }
+
+    localProcessor.onSpanFinished(lastInFirstBucket)
+    localProcessor.onSpanFinished(firstInSecondBucket)
+
+    const bucketTimes = [...localProcessor.buckets.keys()]
+    assert.deepStrictEqual(bucketTimes, [0, bucketSizeNs])
   })
 
   it('should export on interval', () => {


### PR DESCRIPTION
## Summary

`onSpanFinished` computed the bucket time from `span.startTime`, but the span it receives is the post-format span, whose field is `start` (nanoseconds). `startTime` is undefined there, so `start + duration` is NaN and every span collapsed into a single NaN-keyed time bucket. The field was renamed to `start` when stats moved to post-format spans; this read was never updated.

The existing test mocked `{ startTime }`, matching the bug rather than the real formatted shape, so it never caught it. The mock now uses `start`, and a regression test pins the bucket key to a finite value and to its interval boundary.