### PR TITLE
bench(sirun): add high-value missing benchmarks across tracer, plugins, LLMObs and test-opt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,8 @@
 /benchmark/sirun/plugin-cassandra-driver/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-couchbase/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-elasticsearch/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -199,6 +199,7 @@
 /benchmark/sirun/spans/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/sampling/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/span-format/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/test-codeowners/ @DataDog/ci-app-libraries
 
 /integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@
 /benchmark/sirun/plugin-grpc/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-memcached/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@
 /benchmark/sirun/fs/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-aws-sdk/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-cassandra-driver/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-couchbase/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,8 +43,8 @@
 /benchmark/sirun/child_process/ @DataDog/apm-idm-js
 /benchmark/sirun/fs/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-aws-sdk/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-cassandra-driver/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
-/benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -169,6 +169,7 @@
 /.claude/skills/llmobs-integration @DataDog/ml-observability
 /.claude/skills/llmobs-testing @DataDog/ml-observability
 /benchmark/sirun/llmobs/ @DataDog/ml-observability
+/benchmark/sirun/llmobs-span-processor/ @DataDog/ml-observability
 /packages/datadog-instrumentations/src/ai.js @DataDog/ml-observability
 /packages/datadog-instrumentations/src/anthropic.js @DataDog/ml-observability
 /packages/datadog-instrumentations/src/google-cloud-vertexai.js @DataDog/ml-observability

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -170,6 +170,7 @@
 /.claude/skills/llmobs-testing @DataDog/ml-observability
 /benchmark/sirun/llmobs/ @DataDog/ml-observability
 /benchmark/sirun/llmobs-span-processor/ @DataDog/ml-observability
+/benchmark/sirun/llmobs-evaluations/ @DataDog/ml-observability
 /packages/datadog-instrumentations/src/ai.js @DataDog/ml-observability
 /packages/datadog-instrumentations/src/anthropic.js @DataDog/ml-observability
 /packages/datadog-instrumentations/src/google-cloud-vertexai.js @DataDog/ml-observability

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,7 @@
 /benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-pino/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-redis/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-redis-traced/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-ws/ @DataDog/apm-idm-js
 /benchmark/sirun/url/ @DataDog/apm-idm-js
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -197,6 +197,8 @@
 
 /benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/spans/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/sampling/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/span-format/ @DataDog/apm-sdk-capabilities-js
 
 /integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,6 +48,7 @@
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-elasticsearch/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-grpc/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -200,6 +200,7 @@
 /benchmark/sirun/sampling/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/span-format/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/test-codeowners/ @DataDog/ci-app-libraries
+/benchmark/sirun/test-ci-encode/ @DataDog/ci-app-libraries
 
 /integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -305,6 +305,7 @@
 /benchmark/sirun/* @DataDog/lang-platform-js
 /benchmark/stubs/ @DataDog/lang-platform-js
 /benchmark/sirun/async_hooks/ @DataDog/lang-platform-js
+/benchmark/sirun/dogstatsd/ @DataDog/lang-platform-js
 /benchmark/sirun/encoding/ @DataDog/lang-platform-js
 /benchmark/sirun/exporting-pipeline/ @DataDog/lang-platform-js
 /benchmark/sirun/id/ @DataDog/lang-platform-js

--- a/benchmark/sirun/appsec-iast/README.md
+++ b/benchmark/sirun/appsec-iast/README.md
@@ -1,9 +1,4 @@
-This benchmarks HTTP requests from client to server.
-
-The variants are:
-- control tracer with non vulnerable endpoint without iast 
-- tracer with non vulnerable endpoint with iast active and default configuration
-- tracer with non vulnerable endpoint with iast active and sampling 100
-- control tracer with vulnerable endpoint without iast
-- tracer with vulnerable endpoint with iast active and default configuration
-- tracer with vulnerable endpoint with iast active and sampling 100
+Drives real Express request handling with the tracer loaded, measuring IAST's
+per-request taint-tracking overhead -- IAST off vs on (default sampling, and
+always-active), across a non-vulnerable endpoint and one with a command-injection
+sink that triggers vulnerability reporting.

--- a/benchmark/sirun/appsec/README.md
+++ b/benchmark/sirun/appsec/README.md
@@ -1,8 +1,4 @@
-This benchmarks HTTP requests from client to server.
-
-The variants are:
-- control tracer without appsec
-- tracer with appsec but no attacks
-- control tracer without appsec but with attacks
-- tracer with appsec and attacks
+Drives real HTTP client/server traffic with the full tracer loaded, measuring the
+AppSec WAF's per-request overhead -- AppSec off vs on, and on with attack payloads
+(Arachni UA, path traversal, XSS query string) that exercise the WAF's rule paths.
 

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -48,6 +48,7 @@
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
+      "iterations": 7,
       "env": {
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -40,7 +40,7 @@
         "BREAKPOINT_LINE": "37",
         "CAPTURE_SNAPSHOT": "true",
         "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
-        "ITERATIONS": "3500"
+        "ITERATIONS": "2450"
       }
     },
     "line-probe-with-snapshot-minimal": {

--- a/benchmark/sirun/dogstatsd/README.md
+++ b/benchmark/sirun/dogstatsd/README.md
@@ -1,0 +1,8 @@
+# dogstatsd
+
+Measures the in-process DogStatsD egress formatting that every runtime and custom
+metric runs through: `DogStatsDClient._add` builds the `stat:value|type` line,
+splices global and per-metric tags, and appends to the 1KB datagram buffer. The
+`aggregated` variant drives the `MetricsAggregationClient` tag tree that runtime
+metrics accumulate before flushing. The UDP socket is stubbed; nothing leaves the
+process.

--- a/benchmark/sirun/dogstatsd/index.js
+++ b/benchmark/sirun/dogstatsd/index.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const { DogStatsDClient, MetricsAggregationClient } = require('../../../packages/dd-trace/src/dogstatsd')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 5_000_000
+
+// Every metric the tracer emits (runtime metrics, custom metrics) runs through
+// DogStatsDClient._add: build the `stat:value|type` line, splice the global and
+// per-metric tags, and append to the 1KB datagram buffer (Buffer.from on each
+// overflow). The aggregated variant drives the MetricsAggregationClient tag
+// tree that runtime metrics build before flushing. The UDP socket is stubbed so
+// nothing leaves the process — the bench measures the in-process formatting and
+// buffering only.
+class BenchClient extends DogStatsDClient {
+  _socket () {
+    return { send () {}, on () {}, unref () {} }
+  }
+}
+
+const client = new BenchClient({
+  host: '127.0.0.1',
+  port: 8125,
+  tags: ['env:bench', 'service:web-app', 'version:1.2.3'],
+  lookup: (host, cb) => cb(null, host, 4),
+})
+
+const NAME = 'runtime.node.event_loop.delay.max'
+const FEW_TAGS = ['lang:javascript', 'lang_version:20.0.0']
+const MANY_TAGS = []
+for (let i = 0; i < 12; i++) MANY_TAGS.push(`dim_${i}:value_${i}`)
+
+function preflight () {
+  client._add(NAME, 42, 'g', FEW_TAGS)
+  assert.ok(client._buffer.includes(NAME) && client._buffer.includes('env:bench'),
+    '_add did not format the metric line with global tags')
+  client._buffer = ''
+  client._offset = 0
+  client._queue = []
+}
+preflight()
+
+guard.loopStart()
+if (VARIANT === 'aggregated') {
+  // The runtime-metrics path: accumulate into the tag tree, then flush walks the
+  // tree and formats every node through the client. Stubbed socket on flush.
+  const agg = new MetricsAggregationClient(client)
+  for (let i = 0; i < ITERATIONS; i++) {
+    agg.count(NAME, 1, FEW_TAGS)
+    agg.gauge('runtime.node.mem.heap_used', i, FEW_TAGS)
+    if ((i & 0x3FF) === 0) agg.flush()
+  }
+  agg.flush()
+} else {
+  const tags = VARIANT === 'no-tags' ? undefined : (VARIANT === 'many-tags' ? MANY_TAGS : FEW_TAGS)
+  const type = VARIANT === 'no-tags' ? 'c' : 'g'
+  for (let i = 0; i < ITERATIONS; i++) {
+    client._add(NAME, i, type, tags)
+    // Drain the datagram queue without sending so memory stays flat.
+    if ((i & 0x7FF) === 0) client._queue.length = 0
+  }
+}
+guard.done()

--- a/benchmark/sirun/dogstatsd/meta.json
+++ b/benchmark/sirun/dogstatsd/meta.json
@@ -1,0 +1,22 @@
+{
+  "name": "dogstatsd",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "no-tags": {
+      "env": { "VARIANT": "no-tags", "ITERATIONS": "6000000" }
+    },
+    "with-tags": {
+      "env": { "VARIANT": "with-tags", "ITERATIONS": "5000000" }
+    },
+    "many-tags": {
+      "env": { "VARIANT": "many-tags", "ITERATIONS": "3000000" }
+    },
+    "aggregated": {
+      "env": { "VARIANT": "aggregated", "ITERATIONS": "15000000" }
+    }
+  }
+}

--- a/benchmark/sirun/dogstatsd/meta.json
+++ b/benchmark/sirun/dogstatsd/meta.json
@@ -10,7 +10,8 @@
       "env": { "VARIANT": "no-tags", "ITERATIONS": "6000000" }
     },
     "with-tags": {
-      "env": { "VARIANT": "with-tags", "ITERATIONS": "5000000" }
+      "iterations": 8,
+      "env": { "VARIANT": "with-tags", "ITERATIONS": "12500000" }
     },
     "many-tags": {
       "env": { "VARIANT": "many-tags", "ITERATIONS": "3000000" }

--- a/benchmark/sirun/dogstatsd/meta.json
+++ b/benchmark/sirun/dogstatsd/meta.json
@@ -10,8 +10,7 @@
       "env": { "VARIANT": "no-tags", "ITERATIONS": "6000000" }
     },
     "with-tags": {
-      "iterations": 8,
-      "env": { "VARIANT": "with-tags", "ITERATIONS": "12500000" }
+      "env": { "VARIANT": "with-tags", "ITERATIONS": "8300000" }
     },
     "many-tags": {
       "env": { "VARIANT": "many-tags", "ITERATIONS": "3000000" }

--- a/benchmark/sirun/fs/index.js
+++ b/benchmark/sirun/fs/index.js
@@ -79,6 +79,15 @@ if (VARIANT === 'subscribed') {
 assert.equal(VARIANT === 'subscribed', startChannel.hasSubscribers,
   'subscriber state does not match variant')
 
+// Drift guard: getMessage + the wrapper body mirror fs.js (neither is exported), so
+// assert the mirror still produces the production per-call message shape -- otherwise
+// a refactor on either side diverges silently while the loop keeps "passing".
+assert.deepEqual(
+  getMessage('statSync', PARAMS, ARGS),
+  { operation: 'statSync', path: '/var/app/data/file.txt', options: { encoding: 'utf8' } },
+  'getMessage mirror drifted from the fs.js per-call message shape'
+)
+
 guard.loopStart()
 let sink = 0
 for (let i = 0; i < ITERATIONS; i++) {

--- a/benchmark/sirun/fs/meta.json
+++ b/benchmark/sirun/fs/meta.json
@@ -7,7 +7,7 @@
   "instructions": true,
   "variants": {
     "subscribed": {
-      "env": { "VARIANT": "subscribed", "ITERATIONS": "2500000" }
+      "env": { "VARIANT": "subscribed", "ITERATIONS": "857000" }
     }
   }
 }

--- a/benchmark/sirun/llmobs-evaluations/README.md
+++ b/benchmark/sirun/llmobs-evaluations/README.md
@@ -1,0 +1,8 @@
+# llmobs-evaluations
+
+Measures the LLMObs evaluation-metrics writer egress: `append` (buffer + byte
+sizing) and `flush` (`makePayload` plus `_encode`, JSON.stringify with the
+encodeUnicode replacer). It shares the encode path with the `llmobs` (span writer)
+bench but covers the distinct evaluations writer and its payload shape. Variants
+cover categorical metrics, score metrics, and reasoned metrics with non-ASCII text
+that exercises the encodeUnicode branch.

--- a/benchmark/sirun/llmobs-evaluations/index.js
+++ b/benchmark/sirun/llmobs-evaluations/index.js
@@ -1,0 +1,94 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
+
+// Stub the HTTP request module before the writer captures it, so flush runs
+// `_encode` end-to-end (JSON.stringify with the encodeUnicode replacer) while the
+// egress is a synchronous no-op. The existing `llmobs` bench covers the span
+// writer; this covers the evaluation-metrics writer and its payload shape.
+const requestPath = require.resolve('../../../packages/dd-trace/src/exporters/common/request')
+require.cache[requestPath] = {
+  id: requestPath,
+  filename: requestPath,
+  loaded: true,
+  exports: function noopRequest (payload, options, callback) {
+    if (callback) callback(null, '', 200)
+  },
+}
+
+const LLMObsEvalMetricsWriter = require('../../../packages/dd-trace/src/llmobs/writers/evaluations')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 30_000
+
+const writer = new LLMObsEvalMetricsWriter({
+  apiKey: 'placeholder-api-key',
+  site: 'datadoghq.com',
+})
+writer.setAgentless(true)
+clearInterval(writer._periodic)
+
+function buildMetric ({ label, metricType, value, reasoning }) {
+  const event = {
+    join_on: { span: { span_id: '1234567890abcdef', trace_id: '6b3b1c0c1b9e4f1a8c2e7d4a5b6c7d8e' } },
+    label,
+    metric_type: metricType,
+    ml_app: 'support-bot',
+    [`${metricType}_value`]: value,
+    timestamp_ms: 1_716_950_000_000,
+    tags: ['version:1.0.0', 'env:bench', 'service:llmobs-bench', 'ml_app:support-bot'],
+  }
+  if (reasoning != null) event.reasoning = reasoning
+  return event
+}
+
+const CATEGORICAL = [
+  buildMetric({ label: 'sentiment', metricType: 'categorical', value: 'positive' }),
+  buildMetric({ label: 'toxicity', metricType: 'categorical', value: 'none' }),
+  buildMetric({ label: 'relevance', metricType: 'categorical', value: 'high' }),
+]
+const SCORE = [
+  buildMetric({ label: 'faithfulness', metricType: 'score', value: 0.92 }),
+  buildMetric({ label: 'answer_relevancy', metricType: 'score', value: 0.81 }),
+  buildMetric({ label: 'context_precision', metricType: 'score', value: 0.77 }),
+]
+const REASONED_MIXED = [
+  buildMetric({
+    label: 'faithfulness',
+    metricType: 'score',
+    value: 0.92,
+    reasoning: '回答は提供されたコンテキストに忠実で、事実誤認は見られませんでした。🚀 引用も正確です。',
+  }),
+  buildMetric({
+    label: 'sentiment',
+    metricType: 'categorical',
+    value: 'positive',
+    reasoning: 'Тон ответа доброжелательный и профессиональный, без признаков негатива.',
+  }),
+  buildMetric({
+    label: 'relevance',
+    metricType: 'categorical',
+    value: 'high',
+    reasoning: '答案与用户问题高度相关，覆盖了所有关键要点并保留了行动号召。',
+  }),
+]
+
+const EVENTS = VARIANT === 'score' ? SCORE : (VARIANT === 'reasoned-mixed' ? REASONED_MIXED : CATEGORICAL)
+
+// Preflight: confirm the writer buffers and drains.
+writer.append(EVENTS[0])
+assert.equal(writer._buffer.events.length, 1)
+writer.flush()
+assert.equal(writer._buffer.events.length, 0)
+
+guard.loopStart()
+for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+  for (const event of EVENTS) {
+    writer.append(event)
+  }
+  writer.flush()
+}
+guard.done()

--- a/benchmark/sirun/llmobs-evaluations/meta.json
+++ b/benchmark/sirun/llmobs-evaluations/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "llmobs-evaluations",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "categorical": {
+      "env": { "VARIANT": "categorical", "ITERATIONS": "160000" }
+    },
+    "score": {
+      "env": { "VARIANT": "score", "ITERATIONS": "150000" }
+    },
+    "reasoned-mixed": {
+      "env": { "VARIANT": "reasoned-mixed", "ITERATIONS": "30000" }
+    }
+  }
+}

--- a/benchmark/sirun/llmobs-span-processor/README.md
+++ b/benchmark/sirun/llmobs-span-processor/README.md
@@ -1,0 +1,8 @@
+# llmobs-span-processor
+
+Measures `LLMObsSpanProcessor.format()`, run once per finished LLMObs span: it
+reads the tagger's per-span tag map and the APM span tags, then builds the LLMObs
+event (kind-specific input/output, metadata, metrics, tags, error). The existing
+`llmobs` bench covers the writer encode; this covers the per-span formatting that
+feeds it. Variants cover llm chat, embedding, retrieval, and agent spans. It
+allocates per call, so it is GC-noisy locally and CI's pinned core is the gate.

--- a/benchmark/sirun/llmobs-span-processor/index.js
+++ b/benchmark/sirun/llmobs-span-processor/index.js
@@ -1,0 +1,129 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+globalThis[Symbol.for('dd-trace')] ??= { beforeExitHandlers: new Set() }
+
+const LLMObsSpanProcessor = require('../../../packages/dd-trace/src/llmobs/span_processor')
+const LLMObsTagger = require('../../../packages/dd-trace/src/llmobs/tagger')
+const DatadogSpanContext = require('../../../packages/dd-trace/src/opentracing/span_context')
+const id = require('../../../packages/dd-trace/src/id')
+const {
+  SPAN_KIND,
+  MODEL_NAME,
+  MODEL_PROVIDER,
+  METADATA,
+  INPUT_MESSAGES,
+  INPUT_VALUE,
+  OUTPUT_MESSAGES,
+  INPUT_DOCUMENTS,
+  OUTPUT_DOCUMENTS,
+  OUTPUT_VALUE,
+  METRICS,
+  ML_APP,
+  NAME,
+} = require('../../../packages/dd-trace/src/llmobs/constants/tags')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 2_000_000
+
+// Every finished LLMObs span runs through LLMObsSpanProcessor.format(): it reads
+// the tagger's per-span tag map and the APM span tags, then builds the LLMObs
+// event (meta/input/output by span kind, metrics, tags, error). This is the
+// per-span LLMObs hot path, uncovered by the existing llmobs writer bench.
+const processor = new LLMObsSpanProcessor({
+  llmobs: { enabled: true },
+  version: '1.0.0',
+  env: 'bench',
+  service: 'llmobs-bench',
+  parsedDdTags: {},
+})
+
+const METRICS_VALUE = { input_tokens: 312, output_tokens: 96, total_tokens: 408 }
+
+const CHAT_INPUT = [
+  { role: 'system', content: 'You are a helpful assistant for an on-call SRE team.' },
+  { role: 'user', content: 'Summarise the attached support thread in three bullet points.' },
+]
+const CHAT_OUTPUT = [
+  { role: 'assistant', content: '- 502s started at 14:00 UTC.\n- Rolled back at 14:42.\n- Resolved.' },
+]
+const DOCS = [
+  { text: 'Datadog APM traces requests across services.', name: 'apm', id: 'doc-1', score: 0.92 },
+  { text: 'LLM Observability monitors model calls.', name: 'llmobs', id: 'doc-2', score: 0.81 },
+]
+
+const TAG_SETS = {
+  'llm-chat': {
+    [SPAN_KIND]: 'llm',
+    [MODEL_NAME]: 'gpt-4o-2024-11-20',
+    [MODEL_PROVIDER]: 'openai',
+    [INPUT_MESSAGES]: CHAT_INPUT,
+    [OUTPUT_MESSAGES]: CHAT_OUTPUT,
+    [METADATA]: { temperature: 0.2, max_tokens: 512, top_p: 1, stream: false },
+    [METRICS]: METRICS_VALUE,
+    [ML_APP]: 'support-bot',
+    [NAME]: 'openai.createChatCompletion',
+  },
+  embedding: {
+    [SPAN_KIND]: 'embedding',
+    [MODEL_NAME]: 'text-embedding-3-small',
+    [MODEL_PROVIDER]: 'openai',
+    [INPUT_DOCUMENTS]: DOCS,
+    [OUTPUT_VALUE]: '[1536-dim vector]',
+    [METRICS]: { input_tokens: 24 },
+    [ML_APP]: 'search-index',
+    [NAME]: 'openai.createEmbedding',
+  },
+  retrieval: {
+    [SPAN_KIND]: 'retrieval',
+    [INPUT_VALUE]: 'How does Datadog trace LLM calls?',
+    [OUTPUT_DOCUMENTS]: DOCS,
+    [METADATA]: { top_k: 2, index: 'docs-v2' },
+    [ML_APP]: 'rag-pipeline',
+    [NAME]: 'pinecone.query',
+  },
+  agent: {
+    [SPAN_KIND]: 'agent',
+    [INPUT_VALUE]: 'Investigate the deploy that broke checkout and summarise the fix.',
+    [OUTPUT_VALUE]: 'Rolled back deploy 4821; checkout error rate back to baseline.',
+    [METADATA]: { steps: 4, tools_used: ['search', 'rollback'] },
+    [METRICS]: METRICS_VALUE,
+    [ML_APP]: 'sre-agent',
+    [NAME]: 'agent.run',
+  },
+}
+
+const mlObsTags = TAG_SETS[VARIANT]
+assert.ok(mlObsTags, `unknown VARIANT: ${VARIANT}`)
+
+const spanContext = new DatadogSpanContext({
+  traceId: id(),
+  spanId: id(),
+  tags: {},
+})
+spanContext._trace.tags['_dd.p.tid'] = '640cfd8d00000000'
+
+const span = {
+  _name: 'llmobs.span',
+  _startTime: 1_716_950_000_000.5,
+  _duration: 742.5,
+  context () { return spanContext },
+}
+LLMObsTagger.tagMap.set(span, mlObsTags)
+
+// Preflight: confirm format produced an event with the right kind and meta.
+const sample = processor.format(span)
+assert.equal(sample.meta['span.kind'], mlObsTags[SPAN_KIND], 'format did not set the span kind')
+assert.ok(sample.tags.length > 0, 'format did not build the tag array')
+
+guard.loopStart()
+let sink = 0
+for (let i = 0; i < ITERATIONS; i++) {
+  const event = processor.format(span)
+  sink += event.tags.length
+}
+guard.done()
+
+if (sink === 0) throw new Error('unreachable')

--- a/benchmark/sirun/llmobs-span-processor/meta.json
+++ b/benchmark/sirun/llmobs-span-processor/meta.json
@@ -16,7 +16,7 @@
       "env": { "VARIANT": "retrieval", "ITERATIONS": "2000000" }
     },
     "agent": {
-      "env": { "VARIANT": "agent", "ITERATIONS": "2500000" }
+      "env": { "VARIANT": "agent", "ITERATIONS": "1200000" }
     }
   }
 }

--- a/benchmark/sirun/llmobs-span-processor/meta.json
+++ b/benchmark/sirun/llmobs-span-processor/meta.json
@@ -1,0 +1,22 @@
+{
+  "name": "llmobs-span-processor",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "llm-chat": {
+      "env": { "VARIANT": "llm-chat", "ITERATIONS": "2000000" }
+    },
+    "embedding": {
+      "env": { "VARIANT": "embedding", "ITERATIONS": "2000000" }
+    },
+    "retrieval": {
+      "env": { "VARIANT": "retrieval", "ITERATIONS": "2000000" }
+    },
+    "agent": {
+      "env": { "VARIANT": "agent", "ITERATIONS": "2500000" }
+    }
+  }
+}

--- a/benchmark/sirun/llmobs-span-processor/meta.json
+++ b/benchmark/sirun/llmobs-span-processor/meta.json
@@ -16,7 +16,7 @@
       "env": { "VARIANT": "retrieval", "ITERATIONS": "2000000" }
     },
     "agent": {
-      "env": { "VARIANT": "agent", "ITERATIONS": "1200000" }
+      "env": { "VARIANT": "agent", "ITERATIONS": "950000" }
     }
   }
 }

--- a/benchmark/sirun/load-insecure-bank.js
+++ b/benchmark/sirun/load-insecure-bank.js
@@ -2,6 +2,22 @@
 
 const url = require('url')
 
+// This fixture deliberately exercises the legacy `url.parse()`, whose one-time
+// DEP0169 deprecation warning is just noise in the benchmark output. Suppress
+// that single code; forward every other warning untouched.
+const originalEmitWarning = process.emitWarning
+/**
+ * @param {string | Error} warning
+ * @param {...unknown} args
+ */
+process.emitWarning = function patchedEmitWarning (warning, ...args) {
+  const code = typeof args[0] === 'object' && args[0] !== null
+    ? /** @type {{ code?: string }} */ (args[0]).code
+    : args[1]
+  if (code === 'DEP0169') return
+  return originalEmitWarning.call(this, warning, ...args)
+}
+
 /**
  * @returns {import('http').RequestListener}
  */

