### PR TITLE
fix(profiling): handle minor mark-sweep GC events

### DIFF
--- a/integration-tests/profiler/gctest.js
+++ b/integration-tests/profiler/gctest.js
@@ -1,0 +1,20 @@
+'use strict'
+
+require('dd-trace').init()
+
+// Allocate a lot of short-lived objects to force young-generation garbage
+// collections. Under V8's --minor-ms flag these are emitted as Minor
+// Mark-Sweep (kind 2) GC events, which used to crash the profiler. See
+// https://github.com/DataDog/dd-trace-js/issues/8839
+setImmediate(() => {
+  let sink
+  for (let i = 0; i < 1000; i++) {
+    const garbage = []
+    for (let j = 0; j < 10000; j++) {
+      garbage.push({ i, j, payload: `garbage-${i}-${j}` })
+    }
+    sink = garbage[garbage.length - 1]
+  }
+  // Reference sink so V8 can't optimize the allocations away.
+  if (sink === undefined) throw new Error('unexpected')
+})

--- a/integration-tests/profiler/profiler.spec.js
+++ b/integration-tests/profiler/profiler.spec.js
@@ -267,6 +267,48 @@ async function gatherCryptoTimelineEvents (cwd, scriptFilePath, agentPort) {
   return gatherTimelineEvents(cwd, scriptFilePath, agentPort, 'crypto', [], CryptoEventProcessor)
 }
 
+// Gathers the distinct 'gc type' label values seen across the events profile.
+// GC events are sourced through the Node API and don't carry span IDs, so this
+// has a simpler shape than gatherTimelineEvents.
+async function gatherGcTypes (cwd, scriptFilePath, agentPort, execArgv) {
+  const proc = fork(path.join(cwd, scriptFilePath), [], {
+    cwd,
+    execArgv,
+    env: {
+      DD_PROFILING_EXPORTERS: 'file',
+      DD_PROFILING_ENABLED: '1',
+      DD_INTERNAL_PROFILING_TIMELINE_SAMPLING_ENABLED: '0', // capture all events
+      DD_TRACE_AGENT_PORT: agentPort,
+    },
+  })
+
+  // A crash (e.g. issue #8839) would surface here as a non-zero exit.
+  await processExitPromise(proc, TIMEOUT)
+
+  const { profile } = await getLatestProfile(cwd, /^events_.+\.pprof$/)
+  const strings = profile.stringTable
+  const eventKey = strings.dedup('event')
+  const gcTypeKey = strings.dedup('gc type')
+  const gcEventValue = strings.dedup('gc')
+
+  const gcTypes = new Set()
+  for (const sample of profile.sample) {
+    let isGc = false
+    let gcType
+    for (const label of sample.label) {
+      if (label.key === eventKey) {
+        isGc = label.str === gcEventValue
+      } else if (label.key === gcTypeKey) {
+        gcType = strings.strings[label.str]
+      }
+    }
+    if (isGc && gcType !== undefined) {
+      gcTypes.add(gcType)
+    }
+  }
+  return gcTypes
+}
+
 async function gatherTimelineEvents (cwd, scriptFilePath, agentPort, eventType, args, Processor) {
   const procStart = BigInt(Date.now() * 1000000)
   const proc = fork(path.join(cwd, scriptFilePath), args, {
@@ -613,6 +655,21 @@ describe('profiler', () => {
         }
       } finally {
         server1.close()
+      }
+    })
+
+    it('gc timeline events work with the minor mark-sweep collector', async function () {
+      // V8's --minor-ms collector emits GC events with kind 2, which has no
+      // NODE_PERFORMANCE_GC_* constant and used to crash the profiler.
+      // It is stable since Node 22. See issue #8839.
+      if (!satisfies(process.versions.node, '>=22.0.0')) {
+        this.skip()
+      }
+      const gcTypes = await gatherGcTypes(cwd, 'profiler/gctest.js', agent.port, ['--minor-ms'])
+      // The collector was renamed from minor_mark_compact to minor_mark_sweep in Node 22.
+      assert.ok(gcTypes.has('minor_mark_sweep'), `Expected a minor_mark_sweep GC event, got ${inspect(gcTypes)}`)
+      for (const gcType of gcTypes) {
+        assert.doesNotMatch(gcType, /^unknown/, `Unexpected unknown GC type: ${gcType}`)
       }
     })
   })

