### PR TITLE
perf(http): skip the redundant context enter on fresh server requests

### DIFF
--- a/packages/datadog-plugin-http/src/server.js
+++ b/packages/datadog-plugin-http/src/server.js
@@ -34,6 +34,11 @@ class HttpServerPlugin extends ServerPlugin {
     if (this.#startConfig === undefined) {
       this.#refreshStartCache()
     }
+    // A fresh request has no span yet; web.startSpan creates and enters one.
+    // A reused context (HTTP/2 stream, serverless re-entry) returns the
+    // existing span without entering, so the explicit enter below is the only
+    // one in that case.
+    const spanCreated = !web.getContext(req)?.span
     const span = web.startSpan(
       this.tracer,
       this.#startConfig,
@@ -57,7 +62,12 @@ class HttpServerPlugin extends ServerPlugin {
       store = withRequest(store, req)
     }
 
-    this.enter(span, store)
+    // Skip the re-enter when web.startSpan already entered { ...store, span }
+    // and AppSec did not rebuild the store with req: the bind would be
+    // identical to the one startSpan just made.
+    if (!spanCreated || appsecActive) {
+      this.enter(span, store)
+    }
 
     if (!context.instrumented) {
       context.res.writeHead = web.wrapWriteHead(context)


### PR DESCRIPTION
## Summary

`web.startSpan` already enters `{ ...store, span }` for a fresh request via `TracingPlugin.startSpan`, so the unconditional `this.enter(span, store)` that followed bound the same store a second time: one extra `AsyncLocalStorage.enterWith` per request on the hottest server path.

The re-enter is only load-bearing when the bind would differ from the one `startSpan` made: a reused context (HTTP/2 stream, serverless re-entry) where `startSpan` returns the existing span without entering, or when AppSec rebuilt the store with `req`. Gating on `!spanCreated || appsecActive` covers both and drops the redundant `enterWith` to zero on the common path. Existing http and http2 scope tests pin the context correctness across both branches.