### PR TITLE
bench(sirun): update Node.js versions and pin the benchmark image

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -84,29 +84,29 @@ benchmark:
         GROUP: 5
       - MAJOR_VERSION: 20
         GROUP: 6
-      - MAJOR_VERSION: 22
+      - MAJOR_VERSION: 24
         GROUP: 1
-      - MAJOR_VERSION: 22
+      - MAJOR_VERSION: 24
         GROUP: 2
-      - MAJOR_VERSION: 22
+      - MAJOR_VERSION: 24
         GROUP: 3
-      - MAJOR_VERSION: 22
+      - MAJOR_VERSION: 24
         GROUP: 4
-      - MAJOR_VERSION: 22
+      - MAJOR_VERSION: 24
         GROUP: 5
-      - MAJOR_VERSION: 22
+      - MAJOR_VERSION: 24
         GROUP: 6
-      - MAJOR_VERSION: 24
+      - MAJOR_VERSION: 26
         GROUP: 1
-      - MAJOR_VERSION: 24
+      - MAJOR_VERSION: 26
         GROUP: 2
-      - MAJOR_VERSION: 24
+      - MAJOR_VERSION: 26
         GROUP: 3
-      - MAJOR_VERSION: 24
+      - MAJOR_VERSION: 26
         GROUP: 4
-      - MAJOR_VERSION: 24
+      - MAJOR_VERSION: 26
         GROUP: 5
-      - MAJOR_VERSION: 24
+      - MAJOR_VERSION: 26
         GROUP: 6
   variables:
     SPLITS: 6

--- a/benchmark/sirun/Dockerfile
+++ b/benchmark/sirun/Dockerfile
@@ -1,18 +1,21 @@
 # The version of this file in master is used across all PRs regardless of upstream branch
-FROM --platform=linux/amd64 ubuntu:22.04
+# Pinned to the 24.04 manifest-list digest; --platform still selects the linux/amd64 variant.
+FROM --platform=linux/amd64 ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
 	wget curl ca-certificates valgrind \
 	git hwinfo jq procps \
-	software-properties-common build-essential libnss3-dev zlib1g-dev libgdbm-dev libncurses5-dev libssl-dev libffi-dev libreadline-dev libsqlite3-dev libbz2-dev
+	software-properties-common build-essential libnss3-dev
 
-RUN git clone --depth 1 https://github.com/pyenv/pyenv.git --branch "v2.4.1" --single-branch /pyenv
-ENV PYENV_ROOT "/pyenv"
-ENV PATH "/pyenv/shims:/pyenv/bin:$PATH"
-RUN eval "$(pyenv init -)"
-RUN pyenv install 3.9.6 && pyenv global 3.9.6
-RUN pip3 install awscli virtualenv setuptools
-RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 -
+# Prebuilt, relocatable CPython from python-build-standalone (the same builds uv ships).
+# Avoids a slow from-source pyenv compile and stays version-pinned + checksum-verified.
+RUN wget -O /tmp/python.tar.gz https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-x86_64-unknown-linux-gnu-install_only.tar.gz \
+	&& echo "962cc1605e3f82410e5a2dfa3070265693681c56fc1aa1f30967723605c5d38f  /tmp/python.tar.gz" | sha256sum -c - \
+	&& tar -xzf /tmp/python.tar.gz -C /opt \
+	&& rm /tmp/python.tar.gz
+ENV PATH "/opt/python/bin:$PATH"
+RUN pip3 install awscli==1.45.21 virtualenv==21.4.2 setuptools==82.0.1
+RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version 2.4.1
 
 # nvm works much better with bash than sh
 SHELL ["/bin/bash", "--login", "-c"]
@@ -21,20 +24,24 @@ WORKDIR /app
 
 ENV NVM_DIR /usr/local/nvm
 
-RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.10/sirun-v0.1.10-x86_64-unknown-linux-musl.tar.gz \
+RUN wget -O sirun.tar.gz https://github.com/DataDog/sirun/releases/download/v0.1.11/sirun-v0.1.11-x86_64-unknown-linux-musl.tar.gz \
+	&& echo "5f779a5b974dc758b92a7595136e9dbe2bebeaa74daa9d6d9fe0e61961638358  sirun.tar.gz" | sha256sum -c - \
 	&& tar -xzf sirun.tar.gz \
 	&& rm sirun.tar.gz \
 	&& mv sirun /usr/bin/sirun
 
-# This list of installed Node.js versions should include all versions used by any active release line
+# This list of installed Node.js versions should include all versions used by our sirun benchmarks
 RUN mkdir -p /usr/local/nvm \
-	&& wget -q -O - https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash \
+	&& wget -q -O /tmp/nvm-install.sh https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh \
+	&& echo "4b7412c49960c7d31e8df72da90c1fb5b8cccb419ac99537b737028d497aba4f  /tmp/nvm-install.sh" | sha256sum -c - \
+	&& bash /tmp/nvm-install.sh \
+	&& rm /tmp/nvm-install.sh \
 	&& . $NVM_DIR/nvm.sh \
-	&& nvm install --no-progress 18.16.1 \
-	&& nvm install --no-progress 20.4.0 \
-	&& nvm install --no-progress 22.10.0 \
-	&& nvm alias default 22 \
-	&& nvm use 22
+	&& nvm install --no-progress 20.20.2 \
+	&& nvm install --no-progress 24.15.0 \
+	&& nvm install --no-progress 26.1.0 \
+	&& nvm alias default 24 \
+	&& nvm use 24
 
 RUN mkdir /opt/insecure-bank-js
 RUN git clone --depth 1 https://github.com/hdiv/insecure-bank-js.git /opt/insecure-bank-js


### PR DESCRIPTION
## Summary

1. The Node.js versions installed by nvm in the sirun benchmark image move to 20.20.2 / 24.15.0 / 26.1.0 (default 24), matching the suite.
2. Every external artifact the image pulls is pinned — base image (24.04 manifest-list digest), sirun, nvm, poetry, and the pip tools — and each download that publishes a checksum is verified before it runs.
3. CPython comes from a pinned, checksum-verified `python-build-standalone` tarball instead of a from-source pyenv compile, and the eight `-dev` packages that only existed to build CPython are dropped.

## Why

Floating versions plus an unverified `curl | bash` for the nvm installer meant a rebuild was neither reproducible nor guarded against a compromised download. Separately, compiling a single fixed CPython from source dominated build time and forced a full toolchain into the image for no benefit.

## Test plan

- [x] Image builds clean on `linux/amd64`; `python3`, `pip3`, `poetry`, `aws`, `sirun`, and `node` all resolve at their pinned versions.