### PR TITLE
fix(test-optimization): disable mocha retries for managed retries

### DIFF
--- a/integration-tests/ci-visibility/run-mocha.js
+++ b/integration-tests/ci-visibility/run-mocha.js
@@ -5,6 +5,9 @@ const Mocha = require('mocha')
 const mocha = new Mocha({
   parallel: !!process.env.RUN_IN_PARALLEL,
 })
+if (process.env.MOCHA_RETRIES) {
+  mocha.retries(Number(process.env.MOCHA_RETRIES))
+}
 if (process.env.TESTS_TO_RUN) {
   const tests = JSON.parse(process.env.TESTS_TO_RUN)
   tests.forEach(test => {

--- a/integration-tests/ci-visibility/test-early-flake-detection/fails-first-then-passes.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/fails-first-then-passes.js
@@ -4,7 +4,10 @@ const assert = require('assert')
 let numAttempts = 0
 
 describe('fail first then pass', () => {
-  it('fails first then passes', () => {
+  it('fails first then passes', function () {
+    if (process.env.SET_RETRIES_INSIDE_TEST) {
+      this.retries(2)
+    }
     assert.strictEqual(numAttempts++ > 0, true)
   })
 })

--- a/integration-tests/ci-visibility/test-early-flake-detection/fails-first-then-passes.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/fails-first-then-passes.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const assert = require('assert')
+let numAttempts = 0
+
+describe('fail first then pass', () => {
+  it('fails first then passes', () => {
+    assert.strictEqual(numAttempts++ > 0, true)
+  })
+})

--- a/integration-tests/ci-visibility/test-early-flake-detection/fails-first-then-passes.js
+++ b/integration-tests/ci-visibility/test-early-flake-detection/fails-first-then-passes.js
@@ -6,6 +6,7 @@ let numAttempts = 0
 describe('fail first then pass', () => {
   it('fails first then passes', function () {
     if (process.env.SET_RETRIES_INSIDE_TEST) {
+      // eslint-disable-next-line sonarjs/stable-tests -- verifies Datadog-managed retries disable Mocha retries
       this.retries(2)
     }
     assert.strictEqual(numAttempts++ > 0, true)

--- a/integration-tests/ci-visibility/test-management/test-attempt-to-fix-fails-first.js
+++ b/integration-tests/ci-visibility/test-management/test-attempt-to-fix-fails-first.js
@@ -4,7 +4,10 @@ const assert = require('assert')
 let numAttempts = 0
 
 describe('attempt to fix tests that fail first', () => {
-  it('can attempt to fix a test that fails first then passes', () => {
+  it('can attempt to fix a test that fails first then passes', function () {
+    if (process.env.SET_RETRIES_INSIDE_TEST) {
+      this.retries(2)
+    }
     assert.strictEqual(numAttempts++ > 0, true)
   })
 })

--- a/integration-tests/ci-visibility/test-management/test-attempt-to-fix-fails-first.js
+++ b/integration-tests/ci-visibility/test-management/test-attempt-to-fix-fails-first.js
@@ -6,6 +6,7 @@ let numAttempts = 0
 describe('attempt to fix tests that fail first', () => {
   it('can attempt to fix a test that fails first then passes', function () {
     if (process.env.SET_RETRIES_INSIDE_TEST) {
+      // eslint-disable-next-line sonarjs/stable-tests -- verifies Datadog-managed retries disable Mocha retries
       this.retries(2)
     }
     assert.strictEqual(numAttempts++ > 0, true)

--- a/integration-tests/ci-visibility/test-management/test-attempt-to-fix-fails-first.js
+++ b/integration-tests/ci-visibility/test-management/test-attempt-to-fix-fails-first.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const assert = require('assert')
+let numAttempts = 0
+
+describe('attempt to fix tests that fail first', () => {
+  it('can attempt to fix a test that fails first then passes', () => {
+    assert.strictEqual(numAttempts++ > 0, true)
+  })
+})

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6104,6 +6104,9 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
 
   context('impacted tests', () => {
     const NUM_RETRIES = 3
+    // Written into the sandbox fixture by the before hook below.
+    const manualRetryTestTitle = 'fails first then passes after manual retry'
+    const manualRetryTestName = `impacted tests ${manualRetryTestTitle}`
 
     beforeEach(() => {
       receiver.setKnownTests({
@@ -6129,7 +6132,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
              assert.strictEqual(1 + 2, 4)
            })
 
-           it('fails first then passes after manual retry', function () {
+           it('${manualRetryTestTitle}', function () {
              if (process.env.SET_RETRIES_INSIDE_TEST) {
                this.retries(2)
              }
@@ -6264,13 +6267,12 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
 
       onlyLatestIt('disables manual Mocha retries for modified tests retried by EFD', async () => {
-        const testName = 'impacted tests fails first then passes after manual retry'
         receiver.setKnownTests({
           mocha: {
             'ci-visibility/test-impacted-test/test-impacted-1.js': [
               'impacted tests can pass normally',
               'impacted tests can fail',
-              testName,
+              manualRetryTestName,
             ],
           },
         })
@@ -6294,7 +6296,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
             const tests = events
               .filter(event => event.type === 'test')
               .map(event => event.content)
-              .filter(test => test.meta[TEST_NAME] === testName)
+              .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
               .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
 
             assert.strictEqual(tests.length, NUM_RETRIES + 1)

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6124,11 +6124,17 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         `const assert = require('assert')
          let manualRetryAttempts = 0
          describe('impacted tests', () => {
-           it('can pass normally', () => {
+           it('can pass normally', function () {
+             if (process.env.SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS) {
+               this.skip()
+             }
              assert.strictEqual(2 + 2, 3)
            })
 
-           it('can fail', () => {
+           it('can fail', function () {
+             if (process.env.SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS) {
+               this.skip()
+             }
              assert.strictEqual(1 + 2, 4)
            })
 
@@ -6333,14 +6339,17 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
               GITHUB_BASE_REF: '',
               MOCHA_RETRIES: '2',
               SET_RETRIES_INSIDE_TEST: '1',
+              SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS: '1',
+              SHOULD_CHECK_RESULTS: '1',
             },
           }
         )
 
-        await Promise.all([
+        const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),
           eventsPromise,
         ])
+        assert.strictEqual(exitCode, 0)
       })
 
       it('should not be detected as impacted if disabled', async () => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2802,6 +2802,74 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       assert.strictEqual(exitCode, 0, testOutput)
     })
 
+    onlyLatestIt('disables manual Mocha retries for new tests retried by EFD', async () => {
+      receiver.setKnownTests({
+        mocha: {},
+      })
+      const NUM_RETRIES_EFD = 2
+      receiver.setSettings({
+        flaky_test_retries_enabled: false,
+        early_flake_detection: {
+          enabled: true,
+          slow_test_retries: {
+            '5s': NUM_RETRIES_EFD,
+          },
+          faulty_session_threshold: 100,
+        },
+        known_tests_enabled: true,
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events
+            .filter(event => event.type === 'test')
+            .map(event => event.content)
+            .filter(test =>
+              test.meta[TEST_SUITE] === 'ci-visibility/test-early-flake-detection/fails-first-then-passes.js'
+            )
+            .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+          assert.strictEqual(tests.length, NUM_RETRIES_EFD + 1)
+          assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+          assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+          assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
+
+          const retriedTests = tests.slice(1)
+          retriedTests.forEach(test => {
+            assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+            assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+          })
+
+          const externalRetries = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.ext
+          )
+          assert.strictEqual(externalRetries.length, 0)
+        })
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: JSON.stringify([
+              './test-early-flake-detection/fails-first-then-passes.js',
+            ]),
+            MOCHA_RETRIES: '2',
+            SHOULD_CHECK_RESULTS: '1',
+          },
+        }
+      )
+
+      const [[exitCode]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+      assert.strictEqual(exitCode, 0)
+    })
+
     it('uses the retry count from the matching slow_test_retries bucket', async () => {
       receiver.setKnownTests({
         mocha: {},
@@ -3910,6 +3978,55 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
     })
 
+    onlyLatestIt('uses ATR retry count instead of manual Mocha retries', async () => {
+      receiver.setSettings({
+        itr_enabled: false,
+        code_coverage: false,
+        tests_skipping: false,
+        flaky_test_retries_enabled: true,
+        early_flake_detection: {
+          enabled: false,
+        },
+      })
+
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const tests = events.filter(event => event.type === 'test').map(event => event.content)
+
+          assert.strictEqual(tests.length, 2)
+
+          const retries = tests.filter(test => test.meta[TEST_IS_RETRY] === 'true')
+          assert.strictEqual(retries.length, 1)
+          assert.strictEqual(retries[0].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+
+          const externalRetries = tests.filter(
+            test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.ext
+          )
+          assert.strictEqual(externalRetries.length, 0)
+        })
+
+      childProcess = exec(
+        runTestsCommand,
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            TESTS_TO_RUN: JSON.stringify([
+              './test-flaky-test-retries/eventually-passing-test.js',
+            ]),
+            DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '1',
+            MOCHA_RETRIES: '5',
+          },
+        }
+      )
+
+      await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+    })
+
     onlyLatestIt('sets TEST_HAS_FAILED_ALL_RETRIES when all ATR attempts fail', async () => {
       receiver.setInfoResponse({ endpoints: ['/evp_proxy/v4'] })
       // Mark fail-test as known so EFD does not run; only ATR will retry
@@ -4837,6 +4954,86 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 
         runAttemptToFixTest(done, { isAttemptToFix: true, shouldFailSometimes: true })
+      })
+
+      onlyLatestIt('disables manual Mocha retries for attempt-to-fix tests', async () => {
+        const NUM_RETRIES = 2
+        const testName = 'attempt to fix tests that fail first ' +
+          'can attempt to fix a test that fails first then passes'
+        receiver.setSettings({
+          flaky_test_retries_enabled: false,
+          early_flake_detection: { enabled: false },
+          test_management: { enabled: true, attempt_to_fix_retries: NUM_RETRIES },
+        })
+        receiver.setTestManagementTests({
+          mocha: {
+            suites: {
+              'ci-visibility/test-management/test-attempt-to-fix-fails-first.js': {
+                tests: {
+                  [testName]: {
+                    properties: {
+                      attempt_to_fix: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === testName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            assert.strictEqual(tests.length, NUM_RETRIES + 1)
+            assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+            assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+            assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
+
+            const retriedTests = tests.slice(1)
+            retriedTests.forEach(test => {
+              assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atf)
+            })
+
+            const externalRetries = tests.filter(
+              test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.ext
+            )
+            assert.strictEqual(externalRetries.length, 0)
+
+            assert.strictEqual(tests[tests.length - 1].meta[TEST_FINAL_STATUS], 'fail')
+            assert.strictEqual(
+              tests[tests.length - 1].meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED],
+              'false'
+            )
+          })
+
+        childProcess = exec(
+          runTestsCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TESTS_TO_RUN: JSON.stringify([
+                './test-management/test-attempt-to-fix-fails-first.js',
+              ]),
+              MOCHA_RETRIES: '2',
+              SHOULD_CHECK_RESULTS: '1',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 1)
       })
 
       onlyLatestIt('does not attempt to fix tests if test management is not enabled', (done) => {
@@ -5918,6 +6115,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       fs.writeFileSync(
         path.join(cwd, 'ci-visibility/test-impacted-test/test-impacted-1.js'),
         `const assert = require('assert')
+         let manualRetryAttempts = 0
          describe('impacted tests', () => {
            it('can pass normally', () => {
              assert.strictEqual(2 + 2, 3)
@@ -5925,6 +6123,10 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
 
            it('can fail', () => {
              assert.strictEqual(1 + 2, 4)
+           })
+
+           it('fails first then passes after manual retry', () => {
+             assert.strictEqual(manualRetryAttempts++ > 0, true)
            })
          })`
       )
@@ -6052,6 +6254,82 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         receiver.setSettings({ impacted_tests_enabled: true })
 
         await runImpactedTest({ isModified: true })
+      })
+
+      onlyLatestIt('disables manual Mocha retries for modified tests retried by EFD', async () => {
+        const testName = 'impacted tests fails first then passes after manual retry'
+        receiver.setKnownTests({
+          mocha: {
+            'ci-visibility/test-impacted-test/test-impacted-1.js': [
+              'impacted tests can pass normally',
+              'impacted tests can fail',
+              testName,
+            ],
+          },
+        })
+        receiver.setSettings({
+          flaky_test_retries_enabled: false,
+          impacted_tests_enabled: true,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === testName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            assert.strictEqual(tests.length, NUM_RETRIES + 1)
+            assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+            assert.strictEqual(tests[0].meta[TEST_IS_MODIFIED], 'true')
+            assert.ok(!(TEST_IS_NEW in tests[0].meta))
+            assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+            assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
+
+            const retriedTests = tests.slice(1)
+            retriedTests.forEach(test => {
+              assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(test.meta[TEST_IS_MODIFIED], 'true')
+              assert.ok(!(TEST_IS_NEW in test.meta))
+              assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+            })
+
+            const externalRetries = tests.filter(
+              test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.ext
+            )
+            assert.strictEqual(externalRetries.length, 0)
+          })
+
+        childProcess = exec(
+          runTestsCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TESTS_TO_RUN: JSON.stringify([
+                './test-impacted-test/test-impacted-1',
+              ]),
+              GITHUB_BASE_REF: '',
+              MOCHA_RETRIES: '2',
+            },
+          }
+        )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
       })
 
       it('should not be detected as impacted if disabled', async () => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6292,6 +6292,24 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
     }
 
+    const setQuarantineForManualRetryTest = () => {
+      receiver.setTestManagementTests({
+        mocha: {
+          suites: {
+            'ci-visibility/test-impacted-test/test-impacted-1.js': {
+              tests: {
+                [manualRetryTestName]: {
+                  properties: {
+                    quarantined: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    }
+
     const assertAttemptToFixFailThenPass = (tests) => {
       assert.strictEqual(tests.length, 3)
       assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
@@ -6387,6 +6405,83 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
               GITHUB_BASE_REF: '',
               MOCHA_RETRIES: '2',
               SET_RETRIES_INSIDE_TEST: '1',
+              SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS: '1',
+              SHOULD_CHECK_RESULTS: '1',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 0)
+      })
+
+      onlyLatestIt('does not double-subtract quarantined modified tests retried by EFD', async () => {
+        setQuarantineForManualRetryTest()
+        receiver.setKnownTests({
+          mocha: {
+            'ci-visibility/test-impacted-test/test-impacted-1.js': [
+              'impacted tests can pass normally',
+              'impacted tests can fail',
+              manualRetryTestName,
+            ],
+          },
+        })
+        receiver.setSettings({
+          flaky_test_retries_enabled: false,
+          impacted_tests_enabled: true,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+          test_management: { enabled: true },
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const testSession = events.find(event => event.type === 'test_session_end').content
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            assert.strictEqual(testSession.meta[TEST_STATUS], 'pass')
+            assert.strictEqual(tests.length, NUM_RETRIES + 1)
+            assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+            assert.strictEqual(tests[0].meta[TEST_IS_MODIFIED], 'true')
+            assert.strictEqual(tests[0].meta[TEST_MANAGEMENT_IS_QUARANTINED], 'true')
+            assert.ok(!(TEST_IS_NEW in tests[0].meta))
+            assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+            assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
+
+            const retriedTests = tests.slice(1)
+            retriedTests.forEach(test => {
+              assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+              assert.strictEqual(test.meta[TEST_IS_MODIFIED], 'true')
+              assert.ok(!(TEST_IS_NEW in test.meta))
+              assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+            })
+          })
+
+        childProcess = exec(
+          runTestsCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TESTS_TO_RUN: JSON.stringify([
+                './test-impacted-test/test-impacted-1',
+              ]),
+              GITHUB_BASE_REF: '',
               SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS: '1',
               SHOULD_CHECK_RESULTS: '1',
             },

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6274,6 +6274,45 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       ])
     }
 
+    const setAttemptToFixForManualRetryTest = () => {
+      receiver.setTestManagementTests({
+        mocha: {
+          suites: {
+            'ci-visibility/test-impacted-test/test-impacted-1.js': {
+              tests: {
+                [manualRetryTestName]: {
+                  properties: {
+                    attempt_to_fix: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    }
+
+    const assertAttemptToFixFailThenPass = (tests) => {
+      assert.strictEqual(tests.length, 3)
+      assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+      assert.strictEqual(tests[0].meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+      assert.strictEqual(tests[0].meta[TEST_IS_MODIFIED], 'true')
+      assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+      assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
+
+      const retriedTests = tests.slice(1)
+      retriedTests.forEach(test => {
+        assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+        assert.strictEqual(test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX], 'true')
+        assert.strictEqual(test.meta[TEST_IS_MODIFIED], 'true')
+        assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+        assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atf)
+      })
+
+      assert.strictEqual(tests[tests.length - 1].meta[TEST_FINAL_STATUS], 'fail')
+      assert.strictEqual(tests[tests.length - 1].meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+    }
+
     context('test is not new', () => {
       it('should be detected as impacted', async () => {
         receiver.setSettings({ impacted_tests_enabled: true })
@@ -6448,6 +6487,113 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           eventsPromise,
         ])
         assert.strictEqual(exitCode, 0)
+      })
+
+      onlyLatestIt('does not suppress attempt-to-fix failures for modified tests when EFD is enabled', async () => {
+        setAttemptToFixForManualRetryTest()
+        receiver.setSettings({
+          flaky_test_retries_enabled: false,
+          impacted_tests_enabled: true,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES,
+            },
+            faulty_session_threshold: 100,
+          },
+          test_management: { enabled: true, attempt_to_fix_retries: 2 },
+        })
+
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            assertAttemptToFixFailThenPass(tests)
+          })
+
+        childProcess = exec(
+          runTestsCommand,
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TESTS_TO_RUN: JSON.stringify([
+                './test-impacted-test/test-impacted-1',
+              ]),
+              GITHUB_BASE_REF: '',
+              SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS: '1',
+              SHOULD_CHECK_RESULTS: '1',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 1)
+      })
+
+      onlyLatestIt('does not suppress attempt-to-fix failures for modified tests in parallel mode', async () => {
+        setAttemptToFixForManualRetryTest()
+        receiver.setSettings({
+          flaky_test_retries_enabled: false,
+          impacted_tests_enabled: true,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES,
+            },
+            faulty_session_threshold: 100,
+          },
+          test_management: { enabled: true, attempt_to_fix_retries: 2 },
+        })
+
+        childProcess = exec(
+          'node node_modules/mocha/bin/mocha --parallel --jobs 2 ' +
+          './ci-visibility/test-impacted-test/test-impacted-1.js ' +
+          './ci-visibility/test-impacted-test/parallel-helper.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              GITHUB_BASE_REF: '',
+              SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS: '1',
+            },
+          }
+        )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testSession = events.find(event => event.type === 'test_session_end').content
+
+              assert.strictEqual(testSession.meta[MOCHA_IS_PARALLEL], 'true')
+
+              const tests = events
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+                .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              assertAttemptToFixFailThenPass(tests)
+            },
+            { hardTimeout: 60_000 }
+          )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 1)
       })
 
       it('should not be detected as impacted if disabled', async () => {

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2859,6 +2859,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
               './test-early-flake-detection/fails-first-then-passes.js',
             ]),
             MOCHA_RETRIES: '2',
+            SET_RETRIES_INSIDE_TEST: '1',
             SHOULD_CHECK_RESULTS: '1',
           },
         }
@@ -5026,6 +5027,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
                 './test-management/test-attempt-to-fix-fails-first.js',
               ]),
               MOCHA_RETRIES: '2',
+              SET_RETRIES_INSIDE_TEST: '1',
               SHOULD_CHECK_RESULTS: '1',
             },
           }
@@ -6127,7 +6129,10 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
              assert.strictEqual(1 + 2, 4)
            })
 
-           it('fails first then passes after manual retry', () => {
+           it('fails first then passes after manual retry', function () {
+             if (process.env.SET_RETRIES_INSIDE_TEST) {
+               this.retries(2)
+             }
              assert.strictEqual(manualRetryAttempts++ > 0, true)
            })
          })`
@@ -6325,6 +6330,7 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
               ]),
               GITHUB_BASE_REF: '',
               MOCHA_RETRIES: '2',
+              SET_RETRIES_INSIDE_TEST: '1',
             },
           }
         )

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -6146,6 +6146,15 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
            })
          })`
       )
+      fs.writeFileSync(
+        path.join(cwd, 'ci-visibility/test-impacted-test/parallel-helper.js'),
+        `const assert = require('assert')
+         describe('impacted tests parallel helper', () => {
+           it('can pass normally', () => {
+             assert.strictEqual(1 + 2, 3)
+           })
+         })`
+      )
       execSync('git add ci-visibility/test-impacted-test/test-impacted-1.js', { cwd, stdio: 'ignore' })
       execSync('git commit -m "modify test-impacted-1.js"', { cwd, stdio: 'ignore' })
     })
@@ -6344,6 +6353,95 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
             },
           }
         )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          eventsPromise,
+        ])
+        assert.strictEqual(exitCode, 0)
+      })
+
+      onlyLatestIt('preserves passing exit status for modified tests retried by EFD in parallel mode', async () => {
+        receiver.setKnownTests({
+          mocha: {
+            'ci-visibility/test-impacted-test/test-impacted-1.js': [
+              'impacted tests can pass normally',
+              'impacted tests can fail',
+              manualRetryTestName,
+            ],
+            'ci-visibility/test-impacted-test/parallel-helper.js': [
+              'impacted tests parallel helper can pass normally',
+            ],
+          },
+        })
+        receiver.setSettings({
+          flaky_test_retries_enabled: true,
+          flaky_test_retries_count: 5,
+          impacted_tests_enabled: true,
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        childProcess = exec(
+          'node node_modules/mocha/bin/mocha --parallel --jobs 2 --retries 2 ' +
+          './ci-visibility/test-impacted-test/test-impacted-1.js ' +
+          './ci-visibility/test-impacted-test/parallel-helper.js',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              GITHUB_BASE_REF: '',
+              SET_RETRIES_INSIDE_TEST: '1',
+              SKIP_IMPACTED_NON_MANUAL_RETRY_TESTS: '1',
+            },
+          }
+        )
+
+        const eventsPromise = receiver
+          .gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testSession = events.find(event => event.type === 'test_session_end').content
+
+              assert.strictEqual(testSession.meta[MOCHA_IS_PARALLEL], 'true')
+
+              const tests = events
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+                .filter(test => test.meta[TEST_NAME] === manualRetryTestName)
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              assert.strictEqual(tests.length, NUM_RETRIES + 1)
+              assert.strictEqual(tests[0].meta[TEST_STATUS], 'fail')
+              assert.strictEqual(tests[0].meta[TEST_IS_MODIFIED], 'true')
+              assert.ok(!(TEST_IS_NEW in tests[0].meta))
+              assert.ok(!(TEST_IS_RETRY in tests[0].meta))
+              assert.ok(!(TEST_RETRY_REASON in tests[0].meta))
+
+              const retriedTests = tests.slice(1)
+              retriedTests.forEach(test => {
+                assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+                assert.strictEqual(test.meta[TEST_IS_MODIFIED], 'true')
+                assert.ok(!(TEST_IS_NEW in test.meta))
+                assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+                assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.efd)
+              })
+
+              const externalRetries = tests.filter(
+                test => test.meta[TEST_RETRY_REASON] === TEST_RETRY_REASON_TYPES.ext
+              )
+              assert.strictEqual(externalRetries.length, 0)
+            },
+            { hardTimeout: 60_000 }
+          )
 
         const [[exitCode]] = await Promise.all([
           once(childProcess, 'exit'),

--- a/integration-tests/mocha/mocha.spec.js
+++ b/integration-tests/mocha/mocha.spec.js
@@ -2808,7 +2808,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
       })
       const NUM_RETRIES_EFD = 2
       receiver.setSettings({
-        flaky_test_retries_enabled: false,
+        flaky_test_retries_enabled: true,
+        flaky_test_retries_count: 5,
         early_flake_detection: {
           enabled: true,
           slow_test_retries: {
@@ -4961,7 +4962,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
         const testName = 'attempt to fix tests that fail first ' +
           'can attempt to fix a test that fails first then passes'
         receiver.setSettings({
-          flaky_test_retries_enabled: false,
+          flaky_test_retries_enabled: true,
+          flaky_test_retries_count: 5,
           early_flake_detection: { enabled: false },
           test_management: { enabled: true, attempt_to_fix_retries: NUM_RETRIES },
         })
@@ -6268,7 +6270,8 @@ describe(`mocha@${MOCHA_VERSION}`, function () {
           },
         })
         receiver.setSettings({
-          flaky_test_retries_enabled: false,
+          flaky_test_retries_enabled: true,
+          flaky_test_retries_count: 5,
           impacted_tests_enabled: true,
           early_flake_detection: {
             enabled: true,

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -194,11 +194,13 @@ function getCoverageRootDir () {
 }
 
 /**
- * Checks if a serialized parallel worker test suite is modified.
+ * Recomputes whether a parallel worker result belongs to a modified suite.
  *
- * Mocha's parallel worker result serialization does not preserve custom `_ddIsModified`
- * properties from worker Test objects, so the main process must infer modification from
- * the suite path and the impacted-tests response.
+ * In parallel mode, `_ddIsModified` is set on Mocha Test objects inside the worker.
+ * The main process receives `Test.prototype.serialize()` output for test events,
+ * and that fixed serialization drops custom properties. We still need modified-test
+ * bookkeeping in the main process for EFD failure suppression, so infer it again
+ * from the suite path.
  *
  * @param {string} testSuiteAbsolutePath
  * @returns {boolean}

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -1159,6 +1159,9 @@ addHook({
     const isModified = config.isImpactedTestsEnabled && isModifiedTestSuite(testSuiteAbsolutePath)
 
     for (const test of tests) {
+      const testProperties = getTestProperties(test, config.testManagementTests)
+      const isAttemptToFix = config.isTestManagementTestsEnabled && testProperties.isAttemptToFix
+
       // `newTests` is filled in the worker process, so we need to use the test results to fill it here too.
       const isNew = config.isKnownTestsEnabled && isNewTest(test, config.knownTests)
       if (isNew) {
@@ -1172,7 +1175,7 @@ addHook({
         }
       }
       // `efdTests` is filled in the worker process, so we need to use the test results to fill it here too.
-      if (isNew || isModified) {
+      if (!isAttemptToFix && (isNew || isModified)) {
         const testFullName = getTestFullName(test)
         const tests = efdTests[testFullName]
 
@@ -1183,7 +1186,6 @@ addHook({
         }
       }
       // `testsQuarantined` is filled in the worker process, so we need to use the test results to fill it here too.
-      const testProperties = getTestProperties(test, config.testManagementTests)
       if (config.isTestManagementTestsEnabled && testProperties.isQuarantined && !testProperties.isAttemptToFix) {
         testsQuarantined.add(test)
       }

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -24,6 +24,7 @@ const {
   collectTestOptimizationSummariesFromTraces,
   logTestOptimizationSummary,
   getTestOptimizationRequestResults,
+  isModifiedTest,
 } = require('../../../dd-trace/src/plugins/util/test')
 
 const {
@@ -190,6 +191,21 @@ function isTiaCoverageBackfillEnabled () {
 
 function getCoverageRootDir () {
   return config.repositoryRoot || process.cwd()
+}
+
+/**
+ * Checks if a serialized parallel worker test suite is modified.
+ *
+ * Mocha's parallel worker result serialization does not preserve custom `_ddIsModified`
+ * properties from worker Test objects, so the main process must infer modification from
+ * the suite path and the impacted-tests response.
+ *
+ * @param {string} testSuiteAbsolutePath
+ * @returns {boolean}
+ */
+function isModifiedTestSuite (testSuiteAbsolutePath) {
+  const testPath = getTestSuitePath(testSuiteAbsolutePath, getCoverageRootDir())
+  return isModifiedTest(testPath, null, null, config.modifiedFiles, 'mocha')
 }
 
 function shouldReportCodeCoverageLinesPct (hasBackfilledCoverage) {
@@ -1140,6 +1156,7 @@ addHook({
       .events
       .filter(event => event.eventName === 'test end')
       .map(event => event.data)
+    const isModified = config.isImpactedTestsEnabled && isModifiedTestSuite(testSuiteAbsolutePath)
 
     for (const test of tests) {
       // `newTests` is filled in the worker process, so we need to use the test results to fill it here too.
@@ -1155,7 +1172,7 @@ addHook({
         }
       }
       // `efdTests` is filled in the worker process, so we need to use the test results to fill it here too.
-      if (isNew || test._ddIsModified) {
+      if (isNew || isModified) {
         const testFullName = getTestFullName(test)
         const tests = efdTests[testFullName]
 

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -39,6 +39,7 @@ const {
   getOnPendingHandler,
   testFileToSuiteCtx,
   newTests,
+  efdTests,
   testsQuarantined,
   getTestFullName,
   getRunTestsWrapper,
@@ -252,12 +253,12 @@ function getOnEndHandler (isParallel) {
        * The rationale behind is the following: you may still be able to block your CI pipeline by gating
        * on flakiness (the test will be considered flaky), but you may choose to unblock the pipeline too.
        */
-      for (const tests of Object.values(newTests)) {
-        const failingNewTests = tests.filter(test => isTestFailed(test))
-        const areAllNewTestsFailing = failingNewTests.length === tests.length
-        if (failingNewTests.length && !areAllNewTestsFailing) {
-          this.stats.failures -= failingNewTests.length
-          this.failures -= failingNewTests.length
+      for (const tests of Object.values(efdTests)) {
+        const failingEfdTests = tests.filter(test => isTestFailed(test))
+        const areAllEfdTestsFailing = failingEfdTests.length === tests.length
+        if (failingEfdTests.length && !areAllEfdTestsFailing) {
+          this.stats.failures -= failingEfdTests.length
+          this.failures -= failingEfdTests.length
         }
       }
     }
@@ -1142,7 +1143,8 @@ addHook({
 
     for (const test of tests) {
       // `newTests` is filled in the worker process, so we need to use the test results to fill it here too.
-      if (config.isKnownTestsEnabled && isNewTest(test, config.knownTests)) {
+      const isNew = config.isKnownTestsEnabled && isNewTest(test, config.knownTests)
+      if (isNew) {
         const testFullName = getTestFullName(test)
         const tests = newTests[testFullName]
 
@@ -1150,6 +1152,17 @@ addHook({
           tests.push(test)
         } else {
           newTests[testFullName] = [test]
+        }
+      }
+      // `efdTests` is filled in the worker process, so we need to use the test results to fill it here too.
+      if (isNew || test._ddIsModified) {
+        const testFullName = getTestFullName(test)
+        const tests = efdTests[testFullName]
+
+        if (tests) {
+          tests.push(test)
+        } else {
+          efdTests[testFullName] = [test]
         }
       }
       // `testsQuarantined` is filled in the worker process, so we need to use the test results to fill it here too.

--- a/packages/datadog-instrumentations/src/mocha/main.js
+++ b/packages/datadog-instrumentations/src/mocha/main.js
@@ -272,9 +272,10 @@ function getOnEndHandler (isParallel) {
       for (const tests of Object.values(efdTests)) {
         const failingEfdTests = tests.filter(test => isTestFailed(test))
         const areAllEfdTestsFailing = failingEfdTests.length === tests.length
-        if (failingEfdTests.length && !areAllEfdTestsFailing) {
-          this.stats.failures -= failingEfdTests.length
-          this.failures -= failingEfdTests.length
+        const nonQuarantinedFailingEfdTests = failingEfdTests.filter(test => !testsQuarantined.has(test))
+        if (nonQuarantinedFailingEfdTests.length && !areAllEfdTestsFailing) {
+          this.stats.failures -= nonQuarantinedFailingEfdTests.length
+          this.failures -= nonQuarantinedFailingEfdTests.length
         }
       }
     }

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -35,6 +35,7 @@ const testToStartLine = new WeakMap()
 const testFileToSuiteCtx = new Map()
 const wrappedFunctions = new WeakSet()
 const newTests = {}
+const efdTests = {}
 const newTestsWithDynamicNames = new Set()
 const testsAttemptToFix = new Set()
 const testsQuarantined = new Set()
@@ -235,6 +236,21 @@ function getTestFullName (test) {
   return `mocha.${getTestSuitePath(test.file, process.cwd())}.${test.fullTitle()}`
 }
 
+/**
+ * Records every attempt for a test grouped by its full test name.
+ * @param {Record<string, Array<{ file: string, fullTitle: () => string }>>} testsByFullName
+ * @param {{ file: string, fullTitle: () => string }} test
+ * @returns {void}
+ */
+function recordTestAttempt (testsByFullName, test) {
+  const testFullName = getTestFullName(test)
+  if (testsByFullName[testFullName]) {
+    testsByFullName[testFullName].push(test)
+  } else {
+    testsByFullName[testFullName] = [test]
+  }
+}
+
 function getTestStatus (test) {
   if (test.isPending()) {
     return 'skip'
@@ -409,12 +425,10 @@ function getOnTestHandler (isMain) {
     }
     // We want to store the result of the new tests
     if (isNew) {
-      const testFullName = getTestFullName(test)
-      if (newTests[testFullName]) {
-        newTests[testFullName].push(test)
-      } else {
-        newTests[testFullName] = [test]
-      }
+      recordTestAttempt(newTests, test)
+    }
+    if (isNew || isModified) {
+      recordTestAttempt(efdTests, test)
     }
 
     if (!isAttemptToFix && isDisabled) {
@@ -877,6 +891,7 @@ module.exports = {
   testFileToSuiteCtx,
   getRunTestsWrapper,
   newTests,
+  efdTests,
   newTestsWithDynamicNames,
   testsQuarantined,
   testsAttemptToFix,

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -158,6 +158,23 @@ function isDatadogManagedRetryTest (test, config) {
     (config.isEarlyFlakeDetectionEnabled && (test._ddIsNew || test._ddIsModified))
 }
 
+/**
+ * Checks whether a runnable belongs to an Early Flake Detection execution.
+ * @param {{
+ *   _ddIsAttemptToFix?: boolean,
+ *   _ddIsEfdRetry?: boolean,
+ *   _ddIsModified?: boolean,
+ *   _ddIsNew?: boolean
+ * }} test
+ * @param {{ isEarlyFlakeDetectionEnabled?: boolean }} config
+ * @returns {boolean}
+ */
+function isEarlyFlakeDetectionTest (test, config) {
+  return !test._ddIsAttemptToFix &&
+    config.isEarlyFlakeDetectionEnabled &&
+    (test._ddIsEfdRetry || test._ddIsNew || test._ddIsModified)
+}
+
 function retryTest (test, numRetries, tags, slowTestRetries) {
   const suite = test.parent
   const isEfdRetry = tags.includes('_ddIsEfdRetry')
@@ -427,7 +444,7 @@ function getOnTestHandler (isMain) {
     if (isNew) {
       recordTestAttempt(newTests, test)
     }
-    if (isNew || isModified) {
+    if (!isAttemptToFix && (isNew || isModified)) {
       recordTestAttempt(efdTests, test)
     }
 
@@ -497,8 +514,7 @@ function getTestFinishInfo (test, status, config, error) {
 
   const testName = getTestFullName(test)
   if (
-    config.isEarlyFlakeDetectionEnabled &&
-    (test._ddIsNew || test._ddIsModified) &&
+    isEarlyFlakeDetectionTest(test, config) &&
     !test._ddIsEfdRetry &&
     !efdRetryCountByTestFullName.has(testName)
   ) {
@@ -520,8 +536,7 @@ function getTestFinishInfo (test, status, config, error) {
 
   // Needed for the getFinalStatus call. This is because EFD does NOT tag as
   // EFD retry the first run of the test. It only tags as retries the clones
-  const isEfdRetry =
-    test._ddIsEfdRetry || ((test._ddIsNew || test._ddIsModified) && config.isEarlyFlakeDetectionEnabled)
+  const isEfdRetry = isEarlyFlakeDetectionTest(test, config)
 
   if (test._ddIsAttemptToFix && isLastAttempt) {
     if (testStatuses.includes('fail')) {

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -140,6 +140,23 @@ function disableMochaRetries (test) {
   }
 }
 
+/**
+ * Checks whether a runnable belongs to a Datadog-managed clone retry feature.
+ * @param {{
+ *   _ddIsAttemptToFix?: boolean,
+ *   _ddIsEfdRetry?: boolean,
+ *   _ddIsModified?: boolean,
+ *   _ddIsNew?: boolean
+ * }} test
+ * @param {{ isEarlyFlakeDetectionEnabled?: boolean }} config
+ * @returns {boolean}
+ */
+function isDatadogManagedRetryTest (test, config) {
+  return test._ddIsAttemptToFix ||
+    test._ddIsEfdRetry ||
+    (config.isEarlyFlakeDetectionEnabled && (test._ddIsNew || test._ddIsModified))
+}
+
 function retryTest (test, numRetries, tags, slowTestRetries) {
   const suite = test.parent
   const isEfdRetry = tags.includes('_ddIsEfdRetry')
@@ -275,9 +292,6 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
     if (!testFinishCh.hasSubscribers) {
       return run.apply(this, args)
     }
-    if (libraryConfig?.isFlakyTestRetriesEnabled) {
-      this.retries(libraryConfig?.flakyTestRetriesCount)
-    }
     // The reason why the wrapping logic is here is because we need to cover
     // `afterEach` and `beforeEach` hooks as well.
     // It can't be done in `getOnTestHandler` because it's only called for tests.
@@ -285,6 +299,7 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
     const isAfterEach = this.parent._afterEach.includes(this)
 
     const isTestHook = isBeforeEach || isAfterEach
+    const test = isTestHook ? this.ctx.currentTest : this
 
     // we restore the original user defined function
     if (wrappedFunctions.has(this.fn)) {
@@ -293,8 +308,13 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
       wrappedFunctions.delete(this.fn)
     }
 
+    if (isDatadogManagedRetryTest(test, libraryConfig)) {
+      disableMochaRetries(this)
+    } else if (libraryConfig?.isFlakyTestRetriesEnabled) {
+      this.retries(libraryConfig.flakyTestRetriesCount)
+    }
+
     if (isTestHook || this.type === 'test') {
-      const test = isTestHook ? this.ctx.currentTest : this
       const ctx = getTestContext(test)
 
       if (ctx) {

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -129,14 +129,27 @@ function wrapOriginalEfdTest (test, slowTestRetries) {
   })
 }
 
+/**
+ * Disables Mocha's native retry mechanism for Datadog-managed clone retries.
+ * @param {{ retries?: (count: number) => void }} test
+ * @returns {void}
+ */
+function disableMochaRetries (test) {
+  if (typeof test.retries === 'function') {
+    test.retries(0)
+  }
+}
+
 function retryTest (test, numRetries, tags, slowTestRetries) {
   const suite = test.parent
   const isEfdRetry = tags.includes('_ddIsEfdRetry')
+  disableMochaRetries(test)
   if (isEfdRetry) {
     wrapOriginalEfdTest(test, slowTestRetries)
   }
   for (let retryIndex = 0; retryIndex < numRetries; retryIndex++) {
     const clonedTest = test.clone()
+    disableMochaRetries(clonedTest)
     suite.addTest(clonedTest)
     if (isEfdRetry) {
       clonedTest._ddEfdRetryIndex = retryIndex + 1

--- a/packages/datadog-instrumentations/src/mocha/utils.js
+++ b/packages/datadog-instrumentations/src/mocha/utils.js
@@ -310,6 +310,13 @@ function runnableWrapper (RunnablePackage, libraryConfig) {
 
     if (isDatadogManagedRetryTest(test, libraryConfig)) {
       disableMochaRetries(this)
+      if (typeof args[0] === 'function') {
+        const onRunnableFinished = args[0]
+        args[0] = function () {
+          disableMochaRetries(test)
+          return onRunnableFinished.apply(this, arguments)
+        }
+      }
     } else if (libraryConfig?.isFlakyTestRetriesEnabled) {
       this.retries(libraryConfig.flakyTestRetriesCount)
     }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Disables Mocha's native retry mechanism for Datadog-managed retry features.

- EFD new-test retries no longer stack with user-configured Mocha retries.
- EFD modified-test retries no longer stack with user-configured Mocha retries.
- EFD failure-count suppression now applies to all EFD-managed attempts, including modified tests, so a modified test that eventually passes keeps Mocha's process result passing.
- Quarantined modified tests retried by EFD are only suppressed once, so quarantine and EFD failure-count suppression cannot double-subtract the same failed original attempt.
- Parallel modified-test EFD runs infer modified suites in the main process, so serialized worker results still preserve passing EFD process status.
- Attempt-to-fix retries no longer stack with user-configured Mocha retries.
- Attempt-to-fix tests marked as modified are excluded from EFD failure-count suppression, so mixed ATF executions still fail the Mocha process as expected.
- Auto Test Retries continue to own Mocha's native retry count for non-managed retries, but no longer re-enable native retries on EFD or attempt-to-fix runnables.
- Managed retry runnables reset native Mocha retries again after execution, so in-test `this.retries(...)` calls cannot re-enable native retry cloning.

### Motivation
Datadog-managed retry features schedule their own retry executions. If Mocha native retries are also enabled on those runnables, Mocha can add extra executions that are reported as external retries or lose Datadog-managed retry precedence.

This can happen through retries configured before the runnable starts, through ATR re-applying Mocha's retry count, through test code calling `this.retries(...)` inside the test body, through ATF executions also being tagged as modified while EFD is enabled, or through a quarantined modified original attempt being handled by both EFD and quarantine suppression.

### Additional Notes
This is a follow-up to the quarantine-on-framework-retries work. Quarantine-only manual Mocha retries are still supported; the native retry disabling only applies when Datadog schedules managed clone retries.
