### PR TITLE
fix(test-optimization): buffer early worker test traces

### DIFF
--- a/integration-tests/ci-visibility/cucumber-worker-message-delay.js
+++ b/integration-tests/ci-visibility/cucumber-worker-message-delay.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const CUCUMBER_WORKER_TRACE_PAYLOAD_CODE = 70
+const delayCucumberWorkerMessagesMs = Number(process.env.DD_TEST_DELAY_CUCUMBER_WORKER_MESSAGES_MS) || 0
+
+function isDdTraceWorkerTraceMessage (message) {
+  return Array.isArray(message) && message[0] === CUCUMBER_WORKER_TRACE_PAYLOAD_CODE
+}
+
+if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID && process.send) {
+  const originalProcessSend = process.send
+
+  process.send = function (...args) {
+    const [message] = args
+
+    if (isDdTraceWorkerTraceMessage(message)) {
+      return originalProcessSend.apply(process, args)
+    }
+
+    global.setTimeout(() => {
+      originalProcessSend.apply(process, args)
+    }, delayCucumberWorkerMessagesMs)
+
+    return true
+  }
+}
+
+if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID) {
+  try {
+    const { isMainThread, parentPort } = require('node:worker_threads')
+
+    if (!isMainThread && parentPort) {
+      const originalPostMessage = parentPort.postMessage
+
+      parentPort.postMessage = function (...args) {
+        const [message] = args
+
+        if (isDdTraceWorkerTraceMessage(message)) {
+          return originalPostMessage.apply(parentPort, args)
+        }
+
+        global.setTimeout(() => {
+          originalPostMessage.apply(parentPort, args)
+        }, delayCucumberWorkerMessagesMs)
+      }
+    }
+  } catch {
+    // This fixture also runs on old Node versions where worker_threads may be unavailable.
+  }
+}

--- a/integration-tests/ci-visibility/features/support/steps.js
+++ b/integration-tests/ci-visibility/features/support/steps.js
@@ -2,58 +2,10 @@
 
 const tracer = require('dd-trace')
 const assert = require('node:assert/strict')
-const { setTimeout: sleep } = require('node:timers/promises')
+const { setTimeout } = require('node:timers/promises')
 const { When, Then, Before, After } = require('@cucumber/cucumber')
 
-const CUCUMBER_WORKER_TRACE_PAYLOAD_CODE = 70
-const delayCucumberWorkerMessagesMs = Number(process.env.DD_TEST_DELAY_CUCUMBER_WORKER_MESSAGES_MS) || 0
 const slowDurationDelayMs = process.env.SHOULD_ADD_SLOW_DURATION_TEST ? 5100 : 0
