### PR TITLE
fix(otel): OTel updateName now updates the Datadog span's resource name

### DIFF
--- a/integration-tests/opentelemetry.spec.js
+++ b/integration-tests/opentelemetry.spec.js
@@ -390,7 +390,7 @@ describe('opentelemetry', function () {
       const trace = payload.flat()
       assert.strictEqual(trace.length, 9)
 
-      // Should have expected span names and ordering
+      // Should have expected span resource names and ordering
       assert.ok(eachEqual(trace, [
         'GET /second-endpoint',
         'middleware - query',
@@ -402,7 +402,7 @@ describe('opentelemetry', function () {
         'request handler - /first-endpoint',
         'GET',
       ],
-      (span) => span.name))
+      (span) => span.resource))
 
       assert.ok(allEqual(trace, (span) => {
         span.trace_id.toString()

--- a/packages/dd-trace/src/opentelemetry/span-helpers.js
+++ b/packages/dd-trace/src/opentelemetry/span-helpers.js
@@ -270,19 +270,6 @@ function applyOtelStatus (ddSpan, currentCode, status) {
 }
 
 /**
- * OTel `updateName` for OTel-created bridge spans: writes the DD operation name, matching
- * the OTel SDK semantic that `updateName` updates the canonical span identifier.
- *
- * @param {import('../opentracing/span')} ddSpan
- * @param {string} name
- */
-function setOtelOperationName (ddSpan, name) {
-  if (!isWritable(ddSpan)) return
-
-  ddSpan.setOperationName(name)
-}
-
-/**
  * OTel `updateName` for DD-native spans the bridge did not create: writes `resource.name`
  * so the operation name (and the backend metric aggregation it drives) stays stable.
  *
@@ -304,6 +291,5 @@ module.exports = {
   recordException,
   setOtelAttribute,
   setOtelAttributes,
-  setOtelOperationName,
   setOtelResource,
 }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -15,7 +15,7 @@ const kinds = require('../../../../ext/kinds')
 const id = require('../id')
 const BridgeSpanBase = require('./bridge-span-base')
 const SpanContext = require('./span_context')
-const { setOtelOperationName } = require('./span-helpers')
+const { setOtelResource } = require('./span-helpers')
 
 const spanKindNames = {
   [api.SpanKind.INTERNAL]: kinds.INTERNAL,
@@ -223,7 +223,7 @@ class Span extends BridgeSpanBase {
    * @param {string} name
    */
   updateName (name) {
-    setOtelOperationName(this._ddSpan, name)
+    setOtelResource(this._ddSpan, name)
     return this
   }
 

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -165,6 +165,7 @@ class Span extends BridgeSpanBase {
 
     this._parentTracer = parentTracer
     this._context = context
+    this._otelName = spanName || this._ddSpan.context()._name
 
     // NOTE: Need to grab the value before setting it on the span because the
     // math for computing opentracing timestamps is apparently lossy...
@@ -192,7 +193,7 @@ class Span extends BridgeSpanBase {
   }
 
   get name () {
-    return this._ddSpan.context()._name
+    return this._otelName
   }
 
   spanContext () {
@@ -223,6 +224,7 @@ class Span extends BridgeSpanBase {
    * @param {string} name
    */
   updateName (name) {
+    this._otelName = name
     setOtelResource(this._ddSpan, name)
     return this
   }

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -226,6 +226,7 @@ class Span extends BridgeSpanBase {
    * @param {string} name
    */
   updateName (name) {
+    if (this.ended) return this
     this.#otelName = name
     setOtelResource(this._ddSpan, name)
     return this

--- a/packages/dd-trace/src/opentelemetry/span.js
+++ b/packages/dd-trace/src/opentelemetry/span.js
@@ -118,6 +118,8 @@ function spanNameMapper (spanName, kind, attributes) {
  * surface; the underlying DD span carries the lifecycle.
  */
 class Span extends BridgeSpanBase {
+  #otelName
+
   /**
    * @param {import('./tracer')} parentTracer
    * @param {import('@opentelemetry/api').Context} context
@@ -165,7 +167,7 @@ class Span extends BridgeSpanBase {
 
     this._parentTracer = parentTracer
     this._context = context
-    this._otelName = spanName || this._ddSpan.context()._name
+    this.#otelName = spanName || this._ddSpan.context()._name
 
     // NOTE: Need to grab the value before setting it on the span because the
     // math for computing opentracing timestamps is apparently lossy...
@@ -193,7 +195,7 @@ class Span extends BridgeSpanBase {
   }
 
   get name () {
-    return this._otelName
+    return this.#otelName
   }
 
   spanContext () {
@@ -224,7 +226,7 @@ class Span extends BridgeSpanBase {
    * @param {string} name
    */
   updateName (name) {
-    this._otelName = name
+    this.#otelName = name
     setOtelResource(this._ddSpan, name)
     return this
   }

--- a/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
@@ -17,7 +17,6 @@ const {
   recordException,
   setOtelAttribute,
   setOtelAttributes,
-  setOtelOperationName,
   setOtelResource,
 } = require('../../src/opentelemetry/span-helpers')
 
@@ -84,7 +83,6 @@ describe('OTel bridge helpers', () => {
       ])
       addOtelEvent(ddSpan, 'evt', { code: 42 })
       recordException(ddSpan, new Error('boom'))
-      setOtelOperationName(ddSpan, 'internal')
       setOtelResource(ddSpan, 'GET /users')
 
       assert.deepStrictEqual(ddSpan.tags, {})
@@ -302,15 +300,7 @@ describe('OTel bridge helpers', () => {
     })
   })
 
-  describe('setOtelOperationName vs setOtelResource', () => {
-    it('setOtelOperationName routes to setOperationName on the DD span', () => {
-      const ddSpan = createMockDdSpan()
-      setOtelOperationName(ddSpan, 'internal')
-
-      assert.strictEqual(ddSpan.operationName, 'internal')
-      assert.strictEqual(ddSpan.tags['resource.name'], undefined)
-    })
-
+  describe('setOtelResource', () => {
     it('setOtelResource routes to the resource.name tag, not the operation name', () => {
       const ddSpan = createMockDdSpan()
       setOtelResource(ddSpan, 'GET /users')

--- a/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span-helpers.spec.js
@@ -84,7 +84,7 @@ describe('OTel bridge helpers', () => {
       ])
       addOtelEvent(ddSpan, 'evt', { code: 42 })
       recordException(ddSpan, new Error('boom'))
-      setOtelOperationName(ddSpan, 'GET /users')
+      setOtelOperationName(ddSpan, 'internal')
       setOtelResource(ddSpan, 'GET /users')
 
       assert.deepStrictEqual(ddSpan.tags, {})
@@ -305,9 +305,9 @@ describe('OTel bridge helpers', () => {
   describe('setOtelOperationName vs setOtelResource', () => {
     it('setOtelOperationName routes to setOperationName on the DD span', () => {
       const ddSpan = createMockDdSpan()
-      setOtelOperationName(ddSpan, 'GET /users')
+      setOtelOperationName(ddSpan, 'internal')
 
-      assert.strictEqual(ddSpan.operationName, 'GET /users')
+      assert.strictEqual(ddSpan.operationName, 'internal')
       assert.strictEqual(ddSpan.tags['resource.name'], undefined)
     })
 

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -284,11 +284,12 @@ describe('OTel Span', () => {
     })
   })
 
-  it('updateName should set the DD resource name', () => {
+  it('updateName should set the DD resource name and keep span.name in sync', () => {
     const span = makeSpan('original name')
     span.updateName('updated name')
 
     assert.strictEqual(span._ddSpan.context().getTag(RESOURCE_NAME), 'updated name')
+    assert.strictEqual(span.name, 'updated name')
   })
 
   it('updateName is a no-op after end()', () => {

--- a/packages/dd-trace/test/opentelemetry/span.spec.js
+++ b/packages/dd-trace/test/opentelemetry/span.spec.js
@@ -284,11 +284,11 @@ describe('OTel Span', () => {
     })
   })
 
-  it('should update span name', () => {
-    const span = makeSpan('name')
-    span.updateName('new name')
+  it('updateName should set the DD resource name', () => {
+    const span = makeSpan('original name')
+    span.updateName('updated name')
 
-    assert.strictEqual(span.name, 'new name')
+    assert.strictEqual(span._ddSpan.context().getTag(RESOURCE_NAME), 'updated name')
   })
 
   it('updateName is a no-op after end()', () => {


### PR DESCRIPTION
### What does this PR do?
Previously, the `updateName` function in the OTel Bridge (which, as the name suggests, updates the OpenTelemetry span's name after span creation) would update the Datadog span's operation name, which is incorrect. The corresponding field in the Datadog span is the resource name, so this PR fixes the implementation to update the DD span's resource name. 

Note: This is a breaking change for users of this API because the "operation name" displayed in the UI will change. However, OpenTelemetry instrumentation libraries like `opentelemetry-instrumentation-express` use this to update the span's name to match the endpoint, so this is behavior now aligns with expectations.

### Motivation
Exploratory testing of OpenTelemetry Instrumentation Libraries is being conducted via https://github.com/DataDog/evalya/pull/798 which exposed this bug. This issue appears regardless of the trace format (MsgPack or OTLP) so it should be fixed unconditionally in the OTel Tracing API layer.

Note: After testing in the linked evalya branch with this local change, the `name` fields of the corresponding OTLP spans between the two SDKs now match.

### Additional Notes
N/A


