### PR TITLE
bench(plugin-grpc,plugin-memcached): add resolution benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,8 +45,10 @@
 /benchmark/sirun/plugin-aws-sdk/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-dns/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-graphql/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-grpc/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-http/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-kafkajs/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-memcached/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-mongodb-core/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-net/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js

--- a/benchmark/sirun/plugin-grpc/README.md
+++ b/benchmark/sirun/plugin-grpc/README.md
@@ -1,0 +1,6 @@
+# plugin-grpc
+
+Measures the gRPC client plugin `bindStart`: resolve the method metadata from the
+`/pkg.Service/Method` path (parsed once per path, then cached) and assemble the
+method meta bag. Variants cover a single unary method and a mix of methods from a
+typical service definition.

--- a/benchmark/sirun/plugin-grpc/index.js
+++ b/benchmark/sirun/plugin-grpc/index.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const GrpcClientPlugin = require('../../../packages/datadog-plugin-grpc/src/client')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 5_000_000
+
+// Every gRPC client call walks `bindStart`: parse the `/pkg.Service/Method` path
+// (cached per path) into name/service/package, assemble the method meta bag, and
+// start the span. Subclass the real plugin and override only the tracer-reaching
+// hooks so the measured surface is the method-metadata resolution and meta build.
+let lastMeta
+const FAKE_SPAN = { setTag () {}, finish () {} }
+class BenchedGrpcPlugin extends GrpcClientPlugin {
+  addSub () {}
+  addBind () {}
+  addTraceBind () {}
+  operationName () { return 'grpc.client' }
+  serviceName () { return 'grpc-prod' }
+  startSpan (name, options) {
+    lastMeta = options?.meta
+    return FAKE_SPAN
+  }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0', inject () {} }
+const plugin = new BenchedGrpcPlugin(tracer, { spanComputePeerService: false })
+plugin.configure({ enabled: true, service: 'grpc-prod' })
+
+// A service definition exposes a small, finite set of method paths; the parser
+// caches each one, so steady state is the cache hit plus the meta assembly.
+const PATHS = [
+  '/google.pubsub.v1.Publisher/Publish',
+  '/google.pubsub.v1.Subscriber/Pull',
+  '/orders.v2.OrderService/CreateOrder',
+  '/orders.v2.OrderService/GetOrder',
+  '/inventory.InventoryService/Reserve',
+  '/Health/Check',
+]
+
+const VARIANTS = {
+  unary: [PATHS[2]],
+  mixed: PATHS,
+}
+
+const paths = VARIANTS[VARIANT]
+assert.ok(paths, `unknown VARIANT: ${VARIANT}`)
+
+const messages = paths.map((path) => ({ path, type: 'unary', metadata: undefined }))
+
+for (const message of messages) {
+  lastMeta = undefined
+  plugin.bindStart(message)
+  assert.ok(lastMeta && typeof lastMeta['grpc.method.path'] === 'string', 'bindStart did not build the method meta')
+}
+
+const len = messages.length
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.bindStart(messages[i % len])
+}
+guard.done()
+
+assert.ok(lastMeta, 'startSpan stub was never reached')

