### PR TITLE
feat(llmobs): add support for tool definitions with google genai

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/genai/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/genai/index.js
@@ -5,6 +5,7 @@ const {
   getOperation,
   extractMetrics,
   extractMetadata,
+  extractToolDefinitions,
   aggregateStreamingChunks,
   formatInputMessages,
   formatEmbeddingInput,
@@ -78,6 +79,9 @@ class GenAiLLMObsPlugin extends LLMObsPlugin {
 
     const metadata = extractMetadata(config)
     this._tagger.tagMetadata(span, metadata)
+
+    const toolDefinitions = extractToolDefinitions(config)
+    if (toolDefinitions.length > 0) this._tagger.tagToolDefinitions(span, toolDefinitions)
 
     if (error) {
       this._tagger.tagLLMIO(span, inputMessages, [{ content: '' }])

--- a/packages/dd-trace/src/llmobs/plugins/genai/util.js
+++ b/packages/dd-trace/src/llmobs/plugins/genai/util.js
@@ -156,6 +156,50 @@ function extractMetadata (config) {
 }
 
 /**
+ * Extract tool definitions from config
+ * @param {object} config
+ * @returns {Array}
+ */
+function extractToolDefinitions (config) {
+  const toolDefinitions = []
+
+  if (!Array.isArray(config?.tools)) {
+    return toolDefinitions
+  }
+
+  for (const tool of config.tools) {
+    // Only extract tools with valid function declarations
+    if (!Array.isArray(tool?.functionDeclarations)) {
+      continue
+    }
+
+    for (const currDeclaration of tool.functionDeclarations) {
+      // A valid declaration must have a name
+      if (!currDeclaration?.name) {
+        continue
+      }
+
+      const toolDef = { name: currDeclaration.name }
+
+      if (currDeclaration.description !== undefined) {
+        toolDef.description = currDeclaration.description
+      }
+
+      // Parameters can be in two different fields depending on user input
+      if (currDeclaration.parameters !== undefined) {
+        toolDef.schema = currDeclaration.parameters
+      } else if (currDeclaration.parametersJsonSchema !== undefined) {
+        toolDef.schema = currDeclaration.parametersJsonSchema
+      }
+
+      toolDefinitions.push(toolDef)
+    }
+  }
+
+  return toolDefinitions
+}
+
+/**
  * Format function call message
  * @param {Array} parts
  * @param {Array} functionCalls
@@ -498,6 +542,7 @@ module.exports = {
   getOperation,
   extractMetrics,
   extractMetadata,
+  extractToolDefinitions,
   aggregateStreamingChunks,
   formatInputMessages,
   formatEmbeddingInput,

--- a/packages/dd-trace/test/llmobs/cassettes/genai/genai_v1beta_models_gemini-2.5-flash_generateContent_post_8e5467af.json
+++ b/packages/dd-trace/test/llmobs/cassettes/genai/genai_v1beta_models_gemini-2.5-flash_generateContent_post_8e5467af.json
@@ -1,0 +1,39 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+    "headers": {
+      "Connection": "keep-alive",
+      "User-Agent": "google-genai-sdk/1.19.0 gl-node/v26.0.0",
+      "x-goog-api-client": "google-genai-sdk/1.19.0 gl-node/v26.0.0",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "300"
+    },
+    "body": "{\"contents\":[{\"parts\":[{\"text\":\"Hello, world!\"}],\"role\":\"user\"}],\"tools\":[{\"functionDeclarations\":[{\"description\":\"A simple tool\",\"name\":\"tool1\",\"parameters\":{\"type\":\"OBJECT\",\"properties\":{\"location\":{\"type\":\"STRING\",\"description\":\"The city name\"}},\"required\":[\"location\"]}}]}],\"generationConfig\":{}}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "X-Gemini-Service-Tier": "standard",
+      "Content-Type": "application/json; charset=UTF-8",
+      "Vary": "Origin, X-Origin, Referer",
+      "Content-Encoding": "gzip",
+      "Date": "Wed, 10 Jun 2026 15:36:39 GMT",
+      "Server": "scaffolding on HTTPServer2",
+      "X-XSS-Protection": "0",
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-Content-Type-Options": "nosniff",
+      "Server-Timing": "gfet4t7; dur=421",
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000",
+      "Transfer-Encoding": "chunked"
+    },
+    "body": "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\": [\n          {\n            \"text\": \"Hello! How can I help you today?\\n\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 41,\n    \"candidatesTokenCount\": 9,\n    \"totalTokenCount\": 50,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 41\n      }\n    ],\n    \"serviceTier\": \"standard\"\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"h4QpaqGNG8Wu_PUP7JaUmQE\"\n}\n"
+  }
+}

--- a/packages/dd-trace/test/llmobs/cassettes/genai/genai_v1beta_models_gemini-2.5-flash_streamGenerateContent_alt_sse_post_c9b44d2a.json
+++ b/packages/dd-trace/test/llmobs/cassettes/genai/genai_v1beta_models_gemini-2.5-flash_streamGenerateContent_alt_sse_post_c9b44d2a.json
@@ -1,0 +1,38 @@
+{
+  "request": {
+    "method": "POST",
+    "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+    "headers": {
+      "Connection": "keep-alive",
+      "User-Agent": "google-genai-sdk/1.19.0 gl-node/v26.0.0",
+      "x-goog-api-client": "google-genai-sdk/1.19.0 gl-node/v26.0.0",
+      "Content-Type": "application/json",
+      "Accept": "*/*",
+      "Accept-Language": "*",
+      "sec-fetch-mode": "cors",
+      "Accept-Encoding": "gzip, deflate",
+      "Content-Length": "65"
+    },
+    "body": "{\"contents\":[{\"parts\":[{\"text\":\"Hello, world!\"}],\"role\":\"user\"}]}"
+  },
+  "response": {
+    "status": {
+      "code": 200,
+      "message": "OK"
+    },
+    "headers": {
+      "Content-Type": "text/event-stream",
+      "Content-Disposition": "attachment",
+      "Vary": "Origin, X-Origin, Referer",
+      "Transfer-Encoding": "chunked",
+      "Date": "Wed, 10 Jun 2026 14:40:52 GMT",
+      "Server": "scaffolding on HTTPServer2",
+      "X-XSS-Protection": "0",
+      "X-Frame-Options": "SAMEORIGIN",
+      "X-Content-Type-Options": "nosniff",
+      "Server-Timing": "gfet4t7; dur=829",
+      "Alt-Svc": "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"
+    },
+    "body": "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Hello, world! It's good to meet you. How can I help you today?\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 5,\"candidatesTokenCount\": 19,\"totalTokenCount\": 53,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 5}],\"thoughtsTokenCount\": 29,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"c3cpap_xFpLRjMcPt5CUwQw\"}\r\n\r\n"
+  }
+}

