### PR TITLE
feat(instrumentation): warn when Next.js is loaded before dd-trace

### DIFF
--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -76,7 +76,9 @@ module.exports.checkForRequiredModules = function (debug) {
   let didWarn = false
 
   for (const pathToModule of Object.keys(require.cache)) {
-    const { pkg, path } = extractPackageAndModulePath(pathToModule)
+    // require.cache keys use the platform separator; normalize so the
+    // `node_modules/<pkg>` parsing works on Windows (backslash paths).
+    const { pkg, path } = extractPackageAndModulePath(pathToModule.replaceAll('\\', '/'))
 
     if (pkg === null) continue
 

--- a/packages/datadog-instrumentations/src/helpers/check-require-cache.js
+++ b/packages/datadog-instrumentations/src/helpers/check-require-cache.js
@@ -3,6 +3,9 @@
 // This code runs before the tracer is configured and before a logger is ready
 // For that reason we queue up the messages now and decide what to do with them later
 const warnings = []
+// Same idea, but for the high-signal framework warnings that surface by default
+// (see flushFrameworkWarnings) rather than only under DD_TRACE_DEBUG.
+const frameworkWarnings = []
 
 /**
  * Here we maintain a list of packages that an application
@@ -29,6 +32,24 @@ const potentialConflicts = new Set([
 const extractPackageAndModulePath = require('./extract-package-and-module-path')
 
 /**
+ * Frameworks that load their own server code before any user code (and thus
+ * before a late `tracer.init()`) can run. When their server module is already
+ * in `require.cache` at init time, dd-trace was loaded too late to instrument
+ * them and the integration silently no-ops. Unlike the broad scan below, this
+ * set is high-signal enough to warn on by default. `file` is the module whose
+ * presence proves the server is already loaded; `guidance` is the bundler note
+ * appended to the warning.
+ */
+const earlyLoadFrameworks = new Map([
+  ['next', {
+    // dist/server/next-server.js (>=11.1), dist/next-server/server/next-server.js (older)
+    file: 'next-server.js',
+    guidance: "add 'dd-trace' to `serverExternalPackages` (Next.js >=15) or " +
+      '`experimental.serverComponentsExternalPackages` (13-14) so it is not bundled',
+  }],
+])
+
+/**
  * The lowest hanging fruit to debug an app that isn't tracing
  * properly is to check that it is loaded before any modules
  * that need to be instrumented. This function checks the
@@ -43,17 +64,41 @@ const extractPackageAndModulePath = require('./extract-package-and-module-path')
  * app loads a package we instrument but outside of an
  * unsupported version then a warning would still be displayed.
  * This is OK as the tracer should be loaded earlier anyway.
+ *
+ * Curated frameworks (see `earlyLoadFrameworks`) are collected regardless of
+ * `debug`, since they surface by default; the broad list stays debug-only.
+ * @param {boolean} debug Whether to also queue the broad DD_TRACE_DEBUG-only warnings.
  */
-module.exports.checkForRequiredModules = function () {
+module.exports.checkForRequiredModules = function (debug) {
   const packages = require('./hooks')
   const naughties = new Set()
+  const frameworksSeen = new Set()
   let didWarn = false
 
   for (const pathToModule of Object.keys(require.cache)) {
-    const { pkg } = extractPackageAndModulePath(pathToModule)
+    const { pkg, path } = extractPackageAndModulePath(pathToModule)
 
-    if (naughties.has(pkg)) continue
-    if (!(pkg in packages)) continue
+    if (pkg === null) continue
+
+    // A curated framework loads its own server before user code, so its server
+    // module being cached means dd-trace was too late to instrument it. These
+    // surface by default (see flushFrameworkWarnings) with an actionable
+    // message, so they never fall through to the DD_TRACE_DEBUG-only list below.
+    const framework = earlyLoadFrameworks.get(pkg)
+    if (framework !== undefined) {
+      if (!frameworksSeen.has(pkg) && path?.endsWith(framework.file)) {
+        frameworksSeen.add(pkg)
+        frameworkWarnings.push(
+          `'${pkg}' was loaded before dd-trace, so the ${pkg} integration will not be applied. ` +
+          'Initialize dd-trace before your application starts — ' +
+          "NODE_OPTIONS='--require dd-trace/init' (CommonJS) or '--import dd-trace/initialize.mjs' (ESM) — " +
+          `and ${framework.guidance}.`
+        )
+      }
+      continue
+    }
+
+    if (!debug || naughties.has(pkg) || !(pkg in packages)) continue
 
     warnings.push(() => `Warning: Package '${pkg}' was loaded before dd-trace! This may break instrumentation.`)
 
@@ -102,5 +147,17 @@ module.exports.flushStartupLogs = function (log) {
   while (warnings.length) {
     const entry = warnings.shift()
     log.warn(typeof entry === 'function' ? entry() : entry)
+  }
+}
+
+/**
+ * Drains the framework warnings collected by `checkForRequiredModules`. The
+ * caller surfaces them by default (gated on startupLogs), unlike the
+ * DD_TRACE_DEBUG-only `flushStartupLogs` queue.
+ * @param {(message: string) => void} warn
+ */
+module.exports.flushFrameworkWarnings = function (warn) {
+  while (frameworkWarnings.length) {
+    warn(frameworkWarnings.shift())
   }
 }

--- a/packages/datadog-instrumentations/src/helpers/register.js
+++ b/packages/datadog-instrumentations/src/helpers/register.js
@@ -36,8 +36,9 @@ if (!disabledInstrumentations.has('process')) {
   require('../process')
 }
 
-if (DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false') {
-  checkRequireCache.checkForRequiredModules()
+const debugEnabled = DD_TRACE_DEBUG && DD_TRACE_DEBUG.toLowerCase() !== 'false'
+checkRequireCache.checkForRequiredModules(debugEnabled)
+if (debugEnabled) {
   setImmediate(checkRequireCache.checkForPotentialConflicts)
 }
 

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
@@ -97,6 +97,17 @@ describe('check-require-cache', () => {
       }
     })
 
+    it('detects a curated framework when the cache key uses Windows separators', () => {
+      // Literal backslash key reproduces a Windows require.cache entry on any OS.
+      const restore = cacheModule('C:\\app\\node_modules\\next\\dist\\server\\next-server.js')
+      try {
+        checkForRequiredModules(false)
+        assert.ok(drainFrameworkWarnings().some(message => message.includes("'next' was loaded before dd-trace")))
+      } finally {
+        restore()
+      }
+    })
+
     it('ignores non-server files of a curated framework', () => {
       const nextWarnings = messages => messages.filter(message => message.includes("'next'")).length
 

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache.spec.js
@@ -2,8 +2,12 @@
 
 const assert = require('node:assert/strict')
 const { exec } = require('node:child_process')
+const path = require('node:path')
+const Module = require('node:module')
 
 const { describe, it } = require('mocha')
+
+const { checkForRequiredModules, flushFrameworkWarnings } = require('../../src/helpers/check-require-cache')
 
 describe('check-require-cache', () => {
   const opts = {
@@ -26,6 +30,98 @@ describe('check-require-cache', () => {
       assert.strictEqual(error, null)
       assert.match(stderr, /Package 'express' was loaded/)
       done()
+    })
+  })
+
+  describe('frameworks that must load before the tracer', () => {
+    // No DD_TRACE_DEBUG here on purpose: the framework warning has to surface by
+    // default, since the users hitting this (issues #5430 / #5432) never turned
+    // debug logging on.
+    const defaultOpts = { cwd: __dirname, env: {} }
+
+    it('should warn by default when next is loaded before the tracer', (done) => {
+      exec(`${process.execPath} ./check-require-cache/next-loaded-first.js`, defaultOpts, (error, stdout, stderr) => {
+        assert.strictEqual(error, null)
+        assert.match(stderr, /'next' was loaded before dd-trace/)
+        assert.match(stderr, /--require dd-trace\/init/)
+        assert.match(stderr, /--import dd-trace\/initialize\.mjs/)
+        assert.match(stderr, /serverExternalPackages/)
+        done()
+      })
+    })
+
+    it('should not warn when next is loaded after the tracer', (done) => {
+      exec(`${process.execPath} ./check-require-cache/next-loaded-after.js`, defaultOpts, (error, stdout, stderr) => {
+        assert.strictEqual(error, null)
+        assert.doesNotMatch(stderr, /'next' was loaded before dd-trace/)
+        done()
+      })
+    })
+
+    it('should not warn when only a non-server file of next is loaded first', (done) => {
+      exec(`${process.execPath} ./check-require-cache/next-util-loaded-first.js`, defaultOpts, (error, _, stderr) => {
+        assert.strictEqual(error, null)
+        assert.doesNotMatch(stderr, /'next' was loaded before dd-trace/)
+        done()
+      })
+    })
+  })
+
+  describe('checkForRequiredModules framework detection', () => {
+    function cacheModule (modulePath) {
+      const fakeModule = new Module(modulePath)
+      fakeModule.exports = {}
+      fakeModule.loaded = true
+      require.cache[modulePath] = fakeModule
+      return () => delete require.cache[modulePath]
+    }
+
+    function drainFrameworkWarnings () {
+      const messages = []
+      flushFrameworkWarnings(message => messages.push(message))
+      return messages
+    }
+
+    // Clear any residue collected from the real require.cache before asserting.
+    beforeEach(() => drainFrameworkWarnings())
+
+    it('collects a curated framework whose server module is already cached', () => {
+      const restore = cacheModule(
+        path.join('/app', 'node_modules', 'next', 'dist', 'server', 'next-server.js')
+      )
+      try {
+        checkForRequiredModules(false)
+        assert.ok(drainFrameworkWarnings().some(message => message.includes("'next' was loaded before dd-trace")))
+      } finally {
+        restore()
+      }
+    })
+
+    it('ignores non-server files of a curated framework', () => {
+      const nextWarnings = messages => messages.filter(message => message.includes("'next'")).length
+
+      checkForRequiredModules(false)
+      const before = nextWarnings(drainFrameworkWarnings())
+
+      const restore = cacheModule(path.join('/app', 'node_modules', 'next', 'package.json'))
+      try {
+        checkForRequiredModules(false)
+        // Caching only a non-server file must not add a warning, regardless of
+        // whatever else is already in the real require.cache.
+        assert.strictEqual(nextWarnings(drainFrameworkWarnings()), before)
+      } finally {
+        restore()
+      }
+    })
+
+    it('does not collect packages outside the curated set', () => {
+      const restore = cacheModule(path.join('/app', 'node_modules', 'express', 'lib', 'express.js'))
+      try {
+        checkForRequiredModules(false)
+        assert.ok(drainFrameworkWarnings().every(message => !message.includes("'express'")))
+      } finally {
+        restore()
+      }
     })
   })
 })

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache/next-loaded-after.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache/next-loaded-after.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+'use strict'
+
+const Module = require('node:module')
+const path = require('node:path')
+
+const tracer = require('../../../../../')
+tracer.init()
+
+// Next.js loads its server after the tracer is initialized (the supported
+// order). The detector runs during init, so injecting the cache entry now must
+// not produce a warning.
+const nextServer = path.join(__dirname, 'node_modules', 'next', 'dist', 'server', 'next-server.js')
+const fakeModule = new Module(nextServer)
+fakeModule.exports = {}
+fakeModule.loaded = true
+require.cache[nextServer] = fakeModule
+
+process.exit()

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache/next-loaded-first.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache/next-loaded-first.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+'use strict'
+
+const path = require('node:path')
+const Module = require('node:module')
+
+// Reproduce the `instrumentation.ts` ordering trap from issues #5430 / #5432:
+// Next.js loads its own server before the tracer initializes. The detector only
+// reads require.cache keys, so a synthetic entry recreates that runtime state
+// without building and running a real Next.js app.
+const nextServer = path.join(__dirname, 'node_modules', 'next', 'dist', 'server', 'next-server.js')
+const fakeModule = new Module(nextServer)
+fakeModule.exports = {}
+fakeModule.loaded = true
+require.cache[nextServer] = fakeModule
+
+const tracer = require('../../../../../')
+tracer.init()
+
+process.exit()

--- a/packages/datadog-instrumentations/test/helpers/check-require-cache/next-util-loaded-first.js
+++ b/packages/datadog-instrumentations/test/helpers/check-require-cache/next-util-loaded-first.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+'use strict'
+
+const Module = require('node:module')
+const path = require('node:path')
+
+// Only a non-server next file is cached before the tracer. The server module is
+// what the next plugin hooks, so loading a utility first must not warn — the
+// server can still load (and be instrumented) after init.
+const nextUtil = path.join(__dirname, 'node_modules', 'next', 'constants.js')
+const fakeModule = new Module(nextUtil)
+fakeModule.exports = {}
+fakeModule.loaded = true
+require.cache[nextUtil] = fakeModule
+
+const tracer = require('../../../../../')
+tracer.init()
+
+process.exit()

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -5,7 +5,7 @@ const DatadogTracer = require('./tracer')
 const getConfig = require('./config')
 const runtimeMetrics = require('./runtime_metrics')
 const log = require('./log')
-const { setStartupLogPluginManager, startupLog } = require('./startup-log')
+const { setStartupLogPluginManager, startupLog, logLateLoadedFrameworks } = require('./startup-log')
 const DynamicInstrumentation = require('./debugger')
 const telemetry = require('./telemetry')
 const nomenclature = require('./service-naming')
@@ -314,6 +314,7 @@ class Tracer extends NoopProxy {
       DynamicInstrumentation.configure(config)
       setStartupLogPluginManager(this._pluginManager)
       startupLog()
+      logLateLoadedFrameworks()
     }
   }
 

--- a/packages/dd-trace/src/startup-log.js
+++ b/packages/dd-trace/src/startup-log.js
@@ -3,6 +3,7 @@
 const os = require('os')
 const { inspect } = require('util')
 const tracerVersion = require('../../../package.json').version
+const { flushFrameworkWarnings } = require('../../datadog-instrumentations/src/helpers/check-require-cache')
 const { warn } = require('./log/writer')
 
 const errors = {}
@@ -68,6 +69,22 @@ function logGenericError (message) {
   }
 
   warn('DATADOG TRACER DIAGNOSTIC - Generic Error: ' + message)
+}
+
+/**
+ * Surfaces the framework warnings collected by `checkForRequiredModules` (e.g.
+ * Next.js loaded before dd-trace, so its integration silently no-ops). Gated on
+ * startupLogs like the other diagnostics rather than behind DD_TRACE_DEBUG,
+ * since the affected users never have debug logging on. Draining makes repeat
+ * calls idempotent.
+ * @see https://github.com/DataDog/dd-trace-js/issues/5430
+ */
+function logLateLoadedFrameworks () {
+  if (!config?.startupLogs) {
+    return
+  }
+
+  flushFrameworkWarnings(message => warn('DATADOG TRACER DIAGNOSTIC - ' + message))
 }
 
 /**
@@ -145,6 +162,7 @@ module.exports = {
   startupLog,
   logIntegrations,
   logAgentError,
+  logLateLoadedFrameworks,
   setStartupLogConfig,
   setStartupLogPluginManager,
   setSamplingRules,

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -246,21 +246,19 @@ describe('logLateLoadedFrameworks', () => {
   }
 
   afterEach(() => {
+    sinon.restore()
     delete require.cache[nextServer]
     flushFrameworkWarnings(() => {})
   })
 
   it('warns when a curated framework was loaded before the tracer', () => {
-    sinon.stub(console, 'warn')
+    const warnStub = sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
     collectNextWarning()
     setStartupLogConfig({ startupLogs: true })
     logLateLoadedFrameworks()
-    /* eslint-disable-next-line no-console */
-    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
     const message = warnStub.firstCall.args[0]
-    warnStub.restore()
     assert.match(message, /'next' was loaded before dd-trace/)
     assert.match(message, /--require dd-trace\/init/)
     assert.match(message, /--import dd-trace\/initialize\.mjs/)
@@ -268,30 +266,24 @@ describe('logLateLoadedFrameworks', () => {
   })
 
   it('does not warn when startupLogs is false', () => {
-    sinon.stub(console, 'warn')
+    const warnStub = sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
     collectNextWarning()
     setStartupLogConfig({ startupLogs: false })
     logLateLoadedFrameworks()
-    /* eslint-disable-next-line no-console */
-    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
     assert.strictEqual(warnStub.callCount, 0)
-    warnStub.restore()
   })
 
   it('drains so a second call does not repeat the warning', () => {
-    sinon.stub(console, 'warn')
+    const warnStub = sinon.stub(console, 'warn')
     delete require.cache[require.resolve('../src/startup-log')]
     const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
     collectNextWarning()
     setStartupLogConfig({ startupLogs: true })
     logLateLoadedFrameworks()
     logLateLoadedFrameworks()
-    /* eslint-disable-next-line no-console */
-    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
     assert.strictEqual(warnStub.callCount, 1)
-    warnStub.restore()
   })
 })
 

--- a/packages/dd-trace/test/startup-log.spec.js
+++ b/packages/dd-trace/test/startup-log.spec.js
@@ -226,6 +226,75 @@ describe('startup log guards', () => {
   })
 })
 