--- a/benchmark/sirun/plugin-grpc/meta.json
+++ b/benchmark/sirun/plugin-grpc/meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "plugin-grpc",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "unary": {
+      "env": { "VARIANT": "unary", "ITERATIONS": "53000000" }
+    },
+    "mixed": {
+      "env": { "VARIANT": "mixed", "ITERATIONS": "54000000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-memcached/README.md
+++ b/benchmark/sirun/plugin-memcached/README.md
@@ -1,0 +1,5 @@
+# plugin-memcached
+
+Measures the memcached plugin `bindStart`: resolve the server address (pinned
+directly, or via the client HashRing for a key) and assemble the meta bag.
+Variants cover a single-server get and the multi-server HashRing resolution.

--- a/benchmark/sirun/plugin-memcached/index.js
+++ b/benchmark/sirun/plugin-memcached/index.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+const MemcachedPlugin = require('../../../packages/datadog-plugin-memcached/src/index')
+
+const { VARIANT } = process.env
+const ITERATIONS = Number(process.env.ITERATIONS) || 6_000_000
+
+// Every traced memcached command walks `bindStart`: resolve the server address
+// (directly, or via the client HashRing when the server is not pinned), build
+// the meta bag, and start the span. Subclass the real plugin and override only
+// the tracer-reaching hooks so the measured surface is the address resolution
+// and meta assembly.
+let lastMeta
+const FAKE_SPAN = { finish () {}, setTag () {} }
+class BenchedMemcachedPlugin extends MemcachedPlugin {
+  addSub () {}
+  addBind () {}
+  serviceName () { return 'memcached-prod' }
+  startSpan (options) {
+    lastMeta = options?.meta
+    return FAKE_SPAN
+  }
+}
+
+const tracer = { _service: 'web-app', _env: 'prod', _version: '1.0.0' }
+const plugin = new BenchedMemcachedPlugin(tracer, { spanComputePeerService: false })
+plugin.configure({ enabled: true, service: 'memcached-prod', DD_TRACE_MEMCACHED_COMMAND_ENABLED: true })
+
+// HashRing stand-in: a real memcached client picks a server for a key by
+// consistent hashing. Mirror that surface (servers list + HashRing.get) so the
+// hashring variant exercises the multi-server resolution branch.
+const SERVERS = ['cache-1.internal:11211', 'cache-2.internal:11211', 'cache-3.internal:11211']
+const hashringClient = {
+  servers: SERVERS,
+  redundancy: false,
+  HashRing: {
+    get (key) { return SERVERS[key.length % SERVERS.length] },
+  },
+}
+
+// Each variant fixes the client/server topology and rotates a corpus of queries
+// with varied key/command lengths. In the hashring variant the differing key
+// lengths also land on different servers (HashRing.get keys on key.length), so
+// the multi-server resolution branch runs over changing inputs, not one key.
+const GET_QUERIES = [
+  { type: 'get', command: 'get user:1234567', key: 'user:1234567' },
+  { type: 'set', command: 'set session:abcdef0123 0 0 64', key: 'session:abcdef0123' },
+  { type: 'get', command: 'get cart:99887766', key: 'cart:99887766' },
+  { type: 'delete', command: 'delete token:aabbccddeeff', key: 'token:aabbccddeeff' },
+]
+const HASHRING_QUERIES = [
+  { type: 'get', command: 'get session:abcdef', key: 'session:abcdef', redundancyEnabled: false },
+  { type: 'get', command: 'get user:1234567:profile', key: 'user:1234567:profile', redundancyEnabled: false },
+  { type: 'get', command: 'get f', key: 'f', redundancyEnabled: false },
+  { type: 'get', command: 'get inventory:sku-5566', key: 'inventory:sku-5566', redundancyEnabled: false },
+]
+
+const VARIANTS = {
+  get: { client: { servers: ['cache-1.internal:11211'] }, server: 'cache-1.internal:11211', queries: GET_QUERIES },
+  hashring: { client: hashringClient, server: undefined, queries: HASHRING_QUERIES },
+}
+
+const topology = VARIANTS[VARIANT]
+assert.ok(topology, `unknown VARIANT: ${VARIANT}`)
+
+// startSpan is stubbed, so bindStart never writes ctx.currentStore; the corpus of
+// ctxs is pre-built once and rotated, so the loop allocates nothing per iteration.
+const ctxs = topology.queries.map((query) => ({ client: topology.client, server: topology.server, query }))
+const len = ctxs.length
+
+lastMeta = undefined
+plugin.bindStart(ctxs[0])
+assert.ok(lastMeta && typeof lastMeta['out.host'] === 'string', 'bindStart did not resolve the server address')
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  plugin.bindStart(ctxs[i % len])
+}
+guard.done()
+
+assert.ok(lastMeta, 'startSpan stub was never reached')

--- a/benchmark/sirun/plugin-memcached/meta.json
+++ b/benchmark/sirun/plugin-memcached/meta.json
@@ -1,0 +1,16 @@
+{
+  "name": "plugin-memcached",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 12,
+  "instructions": true,
+  "variants": {
+    "get": {
+      "env": { "VARIANT": "get", "ITERATIONS": "39500000" }
+    },
+    "hashring": {
+      "env": { "VARIANT": "hashring", "ITERATIONS": "38000000" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Two small apm-idm client-plugin benches under one owner:
- `plugin-grpc`: per-call method-path resolution.
- `plugin-memcached`: per-command server-address resolution, over a rotating realistic input corpus.

Benchmark-only; no shipped code changes.