--- a/benchmark/sirun/log/README.md
+++ b/benchmark/sirun/log/README.md
@@ -1,6 +1,4 @@
 This test calls the internal logger on various log levels for many iterations.
 
-* `without-log` is the baseline that has logging disabled completely.
-* `skip-log` has logs enabled but uses a log level that isn't so that the handler doesn't run.
 * `with-debug` has logs enabled and sends a debug log.
 * `with-error` has logs enabled and sends an error log.

--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -6,7 +6,7 @@ const { debugChannel, errorChannel } = require('../../../packages/dd-trace/src/l
 const log = require('../../../packages/dd-trace/src/log')
 
 const { WITH_LEVEL = 'debug' } = process.env
-const COUNT = 800_000
+const COUNT = Number(process.env.COUNT) || 800_000
 
 // Override the default console-backed logger to isolate dispatch + filtering cost.
 log.configure({
@@ -31,12 +31,13 @@ assert.equal(
   `errorChannel.hasSubscribers mismatch (DD_TRACE_DEBUG=${process.env.DD_TRACE_DEBUG})`
 )
 
-// The disabled / filtered variants (without-log, skip-log) are node-boot-bound:
-// the disabled path is a near-free dispatch, and lengthening only trades boot
-// domination for a closure-allocation GC cliff (an inline thunk per call), while
-// hoisting the thunk lets V8 dead-code-eliminate the no-op loop. They are left
-// short; with-debug / with-error are the loop-dominant variants. No startup guard
-// for that reason.
+// Both variants drive the logger on every call, so the loop dominates: with-debug
+// runs the (overridden no-op) debug handler, with-error builds an Error per call.
+// COUNT stays at 800k because with-error allocates an Error + message per iteration;
+// growing it hits a major-GC cliff that spikes stddev. The earlier disabled/filtered
+// variants (no subscribers) were dropped: with nothing to dispatch to, V8 dead-code-
+// eliminated the no-op loop, so wall.time flipped between running and elided runs
+// (stddev up to ~66%) and the variant measured nothing that could regress.
 for (let i = 0; i < COUNT; i++) {
   log[WITH_LEVEL](() => 'message')
 }

--- a/benchmark/sirun/log/index.js
+++ b/benchmark/sirun/log/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
 
 const { debugChannel, errorChannel } = require('../../../packages/dd-trace/src/log/channels')
 const log = require('../../../packages/dd-trace/src/log')
@@ -33,11 +34,15 @@ assert.equal(
 
 // Both variants drive the logger on every call, so the loop dominates: with-debug
 // runs the (overridden no-op) debug handler, with-error builds an Error per call.
-// COUNT stays at 800k because with-error allocates an Error + message per iteration;
-// growing it hits a major-GC cliff that spikes stddev. The earlier disabled/filtered
+// COUNT is set per variant (meta.json): with-error stays at 800k because the per-call
+// Error allocation hits a major-GC cliff that spikes stddev if grown; with-debug has
+// no such allocation, so it runs a larger COUNT to keep the loop well clear of the
+// startup-guard floor and tighten per-sample stddev. The earlier disabled/filtered
 // variants (no subscribers) were dropped: with nothing to dispatch to, V8 dead-code-
 // eliminated the no-op loop, so wall.time flipped between running and elided runs
 // (stddev up to ~66%) and the variant measured nothing that could regress.
+guard.loopStart()
 for (let i = 0; i < COUNT; i++) {
   log[WITH_LEVEL](() => 'message')
 }
+guard.done()

--- a/benchmark/sirun/log/meta.json
+++ b/benchmark/sirun/log/meta.json
@@ -6,8 +6,6 @@
   "iterations": 10,
   "instructions": true,
   "variants": {
-    "without-log": { "env": { "DD_TRACE_DEBUG": "false" } },
-    "skip-log": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "debug", "DD_TRACE_LOG_LEVEL": "error" } },
     "with-debug": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "debug", "DD_TRACE_LOG_LEVEL": "debug" } },
     "with-error": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "error", "DD_TRACE_LOG_LEVEL": "error" } }
   }

--- a/benchmark/sirun/log/meta.json
+++ b/benchmark/sirun/log/meta.json
@@ -6,7 +6,7 @@
   "iterations": 10,
   "instructions": true,
   "variants": {
-    "with-debug": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "debug", "DD_TRACE_LOG_LEVEL": "debug" } },
-    "with-error": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "error", "DD_TRACE_LOG_LEVEL": "error" } }
+    "with-debug": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "debug", "DD_TRACE_LOG_LEVEL": "debug", "COUNT": "8000000" } },
+    "with-error": { "env": { "DD_TRACE_DEBUG": "true", "WITH_LEVEL": "error", "DD_TRACE_LOG_LEVEL": "error", "COUNT": "800000" } }
   }
 }

--- a/benchmark/sirun/plugin-aws-sdk/index.js
+++ b/benchmark/sirun/plugin-aws-sdk/index.js
@@ -44,6 +44,9 @@ const EVENTBRIDGE_DETAIL_JSON = JSON.stringify({
 })
 
 guard.loopStart()
