### PR TITLE
bench(test-codeowners): add code-owner resolution benchmark

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -197,6 +197,7 @@
 
 /benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
 /benchmark/sirun/spans/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/test-codeowners/ @DataDog/ci-app-libraries
 
 /integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
 /integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js

--- a/benchmark/sirun/test-codeowners/README.md
+++ b/benchmark/sirun/test-codeowners/README.md
@@ -1,8 +1,13 @@
 # test-codeowners
 
-Measures `getCodeOwnersForFilename`, the per-test-file owner resolution test
-optimization runs across a suite: a reversed walk of the parsed CODEOWNERS
-entries testing each pattern's regex against the path. Entries come from the real
-parser over a generated fixture; each pass uses a fresh cache view so every
-lookup is a real regex scan. Variants cover a small file, a large one, and a
-wildcard-heavy one.
+Measures `getCodeOwnersForFilename`, the per-test-file owner resolution Test
+Optimization runs across a suite: a reversed walk of the parsed CODEOWNERS
+entries testing each pattern's regex against the path until one matches. Entries
+come from the real parser reading a committed CODEOWNERS fixture under
+`fixtures/<variant>/` — `large` is a snapshot of this repo's own
+`.github/CODEOWNERS` (anchored / extension / `**` rules a big monorepo carries),
+`small` a typical small-library file — so the two variants bracket the
+reversed-walk cost on real files rather than synthesized ones. Each variant runs
+lookups over a corpus of paths shaped like that repo's files (matches at varying
+depths plus a full-scan miss); each pass uses a fresh cache view so every lookup
+is a real regex scan.

--- a/benchmark/sirun/test-codeowners/README.md
+++ b/benchmark/sirun/test-codeowners/README.md
@@ -1,0 +1,8 @@
+# test-codeowners
+
+Measures `getCodeOwnersForFilename`, the per-test-file owner resolution test
+optimization runs across a suite: a reversed walk of the parsed CODEOWNERS
+entries testing each pattern's regex against the path. Entries come from the real
+parser over a generated fixture; each pass uses a fresh cache view so every
+lookup is a real regex scan. Variants cover a small file, a large one, and a
+wildcard-heavy one.

