### PR TITLE
ci(release): add urgent Slack alert when commit count reaches 100

### DIFF
--- a/.github/workflows/release-proposal.yml
+++ b/.github/workflows/release-proposal.yml
@@ -42,7 +42,8 @@ jobs:
         if: >
           github.event_name == 'schedule' &&
           steps.proposal.outputs.commit_count != '' &&
-          fromJSON(steps.proposal.outputs.commit_count) >= 50
+          fromJSON(steps.proposal.outputs.commit_count) >= 50 &&
+          fromJSON(steps.proposal.outputs.commit_count) < 100
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -58,5 +59,27 @@ jobs:
                     <${{ steps.proposal.outputs.pr_url }}|${{ steps.proposal.outputs.version }}>*
                     has ${{ steps.proposal.outputs.commit_count }} commits queued.
                     GitHub's rebase limit is 100 — once reached, commits that don't fit
+                    will be deferred to a subsequent release.
+                    Consider cutting this release soon.
+      - uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v2.1.0
+        if: >
+          github.event_name == 'schedule' &&
+          steps.proposal.outputs.commit_count != '' &&
+          fromJSON(steps.proposal.outputs.commit_count) >= 100
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          errors: true
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: >-
+                    :rotating_light: *Release proposal
+                    <${{ steps.proposal.outputs.pr_url }}|${{ steps.proposal.outputs.version }}>*
+                    has ${{ steps.proposal.outputs.commit_count }} commits queued.
+                    GitHub's rebase limit of 100 has been reached — commits that don't fit
                     will be deferred to a subsequent release.
                     Consider cutting this release soon.


### PR DESCRIPTION
### What does this PR do?

Splits the release proposal Slack notification into two steps:
- **50–99 commits**: existing warning, unchanged
- **100+ commits**: new urgent alert (`:rotating_light:`) with a message reflecting that the rebase limit has already been reached

### Motivation

The original warning message ("GitHub's rebase limit is 100 — once reached, commits that don't fit will be deferred") didn't make sense when the count was already at or above 100, since the limit was already hit at that point.

### Additional Notes

_Generated by Claude Code_