### PR TITLE
test(ioredis): pin Redis Cluster command tracing

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1245,7 +1245,7 @@ jobs:
           - 7005:7005
     env:
       PLUGINS: ioredis
-      SERVICES: redis|redis-cluster
+      SERVICES: redis-cluster
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/plugins/test

--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1231,9 +1231,21 @@ jobs:
         image: redis@sha256:a0bb2f95a4672c5bbf3a01fcc2eb6dfb8fd898d83fc71cbf012c6b9479ab1607 # 6.2-alpine
         ports:
           - 6379:6379
+      redis-cluster:
+        image: grokzen/redis-cluster@sha256:f130dd8a322fc4dc595380ec94907539c341d5841de7d31e679223aec04d30f6 # 7.0.10
+        env:
+          IP: 0.0.0.0
+          INITIAL_PORT: 7000
+        ports:
+          - 7000:7000
+          - 7001:7001
+          - 7002:7002
+          - 7003:7003
+          - 7004:7004
+          - 7005:7005
     env:
       PLUGINS: ioredis
-      SERVICES: ioredis
+      SERVICES: redis|redis-cluster
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/plugins/test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,14 @@ services:
     image: redis@sha256:c9d92d840fd011c908f040592857c724ae6d877f2aba5c40ad963276507386b2 # 7.0-alpine
     ports:
       - "127.0.0.1:6379:6379"
+  redis-cluster:
+    image: grokzen/redis-cluster@sha256:f130dd8a322fc4dc595380ec94907539c341d5841de7d31e679223aec04d30f6 # 7.0.10
+    platform: linux/amd64
+    environment:
+      - IP=0.0.0.0
+      - INITIAL_PORT=7000
+    ports:
+      - "127.0.0.1:7000-7005:7000-7005"
   mongo:
     image: circleci/mongo@sha256:ce33f29bababa5d2775f8e945ca0ba8754b727a2251b96eb3eed501628cb7b65 # 4.4
     platform: linux/amd64