+describe('logLateLoadedFrameworks', () => {
+  const Module = require('node:module')
+  const path = require('node:path')
+  const {
+    checkForRequiredModules,
+    flushFrameworkWarnings,
+  } = require('../../datadog-instrumentations/src/helpers/check-require-cache')
+  const nextServer = path.join('/app', 'node_modules', 'next', 'dist', 'server', 'next-server.js')
+
+  // Reproduce the detection step: cache next's server module, then run the scan
+  // that collects the warning logLateLoadedFrameworks later surfaces.
+  function collectNextWarning () {
+    const fakeModule = new Module(nextServer)
+    fakeModule.exports = {}
+    fakeModule.loaded = true
+    require.cache[nextServer] = fakeModule
+    checkForRequiredModules(false)
+  }
+
+  afterEach(() => {
+    delete require.cache[nextServer]
+    flushFrameworkWarnings(() => {})
+  })
+
+  it('warns when a curated framework was loaded before the tracer', () => {
+    sinon.stub(console, 'warn')
+    delete require.cache[require.resolve('../src/startup-log')]
+    const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
+    collectNextWarning()
+    setStartupLogConfig({ startupLogs: true })
+    logLateLoadedFrameworks()
+    /* eslint-disable-next-line no-console */
+    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+    const message = warnStub.firstCall.args[0]
+    warnStub.restore()
+    assert.match(message, /'next' was loaded before dd-trace/)
+    assert.match(message, /--require dd-trace\/init/)
+    assert.match(message, /--import dd-trace\/initialize\.mjs/)
+    assert.match(message, /serverExternalPackages/)
+  })
+
+  it('does not warn when startupLogs is false', () => {
+    sinon.stub(console, 'warn')
+    delete require.cache[require.resolve('../src/startup-log')]
+    const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
+    collectNextWarning()
+    setStartupLogConfig({ startupLogs: false })
+    logLateLoadedFrameworks()
+    /* eslint-disable-next-line no-console */
+    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+    assert.strictEqual(warnStub.callCount, 0)
+    warnStub.restore()
+  })
+
+  it('drains so a second call does not repeat the warning', () => {
+    sinon.stub(console, 'warn')
+    delete require.cache[require.resolve('../src/startup-log')]
+    const { setStartupLogConfig, logLateLoadedFrameworks } = require('../src/startup-log')
+    collectNextWarning()
+    setStartupLogConfig({ startupLogs: true })
+    logLateLoadedFrameworks()
+    logLateLoadedFrameworks()
+    /* eslint-disable-next-line no-console */
+    const warnStub = /** @type {sinon.SinonStub} */ (console.warn)
+    assert.strictEqual(warnStub.callCount, 1)
+    warnStub.restore()
+  })
+})
+
 describe('data_streams_enabled', () => {
   afterEach(() => {
     delete process.env.DD_DATA_STREAMS_ENABLED


### PR DESCRIPTION
## Summary

Initializing dd-trace after Next.js has already loaded — e.g. from Next's
`instrumentation.ts` `register()` hook, which runs once the server modules are
required — leaves the `next` integration silently disabled: the require hook
never sees `next-server.js`, the plugin never attaches, and `tracer.use('next')`
is a no-op with no diagnostic. ESM apps hit this more often, since a top-level
`import` does not guarantee dd-trace evaluates before the framework.

`checkForRequiredModules` already detects packages loaded before dd-trace, but
its call and its log sink were both `DD_TRACE_DEBUG`-only, so affected users saw
nothing. The same scan now also collects a curated set (Next.js, matched on its
server module) and surfaces it by default via the startup-log path (gated on
`startupLogs`), naming the fix — load dd-trace first via `--require dd-trace/init`
or `--import dd-trace/initialize.mjs` and keep it in `serverExternalPackages`.
The broad list stays `DD_TRACE_DEBUG`-only.

## Test plan

- Default-on subprocess tests (no `DD_TRACE_DEBUG`): warns when `next-server.js`
  is cached before init; silent when next loads after init or only a non-server
  file is cached.
- `logLateLoadedFrameworks` gating + drain idempotency; existing `express`
  debug-order tests unchanged.

Fixes: https://github.com/DataDog/dd-trace-js/issues/5430