### PR TITLE
bench(plugin-redis): add traced end-to-end and allocation-churn benchmarks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,7 @@
 /benchmark/sirun/plugin-pg/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-pino/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-redis/ @DataDog/apm-idm-js
+/benchmark/sirun/plugin-redis-traced/ @DataDog/apm-idm-js
 /benchmark/sirun/plugin-ws/ @DataDog/apm-idm-js
 /benchmark/sirun/url/ @DataDog/apm-idm-js
 

--- a/benchmark/sirun/plugin-redis-traced/README.md
+++ b/benchmark/sirun/plugin-redis-traced/README.md
@@ -1,0 +1,8 @@
+# plugin-redis-traced
+
+Measures a full traced redis command end to end: the real tracer and the real
+redis plugin run `bindStart` (meta build), span start, context entry via the
+start channel's `runStores`, span finish, and the processor — the integrated
+per-command cost the isolated `plugin-redis` bench omits by stubbing `startSpan`.
+The processor erases each trace on finish, so spans are built and finished but
+nothing is encoded or sent off-process.

--- a/benchmark/sirun/plugin-redis-traced/index.js
+++ b/benchmark/sirun/plugin-redis-traced/index.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const guard = require('../startup-guard')
+
+// Full traced redis command, end to end. Where the isolated plugin-redis bench
+// stubs startSpan to measure only the meta assembly, this drives the real tracer
+// and the real redis plugin over the diagnostic channels the instrumentation
+// uses, so each iteration pays the whole per-command cost: bindStart meta build,
+// span start, context entry via runStores, span finish and the real processor
+// (priority/span sampling, git-metadata tagging, span formatting and stats).
+// Only the exporter is swapped for a no-op, so the processor still formats and
+// erases each finished trace but nothing is buffered, encoded, or leaves the
+// process.
+const tracer = require('../../..').init()
+tracer._tracer._processor._exporter = { export () {} }
+
+const RedisPlugin = require('../../../packages/datadog-plugin-redis/src/index')
+const { channel } = require('../../../packages/datadog-instrumentations/src/helpers/instrument')
+
+// Construct the real plugin against the real tracer + tracer config (the pair the
+// plugin manager would pass) and enable it, which subscribes bindStart/bindFinish
+// to the redis channels. tracer.use('redis') alone would not: the plugin only
+// subscribes once the redis module loads, and there is no client here.
+const plugin = new RedisPlugin(tracer, tracer._pluginManager._tracerConfig)
+plugin.configure({ enabled: true, service: 'redis-prod' })
+
+const startCh = channel('apm:redis:command:start')
+const finishCh = channel('apm:redis:command:finish')
+
+const ITERATIONS = Number(process.env.ITERATIONS) || 450_000
+
+const CONN = { host: 'redis-primary.internal', port: 6379 }
+const COMMANDS = [
+  { command: 'get', args: ['user:1234567:profile'] },
+  { command: 'set', args: ['session:abcdef', 'active', 'EX', 3600] },
+  { command: 'hset', args: ['user:1234567', 'name', 'Jane', 'email', 'jane@example.com'] },
+  { command: 'get', args: ['cart:99887766'] },
+]
+const len = COMMANDS.length
+
+/**
+ * A fresh per-command context, matching what the instrumentation's getStartCtx
+ * allocates per call: runStores writes the span store onto it, so it cannot be
+ * reused across commands.
+ *
+ * @param {{ command: string, args: unknown[] }} cmd
+ */
+function makeCtx (cmd) {
+  return {
+    db: 0,
+    command: cmd.command,
+    args: cmd.args,
+    argsStartIndex: 0,
+    connectionOptions: CONN,
+    connectionName: 'default',
+  }
+}
+
+const NOOP = () => {}
+
+// Pre-flight: one full command must create, tag and finish a real span.
+const preCtx = makeCtx(COMMANDS[0])
+startCh.runStores(preCtx, NOOP)
+const preSpan = preCtx.currentStore?.span
+assert.ok(preSpan, 'start channel did not create a span (plugin not subscribed?)')
+assert.equal(preSpan.context().getTag('db.type'), 'redis', 'span is missing the redis meta')
+finishCh.publish(preCtx)
+assert.ok(preSpan._duration !== undefined, 'finish channel did not finish the span')
+
+guard.loopStart()
+for (let i = 0; i < ITERATIONS; i++) {
+  const ctx = makeCtx(COMMANDS[i % len])
+  startCh.runStores(ctx, NOOP)
+  finishCh.publish(ctx)
+}
+// This is the heaviest per-iteration loop in the suite (a full span lifecycle
+// through the real processor), so the instruction-counting pass on the stable
+// machine scales steeply with the count: ~600k overran the one-minute budget,
+// 450k keeps the variant under it while staying deterministic. At that count the
+// fixed full-tracer init still settles around 15% of the run -- pushing it below
+// 10% would need a count that overruns the budget -- so allow an 18% startup share.
+guard.done(0.18)

