### PR TITLE
fix(vitest): disable manual retries for managed retries

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/fails-first-then-passes.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/fails-first-then-passes.mjs
@@ -1,0 +1,10 @@
+/* eslint-disable sonarjs/stable-tests */
+import { describe, expect, test } from 'vitest'
+
+let attempt = 0
+
+describe('efd with manual vitest retries', () => {
+  test('fails first then passes', () => {
+    expect(attempt++).to.equal(2)
+  })
+})

--- a/integration-tests/ci-visibility/vitest-tests/fails-first-then-passes.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/fails-first-then-passes.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/stable-tests */
 import { describe, expect, test } from 'vitest'
 
 let attempt = 0

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -63,6 +63,7 @@ const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 versions.forEach((version) => {
   describe(`vitest@${version}`, () => {
     let cwd, receiver, childProcess, testOutput
+    const newerVitestIt = version === '1.6.0' ? it.skip : it
 
     useSandbox([
       `vitest@${version}`,
@@ -978,6 +979,61 @@ versions.forEach((version) => {
               TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
               NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
               SHOULD_ADD_SLOW_DURATION_TEST: '1',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        assert.strictEqual(exitCode, 0)
+      })
+
+      newerVitestIt('disables manual Vitest retries for new tests retried by EFD', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 2,
+            },
+            faulty_session_threshold: 100,
+          },
+          flaky_test_retries_enabled: false,
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          vitest: {},
+        })
+
+        const testName = 'efd with manual vitest retries fails first then passes'
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(test => test.content)
+              .filter(test => test.meta[TEST_NAME] === testName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            const diagnosticTests = tests.map(test => ({
+              status: test.meta[TEST_STATUS],
+              isRetry: test.meta[TEST_IS_RETRY],
+              retryReason: test.meta[TEST_RETRY_REASON],
+            }))
+            assert.deepStrictEqual(diagnosticTests, [
+              { status: 'fail', isRetry: undefined, retryReason: undefined },
+              { status: 'fail', isRetry: 'true', retryReason: TEST_RETRY_REASON_TYPES.efd },
+              { status: 'pass', isRetry: 'true', retryReason: TEST_RETRY_REASON_TYPES.efd },
+            ])
+          }, 55_000)
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run --retry=1',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/fails-first-then-passes.mjs',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
             },
           }
         )

