### PR TITLE
bench(debugger): cap iterations on the heaviest snapshot variant

### DIFF
--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -40,7 +40,7 @@
         "BREAKPOINT_LINE": "37",
         "CAPTURE_SNAPSHOT": "true",
         "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
-        "ITERATIONS": "3500"
+        "ITERATIONS": "2450"
       }
     },
     "line-probe-with-snapshot-minimal": {
@@ -48,6 +48,7 @@
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
+      "iterations": 7,
       "env": {
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",


### PR DESCRIPTION
## Summary
Caps iterations on the heaviest debugger snapshot variant so it stays under the one-minute budget while remaining deterministic. Benchmark-only; no shipped code changes.