### PR TITLE
perf(opentracing): avoid eager baggage copy for child spans

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -181,7 +181,9 @@ class DatadogSpan {
   }
 
   setBaggageItem (key, value) {
-    this._spanContext._baggageItems[key] = value
+    const sc = this._spanContext
+    unshareBaggage(sc)
+    sc._baggageItems[key] = value
     return this
   }
 
@@ -194,11 +196,14 @@ class DatadogSpan {
   }
 
   removeBaggageItem (key) {
-    delete this._spanContext._baggageItems[key]
+    const sc = this._spanContext
+    unshareBaggage(sc)
+    delete sc._baggageItems[key]
   }
 
   removeAllBaggageItems () {
     this._spanContext._baggageItems = {}
+    this._spanContext._baggageItemsShared = false
   }
 
   setTag (key, value) {
@@ -407,12 +412,14 @@ class DatadogSpan {
         startTime = dateNow()
       }
     } else if (parent) {
+      parent._baggageItemsShared = true
       spanContext = new SpanContext({
         traceId: parent._traceId,
         spanId: id(),
         parentId: parent._spanId,
         sampling: parent._sampling,
-        baggageItems: { ...parent._baggageItems },
+        baggageItems: parent._baggageItems,
+        baggageItemsShared: true,
         trace: parent._trace,
         tracestate: parent._tracestate,
       })
@@ -466,6 +473,16 @@ function createRegistry (type) {
 
 function isSamplingPriorityTag (key) {
   return key === MANUAL_KEEP || key === MANUAL_DROP || key === SAMPLING_PRIORITY
+}
+
+/**
+ * @param {import('./span_context')} spanContext
+ */
+function unshareBaggage (spanContext) {
+  if (spanContext._baggageItemsShared) {
+    spanContext._baggageItems = { ...spanContext._baggageItems }
+    spanContext._baggageItemsShared = false
+  }
 }
 
 module.exports = DatadogSpan

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -405,7 +405,15 @@ class DatadogSpan {
     if (parent && parent._isRemote && propagationBehavior !== 'continue') {
       baggage = parent._baggageItems
       baggageShared = propagationBehavior === 'restart' && baggage !== undefined && baggage !== null
-      if (baggageShared) parent._baggageItemsShared = true
+      if (baggageShared) {
+        try {
+          parent._baggageItemsShared = true
+        } catch {
+          // Keep the mutable-parent path free of an eager copy or extensibility check.
+          baggage = { ...baggage }
+          baggageShared = false
+        }
+      }
       parent = null
     }
 
@@ -415,14 +423,22 @@ class DatadogSpan {
         startTime = dateNow()
       }
     } else if (parent) {
-      parent._baggageItemsShared = true
+      let baggageItems = parent._baggageItems
+      let isBaggageShared = true
+      try {
+        parent._baggageItemsShared = true
+      } catch {
+        // Keep the mutable-parent path free of an eager copy or extensibility check.
+        baggageItems = { ...baggageItems }
+        isBaggageShared = false
+      }
       spanContext = new SpanContext({
         traceId: parent._traceId,
         spanId: id(),
         parentId: parent._spanId,
         sampling: parent._sampling,
-        baggageItems: parent._baggageItems,
-        baggageItemsShared: true,
+        baggageItems,
+        baggageItemsShared: isBaggageShared,
         trace: parent._trace,
         tracestate: parent._tracestate,
       })

--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -400,9 +400,12 @@ class DatadogSpan {
     let startTime
 
     let baggage
+    let baggageShared
     const propagationBehavior = this.#parentTracer._config.DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT
     if (parent && parent._isRemote && propagationBehavior !== 'continue') {
       baggage = parent._baggageItems
+      baggageShared = propagationBehavior === 'restart' && baggage !== undefined && baggage !== null
+      if (baggageShared) parent._baggageItemsShared = true
       parent = null
     }
 
@@ -444,6 +447,7 @@ class DatadogSpan {
 
       if (propagationBehavior === 'restart') {
         spanContext._baggageItems = baggage ?? {}
+        spanContext._baggageItemsShared = baggageShared ?? false
       }
     }
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -21,6 +21,10 @@ class DatadogSpanContext {
     this._spanSampling = undefined
     this._links = props.links || []
     this._baggageItems = props.baggageItems || {}
+    // True when `_baggageItems` is a reference shared with another SpanContext
+    // (e.g. a parent we forked from). The owner clones lazily on the next
+    // mutation via Span's baggage methods. Reads never need to clone.
+    this._baggageItemsShared = props.baggageItemsShared || false
     this._traceparent = props.traceparent
     this._tracestate = props.tracestate
     this._noop = props.noop || null

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -245,6 +245,37 @@ describe('Span', () => {
       assert.ok('foo' in span.context()._baggageItems)
       assert.strictEqual(span.context()._baggageItems.foo, 'bar')
     })
+
+    it('should isolate baggage mutations between parent and sibling spans', () => {
+      id.onThirdCall().returns('789')
+
+      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+      parent.setBaggageItem('shared', 'parent')
+
+      const child = new Span(tracer, processor, prioritySampler, {
+        operationName: 'child',
+        parent: parent.context(),
+      })
+      const sibling = new Span(tracer, processor, prioritySampler, {
+        operationName: 'sibling',
+        parent: parent.context(),
+      })
+
+      child.setBaggageItem('child', 'value')
+      parent.setBaggageItem('parent', 'value')
+
+      assert.strictEqual(child.getBaggageItem('shared'), 'parent')
+      assert.strictEqual(child.getBaggageItem('child'), 'value')
+      assert.strictEqual(child.getBaggageItem('parent'), undefined)
+
+      assert.strictEqual(sibling.getBaggageItem('shared'), 'parent')
+      assert.strictEqual(sibling.getBaggageItem('child'), undefined)
+      assert.strictEqual(sibling.getBaggageItem('parent'), undefined)
+
+      assert.strictEqual(parent.getBaggageItem('shared'), 'parent')
+      assert.strictEqual(parent.getBaggageItem('child'), undefined)
+      assert.strictEqual(parent.getBaggageItem('parent'), 'value')
+    })
   })
 
   // TODO are these tests trivial?
@@ -492,6 +523,21 @@ describe('Span', () => {
       assert.strictEqual(span.getBaggageItem('foo'), 'bar')
       span.removeBaggageItem('foo')
       assert.strictEqual(span.getBaggageItem('foo'), undefined)
+    })
+
+    it('should isolate inherited baggage removal from the parent span', () => {
+      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+      parent.setBaggageItem('foo', 'bar')
+
+      span = new Span(tracer, processor, prioritySampler, {
+        operationName: 'operation',
+        parent: parent.context(),
+      })
+
+      span.removeBaggageItem('foo')
+
+      assert.strictEqual(span.getBaggageItem('foo'), undefined)
+      assert.strictEqual(parent.getBaggageItem('foo'), 'bar')
     })
   })
 

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -282,6 +282,25 @@ describe('Span', () => {
       assert.strictEqual(parent.getBaggageItem('child'), undefined)
       assert.strictEqual(parent.getBaggageItem('parent'), 'value')
     })
+
+    for (const [restriction, restrict] of [['frozen', Object.freeze], ['sealed', Object.seal]]) {
+      it(`should isolate baggage when creating a child from a ${restriction} parent context`, () => {
+        const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+        parent.setBaggageItem('shared', 'parent')
+        restrict(parent.context())
+
+        const child = new Span(tracer, processor, prioritySampler, {
+          operationName: 'child',
+          parent: parent.context(),
+        })
+
+        child.setBaggageItem('child', 'value')
+        parent.setBaggageItem('parent', 'value')
+
+        assert.deepStrictEqual(child.context()._baggageItems, { shared: 'parent', child: 'value' })
+        assert.deepStrictEqual(parent.context()._baggageItems, { shared: 'parent', parent: 'value' })
+      })
+    }
   })
 
   // TODO are these tests trivial?
