### PR TITLE
fix(dogstatsd): suppress self-tracing of UDP metric flushes

### DIFF
--- a/packages/dd-trace/src/dogstatsd.js
+++ b/packages/dd-trace/src/dogstatsd.js
@@ -3,11 +3,14 @@
 const dgram = require('dgram')
 const isIP = require('net').isIP
 
+const { storage } = require('../../datadog-core')
 const request = require('./exporters/common/request')
 const log = require('./log')
 const Histogram = require('./histogram')
 const { getAgentUrl } = require('./agent/url')
 const { entityId } = require('./exporters/common/docker')
+
+const legacyStorage = storage('legacy')
 
 const MAX_BUFFER_SIZE = 1024 // limit from the agent
 
@@ -99,14 +102,18 @@ class DogStatsDClient {
   }
 
   _sendUdp (queue) {
-    if (this._family === 0) {
-      this.#lookup(this._host, (err, address, family) => {
-        if (err) return log.error('DogStatsDClient: Host not found', err)
-        this._sendUdpFromQueue(queue, address, family)
-      })
-    } else {
-      this._sendUdpFromQueue(queue, this._host, this._family)
-    }
+    // dgram resolves the local address via the instrumented dns.lookup when it
+    // binds on first send; the noop store keeps that self-traffic off the trace.
+    legacyStorage.run({ noop: true }, () => {
+      if (this._family === 0) {
+        this.#lookup(this._host, (error, address, family) => {
+          if (error) return log.error('DogStatsDClient: Host not found', error)
+          this._sendUdpFromQueue(queue, address, family)
+        })
+      } else {
+        this._sendUdpFromQueue(queue, this._host, this._family)
+      }
+    })
   }
 
   _sendUdpFromQueue (queue, address, family) {

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -296,6 +296,7 @@ describe('dogstatsd', () => {
 
   it('runs the UDP send inside the noop store so its own dns.lookup is not traced', () => {
     const legacyStorage = datadogCore.storage('legacy')
+    const noopBeforeSend = legacyStorage.getHandle()?.noop
     let noopDuringSend
 
     udp4.send = sinon.stub().callsFake(() => {
@@ -309,7 +310,7 @@ describe('dogstatsd', () => {
 
     sinon.assert.called(udp4.send)
     assert.strictEqual(noopDuringSend, true)
-    assert.strictEqual(legacyStorage.getHandle(), undefined)
+    assert.strictEqual(legacyStorage.getHandle()?.noop, noopBeforeSend)
   })
 
   it('runs the UDP send inside the noop store after a DNS lookup resolves the host', () => {

--- a/packages/dd-trace/test/dogstatsd.spec.js
+++ b/packages/dd-trace/test/dogstatsd.spec.js
@@ -9,6 +9,8 @@ const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
+const datadogCore = require('../../datadog-core')
+
 require('./setup/core')
 
 describe('dogstatsd', () => {
@@ -75,6 +77,7 @@ describe('dogstatsd', () => {
 
     const dogstatsd = proxyquire.noPreserveCache().noCallThru()('../src/dogstatsd', {
       dgram,
+      '../../datadog-core': datadogCore,
       './exporters/common/docker': docker,
       './log': log,
     })
@@ -289,6 +292,42 @@ describe('dogstatsd', () => {
 
     sinon.assert.called(udp6.send)
     sinon.assert.notCalled(dns.lookup)
+  })
+
+  it('runs the UDP send inside the noop store so its own dns.lookup is not traced', () => {
+    const legacyStorage = datadogCore.storage('legacy')
+    let noopDuringSend
+
+    udp4.send = sinon.stub().callsFake(() => {
+      noopDuringSend = legacyStorage.getHandle()?.noop
+    })
+
+    client = createDogStatsDClient({ host: '127.0.0.1' })
+
+    client.gauge('test.avg', 1)
+    client.flush()
+
+    sinon.assert.called(udp4.send)
+    assert.strictEqual(noopDuringSend, true)
+    assert.strictEqual(legacyStorage.getHandle(), undefined)
+  })
+
+  it('runs the UDP send inside the noop store after a DNS lookup resolves the host', () => {
+    const legacyStorage = datadogCore.storage('legacy')
+    let noopDuringSend
+
+    udp4.send = sinon.stub().callsFake(() => {
+      noopDuringSend = legacyStorage.getHandle()?.noop
+    })
+
+    client = createDogStatsDClient({ host: 'localhost' })
+
+    client.gauge('test.avg', 1)
+    client.flush()
+
+    sinon.assert.called(dns.lookup)
+    sinon.assert.called(udp4.send)
+    assert.strictEqual(noopDuringSend, true)
   })
 
   it('should support configuration', () => {


### PR DESCRIPTION
## Summary

When DogStatsD delivers metrics over UDP, `dgram` binds the socket on the first send and resolves the local address through the instrumented `dns.lookup`. That lookup ran outside the noop legacy store, so every metric flush emitted a DNS span pointing at the agent host — trace noise the user never created. The HTTP transport already runs inside the noop store via the common request helper; the UDP path did not.

The fix wraps the whole UDP send in the noop store, so both the implicit bind-time lookup and the configured target-host lookup are kept off the trace.

## Test plan

- [ ] `packages/dd-trace/test/dogstatsd.spec.js` — two new regression tests assert the send runs inside the noop store (IP-direct and DNS-resolved host); both fail on master and pass with the fix.

Refs: https://github.com/DataDog/dd-trace-js/issues/4333