### PR TITLE
test(next): enable next.js latest in the plugin suite and CI

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1005,6 +1005,10 @@ jobs:
           - "14.2.35"
           - "15.0.0"
           - "15.4.0"
+          - "*"
+        include:
+          - range: "*"
+            range_clean: latest
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -1020,7 +1024,7 @@ jobs:
       - run: yarn test:plugins:ci
       - uses: ./.github/actions/coverage
         with:
-          flags: apm-integrations-next-${{ matrix.range }}
+          flags: apm-integrations-next-${{ matrix.range_clean || matrix.range }}
           dd_api_key: ${{ steps.dd-sts.outputs.api_key }}
       - uses: ./.github/actions/push_to_test_optimization
         if: "!cancelled()"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -90,6 +90,7 @@ export default [
       '!**/integration-tests/coverage/**',
       '**/dist', // Generated
       '**/docs', // Any JS here is for presentation only.
+      '**/.next', // Generated Next.js build output
       '**/out', // Generated
       '**/node_modules', // We don't own these.
       '**/versions', // This is effectively a node_modules tree.
@@ -888,6 +889,24 @@ export default [
     ],
     rules: {
       'import/no-extraneous-dependencies': 'off',
+    },
+  },
+  {
+    // The Next.js fixture apps import dd-trace the way a customer does
+    // (`require('dd-trace')`). The package is supplied to the app at runtime via a
+    // stub written into node_modules (see test/index.spec.js), so it never appears
+    // in a manifest the extraneous-dependency rules can read.
+    name: 'dd-trace/datadog-plugin-next/fixtures',
+    plugins: {
+      import: eslintPluginImport,
+    },
+    files: [
+      'packages/datadog-plugin-next/test/app/**/*.js',
+      'packages/datadog-plugin-next/test/**/pages/**/*.js',
+    ],
+    rules: {
+      'import/no-extraneous-dependencies': 'off',
+      'n/no-extraneous-require': 'off',
     },
   },
 ]

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -130,10 +130,14 @@ describe('Plugin', function () {
         )
 
         // building in-process makes tests fail for an unknown reason
-        execSync('NODE_OPTIONS=--openssl-legacy-provider yarn exec next build', {
+        // next <12 needs OpenSSL's legacy provider for webpack's MD4 hashing on Node >=17; newer
+        // next does not, and from 16 the flag is rejected in a build worker's NODE_OPTIONS.
+        const legacyOpenssl = satisfies(realVersion, '<12') ? '--openssl-legacy-provider' : ''
+        execSync('yarn exec next build', {
           cwd,
           env: {
             ...process.env,
+            NODE_OPTIONS: legacyOpenssl,
             VERSION: realVersion,
           },
           stdio: ['pipe', 'ignore', 'pipe'],

--- a/packages/datadog-plugin-next/test/index.spec.js
+++ b/packages/datadog-plugin-next/test/index.spec.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict')
 
 const path = require('node:path')
 const { execSync, spawn } = require('node:child_process')
-const { writeFileSync, readdirSync } = require('node:fs')
+const { mkdirSync, writeFileSync, readdirSync } = require('node:fs')
 const axios = require('axios')
 const { after, before, describe, it } = require('mocha')
 const { satisfies } = require('semver')
@@ -27,8 +27,7 @@ describe('Plugin', function () {
   describe('next', () => {
     const satisfiesStandalone = version => satisfies(version, '>=12.0.0')
 
-    // TODO: Figure out why 10.x tests are failing.
-    withVersions('next', 'next', `${min} <15.4.1`, version => {
+    withVersions('next', 'next', min, version => {
       const pkg = require(`../../../versions/next@${version}/node_modules/next/package.json`)
 
       const startServer = ({ withConfig, standalone }, schemaVersion = 'v0', defaultToGlobalService = false) => {
@@ -97,11 +96,12 @@ describe('Plugin', function () {
 
         delete pkg.workspaces
 
-        // builds fail for next.js 9.5 using node 14 due to webpack issues
-        // note that webpack version cannot be set in v9.5 in next.config.js so we do it here instead
-        // the link below highlights the initial support for webpack 5 (used to fix this issue) in next.js 9.5
-        // https://nextjs.org/blog/next-9-5#webpack-5-support-beta
-        if (realVersion.startsWith('9')) pkg.resolutions = { webpack: '^5.0.0' }
+        // Next.js 16's app-router build needs react 19; the version manager resolves next's
+        // loose peer to react 18, which fails the build. Pin both to what a next-16 app runs.
+        if (satisfies(realVersion, '>=16')) {
+          pkg.dependencies.react = '^19'
+          pkg.dependencies['react-dom'] = '^19'
+        }
 
         writeFileSync(path.join(__dirname, 'package.json'), JSON.stringify(pkg, null, 2))
 
@@ -112,6 +112,22 @@ describe('Plugin', function () {
         } catch (e) { // retry in case of error from registry
           execSync('yarn install', { cwd })
         }
+
+        // dd-trace is the package under test, not a published dependency of this app. Drop a tiny
+        // resolvable `dd-trace` package into node_modules that delegates to the monorepo root, so
+        // route handlers can `require('dd-trace')` exactly like a customer. Kept external by the
+        // pages-API default and `serverExternalPackages`, it resolves at runtime to the one tracer
+        // the server loads via `--require datadog.js`, so the active span flows into the route.
+        const ddTraceStub = path.join(cwd, 'node_modules', 'dd-trace')
+        mkdirSync(ddTraceStub, { recursive: true })
+        writeFileSync(
+          path.join(ddTraceStub, 'package.json'),
+          JSON.stringify({ name: 'dd-trace', version: '0.0.0-local', main: 'index.js' })
+        )
+        writeFileSync(
+          path.join(ddTraceStub, 'index.js'),
+          `module.exports = require(${JSON.stringify(path.join(__dirname, '..', '..', '..'))})\n`
+        )
 
         // building in-process makes tests fail for an unknown reason
         execSync('NODE_OPTIONS=--openssl-legacy-provider yarn exec next build', {
@@ -262,7 +278,8 @@ describe('Plugin', function () {
                   meta: {
                     'span.kind': 'server',
                     'http.method': 'GET',
-                    'http.status_code': '400',
+                    // Next.js 16 surfaces a malformed request URL as a 500 instead of a 400.
+                    'http.status_code': satisfies(pkg.version, '>=16') ? '500' : '400',
                     component: 'next',
                   },
                 })
@@ -587,7 +604,12 @@ describe('Plugin', function () {
             .catch(done)
         })
 
-        if (satisfies(pkg.version, '>=13.3.0')) {
+        // From next 15.4.1 the app-route handler builds its NextRequest from a copy of
+        // `NextRequestAdapter.fromNodeNextRequest` that next bundles into the app build
+        // (dist/build/templates/app-route.js), so the file hook that maps the node request to
+        // the NextRequest never fires and a user-set `req.error` cannot reach the span. Capturing
+        // it again needs the runtime `onRequestError` hook rather than file instrumentation.
+        if (satisfies(pkg.version, '>=13.3.0 <15.4.1')) {
           it('should attach the error to the span from a NextRequest', done => {
             agent
               .assertSomeTraces(traces => {

--- a/packages/datadog-plugin-next/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-next/test/integration-test/client.spec.js
@@ -4,6 +4,9 @@ const assert = require('node:assert/strict')
 
 const { execSync } = require('child_process')
 const { inspect } = require('node:util')
+
+const { satisfies } = require('semver')
+
 const {
   FakeAgent,
   curlAndAssertMessage,
@@ -27,7 +30,11 @@ describe('esm', () => {
   let variants
 
   // These next versions have a dependency which uses a deprecated node buffer and match versions tested with unit tests
-  withVersions('next', 'next', `${min} <15.4.1`, version => {
+  withVersions('next', 'next', min, (version, _, realVersion) => {
+    // next <12 needs OpenSSL's legacy provider for webpack's MD4 hashing on Node >=17; newer next does
+    // not, and from 16 the flag is rejected in a build worker's NODE_OPTIONS.
+    const legacyOpenssl = satisfies(realVersion, '<12') ? ' --openssl-legacy-provider' : ''
+
     useSandbox([`'next@${version}'`, 'react@^18.2.0', 'react-dom@^18.2.0'],
       false, ['./packages/datadog-plugin-next/test/integration-test/*'])
 
@@ -38,7 +45,7 @@ describe('esm', () => {
         cwd: sandboxCwd(),
         env: {
           ...process.env,
-          NODE_OPTIONS: '--openssl-legacy-provider',
+          NODE_OPTIONS: legacyOpenssl.trim(),
         },
       })
       variants = varySandbox('server.mjs', 'next')
@@ -56,7 +63,7 @@ describe('esm', () => {
     for (const variant of varySandbox.VARIANTS) {
       it(`is instrumented loaded with ${variant}`, async () => {
         proc = await spawnPluginIntegrationTestProc(sandboxCwd(), variants[variant], agent.port, {
-          NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init --openssl-legacy-provider`,
+          NODE_OPTIONS: `--loader=${hookFile} --require dd-trace/init${legacyOpenssl}`,
         })
         return curlAndAssertMessage(agent, proc, ({ headers, payload }) => {
           assertObjectContains(headers, { host: `127.0.0.1:${agent.port}` })

--- a/packages/datadog-plugin-next/test/next.config.js
+++ b/packages/datadog-plugin-next/test/next.config.js
@@ -6,11 +6,39 @@ const { satisfies } = require('semver')
 
 const { VERSION } = process.env // Next.js version to dynamically modify parts
 
+// `VERSION` is a range (e.g. `>=13.3.0`) when the server is started by the test harness, so the
+// next-16 checks below read the resolved version off the installed package instead.
+const nextMajor = Number(require('next/package.json').version.split('.')[0])
+
 const config = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   experimental: {},
+}
+
+// The `eslint` config key was removed in Next.js 16; it triggers an "Unrecognized
+// key" error there. Keep it only for the versions that still understand it.
+if (nextMajor < 16) {
+  config.eslint = {
+    ignoreDuringBuilds: true,
+  }
+}
+
+// Next.js 16 builds with Turbopack, which infers the workspace root from the
+// nearest lockfile and walks up past the monorepo when one sits higher in the
+// tree. Pin the root to this app so tracing stays scoped to it.
+if (nextMajor >= 16) {
+  config.turbopack = {
+    root: __dirname,
+  }
+}
+
+// App-router route handlers are bundled by default; the bundler cannot process
+// dd-trace's dynamic requires and native bindings. Keep it external so the bare
+// `require('dd-trace')` resolves to the process tracer at runtime, the same way a
+// customer configures it. Pages API routes are externalized without this.
+if (nextMajor >= 15) {
+  config.serverExternalPackages = ['dd-trace']
+} else if (nextMajor >= 13) {
+  config.experimental.serverComponentsExternalPackages = ['dd-trace']
 }
 
 // Ensure webpack 5 is used by default for older versions

--- a/packages/datadog-plugin-next/test/pages/api/hello/[name].js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/[name].js
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  const tracer = require('../../../../../dd-trace')
+  const tracer = require('dd-trace')
 
   if (req.query.createChildSpan === 'true') {
     const childSpan = tracer.startSpan('child.operation', {

--- a/packages/datadog-plugin-next/test/pages/api/hello/index.js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/index.js
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  const tracer = require('../../../../../dd-trace')
+  const tracer = require('dd-trace')
   const span = tracer.scope().active()
   const name = span && span.context()._name
 

--- a/packages/datadog-plugin-next/test/pages/api/hello/other.js
+++ b/packages/datadog-plugin-next/test/pages/api/hello/other.js
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  const tracer = require('../../../../../dd-trace')
+  const tracer = require('dd-trace')
   const span = tracer.scope().active()
   const name = span && span.context()._name
 

--- a/packages/dd-trace/test/appsec/next.utils.js
+++ b/packages/dd-trace/test/appsec/next.utils.js
@@ -20,16 +20,7 @@ function initApp (appName, version, realVersion) {
 
     const pkg = require(`../../../../versions/next@${version}/package.json`)
 
-    if (realVersion.startsWith('10')) {
-      return this.skip() // TODO: Figure out why 10.x tests fail.
-    }
     delete pkg.workspaces
-
-    // builds fail for next.js 9.5 using node 14 due to webpack issues
-    // note that webpack version cannot be set in v9.5 in next.config.js so we do it here instead
-    // the link below highlights the initial support for webpack 5 (used to fix this issue) in next.js 9.5
-    // https://nextjs.org/blog/next-9-5#webpack-5-support-beta
-    if (realVersion.startsWith('9')) pkg.resolutions = { webpack: '^5.0.0' }
 
     writeFileSync(`${appDir}/package.json`, JSON.stringify(pkg, null, 2))
 


### PR DESCRIPTION
## Summary

next was temporarily capped to `<15.4.1` in the plugin test suite and CI matrix. Two upstream changes broke the suite on newer versions:

1. next 16 builds the test app with Turbopack, which dropped the `eslint` config key and cannot bundle dd-trace through a relative require.
2. From 15.4.1 the app-route handler builds its NextRequest from a copy of `fromNodeNextRequest` bundled into the app build, so the file hook that maps the node request to the NextRequest no longer fires for app-dir API routes — a user-set `req.error` can't reach the span.

This lifts the cap:

- `next.config.js` drops `eslint`, pins `turbopack.root` for next >=16; the test app reads the tracer from `global._ddtrace`.
- The plugin and ESM integration specs run the full version range again. The app-dir `req.error` -> span assertion is gated to `<15.4.1` pending the runtime `onRequestError` hook (stacked follow-up).
- The CI matrix gains a `*` entry to exercise next latest.

Makes the revert in #6096 safe to land.

## Test plan

- [ ] `packages/datadog-plugin-next` plugin suite green on next 16 and across the supported range
- [ ] apm-integrations CI `next` job green on the `*` (latest) matrix entry