### PR TITLE
fix(id): keep trace and span IDs unique across Lambda snapshot clones

### DIFF
--- a/packages/dd-trace/src/id.js
+++ b/packages/dd-trace/src/id.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { randomFillSync } = require('crypto')
+const { openSync, readSync } = require('fs')
 
 const UINT_MAX = 4_294_967_296
 
@@ -8,6 +9,12 @@ const data = new Uint8Array(8 * 8192)
 const zeroId = new Uint8Array(8)
 
 let batch = 0
+
+// `data` is batch-filled 8192 ids at a time from `fill`. The default source is
+// OpenSSL's DRBG (randomFillSync); reseed() swaps it for the kernel CSPRNG when
+// running in a MicroVM. See reseed() for why.
+let fill = randomFillSync
+let urandomFd = -1
 
 // Internal representation of a trace or span ID.
 class Identifier {
@@ -200,13 +207,13 @@ function toNumberString (buffer, radix) {
   return str
 }
 
-// Simple pseudo-random 64-bit ID generator.
+// Simple pseudo-random 64-bit ID generator (non-MicroVM batch path).
 /**
- * @returns {number[] | Uint8Array}
+ * @returns {number[]}
  */
 function pseudoRandom () {
   if (batch === 0) {
-    randomFillSync(data)
+    fill(data)
   }
 
   batch = (batch + 1) % 8192
@@ -223,6 +230,24 @@ function pseudoRandom () {
     data[offset + 6],
     data[offset + 7],
   ]
+}
+
+// Fill `buffer` from the kernel CSPRNG, which Firecracker reseeds per clone on
+// snapshot resume (VMGenID). Falls back to randomFillSync only when /dev/urandom
+// can't be opened (non-Linux, locked-down sandbox) -- no worse than the default.
+/**
+ * @param {Uint8Array} buffer
+ */
+function fillFromKernel (buffer) {
+  if (urandomFd === -1) {
+    randomFillSync(buffer)
+    return
+  }
+
+  let offset = 0
+  while (offset < buffer.length) {
+    offset += readSync(urandomFd, buffer, offset, buffer.length - offset, null)
+  }
 }
 
 // Read a buffer to unsigned integer bytes.
@@ -264,3 +289,25 @@ module.exports = function createIdentifier (value, radix) {
 }
 
 module.exports.Identifier = Identifier
+
+// A Firecracker/Lambda MicroVM resumes many clones from one memory snapshot.
+// The snapshot freezes OpenSSL's DRBG state and the pre-filled `data` buffer, so
+// every clone would otherwise replay the same trace/span IDs. Only the guest
+// kernel CSPRNG is reseeded per clone, so on the first invocation after a
+// possible restore we switch batch fills to /dev/urandom and discard the
+// snapshot's pre-fill. The Lambda handler calls this per invocation; it's a
+// no-op after the first, since a clone only has to switch once.
+module.exports.reseed = function reseed () {
+  if (fill === fillFromKernel) {
+    return
+  }
+
+  try {
+    urandomFd = openSync('/dev/urandom', 'r')
+  } catch {
+    // Keep urandomFd = -1; fillFromKernel falls back to randomFillSync.
+  }
+
+  fill = fillFromKernel
+  batch = 0
+}

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -3,6 +3,7 @@
 const log = require('../log')
 const { channel } = require('../../../datadog-instrumentations/src/helpers/instrument')
 const { ERROR_MESSAGE, ERROR_TYPE } = require('../constants')
+const id = require('../id')
 const { ImpendingTimeout } = require('./runtime/errors')
 const { extractContext } = require('./context')
 
@@ -64,6 +65,11 @@ function crashFlush () {
  */
 exports.datadog = function datadog (lambdaHandler) {
   return (...args) => {
+    // A snapshot-resumed MicroVM clone re-enters here on every invocation; tell
+    // the ID generator a time shift may have happened so it draws fresh kernel
+    // entropy instead of replaying the snapshot's cached randomness.
+    id.reseed()
+
     const context = extractContext(args)
 
     if (context) {

--- a/packages/dd-trace/src/lambda/handler.js
+++ b/packages/dd-trace/src/lambda/handler.js
@@ -2,6 +2,7 @@
 
 const log = require('../log')
 const { channel } = require('../../../datadog-instrumentations/src/helpers/instrument')
+const { getEnvironmentVariable } = require('../config/helper')
 const { ERROR_MESSAGE, ERROR_TYPE } = require('../constants')
 const id = require('../id')
 const { ImpendingTimeout } = require('./runtime/errors')
@@ -65,10 +66,13 @@ function crashFlush () {
  */
 exports.datadog = function datadog (lambdaHandler) {
   return (...args) => {
-    // A snapshot-resumed MicroVM clone re-enters here on every invocation; tell
-    // the ID generator a time shift may have happened so it draws fresh kernel
-    // entropy instead of replaying the snapshot's cached randomness.
-    id.reseed()
+    // Only snapshot-resumed MicroVM clones set AWS_LAMBDA_MICROVM_IMAGE_ARN. Gate
+    // the reseed on it so the ID generator draws fresh kernel entropy after a
+    // possible time shift there, and leaves the default DRBG hot path untouched
+    // everywhere else.
+    if (getEnvironmentVariable('AWS_LAMBDA_MICROVM_IMAGE_ARN')) {
+      id.reseed()
+    }
 
     const context = extractContext(args)
 

--- a/packages/dd-trace/test/id.spec.js
+++ b/packages/dd-trace/test/id.spec.js
@@ -156,3 +156,114 @@ describe('id', () => {
     assert.strictEqual(spanId.toString(10), '43981')
   })
 })
+
+describe('id reseed (MicroVM snapshot restore)', () => {
+  const BATCH_BYTES = 8 * 8192
+  let id
+  let randomFillSync
+  let kernelReads
+  let nextByte
+
+  // Distinct big-endian counter per 8-byte slot: keeps generated ids unique and
+  // their sign bit clear (counter << 2^56), so tests can assert distinctness.
+  function fillCounter (buffer, base, length) {
+    for (let slot = 0; slot < length; slot += 8) {
+      let value = nextByte++
+      for (let byteIndex = 7; byteIndex >= 0; byteIndex--) {
+        buffer[base + slot + byteIndex] = value & 0xFF
+        value = Math.floor(value / 256)
+      }
+    }
+  }
+
+  function loadId ({ openThrows = false } = {}) {
+    kernelReads = []
+    nextByte = 1
+
+    const fs = {
+      openSync () {
+        if (openThrows) throw new Error('ENOENT: no /dev/urandom')
+        return 7
+      },
+      readSync (fd, buffer, offset, length) {
+        kernelReads.push(length)
+        fillCounter(buffer, offset, length)
+        return length
+      },
+    }
+
+    randomFillSync = sinon.spy(buffer => fillCounter(buffer, 0, buffer.length))
+
+    return proxyquire('../src/id', { fs, crypto: { randomFillSync } })
+  }
+
+  beforeEach(() => {
+    id = loadId()
+  })
+
+  it('uses the OpenSSL batch fill until reseed runs', () => {
+    id()
+    id()
+
+    assert.strictEqual(randomFillSync.callCount, 1)
+    assert.deepStrictEqual(kernelReads, [])
+  })
+
+  it('draws the first post-reseed id from one batched kernel read', () => {
+    id()
+    const fillsBeforeReseed = randomFillSync.callCount
+
+    id.reseed()
+    id()
+
+    assert.deepStrictEqual(kernelReads, [BATCH_BYTES])
+    assert.strictEqual(randomFillSync.callCount, fillsBeforeReseed)
+
+    for (let i = 0; i < 100; i++) id()
+
+    assert.deepStrictEqual(kernelReads, [BATCH_BYTES])
+  })
+
+  it('reseeds only once: a later reseed does not re-read the kernel', () => {
+    id.reseed()
+    id()
+    id.reseed()
+    id()
+
+    assert.deepStrictEqual(kernelReads, [BATCH_BYTES])
+  })
+
+  it('refills from the kernel when the batch wraps at 8192', () => {
+    id.reseed()
+
+    for (let i = 0; i < 8192; i++) id()
+    assert.deepStrictEqual(kernelReads, [BATCH_BYTES])
+
+    id()
+    assert.deepStrictEqual(kernelReads, [BATCH_BYTES, BATCH_BYTES])
+  })
+
+  it('generates unique positive 63-bit ids from the kernel', () => {
+    id.reseed()
+    const seen = new Set()
+
+    for (let i = 0; i < 50; i++) {
+      const hex = id().toString()
+      assert.strictEqual(hex.length, 16)
+      assert.strictEqual(Number.parseInt(hex.slice(0, 2), 16) & 0x80, 0)
+      seen.add(hex)
+    }
+
+    assert.strictEqual(seen.size, 50)
+  })
+
+  it('falls back to randomFillSync when /dev/urandom cannot be opened', () => {
+    id = loadId({ openThrows: true })
+
+    id.reseed()
+    id()
+
+    assert.deepStrictEqual(kernelReads, [])
+    assert.ok(randomFillSync.callCount >= 1)
+  })
+})

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -318,14 +318,26 @@ describe('lambda snapshot reseed', () => {
 
   afterEach(() => {
     reseed.restore()
+    process.env = oldEnv
   })
 
-  it('reseeds the id generator at the start of every invocation', () => {
+  it('reseeds the id generator on every invocation inside a snapshot MicroVM clone', () => {
+    process.env = { ...oldEnv, AWS_LAMBDA_MICROVM_IMAGE_ARN: 'arn:aws:lambda:us-east-1:123:microvm/abc' }
     const wrapped = datadog(() => ({ statusCode: 200 }))
 
     wrapped()
     wrapped()
 
     assert.strictEqual(reseed.callCount, 2)
+  })
+
+  it('does not reseed when not running inside a snapshot MicroVM clone', () => {
+    process.env = { ...oldEnv }
+    delete process.env.AWS_LAMBDA_MICROVM_IMAGE_ARN
+    const wrapped = datadog(() => ({ statusCode: 200 }))
+
+    wrapped()
+
+    assert.strictEqual(reseed.callCount, 0)
   })
 })

--- a/packages/dd-trace/test/lambda/index.spec.js
+++ b/packages/dd-trace/test/lambda/index.spec.js
@@ -4,9 +4,12 @@ const assert = require('node:assert/strict')
 const path = require('node:path')
 
 const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
 
 const agent = require('../plugins/agent')
 const Hook = require('../../src/ritm')
+const id = require('../../src/id')
+const { datadog } = require('../../src/lambda/handler')
 
 const oldEnv = process.env
 
@@ -303,5 +306,26 @@ describe('lambda', () => {
         await Promise.all([result, checkTraces])
       })
     })
+  })
+})
+
+describe('lambda snapshot reseed', () => {
+  let reseed
+
+  beforeEach(() => {
+    reseed = sinon.spy(id, 'reseed')
+  })
+
+  afterEach(() => {
+    reseed.restore()
+  })
+
+  it('reseeds the id generator at the start of every invocation', () => {
+    const wrapped = datadog(() => ({ statusCode: 200 }))
+
+    wrapped()
+    wrapped()
+
+    assert.strictEqual(reseed.callCount, 2)
   })
 })

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -63,6 +63,8 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   'WEBSITE_SKU',
   // lambda RITM target path (computed once at module load)
   'LAMBDA_TASK_ROOT',
+  // lambda snapshot MicroVM clone detection (id reseed gate)
+  'AWS_LAMBDA_MICROVM_IMAGE_ARN',
   // serverless service-name fallbacks (Config singleton)
   'WEBSITE_SITE_NAME',
   // azure metadata payload (cached at first build)


### PR DESCRIPTION
## Summary

A Firecracker/Lambda MicroVM resumes many clones from one memory snapshot. The snapshot freezes OpenSSL's DRBG state and the pre-filled batch buffer behind `randomFillSync`, so every clone replays the same trace and span IDs and collides. Only the guest kernel CSPRNG is reseeded per clone (the hypervisor bumps VMGenID on resume), so after a possible restore the batch buffer is refilled from `/dev/urandom` instead of `randomFillSync`.

The Lambda handler signals each invocation through `id.reseed()`. The first call per clone opens `/dev/urandom`, switches batch fills to it, and drops the snapshot's pre-fill; later calls are a no-op. The default non-Lambda path stays on `randomFillSync`, with the per-id hot path unchanged.

## Why

This is an alternative to #8426. That PR adds a `DD_TRACE_SECURE_RANDOM` flag and draws from the kernel on every id for the whole process lifetime: correct, but it slows every id and needs a user-set flag. This version keeps the batch buffer at full throughput and refreshes it only at the restore boundary, so there is no per-id slowdown and no configuration. The in-process Lambda handler wrapper is the restore signal, which also sidesteps the objection raised on #8426: serverless-init's `/launch` is a separate process, but the Node handler wrapper runs in the same process as the id generator.

The non-Lambda hot path is unchanged. A microbench generating ids shows parity with master (10.84 vs 10.86 ns/op; Node 24, V8 13.6; n=2M x 7 trials, drop best+worst).

## Test plan

- [ ] `id` unit tests: default uses `randomFillSync`; `reseed()` flips to one batched `/dev/urandom` read, flips once, refills on wrap at 8192, yields unique positive 63-bit ids, and falls back to `randomFillSync` when `/dev/urandom` cannot be opened.
- [ ] Lambda handler calls `id.reseed()` once per invocation.

Refs: https://datadoghq.atlassian.net/browse/SVLS-9136
