### PR TITLE
fix(profiling): map GC kind=2 to minor_mark_sweep so MinorMS doesn't crash the profiler

### DIFF
--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -12,6 +12,7 @@ const {
   ValueType,
 } = require('../../../../../vendor/dist/pprof-format')
 const { availableParallelism, effectiveLibuvThreadCount } = require('../libuv-size')
+const { NODE_MAJOR } = require('../../../../../version')
 const { END_TIMESTAMP_LABEL, SPAN_ID_LABEL, LOCAL_ROOT_SPAN_ID_LABEL, encodeProfileAsync } = require('./shared')
 const PoissonProcessSamplingFilter = require('./poisson')
 // perf_hooks uses millis, with fractional part representing nanos. We emit nanos into the pprof file.
@@ -82,6 +83,17 @@ class GCDecorator {
         this.kindLabels[value] = labelFromStr(stringTable, kindLabelKey, kind)
       }
     }
+
+    // V8's Minor Mark-Sweep collector (--minor-ms, stable in Node 22+) emits
+    // GC events with kind=2, but Node does not expose a corresponding
+    // NODE_PERFORMANCE_GC_* constant, so the loop above misses it and
+    // kindLabels[2] would otherwise be undefined. The runtime_metrics module
+    // handles this case in its gcType() switch; mirror that here so the
+    // profiler doesn't crash with "TypeError: Cannot read properties of
+    // undefined (reading 'key')" inside pprof Sample/Label serialization on
+    // the first MinorMS GC event.
+    const minorMSLabel = NODE_MAJOR >= 22 ? 'minor_mark_sweep' : 'minor_mark_compact'
+    this.kindLabels[2] = labelFromStr(stringTable, kindLabelKey, minorMSLabel)
   }
 
   decorateSample (sampleInput, item) {


### PR DESCRIPTION
Fixes #8839.

## What

`GCDecorator` in `packages/dd-trace/src/profiling/profilers/events.js` builds its `kindLabels` table from `perf_hooks.constants.NODE_PERFORMANCE_GC_*`. V8's `--minor-ms` flag (stable in Node 22+) emits GC events with `kind=2`, but Node does not expose a `NODE_PERFORMANCE_GC_*` constant for it — `perf_hooks.constants` only exposes {MAJOR=4, MINOR=1, INCREMENTAL=8, WEAKCB=16}. So `kindLabels[2]` is `undefined`, and on the first MinorMS event the profiler crashes:

```
TypeError: Cannot read properties of undefined (reading 'key')
    at new Label (.../pprof-format/index.js)
    at create    (.../pprof-format/index.js)
    at Array.map (<anonymous>)
    at new Sample (.../pprof-format/index.js)
    at #createSample (.../profilers/events.js:325)
    at EventSerializer.addEvent (.../events.js:268)
    at NodeApiEventSource.add   (.../events.js:350)
    at [kDispatch] (node:internal/perf/observe:354)
```

## Fix

Mirror the kind=2 mapping that `runtime_metrics.js` already has into `GCDecorator`. The mapping label matches `runtime_metrics.js`:

```js
const minorMSLabel = NODE_MAJOR >= 22 ? 'minor_mark_sweep' : 'minor_mark_compact'
this.kindLabels[2] = labelFromStr(stringTable, kindLabelKey, minorMSLabel)
```

Diff is 12 lines (+ a comment explaining the gap and a cross-reference to `runtime_metrics.js`).

## Verification

Confirmed on Node 25.9.0 that V8 with `--minor-ms` emits `kind=2`:

```
$ node --minor-ms -e '
const obs = new (require("perf_hooks").PerformanceObserver)(l =>
  console.log([...new Set(l.getEntries().map(e => e.detail?.kind))]))
obs.observe({ type: "gc" })
const a = []
for (let i = 0; i < 200; i++) a.push(new Array(50000).fill(i)); a.length = 0
'
[ 2, 8, 4 ]
```

And that `perf_hooks.constants` does not expose a constant for kind=2:

```
NODE_PERFORMANCE_GC_MAJOR       = 4
NODE_PERFORMANCE_GC_MINOR       = 1
NODE_PERFORMANCE_GC_INCREMENTAL = 8
NODE_PERFORMANCE_GC_WEAKCB      = 16
```

After the patch, simulating the `kindLabels` build:

```
Populated indices: [1, 2, 4, 8, 16]
kindLabels[2] = Label { key: 'gc type', str: 'minor_mark_sweep' }
```

## Notes

- Reproduction details and full upstream context are in the linked issue (#8839).
- The change is intentionally minimal — adds one explicit mapping + a comment, doesn't restructure the auto-discovery loop. A more defensive approach (fallback to `'unknown'` when `kindLabels[kind]` is undefined) is also reasonable but expands the change surface; happy to switch on request.
- I haven't added a unit test because there don't appear to be existing tests for `GCDecorator` to extend, and adding one for this specifically would require constructing a mock `PerformanceEntry` with `detail.kind = 2`. Happy to add one if maintainers prefer.