### PR TITLE
fix(vitest): report vitest retry errors

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/early-flake-detection.mjs
@@ -1,11 +1,20 @@
-import { describe, test, expect } from 'vitest'
+import { afterEach, describe, test, expect } from 'vitest'
 import { sum } from './sum'
 
 let numAttempt = 0
 let numOtherAttempt = 0
 let numLastAttempt = 0
+let numCurrentErrorAttempt = 0
+let shouldFailCurrentErrorAfterEach = false
 
 describe('early flake detection', () => {
+  afterEach(() => {
+    if (shouldFailCurrentErrorAfterEach) {
+      shouldFailCurrentErrorAfterEach = false
+      throw new Error('afterEach failure')
+    }
+  })
+
   test('can retry tests that eventually pass', { repeats: process.env.SHOULD_REPEAT && 2 }, () => {
     expect(sum(1, 2)).to.equal(numAttempt++ > 1 ? 3 : 4)
   })
@@ -41,5 +50,15 @@ describe('early flake detection', () => {
       await new Promise(resolve => setTimeout(resolve, 5100))
       expect(sum(1, 2)).to.equal(3)
     }, 7000)
+  }
+  if (process.env.SHOULD_ADD_CURRENT_ERROR_TEST) {
+    test('reports the current failed attempt error', () => {
+      const currentAttempt = numCurrentErrorAttempt++
+
+      if (currentAttempt === 0 || currentAttempt === 2 || currentAttempt === 5 || currentAttempt === 8) {
+        shouldFailCurrentErrorAfterEach = true
+        throw new Error(`failure ${currentAttempt}`)
+      }
+    })
   }
 })

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -14,6 +14,11 @@ const {
 } = require('../helpers')
 const { FakeCiVisIntake } = require('../ci-visibility-intake')
 const {
+  ERROR_MESSAGE,
+  ERROR_STACK,
+  ERROR_TYPE,
+} = require('../../packages/dd-trace/src/constants')
+const {
   TEST_STATUS,
   TEST_TYPE,
   TEST_IS_RETRY,
@@ -979,6 +984,94 @@ versions.forEach((version) => {
               TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
               NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
               SHOULD_ADD_SLOW_DURATION_TEST: '1',
+            },
+          }
+        )
+
+        const [[exitCode]] = await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        assert.strictEqual(exitCode, 0)
+      })
+
+      it('reports the error from each failed EFD attempt', async () => {
+        receiver.setSettings({
+          early_flake_detection: {
+            enabled: true,
+            slow_test_retries: {
+              '5s': 9,
+            },
+            faulty_session_threshold: 100,
+          },
+          known_tests_enabled: true,
+        })
+
+        receiver.setKnownTests({
+          vitest: {},
+        })
+
+        const testName = 'early flake detection reports the current failed attempt error'
+        const eventsPromise = receiver
+          .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', payloads => {
+            const events = payloads.flatMap(({ payload }) => payload.events)
+            const tests = events
+              .filter(event => event.type === 'test')
+              .map(test => test.content)
+              .filter(test => test.meta[TEST_NAME] === testName)
+              .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+            assert.strictEqual(tests.length, 10)
+
+            const failedAttempts = tests.filter(test => test.meta[TEST_STATUS] === 'fail')
+            assert.deepStrictEqual(
+              failedAttempts.map(test => ({
+                isRetry: test.meta[TEST_IS_RETRY],
+                retryReason: test.meta[TEST_RETRY_REASON],
+                errorType: test.meta[ERROR_TYPE],
+                errorMessage: test.meta[ERROR_MESSAGE],
+              })),
+              [
+                {
+                  isRetry: undefined,
+                  retryReason: undefined,
+                  errorType: 'Error',
+                  errorMessage: 'failure 0',
+                },
+                {
+                  isRetry: 'true',
+                  retryReason: TEST_RETRY_REASON_TYPES.efd,
+                  errorType: 'Error',
+                  errorMessage: 'failure 2',
+                },
+                {
+                  isRetry: 'true',
+                  retryReason: TEST_RETRY_REASON_TYPES.efd,
+                  errorType: 'Error',
+                  errorMessage: 'failure 5',
+                },
+                {
+                  isRetry: 'true',
+                  retryReason: TEST_RETRY_REASON_TYPES.efd,
+                  errorType: 'Error',
+                  errorMessage: 'failure 8',
+                },
+              ]
+            )
+            failedAttempts.forEach(test => {
+              assert.ok(
+                test.meta[ERROR_STACK],
+                `Expected failed attempt error stack. Test event: ${inspect(test)}`
+              )
+            })
+          }, 55_000)
+
+        childProcess = exec(
+          './node_modules/.bin/vitest run -t "reports the current failed attempt error"',
+          {
+            cwd,
+            env: {
+              ...getCiVisAgentlessConfig(receiver.port),
+              TEST_DIR: 'ci-visibility/vitest-tests/early-flake-detection*',
+              NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              SHOULD_ADD_CURRENT_ERROR_TEST: '1',
             },
           }
         )

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -57,6 +57,7 @@ const codeCoverageReportCh = channel('ci:vitest:coverage-report')
 
 const taskToCtx = new WeakMap()
 const taskToStatuses = new WeakMap()
