### PR TITLE
bench(sirun): trim runtime of already-merged loop benches

### DIFF
--- a/benchmark/sirun/iast/meta.json
+++ b/benchmark/sirun/iast/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 15,
+  "iterations": 12,
   "instructions": true,
   "variants": {
     "request-lifecycle": {

--- a/benchmark/sirun/llmobs/index.js
+++ b/benchmark/sirun/llmobs/index.js
@@ -23,7 +23,7 @@ const {
   VARIANT,
 } = process.env
 
-const ITERATIONS = 30_000
+const ITERATIONS = 24_000
 
 const writer = new LLMObsSpanWriter({
   apiKey: 'placeholder-api-key',

--- a/benchmark/sirun/plugin-mongodb-core/meta.json
+++ b/benchmark/sirun/plugin-mongodb-core/meta.json
@@ -3,7 +3,7 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 15,
+  "iterations": 12,
   "instructions": true,
   "variants": {
     "plain-find": {

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -3,7 +3,7 @@
   "run": "node spans.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node spans.js\"",
   "cachegrind": false,
-  "iterations": 20,
+  "iterations": 12,
   "instructions": true,
   "variants": {
     "finish-immediately": {

--- a/benchmark/sirun/url/meta.json
+++ b/benchmark/sirun/url/meta.json
@@ -8,7 +8,7 @@
   "variants": {
     "endpoint-and-obfuscation": {
       "env": {
-        "COUNT": "3500000"
+        "COUNT": "3000000"
       }
     }
   }


### PR DESCRIPTION
## Summary

These sirun benches landed before the per-variant runtime budget was set and push the suite toward the job timeout. Lower the sirun repeat counts (and url's loop, llmobs' iterations) so each variant finishes well under a minute; the startup-guard still keeps the load share — and thus wall-time stddev — low at the new counts.

- mongodb-core, iast: iterations 15 -> 12
- spans: iterations 20 -> 12
- url: COUNT 3.5M -> 3M
- llmobs: ITERATIONS 30k -> 24k