### PR TITLE
chore(ci): remove useless call to get-credentials in system-tests workflow

### DIFF
--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -29,27 +29,10 @@ jobs:
           name: system_tests_binaries
           path: ./binaries/**/*
 
-  get-credentials:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    outputs:
-      api_key: ${{ steps.dd-sts.outputs.api_key }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github/actions/dd-sts-api-key
-      - uses: ./.github/actions/dd-sts-api-key
-        id: dd-sts
-
   main:
     needs:
       - build-artifacts
-      - get-credentials
     uses: DataDog/system-tests/.github/workflows/system-tests.yml@main
-    secrets:
-      TEST_OPTIMIZATION_API_KEY: ${{ needs.get-credentials.outputs.api_key }}
-      DD_API_KEY: ${{ needs.get-credentials.outputs.api_key }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION

### What does this PR do?
Per title

### Motivation

This job is useless as secrets can not be passed from on job to another. It was not failing, as system-tests was pulling the secret if the one provided is empty.

Small gain : one job is saved, and one call that could fail is also removed. 

`DD_API_KEY` is not required anymore either.

### Additional Notes
<!-- Anything else we should know when reviewing? -->


