### PR TITLE
docs(types): note that startSpan does not activate the returned span

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,12 @@ interface Tracer extends opentracing.Tracer {
 
   /**
    * Starts and returns a new Span representing a logical unit of work.
+   *
+   * The returned span is not activated on the current scope. Spans created
+   * while it is open — via {@link Tracer.trace} or auto-instrumentation — only
+   * nest under it when it is the active span, so wrap the work in
+   * {@link Scope.activate} (or use {@link Tracer.trace}) when child spans
+   * should descend from it.
    * @param {string} name The name of the operation.
    * @param {tracer.SpanOptions} [options] Options for the newly created span.
    * @returns {Span} A new Span object.

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -19,6 +19,12 @@ interface Tracer extends opentracing.Tracer {
 
   /**
    * Starts and returns a new Span representing a logical unit of work.
+   *
+   * The returned span is not activated on the current scope. Spans created
+   * while it is open — via {@link Tracer.trace} or auto-instrumentation — only
+   * nest under it when it is the active span, so wrap the work in
+   * {@link Scope.activate} (or use {@link Tracer.trace}) when child spans
+   * should descend from it.
    * @param {string} name The name of the operation.
    * @param {tracer.SpanOptions} [options] Options for the newly created span.
    * @returns {Span} A new Span object.


### PR DESCRIPTION
## Summary

`tracer.startSpan()` sets the parent from `childOf` but does not activate the
returned span on the current scope. Spans created while it is open — via
`tracer.trace()` or auto-instrumentation — therefore parent to whatever was
already active rather than to the new span, which the reporter saw as sibling
spans appearing "out of order" in the trace view.

This is OpenTracing-by-design, not a tracer bug: wrapping the work in
`tracer.scope().activate(span, fn)` (or using `tracer.trace()`) makes the
nested spans descend from it. The OpenTelemetry-bridge `startSpan` already
documents the equivalent "does not modify the current Context" behavior; the
OpenTracing-style `Tracer.startSpan` did not. This adds that note to both the
v6 (`index.d.ts`) and v5 (`index.d.v5.ts`) public surfaces.

## Test plan

Documentation-only change to the public `.d.ts` type comments; no runtime code
is touched. `npm run lint` and `npm run type:check` cover the type surfaces.

Refs: https://github.com/DataDog/dd-trace-js/issues/3570