--- a/packages/dd-trace/src/profiling/profilers/events.js
+++ b/packages/dd-trace/src/profiling/profilers/events.js
@@ -66,11 +66,10 @@ class GCDecorator {
   constructor (stringTable) {
     this.stringTable = stringTable
     this.reasonLabelKey = stringTable.dedup('gc reason')
+    this.kindLabelKey = stringTable.dedup('gc type')
     this.kindLabels = []
     this.reasonLabels = []
     this.flagObj = {}
-
-    const kindLabelKey = stringTable.dedup('gc type')
 
     // Create labels for all GC performance flags and kinds of GC
     for (const [key, value] of Object.entries(constants)) {
@@ -79,18 +78,41 @@ class GCDecorator {
       } else if (key.startsWith('NODE_PERFORMANCE_GC_')) {
         // It's a constant for a kind of GC
         const kind = key.slice(20).toLowerCase()
-        this.kindLabels[value] = labelFromStr(stringTable, kindLabelKey, kind)
+        this.kindLabels[value] = labelFromStr(stringTable, this.kindLabelKey, kind)
       }
+    }
+
+    // V8's young-generation collector emits GC events with kind 2, but Node.js
+    // doesn't expose a matching NODE_PERFORMANCE_GC_* constant for it, so we map it
+    // explicitly. The collector was renamed from Minor Mark-Compact to Minor
+    // Mark-Sweep in the V8 version that shipped with Node 22. See equivalent
+    // mapping in runtime_metrics.js.
+    const minorMarkGCKind = 2
+    if (this.kindLabels[minorMarkGCKind] === undefined) {
+      const { NODE_MAJOR } = require('../../../../../version')
+      const minorGCLabel = NODE_MAJOR >= 22 ? 'minor_mark_sweep' : 'minor_mark_compact'
+      this.kindLabels[minorMarkGCKind] = labelFromStr(stringTable, this.kindLabelKey, minorGCLabel)
     }
   }
 
   decorateSample (sampleInput, item) {
     const { kind, flags } = item.detail
-    sampleInput.label.push(this.kindLabels[kind])
+    sampleInput.label.push(this.getKindLabel(kind))
     const reasonLabel = this.getReasonLabel(flags)
     if (reasonLabel) {
       sampleInput.label.push(reasonLabel)
     }
+  }
+
+  getKindLabel (kind) {
+    let kindLabel = this.kindLabels[kind]
+    if (kindLabel === undefined) {
+      // Gracefully handle GC kinds we don't have a label for (e.g. a value
+      // introduced by a future Node.js/V8 version).
+      kindLabel = labelFromStr(this.stringTable, this.kindLabelKey, `unknown_${kind}`)
+      this.kindLabels[kind] = kindLabel
+    }
+    return kindLabel
   }
 
   getReasonLabel (flags) {


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the continuous profiler's events (timeline) profiler when V8's Minor Mark-Sweep collector is active (`--minor-ms`, the default young-generation collector since Node 22).

The collector emits GC performance events with `kind` 2, but Node.js does not expose a matching `NODE_PERFORMANCE_GC_*` constant for it. `GCDecorator` built its kind-label table solely from those constants, so `kindLabels[2]` was `undefined`, got pushed into the pprof `Sample` labels, and crashed the process on the first GC with:

```
TypeError: Cannot read properties of undefined (reading 'key')
    at new Label (.../pprof-format/index.js)
    at #createSample (.../profiling/profilers/events.js)
```

This PR:

- Maps `kind` 2 explicitly, mirroring `runtime_metrics.js`. The collector was renamed from Minor Mark-Compact to Minor Mark-Sweep in the V8 version that shipped with Node 22, so the label is version-dependent: `minor_mark_sweep` on Node >= 22, `minor_mark_compact` otherwise (verified against the V8 `GCType` enum).
- Adds a graceful fallback to an `unknown_<kind>` label for any future GC kind we don't recognize, so a missing constant can never crash the application again.

### Motivation

Closes #8839

The profiler crashed the host process on the first GC when run with `--minor-ms`; the only workaround was disabling profiling.

### Additional Notes

Added an integration test (`integration-tests/profiler/gctest.js` + a case in `profiler.spec.js`) that runs the profiled program with `--minor-ms`, asserts the process does not crash, and asserts a `minor_mark_sweep` GC type appears with no `unknown_*` types leaking. The test fails (process exits with code 1) without the fix and is guarded to Node >= 22 where `--minor-ms` is stable.

Jira: [PROF-15068]

[PROF-15068]: https://datadoghq.atlassian.net/browse/PROF-15068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