### PR TITLE
test: convert agent.load setup hooks to async/await

### DIFF
--- a/packages/datadog-instrumentations/test/fs.spec.js
+++ b/packages/datadog-instrumentations/test/fs.spec.js
@@ -10,17 +10,15 @@ describe('fs instrumentation', () => {
     return agent.close()
   })
 
-  it('require node:fs should work', () => {
-    return agent.load('node:fs', undefined, { flushInterval: 1 }).then(() => {
-      const fs = require('node:fs')
-      assert.notStrictEqual(fs, undefined)
-    })
+  it('require node:fs should work', async () => {
+    await agent.load('node:fs', undefined, { flushInterval: 1 })
+    const fs = require('node:fs')
+    assert.notStrictEqual(fs, undefined)
   })
 
-  it('require fs should work', () => {
-    return agent.load('fs', undefined, { flushInterval: 1 }).then(() => {
-      const fs = require('fs')
-      assert.notStrictEqual(fs, undefined)
-    })
+  it('require fs should work', async () => {
+    await agent.load('fs', undefined, { flushInterval: 1 })
+    const fs = require('fs')
+    assert.notStrictEqual(fs, undefined)
   })
 })

--- a/packages/datadog-plugin-avsc/test/index.spec.js
+++ b/packages/datadog-plugin-avsc/test/index.spec.js
@@ -53,7 +53,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => {
+        before(async () => {
           dateNowStub = sinon.stub(Date, 'now').callsFake(() => {
             const returnValue = mockTime
             mockTime += 50000 // Increment by 50000 ms to ensure each DSM schema is sampled
@@ -61,10 +61,9 @@ describe('Plugin', () => {
           })
           const cache = SchemaBuilder.getCache()
           cache.clear()
-          return agent.load('avsc').then(() => {
-            temporaryWarningExceptions.add('SlowBuffer() is deprecated. Please use Buffer.allocUnsafeSlow()')
-            avro = require(`../../../versions/avsc@${version}`).get()
-          })
+          await agent.load('avsc')
+          temporaryWarningExceptions.add('SlowBuffer() is deprecated. Please use Buffer.allocUnsafeSlow()')
+          avro = require(`../../../versions/avsc@${version}`).get()
         })
 
         after(() => {

--- a/packages/datadog-plugin-child_process/test/index.spec.js
+++ b/packages/datadog-plugin-child_process/test/index.spec.js
@@ -389,17 +389,15 @@ describe('Child process plugin', () => {
     let originalPromise
     let Bluebird
 
-    beforeEach(() => {
-      return agent.load('child_process', undefined, { flushInterval: 1 }).then(() => {
-        tracer = require('../../dd-trace')
-        childProcess = require('child_process')
-        util = require('util')
-        tracer.use('child_process', { enabled: true })
-        Bluebird = require('../../../versions/bluebird').get()
+    beforeEach(async () => {
+      tracer = await agent.load('child_process', undefined, { flushInterval: 1 })
+      childProcess = require('child_process')
+      util = require('util')
+      tracer.use('child_process', { enabled: true })
+      Bluebird = require('../../../versions/bluebird').get()
 
-        originalPromise = global.Promise
-        global.Promise = Bluebird
-      })
+      originalPromise = global.Promise
+      global.Promise = Bluebird
     })
 
     afterEach(() => {
@@ -496,12 +494,10 @@ describe('Child process plugin', () => {
       const execSyncMethods = ['execSync']
       let childProcess, tracer
 
-      beforeEach(() => {
-        return agent.load('child_process', undefined, { flushInterval: 1 }).then(() => {
-          tracer = require('../../dd-trace')
-          childProcess = require('child_process')
-          tracer.use('child_process', { enabled: true })
-        })
+      beforeEach(async () => {
+        tracer = await agent.load('child_process', undefined, { flushInterval: 1 })
+        childProcess = require('child_process')
+        tracer.use('child_process', { enabled: true })
       })
 
       afterEach(() => agent.close())
@@ -641,12 +637,10 @@ describe('Child process plugin', () => {
       const execSyncMethods = ['execFileSync', 'spawnSync']
       let childProcess, tracer
 
-      beforeEach(() => {
-        return agent.load('child_process', undefined, { flushInterval: 1 }).then(() => {
-          tracer = require('../../dd-trace')
-          childProcess = require('child_process')
-          tracer.use('child_process', { enabled: true })
-        })
+      beforeEach(async () => {
+        tracer = await agent.load('child_process', undefined, { flushInterval: 1 })
+        childProcess = require('child_process')
+        tracer.use('child_process', { enabled: true })
       })
 
       afterEach(() => agent.close())

--- a/packages/datadog-plugin-protobufjs/test/index.spec.js
+++ b/packages/datadog-plugin-protobufjs/test/index.spec.js
@@ -49,7 +49,7 @@ describe('Plugin', () => {
       })
 
       describe('without configuration', () => {
-        before(() => {
+        before(async () => {
           dateNowStub = sinon.stub(Date, 'now').callsFake(() => {
             const returnValue = mockTime
             mockTime += 50000 // Increment by 50000 ms to ensure each DSM schema is sampled
@@ -57,9 +57,8 @@ describe('Plugin', () => {
           })
           const cache = SchemaBuilder.getCache()
           cache.clear()
-          return agent.load('protobufjs').then(() => {
-            protobuf = require(`../../../versions/protobufjs@${version}`).get()
-          })
+          await agent.load('protobufjs')
+          protobuf = require(`../../../versions/protobufjs@${version}`).get()
         })
 
         after(() => {

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -407,10 +407,9 @@ describe('Plugin', () => {
       let tds
       let connection
 
-      beforeEach(() => {
-        return agent.load('tedious', { dbmPropagationMode: 'service', service: 'custom' }).then(() => {
-          tds = require(`../../../versions/tedious@${version}`).get()
-        })
+      beforeEach(async () => {
+        await agent.load('tedious', { dbmPropagationMode: 'service', service: 'custom' })
+        tds = require(`../../../versions/tedious@${version}`).get()
       })
 
       afterEach(() => {

--- a/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/fs-plugin.spec.js
@@ -178,9 +178,10 @@ describe('AppsecFsPlugin', () => {
 
       afterEach(() => agent.close())
 
-      beforeEach(() => agent.load('fs', undefined, { flushInterval: 1 }).then(() => {
+      beforeEach(async () => {
+        await agent.load('fs', undefined, { flushInterval: 1 })
         fs = require('fs')
-      }))
+      })
 
       it('should mark root operations', () => {
         let count = 0


### PR DESCRIPTION
## Summary

Convert the `agent.load(...).then(...)` setup hooks — and the two `it` bodies in the `fs` instrumentation spec — to `async`/`await` across six plugin and instrumentation specs.

## Why

amqplib and aws-sdk keep their `.then()` hooks: each wraps a callback API with `done`, which Mocha forbids alongside a returned promise.