### PR TITLE
chore(release): build release notes from conventional commits

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -44,6 +44,14 @@ jobs:
       - uses: ./.github/actions/install
       - run: npm run lint
 
+  release-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/node/latest
+      - uses: ./.github/actions/install
+      - run: npm run test:release
+
   generated-config-types:
     runs-on: ubuntu-latest
     name: Generated config types

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "test:integration:plugins": "yarn services && mocha \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/${SPEC:-*}*.spec.js\"",
     "test:integration:plugins:coverage": "yarn services && node ./integration-tests/coverage/run-suite.js \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/${SPEC:-*}*.spec.js\"",
     "test:unit:plugins": "mocha \"packages/datadog-instrumentations/test/@(${PLUGINS}).spec.js\" \"packages/datadog-plugin-@(${PLUGINS})/test/**/*.spec.js\" --exclude \"packages/datadog-plugin-@(${PLUGINS})/test/integration-test/**/*.spec.js\"",
+    "test:release": "mocha \"scripts/release/**/*.spec.js\"",
     "test:shimmer": "mocha \"packages/datadog-shimmer/test/**/*.spec.js\"",
     "test:shimmer:ci": "nyc --silent node init && nyc -- npm run test:shimmer",
     "verify:workflow-job-names": "node scripts/verify-workflow-job-names.js",

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -88,6 +88,7 @@ for (const [product, scopes] of PRODUCTS) {
  * @typedef {object} CommitEntry
  * @property {string} sha
  * @property {string} subject
+ * @property {string} [author] Display string for the release contributor, e.g. `@handle`.
  */
 
 /**
@@ -113,6 +114,7 @@ for (const [product, scopes] of PRODUCTS) {
  */
 function createReleaseChangelog (entries) {
   const sections = new Map()
+  const contributors = new Set()
   const warnings = []
   let isMinor = false
 
@@ -121,6 +123,7 @@ function createReleaseChangelog (entries) {
 
     if (change.warning) warnings.push(change.warning)
     if (change.category === 'Features') isMinor = true
+    if (entry.author) contributors.add(entry.author)
 
     const section = sections.get(change.category)
     if (section) {
@@ -131,7 +134,7 @@ function createReleaseChangelog (entries) {
   }
 
   return {
-    markdown: renderSections(sections),
+    markdown: renderMarkdown(sections, contributors),
     isMinor,
     warnings,
   }
@@ -258,8 +261,9 @@ function sentenceCase (subject) {
 
 /**
  * @param {Map<string, Change[]>} sections
+ * @param {Set<string>} contributors
  */
-function renderSections (sections) {
+function renderMarkdown (sections, contributors) {
   const lines = []
 
   for (const category of CATEGORY_ORDER) {
@@ -273,7 +277,23 @@ function renderSections (sections) {
     lines.push('')
   }
 
+  if (contributors.size > 0) {
+    lines.push('Contributors')
+    for (const contributor of [...contributors].sort(compareContributors)) {
+      lines.push(`- ${contributor}`)
+    }
+    lines.push('')
+  }
+
   return lines.join('\n')
+}
+
+/**
+ * @param {string} a
+ * @param {string} b
+ */
+function compareContributors (a, b) {
+  return a.toLowerCase().localeCompare(b.toLowerCase())
 }
 
 /**

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -105,6 +105,7 @@ for (const [product, scopes] of PRODUCTS) {
  * @property {string} subject
  * @property {string} pr
  * @property {boolean} internal
+ * @property {boolean} revert
  * @property {string} [warning]
  */
 
@@ -122,7 +123,7 @@ function createReleaseChangelog (entries) {
     const change = parseChange(entry)
 
     if (change.warning) warnings.push(change.warning)
-    if (change.category === 'Features') isMinor = true
+    if (change.category === 'Features' && !change.revert) isMinor = true
     if (entry.author) contributors.add(entry.author)
 
     const section = sections.get(change.category)
@@ -155,6 +156,7 @@ function parseChange (entry) {
       subject: subjectWithPullRequest.subject,
       pr: subjectWithPullRequest.pr,
       internal: true,
+      revert: false,
       warning: `Non-conventional release-note subject for ${entry.sha}: ${entry.subject}`,
     }
   }
@@ -172,6 +174,7 @@ function parseChange (entry) {
     subject: parsed.subject,
     pr: subjectWithPullRequest.pr,
     internal,
+    revert: parsed.isRevert,
     warning,
   }
 }
@@ -206,6 +209,7 @@ function parseConventionalSubject (subject) {
   return {
     type,
     scopes,
+    isRevert,
     subject: isRevert ? `Revert "${parsedSubject}"` : parsedSubject,
   }
 }

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -1,0 +1,293 @@
+'use strict'
+
+const INTERNAL_CATEGORY = '<b>Internal</b> (CI, Testing, Benchmarking)'
+const CATEGORY_ORDER = [
+  'Features',
+  'Fixes',
+  'Performance',
+  'Documentation',
+  INTERNAL_CATEGORY,
+]
+const CONVENTIONAL_PATTERN = new RegExp(
+  String.raw`^(?:(revert)(!)?: )?` +
+    String.raw`(feat|fix|docs|style|refactor|perf|test|bench|build|ci|chore)(?:\(([^)]+)\))?(!)?: (.+)$`
+)
+const PULL_REQUEST_PATTERN = /\s+\(#([0-9]+)\)$/
+const INTERNAL_TYPES = new Set(['bench', 'build', 'chore', 'ci', 'refactor', 'style', 'test'])
+
+const CATEGORY_BY_TYPE = {
+  docs: 'Documentation',
+  feat: 'Features',
+  fix: 'Fixes',
+  perf: 'Performance',
+}
+const PRODUCTS = [
+  ['AppSec', ['appsec', 'iast', 'rasp', 'waf', 'asm']],
+  ['AI Guard', ['aiguard', 'ai-guard']],
+  ['Profiling', ['profiling', 'profiler']],
+  ['CI Visibility', [
+    'ci-visibility',
+    'test-optimization',
+    'testopt',
+    'itr',
+    'efd',
+    'tia',
+    'jest',
+    'mocha',
+    'cucumber',
+    'cypress',
+    'playwright',
+    'vitest',
+    'selenium',
+  ]],
+  ['Crash Tracking', ['crashtracking', 'crash-tracking']],
+  ['Dynamic Instrumentation', ['debugger', 'code-origin', 'dynamic-instrumentation']],
+  ['LLMObs', [
+    'llmobs',
+    'ai',
+    'openai',
+    'anthropic',
+    'langchain',
+    'langgraph',
+    'genai',
+    'vertexai',
+    'bedrockruntime',
+  ]],
+  ['Serverless', ['serverless', 'lambda', 'azure_metadata', 'inferred_proxy']],
+  ['OpenTelemetry', ['otel', 'opentelemetry']],
+  ['General', [
+    'core',
+    'tracing',
+    'span',
+    'format',
+    'encode',
+    'encoder',
+    'opentracing',
+    'http',
+    'http2',
+    'instrumentation',
+    'plugins',
+    'config',
+    'telemetry',
+    'remote-config',
+    'runtime-metrics',
+    'stats',
+    'sampler',
+    'types',
+  ]],
+]
+const PRODUCT_BY_SCOPE = new Map()
+
+for (const [product, scopes] of PRODUCTS) {
+  for (const scope of scopes) {
+    PRODUCT_BY_SCOPE.set(scope, product)
+  }
+}
+
+/**
+ * @typedef {object} CommitEntry
+ * @property {string} sha
+ * @property {string} subject
+ */
+
+/**
+ * @typedef {object} ReleaseChangelog
+ * @property {string} markdown
+ * @property {boolean} isMinor
+ * @property {string[]} warnings
+ */
+
+/**
+ * @typedef {object} Change
+ * @property {string} category
+ * @property {string} product
+ * @property {string} subject
+ * @property {string} pr
+ * @property {boolean} internal
+ * @property {string} [warning]
+ */
+
+/**
+ * @param {CommitEntry[]} entries
+ * @returns {ReleaseChangelog}
+ */
+function createReleaseChangelog (entries) {
+  const sections = new Map()
+  const warnings = []
+  let isMinor = false
+
+  for (const entry of entries) {
+    const change = parseChange(entry)
+
+    if (change.warning) warnings.push(change.warning)
+    if (change.category === 'Features') isMinor = true
+
+    const section = sections.get(change.category)
+    if (section) {
+      section.push(change)
+    } else {
+      sections.set(change.category, [change])
+    }
+  }
+
+  return {
+    markdown: renderSections(sections),
+    isMinor,
+    warnings,
+  }
+}
+
+/**
+ * @param {CommitEntry} entry
+ * @returns {Change}
+ */
+function parseChange (entry) {
+  const subjectWithPullRequest = parsePullRequest(entry.subject)
+  const parsed = parseConventionalSubject(subjectWithPullRequest.subject)
+
+  if (!parsed) {
+    return {
+      category: INTERNAL_CATEGORY,
+      product: 'Other',
+      subject: subjectWithPullRequest.subject,
+      pr: subjectWithPullRequest.pr,
+      internal: true,
+      warning: `Non-conventional release-note subject for ${entry.sha}: ${entry.subject}`,
+    }
+  }
+
+  const category = CATEGORY_BY_TYPE[parsed.type] || INTERNAL_CATEGORY
+  const internal = INTERNAL_TYPES.has(parsed.type)
+  const product = selectProduct(parsed.scopes)
+  const warning = !internal && product === 'Other'
+    ? `Unknown release-note product for ${entry.sha}: ${entry.subject}`
+    : undefined
+
+  return {
+    category,
+    product,
+    subject: parsed.subject,
+    pr: subjectWithPullRequest.pr,
+    internal,
+    warning,
+  }
+}
+
+/**
+ * @param {string} subject
+ */
+function parsePullRequest (subject) {
+  const match = subject.match(PULL_REQUEST_PATTERN)
+  if (!match) {
+    return { subject, pr: '' }
+  }
+
+  return {
+    subject: subject.slice(0, match.index),
+    pr: `#${match[1]}`,
+  }
+}
+
+/**
+ * @param {string} subject
+ */
+function parseConventionalSubject (subject) {
+  const match = subject.match(CONVENTIONAL_PATTERN)
+  if (!match) return
+
+  const isRevert = match[1] === 'revert'
+  const type = match[3]
+  const scopes = splitScopes(match[4])
+  const parsedSubject = sentenceCase(match[6])
+
+  return {
+    type,
+    scopes,
+    subject: isRevert ? `Revert "${parsedSubject}"` : parsedSubject,
+  }
+}
+
+/**
+ * @param {string|undefined} scope
+ */
+function splitScopes (scope) {
+  if (!scope) return []
+
+  const scopes = []
+  for (const part of scope.split(',')) {
+    const normalized = part.trim().toLowerCase()
+    if (normalized) scopes.push(normalized)
+  }
+  return scopes
+}
+
+/**
+ * @param {string[]} scopes
+ */
+function selectProduct (scopes) {
+  let fallback = 'General'
+
+  for (const scope of scopes) {
+    const product = findProduct(scope)
+    if (!product) {
+      fallback = 'Other'
+      continue
+    }
+    if (product !== 'General') return product
+  }
+
+  return fallback
+}
+
+/**
+ * @param {string} scope
+ */
+function findProduct (scope) {
+  for (const part of scope.split('/')) {
+    const product = PRODUCT_BY_SCOPE.get(part)
+    if (product) return product
+  }
+}
+
+/**
+ * @param {string} subject
+ */
+function sentenceCase (subject) {
+  return subject[0].toUpperCase() + subject.slice(1)
+}
+
+/**
+ * @param {Map<string, Change[]>} sections
+ */
+function renderSections (sections) {
+  const lines = []
+
+  for (const category of CATEGORY_ORDER) {
+    const changes = sections.get(category)
+    if (!changes?.length) continue
+
+    lines.push(category)
+    for (const change of changes) {
+      lines.push(renderChange(change))
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * @param {Change} change
+ */
+function renderChange (change) {
+  const suffix = change.pr ? ` ${change.pr}` : ''
+  if (change.internal) {
+    return `- ${change.subject}${suffix}`
+  }
+
+  return `- <b>${change.product}</b> ${change.subject}${suffix}`
+}
+
+module.exports = {
+  createReleaseChangelog,
+}

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -154,6 +154,42 @@ describe('release changelog', () => {
     ].join('\n'))
   })
 
+  it('lists unique contributors sorted case-insensitively after the change sections', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'feat(appsec): add thing (#1)', author: '@Zoe' },
+      { sha: 'abc002', subject: 'fix(profiling): fix thing (#2)', author: '@alice' },
+      { sha: 'abc003', subject: 'ci(release): tweak the workflow (#3)', author: '@Zoe' },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Features',
+      '- <b>AppSec</b> Add thing #1',
+      '',
+      'Fixes',
+      '- <b>Profiling</b> Fix thing #2',
+      '',
+      '<b>Internal</b> (CI, Testing, Benchmarking)',
+      '- Tweak the workflow #3',
+      '',
+      'Contributors',
+      '- @alice',
+      '- @Zoe',
+      '',
+    ].join('\n'))
+  })
+
+  it('omits the Contributors section when no entry carries an author', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'fix(appsec): handle thing (#1)' },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Fixes',
+      '- <b>AppSec</b> Handle thing #1',
+      '',
+    ].join('\n'))
+  })
+
   it('treats unsupported conventional types as non-conventional', () => {
     const changelog = createReleaseChangelog([
       {

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -117,6 +117,29 @@ describe('release changelog', () => {
     ])
   })
 
+  it('does not promote the release to minor when a feature is reverted', () => {
+    const changelog = createReleaseChangelog([
+      {
+        sha: 'abc001',
+        subject: 'revert: feat(appsec): add experimental detection (#8689) (#8790)',
+      },
+      {
+        sha: 'abc002',
+        subject: 'fix(profiling): correct sample counts (#8791)',
+      },
+    ])
+
+    assert.strictEqual(changelog.isMinor, false)
+    assert.strictEqual(changelog.markdown, [
+      'Features',
+      '- <b>AppSec</b> Revert "Add experimental detection (#8689)" #8790',
+      '',
+      'Fixes',
+      '- <b>Profiling</b> Correct sample counts #8791',
+      '',
+    ].join('\n'))
+  })
+
   it('handles breaking markers and subjects without pull request numbers', () => {
     const changelog = createReleaseChangelog([
       {

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -1,0 +1,174 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { createReleaseChangelog } = require('./changelog')
+
+describe('release changelog', () => {
+  it('renders conventional commits in the release changelog format', () => {
+    const entries = [
+      {
+        sha: 'abc001',
+        subject: 'feat(appsec): add AppSec integrations to Laminas Framework ' +
+          '(http.route, endpoint collection, login events) (#3716)',
+      },
+      {
+        sha: 'abc002',
+        subject: 'fix(appsec): treat cleared shared memory as no-config rather than an error in AppSec helper (#3876)',
+      },
+      {
+        sha: 'abc003',
+        subject: 'fix(appsec): avoid the possibility of sensitive data going to the telemetry logs backend ' +
+          'via WAF strings (#3884)',
+      },
+      {
+        sha: 'abc004',
+        subject: 'fix: encoder JSON number type fix (#38799)',
+      },
+      {
+        sha: 'abc005',
+        subject: 'fix(profiling): prevent panics in profiling encoding under out-of-memory and out-of-bounds ' +
+          'conditions (#3888)',
+      },
+      {
+        sha: 'abc006',
+        subject: 'perf(format,encode): reduce per-span format and encode overhead (#8754)',
+      },
+      {
+        sha: 'abc007',
+        subject: 'docs(types): note that startSpan does not activate the returned span (#8771)',
+      },
+      {
+        sha: 'abc008',
+        subject: 'feat(otel): add support for OTLP Runtime Metrics (#8357)',
+      },
+      {
+        sha: 'abc009',
+        subject: 'chore(deps): bump the serverless group across 1 directory with 8 updates (#8782)',
+      },
+      {
+        sha: 'abc010',
+        subject: 'ci(release): cap proposal at 100 commits and notify guild at 50 (#8711)',
+      },
+      {
+        sha: 'abc011',
+        subject: 'bench(llmobs): add the startup guard to the writer encode loop (#8755)',
+      },
+      {
+        sha: 'abc012',
+        subject: 'revert: fix(llmobs): fan array-valued user tags out into one wire entry per element (#8689) (#8790)',
+      },
+      {
+        sha: 'abc013',
+        subject: 'feat(aws-sdk, llmobs): support Bedrock Converse and ConverseStream (#8079)',
+      },
+      {
+        sha: 'abc014',
+        subject: 'feat: add Node.js 26 support (#8429)',
+      },
+      {
+        sha: 'abc015',
+        subject: 'fix(unknown-scope): handle strange thing (#9999)',
+      },
+      {
+        sha: 'abc016',
+        subject: 'Fixes APMS-19181: sets the service discovery logs to respect the log level (#8677)',
+      },
+    ]
+
+    const changelog = createReleaseChangelog(entries)
+
+    assert.strictEqual(changelog.isMinor, true)
+    assert.strictEqual(changelog.markdown, [
+      'Features',
+      '- <b>AppSec</b> Add AppSec integrations to Laminas Framework ' +
+        '(http.route, endpoint collection, login events) #3716',
+      '- <b>OpenTelemetry</b> Add support for OTLP Runtime Metrics #8357',
+      '- <b>LLMObs</b> Support Bedrock Converse and ConverseStream #8079',
+      '- <b>General</b> Add Node.js 26 support #8429',
+      '',
+      'Fixes',
+      '- <b>AppSec</b> Treat cleared shared memory as no-config rather than an error in AppSec helper #3876',
+      '- <b>AppSec</b> Avoid the possibility of sensitive data going to the telemetry logs backend ' +
+        'via WAF strings #3884',
+      '- <b>General</b> Encoder JSON number type fix #38799',
+      '- <b>Profiling</b> Prevent panics in profiling encoding under out-of-memory and out-of-bounds ' +
+        'conditions #3888',
+      '- <b>LLMObs</b> Revert "Fan array-valued user tags out into one wire entry per element (#8689)" #8790',
+      '- <b>Other</b> Handle strange thing #9999',
+      '',
+      'Performance',
+      '- <b>General</b> Reduce per-span format and encode overhead #8754',
+      '',
+      'Documentation',
+      '- <b>General</b> Note that startSpan does not activate the returned span #8771',
+      '',
+      '<b>Internal</b> (CI, Testing, Benchmarking)',
+      '- Bump the serverless group across 1 directory with 8 updates #8782',
+      '- Cap proposal at 100 commits and notify guild at 50 #8711',
+      '- Add the startup guard to the writer encode loop #8755',
+      '- Fixes APMS-19181: sets the service discovery logs to respect the log level #8677',
+      '',
+    ].join('\n'))
+    assert.deepStrictEqual(changelog.warnings, [
+      'Unknown release-note product for abc015: fix(unknown-scope): handle strange thing (#9999)',
+      'Non-conventional release-note subject for abc016: ' +
+        'Fixes APMS-19181: sets the service discovery logs to respect the log level (#8677)',
+    ])
+  })
+
+  it('handles breaking markers and subjects without pull request numbers', () => {
+    const changelog = createReleaseChangelog([
+      {
+        sha: 'abc001',
+        subject: 'feat(opentelemetry)!: add breaking OpenTelemetry behavior',
+      },
+      {
+        sha: 'abc002',
+        subject: 'fix(http/http2): keep request tagging stable',
+      },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Features',
+      '- <b>OpenTelemetry</b> Add breaking OpenTelemetry behavior',
+      '',
+      'Fixes',
+      '- <b>General</b> Keep request tagging stable',
+      '',
+    ].join('\n'))
+  })
+
+  it('ignores empty scopes in multi-scope subjects', () => {
+    const changelog = createReleaseChangelog([
+      {
+        sha: 'abc001',
+        subject: 'fix( , appsec): trim empty scope segments (#1234)',
+      },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Fixes',
+      '- <b>AppSec</b> Trim empty scope segments #1234',
+      '',
+    ].join('\n'))
+  })
+
+  it('treats unsupported conventional types as non-conventional', () => {
+    const changelog = createReleaseChangelog([
+      {
+        sha: 'abc001',
+        subject: 'deps(express): bump express (#1234)',
+      },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      '<b>Internal</b> (CI, Testing, Benchmarking)',
+      '- deps(express): bump express #1234',
+      '',
+    ].join('\n'))
+    assert.deepStrictEqual(changelog.warnings, [
+      'Non-conventional release-note subject for abc001: deps(express): bump express (#1234)',
+    ])
+  })
+})

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -103,11 +103,13 @@ try {
   // Excludes semver-major (gated behind a flag, not user-visible).
   const notesShas = capture(`${notesDiffCmd} --format=sha --reverse v${releaseLine}.x ${upperBoundSha}`)
     .split('\n').filter(Boolean)
+  const contributorBySha = getContributorsBySha(`v${releaseLine}.x`, upperBoundSha)
   const notesEntries = []
   for (const sha of notesShas) {
     notesEntries.push({
       sha,
       subject: capture(`git show -s --format=%s ${sha}`),
+      author: contributorBySha.get(sha),
     })
   }
   const notes = createReleaseChangelog(notesEntries)
@@ -280,4 +282,34 @@ try {
   }
 } catch (e) {
   fail(e)
+}
+
+/**
+ * Map each release commit SHA to its GitHub contributor handle (`@login`), or
+ * the git author name when the commit author is not a GitHub user. Bot accounts
+ * (dependabot, github-actions) are skipped so the Contributors list stays human.
+ *
+ * @param {string} base Release branch the proposal lands on, e.g. `v5.x`.
+ * @param {string} head Upper-bound commit the proposal is capped at.
+ */
+function getContributorsBySha (base, head) {
+  const contributors = new Map()
+  const jq = '.commits[] | [.sha, (.author.login // ""), (.author.type // ""), .commit.author.name] | @tsv'
+
+  let output
+  try {
+    output = capture(`gh api "repos/DataDog/dd-trace-js/compare/${base}...${head}" --paginate --jq '${jq}'`)
+  } catch {
+    log('Warning: unable to fetch contributors from GitHub; skipping the Contributors section.')
+    return contributors
+  }
+
+  for (const line of output.split('\n')) {
+    if (!line) continue
+    const [sha, login, type, name] = line.split('\t')
+    if (type === 'Bot') continue
+    contributors.set(sha, login ? `@${login}` : name)
+  }
+
+  return contributors
 }

--- a/scripts/release/proposal.js
+++ b/scripts/release/proposal.js
@@ -17,6 +17,7 @@ const {
   start,
   run,
 } = require('./helpers/terminal')
+const { createReleaseChangelog } = require('./changelog')
 const { checkAll } = require('./helpers/requirements')
 
 const tmpdir = process.env.RUNNER_TEMP || os.tmpdir()
@@ -97,11 +98,20 @@ try {
     process.exit(0)
   }
 
-  // notesDiff is scoped to upperBoundSha so isMinor and release notes only reflect
+  // notesShas is scoped to upperBoundSha so isMinor and release notes only reflect
   // the capped commits actually included in the proposal, not deferred ones.
   // Excludes semver-major (gated behind a flag, not user-visible).
-  const notesDiff = capture(`${notesDiffCmd} --format=markdown v${releaseLine}.x ${upperBoundSha}`)
-  const isMinor = notesDiff.includes('SEMVER-MINOR')
+  const notesShas = capture(`${notesDiffCmd} --format=sha --reverse v${releaseLine}.x ${upperBoundSha}`)
+    .split('\n').filter(Boolean)
+  const notesEntries = []
+  for (const sha of notesShas) {
+    notesEntries.push({
+      sha,
+      subject: capture(`git show -s --format=%s ${sha}`),
+    })
+  }
+  const notes = createReleaseChangelog(notesEntries)
+  const isMinor = notes.isMinor
   const newPatch = `${releaseLine}.${DD_MINOR}.${DD_PATCH + 1}`
   const newMinor = `${releaseLine}.${DD_MINOR + 1}.0`
   const newVersion = isMinor ? newMinor : newPatch
@@ -181,9 +191,13 @@ try {
   start('Save release notes draft')
 
   fs.mkdirSync(notesDir, { recursive: true })
-  fs.writeFileSync(notesFile, notesDiff)
+  fs.writeFileSync(notesFile, notes.markdown)
 
   pass(notesFile)
+
+  for (const warning of notes.warnings) {
+    log(`Warning: ${warning}`)
+  }
 
   if (flags.n) process.exit(0)
   if (!flags.y) {


### PR DESCRIPTION
## Summary

Replace the branch-diff markdown release notes with a formatter that parses
conventional commit subjects, groups them into Features, Fixes, Performance,
Documentation and Internal sections, and tags each user-facing entry with the
product it belongs to. Dependency, CI, test, build and chore commits collapse
into the Internal section so routine churn stays out of user-facing notes.

A Contributors section lists everyone whose commit is part of the release
(GitHub handles via the compare endpoint, bots filtered out).

The minor-vs-patch decision now derives from the presence of a `feat` commit
rather than the `SEMVER-MINOR` label. Subjects that are not conventional
commits, or whose scope maps to no known product, are still rendered but
logged as warnings during proposal generation.

## Test plan

- `npm run test:release` (new `release-scripts` CI job) runs the formatter spec.