### PR TITLE
bench(appsec-iast): resync README and silence DEP0169 in the shared fixture

### DIFF
--- a/benchmark/sirun/appsec-iast/README.md
+++ b/benchmark/sirun/appsec-iast/README.md
@@ -1,9 +1,4 @@
-This benchmarks HTTP requests from client to server.
-
-The variants are:
-- control tracer with non vulnerable endpoint without iast 
-- tracer with non vulnerable endpoint with iast active and default configuration
-- tracer with non vulnerable endpoint with iast active and sampling 100
-- control tracer with vulnerable endpoint without iast
-- tracer with vulnerable endpoint with iast active and default configuration
-- tracer with vulnerable endpoint with iast active and sampling 100
+Drives real Express request handling with the tracer loaded, measuring IAST's
+per-request taint-tracking overhead -- IAST off vs on (default sampling, and
+always-active), across a non-vulnerable endpoint and one with a command-injection
+sink that triggers vulnerability reporting.

--- a/benchmark/sirun/load-insecure-bank.js
+++ b/benchmark/sirun/load-insecure-bank.js
@@ -2,6 +2,22 @@
 
 const url = require('url')
 
+// This fixture deliberately exercises the legacy `url.parse()`, whose one-time
+// DEP0169 deprecation warning is just noise in the benchmark output. Suppress
+// that single code; forward every other warning untouched.
+const originalEmitWarning = process.emitWarning
+/**
+ * @param {string | Error} warning
+ * @param {...unknown} args
+ */
+process.emitWarning = function patchedEmitWarning (warning, ...args) {
+  const code = typeof args[0] === 'object' && args[0] !== null
+    ? /** @type {{ code?: string }} */ (args[0]).code
+    : args[1]
+  if (code === 'DEP0169') return
+  return originalEmitWarning.call(this, warning, ...args)
+}
+
 /**
  * @returns {import('http').RequestListener}
  */


### PR DESCRIPTION
## Summary
- `appsec-iast` README: one-paragraph description of the per-request taint-tracking path it measures, replacing the stale variant inventory.
- `load-insecure-bank.js` (shared appsec fixture): suppress only the one-time DEP0169 warning from the legacy `url.parse()` it deliberately exercises; all other warnings forwarded untouched.

Split out of the appsec sizing work in #8848 to keep that PR focused. Benchmark/doc-only; no shipped code changes.