### PR TITLE
feat(pg): preserve caller trace context for pooled queries

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -15,6 +15,9 @@ const errorCh = channel('apm:pg:query:error')
 const startPoolQueryCh = channel('datadog:pg:pool:query:start')
 const finishPoolQueryCh = channel('datadog:pg:pool:query:finish')
 
+const poolConnectStartCh = channel('apm:pg:pool:connect:start')
+const poolConnectFinishCh = channel('apm:pg:pool:connect:finish')
+
 // Drivers like pg-promise reuse the same prepared-statement query object across executions; cache
 // the un-injected `text` so the wrap doesn't capture a previous DBM injection as the new original.
 const originalTextCache = new WeakMap()
@@ -30,6 +33,22 @@ addHook({ name: 'pg', versions: ['>=8.0.3'], file: 'lib/client.js' }, Client => 
 })
 
 addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
+  // pg defers a busy pool's connect callback and runs it in the releasing query's async context;
+  // capture the caller's context and restore it around the callback so spans attach to the caller.
+  shimmer.wrap(pg.Pool.prototype, 'connect', connect => function (cb) {
+    if (typeof cb !== 'function' || !poolConnectStartCh.hasSubscribers) {
+      return connect.apply(this, arguments)
+    }
+
+    const ctx = {}
+    arguments[0] = function (...args) {
+      return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+    }
+
+    poolConnectStartCh.publish(ctx)
+
+    return connect.apply(this, arguments)
+  })
   shimmer.wrap(pg.Pool.prototype, 'query', query => wrapPoolQuery(query))
   return pg
 })

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { storage } = require('../../datadog-core')
 const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
@@ -7,6 +8,15 @@ class PGPlugin extends DatabasePlugin {
   static id = 'pg'
   static operation = 'query'
   static system = 'postgres'
+
+  constructor () {
+    super(...arguments)
+
+    this.addSub('apm:pg:pool:connect:start', ctx => {
+      ctx.parentStore = storage('legacy').getStore()
+    })
+    this.addBind('apm:pg:pool:connect:finish', ctx => ctx.parentStore)
+  }
 
   bindStart (ctx) {
     const { params = {}, query, originalText, processId, stream } = ctx

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -372,6 +372,96 @@ describe('Plugin', () => {
         })
       })
 
+      describe('when using a connection pool', () => {
+        let pool
+
+        before(() => {
+          return agent.load('pg')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        beforeEach(() => {
+          pg = require(`../../../versions/pg@${version}`).get()
+
+          pool = new pg.Pool({
+            host: '127.0.0.1',
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test',
+            max: 1,
+          })
+        })
+
+        afterEach(() => {
+          return pool.end()
+        })
+
+        it('keeps a query that waits for a busy pool parented to its own caller', done => {
+          const root = tracer.startSpan('root')
+          const parent1 = tracer.startSpan('parent1', { childOf: root })
+          const parent2 = tracer.startSpan('parent2', { childOf: root })
+
+          agent.assertSomeTraces(traces => {
+            const spans = traces[0]
+            const first = spans.find(span => span.resource === 'SELECT 1 AS one')
+            const second = spans.find(span => span.resource === 'SELECT 2 AS two')
+
+            assert.ok(first, `missing first query span: ${inspect(spans.map(span => span.resource))}`)
+            assert.ok(second, `missing second query span: ${inspect(spans.map(span => span.resource))}`)
+            assert.strictEqual(first.parent_id.toString(), parent1.context().toSpanId())
+            assert.strictEqual(second.parent_id.toString(), parent2.context().toSpanId())
+          })
+            .then(done)
+            .catch(done)
+
+          let remaining = 2
+          const settle = error => {
+            if (error) {
+              done(error)
+            } else if (--remaining === 0) {
+              parent1.finish()
+              parent2.finish()
+              root.finish()
+            }
+          }
+
+          // Both queries are dispatched in the same tick with `max: 1`, so the second one
+          // waits in the pool's pending queue and its connect callback fires from the first
+          // query's release flow — the async context that drops on master.
+          tracer.scope().activate(parent1, () => {
+            pool.query('SELECT 1 AS one', settle)
+          })
+
+          tracer.scope().activate(parent2, () => {
+            pool.query('SELECT 2 AS two', settle)
+          })
+        })
+
+        it('keeps a promise-acquired pooled query parented to its caller', async () => {
+          const parent = tracer.startSpan('promise-parent')
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const span = traces[0].find(query => query.resource === 'SELECT 3 AS three')
+
+            assert.ok(span, `missing query span: ${inspect(traces[0].map(query => query.resource))}`)
+            assert.strictEqual(span.parent_id.toString(), parent.context().toSpanId())
+          })
+
+          await tracer.scope().activate(parent, async () => {
+            const client = await pool.connect()
+            await client.query('SELECT 3 AS three')
+            client.release()
+            parent.finish()
+          })
+
+          await tracePromise
+        })
+      })
+
       describe('with configuration', () => {
         before(() => {
           return agent.load('pg', { service: 'custom', truncate: 12 })


### PR DESCRIPTION
## Summary

`pg.Pool` defers a busy pool's `connect` callback and runs it in the async
context of whichever query released the connection, so a query waiting in
the pending queue attaches to the releasing query's trace instead of its
own caller. Wrapping `Pool.prototype.connect` captures the caller's context
and restores it around the deferred callback via the new
`apm:pg:pool:connect` channels.

## Test plan

- New `datadog-plugin-pg` specs: a busy-pool (`max: 1`) concurrent query and
  a promise-acquired `pool.connect()` query, both asserting the query span is
  parented to its own caller. Fails on master, passes here.

Fixes: https://github.com/DataDog/dd-trace-js/issues/3733
