### PR TITLE
fix(graphql)!: decouple resolver depth from path collapsing

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -113,6 +113,19 @@ The `ingestion: { sampleRate, rateLimit }` wrapper has been removed. Set
 `sampleRate` and `rateLimit` directly on the top-level `TracerOptions` object,
 or use `DD_TRACE_SAMPLE_RATE` / `DD_TRACE_RATE_LIMIT`.
 
+### GraphQL resolver `depth` no longer counts list indices
+
+The `graphql` plugin's `depth` option counted a resolver's full execution path,
+including the numeric list indices that `collapse` folds away. The same query
+therefore reached a different depth depending on whether `collapse` was enabled:
+a field one list-hop below the limit was instrumented with `collapse: false` and
+dropped with the default `collapse: true`.
+
+v6 counts only selection-set nesting (named fields) toward `depth`, so the limit
+tracks query structure rather than execution artifacts and is independent of
+`collapse`. At a given `depth`, a resolver nested under a list is now reached one
+level sooner than on v5's default. Lower `depth` to restore the previous cutoff.
+
 ## 4.0 to 5.0
 
 ### Node 16 is no longer supported

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -11,7 +11,7 @@
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "OPERATIONS": "1150" }
     },
     "with-depth-on-max": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "OPERATIONS": "800" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "6", "OPERATIONS": "800" }
     },
     "with-depth-and-collapse-off": {
       "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "OPERATIONS": "210" }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2531,6 +2531,8 @@ declare namespace tracer {
       /**
        * The maximum depth of fields/resolvers to instrument. Set to `0` to only
        * instrument the operation or to `-1` to instrument all fields/resolvers.
+       * Counts selection-set nesting (named fields) only; list indices do not
+       * count toward the limit, regardless of `collapse`.
        *
        * @default -1
        */

--- a/packages/datadog-plugin-graphql/src/execute.js
+++ b/packages/datadog-plugin-graphql/src/execute.js
@@ -533,14 +533,15 @@ function buildCachedCollapsedPath (path, cache) {
 }
 
 // Depth filtering directly on the linked-list node — no array allocation needed.
-// config.depth < 0 means no limit. In non-collapse mode only string segments
-// count toward depth (array indices are transparent). In collapse mode every
-// node counts (numbers have been conceptually '*'-collapsed).
+// config.depth < 0 means no limit. Only selection-set segments (string keys)
+// count toward depth; list indices are execution artifacts and are transparent.
+// On the v5 line `countListIndices` keeps the legacy behaviour of counting every
+// node when collapsing folds the numeric indices into '*'.
 function shouldInstrumentNode (config, path) {
   if (config.depth < 0) return true
 
   let depth = 0
-  if (config.collapse) {
+  if (config.countListIndices) {
     for (let curr = path; curr; curr = curr.prev) depth++
   } else {
     for (let curr = path; curr; curr = curr.prev) {

--- a/packages/datadog-plugin-graphql/src/index.js
+++ b/packages/datadog-plugin-graphql/src/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const pick = require('../../datadog-core/src/utils/src/pick')
+const { DD_MAJOR } = require('../../../version')
 const CompositePlugin = require('../../dd-trace/src/plugins/composite')
 const log = require('../../dd-trace/src/log')
 const GraphQLExecutePlugin = require('./execute')
@@ -31,11 +32,15 @@ class GraphQLPlugin extends CompositePlugin {
 // config validator helpers
 
 function validateConfig (config) {
+  const collapse = config.collapse === undefined || !!config.collapse
   return {
     ...config,
     depth: getDepth(config),
     variables: getVariablesFilter(config),
-    collapse: config.collapse === undefined || !!config.collapse,
+    collapse,
+    // v5 counted collapsed list indices toward `depth`, so the same query reached a
+    // different depth depending on `collapse`. v6 counts selection-set depth only.
+    countListIndices: DD_MAJOR < 6 && collapse,
     hooks: getHooks(config),
   }
 }

--- a/packages/datadog-plugin-graphql/test/config.spec.js
+++ b/packages/datadog-plugin-graphql/test/config.spec.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { before, describe, it } = require('mocha')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+// `countListIndices` decides whether numeric list-index path segments count toward
+// the resolver `depth` limit. The v5 release line counts them when collapsing; v6
+// never does, so depth always tracks selection-set nesting. The behaviour is gated
+// on DD_MAJOR, so stub the version constant to reach both arms on either release line.
+function loadPluginFor (DD_MAJOR) {
+  const GraphQLPlugin = proxyquire('../src', {
+    '../../../version': { DD_MAJOR, '@noCallThru': true },
+  })
+
+  return new GraphQLPlugin({}, {})
+}
+
+// CompositePlugin spreads the validated config into every sub-plugin, so the
+// execute plugin (which carries the depth gate) sees `countListIndices`.
+function countListIndicesFor (plugin, options) {
+  plugin.configure({ depth: 2, ...options })
+  return plugin.execute.config.countListIndices
+}
+
+describe('graphql plugin depth/collapse gate', () => {
+  describe('v5 (DD_MAJOR < 6)', () => {
+    let plugin
+
+    before(() => {
+      plugin = loadPluginFor(5)
+    })
+
+    it('counts collapsed list indices toward depth (collapse defaults on)', () => {
+      assert.strictEqual(countListIndicesFor(plugin, {}), true)
+      assert.strictEqual(countListIndicesFor(plugin, { collapse: true }), true)
+    })
+
+    it('counts only field segments when collapsing is disabled', () => {
+      assert.strictEqual(countListIndicesFor(plugin, { collapse: false }), false)
+    })
+  })
+
+  describe('v6 (DD_MAJOR >= 6)', () => {
+    let plugin
+
+    before(() => {
+      plugin = loadPluginFor(6)
+    })
+
+    it('never counts list indices, regardless of collapse', () => {
+      assert.strictEqual(countListIndicesFor(plugin, {}), false)
+      assert.strictEqual(countListIndicesFor(plugin, { collapse: true }), false)
+      assert.strictEqual(countListIndicesFor(plugin, { collapse: false }), false)
+    })
+  })
+})

--- a/packages/datadog-plugin-graphql/test/index.spec.js
+++ b/packages/datadog-plugin-graphql/test/index.spec.js
@@ -12,6 +12,7 @@ const semver = require('semver')
 const sinon = require('sinon')
 
 const { assertObjectContains } = require('../../../integration-tests/helpers')
+const { DD_MAJOR } = require('../../../version')
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
@@ -2045,33 +2046,61 @@ describe('Plugin', () => {
           buildSchema()
         })
 
-        it('should only instrument up to the specified depth', () => {
-          const source = `
-            {
-              human {
-                name
-                address {
-                  civicNumber
-                  street
-                }
-              }
-              friends {
-                name
+        const source = `
+          {
+            human {
+              name
+              address {
+                civicNumber
+                street
               }
             }
-          `
+            friends {
+              name
+            }
+          }
+        `
 
+        // friends.*.name sits two fields deep (friends -> name); the list index
+        // between them is an execution artifact, not a query level, so depth: 2
+        // reaches it. human.address.civicNumber / human.address.street sit three
+        // fields deep and stay gated.
+        const v6DepthTest = DD_MAJOR >= 6 ? it : it.skip
+        v6DepthTest('counts selection-set depth only, so a collapsed list field resolves at its field depth', () => {
           const assertion = agent.assertSomeTraces(traces => {
-            const spans = sort(traces[0])
-            const ignored = spans.filter(span => {
-              return [
-                'human.address.civicNumber',
-                'human.address.street',
-              ].indexOf(span.resource) !== -1
-            })
+            const paths = sort(traces[0])
+              .filter(span => span.name === 'graphql.resolve')
+              .map(span => span.meta['graphql.field.path'])
+              .sort()
 
-            assert.strictEqual(spans.length, 5)
-            assert.strictEqual(ignored.length, 0)
+            assert.deepStrictEqual(paths, [
+              'friends',
+              'friends.*.name',
+              'human',
+              'human.address',
+              'human.name',
+            ])
+          })
+
+          return Promise.all([assertion, graphql.graphql({ schema, source })])
+        })
+
+        // v5 counted the collapsed list index toward depth, so friends.*.name sat
+        // three segments deep and was gated. Pin that contract on the v5 line.
+        const legacyDepthTest = DD_MAJOR < 6 ? it : it.skip
+        legacyDepthTest('counts collapsed list indices toward depth on v5', () => {
+          const assertion = agent.assertSomeTraces(traces => {
+            const paths = sort(traces[0])
+              .filter(span => span.name === 'graphql.resolve')
+              .map(span => span.meta['graphql.field.path'])
+              .sort()
+
+            assert.deepStrictEqual(paths, [
+              'friends',
+              'human',
+              'human.address',
+              'human.name',
+            ])
           })
 
           return Promise.all([assertion, graphql.graphql({ schema, source })])


### PR DESCRIPTION
## What

The GraphQL resolver `depth` filter counted the full execution path, including
the numeric list indices that `collapse` later folds away. The same query reached
a different depth depending on whether `collapse` was on, so a field one list-hop
below the limit was instrumented with collapsing off and dropped with it on, even
though both describe the same selection-set nesting.

This counts only selection-set segments (string path keys) toward `depth`, so the
limit tracks query structure rather than execution artifacts.

## Why gated behind `DD_MAJOR`

It shifts which resolvers are instrumented at a given `depth`, so it ships behind
`DD_MAJOR`: the v5 line keeps the old list-index counting when collapsing is on;
v6 counts selection-set depth only. A `countListIndices` config flag carries the
gate so `shouldInstrument` stays free of version checks.

## Test plan

- New v6-default + v5-legacy regression in `test/index.spec.js`, gated on `DD_MAJOR`.
- New `test/config.spec.js` proxyquires both `DD_MAJOR` arms to pin the gate and the
  depth count on either release line.
- `nyc` confirms the changed lines/branches are covered; eslint clean.

Fixes #7468