### PR TITLE
bench(debugger): fire the probe deterministically and measure snapshot capture

### DIFF
--- a/benchmark/sirun/debugger/agent.js
+++ b/benchmark/sirun/debugger/agent.js
@@ -2,12 +2,19 @@
 
 // Minimal agent stand-in for the Dynamic Instrumentation benchmark.
 // `debugger.start()` queries `/info` to choose the diagnostics upload route and
-// blocks on it (~16s connection timeout) when no agent answers. Answer `/info`
-// immediately and drain the diagnostics/input uploads so the benchmark measures
-// probe overhead, not agent discovery.
+// blocks on it (~15s connection-retry budget) when no agent answers. Answer
+// `/info` immediately and drain the diagnostics/input uploads so the benchmark
+// measures probe overhead, not agent discovery.
+//
+// CI runs the variants in parallel, each pinned to its own core via
+// `$CPU_AFFINITY`. Derive the port from the core (like `plugin-http`'s
+// `3031 + CPU_AFFINITY`) so every variant gets a private agent; sharing one port
+// leaves the losers of the bind race with no agent, and they then burn the ~15s
+// retry budget per process. `app.js`'s agent URL derives the same port. Unset
+// affinity (local, sequential runs) falls back to the conventional 8080.
 const http = require('node:http')
 
