### PR TITLE
Added support for manual tool definition annotation in Node.js LLM Observability SDK

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3570,13 +3570,22 @@ declare namespace tracer {
        *    outputData: { content: 'response', role: 'ai' },
        *    metadata: { temperature: 0.7 },
        *    tags: { host: 'localhost' },
-       *    metrics: { inputTokens: 10, outputTokens: 20, totalTokens: 30 }
+       *    metrics: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+       *    toolDefinitions: [
+       *      {
+       *        name: 'get_weather',
+       *        description: 'Returns the current weather for a given location.',
+       *        schema: { type: 'object', properties: { location: { type: 'string' } }, required: ['location'] },
+       *        version: '1.0.0'
+       *      },
+       *      { name: 'get_time' }
+       *    ]
        *  })
        * })
        * ```
        *
        * @param span The span to annotate (defaults to the current LLM Observability span if not provided)
-       * @param options An object containing the inputs, outputs, tags, metadata, and metrics to set on the span.
+       * @param options An object containing the inputs, outputs, tags, metadata, tool definitions, and metrics to set on the span.
        */
       annotate (options: llmobs.AnnotationOptions): void
       annotate (span: tracer.Span | undefined, options: llmobs.AnnotationOptions): void
@@ -3812,6 +3821,13 @@ declare namespace tracer {
       template?: string | Message[]
     }
 
+    interface ToolDefinition {
+      name : string,
+      description? : string,
+      schema? : {[key : string] : any}
+      version? : string
+    }
+
     /**
      * Annotation options for LLM Observability spans.
      */
@@ -3858,6 +3874,11 @@ declare namespace tracer {
        * A Prompt object that represents the prompt used for an LLM call. Only used on `llm` spans.
        */
       prompt?: Prompt,
+      /**
+       * A list of ToolDefinition object that represents the tools available to the LLM for this span
+       * Each definition requires a `name` and optionally accepts `description`, `schema`, and `version`.
+       * */
+      toolDefinitions?: ToolDefinition[]
     }
 
     interface AnnotationContextOptions {

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -4006,6 +4006,14 @@ declare namespace tracer {
       template?: string | Message[]
     }
 
+    interface ToolDefinition {
+      name : string,
+      description? : string,
+      schema? : {[key : string] : any}
+      version? : string
+    }
+
+
     /**
      * Annotation options for LLM Observability spans.
      */
@@ -4052,6 +4060,12 @@ declare namespace tracer {
        * A Prompt object that represents the prompt used for an LLM call. Only used on `llm` spans.
        */
       prompt?: Prompt,
+
+      /**
+       * A list of ToolDefinition object that represents the tools available to the LLM for this span
+       * Each definition requires a `name` and optionally accepts `description`, `schema`, and `version`.
+       * */
+      toolDefinitions?: ToolDefinition[]
     }
 
     interface AnnotationContextOptions {
@@ -4167,7 +4181,6 @@ declare namespace tracer {
        */
       agentlessEnabled?: boolean,
     }
-
     /** @hidden */
     type spanKind = 'agent' | 'workflow' | 'task' | 'tool' | 'retrieval' | 'embedding' | 'llm'
   }

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -259,7 +259,7 @@ class LLMObs extends NoopLLMObs {
         throw new Error('LLMObs span must have a span kind specified')
       }
 
-      const { inputData, outputData, metadata, metrics, tags, prompt, costTags } = options
+      const { inputData, outputData, metadata, metrics, tags, prompt, costTags, toolDefinitions } = options
 
       if (inputData || outputData) {
         if (spanKind === 'llm') {
@@ -288,6 +288,9 @@ class LLMObs extends NoopLLMObs {
       }
       if (prompt) {
         this._tagger.tagPrompt(span, prompt)
+      }
+      if (toolDefinitions != null) {
+        this._tagger.tagToolDefinitions(span, toolDefinitions)
       }
     } catch (e) {
       if (e.ddErrorTag) {

--- a/packages/dd-trace/src/llmobs/tagger.js
+++ b/packages/dd-trace/src/llmobs/tagger.js
@@ -43,7 +43,7 @@ const {
   INSTRUMENTATION_METHOD_ANNOTATED,
 } = require('./constants/tags')
 const { storage } = require('./storage')
-const { findGenAIAncestorSpanId, validateCostTags, writeBridgeTags } = require('./util')
+const { findGenAIAncestorSpanId, validateCostTags, writeBridgeTags, validateToolDefinitions } = require('./util')
 
 // global registry of LLMObs spans
 // maps LLMObs spans to their annotations
@@ -176,8 +176,10 @@ class LLMObsTagger {
   }
 
   tagToolDefinitions (span, toolDefinitions) {
-    if (Array.isArray(toolDefinitions) && toolDefinitions.length > 0) {
-      this._setTag(span, TOOL_DEFINITIONS, toolDefinitions)
+    const validatedToolDefinitions = validateToolDefinitions(toolDefinitions)
+
+    if (validatedToolDefinitions.length > 0) {
+      this._setTag(span, TOOL_DEFINITIONS, validatedToolDefinitions)
     } else {
       this.#handleFailure('Tool definitions must be a non-empty array.', 'invalid_tool_definitions')
     }

--- a/packages/dd-trace/src/llmobs/util.js
+++ b/packages/dd-trace/src/llmobs/util.js
@@ -89,6 +89,59 @@ function validateCostTags (span, costTags, source, spanTags) {
   return [...validatedCostTags]
 }
 
+// Validates tool definition entires
+function validateToolDefinitions (toolDefinitions) {
+  if (!Array.isArray(toolDefinitions)) {
+    log.warn('toolDefinitions must be an array.')
+    return []
+  }
+  const validated = []
+
+  for (let i = 0; i < toolDefinitions.length; i++) {
+    const currToolDef = toolDefinitions[i]
+    if (!currToolDef || typeof currToolDef !== 'object') {
+      log.warn('Tool definition at index %d must be an object. Skipping.', i)
+      continue
+    }
+
+    // Name is not optional
+    if (!currToolDef.name || typeof currToolDef.name !== 'string' || currToolDef.name.length <= 0) {
+      log.warn('Tool definition at index %d must have a non empty string "name". Skipping.', i)
+      continue
+    }
+    const validatedToolDef = { name: currToolDef.name }
+
+    // Description, Schema, and Version are optional types
+    if (currToolDef.description !== undefined) {
+      if (typeof currToolDef.description === 'string') {
+        validatedToolDef.description = currToolDef.description
+      } else {
+        log.warn('Tool definition "description" at index %d must be a string. Skipping field.', i)
+      }
+    }
+
+    if (currToolDef.schema !== undefined) {
+      if (currToolDef.schema !== null && typeof currToolDef.schema === 'object' && !Array.isArray(currToolDef.schema)) {
+        validatedToolDef.schema = currToolDef.schema
+      } else {
+        log.warn('Tool definition "schema" at index %d must be a plain object. Skipping field.', i)
+      }
+    }
+
+    if (currToolDef.version !== undefined) {
+      if (typeof currToolDef.version === 'string') {
+        validatedToolDef.version = currToolDef.version
+      } else {
+        log.warn('Tool definition "version" at index %d must be a string. Skipping field.', i)
+      }
+    }
+
+    validated.push(validatedToolDef)
+  }
+
+  return validated
+}
+
 // extracts the argument names from a function string
 function parseArgumentNames (str) {
   const result = []
@@ -318,4 +371,5 @@ module.exports = {
   safeJsonParse,
   spanHasError,
   writeBridgeTags,
+  validateToolDefinitions,
 }

--- a/packages/dd-trace/test/llmobs/sdk/index.spec.js
+++ b/packages/dd-trace/test/llmobs/sdk/index.spec.js
@@ -1156,6 +1156,77 @@ describe('sdk', () => {
         })
       })
     })
+
+    it('annotates toolDefinitions if present', () => {
+      const toolDefinitions = [
+        { name: 'get_weather', description: 'Gets the weather', schema: { type: 'object' }, version: '1.0' },
+        { name: 'get_time' },
+      ]
+
+      llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+        llmobs.annotate({ toolDefinitions })
+
+        assert.deepStrictEqual(LLMObsTagger.tagMap.get(span), {
+          '_ml_obs.meta.span.kind': 'llm',
+          '_ml_obs.meta.ml_app': 'mlApp',
+          '_ml_obs.llmobs_parent_id': 'undefined',
+          '_ml_obs.meta.tool_definitions': toolDefinitions,
+        })
+      })
+    })
+
+    it('strips invalid optional fields from toolDefinitions items', () => {
+      const toolDefinitions = [
+        { name: 'get_weather', description: 123, schema: 'not-an-object', version: 456 },
+      ]
+
+      llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+        llmobs.annotate({ toolDefinitions })
+
+        assert.deepStrictEqual(LLMObsTagger.tagMap.get(span), {
+          '_ml_obs.meta.span.kind': 'llm',
+          '_ml_obs.meta.ml_app': 'mlApp',
+          '_ml_obs.llmobs_parent_id': 'undefined',
+          '_ml_obs.meta.tool_definitions': [{ name: 'get_weather' }],
+        })
+      })
+    })
+
+    it('skips toolDefinitions items missing a name', () => {
+      const toolDefinitions = [
+        { description: 'no name here' },
+        { name: 'valid_tool' },
+      ]
+
+      llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+        llmobs.annotate({ toolDefinitions })
+
+        assert.deepStrictEqual(LLMObsTagger.tagMap.get(span), {
+          '_ml_obs.meta.span.kind': 'llm',
+          '_ml_obs.meta.ml_app': 'mlApp',
+          '_ml_obs.llmobs_parent_id': 'undefined',
+          '_ml_obs.meta.tool_definitions': [{ name: 'valid_tool' }],
+        })
+      })
+    })
+
+    it('rejects non array toolDefinitions', () => {
+      llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+        assert.throws(() => llmobs.annotate({ toolDefinitions: 'not an array' }))
+      })
+    })
+
+    it('rejects empty toolDefinitions array', () => {
+      llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+        assert.throws(() => llmobs.annotate({ toolDefinitions: [] }))
+      })
+    })
+
+    it('rejects toolDefinitions where all items are invalid', () => {
+      llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+        assert.throws(() => llmobs.annotate({ toolDefinitions: [{ description: 'no name' }, 'not an object'] }))
+      })
+    })
   })
 
   describe('annotationContext', () => {
@@ -1186,6 +1257,35 @@ describe('sdk', () => {
           })
         })
       })
+    })
+  })
+
+  it('annotates toolDefinitions if present', () => {
+    const toolDefinitions = [
+      { name: 'get_weather', description: 'Gets the weather', schema: { type: 'object' }, version: '1.0' },
+      { name: 'get_time' },
+    ]
+
+    llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+      llmobs.annotate({ toolDefinitions })
+      assert.deepStrictEqual(LLMObsTagger.tagMap.get(span), {
+        '_ml_obs.meta.span.kind': 'llm',
+        '_ml_obs.meta.ml_app': 'mlApp',
+        '_ml_obs.llmobs_parent_id': 'undefined',
+        '_ml_obs.meta.tool_definitions': toolDefinitions,
+      })
+    })
+  })
+
+  it('rejects non array toolDefinitions', () => {
+    llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+      assert.throws(() => llmobs.annotate({ toolDefinitions: 'not an array' }))
+    })
+  })
+
+  it('rejects empty toolDefinitions array', () => {
+    llmobs.trace({ kind: 'llm', name: 'test' }, span => {
+      assert.throws(() => llmobs.annotate({ toolDefinitions: [] }))
     })
   })
 

--- a/packages/dd-trace/test/llmobs/tagger.spec.js
+++ b/packages/dd-trace/test/llmobs/tagger.spec.js
@@ -403,9 +403,14 @@ describe('tagger', () => {
     })
 
     describe('tagToolDefinitions', () => {
-      it('tags a span with tool definitions', () => {
+      it('tags a span with a full tool definition', () => {
         const toolDefinitions = [
-          { name: 'get_weather', description: 'Get the weather for a city.', schema: { type: 'object' } },
+          {
+            name: 'get_weather',
+            description: 'Get the weather for a city.',
+            schema: { type: 'object' },
+            version: '1.0',
+          },
         ]
         tagger._register(span)
         tagger.tagToolDefinitions(span, toolDefinitions)
@@ -414,11 +419,48 @@ describe('tagger', () => {
         })
       })
 
-      it('throws for malformed tool definitions', () => {
+      it('tags a span with only a name', () => {
+        tagger._register(span)
+        tagger.tagToolDefinitions(span, [{ name: 'get_time' }])
+        assert.deepStrictEqual(Tagger.tagMap.get(span), {
+          '_ml_obs.meta.tool_definitions': [{ name: 'get_time' }],
+        })
+      })
+
+      it('strips invalid optional fields but keeps the tool', () => {
+        tagger._register(span)
+        tagger.tagToolDefinitions(span, [
+          { name: 'get_weather', description: 123, schema: 'not-an-object', version: 456 },
+        ])
+        assert.deepStrictEqual(Tagger.tagMap.get(span), {
+          '_ml_obs.meta.tool_definitions': [{ name: 'get_weather' }],
+        })
+      })
+
+      it('skips items missing a name but keeps valid tools', () => {
+        tagger._register(span)
+        tagger.tagToolDefinitions(span, [
+          { description: 'no name' },
+          { name: 'valid_tool' },
+        ])
+        assert.deepStrictEqual(Tagger.tagMap.get(span), {
+          '_ml_obs.meta.tool_definitions': [{ name: 'valid_tool' }],
+        })
+      })
+
+      it('throws for a non array input', () => {
         tagger._register(span)
         assert.throws(() => tagger.tagToolDefinitions(span, 'not an array'))
+      })
+
+      it('throws for an empty array', () => {
+        tagger._register(span)
         assert.throws(() => tagger.tagToolDefinitions(span, []))
-        assert.throws(() => tagger.tagToolDefinitions(span))
+      })
+
+      it('throws when all items are invalid', () => {
+        tagger._register(span)
+        assert.throws(() => tagger.tagToolDefinitions(span, [{ description: 'no name' }, 'not an object']))
       })
     })
 


### PR DESCRIPTION
feat(llmobs): add support for tool definitions
[MLOB-1078]


### What does this PR do?
Adds toolDefinitions as an option in LLMObs.annotate(), supporting manual tool definition annotation on LLM spans with per tool validation. Also updates index.d.ts and index.d.v5.ts with the new ToolDefinition interface and adds tests covering valid and error input cases.

### Motivation
Brings the Node.js SDK closer to  Python SDK




[MLOB-1078]: https://datadoghq.atlassian.net/browse/MLOB-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