### PR TITLE
fix(exporters): keep the Datadog API key off cleartext for agentless intake

### DIFF
--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -19,24 +19,20 @@ class AgentlessExporter {
   /**
    * @param {object} config - Configuration object
    * @param {string} [config.site] - The Datadog site. Defaults to 'datadoghq.com'.
-   * @param {string} [config.url] - Override intake URL
    * @param {number} [config.flushInterval] - Batch flush interval in ms
    * @param {string} [config.env] - Environment name
    * @param {object} [config.tags] - Tags including runtime-id
    */
   constructor (config) {
     this._config = config
-    const { site = 'datadoghq.com', url } = config
+    const site = config.site ?? 'datadoghq.com'
 
     try {
-      this._url = url ? new URL(url) : new URL(`https://public-trace-http-intake.logs.${site}`)
+      // Agentless traffic carries the Datadog API key, so the intake is always the public https
+      // endpoint; never derive it from config.url (the agent's cleartext http) or the key leaks.
+      this._url = new URL(`https://public-trace-http-intake.logs.${site}`)
     } catch (err) {
-      log.error(
-        'Invalid URL configuration for agentless exporter. url=%s, site=%s. Error: %s',
-        url || 'not set',
-        site,
-        err.message
-      )
+      log.error('Invalid site for agentless exporter. site=%s. Error: %s', site, err.message)
       this._url = null
     }
 

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -46,6 +46,13 @@ function parseUrl (urlObjOrString) {
 }
 
 /**
+ * @param {string} hostname Host as resolved by {@link parseUrl}; IPv6 is unbracketed (`::1`).
+ */
+function isLoopbackHost (hostname) {
+  return hostname === 'localhost' || hostname === '::1' || hostname.startsWith('127.')
+}
+
+/**
  * @param {Buffer|string|Readable|Array<Buffer|string>} data
  * @param {object} options
  * @param {(error: Error|null, result: string, statusCode: number) => void} callback
@@ -65,6 +72,20 @@ function request (data, options, callback) {
       options.hostname = url.hostname // for IPv6 this should be '::1' and not '[::1]'
       options.port = url.port
     }
+  }
+
+  // Never put the Datadog API key on a cleartext connection to a non-loopback host; that would
+  // expose it on the wire. Loopback (local agent, dev proxy, tests) is exempt. Strip the key
+  // rather than drop the request: the agent proxies telemetry with its own key, while an https
+  // intake URL is required to authenticate agentless traffic.
+  const hasApiKey = options.headers['dd-api-key'] !== undefined || options.headers['DD-API-KEY'] !== undefined
+  if (hasApiKey && options.protocol === 'http:' && !isLoopbackHost(options.hostname)) {
+    log.error(
+      'Not sending the Datadog API key over a non-TLS connection to %s. Configure an https intake URL.',
+      options.hostname
+    )
+    delete options.headers['dd-api-key']
+    delete options.headers['DD-API-KEY']
   }
 
   if (data instanceof Readable) {

--- a/packages/dd-trace/src/exporters/common/request.js
+++ b/packages/dd-trace/src/exporters/common/request.js
@@ -6,6 +6,7 @@
 const { Readable } = require('stream')
 const http = require('http')
 const https = require('https')
+const net = require('net')
 const zlib = require('zlib')
 
 const { storage } = require('../../../../datadog-core')
@@ -49,7 +50,11 @@ function parseUrl (urlObjOrString) {
  * @param {string} hostname Host as resolved by {@link parseUrl}; IPv6 is unbracketed (`::1`).
  */
 function isLoopbackHost (hostname) {
-  return hostname === 'localhost' || hostname === '::1' || hostname.startsWith('127.')
+  // The 127.0.0.0/8 block is loopback, but only when the host is an actual IPv4 literal: a
+  // hostname like `127.evil.com` shares the prefix yet resolves anywhere, so net.isIPv4 gates it.
+  return hostname === 'localhost' ||
+    hostname === '::1' ||
+    (hostname.startsWith('127.') && net.isIPv4(hostname))
 }
 
 /**

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -54,11 +54,10 @@ describe('AgentlessExporter', () => {
       sinon.assert.match(exporter._url.href, expectedUrl.href)
     })
 
-    it('should use provided URL', () => {
-      const customUrl = 'https://custom-intake.example.com'
-      exporter = new Exporter({ url: customUrl, site: 'datadoghq.com' })
+    it('should send to the https intake and ignore the agent URL (config.url)', () => {
+      exporter = new Exporter({ url: 'http://127.0.0.1:8126', site: 'datadoghq.com' })
 
-      sinon.assert.match(exporter._url.href, customUrl)
+      assert.strictEqual(exporter._url.href, 'https://public-trace-http-intake.logs.datadoghq.com/')
     })
 
     it('should default to datadoghq.com site', () => {
@@ -77,7 +76,7 @@ describe('AgentlessExporter', () => {
       )
     })
 
-    it('should handle invalid URL gracefully', () => {
+    it('should handle an invalid site gracefully', () => {
       const log = { error: sinon.spy() }
 
       Exporter = proxyquire('../../../src/exporters/agentless', {
@@ -85,7 +84,7 @@ describe('AgentlessExporter', () => {
         '../../log': log,
       })
 
-      exporter = new Exporter({ url: 'not-a-valid-url' })
+      exporter = new Exporter({ site: 'bad host' })
 
       sinon.assert.calledOnce(log.error)
       assert.strictEqual(exporter._url, null)

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -605,4 +605,79 @@ describe('request', function () {
         })
     }
   })
+
+  describe('stripping the Datadog API key from a non-TLS connection', () => {
+    // `badheaders` only matches when the key is absent, so a passing request proves it was
+    // stripped; a regression that left the key on would miss the interceptor and surface here.
+    it('strips dd-api-key when sending over http to a non-loopback host', (done) => {
+      nock('http://intake.example.com', { badheaders: ['dd-api-key'] })
+        .post('/v1/input')
+        .reply(200, 'OK')
+
+      request(Buffer.from(''), {
+        method: 'POST',
+        url: new URL('http://intake.example.com/v1/input'),
+        headers: { 'dd-api-key': 'secret-key' },
+      }, (err, res) => {
+        assert.strictEqual(res, 'OK')
+        sinon.assert.calledOnce(log.error)
+        assert.match(log.error.getCall(0).args[0], /non-TLS connection/)
+        done(err)
+      })
+    })
+
+    it('strips the DD-API-KEY header casing as well', (done) => {
+      nock('http://intake.example.com', { badheaders: ['dd-api-key'] })
+        .post('/v1/input')
+        .reply(200, 'OK')
+
+      request(Buffer.from(''), {
+        method: 'POST',
+        url: new URL('http://intake.example.com/v1/input'),
+        headers: { 'DD-API-KEY': 'secret-key' },
+      }, (err, res) => {
+        assert.strictEqual(res, 'OK')
+        sinon.assert.calledOnce(log.error)
+        done(err)
+      })
+    })
+
+    for (const loopbackHost of ['127.0.0.1', 'localhost', '[::1]']) {
+      it(`keeps dd-api-key over http to the loopback host ${loopbackHost}`, (done) => {
+        nock(`http://${loopbackHost}:9999`, {
+          reqheaders: { 'dd-api-key': 'secret-key' },
+        })
+          .post('/v1/input')
+          .reply(200, 'OK')
+
+        request(Buffer.from(''), {
+          method: 'POST',
+          url: new URL(`http://${loopbackHost}:9999/v1/input`),
+          headers: { 'dd-api-key': 'secret-key' },
+        }, (err, res) => {
+          assert.strictEqual(res, 'OK')
+          sinon.assert.notCalled(log.error)
+          done(err)
+        })
+      })
+    }
+
+    it('keeps dd-api-key over https to a non-loopback host', (done) => {
+      nock('https://intake.example.com', {
+        reqheaders: { 'dd-api-key': 'secret-key' },
+      })
+        .post('/v1/input')
+        .reply(200, 'OK')
+
+      request(Buffer.from(''), {
+        method: 'POST',
+        url: new URL('https://intake.example.com/v1/input'),
+        headers: { 'dd-api-key': 'secret-key' },
+      }, (err, res) => {
+        assert.strictEqual(res, 'OK')
+        sinon.assert.notCalled(log.error)
+        done(err)
+      })
+    })
+  })
 })

--- a/packages/dd-trace/test/exporters/common/request.spec.js
+++ b/packages/dd-trace/test/exporters/common/request.spec.js
@@ -642,7 +642,23 @@ describe('request', function () {
       })
     })
 
-    for (const loopbackHost of ['127.0.0.1', 'localhost', '[::1]']) {
+    it('strips dd-api-key for a non-loopback host that merely starts with "127."', (done) => {
+      nock('http://127.evil.com', { badheaders: ['dd-api-key'] })
+        .post('/v1/input')
+        .reply(200, 'OK')
+
+      request(Buffer.from(''), {
+        method: 'POST',
+        url: new URL('http://127.evil.com/v1/input'),
+        headers: { 'dd-api-key': 'secret-key' },
+      }, (err, res) => {
+        assert.strictEqual(res, 'OK')
+        sinon.assert.calledOnce(log.error)
+        done(err)
+      })
+    })
+
+    for (const loopbackHost of ['127.0.0.1', '127.1.2.3', 'localhost', '[::1]']) {
       it(`keeps dd-api-key over http to the loopback host ${loopbackHost}`, (done) => {
         nock(`http://${loopbackHost}:9999`, {
           reqheaders: { 'dd-api-key': 'secret-key' },


### PR DESCRIPTION
## Summary
The agentless APM exporter took its intake from `config.url`, which defaults to the local agent URL over plaintext http. Agentless traffic carries the Datadog API key, so the key was pointed at the agent's cleartext endpoint instead of the https intake.
1. The agentless exporter now always builds the intake from the configured site over https and never consults `config.url`; `DD_SITE` stays the knob for redirecting it.
2. `request()` strips the `dd-api-key` header on any plaintext http request to a non-loopback host, so the key can't leak even when another caller points at cleartext. Stripping the header rather than failing the request keeps agent-proxied telemetry working, since the agent authenticates with its own key rather than the forwarded header.
3. The loopback exemption is restricted to real IPv4 loopback (`127.0.0.0/8`), `::1`, and `localhost`; a host that merely starts with `127.` no longer keeps the key.
## Why
The header check covers both `dd-api-key` and `DD-API-KEY`: senders across the codebase use both literal casings as object keys and never normalize before reaching `request()`, and HTTP header names are case-insensitive.

## Test plan

- [ ] `config.DD_TRACE_AGENTLESS_URL` is set from the env var without altering `config.url`
- [ ] agentless exporter ignores a configured agent `config.url` and defaults to the https intake
- [ ] API key is stripped over http to a non-loopback host (both header casings) and logged
- [ ] API key is preserved over http to loopback hosts and over https to any host

Refs: https://datadoghq.atlassian.net/browse/APMSP-3483