--- a/packages/datadog-plugin-ioredis/test/cluster.spec.js
+++ b/packages/datadog-plugin-ioredis/test/cluster.spec.js
@@ -67,12 +67,21 @@ describe('Plugin', () => {
       })
 
       it('runs the command in the active parent context', async () => {
-        const span = tracer.startSpan('test')
+        const parent = tracer.startSpan('test')
 
-        await tracer.scope().activate(span, async () => {
+        const assertion = agent.assertSomeTraces(traces => {
+          const span = traces[0].find(span => span.resource === 'get')
+          assert.ok(span, 'expected a span for the get command')
+          assert.strictEqual(span.parent_id.toString(), parent.context().toSpanId())
+        }, { spanResourceMatch: /^get$/ })
+
+        await tracer.scope().activate(parent, async () => {
           await cluster.get('cluster-key')
-          assert.strictEqual(tracer.scope().active(), span)
+          assert.strictEqual(tracer.scope().active(), parent)
         })
+        parent.finish()
+
+        await assertion
       })
 
       withNamingSchema(

--- a/packages/datadog-plugin-ioredis/test/cluster.spec.js
+++ b/packages/datadog-plugin-ioredis/test/cluster.spec.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { once } = require('node:events')
+
+const { after, before, describe, it } = require('mocha')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withNamingSchema, withVersions } = require('../../dd-trace/test/setup/mocha')
+const { expectedSchema, rawExpectedSchema } = require('./naming')
+
+// grokzen/redis-cluster announces nodes on 127.0.0.1:7000-7005.
+const CLUSTER_NODES = [{ host: '127.0.0.1', port: 7000 }]
+
+describe('Plugin', () => {
+  let Redis
+  let cluster
+  let tracer
+
+  describe('ioredis (cluster)', () => {
+    withVersions('ioredis', 'ioredis', version => {
+      before(async () => {
+        await agent.load(['ioredis'])
+        tracer = require('../../dd-trace')
+        Redis = require(`../../../versions/ioredis@${version}`).get()
+        cluster = new Redis.Cluster(CLUSTER_NODES)
+        // Keep transient node errors from crashing the run as unhandled.
+        cluster.on('error', () => {})
+        await once(cluster, 'ready')
+      })
+
+      after(async () => {
+        await cluster.quit()
+        await agent.close()
+      })
+
+      it('traces commands the cluster dispatches to a node', async () => {
+        const assertion = agent.assertFirstTraceSpan({
+          name: expectedSchema.outbound.opName,
+          service: expectedSchema.outbound.serviceName,
+          resource: 'get',
+          type: 'redis',
+          meta: {
+            component: 'ioredis',
+            'db.type': 'redis',
+            'span.kind': 'client',
+            'redis.raw_command': 'GET cluster-key',
+          },
+        }, { spanResourceMatch: /^get$/ })
+
+        await cluster.get('cluster-key')
+
+        await assertion
+      })
+
+      it('tags the span with the resolved shard endpoint', async () => {
+        const assertion = agent.assertSomeTraces(traces => {
+          const span = traces[0].find(span => span.resource === 'set')
+          assert.ok(span, 'expected a span for the set command')
+          const port = span.metrics['network.destination.port']
+          assert.ok(port >= 7000 && port <= 7005, `expected a cluster shard port, got ${port}`)
+        }, { spanResourceMatch: /^set$/ })
+
+        await cluster.set('cluster-key', 'cluster-value')
+
+        await assertion
+      })
+
+      it('runs the command in the active parent context', async () => {
+        const span = tracer.startSpan('test')
+
+        await tracer.scope().activate(span, async () => {
+          await cluster.get('cluster-key')
+          assert.strictEqual(tracer.scope().active(), span)
+        })
+      })
+
+      withNamingSchema(
+        () => cluster.get('cluster-key'),
+        rawExpectedSchema.outbound
+      )
+    })
+  })
+})

--- a/packages/dd-trace/test/setup/services/redis-cluster.js
+++ b/packages/dd-trace/test/setup/services/redis-cluster.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const RetryOperation = require('../operation')
+const ioredis = require('../../../../../versions/ioredis').get()
+
+const CLUSTER_NODES = [{ host: '127.0.0.1', port: 7000 }]
+
+function waitForRedisCluster () {
+  return new Promise((resolve, reject) => {
+    const operation = new RetryOperation('redis-cluster')
+
+    operation.attempt(() => {
+      const cluster = new ioredis.Cluster(CLUSTER_NODES, {
+        clusterRetryStrategy: () => undefined,
+      })
+
+      cluster.once('ready', () => {
+        cluster.disconnect()
+        resolve()
+      })
+
+      cluster.once('error', (error) => {
+        cluster.disconnect()
+        if (operation.retry(error)) return
+        reject(error)
+      })
+    })
+  })
+}
+
+module.exports = waitForRedisCluster


### PR DESCRIPTION
## Summary

ioredis `Cluster` has no command hook of its own — it delegates every command to a pooled `Redis` node connection that shares the wrapped `Redis.prototype.sendCommand`. Cluster command tracing therefore already works (verified against a live 6-node cluster on `master`, and the same hook shape back through v5), but nothing pinned it: a refactor of that single hook could drop cluster-mode spans with no test failing. This adds a cluster spec — span creation, resolved shard endpoint tag, parent-context propagation, naming — plus the `grokzen/redis-cluster` service it runs against in `docker-compose` and the `ioredis` CI job.

## Why

#6231 reports cluster commands as untraced. They are in fact traced at the node level; the realistic causes of such a report are bundling, a disabled `redis`/`ioredis` plugin, pipelines/auto-pipelining, or pre-`ready` offline-queue context loss — not a missing hook. The honest resolution is a regression test rather than a redundant production hook.

## Test plan

- The `ioredis` CI job now starts a `redis-cluster` service and waits on it; the spec passes across every installed ioredis version (2.x → 5.x).
- Negative control: with `Redis.prototype.sendCommand` wrapping disabled, the spec stops producing the `get` span and fails.

Refs: https://github.com/DataDog/dd-trace-js/issues/6231