### PR TITLE
bench(sirun): gate async_hooks on Node changes and tighten the guard default

### DIFF
--- a/benchmark/sirun/runall.sh
+++ b/benchmark/sirun/runall.sh
@@ -106,8 +106,27 @@ if [[ "${TOLERATE_NEW_BENCHMARK_FAILURES:-}" == "1" ]]; then
   fi
 fi
 
+# async_hooks measures the Node async-hooks primitive floor, not tracer code, so it
+# only moves when the Node version changes. Skip it unless this PR's diff touches a
+# node-<major> pin in the versions manifest runall reads above (the single source of
+# truth for the benchmarked Node patch). Fail open -- run it -- when the diff can't be
+# determined, so a Node bump is never silently skipped. The same gate must apply in
+# both loops below, or the global variant-index shard math drops/misassigns variants.
+RUN_ASYNC_HOOKS="1"
+if [[ -d /app/candidate/.git && -n "${COMMIT_SHA:-}" && -n "${CI_COMMIT_SHA:-}" ]]; then
+  if git -C /app/candidate diff "${COMMIT_SHA}..${CI_COMMIT_SHA}" -- \
+       packages/dd-trace/test/plugins/versions/package.json 2>/dev/null \
+       | grep -qE '^[-+][[:space:]]*"node-[0-9]+":'; then
+    echo "async_hooks: a node-<major> pin changed in this diff; running it."
+  else
+    RUN_ASYNC_HOOKS=""
+    echo "async_hooks: no Node version change in this diff; skipping (Node-primitive floor)."
+  fi
+fi
+
 BENCH_COUNT=0
 for D in "${DIRS[@]}"; do
+  if [[ "${D}" == "async_hooks" && -z "${RUN_ASYNC_HOOKS}" ]]; then continue; fi
   cd "${D}"
   variants="$(node ../get-variants.js)"
   for V in $variants; do BENCH_COUNT=$(($BENCH_COUNT+1)); done
@@ -133,6 +152,7 @@ BENCH_END=$(($GROUP_SIZE*$GROUP))
 BENCH_START=$(($BENCH_END-$GROUP_SIZE))
 
 for D in "${DIRS[@]}"; do
+  if [[ "${D}" == "async_hooks" && -z "${RUN_ASYNC_HOOKS}" ]]; then continue; fi
   cd "${D}"
   variants="$(node ../get-variants.js)"
 

--- a/benchmark/sirun/startup-guard.js
+++ b/benchmark/sirun/startup-guard.js
@@ -11,7 +11,7 @@
 //   // ...requires, setup...
 //   guard.loopStart()
 //   for (...) { ... }
-//   guard.done()            // default 10% ceiling
+//   guard.done()            // default 7% ceiling
 //   guard.done(0.15)        // relaxed ceiling when the loop legitimately can't dominate further
 
 const assert = require('node:assert/strict')
@@ -23,7 +23,7 @@ function loopStart () {
   loopStartedAt = process.hrtime.bigint()
 }
 
-function done (maxShare = 0.10) {
+function done (maxShare = 0.07) {
   const end = process.hrtime.bigint()
   assert.ok(loopStartedAt !== undefined, 'startup-guard: loopStart() was never called')
   const total = Number(end - START)


### PR DESCRIPTION
## Summary
- `runall.sh`: skip the `async_hooks` bench unless the PR diff touches a `node-<major>` pin in the versions manifest (it measures the Node primitive floor, not tracer code). Fails open when git context is missing; gated in both the counting and running loops to keep the shard math consistent.
- `startup-guard.js`: tighten the default ceiling to 7%.

Benchmark-infra-only; no shipped code changes.