--- a/benchmark/sirun/plugin-redis-traced/meta.json
+++ b/benchmark/sirun/plugin-redis-traced/meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "plugin-redis-traced",
+  "run": "node index.js",
+  "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node index.js\"",
+  "cachegrind": false,
+  "iterations": 15,
+  "instructions": true,
+  "variants": {
+    "command": {
+      "env": { "ITERATIONS": "450000" }
+    }
+  }
+}

--- a/benchmark/sirun/plugin-redis/README.md
+++ b/benchmark/sirun/plugin-redis/README.md
@@ -3,4 +3,5 @@ the config filter, the per-connection service cache, then `formatCommand` to
 build the `redis.raw_command` string and `startSpan`. Variants cover the common
 short command (get), per-arg truncation (a value past MAX_ARG_LENGTH), the
 wide-arg loop that hits MAX_COMMAND_LENGTH (mset with many pairs), and a mixed
-rotation of get/set/hset.
+rotation of get/set/hset. The churn variant rebuilds the per-command context each
+iteration to surface the allocation/GC cost the reuse variants hoist out.

--- a/benchmark/sirun/plugin-redis/index.js
+++ b/benchmark/sirun/plugin-redis/index.js
@@ -74,7 +74,17 @@ function preflight (ctx) {
 }
 
 guard.loopStart()
-if (VARIANT === 'mixed') {
+if (VARIANT === 'churn') {
+  // Rebuild the ctx getStartCtx allocates per command instead of reusing one:
+  // the only variant that pays that per-command allocation, isolating the GC
+  // cost the reuse variants hoist out of the loop.
+  const cmd = COMMANDS.get
+  preflight(makeCtx(cmd))
+  lastMeta = undefined
+  for (let i = 0; i < ITERATIONS; i++) {
+    plugin.bindStart(makeCtx(cmd))
+  }
+} else if (VARIANT === 'mixed') {
   const ctxs = MIXED.map(makeCtx)
   for (const ctx of ctxs) preflight(ctx)
   lastMeta = undefined

--- a/benchmark/sirun/plugin-redis/meta.json
+++ b/benchmark/sirun/plugin-redis/meta.json
@@ -13,10 +13,13 @@
       "env": { "VARIANT": "long-value", "ITERATIONS": "13000000" }
     },
     "mset-wide": {
-      "env": { "VARIANT": "mset-wide", "ITERATIONS": "1150000" }
+      "env": { "VARIANT": "mset-wide", "ITERATIONS": "980000" }
     },
     "mixed": {
-      "env": { "VARIANT": "mixed", "ITERATIONS": "13000000" }
+      "env": { "VARIANT": "mixed", "ITERATIONS": "11500000" }
+    },
+    "churn": {
+      "env": { "VARIANT": "churn", "ITERATIONS": "5000000" }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `plugin-redis-traced`: a full traced redis command end to end (meta build, span start, context entry, finish, processor) over a trace-erasing processor so nothing accumulates or leaves the process. Sized under the one-minute budget.
- `plugin-redis`: a churn variant that rebuilds fresh input context per iteration to surface allocation/GC overhead the steady-state variants hide.

Benchmark-only; no shipped code changes.