### PR TITLE
feat(aws-sdk): create SQS consumer spans for promise-based receives

### DIFF
--- a/packages/datadog-instrumentations/src/aws-sdk.js
+++ b/packages/datadog-instrumentations/src/aws-sdk.js
@@ -150,6 +150,7 @@ function wrapDeserialize (deserialize, headersCh, responseIndex = 0) {
 function wrapSmithySend (send) {
   return function (command, ...args) {
     const cb = args.at(-1)
+    const cbExists = typeof cb === 'function'
     const serviceIdentifier = this.config.serviceId.toLowerCase()
     const channelSuffix = getChannelSuffix(serviceIdentifier)
     const channels = getChannelBag(channelSuffix)
@@ -188,6 +189,7 @@ function wrapSmithySend (send) {
       operation,
       awsService: clientName,
       request,
+      cbExists,
     }
 
     return channels.start.runStores(ctx, () => {
@@ -197,7 +199,7 @@ function wrapSmithySend (send) {
         channels.region.publish(ctx)
       })
 
-      if (typeof cb === 'function') {
+      if (cbExists) {
         args[args.length - 1] = shimmer.wrapCallback(cb, cb => function (err, result) {
           addResponse(ctx, err, result)
 

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -172,18 +172,12 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     })
 
     this.addSub(`apm:aws:request:complete:${this.serviceIdentifier}`, ctx => {
-      const { response, cbExists = false, currentStore } = ctx
+      const { response, currentStore } = ctx
       if (!currentStore) return
       const { span } = currentStore
       if (!span) return
 
       storage('legacy').run(currentStore, () => {
-        // try to extract DSM context from response if no callback exists as extraction normally happens in CB
-        if (!cbExists && this.serviceIdentifier === 'sqs') {
-          const params = response.request.params
-          const operation = response.request.operation
-          this.responseExtractDSMContext(operation, params, response.data ?? response, span)
-        }
         this.addResponseTags(span, response)
 
         if (this._tracerConfig?.DD_TRACE_AWS_ADD_SPAN_POINTERS) {

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -54,47 +54,59 @@ class Sqs extends BaseAwsSdkPlugin {
     // in the base class
     this.requestTags = new WeakMap()
 
-    this.addBind('apm:aws:response:start:sqs', ctx => {
-      const { request, response } = ctx
-      const contextExtraction = this.responseExtract(request.params, request.operation, response)
+    this.addBind('apm:aws:response:start:sqs', ctx => this.#startResponseSpan(ctx))
 
-      let store = this._parentMap.get(request)
-      let span
-      let parsedMessageAttributes
-      let parsedFirstBody
-      let firstBodyChecked = false
-      if (contextExtraction !== undefined) {
-        parsedFirstBody = contextExtraction.parsedBody
-        firstBodyChecked = contextExtraction.bodyChecked === true
-        if (contextExtraction.datadogContext !== undefined) {
-          ctx.needsFinish = true
-          const options = {
-            childOf: contextExtraction.datadogContext,
-            meta: {
-              ...this.requestTags.get(request),
-              'span.kind': 'server',
-            },
-            integrationName: 'aws-sdk',
-          }
-          parsedMessageAttributes = contextExtraction.parsedAttributes
-          span = this.startSpan('aws.response', options, ctx)
-          store = ctx.currentStore
-        }
-      }
-
-      // Extract DSM context after, as we might not have a parent-child but may have a DSM context.
-      this.responseExtractDSMContext(
-        request.operation, request.params, response, span ?? null,
-        { parsedAttributes: parsedMessageAttributes, parsedFirstBody, firstBodyChecked }
-      )
-
-      return store
+    // No-callback receives (promises, event emitters) never publish response:start, so link and
+    // finish the consumer span here instead. Callback paths reach the same logic via the bind above.
+    this.addSub('apm:aws:request:complete:sqs', ctx => {
+      if (ctx.cbExists) return
+      // v2 nests the SDK payload under response.data; v3 spreads the output onto response.
+      const responseCtx = { request: ctx.request, response: ctx.response?.data ?? ctx.response }
+      this.#startResponseSpan(responseCtx)
+      if (responseCtx.needsFinish) this.finish(responseCtx)
     })
 
     this.addSub('apm:aws:response:finish:sqs', ctx => {
       if (!ctx.needsFinish) return
       this.finish(ctx)
     })
+  }
+
+  #startResponseSpan (ctx) {
+    const { request, response } = ctx
+    const contextExtraction = this.responseExtract(request.params, request.operation, response)
+
+    let store = this._parentMap.get(request)
+    let span
+    let parsedMessageAttributes
+    let parsedFirstBody
+    let firstBodyChecked = false
+    if (contextExtraction !== undefined) {
+      parsedFirstBody = contextExtraction.parsedBody
+      firstBodyChecked = contextExtraction.bodyChecked === true
+      if (contextExtraction.datadogContext !== undefined) {
+        ctx.needsFinish = true
+        const options = {
+          childOf: contextExtraction.datadogContext,
+          meta: {
+            ...this.requestTags.get(request),
+            'span.kind': 'server',
+          },
+          integrationName: 'aws-sdk',
+        }
+        parsedMessageAttributes = contextExtraction.parsedAttributes
+        span = this.startSpan('aws.response', options, ctx)
+        store = ctx.currentStore
+      }
+    }
+
+    // Extract DSM context after, as we might not have a parent-child but may have a DSM context.
+    this.responseExtractDSMContext(
+      request.operation, request.params, response, span ?? null,
+      { parsedAttributes: parsedMessageAttributes, parsedFirstBody, firstBodyChecked }
+    )
+
+    return store
   }
 
   operationFromRequest (request) {

--- a/packages/datadog-plugin-aws-sdk/src/services/sqs.js
+++ b/packages/datadog-plugin-aws-sdk/src/services/sqs.js
@@ -85,18 +85,23 @@ class Sqs extends BaseAwsSdkPlugin {
       parsedFirstBody = contextExtraction.parsedBody
       firstBodyChecked = contextExtraction.bodyChecked === true
       if (contextExtraction.datadogContext !== undefined) {
-        ctx.needsFinish = true
-        const options = {
-          childOf: contextExtraction.datadogContext,
-          meta: {
-            ...this.requestTags.get(request),
-            'span.kind': 'server',
-          },
-          integrationName: 'aws-sdk',
-        }
         parsedMessageAttributes = contextExtraction.parsedAttributes
-        span = this.startSpan('aws.response', options, ctx)
-        store = ctx.currentStore
+        // request:start records requestTags only after the isEnabled gate, so an absent entry
+        // means this consumer is disabled — gate on it instead of paying isEnabled again here.
+        const requestTags = this.requestTags.get(request)
+        if (requestTags !== undefined) {
+          ctx.needsFinish = true
+          const options = {
+            childOf: contextExtraction.datadogContext,
+            meta: {
+              ...requestTags,
+              'span.kind': 'server',
+            },
+            integrationName: 'aws-sdk',
+          }
+          span = this.startSpan('aws.response', options, ctx)
+          store = ctx.currentStore
+        }
       }
     }
 

--- a/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
+++ b/packages/datadog-plugin-aws-sdk/test/spec_helpers.js
@@ -8,6 +8,18 @@ const AWS_SDK_V3_RANGE = NODE_MAJOR === 18 ? '3.0.0' : '>3.0.0'
 const sort = spans => spans.sort((a, b) => a.start.toString() >= b.start.toString() ? 1 : -1)
 
 /**
+ * @param {object} client SQS client (v2 `AWS.SQS` or v3 aggregated client).
+ * @param {string} method Operation name, e.g. `sendMessage`.
+ * @param {object} params Operation parameters.
+ * @returns {Promise<object>} Resolves with the operation result.
+ */
+function callViaPromise (client, method, params) {
+  const result = client[method](params)
+  // v2 returns an AWS.Request exposing `.promise()`; v3's aggregated client returns a Promise directly.
+  return typeof result.promise === 'function' ? result.promise() : result
+}
+
+/**
  * @callback AwsSdkVersionCallback
  * @param {string} version
  * @param {string} moduleName
@@ -67,6 +79,7 @@ function getAwsSdkV3Range (range) {
 }
 
 const helpers = {
+  callViaPromise,
   sort,
   withAwsSdkV2Versions,
   withAwsSdkV3Versions,

--- a/packages/datadog-plugin-aws-sdk/test/sqs.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.dsm.spec.js
@@ -12,7 +12,7 @@ const { ENTRY_PARENT_HASH } = require('../../dd-trace/src/datastreams/processor'
 const propagationHash = require('../../dd-trace/src/propagation-hash')
 const agent = require('../../dd-trace/test/plugins/agent')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
-const { setup, withAwsSdkVersions } = require('./spec_helpers')
+const { callViaPromise, setup, withAwsSdkVersions } = require('./spec_helpers')
 
 const getQueueParams = (queueName) => {
   return {
@@ -28,7 +28,7 @@ describe('Plugin', () => {
     this.timeout(10000)
     setup()
 
-    withAwsSdkVersions((version, moduleName) => {
+    withAwsSdkVersions((version, moduleName, resolvedVersion) => {
       let AWS
       let sqs
       let queueNameDSM
@@ -40,6 +40,8 @@ describe('Plugin', () => {
       let tracer
 
       const sqsClientName = moduleName === '@aws-sdk/smithy-client' ? '@aws-sdk/client-sqs' : 'aws-sdk'
+      // AWS SDK v2 added `.promise()` in 2.3.0; older v2 releases have no promise API to exercise.
+      const promisesSupported = moduleName === '@aws-sdk/smithy-client' || semver.gte(resolvedVersion, '2.3.0')
 
       beforeEach(() => {
         const id = randomUUID()
@@ -176,14 +178,14 @@ describe('Plugin', () => {
           })
         })
 
-        if (sqsClientName === 'aws-sdk' && semver.intersects(version, '>=2.3')) {
-          it('Should set pathway hash tag on a span when consuming and promise() was used over a callback',
+        if (promisesSupported) {
+          it('Should set pathway hash tag on the consumer span when promises are used over a callback',
             async () => {
               let consumeSpanMeta = {}
               const tracePromise = agent.assertSomeTraces(traces => {
                 const span = traces[0][0]
 
-                if (span.name === 'aws.request' && span.meta['aws.operation'] === 'receiveMessage') {
+                if (span.name === 'aws.response') {
                   consumeSpanMeta = span.meta
                 }
 
@@ -192,8 +194,8 @@ describe('Plugin', () => {
                 })
               })
 
-              await sqs.sendMessage({ MessageBody: 'test DSM', QueueUrl: QueueUrlDsm }).promise()
-              await sqs.receiveMessage({ QueueUrl: QueueUrlDsm }).promise()
+              await callViaPromise(sqs, 'sendMessage', { MessageBody: 'test DSM', QueueUrl: QueueUrlDsm })
+              await callViaPromise(sqs, 'receiveMessage', { QueueUrl: QueueUrlDsm, MessageAttributeNames: ['.*'] })
 
               return tracePromise
             })

--- a/packages/datadog-plugin-aws-sdk/test/sqs.dsm.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.dsm.spec.js
@@ -194,10 +194,13 @@ describe('Plugin', () => {
                 })
               })
 
-              await callViaPromise(sqs, 'sendMessage', { MessageBody: 'test DSM', QueueUrl: QueueUrlDsm })
-              await callViaPromise(sqs, 'receiveMessage', { QueueUrl: QueueUrlDsm, MessageAttributeNames: ['.*'] })
-
-              return tracePromise
+              await Promise.all([
+                tracePromise,
+                (async () => {
+                  await callViaPromise(sqs, 'sendMessage', { MessageBody: 'test DSM', QueueUrl: QueueUrlDsm })
+                  await callViaPromise(sqs, 'receiveMessage', { QueueUrl: QueueUrlDsm, MessageAttributeNames: ['.*'] })
+                })(),
+              ])
             })
         }
 

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -3,12 +3,14 @@
 const assert = require('node:assert/strict')
 const { randomUUID } = require('node:crypto')
 const { inspect } = require('node:util')
+
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+const semver = require('semver')
 
 const agent = require('../../dd-trace/test/plugins/agent')
 const { withNamingSchema, withPeerService } = require('../../dd-trace/test/setup/mocha')
 const { assertObjectContains } = require('../../../integration-tests/helpers')
-const { setup, withAwsSdkVersions } = require('./spec_helpers')
+const { callViaPromise, setup, withAwsSdkVersions } = require('./spec_helpers')
 const { rawExpectedSchema } = require('./sqs-naming')
 
 const getQueueParams = (queueName) => {
@@ -25,7 +27,7 @@ describe('Plugin', () => {
     this.timeout(10000)
     setup()
 
-    withAwsSdkVersions((version, moduleName) => {
+    withAwsSdkVersions((version, moduleName, resolvedVersion) => {
       let AWS
       let sqs
       let queueName
@@ -34,6 +36,8 @@ describe('Plugin', () => {
       let tracer
 
       const sqsClientName = moduleName === '@aws-sdk/smithy-client' ? '@aws-sdk/client-sqs' : 'aws-sdk'
+      // AWS SDK v2 added `.promise()` in 2.3.0; older v2 releases have no promise API to exercise.
+      const promisesSupported = moduleName === '@aws-sdk/smithy-client' || semver.gte(resolvedVersion, '2.3.0')
 
       beforeEach(() => {
         const id = randomUUID()
@@ -166,6 +170,35 @@ describe('Plugin', () => {
             })
           })
         })
+
+        if (promisesSupported) {
+          it('should propagate the tracing context from the producer to the consumer with promises', async () => {
+            let parentId
+            let traceId
+
+            const parentPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0][0]
+
+              assert.strictEqual(span.resource.startsWith('sendMessage'), true)
+
+              parentId = span.span_id.toString()
+              traceId = span.trace_id.toString()
+            }, { timeoutMs: 10000 })
+
+            const childPromise = agent.assertSomeTraces(traces => {
+              const span = traces[0][0]
+
+              assert.strictEqual(typeof parentId, 'string')
+              assert.strictEqual(span.parent_id.toString(), parentId)
+              assert.strictEqual(span.trace_id.toString(), traceId)
+            }, { timeoutMs: 10000 })
+
+            await callViaPromise(sqs, 'sendMessage', { MessageBody: 'test body', QueueUrl })
+            await callViaPromise(sqs, 'receiveMessage', { QueueUrl, MessageAttributeNames: ['.*'] })
+
+            await Promise.all([parentPromise, childPromise])
+          })
+        }
 
         it('should propagate the tracing context from the producer to the consumer in batch operations', async () => {
           let parentId

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -439,6 +439,39 @@ describe('Plugin', () => {
             }
           }, 250)
         })
+
+        it('should not create a consumer span when the consumer is disabled', async () => {
+          let consumerSpans = 0
+          const callViaCallback = (method, params) => new Promise((resolve, reject) => {
+            sqs[method](params, error => error ? reject(error) : resolve())
+          })
+
+          await Promise.all([
+            // Resolves the moment a consumer span leaks; otherwise it times out (swallowed) with none seen.
+            agent.assertSomeTraces(traces => {
+              for (const trace of traces) {
+                for (const span of trace) {
+                  if (span.name === 'aws.response') {
+                    consumerSpans++
+                    return
+                  }
+                }
+              }
+              throw new Error('no consumer span yet')
+            }).catch(() => {}),
+            (async () => {
+              await callViaCallback('sendMessage', { MessageBody: 'callback body', QueueUrl })
+              await callViaCallback('receiveMessage', { QueueUrl, MessageAttributeNames: ['.*'] })
+
+              if (promisesSupported) {
+                await callViaPromise(sqs, 'sendMessage', { MessageBody: 'promise body', QueueUrl })
+                await callViaPromise(sqs, 'receiveMessage', { QueueUrl, MessageAttributeNames: ['.*'] })
+              }
+            })(),
+          ])
+
+          assert.strictEqual(consumerSpans, 0)
+        })
       })
     })
   })

--- a/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/sqs.spec.js
@@ -193,10 +193,14 @@ describe('Plugin', () => {
               assert.strictEqual(span.trace_id.toString(), traceId)
             }, { timeoutMs: 10000 })
 
-            await callViaPromise(sqs, 'sendMessage', { MessageBody: 'test body', QueueUrl })
-            await callViaPromise(sqs, 'receiveMessage', { QueueUrl, MessageAttributeNames: ['.*'] })
-
-            await Promise.all([parentPromise, childPromise])
+            await Promise.all([
+              parentPromise,
+              childPromise,
+              (async () => {
+                await callViaPromise(sqs, 'sendMessage', { MessageBody: 'test body', QueueUrl })
+                await callViaPromise(sqs, 'receiveMessage', { QueueUrl, MessageAttributeNames: ['.*'] })
+              })(),
+            ])
           })
         }
 


### PR DESCRIPTION
## Summary

Promise- and event-emitter-based SQS `receiveMessage` calls produced no consumer span and no
producer→consumer link — only DSM context was extracted. The channel that builds the
`aws.response` consumer span fires only on the callback path, and the v3 Smithy send wrapper
never set `cbExists`, so a no-callback receive could not be distinguished from a callback one.

No-callback receives now start and finish the consumer span on `request:complete`, running the
same span-and-DSM extraction the callback path already ran. The base plugin's DSM-only branch
for the no-callback case is dropped so the extraction runs exactly once.

## Test plan

- New regression in `sqs.spec.js`: a promise-based `receiveMessage` links to the producer span —
  fails on master, passes here — exercised across the supported v2 and v3 lines.
- `sqs.dsm.spec.js` extended to assert the `aws.response` span on the promise path.

Fixes: https://github.com/DataDog/dd-trace-js/issues/1680