### PR TITLE
bench(core): tune the shimmer-runtime and shimmer-startup benches

### DIFF
--- a/benchmark/sirun/shimmer-runtime/README.md
+++ b/benchmark/sirun/shimmer-runtime/README.md
@@ -1,3 +1,6 @@
-This is a test of shimmer performance at startup, meaning the actual shimming operations of shimmer.wrap and shimmer.wrapFunction.
-
-There are variants for different kinds of functions, and for both types of shimming.
+Critical-path bench. Every instrumentation in the tracer routes its wrapped
+calls through shimmer, so a regression here taxes all of them. Measures the
+per-call cost of a shimmer-wrapped function. Two variants: `declared-wrap`
+(wrapped via `shimmer.wrap`) and `declared-wrapfn` (via `shimmer.wrapFunction`).
+Only a sync target is exercised; an async one would mostly measure promise
+allocation rather than shimmer.

--- a/benchmark/sirun/shimmer-runtime/index.js
+++ b/benchmark/sirun/shimmer-runtime/index.js
@@ -1,70 +1,42 @@
 'use strict'
 
-/* eslint-disable require-await */
-
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
 const shimmer = require('../../../packages/datadog-shimmer')
 
-const {
-  ENABLED,
-  WRAP_FUNCTION,
-  FUNCTION_NAME,
-} = process.env
-
-const ITERATIONS = 2e6
+// Measures the per-call cost of a shimmer-wrapped function. shimmer.wrap (object
+// property) and shimmer.wrapFunction (standalone) produce the same wrapper, so
+// the call cost is the same; WRAP_FUNCTION just selects which API created it,
+// and both are kept as a guard against the wrappers diverging. Only a sync
+// target is exercised on purpose: an async target would spend most of the loop
+// allocating promises (not shimmer's cost) and add GC jitter. The wrap-time
+// difference between the two APIs is covered by the shimmer-startup bench.
+const useWrapFunction = process.env.WRAP_FUNCTION === 'true'
+const ITERATIONS = Number(process.env.ITERATIONS) || 5e7
 
 let counter = 0
-function declared () {
+function target () {
   return ++counter // Do very little
 }
 
-const arrow = () => {
-  return ++counter // Do very little
+const passthrough = (original) => function (...args) {
+  return original.apply(this, args)
 }
 
-async function asyncDeclared () {
-  return ++counter // Do very little
-}
-
-const asyncArrow = async () => {
-  return ++counter // Do very little
-}
-
-const testedFn = {
-  declared,
-  arrow,
-  asyncDeclared,
-  asyncArrow,
-}[FUNCTION_NAME]
-if (!testedFn) {
-  throw new Error(`Function ${FUNCTION_NAME} not found`)
-}
-
-if (ENABLED !== 'true') {
-  for (let i = 0; i < ITERATIONS; i++) {
-    testedFn()
-  }
+let wrapped
+if (useWrapFunction) {
+  wrapped = shimmer.wrapFunction(target, passthrough)
 } else {
-  if (WRAP_FUNCTION === 'true') {
-    const wrapped = shimmer.wrapFunction(testedFn, (original) => {
-      return function (...args) {
-        return original.apply(this, args)
-      }
-    })
-    for (let i = 0; i < ITERATIONS; i++) {
-      wrapped()
-    }
-  } else {
-    const obj = {
-      testedFn,
-    }
-    shimmer.wrap(obj, 'testedFn', (original) => {
-      return function (...args) {
-        return original.apply(this, args)
-      }
-    })
-    const wrapped = obj.testedFn
-    for (let i = 0; i < ITERATIONS; i++) {
-      wrapped()
-    }
-  }
+  const obj = { target }
+  shimmer.wrap(obj, 'target', passthrough)
+  wrapped = obj.target
 }
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  wrapped()
+}
+guard.done()
+
+// Fail loudly if the wrapper stops delegating to the original function.
+assert.equal(counter, ITERATIONS, 'wrapped function did not run ITERATIONS times')

--- a/benchmark/sirun/shimmer-runtime/meta.json
+++ b/benchmark/sirun/shimmer-runtime/meta.json
@@ -6,84 +6,16 @@
   "iterations": 10,
   "instructions": true,
   "variants": {
-    "declared-baseline": {
+    "declared-wrap": {
       "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "declared"
-      }
-    },
-    "asyncdeclared-baseline": {
-      "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "asyncDeclared"
-      }
-    },
-    "arrow-baseline": {
-      "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "arrow"
-      }
-    },
-    "asyncarrow-baseline": {
-      "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "asyncArrow"
+        "WRAP_FUNCTION": "false",
+        "ITERATIONS": "1000000000"
       }
     },
     "declared-wrapfn": {
       "env": {
-        "ENABLED": "true",
         "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "declared"
-      }
-    },
-    "asyncdeclared-wrapfn": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "asyncDeclared"
-      }
-    },
-    "arrow-wrapfn": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "arrow"
-      }
-    },
-    "asyncarrow-wrapfn": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "asyncArrow"
-      }
-    },
-    "declared-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "declared"
-      }
-    },
-    "asyncdeclared-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "asyncDeclared"
-      }
-    },
-    "arrow-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "arrow"
-      }
-    },
-    "asyncarrow-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "asyncArrow"
+        "ITERATIONS": "1000000000"
       }
     }
   }