--- a/packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/google-genai/index.spec.js
@@ -28,8 +28,27 @@ describe('Plugin', () => {
     describe('models.generateContent', () => {
       it('creates a span', async () => {
         const result = await client.models.generateContent({
-          model: 'gemini-2.0-flash',
+          model: 'gemini-2.5-flash',
           contents: 'Hello, world!',
+          config: {
+            tools: [
+              {
+                functionDeclarations: [
+                  {
+                    name: 'tool1',
+                    description: 'A simple tool',
+                    parameters: {
+                      type: 'object',
+                      properties: {
+                        location: { type: 'string', description: 'The city name' },
+                      },
+                      required: ['location'],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
         })
 
         assert.ok(result)
@@ -39,7 +58,7 @@ describe('Plugin', () => {
           span: apmSpans[0],
           spanKind: 'llm',
           name: 'google_genai.request',
-          modelName: 'gemini-2.0-flash',
+          modelName: 'gemini-2.5-flash',
           modelProvider: 'google',
           inputMessages: [{ role: 'user', content: 'Hello, world!' }],
           outputMessages: [{ role: 'assistant', content: MOCK_STRING }],
@@ -64,6 +83,17 @@ describe('Plugin', () => {
             output_tokens: MOCK_NUMBER,
             total_tokens: MOCK_NUMBER,
           },
+          toolDefinitions: [{
+            name: 'tool1',
+            description: 'A simple tool',
+            schema: {
+              type: 'OBJECT',
+              properties: {
+                location: { type: 'STRING', description: 'The city name' },
+              },
+              required: ['location'],
+            },
+          }],
           tags: { ml_app: 'test', integration: 'google_genai' },
         })
       })
@@ -72,7 +102,7 @@ describe('Plugin', () => {
     describe('models.generateContentStream', () => {
       it('creates a span', async () => {
         const stream = await client.models.generateContentStream({
-          model: 'gemini-2.0-flash',
+          model: 'gemini-2.5-flash',
           contents: 'Hello, world!',
         })
 
@@ -85,7 +115,7 @@ describe('Plugin', () => {
           span: apmSpans[0],
           spanKind: 'llm',
           name: 'google_genai.request',
-          modelName: 'gemini-2.0-flash',
+          modelName: 'gemini-2.5-flash',
           modelProvider: 'google',
           inputMessages: [{ role: 'user', content: 'Hello, world!' }],
           outputMessages: [{ role: 'assistant', content: MOCK_STRING }],


### PR DESCRIPTION
feat(llmobs): add tool definitions auto extraction for google-genai
[MLOB-7612]

### What does this PR do?
Adds automatic tool definition extraction to the google-genai plugin. When a user passes config.tools to generate content function, the plugin now extracts each function declaration and tags them on the LLM span as tool_definitions.
Also adds and updates integration test covering the tool definitions extraction.

### Motivation
Brings the Node.js google-genai plugin features closer with the Python SDK,
which already extracts tool definitions automatically from requests.


[MLOB-7612]: https://datadoghq.atlassian.net/browse/MLOB-7612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