-const port = Number(process.env.AGENT_PORT) || 8080
+const port = 8080 + Number(process.env.CPU_AFFINITY || 0)
 const info = JSON.stringify({ endpoints: ['/debugger/v1/diagnostics', '/debugger/v2/input'] })
 
 http.createServer((req, res) => {

--- a/benchmark/sirun/debugger/agent.js
+++ b/benchmark/sirun/debugger/agent.js
@@ -1,0 +1,22 @@
+'use strict'
+
+// Minimal agent stand-in for the Dynamic Instrumentation benchmark.
+// `debugger.start()` queries `/info` to choose the diagnostics upload route and
+// blocks on it (~16s connection timeout) when no agent answers. Answer `/info`
+// immediately and drain the diagnostics/input uploads so the benchmark measures
+// probe overhead, not agent discovery.
+const http = require('node:http')
+
+const port = Number(process.env.AGENT_PORT) || 8080
+const info = JSON.stringify({ endpoints: ['/debugger/v1/diagnostics', '/debugger/v2/input'] })
+
+http.createServer((req, res) => {
+  if (req.url === '/info') {
+    res.setHeader('content-type', 'application/json')
+    res.end(info)
+    return
+  }
+  // Drain and acknowledge diagnostics / snapshot uploads.
+  req.on('data', () => {})
+  req.on('end', () => res.end())
+}).listen(port)

--- a/benchmark/sirun/debugger/agent.js
+++ b/benchmark/sirun/debugger/agent.js
@@ -24,6 +24,6 @@ http.createServer((req, res) => {
     return
   }
   // Drain and acknowledge diagnostics / snapshot uploads.
-  req.on('data', () => {})
+  req.resume()
   req.on('end', () => res.end())
 }).listen(port)

--- a/benchmark/sirun/debugger/app.js
+++ b/benchmark/sirun/debugger/app.js
@@ -1,8 +1,8 @@
 'use strict'
 
-// WARNING: the breakpoint targets below are referenced by line number from
-// meta.json (BREAKPOINT_LINE). Update meta.json if you move `data.n = n` or the
-// `dummy()` body.
+// WARNING: the breakpoint target below is referenced by line number from
+// meta.json (BREAKPOINT_LINE). Update the BREAKPOINT_LINE values there if you
+// move the `data.n = n` line.
 
 const guard = require('../startup-guard')
 
@@ -36,12 +36,6 @@ function doSomeWork (n) {
   const data = getSomeData()
   data.n = n
   return data.n
-}
-
-// Never executed: breakpoint target for the not-hit baseline variant.
-// eslint-disable-next-line no-unused-vars
-function dummy () {
-  throw new Error('This line should never execute')
 }
 
 function getSomeData () {

--- a/benchmark/sirun/debugger/app.js
+++ b/benchmark/sirun/debugger/app.js
@@ -29,7 +29,7 @@ function runWork () {
   for (let i = 0; i < ITERATIONS; i++) {
     doSomeWork(i)
   }
-  guard.done(Number(process.env.STARTUP_GUARD_MAX_SHARE) || 0.35)
+  guard.done(0.35)
 }
 
 function doSomeWork (n) {

--- a/benchmark/sirun/debugger/app.js
+++ b/benchmark/sirun/debugger/app.js
@@ -1,25 +1,44 @@
 'use strict'
 
-// WARNING: CHANGES TO THIS FUNCTION WILL AFFECT THE LINE NUMBERS OF THE BREAKPOINTS
+// WARNING: the breakpoint targets below are referenced by line number from
+// meta.json (BREAKPOINT_LINE). Update meta.json if you move `data.n = n` or the
+// `dummy()` body.
+
+const guard = require('../startup-guard')
+
+const ITERATIONS = Number(process.env.ITERATIONS) || 5000
 
 if (process.env.DD_DYNAMIC_INSTRUMENTATION_ENABLED === 'true') {
-  require('./start-devtools-client')
+  // The devtools worker and its ports are unref'd, so nothing holds the event
+  // loop open while the breakpoint installs. Keep it alive until the install
+  // ack, then run the loop so the probe fires on every iteration instead of
+  // racing its installation.
+  const keepAlive = setInterval(() => {}, 2 ** 31 - 1)
+  require('./start-devtools-client')(() => {
+    clearInterval(keepAlive)
+    // The not-hit variant only measures the passive cost of installing a probe,
+    // so it exits here instead of running the guarded work loop.
+    if (process.env.INSTALL_ONLY !== 'true') runWork()
+  })
+} else {
+  runWork()
 }
 
-let n = 0
+function runWork () {
+  guard.loopStart()
+  for (let i = 0; i < ITERATIONS; i++) {
+    doSomeWork(i)
+  }
+  guard.done(0.20)
+}
 
-// Give the devtools client time to connect before doing work
-setTimeout(doSomeWork, 250)
-
-function doSomeWork (arg1 = 1, arg2 = 2) {
+function doSomeWork (n) {
   const data = getSomeData()
   data.n = n
-  if (++n <= 250) {
-    setTimeout(doSomeWork, 1)
-  }
+  return data.n
 }
 
-// Location to put dummy breakpoint that is never hit:
+// Never executed: breakpoint target for the not-hit baseline variant.
 // eslint-disable-next-line no-unused-vars
 function dummy () {
   throw new Error('This line should never execute')

--- a/benchmark/sirun/debugger/app.js
+++ b/benchmark/sirun/debugger/app.js
@@ -29,7 +29,7 @@ function runWork () {
   for (let i = 0; i < ITERATIONS; i++) {
     doSomeWork(i)
   }
-  guard.done(0.20)
+  guard.done(Number(process.env.STARTUP_GUARD_MAX_SHARE) || 0.35)
 }
 
 function doSomeWork (n) {

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -13,7 +13,7 @@
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "INSTALL_ONLY": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "44"
+        "BREAKPOINT_LINE": "37"
       }
     },
     "line-probe-without-snapshot": {

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -39,7 +39,7 @@
         "BREAKPOINT_LINE": "37",
         "CAPTURE_SNAPSHOT": "true",
         "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
-        "ITERATIONS": "1300"
+        "ITERATIONS": "3500"
       }
     },
     "line-probe-with-snapshot-minimal": {

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -5,7 +5,8 @@
   "instructions": true,
   "variants": {
     "enabled-but-breakpoint-not-hit": {
-      "service": "node agent.js",
+      "setup": "bash -c \"nohup node agent.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
@@ -16,7 +17,8 @@
       }
     },
     "line-probe-without-snapshot": {
-      "service": "node agent.js",
+      "setup": "bash -c \"nohup node agent.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
@@ -27,7 +29,8 @@
       }
     },
     "line-probe-with-snapshot-default": {
-      "service": "node agent.js",
+      "setup": "bash -c \"nohup node agent.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
@@ -40,7 +43,8 @@
       }
     },
     "line-probe-with-snapshot-minimal": {
-      "service": "node agent.js",
+      "setup": "bash -c \"nohup node agent.js >/dev/null 2>&1 &\"",
+      "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -25,7 +25,8 @@
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
         "BREAKPOINT_LINE": "37",
-        "ITERATIONS": "35000"
+        "ITERATIONS": "26000",
+        "STARTUP_GUARD_MAX_SHARE": "0.4"
       }
     },
     "line-probe-with-snapshot-default": {
@@ -39,7 +40,8 @@
         "BREAKPOINT_LINE": "37",
         "CAPTURE_SNAPSHOT": "true",
         "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
-        "ITERATIONS": "4500"
+        "ITERATIONS": "4500",
+        "STARTUP_GUARD_MAX_SHARE": "0.6"
       }
     },
     "line-probe-with-snapshot-minimal": {
@@ -57,7 +59,8 @@
         "MAX_COLLECTION_SIZE": "0",
         "MAX_FIELD_COUNT": "0",
         "MAX_LENGTH": "9007199254740991",
-        "ITERATIONS": "12000"
+        "ITERATIONS": "12000",
+        "STARTUP_GUARD_MAX_SHARE": "0.6"
       }
     }
   }

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -1,53 +1,63 @@
 {
   "name": "debugger",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 7,
   "instructions": true,
   "variants": {
     "enabled-but-breakpoint-not-hit": {
-      "service": "while true; do { echo -e 'HTTP/1.1 202 Accepted\r\n\r\n'; } | nc -l 8080 > /dev/null; done",
+      "service": "node agent.js",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
+        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
+        "INSTALL_ONLY": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "25"
+        "BREAKPOINT_LINE": "44"
       }
     },
     "line-probe-without-snapshot": {
-      "service": "while true; do { echo -e 'HTTP/1.1 202 Accepted\r\n\r\n'; } | nc -l 8080 > /dev/null; done",
+      "service": "node agent.js",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
+        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "18"
+        "BREAKPOINT_LINE": "37",
+        "ITERATIONS": "35000"
       }
     },
     "line-probe-with-snapshot-default": {
-      "service": "while true; do { echo -e 'HTTP/1.1 202 Accepted\r\n\r\n'; } | nc -l 8080 > /dev/null; done",
+      "service": "node agent.js",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
+        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "18",
-        "CAPTURE_SNAPSHOT": "true"
+        "BREAKPOINT_LINE": "37",
+        "CAPTURE_SNAPSHOT": "true",
+        "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
+        "ITERATIONS": "4500"
       }
     },
     "line-probe-with-snapshot-minimal": {
-      "service": "while true; do { echo -e 'HTTP/1.1 202 Accepted\r\n\r\n'; } | nc -l 8080 > /dev/null; done",
+      "service": "node agent.js",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
+        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "18",
+        "BREAKPOINT_LINE": "37",
         "CAPTURE_SNAPSHOT": "true",
+        "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
         "MAX_REFERENCE_DEPTH": "0",
         "MAX_COLLECTION_SIZE": "0",
         "MAX_FIELD_COUNT": "0",
-        "MAX_LENGTH": "9007199254740991"
+        "MAX_LENGTH": "9007199254740991",
+        "ITERATIONS": "12000"
       }
     }
   }

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -9,7 +9,6 @@
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
-        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "INSTALL_ONLY": "true",
         "BREAKPOINT_FILE": "app.js",
