### PR TITLE
feat(propagation): inject ot.th tracestate threshold for W3C TraceContext

### DIFF
--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -12,6 +12,14 @@ const telemetryMetrics = require('../../telemetry/metrics')
 const { DD_MAJOR } = require('../../../../../version')
 
 const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../../ext/priority')
+const {
+  SAMPLING_RULE_DECISION,
+  SAMPLING_LIMIT_DECISION,
+  SAMPLING_AGENT_DECISION,
+  SAMPLING_MECHANISM_MANUAL,
+  SAMPLING_MECHANISM_APPSEC,
+  SAMPLING_MECHANISM_AI_GUARD,
+} = require('../../constants')
 const TraceState = require('./tracestate')
 
 const tracerMetrics = telemetryMetrics.manager.namespace('tracers')
@@ -74,6 +82,36 @@ const invalidSegment = /^0+$/
 const zeroTraceId = '0000000000000000'
 const hex16 = /^[0-9A-Fa-f]{16}$/
 const percentByte = /%([0-9A-Fa-f]{2})/g
+
+const TWO_56 = 2n ** 56n
+const PROB_PRECISION = 1_000_000_000n
+
+function probabilityToThreshold (probability) {
+  if (probability >= 1) return '0'
+  if (probability <= 0) return
+  const probInt = BigInt(Math.round(probability * Number(PROB_PRECISION)))
+  const th = ((PROB_PRECISION - probInt) * TWO_56) / PROB_PRECISION
+  return th <= 0n ? '0' : th.toString(16)
+}
+
+function _computeOtThreshold (priority, mechanism, trace) {
+  if (priority < AUTO_KEEP) return
+  if (mechanism === SAMPLING_MECHANISM_MANUAL ||
+      mechanism === SAMPLING_MECHANISM_APPSEC ||
+      mechanism === SAMPLING_MECHANISM_AI_GUARD) {
+    return '0'
+  }
+  const ruleRate = trace[SAMPLING_RULE_DECISION]
+  const limiterRate = trace[SAMPLING_LIMIT_DECISION]
+  if (ruleRate !== undefined && limiterRate !== undefined) {
+    return probabilityToThreshold(ruleRate * limiterRate)
+  }
+  const agentRate = trace[SAMPLING_AGENT_DECISION]
+  if (agentRate !== undefined) {
+    return probabilityToThreshold(agentRate)
+  }
+  return '0'
+}
 
 class TextMapPropagator {
   /** @type {Set<string> | undefined} Cached `Set` view of `_config.baggageTagKeys`. */
@@ -361,6 +399,13 @@ class TextMapPropagator {
         state.set(tagKey, tagValue)
       }
     })
+
+    const otTh = _computeOtThreshold(priority, mechanism, spanContext._trace)
+    if (otTh !== undefined) {
+      ts.forVendor('ot', state => {
+        state.set('th', otTh)
+      })
+    }
 
     carrier.tracestate = ts.toString()
   }

--- a/packages/dd-trace/src/opentracing/propagation/text_map.js
+++ b/packages/dd-trace/src/opentracing/propagation/text_map.js
@@ -362,6 +362,15 @@ class TextMapPropagator {
 
     carrier[traceparentKey] = spanContext.toTraceparent()
 
+    // Inject ot before dd so that dd ends up last in the map and first in the serialized output.
+    // TraceState serializes in reverse insertion order; putting dd last keeps it the leading entry.
+    const otTh = _computeOtThreshold(priority, mechanism, spanContext._trace)
+    if (otTh !== undefined) {
+      ts.forVendor('ot', state => {
+        state.set('th', otTh)
+      })
+    }
+
     ts.forVendor('dd', state => {
       if (!spanContext._isRemote) {
         // SpanContext was created by a ddtrace span.
@@ -399,13 +408,6 @@ class TextMapPropagator {
         state.set(tagKey, tagValue)
       }
     })
-
-    const otTh = _computeOtThreshold(priority, mechanism, spanContext._trace)
-    if (otTh !== undefined) {
-      ts.forVendor('ot', state => {
-        state.set('th', otTh)
-      })
-    }
 
     carrier.tracestate = ts.toString()
   }

--- a/packages/dd-trace/src/standalone/index.js
+++ b/packages/dd-trace/src/standalone/index.js
@@ -50,6 +50,7 @@ function onSpanInject ({ spanContext, carrier }) {
       } else if (lKey === 'tracestate') {
         const tracestate = TraceState.fromString(carrier[key])
         tracestate.forVendor('dd', state => state.clear())
+        tracestate.forVendor('ot', state => state.clear())
         carrier[key] = tracestate.toString()
       }
     }

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -421,7 +421,7 @@ describe('TextMapPropagator', () => {
       assert.ok('tracestate' in carrier)
       assert.strictEqual(
         carrier.tracestate,
-        'ot=th:0,dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;p:5555eeee6666ffff;s:2;o:foo_bar~;t.dm:-4,other=bleh'
+        'dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;p:5555eeee6666ffff;s:2;o:foo_bar~;t.dm:-4,ot=th:0,other=bleh'
       )
     })
 