+// Read a field of every result into `sink` so V8 can't dead-code-eliminate the
+// measured call; asserted non-zero after the loop.
+let sink = 0
 if (VARIANT === 'extract-response-body') {
   const plugin = Object.create(BaseAwsSdkPlugin.prototype)
   // Pre-flight: confirm extractResponseBody strips the SDK envelope keys; catches
@@ -52,7 +55,7 @@ if (VARIANT === 'extract-response-body') {
   assert.equal(sanityBody.$metadata, undefined)
   assert.equal(sanityBody.MessageId, 'msg-cccccccccc')
   for (let iteration = 0; iteration < ITERATIONS; iteration++) {
-    plugin.extractResponseBody(RESPONSE)
+    sink += plugin.extractResponseBody(RESPONSE).MessageId.length
   }
 } else if (VARIANT === 'eventbridge-inject-detail') {
   const plugin = Object.create(EventBridge.prototype)
@@ -70,6 +73,7 @@ if (VARIANT === 'extract-response-body') {
       params: { Entries: [{ Detail: EVENTBRIDGE_DETAIL_JSON }] },
     }
     plugin.requestInject(fakeSpan, request)
+    sink += request.params.Entries[0].Detail.length
   }
 } else if (VARIANT === 'lambda-inject-no-context') {
   const plugin = Object.create(Lambda.prototype)
@@ -80,6 +84,35 @@ if (VARIANT === 'extract-response-body') {
   for (let iteration = 0; iteration < ITERATIONS; iteration++) {
     const request = { operation: 'invoke', params: { FunctionName: 'my-fn' } }
     plugin.requestInject(fakeSpan, request)
+    sink += request.params.ClientContext.length
+  }
+} else if (VARIANT === 'lambda-inject-with-context') {
+  // The heavier real-world Lambda path: an existing ClientContext carrying a `custom`
+  // block, so requestInject base64-decodes it, JSON.parses, Object.assigns the injected
+  // trace keys into custom, then re-stringifies and re-encodes -- exercising the
+  // try/catch around the JSON ops that the no-context path never reaches.
+  const plugin = Object.create(Lambda.prototype)
+  plugin._tracer = fakeTracer
+  const EXISTING_CONTEXT = Buffer.from(
+    JSON.stringify({ custom: { 'app.request.id': 'req-1234567890' } })
+  ).toString('base64')
+  const sanityRequest = {
+    operation: 'invoke',
+    params: { FunctionName: 'my-fn', ClientContext: EXISTING_CONTEXT },
+  }
+  plugin.requestInject(fakeSpan, sanityRequest)
+  const merged = JSON.parse(Buffer.from(sanityRequest.params.ClientContext, 'base64').toString('utf8'))
+  assert.ok(merged.custom['app.request.id'] === 'req-1234567890' && merged.custom['x-datadog-trace-id'],
+    'Lambda requestInject did not merge datadog keys into the existing ClientContext')
+  for (let iteration = 0; iteration < ITERATIONS; iteration++) {
+    const request = {
+      operation: 'invoke',
+      params: { FunctionName: 'my-fn', ClientContext: EXISTING_CONTEXT },
+    }
+    plugin.requestInject(fakeSpan, request)
+    sink += request.params.ClientContext.length
   }
 }
 guard.done()
+
+if (sink === 0) throw new Error('unreachable')

--- a/benchmark/sirun/plugin-aws-sdk/meta.json
+++ b/benchmark/sirun/plugin-aws-sdk/meta.json
@@ -14,12 +14,20 @@
     },
     "eventbridge-inject-detail": {
       "env": {
-        "VARIANT": "eventbridge-inject-detail"
+        "VARIANT": "eventbridge-inject-detail",
+        "ITERATIONS": "3000000"
       }
     },
     "lambda-inject-no-context": {
       "env": {
-        "VARIANT": "lambda-inject-no-context"
+        "VARIANT": "lambda-inject-no-context",
+        "ITERATIONS": "4000000"
+      }
+    },
+    "lambda-inject-with-context": {
+      "env": {
+        "VARIANT": "lambda-inject-with-context",
+        "ITERATIONS": "2000000"
       }
     }
   }

--- a/benchmark/sirun/plugin-cassandra-driver/README.md
+++ b/benchmark/sirun/plugin-cassandra-driver/README.md
@@ -1,0 +1,6 @@
+# plugin-cassandra-driver
+
+Measures the cassandra-driver plugin `bindStart`: combine a batch of statements
+into a single resource string (or trim a single long statement at 5000 chars) and
+assemble the meta bag. Variants cover a single query, a batch, and an over-long
+query that hits the trim path.

