### PR TITLE
fix(electron): skip IPC patching in processes without ipcMain/Renderer

### DIFF
--- a/packages/datadog-instrumentations/src/electron.js
+++ b/packages/datadog-instrumentations/src/electron.js
@@ -218,7 +218,7 @@ addHook({ name: 'electron', versions: ['>=37.0.0'] }, electron => {
     wrap(ipcRenderer, 'removeAllListeners', createWrapRemoveAllListeners(listeners))
 
     ipcRenderer.send('datadog:apm:renderer:patched')
-  } else {
+  } else if (ipcMain) {
     wrap(ipcMain, 'addListener', createWrapAddListener(mainReceiveCh, listeners))
     wrap(ipcMain, 'handle', createWrapAddListener(mainHandleCh, handlers))
     wrap(ipcMain, 'handleOnce', createWrapAddListener(mainHandleCh, handlers))

--- a/packages/datadog-plugin-electron/test/app/main.js
+++ b/packages/datadog-plugin-electron/test/app/main.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 const { join } = require('path')
-const { BrowserWindow, app, ipcMain, net } = require('electron/main')
+const { BrowserWindow, app, ipcMain, net, utilityProcess } = require('electron/main')
 
 const CONFIG_CHANNEL = 'datadog:bridge-config'
 
@@ -22,6 +22,7 @@ app.on('ready', () => {
         case 'send': return onSend()
         case 'receive': return onReceive()
         case 'handle': return onHandle()
+        case 'utility-request': return onUtilityRequest(msg)
       }
     } catch (e) {
       console.error(e)
@@ -73,6 +74,11 @@ function onHandle () {
   loadWindow(win => {
     win.webContents.send('datadog:test:invoke')
   })
+}
+
+function onUtilityRequest ({ url }) {
+  const child = utilityProcess.fork(join(__dirname, 'utility.js'))
+  child.postMessage({ name: 'request', url })
 }
 
 function loadWindow (onShow) {

--- a/packages/datadog-plugin-electron/test/app/utility.js
+++ b/packages/datadog-plugin-electron/test/app/utility.js
@@ -1,0 +1,16 @@
+'use strict'
+
+require('../tracer')
+
+const { net } = require('electron')
+
+process.parentPort.on('message', ({ data }) => {
+  if (data.name !== 'request') return
+  const req = net.request(data.url)
+  req.on('response', res => {
+    res.on('data', () => {})
+    res.on('end', () => {})
+  })
+  req.on('error', () => {})
+  req.end()
+})

--- a/packages/datadog-plugin-electron/test/index.spec.js
+++ b/packages/datadog-plugin-electron/test/index.spec.js
@@ -205,6 +205,30 @@ describe('Plugin', () => {
           child.send({ name: 'send' })
         })
 
+        it('should do automatic instrumentation for net.request from a utility process', done => {
+          agent
+            .assertSomeTraces(traces => {
+              const span = traces[0][0]
+              const { meta } = span
+
+              assert.strictEqual(span.type, 'http')
+              assert.strictEqual(span.name, 'http.request')
+              assert.strictEqual(span.resource, 'GET')
+              assert.strictEqual(span.service, 'test')
+              assert.strictEqual(span.error, 0)
+
+              assert.strictEqual(meta.component, 'electron')
+              assert.strictEqual(meta['span.kind'], 'client')
+              assert.strictEqual(meta['http.url'], `http://127.0.0.1:${port}/utility`)
+              assert.strictEqual(meta['http.method'], 'GET')
+              assert.strictEqual(meta['http.status_code'], '200')
+            })
+            .then(done)
+            .catch(done)
+
+          child.send({ name: 'utility-request', url: `http://127.0.0.1:${port}/utility` })
+        })
+
         it('should do automatic instrumentation for renderer IPC when sending', done => {
           agent
             .assertSomeTraces(traces => {


### PR DESCRIPTION
### What does this PR do?

Guards the IPC patching block in the electron instrumentation hook so it only runs when `ipcMain` is available.

### Motivation

Electron utility processes (and other process types without `ipcMain`/`ipcRenderer`) should be traceable.
For example, `net` requests from a utility process are valid candidates for instrumentation. The instrumentation hook's `else` branch assumed `ipcMain` was always present, which throw and abort the rest of the instrumentation. This fix allows those processes to load dd-trace successfully and benefit from the parts of the instrumentation that do apply to them (e.g. `net`).

### Additional Notes

- One-line fix: `else {` → `else if (ipcMain) {`
- A new integration test forks a utility process that calls `net.request`, verifying that `http.request` spans are emitted correctly.
- `ipcProcess` instrumentation for utility processes is out of scope for now and can be added later.