+const taskToReportedErrorCount = new WeakMap()
 const attemptToFixTaskToStatuses = new WeakMap()
 const originalHookFns = new WeakMap()
 const newTasks = new WeakSet()
@@ -318,6 +319,23 @@ function recordFinalAttemptToFixExecution (task, status, providedContext) {
 
 function disableFrameworkRetries (task) {
   task.retry = 0
+}
+
+/**
+ * Vitest accumulates retry and repeat errors on one task result. The first error added since
+ * the last reported attempt is the primary error for the failed attempt currently being reported.
+ *
+ * @param {object} task
+ * @param {Array<object> | undefined} errors
+ * @returns {object | undefined}
+ */
+function getCurrentAttemptTestError (task, errors) {
+  if (!errors?.length) return
+
+  const previousErrorCount = taskToReportedErrorCount.get(task) ?? 0
+  const testError = errors[previousErrorCount] ?? errors[0]
+  taskToReportedErrorCount.set(task, errors.length)
+  return testError
 }
 
 /**
@@ -993,7 +1011,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
       const promises = {}
       const shouldSetProbe = isDiEnabled && numAttempt === 1
       const ctx = taskToCtx.get(task)
-      const testError = task.result?.errors?.[0]
+      const testError = getCurrentAttemptTestError(task, task.result?.errors)
       if (ctx) {
         testErrorCh.publish({
           error: testError,
@@ -1023,7 +1041,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
       const ctx = taskToCtx.get(task)
       if (ctx) {
         if (lastExecutionStatus === 'fail') {
-          const testError = task.result?.errors?.[0]
+          const testError = getCurrentAttemptTestError(task, task.result?.errors)
           testErrorCh.publish({ error: testError, ...ctx.currentStore })
         } else {
           testPassCh.publish({ task, ...ctx.currentStore })
@@ -1047,7 +1065,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
 
       const ctx = taskToCtx.get(task)
       if (lastExecutionStatus === 'fail') {
-        const testError = task.result?.errors?.[0]
+        const testError = getCurrentAttemptTestError(task, task.result?.errors)
         testErrorCh.publish({ error: testError, ...ctx.currentStore })
       } else {
         testPassCh.publish({ task, ...ctx.currentStore })
@@ -1396,7 +1414,7 @@ addHook({
 
       if (result) {
         const { state, duration, errors } = result
-        const testError = errors?.[0]
+        const testError = getCurrentAttemptTestError(task, errors)
         if (attemptToFixTasks.has(task)) {
           const status = getFinalAttemptToFixStatus(task, state, isSwitchedStatus, testCtx)
           recordFinalAttemptToFixExecution(task, status, providedContext)


### PR DESCRIPTION
### What does this PR do?
Fixes Vitest CI Visibility EFD retry error reporting by using the first newly accumulated Vitest error for each failed attempt.

### Motivation
Vitest stores retry errors on one task result, and dd-trace was reading the first error. In early flake detection, later failed retries could therefore report the first failure error instead of the error from the current failed attempt.

### Additional Notes
The regression also adds a failing afterEach to each failed EFD attempt, so same-attempt secondary errors do not replace the primary test error.

Validated with:
- ./node_modules/.bin/mocha --timeout 180000 integration-tests/vitest/vitest.core.spec.js --grep "reports the error from each failed EFD attempt"