### PR TITLE
refactor(config): parse env values inside getValueFromEnvSources

### DIFF
--- a/ci/init.js
+++ b/ci/init.js
@@ -2,7 +2,6 @@
 
 /* eslint-disable no-console */
 const tracer = require('../packages/dd-trace')
-const { isTrue, isFalse } = require('../packages/dd-trace/src/util')
 const log = require('../packages/dd-trace/src/log')
 const { getEnvironmentVariable, getValueFromEnvSources } = require('../packages/dd-trace/src/config/helper')
 
@@ -43,8 +42,8 @@ const baseOptions = {
   flushInterval: isJestWorker ? JEST_FLUSH_INTERVAL : DEFAULT_FLUSH_INTERVAL,
 }
 
-let shouldInit = !isFalse(getValueFromEnvSources('DD_CIVISIBILITY_ENABLED'))
-const isAgentlessEnabled = isTrue(getValueFromEnvSources('DD_CIVISIBILITY_AGENTLESS_ENABLED'))
+let shouldInit = getValueFromEnvSources('DD_CIVISIBILITY_ENABLED') !== false
+const isAgentlessEnabled = getValueFromEnvSources('DD_CIVISIBILITY_AGENTLESS_ENABLED')
 
 if (!isTestWorker && isPackageManager()) {
   log.debug('dd-trace is not initialized in a package manager.')

--- a/ci/init.js
+++ b/ci/init.js
@@ -42,7 +42,9 @@ const baseOptions = {
   flushInterval: isJestWorker ? JEST_FLUSH_INTERVAL : DEFAULT_FLUSH_INTERVAL,
 }
 
-let shouldInit = getValueFromEnvSources('DD_CIVISIBILITY_ENABLED') !== false
+// skipDefault: CI visibility stays on unless DD_CIVISIBILITY_ENABLED is explicitly false; the
+// registered default (false) would otherwise turn it off whenever the variable is unset.
+let shouldInit = getValueFromEnvSources('DD_CIVISIBILITY_ENABLED', true) !== false
 const isAgentlessEnabled = getValueFromEnvSources('DD_CIVISIBILITY_AGENTLESS_ENABLED')
 
 if (!isTestWorker && isPackageManager()) {

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -13,8 +13,9 @@ const Hook = require('./hook')
 const { isRelativeRequire } = require('./shared-utils')
 const rewriter = require('./rewriter')
 
-const DD_TRACE_DISABLED_INSTRUMENTATIONS = getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS') || ''
-const DD_TRACE_DEBUG = getValueFromEnvSources('DD_TRACE_DEBUG') || ''
+const DD_TRACE_DISABLED_INSTRUMENTATIONS =
+  /** @type {string | undefined} */ (getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS')) || ''
+const DD_TRACE_DEBUG = getValueFromEnvSources('DD_TRACE_DEBUG')
 
 const hooks = require('./hooks')
 const instrumentations = require('./instrumentations')
@@ -36,7 +37,7 @@ if (!disabledInstrumentations.has('process')) {
   require('../process')
 }
 
-if (DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false') {
+if (DD_TRACE_DEBUG) {
   checkRequireCache.checkForRequiredModules()
   setImmediate(checkRequireCache.checkForPotentialConflicts)
 }

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -14,7 +14,7 @@ const { isRelativeRequire } = require('./shared-utils')
 const rewriter = require('./rewriter')
 
 const DD_TRACE_DISABLED_INSTRUMENTATIONS =
-  /** @type {string | undefined} */ (getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS')) || ''
+  /** @type {string | undefined} */ (getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS'))
 const DD_TRACE_DEBUG = getValueFromEnvSources('DD_TRACE_DEBUG')
 
 const hooks = require('./hooks')

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -14,7 +14,7 @@ const { isRelativeRequire } = require('./shared-utils')
 const rewriter = require('./rewriter')
 
 const DD_TRACE_DISABLED_INSTRUMENTATIONS =
-  /** @type {string | undefined} */ (getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS'))
+  /** @type {string} */ (getValueFromEnvSources('DD_TRACE_DISABLED_INSTRUMENTATIONS'))
 const DD_TRACE_DEBUG = getValueFromEnvSources('DD_TRACE_DEBUG')
 
 const hooks = require('./hooks')

--- a/packages/datadog-instrumentations/src/otel-sdk-trace.js
+++ b/packages/datadog-instrumentations/src/otel-sdk-trace.js
@@ -3,7 +3,6 @@
 const shimmer = require('../../datadog-shimmer')
 const tracer = require('../../dd-trace')
 const { getValueFromEnvSources } = require('../../dd-trace/src/config/helper')
-const { isFalse, isTrue } = require('../../dd-trace/src/util')
 const { addHook } = require('./helpers/instrument')
 
 if (isOtelSdkEnabled()) {
@@ -22,8 +21,8 @@ if (isOtelSdkEnabled()) {
 function isOtelSdkEnabled () {
   // Datadog explicit opt-out wins over every OTel signal; check it first.
   const ddTraceOtelEnabled = getValueFromEnvSources('DD_TRACE_OTEL_ENABLED')
-  if (isFalse(ddTraceOtelEnabled)) return false
+  if (ddTraceOtelEnabled === false) return false
   const otelSdkDisabled = getValueFromEnvSources('OTEL_SDK_DISABLED')
-  if (isTrue(otelSdkDisabled)) return false
-  return isTrue(ddTraceOtelEnabled) || isFalse(otelSdkDisabled)
+  if (otelSdkDisabled) return false
+  return ddTraceOtelEnabled || otelSdkDisabled === false
 }

--- a/packages/datadog-instrumentations/src/otel-sdk-trace.js
+++ b/packages/datadog-instrumentations/src/otel-sdk-trace.js
@@ -20,9 +20,11 @@ if (isOtelSdkEnabled()) {
 
 function isOtelSdkEnabled () {
   // Datadog explicit opt-out wins over every OTel signal; check it first.
-  const ddTraceOtelEnabled = getValueFromEnvSources('DD_TRACE_OTEL_ENABLED')
+  // skipDefault: an unset option must stay undefined so the OTel signal still decides — the
+  // registered defaults (false / true) would otherwise force-disable before that check.
+  const ddTraceOtelEnabled = getValueFromEnvSources('DD_TRACE_OTEL_ENABLED', true)
   if (ddTraceOtelEnabled === false) return false
-  const otelSdkDisabled = getValueFromEnvSources('OTEL_SDK_DISABLED')
+  const otelSdkDisabled = getValueFromEnvSources('OTEL_SDK_DISABLED', true)
   if (otelSdkDisabled) return false
   return ddTraceOtelEnabled || otelSdkDisabled === false
 }

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -59,7 +59,7 @@ const testSuiteToTestStatuses = new Map()
 const testSuiteToErrors = new Map()
 const testsToTestStatuses = new Map()
 
-const RUM_FLUSH_WAIT_TIME = getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS') || 500
+const RUM_FLUSH_WAIT_TIME = getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')
 const DD_PROPERTIES_TIMEOUT = 5000
 
 let applyRepeatEachIndex = null

--- a/packages/datadog-instrumentations/src/playwright.js
+++ b/packages/datadog-instrumentations/src/playwright.js
@@ -59,7 +59,7 @@ const testSuiteToTestStatuses = new Map()
 const testSuiteToErrors = new Map()
 const testsToTestStatuses = new Map()
 
-const RUM_FLUSH_WAIT_TIME = Number(getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')) || 500
+const RUM_FLUSH_WAIT_TIME = getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS') || 500
 const DD_PROPERTIES_TIMEOUT = 5000
 
 let applyRepeatEachIndex = null

--- a/packages/datadog-instrumentations/src/selenium.js
+++ b/packages/datadog-instrumentations/src/selenium.js
@@ -19,8 +19,7 @@ if (window.DD_RUM && window.DD_RUM.stopSession) {
 `
 const IS_RUM_ACTIVE_SCRIPT = 'return !!window.DD_RUM'
 
-const DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS =
-  getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS') || 500
+const DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS = getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')
 const DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME = 'datadog-ci-visibility-test-execution-id'
 
 // TODO: can we increase the supported version range?

--- a/packages/datadog-instrumentations/src/selenium.js
+++ b/packages/datadog-instrumentations/src/selenium.js
@@ -20,7 +20,7 @@ if (window.DD_RUM && window.DD_RUM.stopSession) {
 const IS_RUM_ACTIVE_SCRIPT = 'return !!window.DD_RUM'
 
 const DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS =
-Number(getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS')) || 500
+  getValueFromEnvSources('DD_CIVISIBILITY_RUM_FLUSH_WAIT_MILLIS') || 500
 const DD_CIVISIBILITY_TEST_EXECUTION_ID_COOKIE_NAME = 'datadog-ci-visibility-test-execution-id'
 
 // TODO: can we increase the supported version range?

--- a/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
+++ b/packages/datadog-instrumentations/test/otel-sdk-trace.spec.js
@@ -8,10 +8,13 @@ const sinon = require('sinon')
 
 describe('otel-sdk-trace', () => {
   /**
-   * Re-load `otel-sdk-trace.js` with the supplied env values stubbed in via
-   * `getValueFromEnvSources` and report what `addHook` saw.
+   * Re-load `otel-sdk-trace.js` with the supplied config values stubbed in via
+   * `getValueFromEnvSources` and report what `addHook` saw. `getValueFromEnvSources`
+   * already parses these registered boolean options, so the gate sees `true`,
+   * `false`, or `undefined` — never a raw string. Parsing tolerance ('1', 'maybe',
+   * '') is exercised in the config helper's own spec.
    *
-   * @param {{ ddTraceOtelEnabled?: string, otelSdkDisabled?: string }} env
+   * @param {{ ddTraceOtelEnabled?: boolean, otelSdkDisabled?: boolean }} env
    * @param {{ TracerProvider?: unknown }} [tracerStub]
    * @returns {{ addHook: sinon.SinonSpy, wrap: sinon.SinonSpy }}
    */
@@ -35,48 +38,43 @@ describe('otel-sdk-trace', () => {
 
   describe('gate precedence', () => {
     it('disables when DD_TRACE_OTEL_ENABLED is the explicit opt-out', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'false' }).addHook.called, false)
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: '0' }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: false }).addHook.called, false)
     })
 
     it('keeps DD opt-out winning even when OTEL_SDK_DISABLED=false opts in', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'false', otelSdkDisabled: 'false' }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: false, otelSdkDisabled: false }).addHook.called, false)
     })
 
     it('disables when OTEL_SDK_DISABLED is the explicit opt-out', () => {
-      assert.equal(loadWithEnv({ otelSdkDisabled: 'true' }).addHook.called, false)
-      assert.equal(loadWithEnv({ otelSdkDisabled: '1' }).addHook.called, false)
+      assert.equal(loadWithEnv({ otelSdkDisabled: true }).addHook.called, false)
     })
 
     it('keeps OTel opt-out winning even when DD_TRACE_OTEL_ENABLED=true opts in', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'true', otelSdkDisabled: 'true' }).addHook.called, false)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true, otelSdkDisabled: true }).addHook.called, false)
     })
 
     it('enables when DD_TRACE_OTEL_ENABLED is the explicit opt-in', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'true' }).addHook.called, true)
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: '1' }).addHook.called, true)
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'true', otelSdkDisabled: 'false' }).addHook.called, true)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true }).addHook.called, true)
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: true, otelSdkDisabled: false }).addHook.called, true)
     })
 
     it('enables when OTEL_SDK_DISABLED=false is the OTel positive opt-in', () => {
-      assert.equal(loadWithEnv({ otelSdkDisabled: 'false' }).addHook.called, true)
-      assert.equal(loadWithEnv({ otelSdkDisabled: '0' }).addHook.called, true)
+      assert.equal(loadWithEnv({ otelSdkDisabled: false }).addHook.called, true)
     })
 
-    it('stays disabled by default when neither env var is set', () => {
+    it('stays disabled by default when neither option is set', () => {
       assert.equal(loadWithEnv({}).addHook.called, false)
     })
 
-    it('stays disabled for unrecognized values on either side', () => {
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: 'maybe', otelSdkDisabled: 'sure' }).addHook.called, false)
-      assert.equal(loadWithEnv({ ddTraceOtelEnabled: '' }).addHook.called, false)
+    it('treats a value the helper rejected (undefined) as unset', () => {
+      assert.equal(loadWithEnv({ ddTraceOtelEnabled: undefined, otelSdkDisabled: undefined }).addHook.called, false)
     })
   })
 
   describe('hook registration', () => {
     it('wraps NodeTracerProvider with the dd-trace TracerProvider', () => {
       const tracerProvider = function FakeTracerProvider () {}
-      const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: 'true' }, { TracerProvider: tracerProvider })
+      const { addHook, wrap } = loadWithEnv({ ddTraceOtelEnabled: true }, { TracerProvider: tracerProvider })
 
       sinon.assert.calledOnce(addHook)
       const [hookOptions, transform] = addHook.firstCall.args

--- a/packages/dd-trace/src/config/defaults.js
+++ b/packages/dd-trace/src/config/defaults.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const dns = require('dns')
 const util = require('util')
 
 const { DD_MAJOR } = require('../../../../version')
@@ -51,7 +50,6 @@ const defaults = {
   isServiceUserProvided: false,
   plugins: true,
   isCiVisibility: false,
-  lookup: dns.lookup,
   logger: undefined,
 }
 
@@ -347,3 +345,16 @@ module.exports = {
 
   generateTelemetry,
 }
+
+// `dns` is instrumented, so requiring it pulls in the dns plugin, which loads
+// `log`, whose bootstrap calls back into `require('./defaults')`. Resolve the
+// `lookup` default last — after the exports above are fully built — so that the
+// re-entrant require during that cascade sees the complete module instead of a
+// half-initialized one.
+defaults.lookup = require('dns').lookup
+configWithOrigin.set('lookupdefault', {
+  name: 'lookup',
+  value: defaults.lookup,
+  origin: 'default',
+  seq_id: seqId++,
+})

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -152,13 +152,10 @@ function validateAccess (name) {
 let configurationsTable
 let configDefaults
 
-// Lazy require to keep the `config -> helper` import direction acyclic.
-// `config/defaults` participates in a require cycle with `log` (it lazily
-// requires `log` to warn about invalid values, and `log` reads its fallback
-// defaults from there). When an early caller reaches this before
-// `config/defaults` has finished loading, the table is not yet populated; in
-// that window callers fall back to the raw value / no default and the next call
-// resolves it once the module is fully initialized.
+// Lazy require to keep the `config -> helper` import direction acyclic: helper
+// must not pull `config/defaults` at module load. `config/defaults` defers its
+// own instrumented `dns` require until after it exports, so by the time any
+// caller resolves a value the table is fully populated.
 function loadConfigurationsTable () {
   if (configurationsTable === undefined) {
     const defaultsModule = require('./defaults')
@@ -180,9 +177,6 @@ function loadConfigurationsTable () {
  */
 function parseConfigurationValue (name, value, source) {
   loadConfigurationsTable()
-  if (configurationsTable === undefined) {
-    return value
-  }
   const canonical = aliasToCanonical[name] ?? name
   const entry = configurationsTable[canonical]
   if (entry === undefined) {
@@ -202,9 +196,6 @@ function parseConfigurationValue (name, value, source) {
  */
 function getRegisteredDefault (name) {
   loadConfigurationsTable()
-  if (configurationsTable === undefined) {
-    return
-  }
   const canonical = aliasToCanonical[name] ?? name
   const entry = configurationsTable[canonical]
   if (entry === undefined) {

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -263,24 +263,23 @@ module.exports = {
       loadStableConfig()
     }
 
-    let rawValue
-    /** @type {'env_var' | 'fleet_stable_config' | 'local_stable_config'} */
-    let source = 'env_var'
     if (fleetStableConfig !== undefined) {
-      rawValue = getValueFromSource(name, fleetStableConfig)
-      source = 'fleet_stable_config'
-    }
-    if (rawValue === undefined) {
-      rawValue = getValueFromSource(name, process.env)
-      source = 'env_var'
-    }
-    if (rawValue === undefined && localStableConfig !== undefined) {
-      rawValue = getValueFromSource(name, localStableConfig)
-      source = 'local_stable_config'
+      const fromFleet = getValueFromSource(name, fleetStableConfig)
+      if (fromFleet !== undefined) {
+        return parseConfigurationValue(name, fromFleet, 'fleet_stable_config')
+      }
     }
 
-    if (rawValue !== undefined) {
-      return parseConfigurationValue(name, rawValue, source)
+    const fromEnv = getValueFromSource(name, process.env)
+    if (fromEnv !== undefined) {
+      return parseConfigurationValue(name, fromEnv, 'env_var')
+    }
+
+    if (localStableConfig !== undefined) {
+      const fromLocal = getValueFromSource(name, localStableConfig)
+      if (fromLocal !== undefined) {
+        return parseConfigurationValue(name, fromLocal, 'local_stable_config')
+      }
     }
   },
 

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -150,6 +150,22 @@ function validateAccess (name) {
 }
 
 let configurationsTable
+let configDefaults
+
+// Lazy require to keep the `config -> helper` import direction acyclic.
+// `config/defaults` participates in a require cycle with `log` (it lazily
+// requires `log` to warn about invalid values, and `log` reads its fallback
+// defaults from there). When an early caller reaches this before
+// `config/defaults` has finished loading, the table is not yet populated; in
+// that window callers fall back to the raw value / no default and the next call
+// resolves it once the module is fully initialized.
+function loadConfigurationsTable () {
+  if (configurationsTable === undefined) {
+    const defaultsModule = require('./defaults')
+    configurationsTable = defaultsModule.configurationsTable
+    configDefaults = defaultsModule.defaults
+  }
+}
 
 /**
  * Parses and transforms a raw environment value with the same parser and
@@ -163,14 +179,7 @@ let configurationsTable
  * @returns {string | number | boolean | object | undefined}
  */
 function parseConfigurationValue (name, value, source) {
-  // Lazy require to keep the `config -> helper` import direction acyclic.
-  // `config/defaults` participates in a require cycle with `log` (it lazily
-  // requires `log` to warn about invalid values, and `log` reads its fallback
-  // defaults from there). When an early caller reaches this before
-  // `config/defaults` has finished loading, the table is not yet populated; in
-  // that window we return the raw value and the next call parses it once the
-  // module is fully initialized.
-  configurationsTable ??= require('./defaults').configurationsTable
+  loadConfigurationsTable()
   if (configurationsTable === undefined) {
     return value
   }
@@ -181,6 +190,27 @@ function parseConfigurationValue (name, value, source) {
   }
   const parsed = entry.parser(value, canonical, source)
   return parsed !== undefined && entry.transformer ? entry.transformer(parsed, canonical, source) : parsed
+}
+
+/**
+ * Returns the registered default for a configuration — the same value Config
+ * resolves when no environment source sets it. Names without a configuration
+ * entry (any non DD_/OTEL_ variable) have no default and return `undefined`.
+ *
+ * @param {string} name Canonical or alias environment variable name.
+ * @returns {string | number | boolean | object | undefined}
+ */
+function getRegisteredDefault (name) {
+  loadConfigurationsTable()
+  if (configurationsTable === undefined) {
+    return
+  }
+  const canonical = aliasToCanonical[name] ?? name
+  const entry = configurationsTable[canonical]
+  if (entry === undefined) {
+    return
+  }
+  return configDefaults[entry.property ?? canonical]
 }
 
 module.exports = {
@@ -252,11 +282,18 @@ module.exports = {
    * sources, so the returned value is typed (boolean, number, array, map, ...) rather than the
    * raw string. Non DD_/OTEL_ variables have no configuration entry and are returned unparsed.
    *
+   * When the name is not set in any source, the registered default is returned, so callers can
+   * use the value directly. Callers that must distinguish an explicitly configured value from the
+   * default (e.g. an OTel fallback that only applies when the option is unset) pass `skipDefault`
+   * to receive `undefined` for an unset value instead. All sources (process.env, local and fleet
+   * stable config) are read in both modes.
+   *
    * @param {string} name Environment variable name
+   * @param {boolean} [skipDefault] Return `undefined` instead of the registered default when unset.
    * @returns {string | number | boolean | object | undefined}
    * @throws {Error} if the configuration is not supported
    */
-  getValueFromEnvSources (name) {
+  getValueFromEnvSources (name, skipDefault) {
     validateAccess(name)
 
     if (!stableConfigLoaded) {
@@ -281,6 +318,8 @@ module.exports = {
         return parseConfigurationValue(name, fromLocal, 'local_stable_config')
       }
     }
+
+    return skipDefault ? undefined : getRegisteredDefault(name)
   },
 
   /**

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -164,8 +164,16 @@ let configurationsTable
  */
 function parseConfigurationValue (name, value, source) {
   // Lazy require to keep the `config -> helper` import direction acyclic.
-  // `configurationsTable` is already built eagerly via `log -> config/defaults`.
+  // `config/defaults` participates in a require cycle with `log` (it lazily
+  // requires `log` to warn about invalid values, and `log` reads its fallback
+  // defaults from there). When an early caller reaches this before
+  // `config/defaults` has finished loading, the table is not yet populated; in
+  // that window we return the raw value and the next call parses it once the
+  // module is fully initialized.
   configurationsTable ??= require('./defaults').configurationsTable
+  if (configurationsTable === undefined) {
+    return value
+  }
   const canonical = aliasToCanonical[name] ?? name
   const entry = configurationsTable[canonical]
   if (entry === undefined) {

--- a/packages/dd-trace/src/config/helper.js
+++ b/packages/dd-trace/src/config/helper.js
@@ -149,6 +149,32 @@ function validateAccess (name) {
   }
 }
 
+let configurationsTable
+
+/**
+ * Parses and transforms a raw environment value with the same parser and
+ * transformer Config applies when it reads environment sources, so callers
+ * receive the typed value instead of the raw string. Names without a
+ * configuration entry (any non DD_/OTEL_ variable) are returned unparsed.
+ *
+ * @param {string} name Canonical or alias environment variable name.
+ * @param {string} value Raw value read from an environment source.
+ * @param {'env_var'|'fleet_stable_config'|'local_stable_config'} source Source the value was read from.
+ * @returns {string | number | boolean | object | undefined}
+ */
+function parseConfigurationValue (name, value, source) {
+  // Lazy require to keep the `config -> helper` import direction acyclic.
+  // `configurationsTable` is already built eagerly via `log -> config/defaults`.
+  configurationsTable ??= require('./defaults').configurationsTable
+  const canonical = aliasToCanonical[name] ?? name
+  const entry = configurationsTable[canonical]
+  if (entry === undefined) {
+    return value
+  }
+  const parsed = entry.parser(value, canonical, source)
+  return parsed !== undefined && entry.transformer ? entry.transformer(parsed, canonical, source) : parsed
+}
+
 module.exports = {
   /**
    * Expose raw stable config maps and warnings for consumers that need
@@ -214,8 +240,12 @@ module.exports = {
    * from the supported env sources (process.env, local stable config, fleet stable config).
    * Falls back to aliases if the canonical name is not set.
    *
+   * The raw value is parsed and transformed exactly as Config does when it reads environment
+   * sources, so the returned value is typed (boolean, number, array, map, ...) rather than the
+   * raw string. Non DD_/OTEL_ variables have no configuration entry and are returned unparsed.
+   *
    * @param {string} name Environment variable name
-   * @returns {string|undefined}
+   * @returns {string | number | boolean | object | undefined}
    * @throws {Error} if the configuration is not supported
    */
   getValueFromEnvSources (name) {
@@ -225,20 +255,24 @@ module.exports = {
       loadStableConfig()
     }
 
+    let rawValue
+    /** @type {'env_var' | 'fleet_stable_config' | 'local_stable_config'} */
+    let source = 'env_var'
     if (fleetStableConfig !== undefined) {
-      const fromFleet = getValueFromSource(name, fleetStableConfig)
-      if (fromFleet !== undefined) {
-        return fromFleet
-      }
+      rawValue = getValueFromSource(name, fleetStableConfig)
+      source = 'fleet_stable_config'
+    }
+    if (rawValue === undefined) {
+      rawValue = getValueFromSource(name, process.env)
+      source = 'env_var'
+    }
+    if (rawValue === undefined && localStableConfig !== undefined) {
+      rawValue = getValueFromSource(name, localStableConfig)
+      source = 'local_stable_config'
     }
 
-    const fromEnv = getValueFromSource(name, process.env)
-    if (fromEnv !== undefined) {
-      return fromEnv
-    }
-
-    if (localStableConfig !== undefined) {
-      return getValueFromSource(name, localStableConfig)
+    if (rawValue !== undefined) {
+      return parseConfigurationValue(name, rawValue, source)
     }
   },
 

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -5,7 +5,9 @@ const { getValueFromEnvSources } = require('./config/helper')
 // Global `jest` is only present in Jest workers.
 const inJestWorker = typeof jest !== 'undefined'
 
-const ddTraceEnabled = getValueFromEnvSources('DD_TRACE_ENABLED')
+// skipDefault: distinguish an unset DD_TRACE_ENABLED (fall back to the OTel signal) from an
+// explicit value; the registered default would otherwise mask the OTEL_TRACES_EXPORTER check.
+const ddTraceEnabled = getValueFromEnvSources('DD_TRACE_ENABLED', true)
 const ddTraceDisabled = ddTraceEnabled === undefined
   ? getValueFromEnvSources('OTEL_TRACES_EXPORTER') === 'none'
   : ddTraceEnabled === false

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -1,14 +1,14 @@
 'use strict'
 
 const { getValueFromEnvSources } = require('./config/helper')
-const { isFalse } = require('./util')
 
 // Global `jest` is only present in Jest workers.
 const inJestWorker = typeof jest !== 'undefined'
 
-const ddTraceDisabled = getValueFromEnvSources('DD_TRACE_ENABLED')
-  ? isFalse(getValueFromEnvSources('DD_TRACE_ENABLED'))
-  : String(getValueFromEnvSources('OTEL_TRACES_EXPORTER')).toLowerCase() === 'none'
+const ddTraceEnabled = getValueFromEnvSources('DD_TRACE_ENABLED')
+const ddTraceDisabled = ddTraceEnabled === undefined
+  ? String(getValueFromEnvSources('OTEL_TRACES_EXPORTER')).toLowerCase() === 'none'
+  : ddTraceEnabled === false
 
 module.exports = ddTraceDisabled || inJestWorker
   ? require('./noop/proxy')

--- a/packages/dd-trace/src/index.js
+++ b/packages/dd-trace/src/index.js
@@ -7,7 +7,7 @@ const inJestWorker = typeof jest !== 'undefined'
 
 const ddTraceEnabled = getValueFromEnvSources('DD_TRACE_ENABLED')
 const ddTraceDisabled = ddTraceEnabled === undefined
-  ? String(getValueFromEnvSources('OTEL_TRACES_EXPORTER')).toLowerCase() === 'none'
+  ? getValueFromEnvSources('OTEL_TRACES_EXPORTER') === 'none'
   : ddTraceEnabled === false
 
 module.exports = ddTraceDisabled || inJestWorker

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -65,7 +65,9 @@ class LLMObs extends NoopLLMObs {
 
     logger.debug('Enabling LLMObs')
 
-    const DD_LLMOBS_ENABLED = getValueFromEnvSources('DD_LLMOBS_ENABLED')
+    // skipDefault: only an explicit DD_LLMOBS_ENABLED=false blocks enable(); an unset value
+    // (its default is false) must still allow this programmatic opt-in.
+    const DD_LLMOBS_ENABLED = getValueFromEnvSources('DD_LLMOBS_ENABLED', true)
 
     if (DD_LLMOBS_ENABLED === false) {
       logger.debug('LLMObs.enable() called when DD_LLMOBS_ENABLED is false. No action taken.')

--- a/packages/dd-trace/src/llmobs/sdk.js
+++ b/packages/dd-trace/src/llmobs/sdk.js
@@ -2,7 +2,7 @@
 
 const { channel } = require('dc-polyfill')
 
-const { isError, isTrue } = require('../util')
+const { isError } = require('../util')
 const tracerVersion = require('../../../../package.json').version
 const logger = require('../log')
 const { getValueFromEnvSources } = require('../config/helper')
@@ -67,7 +67,7 @@ class LLMObs extends NoopLLMObs {
 
     const DD_LLMOBS_ENABLED = getValueFromEnvSources('DD_LLMOBS_ENABLED')
 
-    if (DD_LLMOBS_ENABLED != null && !isTrue(DD_LLMOBS_ENABLED)) {
+    if (DD_LLMOBS_ENABLED === false) {
       logger.debug('LLMObs.enable() called when DD_LLMOBS_ENABLED is false. No action taken.')
       return
     }

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -86,10 +86,10 @@ const log = {
     configDefaults ??= require('../config/defaults').defaults
     config.logger = options.logger
     config.logLevel = options.logLevel ??
-        getValueFromEnvSources('DD_TRACE_LOG_LEVEL') ??
+        getValueFromEnvSources('DD_TRACE_LOG_LEVEL', true) ??
         config.logLevel ??
         configDefaults?.logLevel
-    config.enabled = getValueFromEnvSources('DD_TRACE_DEBUG') ??
+    config.enabled = getValueFromEnvSources('DD_TRACE_DEBUG', true) ??
       // TODO: Handle this by adding a log buffer so that configure may be called with the actual configurations.
       // eslint-disable-next-line eslint-rules/eslint-process-env
       (process.env.OTEL_LOG_LEVEL === 'debug' || (config.enabled ?? configDefaults?.DD_TRACE_DEBUG))

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -7,17 +7,8 @@ const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = r
 const logWriter = require('./writer')
 const { Log, LogConfig, NoTransmitError } = require('./log')
 
-// `config/defaults` is required lazily inside `configure()` rather than at load
-// time. It only provides the `DD_TRACE_DEBUG`/`logLevel` fallback values, while
-// `config/defaults` itself lazily requires this module to warn about invalid
-// values. Requiring it here at load time lets one module observe the other
-// half-initialized under some require orderings (e.g. when an early
-// `getValueFromEnvSources` caller loads `config/defaults` before `log`).
-let configDefaults
-
 const config = {
   enabled: undefined,
-  logger: undefined,
   logLevel: undefined,
 }
 
@@ -83,19 +74,22 @@ const log = {
   },
 
   configure (options) {
-    configDefaults ??= require('../config/defaults').defaults
-    config.logger = options.logger
-    config.logLevel = options.logLevel ??
+    // Lazy require to avoid a config/defaults <-> log require cycle at load time.
+    const { defaults } = require('../config/defaults')
+    const logger = options.logger
+    const logLevel = options.logLevel ??
         getValueFromEnvSources('DD_TRACE_LOG_LEVEL', true) ??
         config.logLevel ??
-        configDefaults?.logLevel
-    config.enabled = getValueFromEnvSources('DD_TRACE_DEBUG', true) ??
+        defaults?.logLevel
+    const enabled = getValueFromEnvSources('DD_TRACE_DEBUG', true) ??
       // TODO: Handle this by adding a log buffer so that configure may be called with the actual configurations.
       // eslint-disable-next-line eslint-rules/eslint-process-env
-      (process.env.OTEL_LOG_LEVEL === 'debug' || (config.enabled ?? configDefaults?.DD_TRACE_DEBUG))
-    logWriter.configure(config.enabled, config.logLevel, options.logger)
+      (process.env.OTEL_LOG_LEVEL === 'debug' || (config.enabled ?? defaults?.DD_TRACE_DEBUG))
+    config.logLevel = logLevel
+    config.enabled = enabled
+    logWriter.configure(enabled, logLevel, logger)
 
-    return config.enabled
+    return enabled
   },
 }
 

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -2,16 +2,23 @@
 
 const { inspect } = require('util')
 
-const { defaults } = require('../config/defaults')
 const { getValueFromEnvSources } = require('../config/helper')
 const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = require('./channels')
 const logWriter = require('./writer')
 const { Log, LogConfig, NoTransmitError } = require('./log')
 
+// `config/defaults` is required lazily inside `configure()` rather than at load
+// time. It only provides the `DD_TRACE_DEBUG`/`logLevel` fallback values, while
+// `config/defaults` itself lazily requires this module to warn about invalid
+// values. Requiring it here at load time lets one module observe the other
+// half-initialized under some require orderings (e.g. when an early
+// `getValueFromEnvSources` caller loads `config/defaults` before `log`).
+let configDefaults
+
 const config = {
-  enabled: defaults.DD_TRACE_DEBUG,
+  enabled: undefined,
   logger: undefined,
-  logLevel: defaults.logLevel,
+  logLevel: undefined,
 }
 
 // In most places where we know we want to mute a log we use log.error() directly
@@ -76,14 +83,16 @@ const log = {
   },
 
   configure (options) {
+    configDefaults ??= require('../config/defaults').defaults
     config.logger = options.logger
     config.logLevel = options.logLevel ??
         getValueFromEnvSources('DD_TRACE_LOG_LEVEL') ??
-        config.logLevel
+        config.logLevel ??
+        configDefaults?.logLevel
     config.enabled = getValueFromEnvSources('DD_TRACE_DEBUG') ??
       // TODO: Handle this by adding a log buffer so that configure may be called with the actual configurations.
       // eslint-disable-next-line eslint-rules/eslint-process-env
-      (process.env.OTEL_LOG_LEVEL === 'debug' || config.enabled)
+      (process.env.OTEL_LOG_LEVEL === 'debug' || (config.enabled ?? configDefaults?.DD_TRACE_DEBUG))
     logWriter.configure(config.enabled, config.logLevel, options.logger)
 
     return config.enabled

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -3,7 +3,6 @@
 const { inspect } = require('util')
 
 const { defaults } = require('../config/defaults')
-const { isTrue } = require('../util')
 const { getValueFromEnvSources } = require('../config/helper')
 const { traceChannel, debugChannel, infoChannel, warnChannel, errorChannel } = require('./channels')
 const logWriter = require('./writer')
@@ -81,12 +80,10 @@ const log = {
     config.logLevel = options.logLevel ??
         getValueFromEnvSources('DD_TRACE_LOG_LEVEL') ??
         config.logLevel
-    config.enabled = isTrue(
-      getValueFromEnvSources('DD_TRACE_DEBUG') ??
+    config.enabled = getValueFromEnvSources('DD_TRACE_DEBUG') ??
       // TODO: Handle this by adding a log buffer so that configure may be called with the actual configurations.
       // eslint-disable-next-line eslint-rules/eslint-process-env
       (process.env.OTEL_LOG_LEVEL === 'debug' || config.enabled)
-    )
     logWriter.configure(config.enabled, config.logLevel, options.logger)
 
     return config.enabled

--- a/packages/dd-trace/src/log/index.js
+++ b/packages/dd-trace/src/log/index.js
@@ -119,6 +119,9 @@ function getErrorLog (err) {
   return err
 }
 
-log.configure({})
-
+// Assign before the bootstrap configure() call: an invalid DD_TRACE_LOG_LEVEL
+// makes config/defaults re-require this module to warn, which must observe the
+// fully built log object rather than a half-initialized one.
 module.exports = log
+
+log.configure({})

--- a/packages/dd-trace/src/profiling/exporter_cli.js
+++ b/packages/dd-trace/src/profiling/exporter_cli.js
@@ -18,7 +18,7 @@ function exporterFromURL (url) {
     return new FileExporter({ pprofPrefix: fileURLToPath(url) })
   }
   const profilingEnabled =
-    (/** @type {string | undefined} */ (getValueFromEnvSources('DD_PROFILING_ENABLED')) ?? '').toLowerCase()
+    /** @type {string} */ (getValueFromEnvSources('DD_PROFILING_ENABLED'))
   const activation = ['true', '1'].includes(profilingEnabled)
     ? 'manual'
     : profilingEnabled === 'auto'

--- a/packages/dd-trace/src/profiling/exporter_cli.js
+++ b/packages/dd-trace/src/profiling/exporter_cli.js
@@ -17,7 +17,8 @@ function exporterFromURL (url) {
   if (url.protocol === 'file:') {
     return new FileExporter({ pprofPrefix: fileURLToPath(url) })
   }
-  const profilingEnabled = (getValueFromEnvSources('DD_PROFILING_ENABLED') ?? '').toLowerCase()
+  const profilingEnabled =
+    (/** @type {string | undefined} */ (getValueFromEnvSources('DD_PROFILING_ENABLED')) ?? '').toLowerCase()
   const activation = ['true', '1'].includes(profilingEnabled)
     ? 'manual'
     : profilingEnabled === 'auto'

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -8,7 +8,7 @@ const dc = require('dc-polyfill')
 
 const parse = require('../../../vendor/dist/module-details-from-path')
 const { isRelativeRequire } = require('../../datadog-instrumentations/src/helpers/shared-utils')
-const { getEnvironmentVariable } = require('./config/helper')
+const { getConfiguredEnvName, getEnvironmentVariable } = require('./config/helper')
 
 const origRequire = Module.prototype.require
 // derived from require-in-the-middle@3 with tweaks
@@ -143,7 +143,9 @@ function Hook (modules, options, onrequire) {
       name = moduleId
     } else {
       const inAWSLambda = getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME') !== undefined
-      const hasLambdaHandler = getEnvironmentVariable('DD_LAMBDA_HANDLER') !== undefined
+      // Presence check over all sources (incl. stable config) without parsing —
+      // parsing here would re-enter this require hook via config/defaults.
+      const hasLambdaHandler = getConfiguredEnvName('DD_LAMBDA_HANDLER') !== undefined
       const segments = filename.split(path.sep)
       const filenameFromNodeModule = segments.includes('node_modules')
       // decide how to assign the stat

--- a/packages/dd-trace/src/ritm.js
+++ b/packages/dd-trace/src/ritm.js
@@ -8,7 +8,7 @@ const dc = require('dc-polyfill')
 
 const parse = require('../../../vendor/dist/module-details-from-path')
 const { isRelativeRequire } = require('../../datadog-instrumentations/src/helpers/shared-utils')
-const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
+const { getEnvironmentVariable } = require('./config/helper')
 
 const origRequire = Module.prototype.require
 // derived from require-in-the-middle@3 with tweaks
@@ -143,7 +143,7 @@ function Hook (modules, options, onrequire) {
       name = moduleId
     } else {
       const inAWSLambda = getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME') !== undefined
-      const hasLambdaHandler = getValueFromEnvSources('DD_LAMBDA_HANDLER') !== undefined
+      const hasLambdaHandler = getEnvironmentVariable('DD_LAMBDA_HANDLER') !== undefined
       const segments = filename.split(path.sep)
       const filenameFromNodeModule = segments.includes('node_modules')
       // decide how to assign the stat

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { getEnvironmentVariable, getValueFromEnvSources } = require('./config/helper')
-const { isFalse } = require('./util')
 
 function getIsGCPFunction () {
   const isDeprecatedGCPFunction =
@@ -23,7 +22,7 @@ function getIsGCPFunction () {
  */
 function enableGCPPubSubPushSubscription () {
   return getEnvironmentVariable('K_SERVICE') !== undefined &&
-    !isFalse(getValueFromEnvSources('DD_TRACE_GCP_PUBSUB_PUSH_ENABLED'))
+    getValueFromEnvSources('DD_TRACE_GCP_PUBSUB_PUSH_ENABLED') !== false
 }
 
 function getIsAzureFunction () {

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -22,7 +22,7 @@ function getIsGCPFunction () {
  */
 function enableGCPPubSubPushSubscription () {
   return getEnvironmentVariable('K_SERVICE') !== undefined &&
-    getValueFromEnvSources('DD_TRACE_GCP_PUBSUB_PUSH_ENABLED') !== false
+    getValueFromEnvSources('DD_TRACE_GCP_PUBSUB_PUSH_ENABLED')
 }
 
 function getIsAzureFunction () {

--- a/packages/dd-trace/test/config/helper.spec.js
+++ b/packages/dd-trace/test/config/helper.spec.js
@@ -163,21 +163,6 @@ describe('config-helper env resolution', () => {
     assert.strictEqual(getValueFromEnvSources('SOME_UNREGISTERED_VAR'), undefined)
   })
 
-  it('falls back to the raw value and no default while config/defaults is still loading', () => {
-    // Simulate the require-cycle window where config/defaults has not finished
-    // exporting yet: the configuration table is not populated.
-    const mod = proxyquire('../../src/config/helper', {
-      '../serverless': { IS_SERVERLESS: true },
-      './defaults': { '@noCallThru': true },
-    })
-
-    process.env.DD_TRACE_ENABLED = 'true'
-    assert.strictEqual(mod.getValueFromEnvSources('DD_TRACE_ENABLED'), 'true')
-
-    delete process.env.DD_TRACE_ENABLED
-    assert.strictEqual(mod.getValueFromEnvSources('DD_TRACE_ENABLED'), undefined)
-  })
-
   it('prefers canonical name over alias', () => {
     process.env.DD_AGENT_HOST = 'canonical-hostname'
     process.env.DD_TRACE_AGENT_HOSTNAME = 'alias-hostname'

--- a/packages/dd-trace/test/config/helper.spec.js
+++ b/packages/dd-trace/test/config/helper.spec.js
@@ -137,6 +137,47 @@ describe('config-helper env resolution', () => {
     assert.strictEqual(value, undefined)
   })
 
+  it('applies the registered default when the value is unset', () => {
+    delete process.env.DD_TRACE_ENABLED
+
+    // DD_TRACE_ENABLED's registered default is true.
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), true)
+  })
+
+  it('returns undefined for an unset value when skipDefault is set', () => {
+    delete process.env.DD_TRACE_ENABLED
+
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED', true), undefined)
+  })
+
+  it('returns the configured value rather than the default when set', () => {
+    process.env.DD_TRACE_ENABLED = 'false'
+
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), false)
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED', true), false)
+  })
+
+  it('returns undefined for an unset variable without a configuration entry', () => {
+    delete process.env.SOME_UNREGISTERED_VAR
+
+    assert.strictEqual(getValueFromEnvSources('SOME_UNREGISTERED_VAR'), undefined)
+  })
+
+  it('falls back to the raw value and no default while config/defaults is still loading', () => {
+    // Simulate the require-cycle window where config/defaults has not finished
+    // exporting yet: the configuration table is not populated.
+    const mod = proxyquire('../../src/config/helper', {
+      '../serverless': { IS_SERVERLESS: true },
+      './defaults': { '@noCallThru': true },
+    })
+
+    process.env.DD_TRACE_ENABLED = 'true'
+    assert.strictEqual(mod.getValueFromEnvSources('DD_TRACE_ENABLED'), 'true')
+
+    delete process.env.DD_TRACE_ENABLED
+    assert.strictEqual(mod.getValueFromEnvSources('DD_TRACE_ENABLED'), undefined)
+  })
+
   it('prefers canonical name over alias', () => {
     process.env.DD_AGENT_HOST = 'canonical-hostname'
     process.env.DD_TRACE_AGENT_HOSTNAME = 'alias-hostname'

--- a/packages/dd-trace/test/config/helper.spec.js
+++ b/packages/dd-trace/test/config/helper.spec.js
@@ -185,6 +185,33 @@ describe('config-helper env resolution', () => {
     assert.strictEqual(value, 'production')
   })
 
+  it('parses boolean configuration values', () => {
+    process.env.DD_TRACE_ENABLED = 'false'
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), false)
+
+    process.env.DD_TRACE_ENABLED = 'true'
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), true)
+  })
+
+  it('returns undefined for values the parser rejects', () => {
+    process.env.DD_TRACE_ENABLED = 'maybe'
+
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), undefined)
+  })
+
+  it('parses numeric configuration values', () => {
+    process.env.DD_TRACE_SAMPLE_RATE = '0.5'
+
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_SAMPLE_RATE'), 0.5)
+  })
+
+  it('parses and validates values resolved through an alias', () => {
+    process.env.OTEL_LOG_LEVEL = 'debug'
+
+    assert.strictEqual(getValueFromEnvSources('OTEL_LOG_LEVEL'), 'debug')
+    assert.strictEqual(getValueFromEnvSources('DD_TRACE_LOG_LEVEL'), 'debug')
+  })
+
   describe('with stable config and env vars', () => {
     beforeEach(() => {
       // Re-load module with stable config enabled (non-serverless)
@@ -238,9 +265,9 @@ describe('config-helper env resolution', () => {
 
       getValueFromEnvSources = mod.getValueFromEnvSources
 
-      assert.strictEqual(getValueFromEnvSources('DD_TRACE_SAMPLE_RATE'), '0.9')
+      assert.strictEqual(getValueFromEnvSources('DD_TRACE_SAMPLE_RATE'), 0.9)
       assert.strictEqual(getValueFromEnvSources('DD_SERVICE'), 'fleet')
-      assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), 'true')
+      assert.strictEqual(getValueFromEnvSources('DD_TRACE_ENABLED'), true)
     })
 
     it('does not override defined values with undefined', () => {


### PR DESCRIPTION
## Summary

`getValueFromEnvSources` returned the raw environment string, so every caller re-implemented the boolean/int/array parsing `Config` already does. Those divergent copies drift. It now resolves the canonical option (mapping aliases), runs the same parser and transformer `Config` uses, and returns the typed value, so callers drop their ad-hoc `isTrue`/`isFalse`/`Number` coercion.

A registered name whose value the parser rejects resolves to `undefined` (and warns). A name with no config entry falls back to the raw string, so reads of unregistered keys such as per-plugin `DD_TRACE_<X>_ENABLED` stay string-typed and still need explicit `isTrue`/`isFalse`.

## Test plan

- [ ] `packages/dd-trace/test/config/helper.spec.js`: parsing, alias resolution, fleet/env/local precedence
- [ ] caller gates: otel-sdk-trace enable, plugin_manager enable/disable, llmobs `enable()`, serverless GCP push, ci/init agentless