-
-function isDdTraceWorkerTraceMessage (message) {
-  return Array.isArray(message) && message[0] === CUCUMBER_WORKER_TRACE_PAYLOAD_CODE
-}
-
-if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID && process.send) {
-  const originalProcessSend = process.send
-
-  process.send = function (...args) {
-    const [message] = args
-
-    if (isDdTraceWorkerTraceMessage(message)) {
-      return originalProcessSend.apply(process, args)
-    }
-
-    global.setTimeout(() => {
-      originalProcessSend.apply(process, args)
-    }, delayCucumberWorkerMessagesMs)
-
-    return true
-  }
-}
-
-if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID) {
-  try {
-    const { isMainThread, parentPort } = require('node:worker_threads')
-
-    if (!isMainThread && parentPort) {
-      const originalPostMessage = parentPort.postMessage
-
-      parentPort.postMessage = function (...args) {
-        const [message] = args
-
-        if (isDdTraceWorkerTraceMessage(message)) {
-          return originalPostMessage.apply(parentPort, args)
-        }
-
-        global.setTimeout(() => {
-          originalPostMessage.apply(parentPort, args)
-        }, delayCucumberWorkerMessagesMs)
-      }
-    }
-  } catch {
-    // This fixture also runs on old Node versions where worker_threads may be unavailable.
-  }
-}
 
 class Greeter {
   sayFarewell () {
@@ -113,6 +65,6 @@ When('the greeter says greetings', function () {
 })
 
 When('the greeter says whatever', async function () {
-  await sleep(slowDurationDelayMs)
+  await setTimeout(slowDurationDelayMs)
   this.whatIHeard = 'whatever'
 })

--- a/integration-tests/ci-visibility/features/support/steps.js
+++ b/integration-tests/ci-visibility/features/support/steps.js
@@ -2,10 +2,58 @@
 
 const tracer = require('dd-trace')
 const assert = require('node:assert/strict')
-const { setTimeout } = require('node:timers/promises')
+const { setTimeout: sleep } = require('node:timers/promises')
 const { When, Then, Before, After } = require('@cucumber/cucumber')
 
+const CUCUMBER_WORKER_TRACE_PAYLOAD_CODE = 70
+const delayCucumberWorkerMessagesMs = Number(process.env.DD_TEST_DELAY_CUCUMBER_WORKER_MESSAGES_MS) || 0
 const slowDurationDelayMs = process.env.SHOULD_ADD_SLOW_DURATION_TEST ? 5100 : 0
+
+function isDdTraceWorkerTraceMessage (message) {
+  return Array.isArray(message) && message[0] === CUCUMBER_WORKER_TRACE_PAYLOAD_CODE
+}
+
+if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID && process.send) {
+  const originalProcessSend = process.send
+
+  process.send = function (...args) {
+    const [message] = args
+
+    if (isDdTraceWorkerTraceMessage(message)) {
+      return originalProcessSend.apply(process, args)
+    }
+
+    global.setTimeout(() => {
+      originalProcessSend.apply(process, args)
+    }, delayCucumberWorkerMessagesMs)
+
+    return true
+  }
+}
+
+if (delayCucumberWorkerMessagesMs > 0 && process.env.CUCUMBER_WORKER_ID) {
+  try {
+    const { isMainThread, parentPort } = require('node:worker_threads')
+
+    if (!isMainThread && parentPort) {
+      const originalPostMessage = parentPort.postMessage
+
+      parentPort.postMessage = function (...args) {
+        const [message] = args
+
+        if (isDdTraceWorkerTraceMessage(message)) {
+          return originalPostMessage.apply(parentPort, args)
+        }
+
+        global.setTimeout(() => {
+          originalPostMessage.apply(parentPort, args)
+        }, delayCucumberWorkerMessagesMs)
+      }
+    }
+  } catch {
+    // This fixture also runs on old Node versions where worker_threads may be unavailable.
+  }
+}
 
 class Greeter {
   sayFarewell () {
@@ -65,6 +113,6 @@ When('the greeter says greetings', function () {
 })
 
 When('the greeter says whatever', async function () {
-  await setTimeout(slowDurationDelayMs)
+  await sleep(slowDurationDelayMs)
   this.whatIHeard = 'whatever'
 })

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -607,6 +607,7 @@ describe(`cucumber@${version} commonJS`, () => {
                 DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2',
                 DD_TEST_DELAY_CUCUMBER_WORKER_MESSAGES_MS: '100',
                 DD_TEST_SESSION_NAME: 'my-test-session',
+                NODE_OPTIONS: '-r ./ci-visibility/cucumber-worker-message-delay.js -r dd-trace/ci/init',
                 DD_SERVICE: undefined,
               },
             }

--- a/integration-tests/cucumber/cucumber.spec.js
+++ b/integration-tests/cucumber/cucumber.spec.js
@@ -596,6 +596,57 @@ describe(`cucumber@${version} commonJS`, () => {
         })
       })
 
+      if (reportMethod === 'agentless' && version !== '7.0.0') {
+        it('keeps module tags when worker traces arrive before parallel suite start', async () => {
+          childProcess = exec(
+            parallelModeCommand,
+            {
+              cwd,
+              env: {
+                ...envVars,
+                DD_TAGS: 'test.customtag:customvalue,test.customtag2:customvalue2',
+                DD_TEST_DELAY_CUCUMBER_WORKER_MESSAGES_MS: '100',
+                DD_TEST_SESSION_NAME: 'my-test-session',
+                DD_SERVICE: undefined,
+              },
+            }
+          )
+
+          const receiverPromise = receiver.gatherPayloadsUntilChildExit(
+            childProcess,
+            ({ url }) => url.endsWith('/api/v2/citestcycle'),
+            payloads => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const testModuleEvent = events.find(event => event.type === 'test_module_end')
+              const testSuiteEvent = events.find(event => event.type === 'test_suite_end')
+              const testEvents = events.filter(event => event.type === 'test')
+
+              assert.ok(testModuleEvent, 'should have test module event')
+              assert.ok(testSuiteEvent, 'should have test suite event')
+              assert.deepStrictEqual(testEvents.map(test => test.content.resource).sort(), [
+                `${featuresPath}farewell.feature.Say farewell`,
+                `${featuresPath}farewell.feature.Say whatever`,
+                `${featuresPath}greetings.feature.Say greetings`,
+                `${featuresPath}greetings.feature.Say skip`,
+                `${featuresPath}greetings.feature.Say yeah`,
+                `${featuresPath}greetings.feature.Say yo`,
+              ])
+              testEvents.forEach(({ content: { meta, test_suite_id: testSuiteId } }) => {
+                assert.strictEqual(meta[TEST_MODULE], 'cucumber')
+                assert.ok(testSuiteId)
+                assert.strictEqual(meta[CUCUMBER_IS_PARALLEL], 'true')
+              })
+            },
+            { hardTimeout: 10000 }
+          )
+
+          await Promise.all([
+            once(childProcess, 'exit'),
+            receiverPromise,
+          ])
+        })
+      }
+
       context('intelligent test runner', () => {
         it('can report git metadata', (done) => {
           const searchCommitsRequestPromise = receiver.payloadReceived(

--- a/packages/datadog-plugin-cucumber/src/index.js
+++ b/packages/datadog-plugin-cucumber/src/index.js
@@ -80,6 +80,7 @@ class CucumberPlugin extends CiPlugin {
       isTestManagementTestsEnabled,
       isParallel,
     }) => {
+      this._exportPendingWorkerTraces()
       const {
         isSuitesSkippingEnabled,
         isCodeCoverageEnabled,
@@ -186,6 +187,7 @@ class CucumberPlugin extends CiPlugin {
         integrationName: this.constructor.id,
       })
       this._testSuiteSpansByTestSuite.set(testSuitePath, testSuiteSpan)
+      this._exportPendingWorkerTracesForTestSuite(testSuitePath)
 
       this.telemetry.ciVisEvent(TELEMETRY_EVENT_CREATED, 'suite')
       if (this.libraryConfig?.isCodeCoverageEnabled) {

--- a/packages/datadog-plugin-mocha/src/index.js
+++ b/packages/datadog-plugin-mocha/src/index.js
@@ -150,6 +150,7 @@ class MochaPlugin extends CiPlugin {
       ctx.parentStore = store
       ctx.currentStore = { ...store, testSuiteSpan }
       this._testSuiteSpansByTestSuite.set(testSuite, testSuiteSpan)
+      this._exportPendingWorkerTracesForTestSuite(testSuite)
     })
 
     this.addSub('ci:mocha:test-suite:finish', ({ testSuiteSpan, status }) => {
@@ -365,6 +366,7 @@ class MochaPlugin extends CiPlugin {
       isTestManagementEnabled,
       isParallel,
     }) => {
+      this._exportPendingWorkerTraces()
       if (this.testSessionSpan) {
         const {
           isSuitesSkippingEnabled,

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -143,6 +143,7 @@ module.exports = class CiPlugin extends Plugin {
     this.fileLineToProbeId = new Map()
     this.rootDir = process.cwd() // fallback in case :session:start events are not emitted
     this._testSuiteSpansByTestSuite = new Map()
+    this._pendingWorkerTracesByTestSuite = new Map()
     this._pendingRequestErrorTags = []
 
     this.addSub(`ci:${this.constructor.id}:library-configuration`, (ctx) => {
@@ -352,52 +353,8 @@ module.exports = class CiPlugin extends Plugin {
       const formattedTraces = JSON.parse(traces)
 
       for (const trace of formattedTraces) {
-        for (const span of trace) {
-          span.span_id = id(span.span_id)
-          span.trace_id = id(span.trace_id)
-          span.parent_id = id(span.parent_id)
-
-          if (span.name?.startsWith(`${this.constructor.id}.`)) {
-            span.meta[TEST_IS_TEST_FRAMEWORK_WORKER] = 'true'
-            if (span.name === `${this.constructor.id}.test` || span.name === `${this.constructor.id}.test_suite`) {
-              Object.assign(span.meta, getSessionItrSkippingEnabledTags(this.testSessionSpan))
-            }
-            // augment with git information (since it will not be available in the worker)
-            for (const key in this.testEnvironmentMetadata) {
-              // CAREFUL: this bypasses the metadata/metrics distinction
-              // Be careful not to pass numbers in `meta`
-              if (key.startsWith('git.')) {
-                span.meta[key] = this.testEnvironmentMetadata[key]
-              }
-            }
-          }
-
-          // Only test hooks run in the cucumber worker, so the test events do not have the
-          // test session, test module and test suite ids. We have to update them here.
-          if (span.name === 'cucumber.test' || span.name === 'mocha.test') {
-            const testSuite = span.meta[TEST_SUITE]
-            const testSuiteSpan = this._testSuiteSpansByTestSuite.get(testSuite)
-            if (!testSuiteSpan) {
-              log.warn('Test suite span not found for test span with test suite %s', testSuite)
-              continue
-            }
-
-            const testSuiteTags = getTestSuiteLevelVisibilityTags(testSuiteSpan, this.constructor.id)
-            span.meta = {
-              ...span.meta,
-              ...testSuiteTags,
-              ...getSessionRequestErrorTags(this.testSessionSpan),
-            }
-          }
-
-          // Jest and Vitest worker test spans are serialized in the worker and may not include
-          // request error tags; add them from the session span in the main process.
-          if ((span.name === 'jest.test' || span.name === 'vitest.test' || span.name === 'vitest.test_suite') &&
-              this.testSessionSpan) {
-            Object.assign(span.meta, getSessionRequestErrorTags(this.testSessionSpan))
-          }
-        }
-        this.tracer._exporter.export(trace)
+        this._prepareWorkerTrace(trace)
+        this._exportWorkerTraceOrBuffer(trace)
       }
     })
 
@@ -500,6 +457,134 @@ module.exports = class CiPlugin extends Plugin {
    */
   getSessionItrSkippingEnabledTags () {
     return getSessionItrSkippingEnabledTags(this.testSessionSpan)
+  }
+
+  /**
+   * Normalizes worker trace identifiers and adds process-level metadata before exporting or buffering.
+   *
+   * @param {object[]} trace - Worker trace spans decoded from the worker payload.
+   */
+  _prepareWorkerTrace (trace) {
+    for (const span of trace) {
+      span.span_id = id(span.span_id)
+      span.trace_id = id(span.trace_id)
+      span.parent_id = id(span.parent_id)
+
+      if (span.name?.startsWith(`${this.constructor.id}.`)) {
+        span.meta[TEST_IS_TEST_FRAMEWORK_WORKER] = 'true'
+        if (span.name === `${this.constructor.id}.test` || span.name === `${this.constructor.id}.test_suite`) {
+          Object.assign(span.meta, getSessionItrSkippingEnabledTags(this.testSessionSpan))
+        }
+        // augment with git information (since it will not be available in the worker)
+        for (const key in this.testEnvironmentMetadata) {
+          // CAREFUL: this bypasses the metadata/metrics distinction
+          // Be careful not to pass numbers in `meta`
+          if (key.startsWith('git.')) {
+            span.meta[key] = this.testEnvironmentMetadata[key]
+          }
+        }
+      }
+
+      // Jest and Vitest worker test spans are serialized in the worker and may not include
+      // request error tags; add them from the session span in the main process.
+      if ((span.name === 'jest.test' || span.name === 'vitest.test' || span.name === 'vitest.test_suite') &&
+          this.testSessionSpan) {
+        Object.assign(span.meta, getSessionRequestErrorTags(this.testSessionSpan))
+      }
+    }
+  }
+
+  /**
+   * Adds suite-level CI Visibility tags to worker test spans when their suite span is available.
+   *
+   * @param {object[]} trace - Worker trace spans.
+   * @returns {string|undefined} Missing test suite name, if the trace cannot be exported yet.
+   */
+  _addSuiteTagsToWorkerTrace (trace) {
+    for (const span of trace) {
+      // Only test hooks run in Cucumber and Mocha workers, so the test events do not have the
+      // test session, test module and test suite ids. We have to update them in the main process.
+      if (span.name !== 'cucumber.test' && span.name !== 'mocha.test') continue
+
+      const testSuite = span.meta[TEST_SUITE]
+      const testSuiteSpan = this._testSuiteSpansByTestSuite.get(testSuite)
+      if (!testSuiteSpan) return testSuite
+
+      const testSuiteTags = getTestSuiteLevelVisibilityTags(testSuiteSpan, this.constructor.id)
+      span.meta = {
+        ...span.meta,
+        ...testSuiteTags,
+        ...getSessionRequestErrorTags(this.testSessionSpan),
+      }
+    }
+  }
+
+  /**
+   * Stores a worker trace until the matching test suite span exists in the main process.
+   *
+   * @param {string} testSuite - Test suite path used as the pending trace key.
+   * @param {object[]} trace - Worker trace spans.
+   */
+  _bufferWorkerTrace (testSuite, trace) {
+    let pendingTraces = this._pendingWorkerTracesByTestSuite.get(testSuite)
+    if (!pendingTraces) {
+      pendingTraces = []
+      this._pendingWorkerTracesByTestSuite.set(testSuite, pendingTraces)
+    }
+    pendingTraces.push(trace)
+  }
+
+  /**
+   * Exports a worker trace immediately, or buffers it if suite-level tags cannot be added yet.
+   *
+   * @param {object[]} trace - Worker trace spans.
+   */
+  _exportWorkerTraceOrBuffer (trace) {
+    const missingTestSuite = this._addSuiteTagsToWorkerTrace(trace)
+    if (missingTestSuite) {
+      this._bufferWorkerTrace(missingTestSuite, trace)
+      return
+    }
+    this.tracer._exporter.export(trace)
+  }
+
+  /**
+   * Exports buffered worker traces for a suite after its suite span has been created.
+   *
+   * @param {string} testSuite - Test suite path that may now have pending worker traces.
+   */
+  _exportPendingWorkerTracesForTestSuite (testSuite) {
+    const pendingTraces = this._pendingWorkerTracesByTestSuite.get(testSuite)
+    if (!pendingTraces) return
+
+    this._pendingWorkerTracesByTestSuite.delete(testSuite)
+    for (const trace of pendingTraces) {
+      this._exportWorkerTraceOrBuffer(trace)
+    }
+  }
+
+  /**
+   * Drains all buffered worker traces, falling back to the previous unaugmented export behavior
+   * if a matching suite span never appears.
+   */
+  _exportPendingWorkerTraces () {
+    if (!this._pendingWorkerTracesByTestSuite.size) return
+
+    const pendingTraces = new Set()
+    for (const traces of this._pendingWorkerTracesByTestSuite.values()) {
+      for (const trace of traces) {
+        pendingTraces.add(trace)
+      }
+    }
+    this._pendingWorkerTracesByTestSuite.clear()
+
+    for (const trace of pendingTraces) {
+      const missingTestSuite = this._addSuiteTagsToWorkerTrace(trace)
+      if (missingTestSuite) {
+        log.warn('Test suite span not found for test span with test suite %s', missingTestSuite)
+      }
+      this.tracer._exporter.export(trace)
+    }
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
Buffers Cucumber and Mocha worker test traces in the main process until the matching suite span exists, then exports them with the suite-level CI Visibility tags. It keeps a session-finish fallback that drains pending traces with the previous export behavior if a suite never appears.

This also adds a normal parallel Cucumber regression test that delays regular worker IPC while letting dd-trace worker trace IPC through first. That reproduces the ordering where test events were emitted before suite metadata was available.

### Motivation
Parallel Cucumber workers can finish and report a test trace before the coordinator has processed the matching suite-start message. The old handler exported that trace immediately, so the test event existed but missed `test.module`, suite IDs, and related parent metadata. This matches the CI flake observed in `(parallel) can run and report tests`.

### Additional Notes
Validated with the focused Cucumber integration repro, linting on the touched files, whitespace checks, and a red/green check that confirmed the new test fails without the buffering logic and passes when restored. Local verification used Cucumber 12 because this machine is on Node 20 and the suite skips latest on Node 20.