### PR TITLE
bench(sirun): add profiler workload and llmobs guard, shorten over-long benches

### DIFF
--- a/benchmark/sirun/child_process/meta.json
+++ b/benchmark/sirun/child_process/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "shell-string": {
-      "env": { "VARIANT": "shell-string", "ITERATIONS": "6000000" }
+      "env": { "VARIANT": "shell-string", "ITERATIONS": "4700000" }
     },
     "file-args": {
-      "env": { "VARIANT": "file-args", "ITERATIONS": "6000000" }
+      "env": { "VARIANT": "file-args", "ITERATIONS": "3750000" }
     }
   }
 }

--- a/benchmark/sirun/fs/meta.json
+++ b/benchmark/sirun/fs/meta.json
@@ -7,7 +7,7 @@
   "instructions": true,
   "variants": {
     "subscribed": {
-      "env": { "VARIANT": "subscribed", "ITERATIONS": "6000000" }
+      "env": { "VARIANT": "subscribed", "ITERATIONS": "2500000" }
     }
   }
 }

--- a/benchmark/sirun/llmobs/index.js
+++ b/benchmark/sirun/llmobs/index.js
@@ -2,6 +2,8 @@
 
 const assert = require('node:assert/strict')
 
+const guard = require('../startup-guard')
+
 globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
 
 // Stub the HTTP request module before the writer captures it. Flush still runs
@@ -232,9 +234,11 @@ assert.equal(writer._buffer.events.length, 1)
 writer.flush()
 assert.equal(writer._buffer.events.length, 0)
 
+guard.loopStart()
 for (let iteration = 0; iteration < ITERATIONS; iteration++) {
   for (const event of EVENTS) {
     writer.append(event)
   }
   writer.flush()
 }
+guard.done()

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -13,7 +13,7 @@
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "800" }
     },
     "with-depth-and-collapse-off": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "QUERIES": "240" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "QUERIES": "200" }
     }
   }
 }

--- a/benchmark/sirun/plugin-http/meta.json
+++ b/benchmark/sirun/plugin-http/meta.json
@@ -31,7 +31,7 @@
       "env": {
         "SERVER_USE_TRACER": "1",
         "CLIENT_LONG_QUERYSTRING": "1",
-        "REQS": "20000"
+        "REQS": "14000"
       }
     }
   }

--- a/benchmark/sirun/plugin-redis/meta.json
+++ b/benchmark/sirun/plugin-redis/meta.json
@@ -7,13 +7,13 @@
   "instructions": true,
   "variants": {
     "get": {
-      "env": { "VARIANT": "get", "ITERATIONS": "20000000" }
+      "env": { "VARIANT": "get", "ITERATIONS": "13500000" }
     },
     "long-value": {
       "env": { "VARIANT": "long-value", "ITERATIONS": "13000000" }
     },
     "mset-wide": {
-      "env": { "VARIANT": "mset-wide", "ITERATIONS": "2200000" }
+      "env": { "VARIANT": "mset-wide", "ITERATIONS": "1150000" }
     },
     "mixed": {
       "env": { "VARIANT": "mixed", "ITERATIONS": "13000000" }

--- a/benchmark/sirun/profiler/index.js
+++ b/benchmark/sirun/profiler/index.js
@@ -23,7 +23,7 @@ assert.equal(tracer._profilerStarted, true, 'profiler.start did not return true'
 // to stay under the 60s upload period, so no profile is exported and no agent
 // is required.
 guard.loopStart()
-const ROUNDS = 64_000
+const ROUNDS = 32_000
 let sink = 0
 for (let round = 0; round < ROUNDS; round++) {
   for (let i = 0; i < 20_000; i++) {

--- a/benchmark/sirun/profiler/index.js
+++ b/benchmark/sirun/profiler/index.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict')
 
+const guard = require('../startup-guard')
 const tracer = require('../../..')
 
 const { PROFILER } = process.env
@@ -17,3 +18,24 @@ process.env.DD_PROFILING_HEAP_SAMPLING_INTERVAL = '0'
 tracer.init({ profiling: 'true' })
 
 assert.equal(tracer._profilerStarted, true, 'profiler.start did not return true')
+
+// Keep the process busy so the wall and space profilers actually sample. Sized
+// to stay under the 60s upload period, so no profile is exported and no agent
+// is required.
+guard.loopStart()
+const ROUNDS = 64_000
+let sink = 0
+for (let round = 0; round < ROUNDS; round++) {
+  for (let i = 0; i < 20_000; i++) {
+    sink += Math.sqrt(i) * Math.cos(i)
+  }
+  const items = new Array(2000)
+  for (let i = 0; i < items.length; i++) {
+    items[i] = { index: i, label: `item-${i}` }
+  }
+  sink += items[round % items.length].index
+}
+
+assert.notEqual(sink, Infinity)
+
+guard.done()

--- a/benchmark/sirun/startup/meta.json
+++ b/benchmark/sirun/startup/meta.json
@@ -3,7 +3,7 @@
   "run": "node startup-test.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node startup-test.js\"",
   "cachegrind": false,
-  "iterations": 40,
+  "iterations": 35,
   "instructions": true,
   "variants": {
     "with-tracer": {

--- a/benchmark/sirun/tracing-channel/meta.json
+++ b/benchmark/sirun/tracing-channel/meta.json
@@ -3,12 +3,12 @@
   "run": "node index.js",
   "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
   "cachegrind": false,
-  "iterations": 20,
+  "iterations": 11,
   "instructions": true,
   "variants": {
     "command": {
       "env": {
-        "ITERATIONS": "20000000"
+        "ITERATIONS": "3500000"
       }
     }
   }

--- a/benchmark/sirun/url/meta.json
+++ b/benchmark/sirun/url/meta.json
@@ -8,7 +8,7 @@
   "variants": {
     "endpoint-and-obfuscation": {
       "env": {
-        "COUNT": "3000000"
+        "COUNT": "2500000"
       }
     }
   }


### PR DESCRIPTION
## Summary

Three independent sirun tuning changes:

1. **profiler** — the variants started the profiler and exited immediately, so the wall and space profilers had nothing to sample and the bench measured init only. A bounded CPU and allocation workload after init keeps the process busy under the 60 s upload period (no profile is exported, no agent is needed), wrapped in the startup guard so the workload stays dominant over setup.
2. **llmobs** — add the startup guard to the writer encode loop so creeping startup cost can't masquerade as encode cost.
3. **over-long benches** — `child_process`, `fs`, `plugin-graphql-long`, `plugin-http`, `plugin-redis`, `startup`, `tracing-channel`, and `url` ran far longer per process than a stable signal needs; lower iteration counts keep the measurement while cutting CI wall time.