### PR TITLE
feat(aiguard): Add span tags to AI Guard spans for anomaly detection

### DIFF
--- a/integration-tests/aiguard/index.spec.js
+++ b/integration-tests/aiguard/index.spec.js
@@ -89,6 +89,47 @@ describe('AIGuard SDK integration tests', () => {
     })
   })
 
+  describe('service entry tag mirroring', () => {
+    it('copies http.useragent to ai_guard.http.useragent on the guard span', async () => {
+      const response = await executeRequest(`${url}/allow`, 'GET', {
+        'user-agent': 'test-agent/1.0',
+      })
+      assert.strictEqual(response.status, 200)
+
+      await agent.assertMessageReceived(({ payload }) => {
+        const guardSpan = payload[0].find(span => span.name === 'ai_guard')
+        assert.notStrictEqual(guardSpan, undefined)
+        assert.strictEqual(guardSpan.meta['ai_guard.http.useragent'], 'test-agent/1.0')
+      })
+    })
+
+    it('copies http.client_ip and network.client.ip to ai_guard.* tags on the guard span', async () => {
+      const response = await executeRequest(`${url}/allow`, 'GET', {
+        'x-forwarded-for': '203.0.113.10, 10.0.0.1',
+      })
+      assert.strictEqual(response.status, 200)
+
+      await agent.assertMessageReceived(({ payload }) => {
+        const guardSpan = payload[0].find(span => span.name === 'ai_guard')
+        assert.notStrictEqual(guardSpan, undefined)
+        assert.strictEqual(guardSpan.meta['ai_guard.http.client_ip'], '203.0.113.10')
+        assert.ok(guardSpan.meta['ai_guard.network.client.ip'])
+      })
+    })
+
+    it('copies usr.id and usr.session_id to ai_guard.* tags on the guard span', async () => {
+      const response = await executeRequest(`${url}/allow-with-user`, 'GET')
+      assert.strictEqual(response.status, 200)
+
+      await agent.assertMessageReceived(({ payload }) => {
+        const guardSpan = payload[0].find(span => span.name === 'ai_guard')
+        assert.notStrictEqual(guardSpan, undefined)
+        assert.strictEqual(guardSpan.meta['ai_guard.usr.id'], 'user-123')
+        assert.strictEqual(guardSpan.meta['ai_guard.usr.session_id'], 'session-456')
+      })
+    })
+  })
+
   it('adds client ip tags to the request root span when AI Guard runs', async () => {
     const response = await executeRequest(`${url}/allow`, 'GET', {
       'x-forwarded-for': '203.0.113.10, 10.0.0.1',

--- a/integration-tests/aiguard/server.js
+++ b/integration-tests/aiguard/server.js
@@ -24,6 +24,15 @@ app.get('/allow', async (req, res) => {
   res.status(200).json(evaluation)
 })
 
+app.get('/allow-with-user', async (req, res) => {
+  tracer.appsec.setUser({ id: 'user-123', session_id: 'session-456' })
+  const evaluation = await tracer.aiguard.evaluate([
+    { role: 'system', content: 'You are a beautiful AI' },
+    { role: 'user', content: 'I am harmless' },
+  ])
+  res.status(200).json(evaluation)
+})
+
 app.get('/deny', async (req, res) => {
   const block = req.headers['x-blocking-enabled'] === 'true'
   try {

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -200,15 +200,11 @@ class AIGuard extends NoopAIGuard {
    */
   #copyServiceEntryTagsToGuardSpan (guardSpan, rootSpan) {
     const rootTags = rootSpan.context().getTags()
-    const newTags = {}
     for (const [sourceTag, destTag] of SERVICE_ENTRY_TAG_MAPPINGS) {
       const value = rootTags[sourceTag]
       if (value !== undefined && value !== null) {
-        newTags[destTag] = value
+        guardSpan.setTag(destTag, value)
       }
-    }
-    if (Object.keys(newTags).length > 0) {
-      guardSpan.addTags(newTags)
     }
   }
 

--- a/packages/dd-trace/src/aiguard/sdk.js
+++ b/packages/dd-trace/src/aiguard/sdk.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const rfdc = require('../../../../vendor/dist/rfdc')({ proto: false, circles: false })
-const { HTTP_CLIENT_IP, NETWORK_CLIENT_IP } = require('../../../../ext/tags')
+const { HTTP_CLIENT_IP, NETWORK_CLIENT_IP, HTTP_USERAGENT } = require('../../../../ext/tags')
+const { USER_ID, USER_SESSION_ID } = require('../appsec/addresses')
 const { getActiveRequest } = require('../appsec/store')
 const log = require('../log')
 const { extractIp } = require('../plugins/util/ip_extractor')
@@ -16,6 +17,16 @@ const TAGS = require('./tags')
 const aiguardMetrics = telemetryMetrics.manager.namespace('ai_guard')
 
 const ALLOW = 'ALLOW'
+
+// Tags from the service entry span that must be mirrored onto every AI Guard span
+// so anomaly detection pipelines can process each span independently.
+const SERVICE_ENTRY_TAG_MAPPINGS = [
+  [HTTP_USERAGENT, TAGS.HTTP_USERAGENT_TAG_KEY],
+  [HTTP_CLIENT_IP, TAGS.HTTP_CLIENT_IP_TAG_KEY],
+  [NETWORK_CLIENT_IP, TAGS.NETWORK_CLIENT_IP_TAG_KEY],
+  [USER_ID, TAGS.USR_ID_TAG_KEY],
+  [USER_SESSION_ID, TAGS.USR_SESSION_ID_TAG_KEY],
+]
 
 /**
  * Reports a telemetry error
@@ -181,6 +192,26 @@ class AIGuard extends NoopAIGuard {
     }
   }
 
+  /**
+   * Copies service entry span tags needed by anomaly detection to the AI Guard span.
+   *
+   * @param {import('../opentracing/span')} guardSpan
+   * @param {import('../opentracing/span')} rootSpan
+   */
+  #copyServiceEntryTagsToGuardSpan (guardSpan, rootSpan) {
+    const rootTags = rootSpan.context().getTags()
+    const newTags = {}
+    for (const [sourceTag, destTag] of SERVICE_ENTRY_TAG_MAPPINGS) {
+      const value = rootTags[sourceTag]
+      if (value !== undefined && value !== null) {
+        newTags[destTag] = value
+      }
+    }
+    if (Object.keys(newTags).length > 0) {
+      guardSpan.addTags(newTags)
+    }
+  }
+
   evaluate (messages, opts) {
     if (!this.#initialized) {
       return super.evaluate(messages, opts)
@@ -206,6 +237,7 @@ class AIGuard extends NoopAIGuard {
       const rootSpan = span.context()?._trace?.started?.[0]
       if (rootSpan) {
         this.#setRootSpanClientIpTags(rootSpan)
+        this.#copyServiceEntryTagsToGuardSpan(span, rootSpan)
         // keepTrace must be called before executeRequest so the sampling decision
         // is propagated correctly to outgoing HTTP client calls.
         keepTrace(rootSpan, AI_GUARD)

--- a/packages/dd-trace/src/aiguard/tags.js
+++ b/packages/dd-trace/src/aiguard/tags.js
@@ -10,6 +10,12 @@ module.exports = {
   EVENT_TAG_KEY: 'ai_guard.event',
   META_STRUCT_KEY: 'ai_guard',
 
+  HTTP_USERAGENT_TAG_KEY: 'ai_guard.http.useragent',
+  HTTP_CLIENT_IP_TAG_KEY: 'ai_guard.http.client_ip',
+  NETWORK_CLIENT_IP_TAG_KEY: 'ai_guard.network.client.ip',
+  USR_ID_TAG_KEY: 'ai_guard.usr.id',
+  USR_SESSION_ID_TAG_KEY: 'ai_guard.usr.session_id',
+
   TELEMETRY_REQUESTS: 'requests',
   TELEMETRY_TRUNCATED: 'truncated',
   TELEMETRY_ERROR: 'error',


### PR DESCRIPTION
### What does this PR do?
An AI Guard span may arrive without its service entry span to the anomaly detection pipeline.
To ensure the required attributes are always available, copy the following tags from the root span onto every AI Guard span with the `ai_guard.__` prefix

### Motivation
Anomaly detection AI Guard feature


https://github.com/DataDog/system-tests/pull/7099


