### PR TITLE
ci(release): skip release proposal on weekends

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -3,7 +3,7 @@ name: "[Release Proposal]"
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 5 * * *
+    - cron: 0 5 * * 1-5
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
## Summary

- Change the release proposal cron schedule from `0 5 * * *` (daily) to `0 5 * * 1-5` (Monday–Friday only)

## Test Plan

- [ ] Verify the workflow does not trigger on Saturday or Sunday

> Generated by Claude Code