### PR TITLE
feat(mysql2): preserve caller trace context for pooled queries

### DIFF
--- a/packages/datadog-instrumentations/src/mysql2.js
+++ b/packages/datadog-instrumentations/src/mysql2.js
@@ -207,6 +207,32 @@ function wrapConnection (Connection, version) {
   }
 }
 /**
+ * mysql2 defers a busy pool's `getConnection` callback and runs it in the releasing connection's
+ * async context; capture the caller's context and restore it around the callback so spans created
+ * by the queued query attach to the caller rather than the previous query that freed the connection.
+ *
+ * @param {Function} Pool
+ * @returns {Function}
+ */
+function wrapGetConnection (Pool) {
+  const connectionStartCh = channel('apm:mysql2:connection:start')
+  const connectionFinishCh = channel('apm:mysql2:connection:finish')
+
+  shimmer.wrap(Pool.prototype, 'getConnection', getConnection => function (cb) {
+    const ctx = {}
+    arguments[0] = function (...args) {
+      return connectionFinishCh.runStores(ctx, cb, this, ...args)
+    }
+
+    connectionStartCh.publish(ctx)
+
+    return getConnection.apply(this, arguments)
+  })
+
+  return Pool
+}
+
+/**
  * @param {Function} Pool
  * @param {string} version
  * @returns {Function}
@@ -214,6 +240,8 @@ function wrapConnection (Connection, version) {
 function wrapPool (Pool, version) {
   const startOuterQueryCh = channel('datadog:mysql2:outerquery:start')
   const shouldEmitEndAfterQueryAbort = satisfies(version, '>=1.3.3')
+
+  wrapGetConnection(Pool)
 
   shimmer.wrap(Pool.prototype, 'query', query => function (sql, values, cb) {
     if (!startOuterQueryCh.hasSubscribers) return query.apply(this, arguments)
@@ -371,6 +399,12 @@ addHook(
 addHook(
   { name: 'mysql2', file: 'lib/pool.js', versions: ['1 - 3.11.4'] },
   /** @type {(moduleExports: unknown, version: string) => unknown} */ (wrapPool)
+)
+
+// mysql2 >=3.11.5 moved the pool onto BasePool in lib/base/pool.js.
+addHook(
+  { name: 'mysql2', file: 'lib/base/pool.js', versions: ['>=3.11.5'] },
+  /** @type {(moduleExports: unknown, version: string) => unknown} */ (wrapGetConnection)
 )
 
 // PoolNamespace.prototype.query does not exist in mysql2<2.3.0

--- a/packages/datadog-plugin-mariadb/test/index.spec.js
+++ b/packages/datadog-plugin-mariadb/test/index.spec.js
@@ -680,6 +680,40 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('runs a queued pool query callback in its own caller context', done => {
+          const span1 = tracer.startSpan('test1')
+          const span2 = tracer.startSpan('test2')
+          let pending = 2
+
+          const check = expected => error => {
+            if (error) {
+              done(error)
+              return
+            }
+            try {
+              assert.strictEqual(tracer.scope().active(), expected)
+            } catch (assertionError) {
+              done(assertionError)
+              return
+            }
+            if (--pending === 0) {
+              done()
+            }
+          }
+
+          // Both queries are dispatched in the same tick with `connectionLimit: 1`, so the second
+          // waits in the pool's connection queue and its callback fires from the first query's
+          // release flow — the async context that drops without the getConnection wrap.
+          tracer.trace('test', () => {
+            tracer.scope().activate(span1, () => {
+              pool.query('SELECT 1 AS one', check(span1))
+            })
+            tracer.scope().activate(span2, () => {
+              pool.query('SELECT 2 AS two', check(span2))
+            })
+          })
+        })
       })
 
       if (semver.intersects(version, '>=3')) {

--- a/packages/datadog-plugin-mysql/test/index.spec.js
+++ b/packages/datadog-plugin-mysql/test/index.spec.js
@@ -310,6 +310,40 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('runs a queued pool query callback in its own caller context', done => {
+          const span1 = tracer.startSpan('test1')
+          const span2 = tracer.startSpan('test2')
+          let pending = 2
+
+          const check = expected => error => {
+            if (error) {
+              done(error)
+              return
+            }
+            try {
+              assert.strictEqual(tracer.scope().active(), expected)
+            } catch (assertionError) {
+              done(assertionError)
+              return
+            }
+            if (--pending === 0) {
+              done()
+            }
+          }
+
+          // Both queries are dispatched in the same tick with `connectionLimit: 1`, so the second
+          // waits in the pool's connection queue and its callback fires from the first query's
+          // release flow — the async context that drops without the getConnection wrap.
+          tracer.trace('test', () => {
+            tracer.scope().activate(span1, () => {
+              pool.query('SELECT 1 AS one', check(span1))
+            })
+            tracer.scope().activate(span2, () => {
+              pool.query('SELECT 2 AS two', check(span2))
+            })
+          })
+        })
       })
 
       describe('comment injection interaction with peer service', () => {

--- a/packages/datadog-plugin-mysql2/test/index.spec.js
+++ b/packages/datadog-plugin-mysql2/test/index.spec.js
@@ -374,6 +374,40 @@ describe('Plugin', () => {
             })
           })
         })
+
+        it('runs a queued pool query callback in its own caller context', done => {
+          const span1 = tracer.startSpan('test1')
+          const span2 = tracer.startSpan('test2')
+          let pending = 2
+
+          const check = expected => error => {
+            if (error) {
+              done(error)
+              return
+            }
+            try {
+              assert.strictEqual(tracer.scope().active(), expected)
+            } catch (assertionError) {
+              done(assertionError)
+              return
+            }
+            if (--pending === 0) {
+              done()
+            }
+          }
+
+          // Both queries are dispatched in the same tick with `connectionLimit: 1`, so the second
+          // waits in the pool's connection queue and its callback fires from the first query's
+          // release flow — the async context that drops without the getConnection wrap.
+          tracer.trace('test', () => {
+            tracer.scope().activate(span1, () => {
+              pool.query('SELECT 1 AS one', check(span1))
+            })
+            tracer.scope().activate(span2, () => {
+              pool.query('SELECT 2 AS two', check(span2))
+            })
+          })
+        })
       })
       describe('with DBM propagation enabled with service using plugin configurations', () => {
         let connection


### PR DESCRIPTION
## Summary

`mysql2` pools never wrapped `getConnection`, so a busy pool's connection
callback runs in the async context of whichever query released the
connection and a queued query attaches to the wrong trace. This wraps
`getConnection` on both the legacy `Pool` (mysql2 <=3.11.4) and `BasePool`
(>=3.11.5, where the pool moved to `lib/base/pool.js`) to capture and restore
the caller's context via the existing `apm:mysql2:connection` channels.

mysql and mariadb already wrap `getConnection`; the same queued-callback test
is added to both suites to pin that protection against future refactors.

## Test plan

- New queued-pool-callback regression test in the mysql2, mysql, and mariadb
  suites. The mysql2 case fails on master (hangs / wrong context) and passes
  here; mysql and mariadb pass on master too.