--- a/integration-tests/vitest/vitest.test-management.spec.js
+++ b/integration-tests/vitest/vitest.test-management.spec.js
@@ -182,6 +182,7 @@ versions.forEach((version) => {
 
           const getTestAssertions = ({
             isAttemptingToFix,
+            expectedExecutionCount,
             shouldAlwaysPass,
             shouldFailSometimes,
             shouldFailFirstOnly,
@@ -210,7 +211,11 @@ versions.forEach((version) => {
 
                 const attemptedToFixTests = tests.filter(
                   test => test.meta[TEST_NAME] === 'attempt to fix tests can attempt to fix a test'
-                )
+                ).sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+                if (expectedExecutionCount !== undefined) {
+                  assert.strictEqual(attemptedToFixTests.length, expectedExecutionCount)
+                }
 
                 for (let i = 0; i < attemptedToFixTests.length; i++) {
                   const isFirstAttempt = i === 0
@@ -263,26 +268,31 @@ versions.forEach((version) => {
            * @param {() => void} done
            * @param {{
            *   isAttemptingToFix?: boolean,
+           *   expectedExecutionCount?: number,
            *   shouldAlwaysPass?: boolean,
            *   isQuarantining?: boolean,
            *   shouldFailSometimes?: boolean,
            *   shouldFailFirstOnly?: boolean,
            *   isDisabling?: boolean,
-           *   extraEnvVars?: Record<string, string>
+           *   extraEnvVars?: Record<string, string>,
+           *   vitestCommand?: string
            * }} [options]
            */
           const runAttemptToFixTest = (done, {
             isAttemptingToFix,
+            expectedExecutionCount,
             shouldAlwaysPass,
             isQuarantining,
             shouldFailSometimes,
             shouldFailFirstOnly,
             isDisabling,
             extraEnvVars = {},
+            vitestCommand = './node_modules/.bin/vitest run',
           } = {}) => {
             let stdout = ''
             const testAssertionsPromise = getTestAssertions({
               isAttemptingToFix,
+              expectedExecutionCount,
               shouldAlwaysPass,
               shouldFailSometimes,
               shouldFailFirstOnly,
@@ -290,7 +300,7 @@ versions.forEach((version) => {
               isDisabling,
             })
             childProcess = exec(
-              './node_modules/.bin/vitest run',
+              vitestCommand,
               {
                 cwd,
                 env: {
@@ -316,6 +326,9 @@ versions.forEach((version) => {
             childProcess.on('exit', (exitCode) => {
               testAssertionsPromise.then(() => {
                 assert.match(stdout, /I am running/)
+                if (expectedExecutionCount !== undefined) {
+                  assert.strictEqual((stdout.match(/I am running/g) || []).length, expectedExecutionCount)
+                }
                 if (isAttemptingToFix) {
                   assert.match(
                     stdout,
@@ -370,6 +383,20 @@ versions.forEach((version) => {
             receiver.setSettings({ test_management: { enabled: true, attempt_to_fix_retries: 3 } })
 
             runAttemptToFixTest(done, { isAttemptingToFix: true, shouldFailFirstOnly: true })
+          })
+
+          it('disables manual Vitest retries when attempting to fix a test', (done) => {
+            receiver.setSettings({
+              test_management: { enabled: true, attempt_to_fix_retries: 2 },
+              flaky_test_retries_enabled: false,
+            })
+
+            runAttemptToFixTest(done, {
+              isAttemptingToFix: true,
+              shouldFailFirstOnly: true,
+              expectedExecutionCount: 3,
+              vitestCommand: './node_modules/.bin/vitest run --retry=1',
+            })
           })
 
           it('records afterEach failures in attempt to fix summary', async () => {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -316,6 +316,10 @@ function recordFinalAttemptToFixExecution (task, status, providedContext) {
   })
 }
 
+function disableFrameworkRetries (task) {
+  task.retry = 0
+}
+
 /**
  * Wraps a function so it runs inside the current test span context.
  * @param {object} task
@@ -801,6 +805,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
         onDone: (isAttemptToFix) => {
           if (isAttemptToFix) {
             isRetryReasonAttemptToFix = task.repeats !== testManagementAttemptToFixRetries
+            disableFrameworkRetries(task)
             task.repeats = testManagementAttemptToFixRetries
             attemptToFixTasks.add(task)
             attemptToFixTaskToStatuses.set(task, [])
@@ -831,6 +836,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
           if (isImpacted) {
             if (isEarlyFlakeDetectionEnabled) {
               isRetryReasonEfd = true
+              disableFrameworkRetries(task)
               task.repeats = numRepeats
             }
             modifiedTasks.add(task)
@@ -849,6 +855,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
           if (isNew && !attemptToFixTasks.has(task)) {
             if (isEarlyFlakeDetectionEnabled && !modifiedTasks.has(task)) {
               isRetryReasonEfd = true
+              disableFrameworkRetries(task)
               task.repeats = numRepeats
             }
             newTasks.add(task)


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
Disables Vitest native `retry` on tasks that are managed by Datadog Early Flake Detection or attempt-to-fix repeats, while leaving non-managed tasks unchanged.

Adds integration regressions for a new EFD test running with Vitest `--retry` enabled and failing, failing, then passing through Datadog-managed repeats, plus an attempt-to-fix test running with Vitest `--retry` enabled where only Datadog-managed ATF executions are reported.

Removes an unused ESLint suppression from the Vitest EFD fixture so the lint job has no warnings.

### Motivation
Vitest loops native retry attempts inside each repeat, so framework retries can multiply Datadog-managed retry executions. This keeps managed repeat counts and retry reasons stable.

### Additional Notes
Validation: targeted Vitest integration coverage and touched-file lint pass locally.
