### PR TITLE
ci: add --auto-discovery flag to datadog-ci junit upload

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -46,7 +46,7 @@ jobs:
       - if: "!cancelled()"
         uses: ./.github/actions/datadog-ci
       - if: "!cancelled()"
-        run: datadog-ci junit upload --service dd-trace-js-tests junit-results
+        run: datadog-ci junit upload --service dd-trace-js-tests --auto-discovery junit-results
         env:
           DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
       - if: "!cancelled()"


### PR DESCRIPTION
### What does this PR do?

Adds the `--auto-discovery` flag to the `datadog-ci junit upload` command in the all-green workflow.

### Motivation

The `--auto-discovery` flag enables automatic discovery of JUnit report files within the provided directory, ensuring all reports are picked up without requiring explicit file paths.

### Additional Notes

The equivalent flag does not exist for `datadog-ci coverage upload` — that command already performs recursive discovery by default when given a directory path.

> Generated by Claude Code