### PR TITLE
fix(runtime-metrics): normalize TCP resource tag

### DIFF
--- a/packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js
+++ b/packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js
@@ -18,6 +18,9 @@ const ATTR_GC_TYPE_MINOR = { 'v8js.gc.type': 'minor' }
 const ATTR_GC_TYPE_MAJOR = { 'v8js.gc.type': 'major' }
 const ATTR_GC_TYPE_INCREMENTAL = { 'v8js.gc.type': 'incremental' }
 const ATTR_GC_TYPE_WEAKCB = { 'v8js.gc.type': 'weakcb' }
+const NORMALIZED_RESOURCE_TYPE_BY_NAME = new Map([
+  ['TCPSocketWrap', 'TCPWrap'],
+])
 
 // Kind 2 is V8's MinorMarkSweep (Node 20+) and not exposed via perf_hooks.constants.
 const GC_ATTR_BY_KIND = new Map([
@@ -42,6 +45,14 @@ function getHeapSpaceAttr (name) {
     HEAP_SPACE_ATTR_CACHE.set(name, attr)
   }
   return attr
+}
+
+/**
+ * @param {string} resourceType
+ * @returns {string}
+ */
+function normalizeResourceType (resourceType) {
+  return NORMALIZED_RESOURCE_TYPE_BY_NAME.get(resourceType) ?? resourceType
 }
 
 // getMeter() returns a cached meter, so without tracking what we registered we'd
@@ -112,7 +123,8 @@ module.exports = {
       // Stable since Node 22.16; available on 18+ as experimental.
       // eslint-disable-next-line n/no-unsupported-features/node-builtins
       for (const resource of process.getActiveResourcesInfo()) {
-        counts.set(resource, (counts.get(resource) ?? 0) + 1)
+        const resourceType = normalizeResourceType(resource)
+        counts.set(resourceType, (counts.get(resourceType) ?? 0) + 1)
       }
       for (const [type, count] of counts) {
         result.observe(count, { 'v8js.resource.type': type })

--- a/packages/dd-trace/test/runtime_metrics.spec.js
+++ b/packages/dd-trace/test/runtime_metrics.spec.js
@@ -907,7 +907,7 @@ FakePerformanceObserverForOtlp.instances = []
 
 /**
  * Loads otlp_runtime_metrics with a mock meter for unit tests.
- * @param {{ monitorEventLoopDelay?: () => unknown }} [overrides]
+ * @param {{ monitorEventLoopDelay?: () => unknown, getActiveResourcesInfo?: () => string[] }} [overrides]
  * @returns {{
  *   otlpMetrics: object,
  *   createdInstruments: Record<string, object>,
@@ -977,6 +977,8 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
   }
 
   const monitorEventLoopDelay = overrides.monitorEventLoopDelay ?? realPerfHooks.monitorEventLoopDelay
+  const processModule = Object.create(process)
+  processModule.getActiveResourcesInfo = overrides.getActiveResourcesInfo ?? process.getActiveResourcesInfo
 
   const otlpMetrics = proxyquire.noCallThru()('../src/runtime_metrics/otlp_runtime_metrics', {
     '@opentelemetry/api': {
@@ -989,6 +991,7 @@ function loadOtlpRuntimeMetricsTestModule (overrides = {}) {
       PerformanceObserver: FakePerformanceObserverForOtlp,
       constants: realPerfHooks.constants,
     },
+    'node:process': processModule,
     './client': {
       createMetricsClient: () => fakeMetricsClient,
     },
@@ -1165,6 +1168,24 @@ describe('otlp_runtime_metrics', () => {
     assert.ok(resourceCounts.length > 0, 'v8js.resource.active should observe at least one resource type')
     assert.ok(resourceCounts.every(e => e.v > 0 && typeof e.type === 'string'),
       'every v8js.resource.active observation should have a positive count and a type attribute')
+  })
+
+  it('normalizes TCPSocketWrap resource types to TCPWrap', () => {
+    const ctx = loadOtlpRuntimeMetricsTestModule({
+      getActiveResourcesInfo: () => ['TCPSocketWrap', 'TCPSocketWrap', 'Timeout']
+    })
+    ctx.otlpMetrics.start({ runtimeMetrics: { eventLoop: true } })
+
+    const resourceCounts = []
+    ctx.callbacks['v8js.resource.active'][0]({
+      observe: (v, a) => resourceCounts.push({ v, type: a?.['v8js.resource.type'] }),
+    })
+
+    assert.deepStrictEqual(resourceCounts, [
+      { v: 2, type: 'TCPWrap' },
+      { v: 1, type: 'Timeout' },
+    ], 'resource type normalization should map only TCPSocketWrap to TCPWrap')
+    ctx.otlpMetrics.stop()
   })
 
   it('event loop delay batch skips when histogram has fewer than 5 samples', () => {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f8ca57b4-2ff9-469e-b07d-620a199c8029","source":"chat","resourceId":"1ccd1d1b-46ec-4b5d-8ae7-08b26f9aa6df","workflowId":"611f2d0d-4726-4ce0-b50f-9176fe45873f","codeChangeId":"611f2d0d-4726-4ce0-b50f-9176fe45873f","sourceType":"action_platform_custom_agent"} -->
### What does this PR do?

Workflow Automation • [View in Workflow Automation](https://app.datadoghq.com/actions/agents/266e9634-656d-477d-ab50-9ee3a0c8acd4)

Normalizes Node 23+ active resource type reporting for runtime metrics by mapping `TCPSocketWrap` to `TCPWrap` before emitting `v8js.resource.active` with the `v8js.resource.type` attribute.

Changes:
- Added a small helper in `packages/dd-trace/src/runtime_metrics/otlp_runtime_metrics.js` to normalize async resource type names.
- Mapped only `TCPSocketWrap` -> `TCPWrap`; all other resource type names pass through unchanged.
- Updated the `v8js.resource.active` collection path to apply normalization before counting/emitting metric points.
- Extended `packages/dd-trace/test/runtime_metrics.spec.js` with a focused unit test that verifies:
  - `TCPSocketWrap` is recorded as `TCPWrap`
  - Other resource names (example: `Timeout`) are unchanged

### Motivation
System-tests on Node 23+ started failing the `v8js.resource.type` allow-list assertion because Node introduced a new active resource literal, `TCPSocketWrap`, while the expected allow-list remains:
`DNSChannel, FSEvent, FSReqCallback, HTTPClientRequest, HTTPParser, Immediate, MessagePort, Microtask, PipeWrap, SignalWrap, StatWatcher, TCPServerWrap, TCPWrap, TLSWrap, TTYWrap, Timeout, UDPWrap`.

By normalizing `TCPSocketWrap` back to `TCPWrap`, this restores compatibility with the existing allow-list and downstream cardinality expectations without expanding metric tag cardinality or changing metric/tag names.

### Additional Notes
Testing/validation performed:
- `./node_modules/.bin/mocha packages/dd-trace/test/runtime_metrics.spec.js --grep "otlp_runtime_metrics|normalizes TCPSocketWrap"` (pass)
- `./node_modules/.bin/mocha packages/dd-trace/test/runtime_metrics.spec.js` (suite has pre-existing failures in this environment requiring `global.gc`, unrelated to this change)
- `Lint`/`eslint` execution failed in this environment with `SyntaxError: Invalid regular expression flags` before reporting file-level findings; no lint issues were identified in changed logic.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1ccd1d1b-46ec-4b5d-8ae7-08b26f9aa6df)

Comment @datadog to request changes