@@ -750,6 +769,25 @@ describe('Span', () => {
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar', child: 'value' })
         assert.deepStrictEqual(parent._baggageItems, { foo: 'bar' })
       })
+
+      for (const [restriction, restrict] of [['frozen', Object.freeze], ['sealed', Object.seal]]) {
+        it(`should isolate baggage when restarting from a ${restriction} extracted context`, () => {
+          tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
+          const propagator = new TextMapPropagator(tracer._config)
+          parent = propagator.extract({
+            'x-datadog-trace-id': '1234',
+            'x-datadog-parent-id': '5678',
+            'ot-baggage-foo': 'bar',
+          })
+          restrict(parent)
+
+          span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
+          span.setBaggageItem('child', 'value')
+
+          assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar', child: 'value' })
+          assert.deepStrictEqual(parent._baggageItems, { foo: 'bar' })
+        })
+      }
 
       it('should start with empty baggage on restart when there is no parent to inherit from', () => {
         tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }

--- a/packages/dd-trace/test/opentracing/span.spec.js
+++ b/packages/dd-trace/test/opentracing/span.spec.js
@@ -261,8 +261,14 @@ describe('Span', () => {
         parent: parent.context(),
       })
 
+      assert.strictEqual(child.context()._baggageItems, parent.context()._baggageItems)
+      assert.strictEqual(sibling.context()._baggageItems, parent.context()._baggageItems)
+
       child.setBaggageItem('child', 'value')
       parent.setBaggageItem('parent', 'value')
+
+      assert.notStrictEqual(child.context()._baggageItems, parent.context()._baggageItems)
+      assert.notStrictEqual(sibling.context()._baggageItems, parent.context()._baggageItems)
 
       assert.strictEqual(child.getBaggageItem('shared'), 'parent')
       assert.strictEqual(child.getBaggageItem('child'), 'value')
@@ -549,6 +555,21 @@ describe('Span', () => {
       span.removeAllBaggageItems()
       assert.deepStrictEqual(span._spanContext._baggageItems, {})
     })
+
+    it('should isolate inherited baggage removal from the parent span', () => {
+      const parent = new Span(tracer, processor, prioritySampler, { operationName: 'parent' })
+      parent.setBaggageItem('foo', 'bar')
+
+      span = new Span(tracer, processor, prioritySampler, {
+        operationName: 'operation',
+        parent: parent.context(),
+      })
+
+      span.removeAllBaggageItems()
+
+      assert.deepStrictEqual(span._spanContext._baggageItems, {})
+      assert.deepStrictEqual(parent._spanContext._baggageItems, { foo: 'bar' })
+    })
   })
 
   describe('setTag', () => {
@@ -716,6 +737,18 @@ describe('Span', () => {
         tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
         span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
         assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar' })
+      })
+
+      it('should isolate restarted baggage mutations from the remote parent', () => {
+        tracer = { _config: { ...getConfig(), DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT: 'restart' } }
+        span = new Span(tracer, processor, prioritySampler, { operationName: 'operation', parent })
+
+        assert.strictEqual(span._spanContext._baggageItems, parent._baggageItems)
+
+        span.setBaggageItem('child', 'value')
+
+        assert.deepStrictEqual(span._spanContext._baggageItems, { foo: 'bar', child: 'value' })
+        assert.deepStrictEqual(parent._baggageItems, { foo: 'bar' })
       })
 
       it('should start with empty baggage on restart when there is no parent to inherit from', () => {

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -52,6 +52,7 @@ describe('SpanContext', () => {
       _spanSampling: undefined,
       _links: [],
       _baggageItems: { foo: 'bar' },
+      _baggageItemsShared: false,
       _noop: noop,
       _trace: {
         started: ['span1', 'span2'],
@@ -85,6 +86,7 @@ describe('SpanContext', () => {
       _spanSampling: undefined,
       _links: [],
       _baggageItems: {},
+      _baggageItemsShared: false,
       _noop: null,
       _trace: {
         started: [],

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -56,6 +56,7 @@ describe('SpanContext', () => {
       _spanSampling: undefined,
       _links: [],
       _baggageItems: { foo: 'bar' },
+      _baggageItemsShared: false,
       _noop: noop,
       _trace: {
         started: ['span1', 'span2'],
@@ -89,6 +90,7 @@ describe('SpanContext', () => {
       _spanSampling: undefined,
       _links: [],
       _baggageItems: {},
+      _baggageItemsShared: false,
       _noop: null,
       _trace: {
         started: [],


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR changes child span baggage inheritance to use a shared reference instead of copying the baggage map eagerly. The baggage map is copied only when baggage is modified.

### Motivation
<!-- What inspired you to submit this pull request? -->

Child spans used to clone parent baggage during context creation, even when neither the parent nor child ever mutated baggage. Share the baggage map on creation and clone lazily on the first baggage mutation instead.

Localized benchmark:
- 2 inherited items: ~23.7 ns/op -> ~12.1 ns/op
- 8 inherited items: ~28.6 ns/op -> ~11.9 ns/op
- 32 inherited items: ~3.54 us/op -> ~11.9 ns/op

### Additional Notes
<!-- Anything else we should know when reviewing? -->


