### PR TITLE
fix(cypress): disable manual retries for managed retries

### DIFF
--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -8,6 +8,7 @@ async function runCypress () {
   const results = await cypress.run({
     config: {
       defaultCommandTimeout: 1000,
+      retries: Number(process.env.CYPRESS_RETRIES || 0),
       e2e: {
         testIsolation: process.env.CYPRESS_TEST_ISOLATION !== 'false',
         setupNodeEvents (on, config) {

--- a/integration-tests/cypress-esm-config.mjs
+++ b/integration-tests/cypress-esm-config.mjs
@@ -8,7 +8,10 @@ async function runCypress () {
   const results = await cypress.run({
     config: {
       defaultCommandTimeout: 1000,
-      retries: Number(process.env.CYPRESS_RETRIES || 0),
+      retries: {
+        runMode: Number(process.env.CYPRESS_RETRIES || 0),
+        openMode: 0,
+      },
       e2e: {
         testIsolation: process.env.CYPRESS_TEST_ISOLATION !== 'false',
         setupNodeEvents (on, config) {

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -4,7 +4,10 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   defaultCommandTimeout: 1000,
-  retries: Number(process.env.CYPRESS_RETRIES || 0),
+  retries: {
+    runMode: Number(process.env.CYPRESS_RETRIES || 0),
+    openMode: 0,
+  },
   e2e: {
     testIsolation: process.env.CYPRESS_TEST_ISOLATION !== 'false',
     setupNodeEvents (on, config) {

--- a/integration-tests/cypress.config.js
+++ b/integration-tests/cypress.config.js
@@ -4,6 +4,7 @@ const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({
   defaultCommandTimeout: 1000,
+  retries: Number(process.env.CYPRESS_RETRIES || 0),
   e2e: {
     testIsolation: process.env.CYPRESS_TEST_ISOLATION !== 'false',
     setupNodeEvents (on, config) {

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -218,12 +218,13 @@ moduleTypes.forEach(({
         const testName = 'efd with manual cypress retries fails first then passes'
 
         childProcess = exec(
-          `${version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`} --config retries=1`,
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
           {
             cwd,
             env: {
               ...getCiVisEvpProxyConfig(receiver.port),
               CYPRESS_BASE_URL: webAppBaseUrl,
+              CYPRESS_RETRIES: '1',
               SPEC_PATTERN: specToRun,
             },
           }
@@ -771,13 +772,14 @@ moduleTypes.forEach(({
         const testName = 'efd with manual cypress retries fails first then passes'
 
         childProcess = exec(
-          `${version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`} --config retries=1`,
+          version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
           {
             cwd,
             env: {
               ...getCiVisEvpProxyConfig(receiver.port),
               CYPRESS_BASE_URL: webAppBaseUrl,
               CYPRESS_EXPECTED_ATTEMPT: '1',
+              CYPRESS_RETRIES: '1',
               CYPRESS_TEST_ISOLATION: 'false',
               SPEC_PATTERN: specToRun,
             },

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -750,6 +750,72 @@ moduleTypes.forEach(({
         ])
       })
 
+      over12It('preserves manual Cypress retries for new tests when testIsolation is false', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': NUM_RETRIES_EFD,
+            },
+            faulty_session_threshold: 100,
+          },
+          flaky_test_retries_enabled: false,
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          cypress: {},
+        })
+
+        const specToRun = 'cypress/e2e/fails-first-then-passes.cy.js'
+        const testName = 'efd with manual cypress retries fails first then passes'
+
+        childProcess = exec(
+          `${version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`} --config retries=1`,
+          {
+            cwd,
+            env: {
+              ...getCiVisEvpProxyConfig(receiver.port),
+              CYPRESS_BASE_URL: webAppBaseUrl,
+              CYPRESS_EXPECTED_ATTEMPT: '1',
+              CYPRESS_TEST_ISOLATION: 'false',
+              SPEC_PATTERN: specToRun,
+            },
+          }
+        )
+
+        const receiverPromise = receiver.gatherPayloadsUntilChildExit(
+          childProcess,
+          ({ url }) => url.endsWith('/api/v2/citestcycle'),
+          payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(event => event.content)
+              .filter(test => test.meta[TEST_NAME] === testName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            const diagnosticTests = tests.map(test => ({
+              status: test.meta[TEST_STATUS],
+              isNew: test.meta[TEST_IS_NEW],
+              isRetry: test.meta[TEST_IS_RETRY],
+              retryReason: test.meta[TEST_RETRY_REASON],
+            }))
+            assert.deepStrictEqual(diagnosticTests, [
+              { status: 'fail', isNew: 'true', isRetry: undefined, retryReason: undefined },
+              { status: 'pass', isNew: undefined, isRetry: 'true', retryReason: TEST_RETRY_REASON_TYPES.ext },
+            ])
+          },
+          { hardTimeout: 60_000 }
+        )
+
+        const [[exitCode]] = await Promise.all([
+          once(childProcess, 'exit'),
+          receiverPromise,
+        ])
+        assert.strictEqual(exitCode, 0)
+      })
+
       it('retries new tests in the correct order (right after original test)', async () => {
         let testOutput = ''
 

--- a/integration-tests/cypress/cypress-efd.spec.js
+++ b/integration-tests/cypress/cypress-efd.spec.js
@@ -197,6 +197,67 @@ moduleTypes.forEach(({
         ])
       })
 
+      it('disables manual Cypress retries for new tests retried by EFD', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+            },
+            faulty_session_threshold: 100,
+          },
+          flaky_test_retries_enabled: false,
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          cypress: {},
+        })
+
+        const specToRun = 'cypress/e2e/fails-first-then-passes.cy.js'
+        const testName = 'efd with manual cypress retries fails first then passes'
+
+        childProcess = exec(
+          `${version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`} --config retries=1`,
+          {
+            cwd,
+            env: {
+              ...getCiVisEvpProxyConfig(receiver.port),
+              CYPRESS_BASE_URL: webAppBaseUrl,
+              SPEC_PATTERN: specToRun,
+            },
+          }
+        )
+
+        await Promise.all([
+          once(childProcess, 'exit'),
+          receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+                .filter(test => test.meta[TEST_NAME] === testName)
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              const diagnosticTests = tests.map(test => ({
+                status: test.meta[TEST_STATUS],
+                isRetry: test.meta[TEST_IS_RETRY],
+                retryReason: test.meta[TEST_RETRY_REASON],
+              }))
+              assert.deepStrictEqual(diagnosticTests, [
+                { status: 'fail', isRetry: undefined, retryReason: undefined },
+                { status: 'fail', isRetry: 'true', retryReason: TEST_RETRY_REASON_TYPES.efd },
+                { status: 'pass', isRetry: 'true', retryReason: TEST_RETRY_REASON_TYPES.efd },
+              ])
+            },
+            { hardTimeout: 60_000 }
+          ),
+        ])
+      })
+
       it('uses the retry count from the matching slow_test_retries bucket', async () => {
         receiver.setSettings({
           early_flake_detection: {

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -480,6 +480,76 @@ moduleTypes.forEach(({
           await runAttemptToFixTest({ isAttemptToFix: true, shouldFailSometimes: true })
         })
 
+        it('disables manual Cypress retries for attempt to fix tests', async () => {
+          receiver.setSettings({
+            test_management: { enabled: true, attempt_to_fix_retries: 2 },
+            flaky_test_retries_enabled: false,
+          })
+
+          const envVars = getCiVisEvpProxyConfig(receiver.port)
+          const specToRun = 'cypress/e2e/attempt-to-fix.js'
+          const testName = 'attempt to fix is attempt to fix'
+
+          childProcess = exec(
+            `${version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`} --config retries=1`,
+            {
+              cwd,
+              env: {
+                ...envVars,
+                CYPRESS_BASE_URL: webAppBaseUrl,
+                SPEC_PATTERN: specToRun,
+              },
+            }
+          )
+
+          await receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events
+                .filter(event => event.type === 'test')
+                .map(event => event.content)
+                .filter(test => test.meta[TEST_NAME] === testName)
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              const diagnosticTests = tests.map(test => ({
+                status: test.meta[TEST_STATUS],
+                isAttemptToFix: test.meta[TEST_MANAGEMENT_IS_ATTEMPT_TO_FIX],
+                isRetry: test.meta[TEST_IS_RETRY],
+                retryReason: test.meta[TEST_RETRY_REASON],
+              }))
+              assert.deepStrictEqual(diagnosticTests, [
+                {
+                  status: 'fail',
+                  isAttemptToFix: 'true',
+                  isRetry: undefined,
+                  retryReason: undefined,
+                },
+                {
+                  status: 'fail',
+                  isAttemptToFix: 'true',
+                  isRetry: 'true',
+                  retryReason: TEST_RETRY_REASON_TYPES.atf,
+                },
+                {
+                  status: 'fail',
+                  isAttemptToFix: 'true',
+                  isRetry: 'true',
+                  retryReason: TEST_RETRY_REASON_TYPES.atf,
+                },
+              ])
+
+              const lastAttempt = tests[tests.length - 1]
+              assert.strictEqual(lastAttempt.meta[TEST_HAS_FAILED_ALL_RETRIES], 'true')
+              assert.strictEqual(lastAttempt.meta[TEST_MANAGEMENT_ATTEMPT_TO_FIX_PASSED], 'false')
+            },
+            { hardTimeout: 60_000 }
+          )
+
+          assert.strictEqual(childProcess.exitCode, 1)
+        })
+
         it('keeps after hook failures on attempt to fix tests', async () => {
           receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
           receiver.setTestManagementTests({

--- a/integration-tests/cypress/cypress-test-management.spec.js
+++ b/integration-tests/cypress/cypress-test-management.spec.js
@@ -491,12 +491,13 @@ moduleTypes.forEach(({
           const testName = 'attempt to fix is attempt to fix'
 
           childProcess = exec(
-            `${version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`} --config retries=1`,
+            version === 'latest' ? testCommand : `${testCommand} --spec ${specToRun}`,
             {
               cwd,
               env: {
                 ...envVars,
                 CYPRESS_BASE_URL: webAppBaseUrl,
+                CYPRESS_RETRIES: '1',
                 SPEC_PATTERN: specToRun,
               },
             }

--- a/integration-tests/cypress/e2e/fails-first-then-passes.cy.js
+++ b/integration-tests/cypress/e2e/fails-first-then-passes.cy.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+let attempt = 0
+
+describe('efd with manual cypress retries', () => {
+  it('fails first then passes', () => {
+    cy.then(() => {
+      expect(attempt++).to.equal(2)
+    })
+  })
+})

--- a/integration-tests/cypress/e2e/fails-first-then-passes.cy.js
+++ b/integration-tests/cypress/e2e/fails-first-then-passes.cy.js
@@ -4,7 +4,7 @@ let attempt = 0
 describe('efd with manual cypress retries', () => {
   it('fails first then passes', () => {
     cy.then(() => {
-      expect(attempt++).to.equal(2)
+      expect(attempt++).to.equal(Number(Cypress.env('EXPECTED_ATTEMPT') || 2))
     })
   })
 })

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -149,6 +149,10 @@ function getRetriedTests (test, numRetries, tags) {
   return retriedTests
 }
 
+function disableFrameworkRetries (test) {
+  test._retries = 0
+}
+
 const oldRunTests = Cypress.mocha.getRunner().runTests
 Cypress.mocha.getRunner().runTests = function (suite, fn) {
   if (!isKnownTestsEnabled && !isTestManagementEnabled && !isImpactedTestsEnabled) {
@@ -215,7 +219,15 @@ Cypress.mocha.getRunner().runTests = function (suite, fn) {
 }
 
 beforeEach(function () {
-  const testName = Cypress.mocha.getRunner().suite.ctx.currentTest.fullTitle()
+  const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
+  const testName = currentTest.fullTitle()
+
+  if (
+    currentTest._ddIsAttemptToFix ||
+    (isEarlyFlakeDetectionEnabled && (currentTest._ddIsNew || currentTest._ddIsModified))
+  ) {
+    disableFrameworkRetries(currentTest)
+  }
 
   const retryMessage = retryReasonsByTestName.get(testName)
   if (retryMessage) {

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -136,6 +136,7 @@ function getRetriedTests (test, numRetries, tags) {
     // TODO: signal in framework logs that this is a retry.
     // TODO: Change it so these tests are allowed to fail.
     const clonedTest = test.clone()
+    disableFrameworkRetries(clonedTest)
     if (tags.includes('_ddIsEfdRetry')) {
       clonedTest._ddEfdRetryIndex = retryIndex + 1
     }
@@ -151,6 +152,15 @@ function getRetriedTests (test, numRetries, tags) {
 
 function disableFrameworkRetries (test) {
   test._retries = 0
+}
+
+function shouldDisableFrameworkRetries (test) {
+  return test && (
+    test._ddIsAttemptToFix ||
+    (isTestIsolationEnabled &&
+      isEarlyFlakeDetectionEnabled &&
+      (test._ddIsNew || test._ddIsModified))
+  )
 }
 
 const oldRunTests = Cypress.mocha.getRunner().runTests
@@ -192,9 +202,11 @@ Cypress.mocha.getRunner().runTests = function (suite, fn) {
     let retryMessage = ''
     if (isAtemptToFix) {
       test._ddIsAttemptToFix = true
+      disableFrameworkRetries(test)
       retryMessage = 'because it is an attempt to fix'
       retriedTests = getRetriedTests(test, testManagementAttemptToFixRetries, ['_ddIsAttemptToFix'])
     } else if (isModified && isEarlyFlakeDetectionEnabled) {
+      disableFrameworkRetries(test)
       retryMessage = 'to detect flakes because it is modified'
       retriedTests = getRetriedTests(test, earlyFlakeDetectionNumRetries, [
         '_ddIsModified',
@@ -202,6 +214,7 @@ Cypress.mocha.getRunner().runTests = function (suite, fn) {
         isKnownTestsEnabled && isNewTest(test) && '_ddIsNew',
       ])
     } else if (isNew && isEarlyFlakeDetectionEnabled) {
+      disableFrameworkRetries(test)
       retryMessage = 'to detect flakes because it is new'
       retriedTests = getRetriedTests(test, earlyFlakeDetectionNumRetries, ['_ddIsNew', '_ddIsEfdRetry'])
     }
@@ -218,18 +231,15 @@ Cypress.mocha.getRunner().runTests = function (suite, fn) {
   return oldRunTests.apply(this, [suite, fn])
 }
 
+Cypress.on('test:before:run', (attributes, test) => {
+  if (shouldDisableFrameworkRetries(test)) {
+    disableFrameworkRetries(test)
+  }
+})
+
 beforeEach(function () {
   const currentTest = Cypress.mocha.getRunner().suite.ctx.currentTest
   const testName = currentTest.fullTitle()
-
-  if (
-    currentTest._ddIsAttemptToFix ||
-    (isTestIsolationEnabled &&
-      isEarlyFlakeDetectionEnabled &&
-      (currentTest._ddIsNew || currentTest._ddIsModified))
-  ) {
-    disableFrameworkRetries(currentTest)
-  }
 
   const retryMessage = retryReasonsByTestName.get(testName)
   if (retryMessage) {

--- a/packages/datadog-plugin-cypress/src/support.js
+++ b/packages/datadog-plugin-cypress/src/support.js
@@ -224,7 +224,9 @@ beforeEach(function () {
 
   if (
     currentTest._ddIsAttemptToFix ||
-    (isEarlyFlakeDetectionEnabled && (currentTest._ddIsNew || currentTest._ddIsModified))
+    (isTestIsolationEnabled &&
+      isEarlyFlakeDetectionEnabled &&
+      (currentTest._ddIsNew || currentTest._ddIsModified))
   ) {
     disableFrameworkRetries(currentTest)
   }


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Disables native Cypress retries for tests managed by Datadog Early Flake Detection or attempt-to-fix retries, so user-configured Cypress retries do not run alongside Datadog-managed retry executions.

Clears native Cypress retries when Datadog schedules managed retry clones and again before Cypress starts each managed-retry test, so a user hook can fail without Cypress native retries running ahead of Datadog-managed retry executions.

Keeps native Cypress retries enabled for EFD/modified tests when `testIsolation` is false, because Datadog does not schedule managed EFD retry clones in that mode.

Updates the Cypress integration config to pass manual retry settings through `CYPRESS_RETRIES`, which exercises the same retry path for CommonJS and ESM test commands.

Adds integration regressions for a new EFD test, an attempt-to-fix test running with Cypress retries enabled, and a `testIsolation:false` EFD test that should still use Cypress retries.

### Motivation
Native Cypress retries can multiply Datadog-managed retries and report extra retry executions with `retry_reason:external`. This keeps Cypress aligned with managed retry semantics while preserving user-configured retries when Datadog does not schedule managed retries.

### Additional Notes
Validation: targeted Cypress integration coverage and touched-file lint pass locally.