--- a/benchmark/sirun/plugin-cassandra-driver/index.js
+++ b/benchmark/sirun/plugin-cassandra-driver/index.js
@@ -33,31 +33,42 @@ const plugin = new BenchedCassandraPlugin(tracer, { spanComputePeerService: fals
 plugin.configure({ enabled: true, service: 'cassandra-prod' })
 
 const CONTACT_POINTS = ['10.0.0.1', '10.0.0.2', '10.0.0.3']
-const SINGLE = 'SELECT id, name, email FROM users WHERE id = ? AND tenant = ? ALLOW FILTERING'
-const BATCH = []
-for (let i = 0; i < 12; i++) BATCH.push({ query: `INSERT INTO events (id, payload) VALUES (?, ?) -- ${i}` })
-const LONG = 'SELECT * FROM events WHERE ' + Array.from({ length: 400 }, (_, i) => `col_${i} = ?`).join(' OR ')
 
+const SINGLE_QUERIES = [
+  'SELECT id, name, email FROM users WHERE id = ? AND tenant = ? ALLOW FILTERING',
+  'INSERT INTO events (id, payload, ts) VALUES (?, ?, ?)',
+  'SELECT * FROM orders WHERE customer_id = ? LIMIT 100',
+  'UPDATE sessions SET last_seen = ? WHERE id = ?',
+]
+
+function buildBatch (count, table) {
+  const batch = []
+  for (let i = 0; i < count; i++) batch.push({ query: `INSERT INTO ${table} (id, payload) VALUES (?, ?) -- ${i}` })
+  return batch
+}
+
+function buildLong (cols) {
+  return 'SELECT * FROM events WHERE ' + Array.from({ length: cols }, (_, i) => `col_${i} = ?`).join(' OR ')
+}
+
+// Each variant rotates a small corpus of that shape so the resource/meta build
+// runs over varied query lengths (and batch sizes) rather than one fixed query.
+// bindStart only reads ctx (combine reads the batch array without draining it),
+// so the pre-built ctxs are safe to reuse across iterations.
 const VARIANTS = {
-  query: { keyspace: 'app', query: SINGLE, contactPoints: CONTACT_POINTS },
-  batch: { keyspace: 'app', query: BATCH, contactPoints: CONTACT_POINTS },
-  'long-query': { keyspace: 'app', query: LONG, contactPoints: CONTACT_POINTS },
+  query: SINGLE_QUERIES.map((query) => ({ keyspace: 'app', query, contactPoints: CONTACT_POINTS })),
+  batch: [buildBatch(12, 'events'), buildBatch(8, 'audit'), buildBatch(16, 'metrics')]
+    .map((query) => ({ keyspace: 'app', query, contactPoints: CONTACT_POINTS })),
+  'long-query': [buildLong(400), buildLong(520)]
+    .map((query) => ({ keyspace: 'app', query, contactPoints: CONTACT_POINTS })),
 }
 
-const v = VARIANTS[VARIANT]
-assert.ok(v, `unknown VARIANT: ${VARIANT}`)
+const ctxs = VARIANTS[VARIANT]
+assert.ok(ctxs, `unknown VARIANT: ${VARIANT}`)
+const len = ctxs.length
 
-function makeCtx () {
-  // query is reassigned inside bindStart for batches (combine), and arrays would
-  // otherwise be consumed across calls; a fresh ctx per preflight keeps inputs
-  // stable. The hot loop reuses one ctx (startSpan is stubbed, so ctx is not
-  // mutated and the batch array is read, not drained).
-  return { keyspace: v.keyspace, query: v.query, contactPoints: v.contactPoints }
-}
-
-const ctx = makeCtx()
 lastMeta = undefined
-plugin.bindStart(ctx)
+plugin.bindStart(ctxs[0])
 assert.ok(lastMeta && typeof lastResource === 'string', 'bindStart did not build the resource/meta')
 if (VARIANT === 'long-query') {
   assert.ok(lastResource.endsWith('...'), 'long-query should hit the 5000-char trim')
@@ -65,7 +76,7 @@ if (VARIANT === 'long-query') {
 
 guard.loopStart()
 for (let i = 0; i < ITERATIONS; i++) {
-  plugin.bindStart(ctx)
+  plugin.bindStart(ctxs[i % len])
 }
 guard.done()
 

--- a/benchmark/sirun/plugin-cassandra-driver/index.js
+++ b/benchmark/sirun/plugin-cassandra-driver/index.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const CassandraDriverPlugin = require('../../../packages/datadog-plugin-cassandra-driver/src/index')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 3_000_000
+
+// Every traced cassandra query walks `bindStart`: combine a batch of statements
+// into one resource string (or trim a single long one), then assemble the meta
+// bag. Subclass the real plugin and override only the tracer-reaching hooks so
+// the measured surface is that resource/meta work.
+let lastMeta
+let lastResource
+const FAKE_SPAN = { finish () {}, setTag () {} }
+class BenchedCassandraPlugin extends CassandraDriverPlugin {
+  addSub () {}
+  addBind () {}
+  operationName () { return 'cassandra.query' }
+  serviceName () { return 'cassandra-prod' }
+  startSpan (...args) {
+    const opts = args.find((a) => a && a.meta)
+    lastMeta = opts?.meta
+    lastResource = opts?.resource
+    return FAKE_SPAN
+  }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0' }
+const plugin = new BenchedCassandraPlugin(tracer, { spanComputePeerService: false })
+plugin.configure({ enabled: true, service: 'cassandra-prod' })
+
+const CONTACT_POINTS = ['10.0.0.1', '10.0.0.2', '10.0.0.3']
+const SINGLE = 'SELECT id, name, email FROM users WHERE id = ? AND tenant = ? ALLOW FILTERING'
+const BATCH = []
+for (let i = 0; i < 12; i++) BATCH.push({ query: `INSERT INTO events (id, payload) VALUES (?, ?) -- ${i}` })
+const LONG = 'SELECT * FROM events WHERE ' + Array.from({ length: 400 }, (_, i) => `col_${i} = ?`).join(' OR ')
+
+const VARIANTS = {
+  query: { keyspace: 'app', query: SINGLE, contactPoints: CONTACT_POINTS },
+  batch: { keyspace: 'app', query: BATCH, contactPoints: CONTACT_POINTS },
+  'long-query': { keyspace: 'app', query: LONG, contactPoints: CONTACT_POINTS },
+}
+
+const v = VARIANTS[VARIANT]
+assert.ok(v, `unknown VARIANT: ${VARIANT}`)
+
+function makeCtx () {
+  // query is reassigned inside bindStart for batches (combine), and arrays would
+  // otherwise be consumed across calls; a fresh ctx per preflight keeps inputs
+  // stable. The hot loop reuses one ctx (startSpan is stubbed, so ctx is not
+  // mutated and the batch array is read, not drained).
+  return { keyspace: v.keyspace, query: v.query, contactPoints: v.contactPoints }
+}
+
+const ctx = makeCtx()
+lastMeta = undefined
+plugin.bindStart(ctx)
+assert.ok(lastMeta && typeof lastResource === 'string', 'bindStart did not build the resource/meta')
+if (VARIANT === 'long-query') {
+  assert.ok(lastResource.endsWith('...'), 'long-query should hit the 5000-char trim')
+}
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.bindStart(ctx)
+}
+guard.done()
+
+assert.ok(lastMeta, 'startSpan stub was never reached')

--- a/benchmark/sirun/plugin-cassandra-driver/meta.json
+++ b/benchmark/sirun/plugin-cassandra-driver/meta.json
@@ -7,7 +7,7 @@
   "instructions": true,
   "variants": {
     "query": {
-      "env": { "VARIANT": "query", "ITERATIONS": "45000000" }
+      "env": { "VARIANT": "query", "ITERATIONS": "35000000" }
     },
     "batch": {
       "env": { "VARIANT": "batch", "ITERATIONS": "2000000" }

--- a/benchmark/sirun/plugin-cassandra-driver/meta.json
+++ b/benchmark/sirun/plugin-cassandra-driver/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "plugin-cassandra-driver",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "query": {
+      "env": { "VARIANT": "query", "ITERATIONS": "45000000" }
+    },
+    "batch": {
+      "env": { "VARIANT": "batch", "ITERATIONS": "2000000" }
+    },
+    "long-query": {
+      "env": { "VARIANT": "long-query", "ITERATIONS": "30000000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-couchbase/README.md
+++ b/benchmark/sirun/plugin-couchbase/README.md
@@ -1,0 +1,5 @@
+# plugin-couchbase
+
+Measures `CouchBasePlugin.startSpan` tag assembly: the base tag bag plus the
+bucket/collection names and the per-operation custom tags, before delegating to
+the storage base (stubbed here). Variants cover a query and an upsert.

--- a/benchmark/sirun/plugin-couchbase/index.js
+++ b/benchmark/sirun/plugin-couchbase/index.js
@@ -33,37 +33,65 @@ const plugin = new BenchedCouchbasePlugin(tracer, { spanComputePeerService: fals
 plugin.configure({ enabled: true, service: 'couchbase-prod' })
 
 const SEED_NODES = '10.0.0.1,10.0.0.2,10.0.0.3'
-const BUCKET = { name: 'app-data' }
-const COLLECTION = { name: 'orders' }
 
-const VARIANTS = {
-  query: {
-    operation: 'query',
-    customTags: {
-      'span.type': 'sql',
-      'resource.name': 'SELECT * FROM `app-data` WHERE type = $1',
-      'span.kind': 'client',
-    },
-    locator: { bucket: BUCKET, seedNodes: SEED_NODES },
-  },
-  upsert: {
-    operation: 'upsert',
-    customTags: {},
-    locator: { bucket: BUCKET, collection: COLLECTION, seedNodes: SEED_NODES },
-  },
+function sqlTags (resource) {
+  return { 'span.type': 'sql', 'resource.name': resource, 'span.kind': 'client' }
 }
 
-const v = VARIANTS[VARIANT]
-assert.ok(v, `unknown VARIANT: ${VARIANT}`)
+// Each variant rotates a small corpus so the tag assembly runs over varied
+// resource names, buckets and collections. The upsert corpus also covers the
+// sibling insert/replace operations, which share the same span starter.
+const QUERY_OPS = [
+  {
+    operation: 'query',
+    customTags: sqlTags('SELECT * FROM `app-data` WHERE type = $1'),
+    locator: { bucket: { name: 'app-data' }, seedNodes: SEED_NODES },
+  },
+  {
+    operation: 'query',
+    customTags: sqlTags('SELECT id, total FROM `orders` WHERE status = $1 LIMIT 50'),
+    locator: { bucket: { name: 'orders' }, seedNodes: SEED_NODES },
+  },
+  {
+    operation: 'query',
+    customTags: sqlTags('UPDATE `sessions` SET active = true WHERE id = $1'),
+    locator: { bucket: { name: 'sessions' }, seedNodes: SEED_NODES },
+  },
+]
+
+const MUTATE_OPS = [
+  {
+    operation: 'upsert',
+    customTags: {},
+    locator: { bucket: { name: 'app-data' }, collection: { name: 'orders' }, seedNodes: SEED_NODES },
+  },
+  {
+    operation: 'insert',
+    customTags: {},
+    locator: { bucket: { name: 'users' }, collection: { name: 'profiles' }, seedNodes: SEED_NODES },
+  },
+  {
+    operation: 'replace',
+    customTags: {},
+    locator: { bucket: { name: 'events' }, collection: { name: 'audit' }, seedNodes: SEED_NODES },
+  },
+]
+
+const VARIANTS = { query: QUERY_OPS, upsert: MUTATE_OPS }
+
+const ops = VARIANTS[VARIANT]
+assert.ok(ops, `unknown VARIANT: ${VARIANT}`)
+const len = ops.length
 const ctx = {}
 
 lastMeta = undefined
-plugin.startSpan(v.operation, v.customTags, v.locator, ctx)
+plugin.startSpan(ops[0].operation, ops[0].customTags, ops[0].locator, ctx)
 assert.ok(lastMeta && lastMeta['db.type'] === 'couchbase', 'startSpan did not build the couchbase tags')
 
 guard.loopStart()
 for (let i = 0; i < ITERATIONS; i++) {
-  plugin.startSpan(v.operation, v.customTags, v.locator, ctx)
+  const entry = ops[i % len]
+  plugin.startSpan(entry.operation, entry.customTags, entry.locator, ctx)
 }
 guard.done()
 

--- a/benchmark/sirun/plugin-couchbase/index.js
+++ b/benchmark/sirun/plugin-couchbase/index.js
@@ -39,7 +39,11 @@ const COLLECTION = { name: 'orders' }
 const VARIANTS = {
   query: {
     operation: 'query',
-    customTags: { 'span.type': 'sql', 'resource.name': 'SELECT * FROM `app-data` WHERE type = $1', 'span.kind': 'client' },
+    customTags: {
+      'span.type': 'sql',
+      'resource.name': 'SELECT * FROM `app-data` WHERE type = $1',
+      'span.kind': 'client',
+    },
     locator: { bucket: BUCKET, seedNodes: SEED_NODES },
   },
   upsert: {

--- a/benchmark/sirun/plugin-couchbase/index.js
+++ b/benchmark/sirun/plugin-couchbase/index.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const CouchBasePlugin = require('../../../packages/datadog-plugin-couchbase/src/index')
+const StoragePlugin = require('../../../packages/dd-trace/src/plugins/storage')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 5_000_000
+
+// Couchbase builds its span tags in `CouchBasePlugin.startSpan`: assemble the
+// base tag bag, add bucket/collection names, and merge the per-operation custom
+// tags before delegating to the storage base. Stub the storage base's startSpan
+// (the tracer-reaching layer) so the measured surface is the couchbase tag
+// assembly itself, which we drive directly.
+let lastMeta
+const FAKE_SPAN = { finish () {}, setTag () {} }
+StoragePlugin.prototype.startSpan = function (name, options) {
+  lastMeta = options.meta
+  return FAKE_SPAN
+}
+
+class BenchedCouchbasePlugin extends CouchBasePlugin {
+  addSub () {}
+  addBind () {}
+  operationName () { return 'couchbase.query' }
+  serviceName () { return 'couchbase-prod' }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0' }
+const plugin = new BenchedCouchbasePlugin(tracer, { spanComputePeerService: false })
+plugin.configure({ enabled: true, service: 'couchbase-prod' })
+
+const SEED_NODES = '10.0.0.1,10.0.0.2,10.0.0.3'
+const BUCKET = { name: 'app-data' }
+const COLLECTION = { name: 'orders' }
+
+const VARIANTS = {
+  query: {
+    operation: 'query',
+    customTags: { 'span.type': 'sql', 'resource.name': 'SELECT * FROM `app-data` WHERE type = $1', 'span.kind': 'client' },
+    locator: { bucket: BUCKET, seedNodes: SEED_NODES },
+  },
+  upsert: {
+    operation: 'upsert',
+    customTags: {},
+    locator: { bucket: BUCKET, collection: COLLECTION, seedNodes: SEED_NODES },
+  },
+}
+
+const v = VARIANTS[VARIANT]
+assert.ok(v, `unknown VARIANT: ${VARIANT}`)
+const ctx = {}
+
+lastMeta = undefined
+plugin.startSpan(v.operation, v.customTags, v.locator, ctx)
+assert.ok(lastMeta && lastMeta['db.type'] === 'couchbase', 'startSpan did not build the couchbase tags')
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.startSpan(v.operation, v.customTags, v.locator, ctx)
+}
+guard.done()
+
+assert.ok(lastMeta, 'storage startSpan stub was never reached')

--- a/benchmark/sirun/plugin-couchbase/meta.json
+++ b/benchmark/sirun/plugin-couchbase/meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "plugin-couchbase",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "query": {
+      "env": { "VARIANT": "query", "ITERATIONS": "90000000" }
+    },
+    "upsert": {
+      "env": { "VARIANT": "upsert", "ITERATIONS": "180000000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-couchbase/meta.json
+++ b/benchmark/sirun/plugin-couchbase/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "query": {
-      "env": { "VARIANT": "query", "ITERATIONS": "90000000" }
+      "env": { "VARIANT": "query", "ITERATIONS": "44000000" }
     },
     "upsert": {
-      "env": { "VARIANT": "upsert", "ITERATIONS": "180000000" }
+      "env": { "VARIANT": "upsert", "ITERATIONS": "125000000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-dns/index.js
+++ b/benchmark/sirun/plugin-dns/index.js
@@ -80,6 +80,15 @@ assert.equal(lastResult, '127.0.0.1', 'dns lookup wrapper did not deliver the re
 assert.equal(storeInLookup?.span, span, 'start bind did not propagate the span store')
 assert.equal(storeInCallback, undefined, 'finish bind did not restore the parent store')
 
+// Drift guard: buildArgsContext mirrors buildCallbackArgsContext() in dns.js (not
+// exported). Assert it still drops the trailing callback and captures the rest, so
+// the mirror can't silently diverge from the production arg-capture shape.
+assert.deepEqual(
+  buildArgsContext(null, ['localhost', 4, () => {}]),
+  { args: ['localhost', 4] },
+  'buildArgsContext mirror drifted from buildCallbackArgsContext'
+)
+
 guard.loopStart()
 for (let i = 0; i < ITERATIONS; i++) {
   wrappedLookup('localhost', onLookup)

--- a/benchmark/sirun/plugin-elasticsearch/README.md
+++ b/benchmark/sirun/plugin-elasticsearch/README.md
@@ -1,0 +1,6 @@
+# plugin-elasticsearch
+
+Measures the Elasticsearch plugin `bindStart`: serialize the request body
+(JSON.stringify), quantize the path (digits to `?`), serialize the query string,
+and assemble the meta bag. Variants cover a search with a query-DSL body, a bulk
+index payload, and a doc get with no body.

--- a/benchmark/sirun/plugin-elasticsearch/index.js
+++ b/benchmark/sirun/plugin-elasticsearch/index.js
@@ -31,38 +31,74 @@ const tracerConfig = { spanComputePeerService: false }
 const plugin = new BenchedElasticsearchPlugin(tracer, tracerConfig)
 plugin.configure({ enabled: true, service: 'elasticsearch-prod' })
 
-const SEARCH_BODY = {
-  query: {
-    bool: {
-      must: [{ match: { title: 'observability' } }, { term: { status: 'published' } }],
-      filter: [{ range: { created_at: { gte: '2024-01-01' } } }],
+// Each variant is a small corpus of realistic requests of that shape. Rotating
+// over it (rather than one reused request) keeps the bindStart call site
+// polymorphic and varies the path / body / querystring lengths quantizePath and
+// the JSON.stringify calls see, closer to real traffic than a single fixture.
+const SEARCH = [
+  {
+    method: 'POST',
+    path: '/products/_search',
+    body: {
+      query: {
+        bool: {
+          must: [{ match: { title: 'observability' } }, { term: { status: 'published' } }],
+          filter: [{ range: { created_at: { gte: '2024-01-01' } } }],
+        },
+      },
+      sort: [{ created_at: 'desc' }],
+      size: 20,
     },
+    querystring: { timeout: '5s' },
   },
-  sort: [{ created_at: 'desc' }],
-  size: 20,
-}
-const BULK_BODY = []
-for (let i = 0; i < 40; i++) {
-  BULK_BODY.push({ index: { _index: 'logs', _id: `id-${i}` } }, { message: `log line ${i}`, level: 'info', n: i })
+  {
+    method: 'POST',
+    path: '/orders-2024/_search',
+    body: { query: { match: { customer_id: 'c-7788' } }, from: 40, size: 50 },
+    querystring: { routing: 'shard-3' },
+  },
+  {
+    method: 'POST',
+    path: '/users/_search',
+    body: { query: { term: { active: true } } },
+    querystring: { _source: 'id,email' },
+  },
+]
+
+function buildBulkBody (count, index) {
+  const body = []
+  for (let i = 0; i < count; i++) {
+    body.push({ index: { _index: index, _id: `id-${i}` } }, { message: `log line ${i}`, level: 'info', n: i })
+  }
+  return body
 }
 
-const VARIANTS = {
-  search: { method: 'POST', path: '/products/_search', body: SEARCH_BODY, querystring: { timeout: '5s' } },
-  'bulk-index': { method: 'POST', path: '/logs/_bulk', bulkBody: BULK_BODY },
-  get: { method: 'GET', path: '/products/_doc/123456', querystring: { _source: 'title,status' } },
-}
+const BULK = [
+  { method: 'POST', path: '/logs/_bulk', bulkBody: buildBulkBody(40, 'logs') },
+  { method: 'POST', path: '/events/_bulk', bulkBody: buildBulkBody(20, 'events') },
+  { method: 'POST', path: '/metrics-2024/_bulk', bulkBody: buildBulkBody(60, 'metrics') },
+]
 
-const params = VARIANTS[VARIANT]
-assert.ok(params, `unknown VARIANT: ${VARIANT}`)
-const ctx = { params }
+const GET = [
+  { method: 'GET', path: '/products/_doc/123456', querystring: { _source: 'title,status' } },
+  { method: 'GET', path: '/users/_doc/u-998877', querystring: {} },
+  { method: 'GET', path: '/orders-2024/_doc/55', querystring: { _source_excludes: 'payload' } },
+]
+
+const VARIANTS = { search: SEARCH, 'bulk-index': BULK, get: GET }
+
+const corpus = VARIANTS[VARIANT]
+assert.ok(corpus, `unknown VARIANT: ${VARIANT}`)
+const ctxs = corpus.map((params) => ({ params }))
+const len = ctxs.length
 
 lastMeta = undefined
-plugin.bindStart(ctx)
+plugin.bindStart(ctxs[0])
 assert.ok(lastMeta && typeof lastMeta['elasticsearch.url'] === 'string', 'bindStart did not build meta')
 
 guard.loopStart()
 for (let i = 0; i < ITERATIONS; i++) {
-  plugin.bindStart(ctx)
+  plugin.bindStart(ctxs[i % len])
 }
 guard.done()
 

--- a/benchmark/sirun/plugin-elasticsearch/index.js
+++ b/benchmark/sirun/plugin-elasticsearch/index.js
@@ -1,0 +1,69 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const ElasticsearchPlugin = require('../../../packages/datadog-plugin-elasticsearch/src/index')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 2_000_000
+
+// Every traced Elasticsearch request walks `bindStart`: serialize the request
+// body (JSON.stringify), quantize the path (digit -> ?), serialize the query
+// string, and assemble the meta bag. Subclass the real plugin and override only
+// the tracer-reaching hooks so the measured surface is that per-request work.
+let lastMeta
+const FAKE_SPAN = { finish () {}, setTag () {} }
+class BenchedElasticsearchPlugin extends ElasticsearchPlugin {
+  addSub () {}
+  addBind () {}
+  operationName () { return 'elasticsearch.query' }
+  serviceName () { return 'elasticsearch-prod' }
+  startSpan (...args) {
+    const opts = args.find((a) => a && a.meta)
+    lastMeta = opts?.meta
+    return FAKE_SPAN
+  }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0' }
+const tracerConfig = { spanComputePeerService: false }
+const plugin = new BenchedElasticsearchPlugin(tracer, tracerConfig)
+plugin.configure({ enabled: true, service: 'elasticsearch-prod' })
+
+const SEARCH_BODY = {
+  query: {
+    bool: {
+      must: [{ match: { title: 'observability' } }, { term: { status: 'published' } }],
+      filter: [{ range: { created_at: { gte: '2024-01-01' } } }],
+    },
+  },
+  sort: [{ created_at: 'desc' }],
+  size: 20,
+}
+const BULK_BODY = []
+for (let i = 0; i < 40; i++) {
+  BULK_BODY.push({ index: { _index: 'logs', _id: `id-${i}` } }, { message: `log line ${i}`, level: 'info', n: i })
+}
+
+const VARIANTS = {
+  search: { method: 'POST', path: '/products/_search', body: SEARCH_BODY, querystring: { timeout: '5s' } },
+  'bulk-index': { method: 'POST', path: '/logs/_bulk', bulkBody: BULK_BODY },
+  get: { method: 'GET', path: '/products/_doc/123456', querystring: { _source: 'title,status' } },
+}
+
+const params = VARIANTS[VARIANT]
+assert.ok(params, `unknown VARIANT: ${VARIANT}`)
+const ctx = { params }
+
+lastMeta = undefined
+plugin.bindStart(ctx)
+assert.ok(lastMeta && typeof lastMeta['elasticsearch.url'] === 'string', 'bindStart did not build meta')
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.bindStart(ctx)
+}
+guard.done()
+
+assert.ok(lastMeta, 'startSpan stub was never reached')

--- a/benchmark/sirun/plugin-elasticsearch/meta.json
+++ b/benchmark/sirun/plugin-elasticsearch/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "plugin-elasticsearch",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "search": {
+      "env": { "VARIANT": "search", "ITERATIONS": "2000000" }
+    },
+    "bulk-index": {
+      "env": { "VARIANT": "bulk-index", "ITERATIONS": "600000" }
+    },
+    "get": {
+      "env": { "VARIANT": "get", "ITERATIONS": "8000000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-elasticsearch/meta.json
+++ b/benchmark/sirun/plugin-elasticsearch/meta.json
@@ -10,10 +10,10 @@
       "env": { "VARIANT": "search", "ITERATIONS": "2000000" }
     },
     "bulk-index": {
-      "env": { "VARIANT": "bulk-index", "ITERATIONS": "600000" }
+      "env": { "VARIANT": "bulk-index", "ITERATIONS": "350000" }
     },
     "get": {
-      "env": { "VARIANT": "get", "ITERATIONS": "8000000" }
+      "env": { "VARIANT": "get", "ITERATIONS": "5400000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-elasticsearch/meta.json
+++ b/benchmark/sirun/plugin-elasticsearch/meta.json
@@ -10,7 +10,7 @@
       "env": { "VARIANT": "search", "ITERATIONS": "2000000" }
     },
     "bulk-index": {
-      "env": { "VARIANT": "bulk-index", "ITERATIONS": "350000" }
+      "env": { "VARIANT": "bulk-index", "ITERATIONS": "274000" }
     },
     "get": {
       "env": { "VARIANT": "get", "ITERATIONS": "5400000" }

--- a/benchmark/sirun/plugin-graphql-long/index.js
+++ b/benchmark/sirun/plugin-graphql-long/index.js
@@ -62,5 +62,8 @@ guard.loopStart()
       checked = true
     }
   }
-  guard.done()
+  // Node 26 runs this loop ~2x faster than Node 20, so the fixed tracer.init()
+  // plus graphql-load setup is a larger share of the run there. Sizing QUERIES to
+  // keep it under the default 7% would push the Node 20 run past ~110s, so allow 10%.
+  guard.done(0.1)
 })()

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -7,13 +7,15 @@
   "instructions": true,
   "variants": {
     "with-depth-off": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "QUERIES": "1100" }
+      "iterations": 7,
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "QUERIES": "1570" }
     },
     "with-depth-on-max": {
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "800" }
     },
     "with-depth-and-collapse-off": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "QUERIES": "200" }
+      "iterations": 7,
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "QUERIES": "300" }
     }
   }
 }

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -14,8 +14,7 @@
       "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "530" }
     },
     "with-depth-and-collapse-off": {
-      "iterations": 7,
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "QUERIES": "300" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH_AND_COLLAPSE": "4,0", "QUERIES": "210" }
     }
   }
 }

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -8,10 +8,10 @@
   "variants": {
     "with-depth-off": {
       "iterations": 7,
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "QUERIES": "869" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "QUERIES": "1150" }
     },
     "with-depth-on-max": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "407" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "530" }
     },
     "with-depth-and-collapse-off": {
       "iterations": 7,

--- a/benchmark/sirun/plugin-graphql-long/meta.json
+++ b/benchmark/sirun/plugin-graphql-long/meta.json
@@ -8,10 +8,10 @@
   "variants": {
     "with-depth-off": {
       "iterations": 7,
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "QUERIES": "1570" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "0", "QUERIES": "869" }
     },
     "with-depth-on-max": {
-      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "800" }
+      "env": { "WITH_TRACER": "1", "WITH_DEPTH": "4", "QUERIES": "407" }
     },
     "with-depth-and-collapse-off": {
       "iterations": 7,

--- a/benchmark/sirun/plugin-grpc/README.md
+++ b/benchmark/sirun/plugin-grpc/README.md
@@ -1,0 +1,6 @@
+# plugin-grpc
+
+Measures the gRPC client plugin `bindStart`: resolve the method metadata from the
+`/pkg.Service/Method` path (parsed once per path, then cached) and assemble the
+method meta bag. Variants cover a single unary method and a mix of methods from a
+typical service definition.

--- a/benchmark/sirun/plugin-grpc/index.js
+++ b/benchmark/sirun/plugin-grpc/index.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const GrpcClientPlugin = require('../../../packages/datadog-plugin-grpc/src/client')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 5_000_000
+
+// Every gRPC client call walks `bindStart`: parse the `/pkg.Service/Method` path
+// (cached per path) into name/service/package, assemble the method meta bag, and
+// start the span. Subclass the real plugin and override only the tracer-reaching
+// hooks so the measured surface is the method-metadata resolution and meta build.
+let lastMeta
+const FAKE_SPAN = { setTag () {}, finish () {} }
+class BenchedGrpcPlugin extends GrpcClientPlugin {
+  addSub () {}
+  addBind () {}
+  addTraceBind () {}
+  operationName () { return 'grpc.client' }
+  serviceName () { return 'grpc-prod' }
+  startSpan (...args) {
+    const opts = args.find((a) => a && a.meta)
+    lastMeta = opts?.meta
+    return FAKE_SPAN
+  }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0', inject () {} }
+const plugin = new BenchedGrpcPlugin(tracer, { spanComputePeerService: false })
+plugin.configure({ enabled: true, service: 'grpc-prod' })
+
+// A service definition exposes a small, finite set of method paths; the parser
+// caches each one, so steady state is the cache hit plus the meta assembly.
+const PATHS = [
+  '/google.pubsub.v1.Publisher/Publish',
+  '/google.pubsub.v1.Subscriber/Pull',
+  '/orders.v2.OrderService/CreateOrder',
+  '/orders.v2.OrderService/GetOrder',
+  '/inventory.InventoryService/Reserve',
+  '/Health/Check',
+]
+
+const VARIANTS = {
+  unary: [PATHS[2]],
+  mixed: PATHS,
+}
+
+const paths = VARIANTS[VARIANT]
+assert.ok(paths, `unknown VARIANT: ${VARIANT}`)
+
+const messages = paths.map((path) => ({ path, type: 'unary', metadata: undefined }))
+
+for (const message of messages) {
+  lastMeta = undefined
+  plugin.bindStart(message)
+  assert.ok(lastMeta && typeof lastMeta['grpc.method.path'] === 'string', 'bindStart did not build the method meta')
+}
+
+const len = messages.length
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.bindStart(messages[i % len])
+}
+guard.done()
+
+assert.ok(lastMeta, 'startSpan stub was never reached')

--- a/benchmark/sirun/plugin-grpc/meta.json
+++ b/benchmark/sirun/plugin-grpc/meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "plugin-grpc",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "unary": {
+      "env": { "VARIANT": "unary", "ITERATIONS": "120000000" }
+    },
+    "mixed": {
+      "env": { "VARIANT": "mixed", "ITERATIONS": "100000000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-grpc/meta.json
+++ b/benchmark/sirun/plugin-grpc/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "unary": {
-      "env": { "VARIANT": "unary", "ITERATIONS": "120000000" }
+      "env": { "VARIANT": "unary", "ITERATIONS": "53000000" }
     },
     "mixed": {
-      "env": { "VARIANT": "mixed", "ITERATIONS": "100000000" }
+      "env": { "VARIANT": "mixed", "ITERATIONS": "54000000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-http/README.md
+++ b/benchmark/sirun/plugin-http/README.md
@@ -1,4 +1,3 @@
-This benchmarks HTTP requests from client to server.
-
-The variants are with the tracer and without it, and instrumenting on the server
-and the client separately.
+Drives real HTTP client/server round-trips over a keep-alive 127.0.0.1 connection
+with the tracer loaded, measuring the http instrumentation's per-request overhead on
+the client and server paths (including server-side query-string obfuscation).

--- a/benchmark/sirun/plugin-memcached/README.md
+++ b/benchmark/sirun/plugin-memcached/README.md
@@ -1,0 +1,5 @@
+# plugin-memcached
+
+Measures the memcached plugin `bindStart`: resolve the server address (pinned
+directly, or via the client HashRing for a key) and assemble the meta bag.
+Variants cover a single-server get and the multi-server HashRing resolution.

--- a/benchmark/sirun/plugin-memcached/index.js
+++ b/benchmark/sirun/plugin-memcached/index.js
@@ -42,33 +42,43 @@ const hashringClient = {
   },
 }
 
+// Each variant fixes the client/server topology and rotates a corpus of queries
+// with varied key/command lengths. In the hashring variant the differing key
+// lengths also land on different servers (HashRing.get keys on key.length), so
+// the multi-server resolution branch runs over changing inputs, not one key.
+const GET_QUERIES = [
+  { type: 'get', command: 'get user:1234567', key: 'user:1234567' },
+  { type: 'set', command: 'set session:abcdef0123 0 0 64', key: 'session:abcdef0123' },
+  { type: 'get', command: 'get cart:99887766', key: 'cart:99887766' },
+  { type: 'delete', command: 'delete token:aabbccddeeff', key: 'token:aabbccddeeff' },
+]
+const HASHRING_QUERIES = [
+  { type: 'get', command: 'get session:abcdef', key: 'session:abcdef', redundancyEnabled: false },
+  { type: 'get', command: 'get user:1234567:profile', key: 'user:1234567:profile', redundancyEnabled: false },
+  { type: 'get', command: 'get f', key: 'f', redundancyEnabled: false },
+  { type: 'get', command: 'get inventory:sku-5566', key: 'inventory:sku-5566', redundancyEnabled: false },
+]
+
 const VARIANTS = {
-  get: {
-    client: { servers: ['cache-1.internal:11211'] },
-    server: 'cache-1.internal:11211',
-    query: { type: 'get', command: 'get user:1234567', key: 'user:1234567' },
-  },
-  hashring: {
-    client: hashringClient,
-    server: undefined,
-    query: { type: 'get', command: 'get session:abcdef', key: 'session:abcdef', redundancyEnabled: false },
-  },
+  get: { client: { servers: ['cache-1.internal:11211'] }, server: 'cache-1.internal:11211', queries: GET_QUERIES },
+  hashring: { client: hashringClient, server: undefined, queries: HASHRING_QUERIES },
 }
 
-const v = VARIANTS[VARIANT]
-assert.ok(v, `unknown VARIANT: ${VARIANT}`)
+const topology = VARIANTS[VARIANT]
+assert.ok(topology, `unknown VARIANT: ${VARIANT}`)
 
-// startSpan is stubbed, so bindStart never writes ctx.currentStore; one ctx can
-// be reused across iterations without per-iteration allocation skewing the loop.
-const ctx = { client: v.client, server: v.server, query: v.query }
+// startSpan is stubbed, so bindStart never writes ctx.currentStore; the corpus of
+// ctxs is pre-built once and rotated, so the loop allocates nothing per iteration.
+const ctxs = topology.queries.map((query) => ({ client: topology.client, server: topology.server, query }))
+const len = ctxs.length
 
 lastMeta = undefined
-plugin.bindStart(ctx)
+plugin.bindStart(ctxs[0])
 assert.ok(lastMeta && typeof lastMeta['out.host'] === 'string', 'bindStart did not resolve the server address')
 
 guard.loopStart()
 for (let i = 0; i < ITERATIONS; i++) {
-  plugin.bindStart(ctx)
+  plugin.bindStart(ctxs[i % len])
 }
 guard.done()
 

--- a/benchmark/sirun/plugin-memcached/index.js
+++ b/benchmark/sirun/plugin-memcached/index.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const MemcachedPlugin = require('../../../packages/datadog-plugin-memcached/src/index')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 6_000_000
+
+// Every traced memcached command walks `bindStart`: resolve the server address
+// (directly, or via the client HashRing when the server is not pinned), build
+// the meta bag, and start the span. Subclass the real plugin and override only
+// the tracer-reaching hooks so the measured surface is the address resolution
+// and meta assembly.
+let lastMeta
+const FAKE_SPAN = { finish () {}, setTag () {} }
+class BenchedMemcachedPlugin extends MemcachedPlugin {
+  addSub () {}
+  addBind () {}
+  serviceName () { return 'memcached-prod' }
+  startSpan (...args) {
+    const opts = args.find((a) => a && a.meta)
+    lastMeta = opts?.meta
+    return FAKE_SPAN
+  }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0' }
+const plugin = new BenchedMemcachedPlugin(tracer, { spanComputePeerService: false })
+plugin.configure({ enabled: true, service: 'memcached-prod', DD_TRACE_MEMCACHED_COMMAND_ENABLED: true })
+
+// HashRing stand-in: a real memcached client picks a server for a key by
+// consistent hashing. Mirror that surface (servers list + HashRing.get) so the
+// hashring variant exercises the multi-server resolution branch.
+const SERVERS = ['cache-1.internal:11211', 'cache-2.internal:11211', 'cache-3.internal:11211']
+const hashringClient = {
+  servers: SERVERS,
+  redundancy: false,
+  HashRing: {
+    get (key) { return SERVERS[key.length % SERVERS.length] },
+  },
+}
+
+const VARIANTS = {
+  get: {
+    client: { servers: ['cache-1.internal:11211'] },
+    server: 'cache-1.internal:11211',
+    query: { type: 'get', command: 'get user:1234567', key: 'user:1234567' },
+  },
+  hashring: {
+    client: hashringClient,
+    server: undefined,
+    query: { type: 'get', command: 'get session:abcdef', key: 'session:abcdef', redundancyEnabled: false },
+  },
+}
+
+const v = VARIANTS[VARIANT]
+assert.ok(v, `unknown VARIANT: ${VARIANT}`)
+
+// startSpan is stubbed, so bindStart never writes ctx.currentStore; one ctx can
+// be reused across iterations without per-iteration allocation skewing the loop.
+const ctx = { client: v.client, server: v.server, query: v.query }
+
+lastMeta = undefined
+plugin.bindStart(ctx)
+assert.ok(lastMeta && typeof lastMeta['out.host'] === 'string', 'bindStart did not resolve the server address')
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.bindStart(ctx)
+}
+guard.done()
+
+assert.ok(lastMeta, 'startSpan stub was never reached')

--- a/benchmark/sirun/plugin-memcached/meta.json
+++ b/benchmark/sirun/plugin-memcached/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "get": {
-      "env": { "VARIANT": "get", "ITERATIONS": "120000000" }
+      "env": { "VARIANT": "get", "ITERATIONS": "60000000" }
     },
     "hashring": {
-      "env": { "VARIANT": "hashring", "ITERATIONS": "120000000" }
+      "env": { "VARIANT": "hashring", "ITERATIONS": "57000000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-memcached/meta.json
+++ b/benchmark/sirun/plugin-memcached/meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "plugin-memcached",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "get": {
+      "env": { "VARIANT": "get", "ITERATIONS": "120000000" }
+    },
+    "hashring": {
+      "env": { "VARIANT": "hashring", "ITERATIONS": "120000000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-memcached/meta.json
+++ b/benchmark/sirun/plugin-memcached/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "get": {
-      "env": { "VARIANT": "get", "ITERATIONS": "60000000" }
+      "env": { "VARIANT": "get", "ITERATIONS": "39500000" }
     },
     "hashring": {
-      "env": { "VARIANT": "hashring", "ITERATIONS": "57000000" }
+      "env": { "VARIANT": "hashring", "ITERATIONS": "38000000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-mongodb-core/meta.json
+++ b/benchmark/sirun/plugin-mongodb-core/meta.json
@@ -7,10 +7,10 @@
   "instructions": true,
   "variants": {
     "plain-find": {
-      "env": { "VARIANT": "plain-find", "ITERATIONS": "11000000" }
+      "env": { "VARIANT": "plain-find", "ITERATIONS": "8200000" }
     },
     "deep-aggregate": {
-      "env": { "VARIANT": "deep-aggregate", "ITERATIONS": "1600000" }
+      "env": { "VARIANT": "deep-aggregate", "ITERATIONS": "1170000" }
     },
     "bigint-id": {
       "env": { "VARIANT": "bigint-id", "ITERATIONS": "5500000" }

--- a/benchmark/sirun/plugin-net/README.md
+++ b/benchmark/sirun/plugin-net/README.md
@@ -1,3 +1,3 @@
-Benchmarks connections between a net server and net client, doing a simple
-echo request. Since we only instrument client-side net connections, our variants
-are having the client with and without the tracer.
+Drives real TCP connect + echo round-trips between a net client and server with the
+tracer loaded, measuring the client-side net connection instrumentation's per-call
+overhead.

--- a/benchmark/sirun/plugin-pg/index.js
+++ b/benchmark/sirun/plugin-pg/index.js
@@ -32,7 +32,7 @@ const plugin = new BenchedPGPlugin(tracer, tracerConfig)
 plugin.configure({
   enabled: true,
   service: 'pg-prod',
-  dbmPropagationMode: VARIANT === 'disabled' ? 'disabled' : (VARIANT === 'full' ? 'full' : 'service'),
+  dbmPropagationMode: VARIANT === 'full' ? 'full' : 'service',
   appendComment: false,
   truncate: 5000,
 })
@@ -61,15 +61,11 @@ function injectOnce () {
   return plugin.injectDbmQuery(span, QUERY, 'pg-prod', false)
 }
 
-// Preflight: confirm the comment was actually spliced (or, for disabled, that
-// the query is returned untouched), so a refactor cannot silently no-op it.
+// Preflight: confirm the comment was actually spliced, so a refactor cannot
+// silently no-op it.
 const sample = injectOnce()
-if (VARIANT === 'disabled') {
-  assert.equal(sample, QUERY, 'disabled mode should return the query untouched')
-} else {
-  assert.ok(sample.includes("dddb='orders'") && sample.length > QUERY.length,
-    'injectDbmQuery did not splice the dbm comment')
-}
+assert.ok(sample.includes("dddb='orders'") && sample.length > QUERY.length,
+  'injectDbmQuery did not splice the dbm comment')
 
 guard.loopStart()
 let sink = 0

--- a/benchmark/sirun/plugin-redis-traced/README.md
+++ b/benchmark/sirun/plugin-redis-traced/README.md
@@ -1,0 +1,8 @@
+# plugin-redis-traced
+
+Measures a full traced redis command end to end: the real tracer and the real
+redis plugin run `bindStart` (meta build), span start, context entry via the
+start channel's `runStores`, span finish, and the processor — the integrated
+per-command cost the isolated `plugin-redis` bench omits by stubbing `startSpan`.
+The processor erases each trace on finish, so spans are built and finished but
+nothing is encoded or sent off-process.

--- a/benchmark/sirun/plugin-redis-traced/index.js
+++ b/benchmark/sirun/plugin-redis-traced/index.js
@@ -28,7 +28,7 @@ plugin.configure({ enabled: true, service: 'redis-prod' })
 const startCh = channel('apm:redis:command:start')
 const finishCh = channel('apm:redis:command:finish')
 
-const ITERATIONS = Number(process.env.ITERATIONS) || 1_500_000
+const ITERATIONS = Number(process.env.ITERATIONS) || 450_000
 
 const CONN = { host: 'redis-primary.internal', port: 6379 }
 const COMMANDS = [
@@ -74,6 +74,11 @@ for (let i = 0; i < ITERATIONS; i++) {
   startCh.runStores(ctx, NOOP)
   finishCh.publish(ctx)
 }
-// Full-tracer init is a fixed cost the per-command span work can't fully dwarf at
-// a sane iteration count without overrunning the time budget, so allow a 10% share.
-guard.done(0.1)
+// This is the heaviest per-iteration loop in the suite (a full span lifecycle), so
+// the instruction-counting pass on the stable machine scales steeply with the count:
+// 1.5M overran the one-minute budget at ~2m40s. 450k keeps the variant well under it
+// while staying deterministic. The two ceilings squeeze each other -- dwarfing the
+// fixed full-tracer init below 10% would need ~600k iterations, which puts the
+// instruction pass back over a minute -- so at the count that fits the budget the
+// init settles around 15% of the run; allow an 18% startup share to clear it.
+guard.done(0.18)

--- a/benchmark/sirun/plugin-redis-traced/index.js
+++ b/benchmark/sirun/plugin-redis-traced/index.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+// Full traced redis command, end to end. Where the isolated plugin-redis bench
+// stubs startSpan to measure only the meta assembly, this drives the real tracer
+// and the real redis plugin over the diagnostic channels the instrumentation
+// uses, so each iteration pays the whole per-command cost: bindStart meta build,
+// span start, context entry via runStores, span finish and the processor. The
+// processor is replaced with one that erases the trace on finish, so spans are
+// built and finished but nothing accumulates, encodes, or leaves the process.
+const tracer = require('../../..').init()
+tracer._tracer._processor.process = function process (span) {
+  this._erase(span.context()._trace)
+}
+
+const RedisPlugin = require('../../../packages/datadog-plugin-redis/src/index')
+const { channel } = require('../../../packages/datadog-instrumentations/src/helpers/instrument')
+
+// Construct the real plugin against the real tracer + tracer config (the pair the
+// plugin manager would pass) and enable it, which subscribes bindStart/bindFinish
+// to the redis channels. tracer.use('redis') alone would not: the plugin only
+// subscribes once the redis module loads, and there is no client here.
+const plugin = new RedisPlugin(tracer, tracer._pluginManager._tracerConfig)
+plugin.configure({ enabled: true, service: 'redis-prod' })
+
+const startCh = channel('apm:redis:command:start')
+const finishCh = channel('apm:redis:command:finish')
+
+const ITERATIONS = Number(process.env.ITERATIONS) || 1_500_000
+
+const CONN = { host: 'redis-primary.internal', port: 6379 }
+const COMMANDS = [
+  { command: 'get', args: ['user:1234567:profile'] },
+  { command: 'set', args: ['session:abcdef', 'active', 'EX', 3600] },
+  { command: 'hset', args: ['user:1234567', 'name', 'Jane', 'email', 'jane@example.com'] },
+  { command: 'get', args: ['cart:99887766'] },
+]
+const len = COMMANDS.length
+
+/**
+ * A fresh per-command context, matching what the instrumentation's getStartCtx
+ * allocates per call: runStores writes the span store onto it, so it cannot be
+ * reused across commands.
+ *
+ * @param {{ command: string, args: unknown[] }} cmd
+ */
+function makeCtx (cmd) {
+  return {
+    db: 0,
+    command: cmd.command,
+    args: cmd.args,
+    argsStartIndex: 0,
+    connectionOptions: CONN,
+    connectionName: 'default',
+  }
+}
+
+const NOOP = () => {}
+
+// Pre-flight: one full command must create, tag and finish a real span.
+const preCtx = makeCtx(COMMANDS[0])
+startCh.runStores(preCtx, NOOP)
+const preSpan = preCtx.currentStore?.span
+assert.ok(preSpan, 'start channel did not create a span (plugin not subscribed?)')
+assert.equal(preSpan.context().getTag('db.type'), 'redis', 'span is missing the redis meta')
+finishCh.publish(preCtx)
+assert.ok(preSpan._duration !== undefined, 'finish channel did not finish the span')
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  const ctx = makeCtx(COMMANDS[i % len])
+  startCh.runStores(ctx, NOOP)
+  finishCh.publish(ctx)
+}
+// Full-tracer init is a fixed cost the per-command span work can't fully dwarf at
+// a sane iteration count without overrunning the time budget, so allow a 10% share.
+guard.done(0.1)

--- a/benchmark/sirun/plugin-redis-traced/meta.json
+++ b/benchmark/sirun/plugin-redis-traced/meta.json
@@ -7,7 +7,7 @@
   "instructions": true,
   "variants": {
     "command": {
-      "env": { "ITERATIONS": "1500000" }
+      "env": { "ITERATIONS": "450000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-redis-traced/meta.json
+++ b/benchmark/sirun/plugin-redis-traced/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "plugin-redis-traced",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 15,
+  "instructions": true,
+  "variants": {
+    "command": {
+      "env": { "ITERATIONS": "1500000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-redis/README.md
+++ b/benchmark/sirun/plugin-redis/README.md
@@ -3,4 +3,5 @@ the config filter, the per-connection service cache, then `formatCommand` to
 build the `redis.raw_command` string and `startSpan`. Variants cover the common
 short command (get), per-arg truncation (a value past MAX_ARG_LENGTH), the
 wide-arg loop that hits MAX_COMMAND_LENGTH (mset with many pairs), and a mixed
-rotation of get/set/hset.
+rotation of get/set/hset. The churn variant rebuilds the per-command context each
+iteration to surface the allocation/GC cost the reuse variants hoist out.

--- a/benchmark/sirun/plugin-redis/index.js
+++ b/benchmark/sirun/plugin-redis/index.js
@@ -74,7 +74,17 @@ function preflight (ctx) {
 }
 
 guard.loopStart()
-if (VARIANT === 'mixed') {
+if (VARIANT === 'churn') {
+  // Rebuild the ctx getStartCtx allocates per command instead of reusing one:
+  // the only variant that pays that per-command allocation, isolating the GC
+  // cost the reuse variants hoist out of the loop.
+  const cmd = COMMANDS.get
+  preflight(makeCtx(cmd))
+  lastMeta = undefined
+  for (let i = 0; i < ITERATIONS; i++) {
+    plugin.bindStart(makeCtx(cmd))
+  }
+} else if (VARIANT === 'mixed') {
   const ctxs = MIXED.map(makeCtx)
   for (const ctx of ctxs) preflight(ctx)
   lastMeta = undefined

--- a/benchmark/sirun/plugin-redis/meta.json
+++ b/benchmark/sirun/plugin-redis/meta.json
@@ -17,6 +17,9 @@
     },
     "mixed": {
       "env": { "VARIANT": "mixed", "ITERATIONS": "11500000" }
+    },
+    "churn": {
+      "env": { "VARIANT": "churn", "ITERATIONS": "5000000" }
     }
   }
 }

--- a/benchmark/sirun/plugin-redis/meta.json
+++ b/benchmark/sirun/plugin-redis/meta.json
@@ -13,10 +13,10 @@
       "env": { "VARIANT": "long-value", "ITERATIONS": "13000000" }
     },
     "mset-wide": {
-      "env": { "VARIANT": "mset-wide", "ITERATIONS": "1150000" }
+      "env": { "VARIANT": "mset-wide", "ITERATIONS": "980000" }
     },
     "mixed": {
-      "env": { "VARIANT": "mixed", "ITERATIONS": "13000000" }
+      "env": { "VARIANT": "mixed", "ITERATIONS": "11500000" }
     }
   }
 }

--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -106,8 +106,27 @@ if [[ "${TOLERATE_NEW_BENCHMARK_FAILURES:-}" == "1" ]]; then
   fi
 fi
 
+# async_hooks measures the Node async-hooks primitive floor, not tracer code, so it
+# only moves when the Node version changes. Skip it unless this PR's diff touches a
+# node-<major> pin in the versions manifest runall reads above (the single source of
+# truth for the benchmarked Node patch). Fail open -- run it -- when the diff can't be
+# determined, so a Node bump is never silently skipped. The same gate must apply in
+# both loops below, or the global variant-index shard math drops/misassigns variants.
+RUN_ASYNC_HOOKS="1"
+if [[ -d /app/candidate/.git && -n "${COMMIT_SHA:-}" && -n "${CI_COMMIT_SHA:-}" ]]; then
+  if git -C /app/candidate diff "${COMMIT_SHA}..${CI_COMMIT_SHA}" -- \
+       packages/dd-trace/test/plugins/versions/package.json 2>/dev/null \
+       | grep -qE '^[-+][[:space:]]*"node-[0-9]+":'; then
+    echo "async_hooks: a node-<major> pin changed in this diff; running it."
+  else
+    RUN_ASYNC_HOOKS=""
+    echo "async_hooks: no Node version change in this diff; skipping (Node-primitive floor)."
+  fi
+fi
+
 BENCH_COUNT=0
 for D in "${DIRS[@]}"; do
+  if [[ "${D}" == "async_hooks" && -z "${RUN_ASYNC_HOOKS}" ]]; then continue; fi
   cd "${D}"
   variants="$(node ../get-variants.js)"
   for V in $variants; do BENCH_COUNT=$(($BENCH_COUNT+1)); done
@@ -133,6 +152,7 @@ BENCH_END=$(($GROUP_SIZE*$GROUP))
 BENCH_START=$(($BENCH_END-$GROUP_SIZE))
 
 for D in "${DIRS[@]}"; do
+  if [[ "${D}" == "async_hooks" && -z "${RUN_ASYNC_HOOKS}" ]]; then continue; fi
   cd "${D}"
   variants="$(node ../get-variants.js)"
 

--- a/benchmark/sirun/runtime-metrics/README.md
+++ b/benchmark/sirun/runtime-metrics/README.md
@@ -1,5 +1,6 @@
-This benchmark runs the with runtime metrics and an accelerated flush. While
-this can catch code regressions, it's mostly meant to catch things like memory
-leaks where metrics would start piling up. This can be hard to catch in tests,
-but it would cause the app to become slower and slower over time which would
-be visible in the benchmark.
+Measures the startup cost of enabling runtime metrics: `init()` wires up the
+native-metrics collector, the GC PerformanceObserver, the event-loop monitor, the
+dogstatsd client and the flush interval. The control vs with-metrics delta is that
+wiring cost. (The old idle-window shape timed a 1s flush window rather than real
+work and read as ~16% jitter; the per-collection cost is sub-millisecond and would
+need the collector's private capture path exposed to measure directly.)

--- a/benchmark/sirun/sampling/README.md
+++ b/benchmark/sirun/sampling/README.md
@@ -1,0 +1,7 @@
+# sampling
+
+Measures `PrioritySampler.sample()`, the per-trace sampling decision run once at
+each trace root: manual-tag check, sampling-rule glob match, deterministic Knuth
+hash, token-bucket rate limit, agent-rate fallback, and decision-maker tagging.
+Variants exercise the agent-rate path, a matching rule, a non-matching rule scan,
+and the rate-limited reject branch.

--- a/benchmark/sirun/sampling/index.js
+++ b/benchmark/sirun/sampling/index.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const PrioritySampler = require('../../../packages/dd-trace/src/priority_sampler')
+const DatadogSpanContext = require('../../../packages/dd-trace/src/opentracing/span_context')
+const id = require('../../../packages/dd-trace/src/id')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 3_000_000
+
+// Every trace runs PrioritySampler.sample() once at the root: it derives a
+// priority from manual tags, sampling rules (glob match + deterministic Knuth
+// hash + token-bucket rate limit), or agent-provided rates, then stamps the
+// decision-maker tag. This is the per-trace sampling hot path. Build a real
+// PrioritySampler and drive sample() over a corpus of real span contexts whose
+// trace ids vary, so the Knuth hash stays unwarmed (a single reused id would
+// hash to a constant and measure nothing).
+const CONFIGS = {
+  // Non-unit agent rate: forces the Knuth hash + formatKnuthRate, the common
+  // case once the agent has reported per-service rates.
+  agent: { rateLimit: 100 },
+  // A matching rule: glob match, then rule.sample (hash + limiter).
+  'rule-match': { rules: [{ service: 'web-*', sampleRate: 0.5, maxPerSecond: 100 }], rateLimit: 100 },
+  // Several non-matching rules: measures the glob-miss scan before falling back
+  // to the agent decision.
+  'rule-miss': {
+    rules: [
+      { service: 'cron-*', sampleRate: 0.1 },
+      { name: 'redis.*', sampleRate: 0.2 },
+      { resource: 'GET /health', sampleRate: 0 },
+    ],
+    rateLimit: 100,
+  },
+  // A keep-everything rule capped at 1/s: after the first token the limiter
+  // rejects, exercising the USER_REJECT + decision-maker-removal branch.
+  'rate-limited': { rules: [{ service: 'web-*', sampleRate: 1, maxPerSecond: 1 }], rateLimit: 1 },
+}
+
+const config = CONFIGS[VARIANT]
+assert.ok(config, `unknown VARIANT: ${VARIANT}`)
+
+const sampler = new PrioritySampler('production', config)
+// The agent variant needs non-default per-service rates so the non-unit Knuth
+// path runs instead of the rate===1 short circuit.
+if (VARIANT === 'agent') {
+  sampler.update({ 'service:web-app,env:production': 0.5 })
+}
+
+// A corpus of real span contexts with distinct trace ids. Each carries the tag
+// surface the rule locators read (service/resource/name). The span wrapper
+// exposes context()/tracer() and is its own trace root.
+const CORPUS_SIZE = 64
+const tracer = { _service: 'web-app' }
+const spans = []
+for (let i = 0; i < CORPUS_SIZE; i++) {
+  const spanContext = new DatadogSpanContext({
+    traceId: id(),
+    spanId: id(),
+    name: 'web.request',
+    tags: { service: 'web-app', resource: 'GET /api/v2/orders' },
+  })
+  const span = {
+    _spanContext: spanContext,
+    context () { return spanContext },
+    tracer () { return tracer },
+  }
+  spanContext._trace.started.push(span)
+  spans.push(span)
+}
+
+function sampleOnce (span) {
+  // Reset the per-trace decision so sample() does the work again instead of
+  // early-returning on an already-assigned priority.
+  span.context()._sampling.priority = undefined
+  sampler.sample(span)
+  return span.context()._sampling.priority
+}
+
+// Preflight: confirm sample() actually assigns a priority (catches a refactor
+// that turns the bench into a no-op early return).
+const sampled = sampleOnce(spans[0])
+assert.ok(sampled !== undefined, 'sample() did not assign a sampling priority')
+
+guard.loopStart()
+let sink = 0
+for (let i = 0; i < ITERATIONS; i++) {
+  sink += sampleOnce(spans[i % CORPUS_SIZE])
+}
+guard.done()
+
+if (sink === undefined) throw new Error('unreachable')

--- a/benchmark/sirun/sampling/meta.json
+++ b/benchmark/sirun/sampling/meta.json
@@ -7,7 +7,7 @@
   "instructions": true,
   "variants": {
     "agent": {
-      "env": { "VARIANT": "agent", "ITERATIONS": "3000000" }
+      "env": { "VARIANT": "agent", "ITERATIONS": "12000000" }
     },
     "rule-match": {
       "env": { "VARIANT": "rule-match", "ITERATIONS": "3000000" }

--- a/benchmark/sirun/sampling/meta.json
+++ b/benchmark/sirun/sampling/meta.json
@@ -1,0 +1,22 @@
+{
+  "name": "sampling",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "agent": {
+      "env": { "VARIANT": "agent", "ITERATIONS": "3000000" }
+    },
+    "rule-match": {
+      "env": { "VARIANT": "rule-match", "ITERATIONS": "3000000" }
+    },
+    "rule-miss": {
+      "env": { "VARIANT": "rule-miss", "ITERATIONS": "3000000" }
+    },
+    "rate-limited": {
+      "env": { "VARIANT": "rate-limited", "ITERATIONS": "3000000" }
+    }
+  }
+}

--- a/benchmark/sirun/scope/README.md
+++ b/benchmark/sirun/scope/README.md
@@ -1,4 +1,4 @@
-Measures the scope manager's per-hop async-context cost. Chains `COUNT` promise
-continuations; the `scope_enabled` variant wraps each in `scope.activate()`, the
-path the tracer drives under every traced async operation. The delta is the
-`AsyncLocalStorage` enterWith plus store-copy cost per continuation.
+Measures the scope manager's per-hop async-context cost: chains `COUNT` promise
+continuations, each wrapped in `scope.activate()` -- the path the tracer drives
+under every traced async operation (an `AsyncLocalStorage` enterWith plus the
+parent store copy). Rendered commit-over-commit; there is no baseline variant.

--- a/benchmark/sirun/scope/index.js
+++ b/benchmark/sirun/scope/index.js
@@ -52,10 +52,11 @@ if (MODE === 'bind') {
   assert.ok(sink > 0, 'scope.bind loop produced no work')
 } else {
   // The microtask shape the tracer rides under each traced async operation: a
-  // continuation that resolves, schedules the next, and so on. When enabled, every
-  // hop is wrapped in scope.activate() exactly as the tracer does; the delta
-  // against the base variant is the per-hop AsyncLocalStorage enterWith plus
-  // store-copy cost.
+  // continuation that resolves, schedules the next, and so on. When SCOPE_ENABLED is
+  // set, every hop is wrapped in scope.activate() exactly as the tracer does (the
+  // per-hop AsyncLocalStorage enterWith plus parent store copy); unset, the hop runs
+  // bare. CI runs only the enabled variant -- there is no baseline wiring -- but the
+  // bare path stays available for a local A/B.
   let activate
   if (SCOPE_ENABLED === 'true') {
     const Scope = require('../../../packages/dd-trace/src/scope')

--- a/benchmark/sirun/scope/meta.json
+++ b/benchmark/sirun/scope/meta.json
@@ -6,21 +6,10 @@
   "iterations": 10,
   "instructions": true,
   "variants": {
-    "base": {
-      "env": {
-        "COUNT": "100000000"
-      }
-    },
     "scope_enabled": {
       "env": {
         "SCOPE_ENABLED": "true",
-        "COUNT": "4000000"
-      }
-    },
-    "bind": {
-      "env": {
-        "MODE": "bind",
-        "COUNT": "3000000"
+        "COUNT": "250000"
       }
     }
   }

--- a/benchmark/sirun/span-format/README.md
+++ b/benchmark/sirun/span-format/README.md
@@ -1,0 +1,6 @@
+# span-format
+
+Measures `span_format.format()`, the per-span step that runs before the msgpack
+encoder: the per-tag switch that splits the tag bag into meta/metrics, key/value
+truncation, error-field extraction, and root/chunk tag stamping. Variants cover a
+flat web span, a wide tag bag, an errored span, and a typical HTTP-server span.

--- a/benchmark/sirun/span-format/index.js
+++ b/benchmark/sirun/span-format/index.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const format = require('../../../packages/dd-trace/src/span_format')
+const DatadogSpanContext = require('../../../packages/dd-trace/src/opentracing/span_context')
+const id = require('../../../packages/dd-trace/src/id')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 3_000_000
+
+// Every finished span runs through span_format.format() before the msgpack
+// encoder sees it: the per-tag switch splits the tag bag into meta/metrics,
+// truncates over-long keys/values, lifts the error fields, and stamps the
+// root/chunk tags. The `encoding` bench measures the encode of an already
+// formatted span and `spans` measures the span lifecycle; neither isolates
+// format(). Drive it directly over pre-built tag bags.
+const ERROR = new Error('connection reset by peer')
+
+const FLAT_TAGS = {
+  'service.name': 'web-app',
+  'span.type': 'web',
+  'resource.name': 'GET /api/v2/orders',
+  'span.kind': 'server',
+  'http.method': 'GET',
+  'http.status_code': 200,
+  'http.url': 'https://api.example.com/api/v2/orders?page=2',
+  component: 'express',
+}
+
+function buildManyTags () {
+  const tags = { ...FLAT_TAGS }
+  for (let i = 0; i < 40; i++) {
+    tags[`custom.tag.${i}`] = i % 3 === 0 ? i : `value-${i}`
+  }
+  return tags
+}
+
+const VARIANTS = {
+  'flat-tags': FLAT_TAGS,
+  'many-tags': buildManyTags(),
+  error: { ...FLAT_TAGS, 'http.status_code': 500, error: ERROR },
+  'http-server': {
+    'service.name': 'web-app',
+    'span.type': 'web',
+    'resource.name': 'GET /users/:id',
+    'span.kind': 'server',
+    'http.method': 'GET',
+    'http.status_code': 200,
+    'analytics.event': true,
+    _dd_measured: 1,
+  },
+}
+
+const tags = VARIANTS[VARIANT]
+assert.ok(tags, `unknown VARIANT: ${VARIANT}`)
+
+// serviceLower matches service.name so the BASE_SERVICE / registerExtraService
+// branch stays off (it would mutate the shared tag bag after the first call).
+const tracer = { serviceLower: 'web-app' }
+
+const spanContext = new DatadogSpanContext({
+  traceId: id(),
+  spanId: id(),
+  parentId: id('0'),
+  name: 'web.request',
+  tags,
+  sampling: { priority: 1 },
+})
+spanContext._trace.origin = 'synthetics'
+spanContext._trace.tags['_dd.p.tid'] = '640cfd8d00000000'
+spanContext._trace.tags['_dd.p.dm'] = '-1'
+spanContext._hostname = 'web-1.internal'
+
+const span = {
+  _startTime: 1_716_950_000_000.5,
+  _duration: 12.345,
+  _links: [],
+  _events: [],
+  meta_struct: undefined,
+  context () { return spanContext },
+  tracer () { return tracer },
+  setTag (key, value) { spanContext.setTag(key, value) },
+}
+spanContext._trace.started.push(span)
+
+// Preflight: confirm the formatter split tags into meta/metrics and produced
+// the language meta every span carries.
+const sample = format(span, true, '-1')
+assert.equal(sample.meta.language, 'javascript')
+if (VARIANT === 'error') assert.equal(sample.error, 1, 'error span should set error=1')
+
+guard.loopStart()
+let sink = 0
+for (let i = 0; i < ITERATIONS; i++) {
+  const formatted = format(span, true, '-1')
+  sink += formatted.error
+}
+guard.done()
+
+if (sink === undefined) throw new Error('unreachable')

--- a/benchmark/sirun/span-format/meta.json
+++ b/benchmark/sirun/span-format/meta.json
@@ -1,0 +1,22 @@
+{
+  "name": "span-format",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "flat-tags": {
+      "env": { "VARIANT": "flat-tags", "ITERATIONS": "3000000" }
+    },
+    "many-tags": {
+      "env": { "VARIANT": "many-tags", "ITERATIONS": "900000" }
+    },
+    "error": {
+      "env": { "VARIANT": "error", "ITERATIONS": "2000000" }
+    },
+    "http-server": {
+      "env": { "VARIANT": "http-server", "ITERATIONS": "3000000" }
+    }
+  }
+}

--- a/benchmark/sirun/spans/meta.json
+++ b/benchmark/sirun/spans/meta.json
@@ -14,10 +14,11 @@
       }
     },
     "finish-later": {
+      "iterations": 16,
       "env": {
         "DD_TRACE_SCOPE": "noop",
         "FINISH": "later",
-        "COUNT": "2000000"
+        "COUNT": "3000000"
       }
     },
     "finish-immediately-with-tags": {

--- a/benchmark/sirun/spans/spans.js
+++ b/benchmark/sirun/spans/spans.js
@@ -14,7 +14,9 @@ const { FINISH, SHAPE = 'plain' } = process.env
 
 // Total spans created per process. The fixed tracer load (~75 ms) must be a small
 // fraction of the run so the bench measures span construction, not startup; at
-// 2M it is well under 10%. COUNT keeps it tunable per variant.
+// 2M it is well under 10%. COUNT keeps it tunable per variant: finish-later (the
+// noisiest variant) runs a heavier 3M over more sirun iterations (meta.json) so its
+// deferred-finish GC jitter averages out run-to-run, within the one-minute budget.
 const COUNT = Number(process.env.COUNT) || 2_000_000
 
 // finish-later defers the finish so it runs off the active-span path. Holding all

--- a/benchmark/sirun/spans/spans.js
+++ b/benchmark/sirun/spans/spans.js
@@ -20,8 +20,11 @@ const COUNT = Number(process.env.COUNT) || 2_000_000
 // finish-later defers the finish so it runs off the active-span path. Holding all
 // COUNT spans live at once would blow the heap (a 1M array of spans is ~1.6 GB);
 // instead run in fixed-size batches so the deferred-finish path is still exercised
-// while live memory stays flat.
-const BATCH = 10_000
+// while live memory stays flat. The batch size sets peak live spans, hence major-GC
+// pause size: 10k drove run-to-run jitter (the major share of finish-later's noise),
+// 500 added loop/reset overhead and got noisy again, 2000 sits in the valley (lower
+// stddev and ~10% faster locally). Overridable to re-sweep if the span shape changes.
+const BATCH = Number(process.env.BATCH) || 2000
 
 const spans = []
 

--- a/benchmark/sirun/startup-guard.js
+++ b/benchmark/sirun/startup-guard.js
@@ -11,7 +11,7 @@
 //   // ...requires, setup...
 //   guard.loopStart()
 //   for (...) { ... }
-//   guard.done()            // default 10% ceiling
+//   guard.done()            // default 7% ceiling
 //   guard.done(0.15)        // relaxed ceiling when the loop legitimately can't dominate further
 
 const assert = require('node:assert/strict')
@@ -23,7 +23,7 @@ function loopStart () {
   loopStartedAt = process.hrtime.bigint()
 }
 
-function done (maxShare = 0.10) {
+function done (maxShare = 0.07) {
   const end = process.hrtime.bigint()
   assert.ok(loopStartedAt !== undefined, 'startup-guard: loopStart() was never called')
   const total = Number(end - START)

--- a/benchmark/sirun/test-ci-encode/README.md
+++ b/benchmark/sirun/test-ci-encode/README.md
@@ -1,0 +1,7 @@
+# test-ci-encode
+
+Measures the agentless CI-visibility msgpack encoder, the egress path for every
+test, suite, module and session event: `truncateSpanTestOpt`, `normalizeSpan`,
+the per-event-type map encode, and `makePayload`. It is the CI sibling of the
+`encoding` (trace) bench. Variants cover a small suite, a large suite, and a
+wide-tag event shape.

--- a/benchmark/sirun/test-ci-encode/index.js
+++ b/benchmark/sirun/test-ci-encode/index.js
@@ -1,0 +1,153 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const {
+  AgentlessCiVisibilityEncoder,
+} = require('../../../packages/dd-trace/src/encode/agentless-ci-visibility')
+const id = require('../../../packages/dd-trace/src/id')
+
+const { VARIANT } = process.env
+const ENCODE_COUNT = Number(process.env.ENCODE_COUNT) || 60_000
+
+// Test optimization ships every test, suite, module and session event through
+// the agentless CI-visibility msgpack encoder: truncateSpanTestOpt, normalizeSpan,
+// then the per-event-type map encode. This is the test-event egress hot path, the
+// CI sibling of the `encoding` (trace) bench. Build a realistic session payload
+// and drive encode()+makePayload() over it. The encoder normalizes copies, so the
+// source trace is reused untouched across iterations.
+const SESSION_ID = '7100000000000001'
+const MODULE_ID = '7100000000000002'
+
+function baseMeta (extra) {
+  return {
+    language: 'javascript',
+    'test.framework': 'mocha',
+    'test.framework_version': '10.2.0',
+    'os.platform': 'linux',
+    'runtime.name': 'node',
+    test_session_id: SESSION_ID,
+    test_module_id: MODULE_ID,
+    ...extra,
+  }
+}
+
+function buildTest (i, suiteId, wide) {
+  const suite = `packages/module/test/feature-${i % 20}.spec.js`
+  const meta = baseMeta({
+    test_suite_id: suiteId,
+    'test.name': `handles scenario ${i}`,
+    'test.suite': suite,
+    'test.status': 'pass',
+    'test.type': 'test',
+  })
+  if (wide) {
+    for (let t = 0; t < 25; t++) meta[`test.tag.${t}`] = `value-${t}`
+  }
+  return {
+    type: 'test',
+    trace_id: id(),
+    span_id: id(),
+    parent_id: id('0'),
+    name: 'mocha.test',
+    resource: `${suite}.handles scenario ${i}`,
+    service: 'my-service',
+    error: 0,
+    start: 1_716_950_000_000_000_000 + i * 1000,
+    duration: 1_500_000 + i,
+    meta,
+    metrics: { 'test.source.start': 12, 'test.source.end': 48, _dd_top_level: 1 },
+  }
+}
+
+function buildTrace (testCount, suiteCount, wide) {
+  const trace = [
+    {
+      type: 'test_session_end',
+      trace_id: id(SESSION_ID, 10),
+      span_id: id(SESSION_ID, 10),
+      parent_id: id('0'),
+      name: 'mocha.test_session',
+      resource: 'test_session.mocha test',
+      service: 'my-service',
+      error: 0,
+      start: 1_716_950_000_000_000_000,
+      duration: 9_000_000_000,
+      meta: baseMeta({ 'test.command': 'mocha test', 'test.status': 'pass' }),
+      metrics: { _dd_top_level: 1 },
+    },
+    {
+      type: 'test_module_end',
+      trace_id: id(SESSION_ID, 10),
+      span_id: id(MODULE_ID, 10),
+      parent_id: id('0'),
+      name: 'mocha.test_module',
+      resource: 'test_module.mocha',
+      service: 'my-service',
+      error: 0,
+      start: 1_716_950_000_000_000_000,
+      duration: 8_500_000_000,
+      meta: baseMeta({ 'test.module': 'mocha', 'test.status': 'pass' }),
+      metrics: { _dd_top_level: 1 },
+    },
+  ]
+  for (let s = 0; s < suiteCount; s++) {
+    const suiteId = `72000000000000${(s + 10).toString()}`
+    trace.push({
+      type: 'test_suite_end',
+      trace_id: id(SESSION_ID, 10),
+      parent_id: id(MODULE_ID, 10),
+      span_id: id(suiteId, 10),
+      name: 'mocha.test_suite',
+      resource: `test_suite.packages/module/test/suite-${s}.spec.js`,
+      service: 'my-service',
+      error: 0,
+      start: 1_716_950_000_000_000_000,
+      duration: 2_000_000_000,
+      meta: baseMeta({ 'test.suite': `suite-${s}`, 'test.status': 'pass' }),
+      metrics: { _dd_top_level: 1 },
+    })
+    const perSuite = Math.ceil(testCount / suiteCount)
+    for (let i = 0; i < perSuite; i++) {
+      trace.push(buildTest(s * perSuite + i, suiteId, wide))
+    }
+  }
+  return trace
+}
+
+const SHAPES = {
+  'small-suite': { tests: 48, suites: 3, wide: false },
+  'large-suite': { tests: 480, suites: 16, wide: false },
+  'wide-tags': { tests: 96, suites: 4, wide: true },
+}
+
+const shape = SHAPES[VARIANT]
+assert.ok(shape, `unknown VARIANT: ${VARIANT}`)
+
+const trace = buildTrace(shape.tests, shape.suites, shape.wide)
+const encoder = new AgentlessCiVisibilityEncoder(
+  { flush () {} },
+  { runtimeId: 'a1b2c3d4-0000-0000-0000-000000000000', service: 'my-service', env: 'ci' }
+)
+
+// Preflight: encode once and confirm the encoder buffered bytes and counted the
+// events, then a second encode to confirm the source trace survives normalization
+// (the encoder mutates only its per-encode copies).
+encoder.encode(trace)
+assert.ok(encoder._traceBytes.length > 0 && encoder._eventCount === trace.length,
+  'CI encoder did not buffer the events')
+encoder.encode(trace)
+assert.equal(encoder._eventCount, trace.length * 2, 'second encode produced a different event count')
+encoder.makePayload()
+assert.equal(encoder._eventCount, 0, 'makePayload did not reset the encoder')
+
+guard.loopStart()
+let sink = 0
+for (let iteration = 0; iteration < ENCODE_COUNT; iteration++) {
+  encoder.encode(trace)
+  sink += encoder.makePayload().length
+}
+guard.done()
+
+if (sink === 0) throw new Error('unreachable')

--- a/benchmark/sirun/test-ci-encode/meta.json
+++ b/benchmark/sirun/test-ci-encode/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-ci-encode",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "small-suite": {
+      "env": { "VARIANT": "small-suite", "ENCODE_COUNT": "40000" }
+    },
+    "large-suite": {
+      "env": { "VARIANT": "large-suite", "ENCODE_COUNT": "4000" }
+    },
+    "wide-tags": {
+      "env": { "VARIANT": "wide-tags", "ENCODE_COUNT": "15000" }
+    }
+  }
+}

--- a/benchmark/sirun/test-ci-encode/meta.json
+++ b/benchmark/sirun/test-ci-encode/meta.json
@@ -7,13 +7,13 @@
   "instructions": true,
   "variants": {
     "small-suite": {
-      "env": { "VARIANT": "small-suite", "ENCODE_COUNT": "40000" }
+      "env": { "VARIANT": "small-suite", "ENCODE_COUNT": "20000" }
     },
     "large-suite": {
-      "env": { "VARIANT": "large-suite", "ENCODE_COUNT": "4000" }
+      "env": { "VARIANT": "large-suite", "ENCODE_COUNT": "2400" }
     },
     "wide-tags": {
-      "env": { "VARIANT": "wide-tags", "ENCODE_COUNT": "15000" }
+      "env": { "VARIANT": "wide-tags", "ENCODE_COUNT": "6000" }
     }
   }
 }

--- a/benchmark/sirun/test-codeowners/README.md
+++ b/benchmark/sirun/test-codeowners/README.md
@@ -1,0 +1,8 @@
+# test-codeowners
+
+Measures `getCodeOwnersForFilename`, the per-test-file owner resolution test
+optimization runs across a suite: a reversed walk of the parsed CODEOWNERS
+entries testing each pattern's regex against the path. Entries come from the real
+parser over a generated fixture; each pass uses a fresh cache view so every
+lookup is a real regex scan. Variants cover a small file, a large one, and a
+wildcard-heavy one.

--- a/benchmark/sirun/test-codeowners/index.js
+++ b/benchmark/sirun/test-codeowners/index.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const guard = require('../startup-guard')
+
+const {
+  getCodeOwnersFileEntries,
+  getCodeOwnersForFilename,
+} = require('../../../packages/dd-trace/src/plugins/util/test')
+
+const { VARIANT } = process.env
+const COUNT = Number(process.env.COUNT) || 2_000_000
+
+// Test optimization resolves the code owners of every test file it reports.
+// getCodeOwnersForFilename walks the parsed CODEOWNERS entries (reversed, first
+// match wins) testing each pattern's regex against the path. On a large suite
+// this runs per test file. Build the entries through the real parser from a
+// generated CODEOWNERS fixture, then drive lookups over a corpus of realistic
+// paths. The lookup memoizes per filename, so each measured pass gets a fresh
+// cache view (a new array reference reusing the precompiled regex entries) to
+// keep every lookup a real regex scan rather than a Map hit.
+function buildCodeowners (variant) {
+  const lines = []
+  if (variant === 'small') {
+    lines.push(
+      '/src/ @team-core',
+      '/packages/ @team-pkg',
+      '*.md @team-docs',
+      '/docs/ @team-docs',
+      '/test/ @team-qa',
+      '*.spec.js @team-qa',
+      '/packages/api/ @team-api',
+      '/packages/api/auth/ @team-auth',
+      '/packages/web/ @team-web',
+      '/scripts/ @team-build',
+      '/.github/ @team-ci',
+      '*.json @team-core',
+      '/packages/db/ @team-data',
+      '/integration-tests/ @team-qa',
+      '/benchmark/ @team-perf',
+    )
+  } else if (variant === 'large') {
+    for (let i = 0; i < 200; i++) {
+      lines.push(`/packages/module-${i}/ @team-${i % 12}`)
+    }
+    lines.push('*.spec.js @team-qa', '*.md @team-docs', '/integration-tests/ @team-qa')
+  } else { // wildcard
+    for (let i = 0; i < 50; i++) {
+      lines.push(`packages/**/module-${i}/**/*.js @team-${i % 8}`)
+    }
+    lines.push(
+      '**/*.spec.js @team-qa',
+      '**/fixtures/** @team-fixtures',
+      '**/test/**/*.js @team-qa',
+      '*.config.* @team-build',
+      'packages/**/*.ts @team-types',
+    )
+  }
+  return lines.join('\n') + '\n'
+}
+
+function buildFilenames () {
+  const names = []
+  for (let i = 0; i < 256; i++) {
+    const m = i % 200
+    const kind = i % 4
+    if (kind === 0) names.push(`packages/module-${m}/src/index.js`)
+    else if (kind === 1) names.push(`packages/module-${m}/test/feature-${i}.spec.js`)
+    else if (kind === 2) names.push(`packages/web/components/widget-${i}/render.js`)
+    else names.push(`integration-tests/scenarios/case-${i}/fixtures/data-${i}.json`)
+  }
+  return names
+}
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeowners-bench-'))
+fs.writeFileSync(path.join(tmpDir, 'CODEOWNERS'), buildCodeowners(VARIANT))
+
+const baseEntries = getCodeOwnersFileEntries(tmpDir)
+assert.ok(Array.isArray(baseEntries) && baseEntries.length > 0, 'failed to parse CODEOWNERS fixture')
+
+const filenames = buildFilenames()
+
+// Preflight: confirm at least one path resolves to an owner (a *.spec.js path
+// matches in every fixture), so the bench is exercising a real match, not an
+// all-miss scan that returns null without testing the owners path.
+const probeEntries = baseEntries.slice()
+const matched = filenames.some((fn) => getCodeOwnersForFilename(fn, probeEntries) !== null)
+assert.ok(matched, 'no filename matched any CODEOWNERS entry')
+
+const passSize = filenames.length
+const passes = Math.ceil(COUNT / passSize)
+
+guard.loopStart()
+let sink = 0
+for (let p = 0; p < passes; p++) {
+  const view = baseEntries.slice()
+  for (let f = 0; f < passSize; f++) {
+    if (getCodeOwnersForFilename(filenames[f], view) !== null) sink++
+  }
+}
+guard.done()
+
+if (sink === 0) throw new Error('unreachable')
+
+fs.rmSync(tmpDir, { recursive: true, force: true })

--- a/benchmark/sirun/test-codeowners/meta.json
+++ b/benchmark/sirun/test-codeowners/meta.json
@@ -13,7 +13,7 @@
       "env": { "VARIANT": "large", "COUNT": "400000" }
     },
     "wildcard": {
-      "env": { "VARIANT": "wildcard", "COUNT": "1300000" }
+      "env": { "VARIANT": "wildcard", "COUNT": "740000" }
     }
   }
 }

--- a/benchmark/sirun/test-codeowners/meta.json
+++ b/benchmark/sirun/test-codeowners/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-codeowners",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 10,
+  "instructions": true,
+  "variants": {
+    "small": {
+      "env": { "VARIANT": "small", "COUNT": "3000000" }
+    },
+    "large": {
+      "env": { "VARIANT": "large", "COUNT": "400000" }
+    },
+    "wildcard": {
+      "env": { "VARIANT": "wildcard", "COUNT": "1300000" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds sirun coverage for hot paths that currently regress silently, one benchmark
per commit. Each new bench drives the real code under test (subclassing the
plugin/processor and stubbing only the tracer-reaching layer) with a preflight
assertion so a broken harness fails loudly instead of measuring nothing.

Core tracer:

1. `sampling` — `PrioritySampler.sample()`: rule glob matching, the Knuth hash,
   the token-bucket limiter, and the agent-rate fallback.
2. `span-format` — `span_format.format()`: tag splitting, truncation, root/chunk
   tags.
3. `dogstatsd` — metric line formatting and buffering plus the aggregated-client
   flush.

Test Optimization:

4. `test-codeowners` — `getCodeOwnersForFilename` across small, large and
   wildcard-heavy CODEOWNERS files.
5. `test-ci-encode` — the agentless CI-visibility msgpack encoder, the egress
   path for every test/suite/module/session event.

LLMObs:

6. `llmobs-span-processor` — `LLMObsSpanProcessor.format()` over chat, embedding,
   retrieval and agent span tag maps.
7. `llmobs-evaluations` — the evaluation-metrics writer append/flush path.

Instrumented libraries (distinct from the DBM-comment path the existing pg/redis
benches already cover):

8. `plugin-cassandra-driver` — batch resource combination and the 5000-char trim.
9. `plugin-couchbase` — `startSpan` tag assembly (the plugin builds its own bag).
10. `plugin-elasticsearch` — request-body JSON serialization and path quantization.
11. `plugin-grpc` — `/pkg.Service/Method` resolution and method meta build.
12. `plugin-memcached` — direct vs HashRing server-address resolution.

Stability fixes to existing benches:

13. `log` — drop the no-subscriber variants; with nothing to dispatch to, V8
    dead-code-eliminated the loop and stddev swung to ~66%.
14. `spans` — move the finish-later batch size into the GC valley (2000).
15. `debugger` — cap the unbounded-snapshot variant at 7 iterations.

## Why

Several of the new benches are allocation-bound (BigInt sampling math, string
trims, JSON serialization) and read noisier than the 2% target on an unpinned
macOS. The pinned-core CI runner is the authoritative gate; the per-bench
READMEs and commit bodies note which variants carry that local-only noise.

## Test plan

- [ ] CI sirun job runs each new bench green on a pinned core.
- [ ] Confirm per-variant wall time stays within the suite budget (~1 min/bench).

## Follow-ups (not in this PR)

Messaging (`amqplib`, `bullmq`) and web-framework (`express`, `fastify`) benches
were scoped but deferred: express/fastify overlap heavily with the existing
`plugin-http` span path, and the messaging benches need their own duplication
audit before they earn a slot.