@@ -437,7 +437,8 @@ describe('TextMapPropagator', () => {
           isRemote: false,
         })
         propagator.inject(spanContext, carrier)
-        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:0'))
       })
 
       it('injects th:0 for force-keep with appsec mechanism', () => {
@@ -447,7 +448,8 @@ describe('TextMapPropagator', () => {
           isRemote: false,
         })
         propagator.inject(spanContext, carrier)
-        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:0'))
       })
 
       it('injects th:0 for force-keep with ai_guard mechanism', () => {
@@ -457,7 +459,8 @@ describe('TextMapPropagator', () => {
           isRemote: false,
         })
         propagator.inject(spanContext, carrier)
-        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:0'))
       })
 
       it('injects th computed from rule + limiter rates', () => {
@@ -469,7 +472,8 @@ describe('TextMapPropagator', () => {
         })
         propagator.inject(spanContext, carrier)
         // 50% keep rate → th = (1 - 0.5) * 2^56 = 2^55 = 0x80000000000000
-        assert.ok(carrier.tracestate.startsWith('ot=th:80000000000000,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:80000000000000'))
       })
 
       it('combines rule and limiter rates for th', () => {
@@ -481,7 +485,8 @@ describe('TextMapPropagator', () => {
         })
         propagator.inject(spanContext, carrier)
         // 100% keep rate → th = 0
-        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:0'))
       })
 
       it('injects th from agent sampling rate', () => {
@@ -493,7 +498,8 @@ describe('TextMapPropagator', () => {
         })
         propagator.inject(spanContext, carrier)
         // 100% agent rate → th = 0
-        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:0'))
       })
 
       it('does not inject ot entry for rejected spans', () => {
@@ -514,7 +520,8 @@ describe('TextMapPropagator', () => {
           isRemote: false,
         })
         propagator.inject(spanContext, carrier)
-        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+        assert.ok(carrier.tracestate.startsWith('dd='))
+        assert.ok(carrier.tracestate.includes(',ot=th:0'))
       })
     })
 

--- a/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
+++ b/packages/dd-trace/test/opentracing/propagation/text_map.spec.js
@@ -17,7 +17,14 @@ const SpanContext = require('../../../src/opentracing/span_context')
 const TraceState = require('../../../src/opentracing/propagation/tracestate')
 const { setBaggageItem, getBaggageItem, getAllBaggageItems, removeAllBaggageItems } = require('../../../src/baggage')
 const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../../ext/priority')
-const { SAMPLING_MECHANISM_MANUAL } = require('../../../src/constants')
+const {
+  SAMPLING_MECHANISM_MANUAL,
+  SAMPLING_MECHANISM_APPSEC,
+  SAMPLING_MECHANISM_AI_GUARD,
+  SAMPLING_RULE_DECISION,
+  SAMPLING_LIMIT_DECISION,
+  SAMPLING_AGENT_DECISION,
+} = require('../../../src/constants')
 
 // v5 spells single-header B3 propagation as `'b3 single header'`; v6 reuses `'b3'` for it.
 const B3_SINGLE_STYLE = DD_MAJOR >= 6 ? 'b3' : 'b3 single header'