@@ -21,12 +20,10 @@
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
-        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
         "BREAKPOINT_LINE": "37",
-        "ITERATIONS": "26000",
-        "STARTUP_GUARD_MAX_SHARE": "0.4"
+        "ITERATIONS": "3500"
       }
     },
     "line-probe-with-snapshot-default": {
@@ -34,14 +31,12 @@
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
-        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
         "BREAKPOINT_LINE": "37",
         "CAPTURE_SNAPSHOT": "true",
         "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
-        "ITERATIONS": "4500",
-        "STARTUP_GUARD_MAX_SHARE": "0.6"
+        "ITERATIONS": "1300"
       }
     },
     "line-probe-with-snapshot-minimal": {
@@ -49,7 +44,6 @@
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
-        "DD_TRACE_AGENT_URL": "http://127.0.0.1:8080",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
         "BREAKPOINT_LINE": "37",
@@ -59,8 +53,7 @@
         "MAX_COLLECTION_SIZE": "0",
         "MAX_FIELD_COUNT": "0",
         "MAX_LENGTH": "9007199254740991",
-        "ITERATIONS": "12000",
-        "STARTUP_GUARD_MAX_SHARE": "0.6"
+        "ITERATIONS": "3500"
       }
     }
   }

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "debugger",
   "cachegrind": false,