--- a/benchmark/sirun/shimmer-startup/README.md
+++ b/benchmark/sirun/shimmer-startup/README.md
@@ -1,3 +1,6 @@
-This is a test of shimmer performance at runtime, meaning the performance of functions shimmed by shimmer.wrap and shimmer.wrapFunction.
-
-There are variants for different kinds of functions, and for both types of shimming.
+Critical-path bench. Every instrumentation wraps its targets through shimmer at
+load time, so a regression here slows startup across all integrations. Measures
+the wrap operation itself. Two variants: `declared-wrap` (`shimmer.wrap`, which
+manipulates property descriptors) and `declared-wrapfn` (`shimmer.wrapFunction`,
+a standalone wrap). The wrapped function's shape does not affect the wrap cost,
+so a single sync target is used.

--- a/benchmark/sirun/shimmer-startup/index.js
+++ b/benchmark/sirun/shimmer-startup/index.js
@@ -1,63 +1,41 @@
 'use strict'
 
-/* eslint-disable require-await */
-
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
 const shimmer = require('../../../packages/datadog-shimmer')
 
-const {
-  ENABLED,
-  WRAP_FUNCTION,
-  FUNCTION_NAME,
-} = process.env
-
-const ITERATIONS = 1e5
+// Measures the cost of the wrap operation itself (what every instrumentation
+// pays at load time), not the cost of calling the result. shimmer.wrap (object
+// property, via property descriptors) and shimmer.wrapFunction (standalone) are
+// genuinely different operations here, so WRAP_FUNCTION selects which one. The
+// wrapped function's shape is irrelevant to the wrap cost, so a single sync
+// target is used. A fresh object is wrapped each iteration so nothing nests and
+// memory stays flat as ITERATIONS grows.
+const useWrapFunction = process.env.WRAP_FUNCTION === 'true'
+const ITERATIONS = Number(process.env.ITERATIONS) || 1e6
 
 let counter = 0
-function declared () {
+function target () {
   return ++counter // Do very little
 }
 
-const arrow = () => {
-  return ++counter // Do very little
+const passthrough = (original) => function (...args) {
+  return original.apply(this, args)
 }
 
-async function asyncDeclared () {
-  return ++counter // Do very little
-}
-
-const asyncArrow = async () => {
-  return ++counter // Do very little
-}
-
-const testedFn = {
-  declared,
-  arrow,
-  asyncDeclared,
-  asyncArrow,
-}[FUNCTION_NAME]
-if (!testedFn) {
-  throw new Error(`Function ${FUNCTION_NAME} not found`)
-}
-
-if (ENABLED === 'true') {
-  if (WRAP_FUNCTION === 'true') {
-    for (let i = 0; i < ITERATIONS; i++) {
-      shimmer.wrapFunction(testedFn, (original) => {
-        return function (...args) {
-          return original.apply(this, args)
-        }
-      })
-    }
+guard.loopStart()
+let lastWrapped
+for (let i = 0; i < ITERATIONS; i++) {
+  if (useWrapFunction) {
+    lastWrapped = shimmer.wrapFunction(target, passthrough)
   } else {
-    const obj = {
-      testedFn,
-    }
-    for (let i = 0; i < ITERATIONS; i++) {
-      shimmer.wrap(obj, 'testedFn', (original) => {
-        return function (...args) {
-          return original.apply(this, args)
-        }
-      })
-    }
+    const obj = { target }
+    shimmer.wrap(obj, 'target', passthrough)
+    lastWrapped = obj.target
   }
 }
+guard.done()
+
+// Fail loudly if the wrap operation stops producing a delegating wrapper.
+assert.equal(typeof lastWrapped, 'function')
+assert.equal(lastWrapped(), 1, 'wrapped function should delegate to the original')

--- a/benchmark/sirun/shimmer-startup/meta.json
+++ b/benchmark/sirun/shimmer-startup/meta.json
@@ -6,84 +6,16 @@
   "iterations": 20,
   "instructions": true,
   "variants": {
-    "declared-baseline": {
+    "declared-wrap": {
       "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "declared"
-      }
-    },
-    "asyncdeclared-baseline": {
-      "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "asyncDeclared"
-      }
-    },
-    "arrow-baseline": {
-      "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "arrow"
-      }
-    },
-    "asyncarrow-baseline": {
-      "env": {
-        "ENABLED": "false",
-        "FUNCTION_NAME": "asyncArrow"
+        "WRAP_FUNCTION": "false",
+        "ITERATIONS": "1000000"
       }
     },
     "declared-wrapfn": {
       "env": {
-        "ENABLED": "true",
         "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "declared"
-      }
-    },
-    "asyncdeclared-wrapfn": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "asyncDeclared"
-      }
-    },
-    "arrow-wrapfn": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "arrow"
-      }
-    },
-    "asyncarrow-wrapfn": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "true",
-        "FUNCTION_NAME": "asyncArrow"
-      }
-    },
-    "declared-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "declared"
-      }
-    },
-    "asyncdeclared-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "asyncDeclared"
-      }
-    },
-    "arrow-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "arrow"
-      }
-    },
-    "asyncarrow-wrap": {
-      "env": {
-        "ENABLED": "true",
-        "WRAP_FUNCTION": "false",
-        "FUNCTION_NAME": "asyncArrow"
+        "ITERATIONS": "1000000"
       }
     }
   }


### PR DESCRIPTION
## Summary

Collapse both shimmer benches from twelve variants (every function shape paired with a disabled baseline) down to the two that matter, add a startup guard, and drive the loop from `ITERATIONS` so the wrap overhead stays loop-dominated.