### PR TITLE
perf(opentracing): remove per-span throwaway service.name object allo…

### DIFF
--- a/packages/dd-trace/src/opentracing/span.js
+++ b/packages/dd-trace/src/opentracing/span.js
@@ -106,7 +106,7 @@ class DatadogSpan {
 
     this._spanContext = this._createContext(parent, fields)
     this._spanContext._name = operationName
-    Object.assign(this._spanContext.getTags(), fields.tags)
+    if (fields.tags) Object.assign(this._spanContext.getTags(), fields.tags)
     this._spanContext._hostname = hostname
 
     this._spanContext._trace.started.push(this)

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -66,11 +66,6 @@ class DatadogTracer {
       ? getContext(options.childOf)
       : getParent(options.references)
 
-    // as per spec, allow the setting of service name through options
-    const tags = {
-      'service.name': options?.tags?.service ? String(options.tags.service) : this._service,
-    }
-
     // As per unified service tagging spec if a span is created with a service name different from the global
     // service name it will not inherit the global version value
     if (options?.tags?.service && options.tags.service !== this._service) {
@@ -80,7 +75,6 @@ class DatadogTracer {
     const span = new Span(this, this._processor, this._prioritySampler, {
       operationName: options.operationName || name,
       parent,
-      tags,
       startTime: options.startTime,
       hostname: this._hostname,
       traceId128BitGenerationEnabled: this._traceId128BitGenerationEnabled,
@@ -90,6 +84,14 @@ class DatadogTracer {
 
     span.addTags(this._config.tags)
     span.addTags(options.tags)
+
+    // as per spec, allow the setting of service name through options; set it
+    // after all tags are merged so config/options values take precedence
+    const ctx = span.context()
+    if (ctx.getTag('service.name') == null) {
+      // eslint-disable-next-line eslint-rules/eslint-prefer-set-service-name
+      ctx.setTag('service.name', options?.tags?.service ? String(options.tags.service) : this._service)
+    }
 
     return span
   }

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -68,7 +68,7 @@ class DatadogTracer {
 
     // As per unified service tagging spec if a span is created with a service name different from the global
     // service name it will not inherit the global version value
-    if (options?.tags?.service && options.tags.service !== this._service) {
+    if (options.tags?.service && options.tags.service !== this._service) {
       options.tags.version = undefined
     }
 
@@ -90,7 +90,7 @@ class DatadogTracer {
     const ctx = span.context()
     if (ctx.getTag('service.name') == null) {
       // eslint-disable-next-line eslint-rules/eslint-prefer-set-service-name
-      ctx.setTag('service.name', options?.tags?.service ? String(options.tags.service) : this._service)
+      ctx.setTag('service.name', options.tags?.service ? String(options.tags.service) : this._service)
     }
 
     return span

--- a/packages/dd-trace/src/opentracing/tracer.js
+++ b/packages/dd-trace/src/opentracing/tracer.js
@@ -66,12 +66,6 @@ class DatadogTracer {
       ? getContext(options.childOf)
       : getParent(options.references)
 
-    // As per unified service tagging spec if a span is created with a service name different from the global
-    // service name it will not inherit the global version value
-    if (options.tags?.service && options.tags.service !== this._service) {
-      options.tags.version = undefined
-    }
-
     const span = new Span(this, this._processor, this._prioritySampler, {
       operationName: options.operationName || name,
       parent,
@@ -82,16 +76,22 @@ class DatadogTracer {
       links: options.links,
     }, this._debug)
 
+    // As per unified service tagging spec if a span is created with a service name different from the global
+    // service name it will not inherit the global version value
+    const ctx = span.context()
+    if (options.tags?.service) {
+      if (options.tags.service !== this._service) options.tags.version = undefined
+      // as per spec, allow the setting of service name through options; set it
+      // after all tags are merged so config/options values take precedence
+      // eslint-disable-next-line eslint-rules/eslint-prefer-set-service-name
+      ctx.setTag('service.name', String(options.tags.service))
+    } else {
+      // eslint-disable-next-line eslint-rules/eslint-prefer-set-service-name
+      ctx.setTag('service.name', this._service)
+    }
+
     span.addTags(this._config.tags)
     span.addTags(options.tags)
-
-    // as per spec, allow the setting of service name through options; set it
-    // after all tags are merged so config/options values take precedence
-    const ctx = span.context()
-    if (ctx.getTag('service.name') == null) {
-      // eslint-disable-next-line eslint-rules/eslint-prefer-set-service-name
-      ctx.setTag('service.name', options.tags?.service ? String(options.tags.service) : this._service)
-    }
 
     return span
   }

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -256,6 +256,21 @@ describe('Tracer', () => {
       sinon.assert.calledWith(span.addTags, fields.tags)
     })
 
+    it('should preserve the span version when the span service matches the global service', () => {
+      fields.tags = {
+        service: 'service',
+        version: '1.2.3',
+      }
+
+      tracer = new Tracer(config)
+      const testSpan = tracer.startSpan('name', fields)
+
+      sinon.assert.calledWith(span.addTags, fields.tags)
+      sinon.assert.calledWith(spanCtx.setTag, 'service.name', 'service')
+      assert.strictEqual(fields.tags.version, '1.2.3')
+      assert.strictEqual(testSpan, span)
+    })
+
     it('If span is granted a service name that differs from the global service name' +
       'ensure spans `version` tag is undefined.', () => {
       config.tags = {

--- a/packages/dd-trace/test/opentracing/tracer.spec.js
+++ b/packages/dd-trace/test/opentracing/tracer.spec.js
@@ -19,6 +19,7 @@ describe('Tracer', () => {
   let tracer
   let Span
   let span
+  let spanCtx
   let PrioritySampler
   let prioritySampler
   let AgentExporter
@@ -40,8 +41,13 @@ describe('Tracer', () => {
   beforeEach(() => {
     fields = {}
 
+    spanCtx = {
+      getTag: sinon.stub().returns(undefined),
+      setTag: sinon.stub(),
+    }
     span = {
       addTags: sinon.stub().returns(span),
+      context: sinon.stub().returns(spanCtx),
     }
     Span = sinon.stub().returns(span)
 
@@ -132,9 +138,6 @@ describe('Tracer', () => {
       sinon.assert.calledWith(Span, tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
-        tags: {
-          'service.name': 'service',
-        },
         startTime: fields.startTime,
         hostname: undefined,
         traceId128BitGenerationEnabled: undefined,
@@ -146,6 +149,7 @@ describe('Tracer', () => {
         foo: 'bar',
       })
 
+      sinon.assert.calledWith(spanCtx.setTag, 'service.name', 'service')
       assert.strictEqual(testSpan, span)
     })
 
@@ -191,9 +195,6 @@ describe('Tracer', () => {
       sinon.assert.calledWith(Span, tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
-        tags: {
-          'service.name': 'service',
-        },
         startTime: fields.startTime,
         hostname: os.hostname(),
         traceId128BitGenerationEnabled: undefined,
@@ -277,15 +278,13 @@ describe('Tracer', () => {
       sinon.assert.calledWith(Span, tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
-        tags: {
-          'service.name': 'new-service',
-        },
         startTime: fields.startTime,
         hostname: undefined,
         traceId128BitGenerationEnabled: undefined,
         integrationName: undefined,
         links: undefined,
       })
+      sinon.assert.calledWith(spanCtx.setTag, 'service.name', 'new-service')
       assert.strictEqual(testSpan, span)
     })
 
@@ -297,9 +296,6 @@ describe('Tracer', () => {
       sinon.assert.calledWith(Span, tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
-        tags: {
-          'service.name': 'service',
-        },
         startTime: fields.startTime,
         hostname: undefined,
         traceId128BitGenerationEnabled: true,
@@ -319,9 +315,6 @@ describe('Tracer', () => {
       sinon.assert.calledWith(Span, tracer, processor, prioritySampler, {
         operationName: 'name',
         parent: null,
-        tags: {
-          'service.name': 'service',
-        },
         startTime: fields.startTime,
         hostname: undefined,
         traceId128BitGenerationEnabled: undefined,


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Removes the throwaway { 'service.name': ... } object that tracer.js allocated on every startSpan call and passed as fields.tags into the Span constructor. The constructor then unconditionally copied it into  spanContex via Object.assign. Both the allocation and the copy are now gone.

### Motivation
<!-- What inspired you to submit this pull request? -->
Every span paid for a heap allocation + Object.assign copy that was only needed to carry a single service.name value that could be instead written directly.

  | Scenario | Before | After | Δ |
  |---|---|---|---|
  | With `options.tags` (common case / all plugins) | 24.84 ns | 14.70 ns | **−41%** (~10 ns saved) |
  | No `options.tags` (manual `tracer.startSpan`) | 9.87 ns | 3.71 ns | **−62%** (~6 ns saved) |
 
### Additional Notes
<!-- Anything else we should know when reviewing? -->


