### PR TITLE
chore(debugger): note stale probe diagnostics edge case

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -269,6 +269,8 @@ async function reEvaluateProbe (probe) {
     if (probeToLocation.has(probe.id)) {
       await removeBreakpoint(probe)
     }
+    // TODO: Revisit diagnostic status handling for probes that recover during re-evaluation. A probe can initially
+    // report ERROR because no script matched, then attach successfully here without reporting INSTALLED.
     await addBreakpoint(probe)
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a TODO documenting a rare Debugger diagnostic status edge case in the debugger devtools client re-evaluation path.

### Motivation

A probe can initially fail to attach because no loaded script matches, causing the tracer to report `ERROR`. The probe is still kept locally, so a later lazy-loaded script can trigger re-evaluation and allow the probe to attach successfully. That recovery path currently does not emit a new `INSTALLED` status, so backend diagnostics can remain stale.