@@ -414,8 +421,101 @@ describe('TextMapPropagator', () => {
       assert.ok('tracestate' in carrier)
       assert.strictEqual(
         carrier.tracestate,
-        'dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;p:5555eeee6666ffff;s:2;o:foo_bar~;t.dm:-4,other=bleh'
+        'ot=th:0,dd=t.foo_bar_baz_:abc_!@#$%^&*()_+`-~;p:5555eeee6666ffff;s:2;o:foo_bar~;t.dm:-4,other=bleh'
       )
+    })
+
+    describe('ot.th tracestate injection', () => {
+      beforeEach(() => {
+        config.tracePropagationStyle.inject = ['tracecontext']
+      })
+
+      it('injects th:0 for force-keep with manual mechanism', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: USER_KEEP, mechanism: SAMPLING_MECHANISM_MANUAL },
+          isRemote: false,
+        })
+        propagator.inject(spanContext, carrier)
+        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+      })
+
+      it('injects th:0 for force-keep with appsec mechanism', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: USER_KEEP, mechanism: SAMPLING_MECHANISM_APPSEC },
+          isRemote: false,
+        })
+        propagator.inject(spanContext, carrier)
+        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+      })
+
+      it('injects th:0 for force-keep with ai_guard mechanism', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: USER_KEEP, mechanism: SAMPLING_MECHANISM_AI_GUARD },
+          isRemote: false,
+        })
+        propagator.inject(spanContext, carrier)
+        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+      })
+
+      it('injects th computed from rule + limiter rates', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: AUTO_KEEP, mechanism: 3 },
+          isRemote: false,
+          trace: { [SAMPLING_RULE_DECISION]: 0.5, [SAMPLING_LIMIT_DECISION]: 1.0 },
+        })
+        propagator.inject(spanContext, carrier)
+        // 50% keep rate → th = (1 - 0.5) * 2^56 = 2^55 = 0x80000000000000
+        assert.ok(carrier.tracestate.startsWith('ot=th:80000000000000,'))
+      })
+
+      it('combines rule and limiter rates for th', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: AUTO_KEEP, mechanism: 3 },
+          isRemote: false,
+          trace: { [SAMPLING_RULE_DECISION]: 1.0, [SAMPLING_LIMIT_DECISION]: 1.0 },
+        })
+        propagator.inject(spanContext, carrier)
+        // 100% keep rate → th = 0
+        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+      })
+
+      it('injects th from agent sampling rate', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: AUTO_KEEP, mechanism: 1 },
+          isRemote: false,
+          trace: { [SAMPLING_AGENT_DECISION]: 1.0 },
+        })
+        propagator.inject(spanContext, carrier)
+        // 100% agent rate → th = 0
+        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+      })
+
+      it('does not inject ot entry for rejected spans', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: AUTO_REJECT, mechanism: 1 },
+          isRemote: false,
+          trace: { [SAMPLING_AGENT_DECISION]: 0.1 },
+        })
+        propagator.inject(spanContext, carrier)
+        assert.ok(!carrier.tracestate.includes('ot='))
+      })
+
+      it('injects th:0 when no sampling rates are available but span is kept', () => {
+        const carrier = {}
+        const spanContext = createContext({
+          sampling: { priority: AUTO_KEEP, mechanism: 1 },
+          isRemote: false,
+        })
+        propagator.inject(spanContext, carrier)
+        assert.ok(carrier.tracestate.startsWith('ot=th:0,'))
+      })
     })
 
     it('should skip injection of B3 headers without the feature flag', () => {


### PR DESCRIPTION
### What does this PR do?

Injects the `ot.th` rejection-threshold entry into W3C tracestate on outbound spans, so that Span Metrics Connector and other OTel backends can extrapolate aggregate metrics from sampled data.

Also fixes vendor-entry ordering so `dd=` always leads the serialized tracestate header, and strips the `ot` entry in standalone mode (where APM trace headers are suppressed).

### Motivation

Required for OTLP-native deployments to report accurate span metrics without 100% sampling. The hex threshold is the complement of the effective sampling probability, matching the OTel specification.

### Changes

- **`opentracing/propagation/text_map.js`** — computes `ot.th` from sampling rate (rule×limiter, agent, or force-keep); injects `ot` before `dd` so `dd` leads the serialized header (TraceState serializes in reverse insertion order)
- **`standalone/index.js`** — clears `ot` vendor entry when stripping outbound APM trace headers

### Threshold derivation

| Sampling decision | `ot.th` value |
|---|---|
| Rule-sampled | `hex(1 − ruleRate × limiterRate)` |
| Agent-sampled | `hex(1 − agentRate)` |
| Force-kept (manual / appsec / ai_guard) | `0` (accept all) |
| Rejected (p0) | not emitted |