### PR TITLE
bench(sirun): cut runtime of the slowest child_process and debugger variants

### DIFF
--- a/benchmark/sirun/child_process/meta.json
+++ b/benchmark/sirun/child_process/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "shell-string": {
-      "env": { "VARIANT": "shell-string", "ITERATIONS": "4700000" }
+      "env": { "VARIANT": "shell-string", "ITERATIONS": "1100000" }
     },
     "file-args": {
-      "env": { "VARIANT": "file-args", "ITERATIONS": "3750000" }
+      "env": { "VARIANT": "file-args", "ITERATIONS": "1000000" }
     }
   }
 }

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -33,6 +33,7 @@
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
+      "iterations": 5,
       "env": {
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",


### PR DESCRIPTION
## Summary

`child_process/{shell-string,file-args}` and `debugger/line-probe-with-snapshot-default` ran ~4m9s, ~3m39s, and ~2m19s per variant on CI, far over the per-variant runtime cap.

1. **child_process** — startup is ~2% of each process, so the inner loop dominates. Cut `ITERATIONS` ~4x and keep `iterations=15`; each sample still runs several seconds, so within-run stddev and the across-run sample count both hold (~58s).
2. **debugger/line-probe-with-snapshot-default** — the devtools-worker startup is a large per-process cost the loop can't amortize away (the startup guard caps it at 35%), so shrinking the loop would make the bench measure startup and trip the guard. The only guard-safe lever is the sample count, which floors per-sample time at ~14s. Drop the sirun sample count for this variant alone (10→5) via a per-variant `iterations` override, leaving the loop and startup share untouched (~70s).

## Why

Local macOS timing is not representative for these (a single process runs ~22x faster here than on CI, and the debugger's startup/loop split inverts), so the counts are scaled from the reported CI numbers. CI's pinned isolated core is the gate for the final stddev/runtime.

The debugger can't fit both ≥5 samples and ≤60s guard-safely: the fixed devtools startup floors per-sample time at ~14s and the guard forbids shrinking the loop further, so 5 samples lands ~70s. 5 keeps the repo's existing sample-count floor (profiler/llmobs also use 5) and stays well under the 90s hard cap.

## Test plan

- [ ] Confirm child_process variants land near ~60s and the debugger variant near ~70s on the sirun benchmark CI job.
- [ ] Confirm `wall.time.stddev_pct` stays in budget and the startup guard passes for `line-probe-with-snapshot-default`.