### PR TITLE
bench(appsec): stabilize live variants by sizing requests per variant

### DIFF
--- a/benchmark/sirun/appsec/README.md
+++ b/benchmark/sirun/appsec/README.md
@@ -1,8 +1,6 @@
-This benchmarks HTTP requests from client to server.
-
-The variants are:
-- control tracer without appsec
-- tracer with appsec but no attacks
-- control tracer without appsec but with attacks
-- tracer with appsec and attacks
+This benchmarks the cost Datadog AppSec adds to an HTTP server: per-request WAF
+handling (a keep-alive client drives the tracer-instrumented server, with
+`DD_APPSEC_ENABLED` toggled and an attack-payload variant) and process startup
+(loading the tracer with AppSec on versus off). Variants, request counts, and
+attack payloads are defined in `meta.json`.
 

--- a/benchmark/sirun/appsec/common.js
+++ b/benchmark/sirun/appsec/common.js
@@ -2,10 +2,13 @@
 
 module.exports = {
   port: 3231 + parseInt(process.env.CPU_AFFINITY || '0'),
-  // A larger request count keeps the per-iteration tracer+AppSec reload a
-  // smaller fraction of the run so request handling dominates. Capped at 1000:
-  // beyond that, WAF per-request allocations accumulate (no draining agent in
-  // the bench) and per-request cost falls off a cliff. The client uses a
-  // keep-alive connection so this count does not churn ephemeral ports.
+  // Requests per iteration, sized per variant in meta.json (REQS). A higher count
+  // dilutes the fixed startup (node boot + tracer/AppSec init), which is otherwise
+  // a large, run-to-run-variable share of a short run and dominates stddev (control
+  // drifted 290-440 ms between runs at 1000). It can't just be maximized: with no
+  // draining agent, spans (control) and WAF events (AppSec on) accumulate, so each
+  // variant has a GC cliff above which stddev explodes (control ~8000). Each REQS
+  // sits in its variant's valley -- diluted startup, below the cliff, under ~45 s
+  // at 30 iterations. The keep-alive client avoids ephemeral-port churn.
   reqs: Number(process.env.REQS) || 1000,
 }

--- a/benchmark/sirun/appsec/meta.json
+++ b/benchmark/sirun/appsec/meta.json
@@ -9,7 +9,8 @@
       "run": "node server.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node server.js\"",
       "env": {
-        "DD_APPSEC_ENABLED": "0"
+        "DD_APPSEC_ENABLED": "0",
+        "REQS": "6000"
       }
     },
     "appsec-enabled": {
@@ -17,7 +18,8 @@
       "run": "node server.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node server.js\"",
       "env": {
-        "DD_APPSEC_ENABLED": "1"
+        "DD_APPSEC_ENABLED": "1",
+        "REQS": "7000"
       }
     },
     "appsec-enabled-with-attacks": {
@@ -28,7 +30,8 @@
         "DD_APPSEC_ENABLED": "1",
         "ATTACK_UA": "1",
         "ATTACK_404": "1",
-        "ATTACK_QS": "1"
+        "ATTACK_QS": "1",
+        "REQS": "5000"
       }
     },
     "startup-time-control": {


### PR DESCRIPTION
## Summary

The live appsec variants measured each iteration's whole process lifetime, so the fixed startup (node boot + tracer/AppSec init + client handshake) was a large, run-to-run-variable share of a short run and dominated stddev: control drifted 290-440 ms between runs at 1000 requests (5-31%).

Each variant now sets its own `REQS` to dilute that startup while staying below its GC cliff. With no draining agent, spans (control) and WAF events (appsec on) accumulate, so pushing control past ~8000 sends stddev back to double digits. control sits at 6000, appsec-enabled at 7000, with-attacks at 5000 -- each in its valley and under ~45 s at 30 iterations.

## Why

The ready-fd clock reset on sirun `main` would have excluded startup directly, but CI pins v0.1.10/v0.1.11, which lack it -- it would be a silent no-op. Sizing requests per variant is version-independent and matches the existing plugin-http/plugin-net benches.

## Test plan

Local macOS (unpinned, so directional only -- CI's core-pinned run is authoritative): three clean runs hold control at ~635 ms with across-run drift ~2% (was ~50%), and the appsec variants at 0.5-3.2%.