--- a/benchmark/sirun/test-codeowners/fixtures/large/CODEOWNERS
+++ b/benchmark/sirun/test-codeowners/fixtures/large/CODEOWNERS
@@ -1,0 +1,370 @@
+# TODO: Restructure the project by product and clean up this file.
+
+# AppSec
+/benchmark/sirun/appsec/ @DataDog/asm-js
+/benchmark/sirun/appsec-iast/ @DataDog/asm-js
+/benchmark/sirun/iast/ @DataDog/asm-js
+/integration-tests/appsec/ @DataDog/asm-js
+/packages/dd-trace/src/appsec/ @DataDog/asm-js
+/packages/dd-trace/test/appsec/ @DataDog/asm-js
+
+/integration-tests/aiguard/ @DataDog/asm-js
+/packages/dd-trace/src/aiguard/ @DataDog/asm-js
+/packages/dd-trace/test/aiguard/ @DataDog/asm-js
+/packages/dd-trace/test/plugins/util/ip_extractor.spec.js @DataDog/asm-js
+
+/packages/dd-trace/*/standalone @DataDog/asm-js
+
+# Dynamic Instrumentation
+/benchmark/sirun/debugger/ @DataDog/debugger-nodejs
+
+/integration-tests/code-origin/ @DataDog/debugger-nodejs
+/integration-tests/code-origin-remote-config.spec.js @DataDog/debugger-nodejs
+/integration-tests/code-origin.spec.js @DataDog/debugger-nodejs
+/integration-tests/debugger/ @DataDog/debugger-nodejs
+
+/packages/datadog-code-origin/ @DataDog/debugger-nodejs
+/packages/datadog-plugin-*/**/code_origin.* @DataDog/debugger-nodejs
+/packages/dd-trace/src/debugger/ @DataDog/debugger-nodejs
+/packages/dd-trace/test/debugger/ @DataDog/debugger-nodejs
+/packages/dd-trace/test/plugins/util/stacktrace.spec.js @DataDog/debugger-nodejs
+
+# Serverless
+/packages/dd-trace/src/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/test/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/test/azure_metadata.spec.js @DataDog/apm-serverless
+/packages/dd-trace/test/serverless.spec.js @DataDog/apm-serverless
+/packages/dd-trace/test/plugins/util/inferred_proxy.spec.js @DataDog/serverless-aws @DataDog/apm-serverless
+
+# IDM
+/.agents/skills/apm-integrations/ @DataDog/apm-idm-js
+/.claude/skills/apm-integrations @DataDog/apm-idm-js
+
+/benchmark/sirun/child_process/ @DataDog/apm-idm-js
+/benchmark/sirun/fs/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-aws-sdk/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-pino/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-redis/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-ws/ @DataDog/apm-idm-js
+/benchmark/sirun/url/ @DataDog/apm-idm-js
+
+/integration-tests/electron/ @DataDog/apm-idm-js
+/integration-tests/esbuild/ @DataDog/apm-idm-js
+/integration-tests/webpack/ @DataDog/apm-idm-js
+/integration-tests/pino.spec.js @DataDog/apm-idm-js
+
+/benchmark/sirun/plugin-graphql-long/ @DataDog/apm-idm-js
+
+/packages/datadog-esbuild @DataDog/apm-idm-js
+/packages/datadog-webpack @DataDog/apm-idm-js
+/packages/datadog-plugin-*/ @DataDog/apm-idm-js
+/packages/datadog-instrumentations/ @DataDog/apm-idm-js
+/packages/dd-trace/src/exporters/electron/ @DataDog/apm-idm-js
+/packages/dd-trace/src/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/test/plugins/ @DataDog/apm-idm-js
+/packages/dd-trace/src/service-naming/ @DataDog/apm-idm-js
+/packages/dd-trace/test/service-naming/ @DataDog/apm-idm-js
+/packages/dd-trace/test/payload_tagging.spec.js @DataDog/apm-idm-js
+/packages/dd-trace/test/payload-tagging/ @DataDog/apm-idm-js
+/packages/dd-trace/test/propagation-hash.spec.js @DataDog/apm-idm-js
+/packages/dd-trace/test/tracer_metadata.spec.js @DataDog/apm-idm-js
+
+# Test Optimization
+/ci @DataDog/ci-app-libraries
+
+/integration-tests/selenium/ @DataDog/ci-app-libraries
+
+/packages/dd-trace/src/ci-visibility/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-jest/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-mocha/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-cucumber/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-cypress/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-playwright/ @DataDog/ci-app-libraries
+/packages/datadog-plugin-vitest/ @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/ci_plugin.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/ci-visibility/ @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/agentless-ci-visibility.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/encode/coverage-ci-visibility.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/git_metadata.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/git_metadata_tagger.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/git.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/ci-env/ @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/test.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/test-environment.spec.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/agentless-ci-visibility.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/agentless-json.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/coverage-ci-visibility.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/encode/tags-processors.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/exporters/agentless/ @DataDog/ci-app-libraries
+/packages/dd-trace/src/git_metadata.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/git_metadata_tagger.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/ci.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/env.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/git-cache.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/tags.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/test.js @DataDog/ci-app-libraries
+/packages/dd-trace/src/plugins/util/user-provided-git.js @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/__test__/CODEOWNERS @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/github_event_payload_malformed.json @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/github_event_payload.json @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/istanbul-map-fixture.json @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/runner/ @DataDog/ci-app-libraries
+/packages/dd-trace/test/plugins/util/fixtures/runner_empty/ @DataDog/ci-app-libraries
+
+/packages/datadog-instrumentations/src/jest.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/jest/bail-reporter.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/mocha/ @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cucumber.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/cypress.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/playwright.js @DataDog/ci-app-libraries
+/packages/datadog-instrumentations/src/vitest.js @DataDog/ci-app-libraries
+
+/integration-tests/ci-visibility/ @DataDog/ci-app-libraries
+/integration-tests/cucumber/ @DataDog/ci-app-libraries
+/integration-tests/cypress/ @DataDog/ci-app-libraries
+/integration-tests/jest/ @DataDog/ci-app-libraries
+/integration-tests/mocha/ @DataDog/ci-app-libraries
+/integration-tests/playwright/ @DataDog/ci-app-libraries
+/integration-tests/vitest/ @DataDog/ci-app-libraries
+/integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
+/integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
+/integration-tests/ci-visibility-intake.spec.js @DataDog/ci-app-libraries
+/integration-tests/CODEOWNERS @DataDog/ci-app-libraries
+/integration-tests/config-jest-multiproject.js @DataDog/ci-app-libraries
+/integration-tests/config-jest.js @DataDog/ci-app-libraries
+/integration-tests/cypress-config.json @DataDog/ci-app-libraries
+/integration-tests/cypress-custom-after-hooks.config.js @DataDog/ci-app-libraries
+/integration-tests/cypress-custom-after-hooks.config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-auto-esm.config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-double-run.js @DataDog/ci-app-libraries
+/integration-tests/cypress-double-run.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-esm-config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-legacy-plugin.config.js @DataDog/ci-app-libraries
+/integration-tests/cypress-legacy-plugin.config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-auto.config.js @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-auto.config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-manual.config.js @DataDog/ci-app-libraries
+/integration-tests/cypress-plain-object-manual.config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-return-config.config.js @DataDog/ci-app-libraries
+/integration-tests/cypress-return-config.config.mjs @DataDog/ci-app-libraries
+/integration-tests/cypress-typescript.config.ts @DataDog/ci-app-libraries
+/integration-tests/cypress.config.js @DataDog/ci-app-libraries
+/integration-tests/my-nyc.config.js @DataDog/ci-app-libraries
+/integration-tests/playwright.config.js @DataDog/ci-app-libraries
+/integration-tests/playwright.config.ts @DataDog/ci-app-libraries
+
+/benchmark/e2e-test-optimization/ @DataDog/ci-app-libraries
+
+# LLM Observability
+/.agents/skills/llmobs-integration/ @DataDog/ml-observability
+/.agents/skills/llmobs-testing/ @DataDog/ml-observability
+/.claude/skills/llmobs-integration @DataDog/ml-observability
+/.claude/skills/llmobs-testing @DataDog/ml-observability
+/benchmark/sirun/llmobs/ @DataDog/ml-observability
+/packages/datadog-instrumentations/src/ai.js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/anthropic.js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/google-cloud-vertexai.js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/langchain.js @DataDog/ml-observability
+/packages/datadog-instrumentations/src/openai.js @DataDog/ml-observability
+/packages/datadog-plugin-ai/ @DataDog/ml-observability
+/packages/datadog-plugin-anthropic/ @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/src/services/bedrockruntime @DataDog/ml-observability
+/packages/datadog-plugin-aws-sdk/test/bedrockruntime.spec.js @DataDog/ml-observability
+/packages/datadog-plugin-google-cloud-vertexai/ @DataDog/ml-observability
+/packages/datadog-plugin-langchain/ @DataDog/ml-observability
+/packages/datadog-plugin-openai/ @DataDog/ml-observability
+/packages/dd-trace/src/llmobs/ @DataDog/ml-observability
+/packages/dd-trace/test/llmobs/ @DataDog/ml-observability
+/packages/dd-trace/test/plugins/util/llm.spec.js @DataDog/ml-observability
+
+# Data Streams Monitoring
+/benchmark/sirun/datastreams/ @DataDog/data-streams-monitoring
+/packages/dd-trace/src/datastreams/ @DataDog/data-streams-monitoring
+/packages/dd-trace/test/datastreams/ @DataDog/data-streams-monitoring
+/packages/**/dsm.spec.js @DataDog/data-streams-monitoring
+/packages/**/*.dsm.spec.js @DataDog/data-streams-monitoring
+
+# API SDK Capabilities
+/eslint-rules/ @DataDog/apm-sdk-capabilities-js
+
+/benchmark/sirun/propagation/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/spans/ @DataDog/apm-sdk-capabilities-js
+/benchmark/sirun/test-codeowners/ @DataDog/ci-app-libraries
+
+/integration-tests/log_injection.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry/ @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry-logs.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry-traces.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/opentelemetry.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/remote_config.spec.js @DataDog/apm-sdk-capabilities-js
+/integration-tests/telemetry.spec.js @DataDog/apm-sdk-capabilities-js
+
+/packages/dd-trace/src/telemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/telemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/opentelemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/opentelemetry/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/opentracing/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/opentracing/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/remote_config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/remote_config/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/baggage.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/baggage.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/priority_sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/priority_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/ramdom_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/rate_limiter.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/sampling_rule.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/sampling_rule.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/span_sampler.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/analytics_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/custom-metrics.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/process-tags.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/src/runtime_metrics/ @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/runtime_metrics.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/scope.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/span_format.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/span_processor.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/span_stats.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/span_sampler.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/startup-log.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/tagger.spec.js @DataDog/apm-sdk-capabilities-js
+/packages/dd-trace/test/tracer.spec.js @DataDog/apm-sdk-capabilities-js
+
+/scripts/generate-config-types.js @DataDog/apm-sdk-capabilities-js
+/scripts/generate-supported-integrations.js @DataDog/apm-sdk-capabilities-js
+/scripts/verify-exercised-tests.js @DataDog/apm-sdk-capabilities-js
+/supported_versions_output.json @DataDog/apm-sdk-capabilities-js
+/supported_versions_table.csv @DataDog/apm-sdk-capabilities-js
+
+# Feature Flagging
+/integration-tests/openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
+/packages/dd-trace/src/openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
+/packages/dd-trace/test/openfeature/ @DataDog/feature-flagging-and-experimentation-sdk
+
+# CI
+/.github/actions/dd-sts-app-key/action.yml @Datadog/lang-platform-js
+/.github/actions/dd-sts-api-key/action.yml @Datadog/lang-platform-js
+/.github/actions/push_to_test_optimization/ @DataDog/ci-app-libraries
+/.github/playwright/ @DataDog/ci-app-libraries
+/.github/selenium/ @DataDog/ci-app-libraries
+/.github/actions/upload-node-reports/action.yml @Datadog/lang-platform-js
+/.github/chainguard @DataDog/sdlc-security
+/.github/codeql_config.yml @DataDog/sdlc-security
+/.github/workflows/codeql-analysis.yml @DataDog/sdlc-security
+/.github/workflows/mirror-image.yml @Datadog/lang-platform-js
+/.github/workflows/all-green.yml @Datadog/lang-platform-js
+/.github/workflows/custom-node-version-dispatch.yml @Datadog/lang-platform-js
+/.github/workflows/project.yml @Datadog/lang-platform-js
+/.github/workflows/stale.yml @Datadog/lang-platform-js
+/scripts/check-no-mcr-images.js @Datadog/lang-platform-js
+
+/.github/workflows/apm-capabilities.yml @DataDog/apm-sdk-capabilities-js
+/.github/workflows/apm-integrations.yml @DataDog/apm-idm-js
+/.github/workflows/aiguard.yml @DataDog/asm-js
+/.github/workflows/appsec.yml @DataDog/asm-js
+/.github/workflows/debugger.yml @DataDog/debugger-nodejs
+/.github/workflows/instrumentation.yml @DataDog/apm-idm-js
+/.github/workflows/electron.yml @DataDog/apm-idm-js
+/.github/workflows/serverless.yml @DataDog/serverless-aws @DataDog/apm-serverless
+/.github/workflows/llmobs.yml @DataDog/ml-observability
+/.github/workflows/openfeature.yml @DataDog/feature-flagging-and-experimentation-sdk
+/.github/workflows/pr-title.yml @DataDog/lang-platform-js
+/.github/workflows/profiling.yml @DataDog/profiling-js
+/.github/workflows/system-tests.yml @DataDog/asm-js
+/.github/workflows/test-optimization.yml @DataDog/ci-app-libraries
+
+# Profiling
+/benchmark/sirun/profiler/ @DataDog/profiling-js
+
+/integration-tests/profiler @DataDog/profiling-js
+
+/packages/dd-trace/*/profiling @DataDog/profiling-js
+/packages/dd-trace/test/exporters/common/form-data.spec.js @DataDog/profiling-js
+
+# Language Platform
+/* @DataDog/lang-platform-js
+
+/.github/actions/ @DataDog/lang-platform-js
+
+/.gitlab/benchmarks/ @DataDog/lang-platform-js @DataDog/ecosystems-performance
+
+/benchmark/* @DataDog/lang-platform-js
+/benchmark/sirun/* @DataDog/lang-platform-js
+/benchmark/stubs/ @DataDog/lang-platform-js
+/benchmark/sirun/async_hooks/ @DataDog/lang-platform-js
+/benchmark/sirun/encoding/ @DataDog/lang-platform-js
+/benchmark/sirun/exporting-pipeline/ @DataDog/lang-platform-js
+/benchmark/sirun/id/ @DataDog/lang-platform-js
+/benchmark/sirun/log/ @DataDog/lang-platform-js
+/benchmark/sirun/runtime-metrics/ @DataDog/lang-platform-js
+/benchmark/sirun/scope/ @DataDog/lang-platform-js
+/benchmark/sirun/shimmer-runtime/ @DataDog/lang-platform-js
+/benchmark/sirun/shimmer-startup/ @DataDog/lang-platform-js
+/benchmark/sirun/startup/ @DataDog/lang-platform-js
+/benchmark/sirun/tracing-channel/ @DataDog/lang-platform-js
+
+/integration-tests/bun/ @DataDog/lang-platform-js
+/integration-tests/coverage/ @DataDog/lang-platform-js
+/integration-tests/coverage-child-process.spec.js @DataDog/lang-platform-js
+/integration-tests/coverage-fixtures/parent.js @DataDog/lang-platform-js
+/integration-tests/coverage-fixtures/worker.js @DataDog/lang-platform-js
+/integration-tests/coverage-manual-process.spec.js @DataDog/lang-platform-js
+/integration-tests/crashtracking/ @DataDog/lang-platform-js
+/integration-tests/init.spec.js @DataDog/lang-platform-js
+/integration-tests/mocha-parallel-files-fixtures/ @DataDog/lang-platform-js
+/integration-tests/mocha-parallel-files.spec.js @DataDog/lang-platform-js
+/integration-tests/package-guardrails.spec.js @DataDog/lang-platform-js
+/integration-tests/package-guardrails/flush.js @DataDog/lang-platform-js
+/integration-tests/startup.spec.js @DataDog/lang-platform-js
+
+/scripts/mocha-parallel-files.js @DataDog/lang-platform-js
+
+/packages/datadog-core @DataDog/lang-platform-js
+/packages/datadog-shimmer @DataDog/lang-platform-js
+/packages/dd-trace/*/crashtracking @DataDog/lang-platform-js
+/packages/dd-trace/src/exporters/common/retry.js @DataDog/lang-platform-js
+/packages/dd-trace/test/agent/ @DataDog/lang-platform-js
+/packages/dd-trace/test/dd-trace.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/dogstatsd.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/encode/ @DataDog/lang-platform-js
+/packages/dd-trace/test/esm-named-exports.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/exporter.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/exporters/ @DataDog/lang-platform-js
+/packages/dd-trace/test/external-logger/ @DataDog/lang-platform-js
+/packages/dd-trace/test/flare.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/guardrails/ @DataDog/lang-platform-js
+/packages/dd-trace/test/heap_snapshots.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/histogram.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/id.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/iitm.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/log.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/msgpack/ @DataDog/lang-platform-js
+/packages/dd-trace/test/mocha-hooks.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/noop.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/pkg.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/plugin_manager.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/plugins/plugin.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/plugins/util/env.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/proxy.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/require-package-json.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/ritm-tests @DataDog/lang-platform-js
+/packages/dd-trace/test/ritm.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/setup @DataDog/lang-platform-js
+/packages/dd-trace/test/util.spec.js @DataDog/lang-platform-js
+
+/scripts/** @DataDog/lang-platform-js
+
+# Multiple teams
+/eslint-rules/* @DataDog/apm-sdk-capabilities-js @DataDog/lang-platform-js

--- a/benchmark/sirun/test-codeowners/fixtures/small/CODEOWNERS
+++ b/benchmark/sirun/test-codeowners/fixtures/small/CODEOWNERS
@@ -1,0 +1,28 @@
+# CODEOWNERS for a small Node library. Representative of the common case: a
+# couple dozen rules, mostly anchored directories plus a few extension globs,
+# and no global `*` default (so unowned paths fall through to a full-scan miss).
+
+# Source
+/src/ @acme/core
+/src/parser/ @acme/parser
+/src/serializer/ @acme/serializer
+/lib/ @acme/core
+
+# Types
+/types/ @acme/types
+*.d.ts @acme/types
+
+# Tests
+/test/ @acme/qa
+*.spec.js @acme/qa
+*.test.js @acme/qa
+
+# Tooling / CI
+/.github/ @acme/platform
+/scripts/ @acme/platform
+*.yml @acme/platform
+
+# Docs
+/docs/ @acme/docs
+*.md @acme/docs
+README.md @acme/docs

--- a/benchmark/sirun/test-codeowners/index.js
+++ b/benchmark/sirun/test-codeowners/index.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const guard = require('../startup-guard')
+
+const {
+  getCodeOwnersFileEntries,
+  getCodeOwnersForFilename,
+} = require('../../../packages/dd-trace/src/plugins/util/test')
+
+const { VARIANT } = process.env
+const COUNT = Number(process.env.COUNT) || 2_000_000
+
+// Test optimization resolves the code owners of every test file it reports.
+// getCodeOwnersForFilename walks the parsed CODEOWNERS entries (reversed, first
+// match wins) testing each pattern's regex against the path. On a large suite
+// this runs per test file. Build the entries through the real parser from a
+// generated CODEOWNERS fixture, then drive lookups over a corpus of realistic
+// paths. The lookup memoizes per filename, so each measured pass gets a fresh
+// cache view (a new array reference reusing the precompiled regex entries) to
+// keep every lookup a real regex scan rather than a Map hit.
+function buildCodeowners (variant) {
+  const lines = []
+  if (variant === 'small') {
+    lines.push(
+      '/src/ @team-core',
+      '/packages/ @team-pkg',
+      '*.md @team-docs',
+      '/docs/ @team-docs',
+      '/test/ @team-qa',
+      '*.spec.js @team-qa',
+      '/packages/api/ @team-api',
+      '/packages/api/auth/ @team-auth',
+      '/packages/web/ @team-web',
+      '/scripts/ @team-build',
+      '/.github/ @team-ci',
+      '*.json @team-core',
+      '/packages/db/ @team-data',
+      '/integration-tests/ @team-qa',
+      '/benchmark/ @team-perf',
+    )
+  } else if (variant === 'large') {
+    for (let i = 0; i < 200; i++) {
+      lines.push(`/packages/module-${i}/ @team-${i % 12}`)
+    }
+    lines.push('*.spec.js @team-qa', '*.md @team-docs', '/integration-tests/ @team-qa')
+  } else { // wildcard
+    for (let i = 0; i < 50; i++) {
+      lines.push(`packages/**/module-${i}/**/*.js @team-${i % 8}`)
+    }
+    lines.push(
+      '**/*.spec.js @team-qa',
+      '**/fixtures/** @team-fixtures',
+      '**/test/**/*.js @team-qa',
+      '*.config.* @team-build',
+      'packages/**/*.ts @team-types',
+    )
+  }
+  return lines.join('\n') + '\n'
+}
+
+function buildFilenames () {
+  const names = []
+  for (let i = 0; i < 256; i++) {
+    const m = i % 200
+    const kind = i % 4
+    if (kind === 0) names.push(`packages/module-${m}/src/index.js`)
+    else if (kind === 1) names.push(`packages/module-${m}/test/feature-${i}.spec.js`)
+    else if (kind === 2) names.push(`packages/web/components/widget-${i}/render.js`)
+    else names.push(`integration-tests/scenarios/case-${i}/fixtures/data-${i}.json`)
+  }
+  return names
+}
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeowners-bench-'))
+fs.writeFileSync(path.join(tmpDir, 'CODEOWNERS'), buildCodeowners(VARIANT))
+
+const baseEntries = getCodeOwnersFileEntries(tmpDir)
+assert.ok(Array.isArray(baseEntries) && baseEntries.length > 0, 'failed to parse CODEOWNERS fixture')
+
+const filenames = buildFilenames()
+
+// Preflight: confirm at least one path resolves to an owner (a *.spec.js path
+// matches in every fixture), so the bench is exercising a real match, not an
+// all-miss scan that returns null without testing the owners path.
+const probeEntries = baseEntries.slice()
+const matched = filenames.some((fn) => getCodeOwnersForFilename(fn, probeEntries) !== null)
+assert.ok(matched, 'no filename matched any CODEOWNERS entry')
+
+const passSize = filenames.length
+const passes = Math.ceil(COUNT / passSize)
+
+guard.loopStart()
+let sink = 0
+for (let p = 0; p < passes; p++) {
+  const view = baseEntries.slice()
+  for (let f = 0; f < passSize; f++) {
+    if (getCodeOwnersForFilename(filenames[f], view) !== null) sink++
+  }
+}
+guard.done()
+
+if (sink === 0) throw new Error('unreachable')
+
+fs.rmSync(tmpDir, { recursive: true, force: true })

--- a/benchmark/sirun/test-codeowners/index.js
+++ b/benchmark/sirun/test-codeowners/index.js
@@ -1,8 +1,6 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const fs = require('node:fs')
-const os = require('node:os')
 const path = require('node:path')
 const guard = require('../startup-guard')
 
@@ -11,84 +9,97 @@ const {
   getCodeOwnersForFilename,
 } = require('../../../packages/dd-trace/src/plugins/util/test')
 
-const { VARIANT } = process.env
-const COUNT = Number(process.env.COUNT) || 2_000_000
+const VARIANT = process.env.VARIANT || 'large'
+const COUNT = Number(process.env.COUNT) || 100_000
 
 // Test optimization resolves the code owners of every test file it reports.
 // getCodeOwnersForFilename walks the parsed CODEOWNERS entries (reversed, first
 // match wins) testing each pattern's regex against the path. On a large suite
-// this runs per test file. Build the entries through the real parser from a
-// generated CODEOWNERS fixture, then drive lookups over a corpus of realistic
-// paths. The lookup memoizes per filename, so each measured pass gets a fresh
-// cache view (a new array reference reusing the precompiled regex entries) to
-// keep every lookup a real regex scan rather than a Map hit.
-function buildCodeowners (variant) {
-  const lines = []
-  if (variant === 'small') {
-    lines.push(
-      '/src/ @team-core',
-      '/packages/ @team-pkg',
-      '*.md @team-docs',
-      '/docs/ @team-docs',
-      '/test/ @team-qa',
-      '*.spec.js @team-qa',
-      '/packages/api/ @team-api',
-      '/packages/api/auth/ @team-auth',
-      '/packages/web/ @team-web',
-      '/scripts/ @team-build',
-      '/.github/ @team-ci',
-      '*.json @team-core',
-      '/packages/db/ @team-data',
-      '/integration-tests/ @team-qa',
-      '/benchmark/ @team-perf',
-    )
-  } else if (variant === 'large') {
-    for (let i = 0; i < 200; i++) {
-      lines.push(`/packages/module-${i}/ @team-${i % 12}`)
-    }
-    lines.push('*.spec.js @team-qa', '*.md @team-docs', '/integration-tests/ @team-qa')
-  } else { // wildcard
-    for (let i = 0; i < 50; i++) {
-      lines.push(`packages/**/module-${i}/**/*.js @team-${i % 8}`)
-    }
-    lines.push(
-      '**/*.spec.js @team-qa',
-      '**/fixtures/** @team-fixtures',
-      '**/test/**/*.js @team-qa',
-      '*.config.* @team-build',
-      'packages/**/*.ts @team-types',
-    )
-  }
-  return lines.join('\n') + '\n'
+// this runs per test file. Entries come from the real parser reading a committed
+// CODEOWNERS fixture under fixtures/<variant>/ (`large` is a snapshot of this
+// repo's own .github/CODEOWNERS, `small` a typical small-library file), so the
+// bench measures the anchored/extension/** pattern mix real repos carry rather
+// than a synthesized one. The two sizes bracket the reversed-walk cost. Drive
+// lookups over a corpus of paths shaped like that repo's files. The lookup
+// memoizes per filename, so each measured pass gets a fresh cache view (a new
+// array reference reusing the precompiled regex entries) to keep every lookup a
+// real regex scan rather than a Map hit.
+
+// Paths shaped like the files each fixture's repo reports: team-owned source and
+// test files matched at varying depths, a few extension/** wildcard matches, and
+// a couple of unowned shapes that fall through to a full-scan miss.
+const SHAPES = {
+  large: [
+    'packages/dd-trace/test/llmobs/foo.spec.js',
+    'packages/dd-trace/src/appsec/waf/index.js',
+    'packages/datadog-plugin-jest/test/index.spec.js',
+    'packages/datadog-plugin-redis/src/index.js',
+    'packages/datadog-instrumentations/src/openai.js',
+    'integration-tests/cypress/cypress.spec.js',
+    'integration-tests/playwright/playwright.spec.js',
+    'packages/dd-trace/test/plugins/util/test.spec.js',
+    'packages/datadog-plugin-http/src/client.dsm.spec.js',
+    'packages/datadog-plugin-ai/src/code_origin.js',
+    'packages/dd-trace/src/config/index.js',
+    'packages/dd-trace/test/telemetry/telemetry.spec.js',
+    'benchmark/sirun/scope/index.js',
+    'scripts/release/helpers/requirements.js',
+    'README.md',
+    'packages/dd-trace/src/some-unowned-area/deep/module.js',
+  ],
+  small: [
+    'src/parser/tokenizer.js',
+    'src/serializer/encode.js',
+    'src/index.js',
+    'lib/runtime.js',
+    'types/index.d.ts',
+    'test/parser.spec.js',
+    'test/unit/serializer.test.js',
+    'scripts/build.js',
+    'docs/guide.md',
+    'README.md',
+    '.github/workflows/ci.yml',
+    'examples/demo/app.js',
+    'benchmarks/throughput.js',
+    'config/settings.json',
+  ],
 }
 
-function buildFilenames () {
+function buildFilenames (variant) {
+  const shapes = SHAPES[variant]
   const names = []
-  for (let i = 0; i < 256; i++) {
-    const m = i % 200
-    const kind = i % 4
-    if (kind === 0) names.push(`packages/module-${m}/src/index.js`)
-    else if (kind === 1) names.push(`packages/module-${m}/test/feature-${i}.spec.js`)
-    else if (kind === 2) names.push(`packages/web/components/widget-${i}/render.js`)
-    else names.push(`integration-tests/scenarios/case-${i}/fixtures/data-${i}.json`)
+  for (let i = 0; i < 2048; i++) {
+    const shape = shapes[i % shapes.length]
+    // Make each name distinct (forcing a real scan rather than a memoized hit)
+    // while keeping the matching rule intact: insert a unique directory segment
+    // before the basename, or for a top-level file vary the basename itself.
+    const slash = shape.lastIndexOf('/')
+    if (slash === -1) {
+      names.push(shape.replace(/(\.[^.]+)$/, `-${i}$1`))
+    } else {
+      names.push(`${shape.slice(0, slash)}/u${i}/${shape.slice(slash + 1)}`)
+    }
   }
   return names
 }
 
-const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codeowners-bench-'))
-fs.writeFileSync(path.join(tmpDir, 'CODEOWNERS'), buildCodeowners(VARIANT))
-
-const baseEntries = getCodeOwnersFileEntries(tmpDir)
+const baseEntries = getCodeOwnersFileEntries(path.join(__dirname, 'fixtures', VARIANT))
 assert.ok(Array.isArray(baseEntries) && baseEntries.length > 0, 'failed to parse CODEOWNERS fixture')
 
-const filenames = buildFilenames()
+const filenames = buildFilenames(VARIANT)
 
-// Preflight: confirm at least one path resolves to an owner (a *.spec.js path
-// matches in every fixture), so the bench is exercising a real match, not an
-// all-miss scan that returns null without testing the owners path.
+// Preflight: confirm the corpus exercises both branches — at least one path
+// resolves to an owner and at least one falls through to null — so the bench is
+// a real mix of matches and full-scan misses, not an all-hit or all-miss loop.
 const probeEntries = baseEntries.slice()
-const matched = filenames.some((fn) => getCodeOwnersForFilename(fn, probeEntries) !== null)
-assert.ok(matched, 'no filename matched any CODEOWNERS entry')
+let probeMatched = false
+let probeMissed = false
+for (const fn of filenames) {
+  if (getCodeOwnersForFilename(fn, probeEntries) === null) probeMissed = true
+  else probeMatched = true
+}
+assert.ok(probeMatched, 'no filename matched any CODEOWNERS entry')
+assert.ok(probeMissed, 'every filename matched; corpus exercises no full-scan miss')
 
 const passSize = filenames.length
 const passes = Math.ceil(COUNT / passSize)
@@ -104,5 +115,3 @@ for (let p = 0; p < passes; p++) {
 guard.done()
 
 if (sink === 0) throw new Error('unreachable')
-
-fs.rmSync(tmpDir, { recursive: true, force: true })

--- a/benchmark/sirun/test-codeowners/meta.json
+++ b/benchmark/sirun/test-codeowners/meta.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-codeowners",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 10,
+  "instructions": true,
+  "variants": {
+    "small": {
+      "env": { "VARIANT": "small", "COUNT": "3000000" }
+    },
+    "large": {
+      "env": { "VARIANT": "large", "COUNT": "400000" }
+    },
+    "wildcard": {
+      "env": { "VARIANT": "wildcard", "COUNT": "740000" }
+    }
+  }
+}

--- a/benchmark/sirun/test-codeowners/meta.json
+++ b/benchmark/sirun/test-codeowners/meta.json
@@ -7,13 +7,10 @@
   "instructions": true,
   "variants": {
     "small": {
-      "env": { "VARIANT": "small", "COUNT": "3000000" }
+      "env": { "VARIANT": "small", "COUNT": "1700000" }
     },
     "large": {
-      "env": { "VARIANT": "large", "COUNT": "400000" }
-    },
-    "wildcard": {
-      "env": { "VARIANT": "wildcard", "COUNT": "740000" }
+      "env": { "VARIANT": "large", "COUNT": "100000" }
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds a sirun microbenchmark for the CODEOWNERS path-matching resolver used per test to attribute owners. Benchmark-only; no shipped code changes.