### PR TITLE
fix(exporters): route agentless spans to the regional data-center intake

### DIFF
--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -7,6 +7,7 @@ const log = require('../../log')
 const { entityId } = require('../common/docker')
 const tracerVersion = require('../../../../../package.json').version
 const Writer = require('./writer')
+const { computeIntakeUrl } = require('./intake')
 
 /**
  * Agentless exporter for APM trace intake.
@@ -28,9 +29,9 @@ class AgentlessExporter {
     const site = config.site ?? 'datadoghq.com'
 
     try {
-      // Agentless traffic carries the Datadog API key, so the intake is always the public https
-      // endpoint; never derive it from config.url (the agent's cleartext http) or the key leaks.
-      this._url = new URL(`https://public-trace-http-intake.logs.${site}`)
+      // Agentless traffic carries the Datadog API key, so the intake is always an https endpoint
+      // derived from the site; never config.url (the agent's cleartext http) or the key leaks.
+      this._url = new URL(computeIntakeUrl(site))
     } catch (err) {
       log.error('Invalid site for agentless exporter. site=%s. Error: %s', site, err.message)
       this._url = null

--- a/packages/dd-trace/src/exporters/agentless/index.js
+++ b/packages/dd-trace/src/exporters/agentless/index.js
@@ -16,6 +16,7 @@ const { computeIntakeUrl } = require('./intake')
  */
 class AgentlessExporter {
   #timer
+  #config
 
   /**
    * @param {object} config - Configuration object
@@ -25,7 +26,7 @@ class AgentlessExporter {
    * @param {object} [config.tags] - Tags including runtime-id
    */
   constructor (config) {
-    this._config = config
+    this.#config = config
     const site = config.site ?? 'datadoghq.com'
 
     try {
@@ -90,7 +91,7 @@ class AgentlessExporter {
   export (spans) {
     this._writer.append(spans)
 
-    const { flushInterval } = this._config
+    const { flushInterval } = this.#config
 
     if (flushInterval === 0) {
       try {

--- a/packages/dd-trace/src/exporters/agentless/intake.js
+++ b/packages/dd-trace/src/exporters/agentless/intake.js
@@ -1,0 +1,43 @@
+'use strict'
+
+// Per-site hosts for the agentless JSON span intake. Regional data centers serve it from
+// browser-intake-* hosts rather than public-trace-http-intake.logs.<site>, so a single template
+// silently drops spans on us3/us5/ap1/ap2. Mirrors dd-trace-py's AgentlessTraceWriter.INTAKE_URLS
+// (DataDog/dd-trace-py#18514).
+const INTAKE_URLS = {
+  'datadoghq.com': 'https://public-trace-http-intake.logs.datadoghq.com',
+  'datadoghq.eu': 'https://public-trace-http-intake.logs.datadoghq.eu',
+  'us3.datadoghq.com': 'https://trace.browser-intake-us3-datadoghq.com',
+  'us5.datadoghq.com': 'https://trace.browser-intake-us5-datadoghq.com',
+  'ap1.datadoghq.com': 'https://browser-intake-ap1-datadoghq.com',
+  'ap2.datadoghq.com': 'https://browser-intake-ap2-datadoghq.com',
+  'uk1.datadoghq.com': 'https://browser-intake-uk1-datadoghq.com',
+  'datad0g.com': 'https://public-trace-http-intake.logs.datad0g.com',
+}
+
+// Path of the JSON span intake on every intake host.
+const INTAKE_PATH = '/api/v2/spans'
+
+/**
+ * Resolves the agentless intake origin for a Datadog site.
+ *
+ * Unknown sites fall back to the browser-intake naming: strip the TLD, dash-join the rest, then
+ * reattach the TLD, e.g. 'us2.ddog-gov.com' -> 'https://browser-intake-us2-ddog-gov.com'.
+ *
+ * @param {string} [site] - The Datadog site, e.g. 'us3.datadoghq.com'. Defaults to 'datadoghq.com'.
+ * @returns {string} The intake origin, without a path.
+ */
+function computeIntakeUrl (site = 'datadoghq.com') {
+  const normalized = site.toLowerCase()
+  const known = INTAKE_URLS[normalized]
+  if (known !== undefined) {
+    return known
+  }
+
+  const lastDot = normalized.lastIndexOf('.')
+  const prefix = lastDot === -1 ? '' : normalized.slice(0, lastDot)
+  const tld = lastDot === -1 ? normalized : normalized.slice(lastDot + 1)
+  return `https://browser-intake-${prefix.replaceAll('.', '-')}.${tld}`
+}
+
+module.exports = { INTAKE_URLS, INTAKE_PATH, computeIntakeUrl }

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -7,6 +7,7 @@ const tracerVersion = require('../../../../../package.json').version
 
 const BaseWriter = require('../common/writer')
 const { AgentlessJSONEncoder } = require('../../encode/agentless-json')
+const { computeIntakeUrl, INTAKE_PATH } = require('./intake')
 
 /**
  * Writer for agentless APM trace intake.
@@ -28,7 +29,7 @@ class AgentlessWriter extends BaseWriter {
 
     if (!url) {
       try {
-        this._url = new URL(`https://public-trace-http-intake.logs.${site}`)
+        this._url = new URL(computeIntakeUrl(site))
       } catch (err) {
         log.error(
           'Invalid site value for agentless intake: %s. Cannot construct URL. Error: %s',
@@ -121,7 +122,7 @@ class AgentlessWriter extends BaseWriter {
     this.#apiKeyMissing = false
 
     const options = {
-      path: '/v1/input',
+      path: INTAKE_PATH,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/dd-trace/src/exporters/agentless/writer.js
+++ b/packages/dd-trace/src/exporters/agentless/writer.js
@@ -141,7 +141,7 @@ class AgentlessWriter extends BaseWriter {
 
     request(data, options, (err, res, statusCode) => {
       if (err) {
-        this._logRequestError(err, statusCode, count)
+        this.#logRequestError(err, statusCode, count)
         done()
         return
       }
@@ -157,7 +157,7 @@ class AgentlessWriter extends BaseWriter {
    * @param {number} statusCode - HTTP status code (if available)
    * @param {number} count - Number of traces that were being sent
    */
-  _logRequestError (err, statusCode, count) {
+  #logRequestError (err, statusCode, count) {
     if (statusCode === 401 || statusCode === 403) {
       log.error(
         'Authentication failed sending %d trace(s) (status %s). Verify DD_API_KEY is valid.',

--- a/packages/dd-trace/test/exporters/agentless/exporter.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/exporter.spec.js
@@ -66,6 +66,12 @@ describe('AgentlessExporter', () => {
       sinon.assert.match(exporter._url.hostname, 'public-trace-http-intake.logs.datadoghq.com')
     })
 
+    it('should map a regional site to its data-center intake host', () => {
+      exporter = new Exporter({ site: 'us3.datadoghq.com' })
+
+      assert.strictEqual(exporter._url.hostname, 'trace.browser-intake-us3-datadoghq.com')
+    })
+
     it('should register beforeExit handler', () => {
       exporter = new Exporter({})
 

--- a/packages/dd-trace/test/exporters/agentless/intake.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/intake.spec.js
@@ -1,0 +1,41 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+
+const { computeIntakeUrl, INTAKE_URLS, INTAKE_PATH } = require('../../../src/exporters/agentless/intake')
+
+require('../../setup/core')
+
+describe('agentless intake', () => {
+  describe('computeIntakeUrl', () => {
+    for (const [site, expected] of Object.entries(INTAKE_URLS)) {
+      it(`maps the ${site} site to its intake host`, () => {
+        assert.strictEqual(computeIntakeUrl(site), expected)
+      })
+    }
+
+    it('defaults to the datadoghq.com intake', () => {
+      assert.strictEqual(computeIntakeUrl(), INTAKE_URLS['datadoghq.com'])
+    })
+
+    it('lowercases the site before lookup', () => {
+      assert.strictEqual(computeIntakeUrl('US3.DataDogHQ.com'), INTAKE_URLS['us3.datadoghq.com'])
+    })
+
+    for (const [site, expected] of [
+      ['ap3.datadoghq.com', 'https://browser-intake-ap3-datadoghq.com'],
+      ['ddog-gov.com', 'https://browser-intake-ddog-gov.com'],
+      ['us2.ddog-gov.com', 'https://browser-intake-us2-ddog-gov.com'],
+    ]) {
+      it(`falls back to the browser-intake host for the unknown ${site} site`, () => {
+        assert.strictEqual(computeIntakeUrl(site), expected)
+      })
+    }
+  })
+
+  it('targets the JSON span intake path', () => {
+    assert.strictEqual(INTAKE_PATH, '/api/v2/spans')
+  })
+})

--- a/packages/dd-trace/test/exporters/agentless/writer.spec.js
+++ b/packages/dd-trace/test/exporters/agentless/writer.spec.js
@@ -82,6 +82,12 @@ describe('AgentlessWriter', () => {
       assert.strictEqual(writer._url.hostname, 'public-trace-http-intake.logs.datadoghq.com')
     })
 
+    it('should map a regional site to its data-center intake host', () => {
+      writer = new Writer({ site: 'ap1.datadoghq.com' })
+
+      assert.strictEqual(writer._url.hostname, 'browser-intake-ap1-datadoghq.com')
+    })
+
     it('should pass writer reference and metadata to encoder', () => {
       const metadata = {
         hostname: 'test-host',
@@ -132,7 +138,7 @@ describe('AgentlessWriter', () => {
         assert.deepStrictEqual(request.getCall(0).args[0], expectedData)
         assertObjectContains(request.getCall(0).args[1], {
           url,
-          path: '/v1/input',
+          path: '/api/v2/spans',
           method: 'POST',
           timeout: 15_000,
           headers: {


### PR DESCRIPTION
## Summary

The agentless exporter built the intake from a single `public-trace-http-intake.logs.<site>` host over `/v1/input`. That host only resolves for `datadoghq.com`, `datadoghq.eu`, and `datad0g.com`, so agentless spans were silently dropped on `us3`, `us5`, `ap1`, and `ap2`.

Intake hosts are now resolved per site (regional centers use the `browser-intake-*` hosts, with a `browser-intake-<region>` fallback for sites without an explicit entry) and posted to `api/v2/spans`, matching `dd-trace-py`. The site is lowercased before lookup so a mixed-case `DD_SITE` still resolves.

## Test plan

- [ ] `npx mocha packages/dd-trace/test/exporters/agentless/intake.spec.js`
- [ ] `npx mocha packages/dd-trace/test/exporters/agentless/exporter.spec.js packages/dd-trace/test/exporters/agentless/writer.spec.js`

Refs: https://github.com/DataDog/dd-trace-py/pull/18514
