### PR TITLE
fix(fastify): guard error publishing against re-entrant recursion

### DIFF
--- a/packages/datadog-instrumentations/src/fastify.js
+++ b/packages/datadog-instrumentations/src/fastify.js
@@ -207,11 +207,14 @@ function preHandler (request, reply, done) {
 
 function preValidation (request, reply, done) {
   const req = getReq(request)
-  const res = getRes(reply)
   const ctx = parsingContexts.get(req)
-  ctx.res = res
 
-  if (!ctx) return processInContext(request, ctx, done, req)
+  // No stored context means the onRequest/preParsing fast path ran (no error /
+  // cookie / callback subscribers), so there is nothing to publish on; forward
+  // `done` instead of dereferencing a missing ctx in processInContext.
+  if (!ctx) return done()
+
+  ctx.res = getRes(reply)
 
   preValidationCh.runStores(ctx, processInContext, undefined, request, ctx, done, req)
 }
@@ -276,7 +279,7 @@ function wrapSend (send, req) {
     const ctx = { req }
     if (payload instanceof Error) {
       ctx.error = payload
-      errorChannel.publish(ctx)
+      publishError(ctx)
     } else if (canPublishResponsePayload(payload)) {
       const res = getRes(this)
       ctx.res = res
@@ -300,9 +303,18 @@ function getRouteConfig (request) {
   return request?.routeOptions?.config
 }
 
+let publishingError = false
+
 function publishError (ctx) {
-  if (ctx.error) {
-    errorChannel.publish(ctx)
+  // `errorChannel` is public: a subscriber that re-enters the hook pipeline while
+  // handling the error republishes here and recurses until the stack overflows.
+  if (ctx.error && !publishingError) {
+    publishingError = true
+    try {
+      errorChannel.publish(ctx)
+    } finally {
+      publishingError = false
+    }
   }
 
   return ctx.error

--- a/packages/datadog-instrumentations/test/fastify.spec.js
+++ b/packages/datadog-instrumentations/test/fastify.spec.js
@@ -170,6 +170,28 @@ describe('fastify instrumentation (unit)', () => {
       assert.strictEqual(errorListener.firstCall.args[0].error, error)
     })
 
+    it('drops the re-entrant publish when an error subscriber re-enters another hook', () => {
+      // A subscriber that drives another hook error while handling the current
+      // one would loop publishError -> errorChannel -> subscriber -> hook ->
+      // publishError until the stack overflows. The guard runs the subscriber once.
+      const { app, registered } = buildWrappedAddHook()
+      const userHook = sinon.stub().callsFake((request, reply, done) => done(new Error('boom')))
+      app.addHook('preHandler', userHook)
+      const wrapper = registered[0].fn
+
+      let depth = 0
+      const errorListener = sinon.stub().callsFake(() => {
+        depth++
+        if (depth > 50) return // safety stop: a regressed guard fails the assert, not the runner
+        wrapper({}, {}, () => {})
+      })
+      subscribe(errorChannel, errorListener)
+
+      wrapper({}, {}, () => {})
+
+      assert.strictEqual(depth, 1)
+    })
+
     it('returns the user value unchanged when the hook is callbackless and returns non-thenable', () => {
       const errorListener = sinon.stub()
       subscribe(errorChannel, errorListener)
@@ -528,6 +550,71 @@ describe('fastify instrumentation (unit)', () => {
       preValidationFn(request, reply, sinon.stub())
 
       sinon.assert.calledOnce(bodyListener)
+    })
+
+    it('forwards done without touching ctx when preParsing left no stored context', () => {
+      // fastify dispatches preValidation even when the preParsing phase never
+      // ran for this request, so `parsingContexts` has no entry. The
+      // missing-context guard must short-circuit before any `ctx` access, even
+      // when a param channel has a subscriber - otherwise processInContext
+      // dereferences the missing ctx (ctx.abortController = ...) and throws.
+      const queryListener = sinon.stub()
+      subscribe(queryParamsReadCh, queryListener)
+
+      const { internalByName } = buildWrappedAddHook()
+      const [preValidationFn] = internalByName('preValidation')
+
+      const request = { query: { q: '1' }, body: { b: '2' }, params: { p: '3' } }
+      const reply = {}
+      const preValidationDone = sinon.stub()
+
+      preValidationFn(request, reply, preValidationDone)
+
+      sinon.assert.calledOnce(preValidationDone)
+      // No ctx means nothing to publish on, so the param channel stays untouched.
+      sinon.assert.notCalled(queryListener)
+    })
+  })
+
+  describe('wrapSend (reply.send error publishing)', () => {
+    const subscriptions = []
+
+    function subscribe (channel, listener) {
+      channel.subscribe(listener)
+      subscriptions.push({ channel, listener })
+    }
+
+    afterEach(() => {
+      while (subscriptions.length > 0) {
+        const { channel, listener } = subscriptions.pop()
+        channel.unsubscribe(listener)
+      }
+    })
+
+    it('publishes through the guarded publishError when reply.send is called with an Error', () => {
+      const errorListener = sinon.stub()
+      subscribe(errorChannel, errorListener)
+
+      const { internalByName } = buildWrappedAddHook()
+      const [preHandlerFn] = internalByName('preHandler')
+
+      // preHandler swaps reply.send for the tracing wrapper (wrapSend).
+      const originalSend = sinon.stub()
+      const reply = { send: originalSend }
+      const preHandlerDone = sinon.stub()
+      preHandlerFn({}, reply, preHandlerDone)
+      sinon.assert.calledOnce(preHandlerDone)
+      assert.notStrictEqual(reply.send, originalSend)
+
+      // Sending an Error routes through publishError, not a bare errorChannel.publish.
+      const error = new Error('send boom')
+      reply.send(error)
+
+      sinon.assert.calledOnce(errorListener)
+      assert.strictEqual(errorListener.firstCall.args[0].error, error)
+      // The original send still runs with the untouched arguments.
+      sinon.assert.calledOnce(originalSend)
+      assert.strictEqual(originalSend.firstCall.args[0], error)
     })
   })
 })


### PR DESCRIPTION
## Summary

A subscriber on the public `apm:fastify:middleware:error` channel that re-enters a wrapped hook while handling the error republishes through `publishError`, which republishes again, until the stack overflows (`RangeError: Maximum call stack size exceeded` during plugin registration).

Two coordinated pieces close it:

1. `publishError` tracks an in-flight flag and drops the re-entrant publish instead of recursing; `try/finally` clears it even when a subscriber throws.
2. `reply.send(error)` routes through `publishError` rather than a bare `errorChannel.publish`, so the response-error path is guarded too.

## Drive-by

- `preValidation` forwards `done()` when `parsingContexts` holds no entry, instead of dereferencing a missing `ctx` in `processInContext` (`TypeError` when a param channel has a subscriber but `onRequest` took the fast path).

## Test plan

- [x] `packages/datadog-instrumentations/test/fastify.spec.js` re-entrancy regression test fails without the guard (depth 51) and passes with it.

This PR addresses: #8783 