### PR TITLE
bench(core): tune the async_hooks and scope benches

### DIFF
--- a/benchmark/sirun/async_hooks/README.md
+++ b/benchmark/sirun/async_hooks/README.md
@@ -1,0 +1,4 @@
+Critical-path bench. The tracer's async-context propagation rides on async_hooks,
+so per-hook overhead is paid on every async operation in a traced app. Measures
+the cost of enabling `createHook` over a fixed promise workload, with an init-only
+and an all-hooks variant.

--- a/benchmark/sirun/async_hooks/index.js
+++ b/benchmark/sirun/async_hooks/index.js
@@ -1,8 +1,11 @@
 'use strict'
 
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
 const ASYNC_HOOKS = process.env.ASYNC_HOOKS && process.env.ASYNC_HOOKS.split(',')
-const PROMISES_PER_INTERVAL = process.env.PROMISES_PER_INTERVAL || 100000
-const INTERVALS = process.env.INTERVALS || 10
+const PROMISES_PER_INTERVAL = Number(process.env.PROMISES_PER_INTERVAL) || 100000
+const INTERVALS = Number(process.env.INTERVALS) || 10
 
 if (ASYNC_HOOKS) {
   const { createHook } = require('async_hooks')
@@ -16,20 +19,29 @@ if (ASYNC_HOOKS) {
   createHook(hooks).enable()
 }
 
-async function run (count = 0) {
-  if (count >= INTERVALS) return
+// Each interval allocates and resolves a burst of promises so the enabled hooks
+// fire across the full promise lifecycle. Bursts run back-to-back: awaiting each
+// batch drains the microtask queue and lets the previous array be collected, so
+// live memory stays flat without an idle timer between bursts (idle time would
+// add scheduler variance while measuring nothing).
+async function run () {
+  let intervalsRun = 0
 
-  const promises = []
+  while (intervalsRun < INTERVALS) {
+    const promises = []
 
-  for (let i = 0; i < PROMISES_PER_INTERVAL; i++) {
-    promises.push(new Promise((resolve, reject) => resolve()))
+    for (let i = 0; i < PROMISES_PER_INTERVAL; i++) {
+      promises.push(new Promise((resolve) => resolve()))
+    }
+
+    await Promise.all(promises)
+
+    intervalsRun++
   }
 
-  await Promise.all(promises)
-
-  count++
-
-  setTimeout(() => run(count + 1), 100)
+  assert.equal(intervalsRun, INTERVALS, 'async_hooks bench did not run all intervals')
+  guard.done()
 }
 
+guard.loopStart()
 run()

--- a/benchmark/sirun/async_hooks/meta.json
+++ b/benchmark/sirun/async_hooks/meta.json
@@ -6,13 +6,10 @@
   "instructions": true,
   "iterations": 24,
   "variants": {
-    "no-hooks": { "env": { "ASYNC_HOOKS": "" } },
     "init-only": {
-      "baseline": "no-hooks",
       "env": { "ASYNC_HOOKS": "init" }
     },
     "all-hooks": {
-      "baseline": "no-hooks",
       "env": { "ASYNC_HOOKS": "init,before,after,destroy,promiseResolve" }
     }
   }

--- a/benchmark/sirun/scope/README.md
+++ b/benchmark/sirun/scope/README.md
@@ -1,2 +1,4 @@
-This test creates a number (`COUNT`) of promises, awaits, setImmediates and
-setTimeouts which a given scope manager (`DD_TRACE_SCOPE`).
+Measures the scope manager's per-hop async-context cost. Chains `COUNT` promise
+continuations; the `scope_enabled` variant wraps each in `scope.activate()`, the
+path the tracer drives under every traced async operation. The delta is the
+`AsyncLocalStorage` enterWith plus store-copy cost per continuation.

--- a/benchmark/sirun/scope/index.js
+++ b/benchmark/sirun/scope/index.js
@@ -1,45 +1,87 @@
 'use strict'
 
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
 const {
   SCOPE_ENABLED,
+  MODE,
   COUNT,
 } = process.env
 
-if (SCOPE_ENABLED === 'true') {
+const count = Number(COUNT)
+
+if (MODE === 'bind') {
+  // scope.bind wraps a callback so it later runs inside a captured span context
+  // -- the path every bound continuation, timer and event handler takes. Each
+  // call is one closure allocation plus one activate (AsyncLocalStorage enterWith
+  // + store copy + restore). Run synchronously so the measurement is the bind +
+  // activate cost itself rather than promise scheduling; the async-chain shape is
+  // the scope_enabled variant.
   const Scope = require('../../../packages/dd-trace/src/scope')
   const scope = new Scope()
-  if (scope.enable) {
-    scope.enable()
-  }
-}
+  const span = { _store: {} }
+  let sink = 0
+  const target = () => ++sink
 
-function promises (n, cb) {
-  let p = Promise.resolve()
-  for (let i = 1; i < n; i++) {
-    p = p.then(() => {})
-  }
-  p.then(cb)
-}
+  // Sanity: a bound function runs its target and returns its value.
+  scope.activate(span, () => {})
+  assert.equal(scope.bind(target, span)(), 1, 'bound function did not invoke its target')
 
-function awaits (n, cb) {
-  (async () => {
-    for (let i = 0; i < n; i++) {
-      await 0
+  guard.loopStart()
+  for (let i = 0; i < count; i++) {
+    scope.bind(target, span)()
+  }
+  guard.done()
+
+  assert.ok(sink > 0, 'scope.bind loop produced no work')
+} else {
+  // The microtask shape the tracer rides under each traced async operation: a
+  // continuation that resolves, schedules the next, and so on. When enabled, every
+  // hop is wrapped in scope.activate() exactly as the tracer does; the delta
+  // against the base variant is the per-hop AsyncLocalStorage enterWith plus
+  // store-copy cost.
+  let activate
+  if (SCOPE_ENABLED === 'true') {
+    const Scope = require('../../../packages/dd-trace/src/scope')
+    const scope = new Scope()
+    const span = { _store: {} }
+    activate = (cb) => scope.activate(span, cb)
+  } else {
+    activate = (cb) => cb()
+  }
+
+  // Sanity-check the wiring once before the timed wave: a broken scope.activate
+  // that skipped its callback would otherwise measure a near-empty loop and
+  // silently "pass".
+  let activated = false
+  activate(() => { activated = true })
+  assert.ok(activated, 'scope.activate did not invoke its callback')
+
+  // Run the hops as many short independent chains rather than one `count`-deep
+  // `.then()` chain. A single deep chain pins every promise + reaction object live
+  // at once (~1.3 GB at 7M hops), which OOM-thrashes under a constrained CI heap;
+  // short chains keep live memory flat while still performing `count` activate
+  // hops. CHAIN_DEPTH balances scheduler overhead against live-set size.
+  const CHAIN_DEPTH = 1000
+
+  const runChain = (hops) => {
+    let p = Promise.resolve()
+    for (let i = 0; i < hops; i++) {
+      p = p.then(() => activate(() => {}))
     }
-  })().then(cb)
-}
-
-function immediates (n, cb) {
-  if (n === 0) {
-    cb()
-    return
+    return p
   }
-  setImmediate(immediates, n - 1, cb)
-}
 
-promises(COUNT, () => {
-  awaits(COUNT, () => {
-    immediates(COUNT, () => {
-    })
-  })
-})
+  const runWave = (remaining) => {
+    if (remaining <= 0) {
+      guard.done()
+      return
+    }
+    const hops = remaining < CHAIN_DEPTH ? remaining : CHAIN_DEPTH
+    runChain(hops).then(() => runWave(remaining - hops))
+  }
+
+  guard.loopStart()
+  runWave(count)
+}

--- a/benchmark/sirun/scope/index.js
+++ b/benchmark/sirun/scope/index.js
@@ -11,6 +11,21 @@ const {
 
 const count = Number(COUNT)
 
+// Build a span whose `_store` is a real legacy-storage handle, exactly as a span
+// created under an active parent captures one. activate() resolves the parent
+// store via `getStore(span._store)`; a plain-object handle misses the storage
+// WeakMap, so the per-hop parent-store copy never runs and the bench measures
+// only enterWith. The handle has to resolve to a populated store for the copy to
+// be exercised, so seed an active store first and capture its handle.
+function makeSpan () {
+  const { storage } = require('../../../packages/datadog-core')
+  const legacyStorage = storage('legacy')
+  legacyStorage.enterWith({ span: {} })
+  const span = { _store: legacyStorage.getHandle() }
+  assert.ok(legacyStorage.getStore(span._store), 'synthetic span handle does not resolve to a store')
+  return span
+}
+
 if (MODE === 'bind') {
   // scope.bind wraps a callback so it later runs inside a captured span context
   // -- the path every bound continuation, timer and event handler takes. Each
@@ -20,7 +35,7 @@ if (MODE === 'bind') {
   // the scope_enabled variant.
   const Scope = require('../../../packages/dd-trace/src/scope')
   const scope = new Scope()
-  const span = { _store: {} }
+  const span = makeSpan()
   let sink = 0
   const target = () => ++sink
 
@@ -45,7 +60,7 @@ if (MODE === 'bind') {
   if (SCOPE_ENABLED === 'true') {
     const Scope = require('../../../packages/dd-trace/src/scope')
     const scope = new Scope()
-    const span = { _store: {} }
+    const span = makeSpan()
     activate = (cb) => scope.activate(span, cb)
   } else {
     activate = (cb) => cb()

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -8,14 +8,19 @@
   "variants": {
     "base": {
       "env": {
-        "COUNT": "250000"
+        "COUNT": "100000000"
       }
     },
     "scope_enabled": {
-      "baseline": "base",
       "env": {
         "SCOPE_ENABLED": "true",
-        "COUNT": "250000"
+        "COUNT": "4000000"
+      }
+    },
+    "bind": {
+      "env": {
+        "MODE": "bind",
+        "COUNT": "3000000"
       }
     }
   }


### PR DESCRIPTION
## Summary

- async_hooks: drop the no-hooks baseline variant, leaving init-only and all-hooks.
- scope: add a startup guard and a `bind` variant, and retune the per-variant counts so each run stays loop-dominated.