### PR TITLE
bench(dns): drive the callback instrumentor over a no-op lookup

### DIFF
--- a/benchmark/sirun/plugin-dns/README.md
+++ b/benchmark/sirun/plugin-dns/README.md
@@ -1,2 +1,4 @@
-Runs `dns.lookup('localhost', cb)` many times. In the `with-tracer` variant,
-tracing is enabled. Iteration count is set to 10.
+Drives the per-lookup work the dns instrumentation's callback instrumentor adds
+(argument capture, context build, start/finish channel dispatch, callback wrap)
+over a no-op underlying lookup, so the measurement isolates the tracer's cost
+from the libuv `getaddrinfo` syscall.

--- a/benchmark/sirun/plugin-dns/index.js
+++ b/benchmark/sirun/plugin-dns/index.js
@@ -14,6 +14,7 @@ const guard = require('../startup-guard')
 const { createCallbackInstrumentor } =
   require('../../../packages/datadog-instrumentations/src/helpers/callback-instrumentor')
 const { channel } = require('../../../packages/datadog-instrumentations/src/helpers/instrument')
+const { storage } = require('../../../packages/datadog-core')
 
 const ITERATIONS = Number(process.env.ITERATIONS) || 8_000_000
 
@@ -35,21 +36,49 @@ function noopLookup (hostname, callback) {
 const lookup = createCallbackInstrumentor('apm:dns:lookup', { captureResult: true })
 const wrappedLookup = lookup(buildArgsContext)(noopLookup)
 
-// Real subscribers so hasSubscribers is true and runStores does the
-// context-propagation work the tracer pays in production.
+const startCh = channel('apm:dns:lookup:start')
+const finishCh = channel('apm:dns:lookup:finish')
+
+// runStores only propagates context when a store is bound; a subscriber alone makes it
+// a pass-through. Bind the tracer's async-context store the way TracingPlugin.addTraceBind
+// does -- start enters a store carrying the span (DNSLookupPlugin.bindStart), finish
+// restores the parent (OutboundPlugin.bindFinish) -- so the loop pays the real per-lookup
+// propagation cost. The subscribers keep hasSubscribers true and drive the assertions.
+const legacyStorage = storage('legacy')
+const span = {} // stand-in for the span the plugin binds; the bench isolates propagation, not span creation
+
 let started = 0
 let finished = 0
-channel('apm:dns:lookup:start').subscribe(() => { started++ })
-channel('apm:dns:lookup:finish').subscribe(() => { finished++ })
+startCh.subscribe(() => { started++ })
+finishCh.subscribe(() => { finished++ })
+startCh.bindStore(legacyStorage, (ctx) => {
+  ctx.parentStore = legacyStorage.getStore()
+  ctx.currentStore = { ...ctx.parentStore, span }
+  return ctx.currentStore
+})
+finishCh.bindStore(legacyStorage, (ctx) => ctx.parentStore)
 
 let lastResult
 const onLookup = (_, address) => { lastResult = address }
 
-// Confirm the wrapper dispatches through both channels and captures the result before
-// timing, so broken wiring fails loudly instead of silently measuring a bypass.
-wrappedLookup('localhost', onLookup)
+// Before timing, confirm the wrapper dispatches through both channels, captures the
+// result, and that the bound stores actually propagate context: the start bind enters a
+// store carrying the span, the finish bind restores the parent. This fails loudly if an
+// edit drops a binding instead of silently measuring a no-op pass-through again.
+let storeInLookup
+let storeInCallback
+const verifyLookup = lookup(buildArgsContext)((hostname, callback) => {
+  storeInLookup = legacyStorage.getStore()
+  return callback(null, '127.0.0.1', 4)
+})
+verifyLookup('localhost', (_, address) => {
+  lastResult = address
+  storeInCallback = legacyStorage.getStore()
+})
 assert.ok(started > 0 && finished > 0, 'dns lookup wrapper did not reach the channels')
 assert.equal(lastResult, '127.0.0.1', 'dns lookup wrapper did not deliver the result')
+assert.equal(storeInLookup?.span, span, 'start bind did not propagate the span store')
+assert.equal(storeInCallback, undefined, 'finish bind did not restore the parent store')
 
 guard.loopStart()
 for (let i = 0; i < ITERATIONS; i++) {

--- a/benchmark/sirun/plugin-dns/index.js
+++ b/benchmark/sirun/plugin-dns/index.js
@@ -3,34 +3,58 @@
 const assert = require('node:assert/strict')
 const guard = require('../startup-guard')
 
-if (Number(process.env.USE_TRACER)) {
-  require('../../..').init()
+// Every traced dns.lookup walks the callback instrumentor the dns instrumentation
+// installs: capture the call args (minus the callback), open the start channel via
+// runStores, wrap the user callback to capture the result and publish finish, then
+// run the underlying lookup. The real getaddrinfo is a libuv syscall whose time
+// swamps and destabilizes the tracer's added work, so -- like the fs and
+// child_process benches -- we drive that wrapper over a no-op underlying lookup that
+// invokes the callback synchronously, using the real instrumentor helper so the
+// measured path can't drift from production.
+const { createCallbackInstrumentor } =
+  require('../../../packages/datadog-instrumentations/src/helpers/callback-instrumentor')
+const { channel } = require('../../../packages/datadog-instrumentations/src/helpers/instrument')
+
+const ITERATIONS = Number(process.env.ITERATIONS) || 8_000_000
+
+// Mirrors buildCallbackArgsContext() in datadog-instrumentations/src/dns.js for the
+// lookup shape (no rrtype): drop the trailing callback and capture the rest.
+function buildArgsContext (_, args) {
+  if (args.length < 2) return
+  const captured = [...args]
+  captured.pop()
+  return { args: captured }
 }
 
-// eslint-disable-next-line import/order -- dns must be required after tracer.init() so it gets instrumented
-const dns = require('dns')
-
-// Total lookups per process. The tracer's dns instrumentation is paid per lookup,
-// so a large total keeps the fixed tracer load a small fraction of the run. The
-// lookups are serialized, so live memory stays flat regardless of COUNT.
-const COUNT = process.env.COUNT ? Number(process.env.COUNT) : 20000
-
-let checked = false
-
-function testRun (count) {
-  if (++count === COUNT) {
-    // Tracer init is a large fixed cost here, so dns needs the relaxed ceiling.
-    guard.done(0.15)
-    return
-  }
-  dns.lookup('localhost', (error, address) => {
-    if (!checked) {
-      assert.ok(!error && address, 'dns.lookup did not resolve localhost')
-      checked = true
-    }
-    testRun(count)
-  })
+// No-op underlying lookup: deliver a representative localhost result synchronously so
+// the loop measures the wrapper, never getaddrinfo.
+function noopLookup (hostname, callback) {
+  return callback(null, '127.0.0.1', 4)
 }
+
+const lookup = createCallbackInstrumentor('apm:dns:lookup', { captureResult: true })
+const wrappedLookup = lookup(buildArgsContext)(noopLookup)
+
+// Real subscribers so hasSubscribers is true and runStores does the
+// context-propagation work the tracer pays in production.
+let started = 0
+let finished = 0
+channel('apm:dns:lookup:start').subscribe(() => { started++ })
+channel('apm:dns:lookup:finish').subscribe(() => { finished++ })
+
+let lastResult
+const onLookup = (_, address) => { lastResult = address }
+
+// Confirm the wrapper dispatches through both channels and captures the result before
+// timing, so broken wiring fails loudly instead of silently measuring a bypass.
+wrappedLookup('localhost', onLookup)
+assert.ok(started > 0 && finished > 0, 'dns lookup wrapper did not reach the channels')
+assert.equal(lastResult, '127.0.0.1', 'dns lookup wrapper did not deliver the result')
 
 guard.loopStart()
-testRun(0)
+for (let i = 0; i < ITERATIONS; i++) {
+  wrappedLookup('localhost', onLookup)
+}
+guard.done()
+
+assert.ok(started > ITERATIONS && finished > ITERATIONS, 'dns lookup wrapper produced no work')

--- a/benchmark/sirun/plugin-dns/meta.json
+++ b/benchmark/sirun/plugin-dns/meta.json
@@ -3,11 +3,11 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 15,
   "instructions": true,
   "variants": {
-    "with-tracer": {
-      "env": { "USE_TRACER": "1", "COUNT": "10000" }
+    "lookup": {
+      "env": { "ITERATIONS": "1000000" }
     }
   }
 }


### PR DESCRIPTION
## Summary

The real `getaddrinfo` syscall swamped and destabilized the per-lookup work the dns instrumentation adds, so the variant measured the syscall, not the tracer. It now drives the production callback instrumentor (argument capture, `runStores` start/finish dispatch, callback wrap) over a synchronous no-op lookup, matching the `fs` and `child_process` benches, so the signal isolates the tracer's added cost rather than kernel resolver latency.