### PR TITLE
ci(dependabot): track Docker base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,29 @@ updates:
       - github_actions
       - semver-patch
 
+  # Docker base images in our Dockerfiles. Already digest-pinned references
+  # (image:tag@sha256:...) get both the tag and the digest bumped on each
+  # release; bare tags would only have the tag bumped, so every FROM here is
+  # pinned by digest. docker-compose.yml is handled separately (GHCR mirror).
+  - package-ecosystem: "docker"
+    directories:
+      - "/.github/playwright"
+      - "/.github/selenium"
+      - "/benchmark/sirun"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+    labels:
+      - dependabot
+      - dependencies
+      - docker
+      - semver-patch
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
   # Regular npm packages that fall into our supported ranges besides OTEL
   - package-ecosystem: "npm"
     directories:


### PR DESCRIPTION
## Summary

Add a `docker` ecosystem to Dependabot covering the `playwright`, `selenium`, and `sirun` Dockerfiles. Each `FROM` there is pinned as `image:tag@sha256:...`, so Dependabot bumps both the tag and the digest on every release; without this block those digests never refresh and base-image security fixes are missed.

`docker-compose.yml` is intentionally left out: its images are GHCR-mirrored and version-pinned through the `mirror-image` workflow, so pointing Dependabot at them would make it chase `latest` and fight the mirror.

The new group is not wired into `dependabot-automation.yml` auto-merge — base-image bumps are reviewed manually for now.