-  "iterations": 7,
+  "iterations": 10,
   "instructions": true,
   "variants": {
     "enabled-but-breakpoint-not-hit": {

--- a/benchmark/sirun/debugger/start-devtools-client.js
+++ b/benchmark/sirun/debugger/start-devtools-client.js
@@ -4,6 +4,12 @@ const assert = require('node:assert/strict')
 const fs = require('node:fs')
 const Module = require('node:module')
 
+// Point the tracer at this variant's per-core agent (port matches `agent.js`)
+// before `getConfig()` reads the URL. Set it unconditionally so a globally
+// inherited `DD_TRACE_AGENT_URL` can't redirect us back to a shared port that
+// another parallel variant owns.
+process.env.DD_TRACE_AGENT_URL = `http://127.0.0.1:${8080 + Number(process.env.CPU_AFFINITY || 0)}`
+
 // The trace-context expression the devtools client evaluates on the paused frame
 // for every hit does `global.require('dd-trace')`. This bench loads the tracer by
 // relative path, so the bare specifier would otherwise throw MODULE_NOT_FOUND on

--- a/benchmark/sirun/debugger/start-devtools-client.js
+++ b/benchmark/sirun/debugger/start-devtools-client.js
@@ -22,12 +22,10 @@ Module._resolveFilename = function (request, ...rest) {
 
 // The global snapshot cap (MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) is read in the
 // devtools worker thread at module load, with no config or env path to override
-// it. To let the snapshot variants measure capture cost on every hit instead of
-// the rate-limited path, rewrite the on-disk value before `start()` spawns the
-// worker. The worker captures the value into a const at load, so the install ack
-// restores the file right after — the long work loop runs with the source
-// unchanged. No-op unless the variant opts in via the env var.
-const restoreSnapshotCap = patchGlobalSnapshotCap(process.env.MAX_SNAPSHOTS_PER_SECOND_GLOBALLY)
+// it. Rewrite the on-disk value before `start()` spawns the worker so the snapshot
+// variants measure capture cost on every hit instead of the rate-limited path.
+// No-op unless the variant opts in via the env var.
+patchGlobalSnapshotCap(process.env.MAX_SNAPSHOTS_PER_SECOND_GLOBALLY)
 
 // Entry point normally primes this; bench imports src directly.
 globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
@@ -55,35 +53,49 @@ function intEnv (name) {
 }
 
 /**
- * Rewrite `MAX_SNAPSHOTS_PER_SECOND_GLOBALLY` in the devtools defaults file to
- * `cap` and return an idempotent restore. A single-line numeric replace keeps the
- * file byte-identical except the value. The caller restores from the install ack
- * (the worker has captured the value by then); an exit handler is a fallback.
+ * Replace `filePath` with `content` atomically, so the devtools worker's
+ * concurrent `require('./defaults')` read in another variant only ever sees
+ * complete file contents, never a half-written file.
+ *
+ * @param {string} filePath
+ * @param {string} content
+ */
+function writeFileAtomic (filePath, content) {
+  const tempPath = `${filePath}.${process.pid}.tmp`
+  fs.writeFileSync(tempPath, content)
+  fs.renameSync(tempPath, filePath)
+}
+
+/**
+ * Raise `MAX_SNAPSHOTS_PER_SECOND_GLOBALLY` in the devtools defaults file to `cap`
+ * and restore the committed default on exit.
+ *
+ * `runall.sh` pins one variant per core, so the two snapshot variants rewrite this
+ * shared file in parallel. Two properties keep that race-free without a lock (a
+ * lock would serialize startup and inflate the measured run): a sibling that has
+ * already raised the cap is left to restore it, so its value is never captured as
+ * the baseline; and the restore runs on exit, long after every worker has read the
+ * cap at load, so no worker can observe the default mid-run.
  *
  * @param {string | undefined} value Desired cap; skips the rewrite when unset.
- * @returns {() => void} Restores the original file contents (idempotent).
  */
 function patchGlobalSnapshotCap (value) {
-  if (!value) return () => {}
+  if (!value) return
 
   const cap = Number(value)
   assert(Number.isInteger(cap) && cap > 0, 'MAX_SNAPSHOTS_PER_SECOND_GLOBALLY must be a positive integer')
 
   const defaultsPath = require.resolve('../../../packages/dd-trace/src/debugger/devtools_client/defaults')
-  const pattern = /(MAX_SNAPSHOTS_PER_SECOND_GLOBALLY:\s*)\d+/
-  const original = fs.readFileSync(defaultsPath, 'utf8')
-  assert.match(original, pattern, 'MAX_SNAPSHOTS_PER_SECOND_GLOBALLY not found in defaults file')
+  const pattern = /(MAX_SNAPSHOTS_PER_SECOND_GLOBALLY:\s*)(\d+)/
+  const committed = fs.readFileSync(defaultsPath, 'utf8')
+  const match = committed.match(pattern)
+  assert(match, 'MAX_SNAPSHOTS_PER_SECOND_GLOBALLY not found in defaults file')
 
-  fs.writeFileSync(defaultsPath, original.replace(pattern, `$1${cap}`))
+  // Already raised by a sibling variant: leave its exit handler to restore it.
+  if (Number(match[2]) === cap) return
 
-  let restored = false
-  const restore = () => {
-    if (restored) return
-    restored = true
-    fs.writeFileSync(defaultsPath, original)
-  }
-  process.once('exit', restore)
-  return restore
+  writeFileAtomic(defaultsPath, committed.replace(pattern, `$1${cap}`))
+  process.once('exit', () => writeFileAtomic(defaultsPath, committed))
 }
 
 /**
@@ -108,7 +120,6 @@ module.exports = function startDebugger (onProbeInstalled) {
         },
       })
       cb(action, conf, 'id', (error) => {
-        restoreSnapshotCap()
         if (error) throw error
         onProbeInstalled()
       })

--- a/benchmark/sirun/debugger/start-devtools-client.js
+++ b/benchmark/sirun/debugger/start-devtools-client.js
@@ -1,6 +1,27 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const Module = require('node:module')
+
+// The trace-context expression the devtools client evaluates on the paused frame
+// for every hit does `global.require('dd-trace')`. This bench loads the tracer by
+// relative path, so the bare specifier would otherwise throw MODULE_NOT_FOUND on
+// every hit and skew the measurement. Resolve it to this checkout's entry point.
+const ddTraceEntry = require.resolve('../../..')
+const originalResolveFilename = Module._resolveFilename
+Module._resolveFilename = function (request, ...rest) {
+  return originalResolveFilename.call(this, request === 'dd-trace' ? ddTraceEntry : request, ...rest)
+}
+
+// The global snapshot cap (MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) is read in the
+// devtools worker thread at module load, with no config or env path to override
+// it. To let the snapshot variants measure capture cost on every hit instead of
+// the rate-limited path, rewrite the on-disk value before `start()` spawns the
+// worker. The worker captures the value into a const at load, so the install ack
+// restores the file right after — the long work loop runs with the source
+// unchanged. No-op unless the variant opts in via the env var.
+const restoreSnapshotCap = patchGlobalSnapshotCap(process.env.MAX_SNAPSHOTS_PER_SECOND_GLOBALLY)
 
 // Entry point normally primes this; bench imports src directly.
 globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
@@ -15,26 +36,80 @@ assert(sourceFile, 'BREAKPOINT_FILE environment variable must be set')
 assert(!Number.isNaN(line), 'BREAKPOINT_LINE environment variable must be a number')
 
 const breakpoint = { sourceFile, line }
-const config = getConfig()
-const rc = {
-  setProductHandler (product, cb) {
-    const action = 'apply'
-    const conf = generateProbeConfig(breakpoint, {
-      captureSnapshot: process.env.CAPTURE_SNAPSHOT === 'true',
-      capture: {
-        maxReferenceDepth: process.env.MAX_REFERENCE_DEPTH ? parseInt(process.env.MAX_REFERENCE_DEPTH, 10) : undefined,
-        maxCollectionSize: process.env.MAX_COLLECTION_SIZE ? parseInt(process.env.MAX_COLLECTION_SIZE, 10) : undefined,
-        maxFieldCount: process.env.MAX_FIELD_COUNT ? parseInt(process.env.MAX_FIELD_COUNT, 10) : undefined,
-        maxLength: process.env.MAX_LENGTH ? parseInt(process.env.MAX_LENGTH, 10) : undefined,
-      },
-    })
-    const id = 'id'
-    const ack = () => {}
 
-    cb(action, conf, id, ack)
-  },
+/**
+ * Parse an integer environment variable, returning undefined when it is unset so
+ * the probe config falls back to its defaults.
+ *
+ * @param {string} name
+ * @returns {number | undefined}
+ */
+function intEnv (name) {
+  return process.env[name] ? parseInt(process.env[name], 10) : undefined
 }
 
-start(config, rc)
+/**
+ * Rewrite `MAX_SNAPSHOTS_PER_SECOND_GLOBALLY` in the devtools defaults file to
+ * `cap` and return an idempotent restore. A single-line numeric replace keeps the
+ * file byte-identical except the value. The caller restores from the install ack
+ * (the worker has captured the value by then); an exit handler is a fallback.
+ *
+ * @param {string | undefined} value Desired cap; skips the rewrite when unset.
+ * @returns {() => void} Restores the original file contents (idempotent).
+ */
+function patchGlobalSnapshotCap (value) {
+  if (!value) return () => {}
 
-assert.ok(globalThis[Symbol.for('dd-trace')].utilTypes, 'debugger.start did not populate utilTypes')
+  const cap = Number(value)
+  assert(Number.isInteger(cap) && cap > 0, 'MAX_SNAPSHOTS_PER_SECOND_GLOBALLY must be a positive integer')
+
+  const defaultsPath = require.resolve('../../../packages/dd-trace/src/debugger/devtools_client/defaults')
+  const pattern = /(MAX_SNAPSHOTS_PER_SECOND_GLOBALLY:\s*)\d+/
+  const original = fs.readFileSync(defaultsPath, 'utf8')
+  assert.match(original, pattern, 'MAX_SNAPSHOTS_PER_SECOND_GLOBALLY not found in defaults file')
+
+  fs.writeFileSync(defaultsPath, original.replace(pattern, `$1${cap}`))
+
+  let restored = false
+  const restore = () => {
+    if (restored) return
+    restored = true
+    fs.writeFileSync(defaultsPath, original)
+  }
+  process.once('exit', restore)
+  return restore
+}
+
+/**
+ * Install the Dynamic Instrumentation probe and run `onProbeInstalled` once the
+ * breakpoint is live. The ack fires only after `Debugger.setBreakpoint` resolves,
+ * so the caller runs against an installed breakpoint instead of racing it.
+ *
+ * @param {() => void} onProbeInstalled
+ */
+module.exports = function startDebugger (onProbeInstalled) {
+  const config = getConfig()
+  const rc = {
+    setProductHandler (product, cb) {
+      const action = 'apply'
+      const conf = generateProbeConfig(breakpoint, {
+        captureSnapshot: process.env.CAPTURE_SNAPSHOT === 'true',
+        capture: {
+          maxReferenceDepth: intEnv('MAX_REFERENCE_DEPTH'),
+          maxCollectionSize: intEnv('MAX_COLLECTION_SIZE'),
+          maxFieldCount: intEnv('MAX_FIELD_COUNT'),
+          maxLength: intEnv('MAX_LENGTH'),
+        },
+      })
+      cb(action, conf, 'id', (error) => {
+        restoreSnapshotCap()
+        if (error) throw error
+        onProbeInstalled()
+      })
+    },
+  }
+
+  start(config, rc)
+
+  assert.ok(globalThis[Symbol.for('dd-trace')].utilTypes, 'debugger.start did not populate utilTypes')
+}


### PR DESCRIPTION
## Summary

The hit loop ran on a fixed `setTimeout` that raced the asynchronous breakpoint install, so the probe usually never fired and the bench measured startup instead of probe overhead. The loop now starts from the install ack, so every iteration hits an installed breakpoint.

The snapshot variants were bound by the 25/s global snapshot cap, which has no config or env override, so they re-measured the rate-limited non-snapshot path. The bench rewrites `MAX_SNAPSHOTS_PER_SECOND_GLOBALLY` on disk before the worker loads it and restores it at the install ack; the worker keeps the value in memory, so the loop runs with the source pristine and the committed tree is unchanged. A snapshot is then captured on every hit (~1.6 ms vs ~0.2 ms bare).

The enabled-but-breakpoint-not-hit variant measures fixed install cost, so it installs the probe and exits without the work loop or the startup guard.

## Test plan

- Run `sirun meta.json` in `benchmark/sirun/debugger`; confirm all four variants complete and that `git status` shows `packages/dd-trace/src/debugger/devtools_client/defaults.js` unmodified afterward (restored at the install ack).