### PR TITLE
feat(pg): trace pool connection-acquire wait time

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -266,13 +266,13 @@ const finish = (ctx) => {
  * @typedef {{ database?: string, user?: string, host?: string, port?: number }} PoolConnectionParameters
  * @typedef {{ connectionParameters?: PoolConnectionParameters }} PoolClient
  * @typedef {{
- *   options: PoolConnectionParameters,
+ *   options?: PoolConnectionParameters,
  *   idleCount: number,
  *   waitingCount: number,
  *   _clients?: PoolClient[]
  * }} InstrumentedPool
  * @typedef {{
- *   poolOptions: PoolConnectionParameters,
+ *   poolOptions?: PoolConnectionParameters,
  *   params?: PoolConnectionParameters,
  *   error?: unknown,
  *   poolWaitTime?: number

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -262,10 +262,27 @@ const finish = (ctx) => {
   finishPoolQueryCh.publish(ctx)
 }
 
+/**
+ * @typedef {{ database?: string, user?: string, host?: string, port?: number }} PoolConnectionParameters
+ * @typedef {{ connectionParameters?: PoolConnectionParameters }} PoolClient
+ * @typedef {{
+ *   options: PoolConnectionParameters,
+ *   idleCount: number,
+ *   waitingCount: number,
+ *   _clients?: PoolClient[]
+ * }} InstrumentedPool
+ * @typedef {{
+ *   poolOptions: PoolConnectionParameters,
+ *   params?: PoolConnectionParameters,
+ *   error?: unknown,
+ *   poolWaitTime?: number
+ * }} AcquireContext
+ */
+
 // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
 // outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
 /**
- * @param {import('pg').Pool} pool
+ * @param {InstrumentedPool} pool
  */
 function acquireStart (pool) {
   return pool.idleCount > pool.waitingCount ? undefined : performance.now()
@@ -279,7 +296,7 @@ function acquireWait (start) {
 }
 
 /**
- * @param {import('pg').Pool} pool
+ * @param {InstrumentedPool} pool
  */
 function latestPoolConnectionParameters (pool) {
   // pg-pool removes a failed client before invoking the acquire callback, so snapshot it while
@@ -289,10 +306,10 @@ function latestPoolConnectionParameters (pool) {
 }
 
 /**
- * @param {import('pg').Pool['connect']} connect
- * @param {import('pg').Pool} pool
+ * @param {Function} connect
+ * @param {InstrumentedPool} pool
  * @param {IArguments} args
- * @param {{ params?: object, error?: unknown }} acquireCtx
+ * @param {AcquireContext} acquireCtx
  * @param {number | undefined} start
  */
 function connectForAcquire (connect, pool, args, acquireCtx, start) {
@@ -312,7 +329,7 @@ function connectForAcquire (connect, pool, args, acquireCtx, start) {
 }
 
 /**
- * @param {{ poolWaitTime?: number }} ctx
+ * @param {AcquireContext} ctx
  * @param {number | undefined} start
  */
 function finishAcquire (ctx, start) {
@@ -321,9 +338,9 @@ function finishAcquire (ctx, start) {
 }
 
 /**
- * @param {import('pg').Pool['query']} query
- * @param {import('pg').Pool} pool
- * @param {Parameters<import('pg').Pool['query']>} args
+ * @param {Function} query
+ * @param {InstrumentedPool} pool
+ * @param {unknown[]} args
  */
 function acquireForPoolQuery (query, pool, args) {
   acquiringForPoolQuery = true

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -59,7 +59,10 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
       const acquireCtx = { poolOptions: this.options }
       poolAcquireStartCh.publish(acquireCtx)
 
-      return connect.apply(this, arguments).then(client => {
+      const connectResult = connect.apply(this, arguments)
+      acquireCtx.params = latestPoolConnectionParameters(this)
+
+      return connectResult.then(client => {
         acquireCtx.params = client.connectionParameters
         finishAcquire(acquireCtx, start)
         return client
@@ -76,6 +79,7 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
 
     const ctx = {}
     const start = acquireStart(this)
+    let acquireCtx
 
     if (acquiringForPoolQuery) {
       arguments[0] = function (...args) {
@@ -94,7 +98,7 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
         }
       }
     } else {
-      const acquireCtx = { poolOptions: this.options }
+      acquireCtx = { poolOptions: this.options }
       poolAcquireStartCh.publish(acquireCtx)
 
       arguments[0] = function (...args) {
@@ -107,7 +111,11 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
 
     poolConnectStartCh.publish(ctx)
 
-    return connect.apply(this, arguments)
+    const connectResult = connect.apply(this, arguments)
+    if (acquireCtx !== undefined && acquireCtx.params === undefined) {
+      acquireCtx.params = latestPoolConnectionParameters(this)
+    }
+    return connectResult
   })
   shimmer.wrap(pg.Pool.prototype, 'query', query => wrapPoolQuery(query))
   return pg
@@ -271,6 +279,16 @@ function acquireStart (pool) {
  */
 function acquireWait (start) {
   return start === undefined ? 0 : performance.now() - start
+}
+
+/**
+ * @param {import('pg').Pool} pool
+ */
+function latestPoolConnectionParameters (pool) {
+  // pg-pool removes a failed client before invoking the acquire callback, so snapshot it while
+  // connect is still pending.
+  const clients = pool._clients
+  return clients?.at(-1)?.connectionParameters
 }
 
 /**

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -99,8 +99,12 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
       poolAcquireStartCh.publish(acquireCtx)
 
       arguments[0] = function (...args) {
+        const client = args[1]
         acquireCtx.error = args[0]
-        acquireCtx.params = args[1]?.connectionParameters
+        // A failed acquire has no client, so keep the parameters `connectForAcquire` snapshotted.
+        if (client !== undefined) {
+          acquireCtx.params = client.connectionParameters
+        }
         finishAcquire(acquireCtx, start)
         return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
       }

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { errorMonitor } = require('node:events')
+const { performance } = require('node:perf_hooks')
 
 const shimmer = require('../../datadog-shimmer')
 const {
@@ -22,6 +23,13 @@ const poolConnectFinishCh = channel('apm:pg:pool:connect:finish')
 // the un-injected `text` so the wrap doesn't capture a previous DBM injection as the new original.
 const originalTextCache = new WeakMap()
 
+// pg dispatches the pooled query synchronously from the connect callback, so the acquire wait
+// reaches `wrapQuery` through this stack: `_release` pulses the pending queue synchronously, which
+// nests acquires, and the client pins each wait to the connection that actually waited for it.
+// Each entry is popped by the frame that pushed it, so no client outlives its callback.
+const poolWaitClients = []
+const poolWaitTimes = []
+
 addHook({ name: 'pg', versions: ['>=8.0.3'], file: 'lib/native/client.js' }, Client => {
   shimmer.wrap(Client.prototype, 'query', query => wrapQuery(query))
   return Client
@@ -41,8 +49,23 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
     }
 
     const ctx = {}
+    // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
+    // outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
+    const start = this.idleCount > this.waitingCount ? 0 : performance.now()
     arguments[0] = function (...args) {
-      return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+      const client = args[1]
+      if (client !== undefined) {
+        poolWaitClients.push(client)
+        poolWaitTimes.push(start === 0 ? 0 : performance.now() - start)
+      }
+      try {
+        return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+      } finally {
+        if (client !== undefined) {
+          poolWaitClients.pop()
+          poolWaitTimes.pop()
+        }
+      }
     }
 
     poolConnectStartCh.publish(ctx)
@@ -83,6 +106,17 @@ function wrapQuery (query) {
       abortController,
       stream,
     }
+
+    if (poolWaitClients.length !== 0) {
+      for (let i = poolWaitClients.length - 1; i >= 0; i--) {
+        if (poolWaitClients[i] === this) {
+          ctx.poolWaitTime = poolWaitTimes[i]
+          poolWaitClients[i] = undefined
+          break
+        }
+      }
+    }
+
     const finish = (error, res) => {
       if (error) {
         ctx.error = error

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -26,17 +26,13 @@ const poolAcquireFinishCh = channel('apm:pg:pool:acquire:finish')
 // the un-injected `text` so the wrap doesn't capture a previous DBM injection as the new original.
 const originalTextCache = new WeakMap()
 
-// pg dispatches the pooled query synchronously from the connect callback, so the acquire wait
-// reaches `wrapQuery` through this stack: `_release` pulses the pending queue synchronously, which
-// nests acquires, and the client pins each wait to the connection that actually waited for it.
-// Each entry is popped by the frame that pushed it, so no client outlives its callback.
+// Pool.query dispatches its client query synchronously from the connect callback, including nested
+// `_release` queue pulses, so the wait can cross that callback without retaining the client.
 const poolWaitClients = []
 const poolWaitTimes = []
 
-// `Pool.prototype.query` acquires a client internally via `connect`. That acquire is reported as a
-// tag on the resulting query span, so the connect wrap must not also open a standalone acquire span
-// for it; an explicit user `pool.connect()` gets the standalone span instead. `connect` is invoked
-// synchronously from within `query`, so a module flag set around the call reliably distinguishes them.
+// Pool.query reports its internal acquire on the query span; explicit connects get an acquire span.
+// Pool.query calls connect synchronously, so a module flag reliably distinguishes the two.
 let acquiringForPoolQuery = false
 
 addHook({ name: 'pg', versions: ['>=8.0.3'], file: 'lib/native/client.js' }, Client => {
@@ -53,9 +49,7 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
   // pg defers a busy pool's connect callback and runs it in the releasing query's async context;
   // capture the caller's context and restore it around the callback so spans attach to the caller.
   shimmer.wrap(pg.Pool.prototype, 'connect', connect => function (cb) {
-    // `await pool.connect()`: no callback, so the caller's async context is preserved by the await
-    // itself and only the standalone acquire span is needed. `Pool.query` always acquires with a
-    // callback, so a missing callback is always an explicit caller-initiated acquire.
+    // Pool.query always supplies a callback, so a missing callback is an explicit acquire.
     if (typeof cb !== 'function') {
       if (!poolAcquireStartCh.hasSubscribers) {
         return connect.apply(this, arguments)
@@ -260,18 +254,37 @@ function wrapQuery (query) {
 const finish = (ctx) => {
   finishPoolQueryCh.publish(ctx)
 }
+
 // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
 // outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
+/**
+ * @param {import('pg').Pool} pool
+ */
 function acquireStart (pool) {
-  return pool.idleCount > pool.waitingCount ? 0 : performance.now()
+  return pool.idleCount > pool.waitingCount ? undefined : performance.now()
 }
+
+/**
+ * @param {number | undefined} start
+ */
 function acquireWait (start) {
-  return start === 0 ? 0 : performance.now() - start
+  return start === undefined ? 0 : performance.now() - start
 }
+
+/**
+ * @param {{ poolWaitTime?: number }} ctx
+ * @param {number | undefined} start
+ */
 function finishAcquire (ctx, start) {
   ctx.poolWaitTime = acquireWait(start)
   poolAcquireFinishCh.publish(ctx)
 }
+
+/**
+ * @param {import('pg').Pool['query']} query
+ * @param {import('pg').Pool} pool
+ * @param {Parameters<import('pg').Pool['query']>} args
+ */
 function acquireForPoolQuery (query, pool, args) {
   acquiringForPoolQuery = true
   try {
@@ -283,7 +296,9 @@ function acquireForPoolQuery (query, pool, args) {
 function wrapPoolQuery (query) {
   return function (...args) {
     if (!startPoolQueryCh.hasSubscribers) {
-      return acquireForPoolQuery(query, this, args)
+      return poolConnectStartCh.hasSubscribers
+        ? acquireForPoolQuery(query, this, args)
+        : query.apply(this, args)
     }
 
     const pgQuery = args[0] !== null && typeof args[0] === 'object' ? args[0] : { text: args[0] }
@@ -313,7 +328,9 @@ function wrapPoolQuery (query) {
         })
       }
 
-      const retval = acquireForPoolQuery(query, this, args)
+      const retval = poolConnectStartCh.hasSubscribers
+        ? acquireForPoolQuery(query, this, args)
+        : query.apply(this, args)
 
       if (retval?.then) {
         retval.then(() => {

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -60,6 +60,7 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
       poolAcquireStartCh.publish(acquireCtx)
 
       return connect.apply(this, arguments).then(client => {
+        acquireCtx.params = client.connectionParameters
         finishAcquire(acquireCtx, start)
         return client
       }, error => {
@@ -98,6 +99,7 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
 
       arguments[0] = function (...args) {
         acquireCtx.error = args[0]
+        acquireCtx.params = args[1]?.connectionParameters
         finishAcquire(acquireCtx, start)
         return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
       }

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -59,10 +59,7 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
       const acquireCtx = { poolOptions: this.options }
       poolAcquireStartCh.publish(acquireCtx)
 
-      const connectResult = connect.apply(this, arguments)
-      acquireCtx.params = latestPoolConnectionParameters(this)
-
-      return connectResult.then(client => {
+      return connectForAcquire(connect, this, arguments, acquireCtx, start).then(client => {
         acquireCtx.params = client.connectionParameters
         finishAcquire(acquireCtx, start)
         return client
@@ -111,11 +108,11 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
 
     poolConnectStartCh.publish(ctx)
 
-    const connectResult = connect.apply(this, arguments)
-    if (acquireCtx !== undefined && acquireCtx.params === undefined) {
-      acquireCtx.params = latestPoolConnectionParameters(this)
+    if (acquireCtx === undefined) {
+      return connect.apply(this, arguments)
     }
-    return connectResult
+
+    return connectForAcquire(connect, this, arguments, acquireCtx, start)
   })
   shimmer.wrap(pg.Pool.prototype, 'query', query => wrapPoolQuery(query))
   return pg
@@ -289,6 +286,29 @@ function latestPoolConnectionParameters (pool) {
   // connect is still pending.
   const clients = pool._clients
   return clients?.at(-1)?.connectionParameters
+}
+
+/**
+ * @param {import('pg').Pool['connect']} connect
+ * @param {import('pg').Pool} pool
+ * @param {IArguments} args
+ * @param {{ params?: object, error?: unknown }} acquireCtx
+ * @param {number | undefined} start
+ */
+function connectForAcquire (connect, pool, args, acquireCtx, start) {
+  let result
+  try {
+    result = connect.apply(pool, args)
+  } catch (error) {
+    // pg throws synchronously when it cannot even build a client, from a malformed connection
+    // string or a caller-supplied `Client` constructor, so the span needs finishing here.
+    acquireCtx.error = error
+    finishAcquire(acquireCtx, start)
+    throw error
+  }
+
+  acquireCtx.params = latestPoolConnectionParameters(pool)
+  return result
 }
 
 /**

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -19,6 +19,9 @@ const finishPoolQueryCh = channel('datadog:pg:pool:query:finish')
 const poolConnectStartCh = channel('apm:pg:pool:connect:start')
 const poolConnectFinishCh = channel('apm:pg:pool:connect:finish')
 
+const poolAcquireStartCh = channel('apm:pg:pool:acquire:start')
+const poolAcquireFinishCh = channel('apm:pg:pool:acquire:finish')
+
 // Drivers like pg-promise reuse the same prepared-statement query object across executions; cache
 // the un-injected `text` so the wrap doesn't capture a previous DBM injection as the new original.
 const originalTextCache = new WeakMap()
@@ -29,6 +32,12 @@ const originalTextCache = new WeakMap()
 // Each entry is popped by the frame that pushed it, so no client outlives its callback.
 const poolWaitClients = []
 const poolWaitTimes = []
+
+// `Pool.prototype.query` acquires a client internally via `connect`. That acquire is reported as a
+// tag on the resulting query span, so the connect wrap must not also open a standalone acquire span
+// for it; an explicit user `pool.connect()` gets the standalone span instead. `connect` is invoked
+// synchronously from within `query`, so a module flag set around the call reliably distinguishes them.
+let acquiringForPoolQuery = false
 
 addHook({ name: 'pg', versions: ['>=8.0.3'], file: 'lib/native/client.js' }, Client => {
   shimmer.wrap(Client.prototype, 'query', query => wrapQuery(query))
@@ -44,27 +53,59 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
   // pg defers a busy pool's connect callback and runs it in the releasing query's async context;
   // capture the caller's context and restore it around the callback so spans attach to the caller.
   shimmer.wrap(pg.Pool.prototype, 'connect', connect => function (cb) {
-    if (typeof cb !== 'function' || !poolConnectStartCh.hasSubscribers) {
+    // `await pool.connect()`: no callback, so the caller's async context is preserved by the await
+    // itself and only the standalone acquire span is needed. `Pool.query` always acquires with a
+    // callback, so a missing callback is always an explicit caller-initiated acquire.
+    if (typeof cb !== 'function') {
+      if (!poolAcquireStartCh.hasSubscribers) {
+        return connect.apply(this, arguments)
+      }
+
+      const start = acquireStart(this)
+      const acquireCtx = { poolOptions: this.options }
+      poolAcquireStartCh.publish(acquireCtx)
+
+      return connect.apply(this, arguments).then(client => {
+        finishAcquire(acquireCtx, start)
+        return client
+      }, error => {
+        acquireCtx.error = error
+        finishAcquire(acquireCtx, start)
+        throw error
+      })
+    }
+
+    if (!poolConnectStartCh.hasSubscribers) {
       return connect.apply(this, arguments)
     }
 
     const ctx = {}
-    // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
-    // outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
-    const start = this.idleCount > this.waitingCount ? 0 : performance.now()
-    arguments[0] = function (...args) {
-      const client = args[1]
-      if (client !== undefined) {
-        poolWaitClients.push(client)
-        poolWaitTimes.push(start === 0 ? 0 : performance.now() - start)
-      }
-      try {
-        return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
-      } finally {
+    const start = acquireStart(this)
+
+    if (acquiringForPoolQuery) {
+      arguments[0] = function (...args) {
+        const client = args[1]
         if (client !== undefined) {
-          poolWaitClients.pop()
-          poolWaitTimes.pop()
+          poolWaitClients.push(client)
+          poolWaitTimes.push(acquireWait(start))
         }
+        try {
+          return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+        } finally {
+          if (client !== undefined) {
+            poolWaitClients.pop()
+            poolWaitTimes.pop()
+          }
+        }
+      }
+    } else {
+      const acquireCtx = { poolOptions: this.options }
+      poolAcquireStartCh.publish(acquireCtx)
+
+      arguments[0] = function (...args) {
+        acquireCtx.error = args[0]
+        finishAcquire(acquireCtx, start)
+        return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
       }
     }
 
@@ -219,10 +260,30 @@ function wrapQuery (query) {
 const finish = (ctx) => {
   finishPoolQueryCh.publish(ctx)
 }
+// pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
+// outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
+function acquireStart (pool) {
+  return pool.idleCount > pool.waitingCount ? 0 : performance.now()
+}
+function acquireWait (start) {
+  return start === 0 ? 0 : performance.now() - start
+}
+function finishAcquire (ctx, start) {
+  ctx.poolWaitTime = acquireWait(start)
+  poolAcquireFinishCh.publish(ctx)
+}
+function acquireForPoolQuery (query, pool, args) {
+  acquiringForPoolQuery = true
+  try {
+    return query.apply(pool, args)
+  } finally {
+    acquiringForPoolQuery = false
+  }
+}
 function wrapPoolQuery (query) {
   return function (...args) {
     if (!startPoolQueryCh.hasSubscribers) {
-      return query.apply(this, args)
+      return acquireForPoolQuery(query, this, args)
     }
 
     const pgQuery = args[0] !== null && typeof args[0] === 'object' ? args[0] : { text: args[0] }
@@ -252,7 +313,7 @@ function wrapPoolQuery (query) {
         })
       }
 
-      const retval = query.apply(this, args)
+      const retval = acquireForPoolQuery(query, this, args)
 
       if (retval?.then) {
         retval.then(() => {

--- a/packages/datadog-instrumentations/test/pg.spec.js
+++ b/packages/datadog-instrumentations/test/pg.spec.js
@@ -26,6 +26,8 @@ describe('pg instrumentation', () => {
       abortController.abort(error)
     }
 
+    function observeQuery () {}
+
     before(() => {
       return agent.load(['pg'])
     })
@@ -197,11 +199,20 @@ describe('pg instrumentation', () => {
         afterEach(() => {
           if (queryPoolStartChannel.hasSubscribers) {
             queryPoolStartChannel.unsubscribe(abortQuery)
+            queryPoolStartChannel.unsubscribe(observeQuery)
           }
         })
 
         describe('using callback', () => {
           it('Should not fail if it is not aborted', (done) => {
+            pool.query('SELECT 1', (err) => {
+              done(err)
+            })
+          })
+
+          it('Should run the query when a subscriber does not abort it', (done) => {
+            queryPoolStartChannel.subscribe(observeQuery)
+
             pool.query('SELECT 1', (err) => {
               done(err)
             })

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -99,14 +99,16 @@ class PGPlugin extends DatabasePlugin {
 }
 
 /**
- * @param {{ database?: string, user?: string, host?: string, port?: number }} params
+ * `Pool.options` and `Client.connectionParameters` are pg internals, so either can be missing.
+ *
+ * @param {{ database?: string, user?: string, host?: string, port?: number } | undefined} params
  */
 function connectionMeta (params) {
   return {
-    'db.name': params.database,
-    'db.user': params.user,
-    'out.host': params.host,
-    [CLIENT_PORT_KEY]: params.port,
+    'db.name': params?.database,
+    'db.user': params?.user,
+    'out.host': params?.host,
+    [CLIENT_PORT_KEY]: params?.port,
   }
 }
 

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const { storage } = require('../../datadog-core')
-const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
+const { CLIENT_PORT_KEY, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
+
+const SERVICE_FALLBACK_CONFIG = {}
 
 class PGPlugin extends DatabasePlugin {
   static id = 'pg'
@@ -20,9 +22,12 @@ class PGPlugin extends DatabasePlugin {
     this.addSub('apm:pg:pool:acquire:start', ctx => {
       const params = ctx.poolOptions
       const operationName = this.operationName({ operation: 'pool.acquire' })
+      const deferServiceResolution = typeof this.config.service === 'function'
+      const pluginConfig = deferServiceResolution ? SERVICE_FALLBACK_CONFIG : this.config
+      ctx.deferServiceResolution = deferServiceResolution
 
       this.startSpan(operationName, {
-        service: this.serviceName({ pluginConfig: this.config, params }),
+        service: this.serviceName({ pluginConfig, params }),
         resource: operationName,
         type: 'sql',
         kind: 'client',
@@ -45,6 +50,13 @@ class PGPlugin extends DatabasePlugin {
       // client exists.
       if (ctx.params !== undefined) {
         span.addTags(connectionMeta(ctx.params))
+        if (ctx.deferServiceResolution) {
+          const service = this.serviceName({ pluginConfig: this.config, params: ctx.params })
+          if (service.name) {
+            this.setServiceName(span, service.name)
+            span.setTag(SVC_SRC_KEY, service.source)
+          }
+        }
       }
       this.finish(ctx)
     })

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -16,6 +16,33 @@ class PGPlugin extends DatabasePlugin {
       ctx.parentStore = storage('legacy').getStore()
     })
     this.addBind('apm:pg:pool:connect:finish', ctx => ctx.parentStore)
+
+    this.addSub('apm:pg:pool:acquire:start', ctx => {
+      const params = ctx.poolOptions
+
+      ctx.acquireSpan = this.startSpan('pg.pool.acquire', {
+        service: this.serviceName({ pluginConfig: this.config, params }),
+        resource: 'pg.pool.acquire',
+        type: 'sql',
+        kind: 'client',
+        meta: {
+          'db.type': 'postgres',
+          'db.name': params.database,
+          'db.user': params.user,
+          'out.host': params.host,
+          [CLIENT_PORT_KEY]: params.port,
+        },
+      }, false)
+    })
+    this.addSub('apm:pg:pool:acquire:finish', ctx => {
+      const span = ctx.acquireSpan
+
+      if (ctx.error) {
+        this.addError(ctx.error, span)
+      }
+      span.setTag('db.pool.wait_time_ms', ctx.poolWaitTime)
+      span.finish()
+    })
   }
 
   bindStart (ctx) {

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -20,7 +20,7 @@ class PGPlugin extends DatabasePlugin {
     this.addSub('apm:pg:pool:acquire:start', ctx => {
       const params = ctx.poolOptions
 
-      ctx.acquireSpan = this.startSpan('pg.pool.acquire', {
+      this.startSpan('pg.pool.acquire', {
         service: this.serviceName({ pluginConfig: this.config, params }),
         resource: 'pg.pool.acquire',
         type: 'sql',
@@ -32,16 +32,16 @@ class PGPlugin extends DatabasePlugin {
           'out.host': params.host,
           [CLIENT_PORT_KEY]: params.port,
         },
-      }, false)
+      }, ctx)
     })
     this.addSub('apm:pg:pool:acquire:finish', ctx => {
-      const span = ctx.acquireSpan
+      const span = ctx.currentStore.span
 
       if (ctx.error) {
         this.addError(ctx.error, span)
       }
       span.setTag('db.pool.wait_time_ms', ctx.poolWaitTime)
-      span.finish()
+      this.finish(ctx)
     })
   }
 

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -52,6 +52,8 @@ class PGPlugin extends DatabasePlugin {
         span.addTags(connectionMeta(ctx.params))
         if (ctx.deferServiceResolution) {
           const service = this.serviceName({ pluginConfig: this.config, params: ctx.params })
+          // A `service` callback may return no name, and the start-time fallback already carries
+          // the schema default every other pg span falls back to.
           if (service.name) {
             this.setServiceName(span, service.name)
             span.setTag(SVC_SRC_KEY, service.source)

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -19,28 +19,33 @@ class PGPlugin extends DatabasePlugin {
 
     this.addSub('apm:pg:pool:acquire:start', ctx => {
       const params = ctx.poolOptions
+      const operationName = this.operationName({ operation: 'pool.acquire' })
 
-      this.startSpan('pg.pool.acquire', {
+      this.startSpan(operationName, {
         service: this.serviceName({ pluginConfig: this.config, params }),
-        resource: 'pg.pool.acquire',
+        resource: operationName,
         type: 'sql',
         kind: 'client',
         meta: {
           'db.type': 'postgres',
-          'db.name': params.database,
-          'db.user': params.user,
-          'out.host': params.host,
-          [CLIENT_PORT_KEY]: params.port,
+          ...connectionMeta(params),
         },
       }, ctx)
     })
     this.addSub('apm:pg:pool:acquire:finish', ctx => {
-      const span = ctx.currentStore.span
+      const span = ctx.currentStore?.span
+      if (span === undefined) return
 
       if (ctx.error) {
         this.addError(ctx.error, span)
       }
       span.setTag('db.pool.wait_time_ms', ctx.poolWaitTime)
+      // `Pool` options carry only what the caller passed, so anything pg resolves later - a
+      // connection string, the default port, `PG*` environment variables - is known once the
+      // client exists.
+      if (ctx.params !== undefined) {
+        span.addTags(connectionMeta(ctx.params))
+      }
       this.finish(ctx)
     })
   }
@@ -76,6 +81,18 @@ class PGPlugin extends DatabasePlugin {
     ctx.injected = this.injectDbmQuery(span, originalText, service.name, !!query.name)
 
     return ctx.currentStore
+  }
+}
+
+/**
+ * @param {{ database?: string, user?: string, host?: string, port?: number }} params
+ */
+function connectionMeta (params) {
+  return {
+    'db.name': params.database,
+    'db.user': params.user,
+    'out.host': params.host,
+    [CLIENT_PORT_KEY]: params.port,
   }
 }
 

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -4,8 +4,6 @@ const { storage } = require('../../datadog-core')
 const { CLIENT_PORT_KEY, SVC_SRC_KEY } = require('../../dd-trace/src/constants')
 const DatabasePlugin = require('../../dd-trace/src/plugins/database')
 
-const SERVICE_FALLBACK_CONFIG = {}
-
 class PGPlugin extends DatabasePlugin {
   static id = 'pg'
   static operation = 'query'
@@ -23,11 +21,13 @@ class PGPlugin extends DatabasePlugin {
       const params = ctx.poolOptions
       const operationName = this.operationName({ operation: 'pool.acquire' })
       const deferServiceResolution = typeof this.config.service === 'function'
-      const pluginConfig = deferServiceResolution ? SERVICE_FALLBACK_CONFIG : this.config
+      const service = deferServiceResolution
+        ? undefined
+        : this.serviceName({ pluginConfig: this.config, params })
       ctx.deferServiceResolution = deferServiceResolution
 
       this.startSpan(operationName, {
-        service: this.serviceName({ pluginConfig, params }),
+        service,
         resource: operationName,
         type: 'sql',
         kind: 'client',

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -42,6 +42,10 @@ class PGPlugin extends DatabasePlugin {
       span.setTag('db.stream', 1)
     }
 
+    if (ctx.poolWaitTime !== undefined) {
+      span.setTag('db.pool.wait_time_ms', ctx.poolWaitTime)
+    }
+
     ctx.injected = this.injectDbmQuery(span, originalText, service.name, !!query.name)
 
     return ctx.currentStore

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -902,6 +902,29 @@ describe('Plugin', () => {
           }
         })
 
+        it('finishes the acquire span when connecting throws synchronously', async () => {
+          const throwingPool = new pg.Pool({ connectionString: 'postgres://[invalid' })
+          const parent = tracer.startSpan('sync-throw-parent')
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.error, 1)
+          })
+
+          await Promise.all([
+            tracePromise,
+            tracer.scope().activate(parent, async () => {
+              try {
+                assert.throws(() => throwingPool.connect(), { message: 'Invalid URL' })
+              } finally {
+                parent.finish()
+              }
+            }),
+          ])
+        })
+
         it('does not create an acquire span for pool.query', async () => {
           await Promise.all([
             agent.assertSomeTraces(traces => {
@@ -975,9 +998,11 @@ describe('Plugin', () => {
       describe('with a service name callback', () => {
         before(() => {
           return agent.load('pg', {
-            service: params => params.application_name === 'tracer-service'
-              ? 'test'
-              : `${params.host.toUpperCase()}-${params.database}`,
+            service (params) {
+              if (params.application_name === 'tracer-service') return 'test'
+              if (params.application_name === 'no-service') return undefined
+              return `${params.host.toUpperCase()}-${params.database}`
+            },
           })
         })
 
@@ -1043,6 +1068,46 @@ describe('Plugin', () => {
                 try {
                   poolClient = await connectionStringPool.connect()
                   await poolClient.query('SELECT 16 AS service_probe')
+                } finally {
+                  poolClient?.release()
+                  parent.finish()
+                }
+              }),
+            ])
+          } finally {
+            await connectionStringPool.end()
+          }
+        })
+
+        it('keeps the schema fallback when a pool callback returns no name', async () => {
+          await client.end()
+
+          const connectionStringPool = new pg.Pool({
+            connectionString: 'postgres://postgres:postgres@127.0.0.1:5432/postgres',
+            application_name: 'no-service',
+            max: 1,
+          })
+          const parent = tracer.startSpan('no-service-parent')
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+            const querySpan = traces[0].find(span => span.resource === 'SELECT 17 AS fallback_probe')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.service, 'test-postgres')
+
+            assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.strictEqual(querySpan.service, acquireSpan.service)
+          })
+
+          try {
+            await Promise.all([
+              tracePromise,
+              tracer.scope().activate(parent, async () => {
+                let poolClient
+                try {
+                  poolClient = await connectionStringPool.connect()
+                  await poolClient.query('SELECT 17 AS fallback_probe')
                 } finally {
                   poolClient?.release()
                   parent.finish()

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -405,6 +405,18 @@ describe('Plugin', () => {
           return pool.end()
         })
 
+        withPeerService(
+          () => tracer,
+          'pg',
+          async () => {
+            const client = await pool.connect()
+            client.release()
+          },
+          'postgres',
+          'db.name',
+          { resource: 'pg.pool.acquire' }
+        )
+
         it('keeps a query that waits for a busy pool parented to its own caller', done => {
           const root = tracer.startSpan('root')
           const parent1 = tracer.startSpan('parent1', { childOf: root })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -472,6 +472,23 @@ describe('Plugin', () => {
           ])
         })
 
+        it('traces an acquire for a pool that exposes no connection options', async () => {
+          const ctx = {}
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.meta['db.type'], 'postgres')
+            assert.strictEqual(acquireSpan.meta['db.name'], undefined)
+          })
+
+          dc.channel('apm:pg:pool:acquire:start').publish(ctx)
+          dc.channel('apm:pg:pool:acquire:finish').publish(ctx)
+
+          await tracePromise
+        })
+
         it('keeps a query that waits for a busy pool parented to its own caller', done => {
           const root = tracer.startSpan('root')
           const parent1 = tracer.startSpan('parent1', { childOf: root })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -904,6 +904,41 @@ describe('Plugin', () => {
           })
         })
 
+        it('records resolved connection tags when a callback connect fails', async () => {
+          await withUnreachablePort(async port => {
+            const failingPool = new pg.Pool({
+              connectionString: `postgres://postgres:postgres@127.0.0.1:${port}/postgres`,
+              connectionTimeoutMillis: 500,
+            })
+            failingPool.on('error', () => {})
+
+            const tracePromise = agent.assertSomeTraces(traces => {
+              const acquireSpan = findAcquireSpan(traces[0])
+
+              assert.strictEqual(acquireSpan.error, 1)
+              assertObjectContains(acquireSpan, {
+                meta: {
+                  'db.name': 'postgres',
+                  'db.user': 'postgres',
+                  'out.host': '127.0.0.1',
+                },
+                metrics: {
+                  'network.destination.port': port,
+                },
+              })
+            })
+
+            await withPool(failingPool, async () => {
+              const error = await new Promise(resolve => {
+                failingPool.connect(resolve)
+              })
+
+              assert.ok(error, 'expected the callback connect to fail')
+              await tracePromise
+            })
+          })
+        })
+
         it('finishes the acquire span when connecting throws synchronously', async () => {
           const throwingPool = new pg.Pool({ connectionString: 'postgres://[invalid' })
           const parent = tracer.startSpan('sync-throw-parent')

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -25,6 +25,97 @@ if (process.env.PG_TEST_NATIVE === 'true') {
   clients['pg.native'] = pg => pg.native.Client
 }
 
+const POSTGRES_TARGET = {
+  host: '127.0.0.1',
+  user: 'postgres',
+  password: 'postgres',
+  database: 'postgres',
+  application_name: 'test',
+}
+
+/**
+ * @param {Record<string, string | number>} [overrides]
+ */
+function poolOptions (overrides) {
+  return { ...POSTGRES_TARGET, max: 1, ...overrides }
+}
+
+/**
+ * @param {number} start
+ * @param {(advanceTo: (value: number) => void) => Promise<unknown>} run
+ */
+async function withFakeNow (start, run) {
+  const nowStub = sinon.stub(performance, 'now').returns(start)
+
+  try {
+    await run(value => nowStub.returns(value))
+  } finally {
+    nowStub.restore()
+  }
+}
+
+/**
+ * Serve a port that accepts the TCP connection and destroys it, so pg fails after connecting.
+ *
+ * @param {(port: number) => Promise<unknown>} run
+ */
+async function withUnreachablePort (run) {
+  const probe = net.createServer(socket => socket.destroy())
+  probe.listen(0, '127.0.0.1')
+  await once(probe, 'listening')
+
+  try {
+    await run(probe.address().port)
+  } finally {
+    const closed = once(probe, 'close')
+    probe.close()
+    await closed
+  }
+}
+
+/**
+ * @param {{ end: () => Promise<unknown> }} pool
+ * @param {(pool: object) => Promise<unknown>} run
+ */
+async function withPool (pool, run) {
+  try {
+    await run(pool)
+  } finally {
+    await pool.end()
+  }
+}
+
+/**
+ * @param {Array<{ name: string }>} spans
+ */
+function findAcquireSpan (spans) {
+  const span = spans.find(candidate => candidate.name.endsWith('.pool.acquire'))
+  assert.ok(span, `missing acquire span: ${inspect(spans.map(candidate => candidate.name))}`)
+  return span
+}
+
+/**
+ * The body owns `release` on success so a test can time it; a throwing body releases with the error.
+ *
+ * @param {{ connect: Function }} pool
+ * @param {(client: object, release: (error?: unknown) => void) => unknown} run
+ */
+function acquireWithCallback (pool, run) {
+  return new Promise((resolve, reject) => {
+    pool.connect((error, client, release) => {
+      if (error) {
+        reject(error)
+        return
+      }
+
+      Promise.resolve(run(client, release)).then(resolve, failure => {
+        release(failure)
+        reject(failure)
+      })
+    })
+  })
+}
+
 describe('Plugin', () => {
   let pg
   let client
@@ -391,14 +482,7 @@ describe('Plugin', () => {
         beforeEach(() => {
           pg = require(`../../../versions/pg@${version}`).get()
 
-          pool = new pg.Pool({
-            host: '127.0.0.1',
-            user: 'postgres',
-            password: 'postgres',
-            database: 'postgres',
-            application_name: 'test',
-            max: 1,
-          })
+          pool = new pg.Pool(poolOptions())
         })
 
         afterEach(() => {
@@ -436,9 +520,7 @@ describe('Plugin', () => {
           })
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
-
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            const acquireSpan = findAcquireSpan(traces[0])
             assertObjectContains(acquireSpan, {
               meta: {
                 'db.name': 'postgres',
@@ -451,14 +533,12 @@ describe('Plugin', () => {
             })
           })
 
-          try {
+          await withPool(connectionStringPool, async () => {
             const client = await connectionStringPool.connect()
             client.release()
 
             await tracePromise
-          } finally {
-            await connectionStringPool.end()
-          }
+          })
         })
 
         it('keeps tracing when an acquire finishes without a matching start', async () => {
@@ -476,9 +556,7 @@ describe('Plugin', () => {
           const ctx = {}
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
-
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            const acquireSpan = findAcquireSpan(traces[0])
             assert.strictEqual(acquireSpan.meta['db.type'], 'postgres')
             assert.strictEqual(acquireSpan.meta['db.name'], undefined)
           })
@@ -551,23 +629,19 @@ describe('Plugin', () => {
         })
 
         it('records the wait of an acquire that opens a new connection', async () => {
-          const nowStub = sinon.stub(performance, 'now').returns(100)
-
           const tracePromise = agent.assertSomeTraces(traces => {
             assert.strictEqual(traces[0][0].metrics['db.pool.wait_time_ms'], 50)
           }, { spanResourceMatch: /^SELECT 4 AS pool_wait_probe$/ })
 
-          try {
+          await withFakeNow(100, async advanceTo => {
             const queryPromise = pool.query('SELECT 4 AS pool_wait_probe')
-            nowStub.returns(150)
+            advanceTo(150)
 
             await Promise.all([
               tracePromise,
               queryPromise,
             ])
-          } finally {
-            nowStub.restore()
-          }
+          })
         })
 
         it('reports a zero wait time when an idle pooled client is reused', async () => {
@@ -584,66 +658,55 @@ describe('Plugin', () => {
         it('reports a queued warm-pool wait without charging the first idle handoff', async () => {
           await pool.query('SELECT 1')
 
-          const nowStub = sinon.stub(performance, 'now').returns(100)
           const tracePromise = agent.assertSomeTraces(traces => {
             assert.strictEqual(traces[0][0].metrics['db.pool.wait_time_ms'], 50)
           }, { spanResourceMatch: /^SELECT 9 AS queued_probe$/ })
 
-          try {
+          await withFakeNow(100, async advanceTo => {
             const idleQuery = pool.query('SELECT 8 AS idle_taker')
             const queuedQuery = pool.query('SELECT 9 AS queued_probe')
-            nowStub.returns(150)
+            advanceTo(150)
 
             await Promise.all([
               tracePromise,
               idleQuery,
               queuedQuery,
             ])
-          } finally {
-            nowStub.restore()
-          }
+          })
         })
 
         it('keeps a concurrent acquire on another pool independent', async () => {
-          const otherPool = new pg.Pool({
-            host: '127.0.0.1',
-            user: 'postgres',
-            password: 'postgres',
-            database: 'postgres',
-            application_name: 'test',
-            max: 1,
-          })
+          const otherPool = new pg.Pool(poolOptions())
 
           let starvedWaitTime
           let idleWaitTime
           let heldClient
           let released = false
-          let nowStub
 
           try {
             await otherPool.query('SELECT 1')
             heldClient = await pool.connect()
-            nowStub = sinon.stub(performance, 'now').returns(100)
 
-            const starvedTrace = agent.assertSomeTraces(traces => {
-              starvedWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
-            }, { spanResourceMatch: /^SELECT 5 AS starved_probe$/ })
-            const idleTrace = agent.assertSomeTraces(traces => {
-              idleWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
-            }, { spanResourceMatch: /^SELECT 6 AS other_pool_probe$/ })
-            const starvedQuery = pool.query('SELECT 5 AS starved_probe')
-            const idleQuery = otherPool.query('SELECT 6 AS other_pool_probe')
+            await withFakeNow(100, async advanceTo => {
+              const starvedTrace = agent.assertSomeTraces(traces => {
+                starvedWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+              }, { spanResourceMatch: /^SELECT 5 AS starved_probe$/ })
+              const idleTrace = agent.assertSomeTraces(traces => {
+                idleWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+              }, { spanResourceMatch: /^SELECT 6 AS other_pool_probe$/ })
+              const starvedQuery = pool.query('SELECT 5 AS starved_probe')
+              const idleQuery = otherPool.query('SELECT 6 AS other_pool_probe')
 
-            nowStub.returns(150)
-            heldClient.release()
-            released = true
+              advanceTo(150)
+              heldClient.release()
+              released = true
 
-            await Promise.all([starvedTrace, idleTrace, starvedQuery, idleQuery])
+              await Promise.all([starvedTrace, idleTrace, starvedQuery, idleQuery])
+            })
           } finally {
             if (heldClient !== undefined && !released) {
               heldClient.release()
             }
-            nowStub?.restore()
             await otherPool.end()
           }
 
@@ -652,13 +715,7 @@ describe('Plugin', () => {
         })
 
         it('reports an explicit acquire on its own span and leaves every query span untagged', async () => {
-          const standalone = new pg.Client({
-            host: '127.0.0.1',
-            user: 'postgres',
-            password: 'postgres',
-            database: 'postgres',
-            application_name: 'test',
-          })
+          const standalone = new pg.Client(POSTGRES_TARGET)
 
           await standalone.connect()
 
@@ -682,29 +739,14 @@ describe('Plugin', () => {
           })
 
           try {
-            const operation = new Promise((resolve, reject) => {
-              tracer.scope().activate(parent, () => {
-                pool.connect(async (error, client, release) => {
-                  if (error) {
-                    parent.finish()
-                    reject(error)
-                    return
-                  }
-
-                  try {
-                    await Promise.all([
-                      standalone.query('SELECT 10 AS unrelated_probe'),
-                      client.query('SELECT 11 AS acquired_probe'),
-                    ])
-                    release()
-                    parent.finish()
-                    resolve()
-                  } catch (error) {
-                    release(error)
-                    parent.finish()
-                    reject(error)
-                  }
-                })
+            const operation = tracer.scope().activate(parent, () => {
+              return acquireWithCallback(pool, async (client, release) => {
+                await Promise.all([
+                  standalone.query('SELECT 10 AS unrelated_probe'),
+                  client.query('SELECT 11 AS acquired_probe'),
+                ])
+                release()
+                parent.finish()
               })
             })
 
@@ -716,7 +758,6 @@ describe('Plugin', () => {
 
         it('gives an acquire nested in a release its own wait', async () => {
           const parent = tracer.startSpan('nested-acquire-parent')
-          const nowStub = sinon.stub(performance, 'now').returns(100)
 
           const tracePromise = agent.assertSomeTraces(traces => {
             const waits = traces[0]
@@ -726,73 +767,41 @@ describe('Plugin', () => {
             assert.deepStrictEqual(waits, [10, 10])
           })
 
-          try {
-            const operation = new Promise((resolve, reject) => {
-              tracer.scope().activate(parent, () => {
-                pool.connect((error, client, release) => {
-                  if (error) {
-                    reject(error)
-                    return
-                  }
-
-                  pool.connect((nestedError, nestedClient, nestedRelease) => {
-                    if (nestedError) {
-                      reject(nestedError)
-                      return
-                    }
-
-                    nestedClient.query('SELECT 12 AS nested_probe', queryError => {
-                      nestedRelease()
-                      parent.finish()
-
-                      if (queryError) {
-                        reject(queryError)
-                      } else {
-                        resolve()
-                      }
-                    })
-                  })
-
-                  nowStub.returns(120)
-                  release()
+          await withFakeNow(100, async advanceTo => {
+            const operation = tracer.scope().activate(parent, () => {
+              return acquireWithCallback(pool, (client, release) => {
+                const nested = acquireWithCallback(pool, async (nestedClient, nestedRelease) => {
+                  await nestedClient.query('SELECT 12 AS nested_probe')
+                  nestedRelease()
+                  parent.finish()
                 })
+
+                advanceTo(120)
+                release()
+
+                return nested
               })
             })
 
-            nowStub.returns(110)
+            advanceTo(110)
 
             await Promise.all([tracePromise, operation])
-          } finally {
-            nowStub.restore()
-          }
+          })
         })
 
         it('does not throw when the pool fails to acquire a connection', async () => {
-          const probe = net.createServer(socket => socket.destroy())
-          probe.listen(0, '127.0.0.1')
-          await once(probe, 'listening')
+          await withUnreachablePort(async port => {
+            const failingPool = new pg.Pool(poolOptions({ port, connectionTimeoutMillis: 500 }))
+            failingPool.on('error', () => {})
 
-          const { port } = probe.address()
-          const failingPool = new pg.Pool({
-            host: '127.0.0.1',
-            port,
-            user: 'postgres',
-            database: 'postgres',
-            connectionTimeoutMillis: 500,
-          })
-          failingPool.on('error', () => {})
+            await withPool(failingPool, async () => {
+              const error = await new Promise(resolve => {
+                failingPool.query('SELECT 1', resolve)
+              })
 
-          try {
-            const error = await new Promise(resolve => {
-              failingPool.query('SELECT 1', resolve)
+              assert.ok(error, 'expected the pool connection to fail')
             })
-
-            assert.ok(error, 'expected the pool connection to fail')
-          } finally {
-            const closePromise = once(probe, 'close')
-            probe.close()
-            await Promise.all([failingPool.end(), closePromise])
-          }
+          })
         })
 
         it('creates a dedicated acquire span for an explicit promise pool.connect()', async () => {
@@ -825,7 +834,6 @@ describe('Plugin', () => {
         it('keeps the acquire wait when an async callback defers its query', async () => {
           const blocker = await pool.connect()
           const parent = tracer.startSpan('acquire-callback-parent')
-          const nowStub = sinon.stub(performance, 'now').returns(100)
           let blockerReleased = false
 
           const tracePromise = agent.assertSomeTraces(traces => {
@@ -841,82 +849,59 @@ describe('Plugin', () => {
           })
 
           try {
-            const operation = new Promise((resolve, reject) => {
-              tracer.scope().activate(parent, () => {
-                pool.connect(async (error, client, release) => {
-                  if (error) {
-                    parent.finish()
-                    reject(error)
-                    return
-                  }
-
-                  try {
-                    await new Promise(resolve => setImmediate(resolve))
-                    await client.query('SELECT 14 AS deferred_probe')
-                    release()
-                    parent.finish()
-                    resolve()
-                  } catch (error) {
-                    release(error)
-                    parent.finish()
-                    reject(error)
-                  }
+            await withFakeNow(100, async advanceTo => {
+              const operation = tracer.scope().activate(parent, () => {
+                return acquireWithCallback(pool, async (client, release) => {
+                  await new Promise(resolve => setImmediate(resolve))
+                  await client.query('SELECT 14 AS deferred_probe')
+                  release()
+                  parent.finish()
                 })
               })
+
+              advanceTo(150)
+              blocker.release()
+              blockerReleased = true
+
+              await Promise.all([tracePromise, operation])
             })
-
-            nowStub.returns(150)
-            blocker.release()
-            blockerReleased = true
-
-            await Promise.all([tracePromise, operation])
           } finally {
             if (!blockerReleased) {
               blocker.release()
             }
-            nowStub.restore()
           }
         })
 
         it('records an error on the acquire span when an explicit connect fails', async () => {
-          const probe = net.createServer(socket => socket.destroy())
-          probe.listen(0, '127.0.0.1')
-          await once(probe, 'listening')
-          const { port } = probe.address()
+          await withUnreachablePort(async port => {
+            const failingPool = new pg.Pool({
+              connectionString: `postgres://postgres:postgres@127.0.0.1:${port}/postgres`,
+              connectionTimeoutMillis: 500,
+            })
+            failingPool.on('error', () => {})
 
-          const failingPool = new pg.Pool({
-            connectionString: `postgres://postgres:postgres@127.0.0.1:${port}/postgres`,
-            connectionTimeoutMillis: 500,
-          })
-          failingPool.on('error', () => {})
+            const tracePromise = agent.assertSomeTraces(traces => {
+              const acquireSpan = findAcquireSpan(traces[0])
+              assert.strictEqual(acquireSpan.error, 1)
+              assertObjectContains(acquireSpan, {
+                meta: {
+                  'db.name': 'postgres',
+                  'db.user': 'postgres',
+                  'out.host': '127.0.0.1',
+                },
+                metrics: {
+                  'network.destination.port': port,
+                },
+              })
+            })
 
-          const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
-
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
-            assert.strictEqual(acquireSpan.error, 1)
-            assertObjectContains(acquireSpan, {
-              meta: {
-                'db.name': 'postgres',
-                'db.user': 'postgres',
-                'out.host': '127.0.0.1',
-              },
-              metrics: {
-                'network.destination.port': port,
-              },
+            await withPool(failingPool, async () => {
+              await Promise.all([
+                assert.rejects(failingPool.connect()),
+                tracePromise,
+              ])
             })
           })
-
-          try {
-            await Promise.all([
-              assert.rejects(failingPool.connect()),
-              tracePromise,
-            ])
-          } finally {
-            const closePromise = once(probe, 'close')
-            probe.close()
-            await Promise.all([failingPool.end(), closePromise])
-          }
         })
 
         it('finishes the acquire span when connecting throws synchronously', async () => {
@@ -924,9 +909,7 @@ describe('Plugin', () => {
           const parent = tracer.startSpan('sync-throw-parent')
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
-
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            const acquireSpan = findAcquireSpan(traces[0])
             assert.strictEqual(acquireSpan.error, 1)
           })
 
@@ -1067,17 +1050,16 @@ describe('Plugin', () => {
           const parent = tracer.startSpan('pool-service-parent')
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+            const acquireSpan = findAcquireSpan(traces[0])
             const querySpan = traces[0].find(span => span.resource === 'SELECT 16 AS service_probe')
 
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
             assert.strictEqual(acquireSpan.service, '127.0.0.1-postgres')
             assert.strictEqual(acquireSpan.meta['_dd.svc_src'], 'opt.plugin')
             assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
             assert.strictEqual(querySpan.service, acquireSpan.service)
           })
 
-          try {
+          await withPool(connectionStringPool, async () => {
             await Promise.all([
               tracePromise,
               tracer.scope().activate(parent, async () => {
@@ -1091,9 +1073,7 @@ describe('Plugin', () => {
                 }
               }),
             ])
-          } finally {
-            await connectionStringPool.end()
-          }
+          })
         })
 
         it('keeps the schema fallback when a pool callback returns no name', async () => {
@@ -1107,10 +1087,9 @@ describe('Plugin', () => {
           const parent = tracer.startSpan('no-service-parent')
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+            const acquireSpan = findAcquireSpan(traces[0])
             const querySpan = traces[0].find(span => span.resource === 'SELECT 17 AS fallback_probe')
 
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
             assert.strictEqual(acquireSpan.service, 'test-postgres')
             assert.strictEqual(acquireSpan.meta['_dd.svc_src'], 'postgres')
 
@@ -1119,7 +1098,7 @@ describe('Plugin', () => {
             assert.strictEqual(querySpan.meta['_dd.svc_src'], acquireSpan.meta['_dd.svc_src'])
           })
 
-          try {
+          await withPool(connectionStringPool, async () => {
             await Promise.all([
               tracePromise,
               tracer.scope().activate(parent, async () => {
@@ -1133,9 +1112,7 @@ describe('Plugin', () => {
                 }
               }),
             ])
-          } finally {
-            await connectionStringPool.end()
-          }
+          })
         })
 
         it('clears the service source when a pool callback resolves to the tracer service', async () => {
@@ -1148,14 +1125,12 @@ describe('Plugin', () => {
           })
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
-
-            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            const acquireSpan = findAcquireSpan(traces[0])
             assert.strictEqual(acquireSpan.service, 'test')
             assert.ok(!Object.hasOwn(acquireSpan.meta, '_dd.svc_src'))
           })
 
-          try {
+          await withPool(connectionStringPool, async () => {
             await Promise.all([
               tracePromise,
               (async () => {
@@ -1163,9 +1138,7 @@ describe('Plugin', () => {
                 poolClient.release()
               })(),
             ])
-          } finally {
-            await connectionStringPool.end()
-          }
+          })
         })
 
         withNamingSchema(

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -417,6 +417,61 @@ describe('Plugin', () => {
           { resource: 'pg.pool.acquire' }
         )
 
+        withNamingSchema(
+          async () => {
+            const client = await pool.connect()
+            client.release()
+          },
+          rawExpectedSchema.poolAcquire,
+          {
+            desc: 'pool acquire',
+            selectSpan: traces => traces[0].find(span => span.name.endsWith('.pool.acquire')),
+          }
+        )
+
+        it('resolves acquire tags for a pool configured with a connection string', async () => {
+          const connectionStringPool = new pg.Pool({
+            connectionString: 'postgres://postgres:postgres@127.0.0.1:5432/postgres',
+            max: 1,
+          })
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assertObjectContains(acquireSpan, {
+              meta: {
+                'db.name': 'postgres',
+                'db.user': 'postgres',
+                'out.host': '127.0.0.1',
+              },
+              metrics: {
+                'network.destination.port': 5432,
+              },
+            })
+          })
+
+          try {
+            const client = await connectionStringPool.connect()
+            client.release()
+
+            await tracePromise
+          } finally {
+            await connectionStringPool.end()
+          }
+        })
+
+        it('keeps tracing when an acquire finishes without a matching start', async () => {
+          dc.channel('apm:pg:pool:acquire:finish').publish({ poolWaitTime: 1 })
+
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].meta['db.type'], 'postgres')
+            }, { spanResourceMatch: /^SELECT 15 AS survivor$/ }),
+            pool.query('SELECT 15 AS survivor'),
+          ])
+        })
+
         it('keeps a query that waits for a busy pool parented to its own caller', done => {
           const root = tracer.startSpan('root')
           const parent1 = tracer.startSpan('parent1', { childOf: root })

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -868,19 +868,26 @@ describe('Plugin', () => {
           const { port } = probe.address()
 
           const failingPool = new pg.Pool({
-            host: '127.0.0.1',
-            port,
-            user: 'postgres',
-            database: 'postgres',
+            connectionString: `postgres://postgres:postgres@127.0.0.1:${port}/postgres`,
             connectionTimeoutMillis: 500,
           })
           failingPool.on('error', () => {})
 
           const tracePromise = agent.assertSomeTraces(traces => {
-            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
 
             assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
             assert.strictEqual(acquireSpan.error, 1)
+            assertObjectContains(acquireSpan, {
+              meta: {
+                'db.name': 'postgres',
+                'db.user': 'postgres',
+                'out.host': '127.0.0.1',
+              },
+              metrics: {
+                'network.destination.port': port,
+              },
+            })
           })
 
           try {
@@ -967,7 +974,11 @@ describe('Plugin', () => {
 
       describe('with a service name callback', () => {
         before(() => {
-          return agent.load('pg', { service: params => `${params.host}-${params.database}` })
+          return agent.load('pg', {
+            service: params => params.application_name === 'tracer-service'
+              ? 'test'
+              : `${params.host.toUpperCase()}-${params.database}`,
+          })
         })
 
         after(() => {
@@ -1002,6 +1013,75 @@ describe('Plugin', () => {
               if (err) throw err
             })
           })
+        })
+
+        it('resolves a pool acquire service from normalized connection parameters', async () => {
+          await client.end()
+
+          const connectionStringPool = new pg.Pool({
+            connectionString: 'postgres://postgres:postgres@127.0.0.1:5432/postgres',
+            max: 1,
+          })
+          const parent = tracer.startSpan('pool-service-parent')
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+            const querySpan = traces[0].find(span => span.resource === 'SELECT 16 AS service_probe')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.service, '127.0.0.1-postgres')
+            assert.strictEqual(acquireSpan.meta['_dd.svc_src'], 'opt.plugin')
+            assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.strictEqual(querySpan.service, acquireSpan.service)
+          })
+
+          try {
+            await Promise.all([
+              tracePromise,
+              tracer.scope().activate(parent, async () => {
+                let poolClient
+                try {
+                  poolClient = await connectionStringPool.connect()
+                  await poolClient.query('SELECT 16 AS service_probe')
+                } finally {
+                  poolClient?.release()
+                  parent.finish()
+                }
+              }),
+            ])
+          } finally {
+            await connectionStringPool.end()
+          }
+        })
+
+        it('clears the service source when a pool callback resolves to the tracer service', async () => {
+          await client.end()
+
+          const connectionStringPool = new pg.Pool({
+            connectionString: 'postgres://postgres:postgres@127.0.0.1:5432/postgres',
+            application_name: 'tracer-service',
+            max: 1,
+          })
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name.endsWith('.pool.acquire'))
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.service, 'test')
+            assert.ok(!Object.hasOwn(acquireSpan.meta, '_dd.svc_src'))
+          })
+
+          try {
+            await Promise.all([
+              tracePromise,
+              (async () => {
+                const poolClient = await connectionStringPool.connect()
+                poolClient.release()
+              })(),
+            ])
+          } finally {
+            await connectionStringPool.end()
+          }
         })
 
         withNamingSchema(

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -1095,9 +1095,11 @@ describe('Plugin', () => {
 
             assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
             assert.strictEqual(acquireSpan.service, 'test-postgres')
+            assert.strictEqual(acquireSpan.meta['_dd.svc_src'], 'postgres')
 
             assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
             assert.strictEqual(querySpan.service, acquireSpan.service)
+            assert.strictEqual(querySpan.meta['_dd.svc_src'], acquireSpan.meta['_dd.svc_src'])
           })
 
           try {

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -1,11 +1,14 @@
 'use strict'
 
-const assert = require('node:assert')
-const EventEmitter = require('node:events')
+const assert = require('node:assert/strict')
+const { EventEmitter, once } = require('node:events')
 const net = require('node:net')
+const { performance } = require('node:perf_hooks')
 const { inspect } = require('node:util')
 
+const dc = require('dc-polyfill')
 const semver = require('semver')
+const sinon = require('sinon')
 
 const ddpv = require('mocha/package.json').version
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
@@ -464,14 +467,23 @@ describe('Plugin', () => {
         })
 
         it('records the wait of an acquire that opens a new connection', async () => {
-          await Promise.all([
-            agent.assertSomeTraces(traces => {
-              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const nowStub = sinon.stub(performance, 'now').returns(100)
 
-              assert.ok(waitTime > 0, `expected a positive wait, got ${waitTime}`)
-            }, { spanResourceMatch: /^SELECT 4 AS pool_wait_probe$/ }),
-            pool.query('SELECT 4 AS pool_wait_probe'),
-          ])
+          const tracePromise = agent.assertSomeTraces(traces => {
+            assert.strictEqual(traces[0][0].metrics['db.pool.wait_time_ms'], 50)
+          }, { spanResourceMatch: /^SELECT 4 AS pool_wait_probe$/ })
+
+          try {
+            const queryPromise = pool.query('SELECT 4 AS pool_wait_probe')
+            nowStub.returns(150)
+
+            await Promise.all([
+              tracePromise,
+              queryPromise,
+            ])
+          } finally {
+            nowStub.restore()
+          }
         })
 
         it('reports a zero wait time when an idle pooled client is reused', async () => {
@@ -485,20 +497,27 @@ describe('Plugin', () => {
           ])
         })
 
-        it('reports a positive wait time when a same-tick query takes the only idle client', async () => {
+        it('reports a queued warm-pool wait without charging the first idle handoff', async () => {
           await pool.query('SELECT 1')
 
-          // The first query takes the idle client and the second queues behind it, while
-          // `idleCount` still reads 1 for both.
-          await Promise.all([
-            agent.assertSomeTraces(traces => {
-              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const nowStub = sinon.stub(performance, 'now').returns(100)
+          const tracePromise = agent.assertSomeTraces(traces => {
+            assert.strictEqual(traces[0][0].metrics['db.pool.wait_time_ms'], 50)
+          }, { spanResourceMatch: /^SELECT 9 AS queued_probe$/ })
 
-              assert.ok(waitTime > 0, `expected a positive wait, got ${waitTime}`)
-            }, { spanResourceMatch: /^SELECT 9 AS queued_probe$/ }),
-            pool.query('SELECT 8 AS idle_taker'),
-            pool.query('SELECT 9 AS queued_probe'),
-          ])
+          try {
+            const idleQuery = pool.query('SELECT 8 AS idle_taker')
+            const queuedQuery = pool.query('SELECT 9 AS queued_probe')
+            nowStub.returns(150)
+
+            await Promise.all([
+              tracePromise,
+              idleQuery,
+              queuedQuery,
+            ])
+          } finally {
+            nowStub.restore()
+          }
         })
 
         it('keeps a concurrent acquire on another pool independent', async () => {
@@ -513,26 +532,38 @@ describe('Plugin', () => {
 
           let starvedWaitTime
           let idleWaitTime
+          let heldClient
+          let released = false
+          let nowStub
 
           try {
-            await Promise.all([pool.query('SELECT 1'), otherPool.query('SELECT 1')])
+            await otherPool.query('SELECT 1')
+            heldClient = await pool.connect()
+            nowStub = sinon.stub(performance, 'now').returns(100)
 
-            await Promise.all([
-              agent.assertSomeTraces(traces => {
-                starvedWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
-              }, { spanResourceMatch: /^SELECT 5 AS starved_probe$/ }),
-              agent.assertSomeTraces(traces => {
-                idleWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
-              }, { spanResourceMatch: /^SELECT 6 AS other_pool_probe$/ }),
-              pool.query('SELECT pg_sleep(0.2)'),
-              pool.query('SELECT 5 AS starved_probe'),
-              otherPool.query('SELECT 6 AS other_pool_probe'),
-            ])
+            const starvedTrace = agent.assertSomeTraces(traces => {
+              starvedWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+            }, { spanResourceMatch: /^SELECT 5 AS starved_probe$/ })
+            const idleTrace = agent.assertSomeTraces(traces => {
+              idleWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+            }, { spanResourceMatch: /^SELECT 6 AS other_pool_probe$/ })
+            const starvedQuery = pool.query('SELECT 5 AS starved_probe')
+            const idleQuery = otherPool.query('SELECT 6 AS other_pool_probe')
+
+            nowStub.returns(150)
+            heldClient.release()
+            released = true
+
+            await Promise.all([starvedTrace, idleTrace, starvedQuery, idleQuery])
           } finally {
+            if (heldClient !== undefined && !released) {
+              heldClient.release()
+            }
+            nowStub?.restore()
             await otherPool.end()
           }
 
-          assert.ok(starvedWaitTime > 150, `expected the starved pool to wait for its sleep, got ${starvedWaitTime}`)
+          assert.strictEqual(starvedWaitTime, 50)
           assert.strictEqual(idleWaitTime, 0)
         })
 
@@ -557,7 +588,7 @@ describe('Plugin', () => {
             assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
 
             const waitTime = acquireSpan.metrics['db.pool.wait_time_ms']
-            assert.ok(waitTime > 0, `expected the acquire span to carry the wait, got ${waitTime}`)
+            assert.strictEqual(typeof waitTime, 'number')
 
             assert.ok(unrelatedSpan, `missing unrelated span: ${inspect(traces[0].map(span => span.resource))}`)
             assert.ok(!Object.hasOwn(unrelatedSpan.metrics, 'db.pool.wait_time_ms'))
@@ -567,27 +598,33 @@ describe('Plugin', () => {
           })
 
           try {
-            await new Promise((resolve, reject) => {
+            const operation = new Promise((resolve, reject) => {
               tracer.scope().activate(parent, () => {
-                pool.connect((error, client, release) => {
+                pool.connect(async (error, client, release) => {
                   if (error) {
+                    parent.finish()
                     reject(error)
                     return
                   }
 
-                  const unrelated = standalone.query('SELECT 10 AS unrelated_probe')
-                  const acquired = client.query('SELECT 11 AS acquired_probe')
-
-                  Promise.all([unrelated, acquired]).then(() => {
+                  try {
+                    await Promise.all([
+                      standalone.query('SELECT 10 AS unrelated_probe'),
+                      client.query('SELECT 11 AS acquired_probe'),
+                    ])
                     release()
                     parent.finish()
                     resolve()
-                  }, reject)
+                  } catch (error) {
+                    release(error)
+                    parent.finish()
+                    reject(error)
+                  }
                 })
               })
             })
 
-            await tracePromise
+            await Promise.all([tracePromise, operation])
           } finally {
             await standalone.end()
           }
@@ -595,86 +632,33 @@ describe('Plugin', () => {
 
         it('gives an acquire nested in a release its own wait', async () => {
           const parent = tracer.startSpan('nested-acquire-parent')
+          const nowStub = sinon.stub(performance, 'now').returns(100)
 
           const tracePromise = agent.assertSomeTraces(traces => {
             const waits = traces[0]
               .filter(span => span.name === 'pg.pool.acquire')
               .map(span => span.metrics['db.pool.wait_time_ms'])
 
-            assert.strictEqual(waits.length, 2, `expected one span per acquire, got ${inspect(waits)}`)
-
-            for (const wait of waits) {
-              assert.ok(wait > 0, `expected each acquire to carry its own wait, got ${inspect(waits)}`)
-            }
+            assert.deepStrictEqual(waits, [10, 10])
           })
 
-          await new Promise((resolve, reject) => {
-            tracer.scope().activate(parent, () => {
-              pool.connect((error, client, release) => {
-                if (error) {
-                  reject(error)
-                  return
-                }
-
-                pool.connect((nestedError, nestedClient, nestedRelease) => {
-                  if (nestedError) {
-                    reject(nestedError)
-                    return
-                  }
-
-                  nestedClient.query('SELECT 12 AS nested_probe', queryError => {
-                    nestedRelease()
-                    parent.finish()
-
-                    if (queryError) {
-                      reject(queryError)
-                    } else {
-                      resolve()
-                    }
-                  })
-                })
-
-                // `release` pulses the pending queue synchronously, so the acquire queued above runs
-                // inside this callback.
-                release()
-              })
-            })
-          })
-
-          await tracePromise
-        })
-
-        it('records the deepest wait when acquires nest six releases deep', async () => {
-          const deepest = 6
-          const blockMs = 50
-
-          const parent = tracer.startSpan('deep-acquire-parent')
-
-          const tracePromise = agent.assertSomeTraces(traces => {
-            const waits = traces[0]
-              .filter(span => span.name === 'pg.pool.acquire')
-              .map(span => span.metrics['db.pool.wait_time_ms'])
-
-            assert.strictEqual(waits.length, deepest, `expected one span per acquire, got ${inspect(waits)}`)
-            assert.strictEqual(
-              waits.filter(wait => wait > 40).length,
-              1,
-              `expected exactly one acquire to carry the ~${blockMs}ms block, got ${inspect(waits)}`
-            )
-          })
-
-          await new Promise((resolve, reject) => {
-            tracer.scope().activate(parent, () => {
-              const acquireLevel = level => {
+          try {
+            const operation = new Promise((resolve, reject) => {
+              tracer.scope().activate(parent, () => {
                 pool.connect((error, client, release) => {
                   if (error) {
                     reject(error)
                     return
                   }
 
-                  if (level === deepest) {
-                    client.query('SELECT 13 AS deep_probe', queryError => {
-                      release()
+                  pool.connect((nestedError, nestedClient, nestedRelease) => {
+                    if (nestedError) {
+                      reject(nestedError)
+                      return
+                    }
+
+                    nestedClient.query('SELECT 12 AS nested_probe', queryError => {
+                      nestedRelease()
                       parent.finish()
 
                       if (queryError) {
@@ -683,49 +667,48 @@ describe('Plugin', () => {
                         resolve()
                       }
                     })
-                    return
-                  }
+                  })
 
-                  acquireLevel(level + 1)
-
-                  // Every level acquires the same `max: 1` client, so only the size of the wait tells
-                  // the acquires apart. A timer instead of a block would end the nesting chain.
-                  if (level === deepest - 1) {
-                    const until = performance.now() + blockMs
-                    while (performance.now() < until) { /* block the acquire queued above */ }
-                  }
-
+                  nowStub.returns(120)
                   release()
                 })
-              }
-
-              acquireLevel(1)
+              })
             })
-          })
 
-          await tracePromise
+            nowStub.returns(110)
+
+            await Promise.all([tracePromise, operation])
+          } finally {
+            nowStub.restore()
+          }
         })
 
-        it('does not throw when the pool fails to acquire a connection', done => {
-          const probe = net.createServer().listen(0, '127.0.0.1', () => {
-            const { port } = probe.address()
+        it('does not throw when the pool fails to acquire a connection', async () => {
+          const probe = net.createServer(socket => socket.destroy())
+          probe.listen(0, '127.0.0.1')
+          await once(probe, 'listening')
 
-            probe.close(() => {
-              const failingPool = new pg.Pool({
-                host: '127.0.0.1',
-                port,
-                user: 'postgres',
-                database: 'postgres',
-                connectionTimeoutMillis: 500,
-              })
-              failingPool.on('error', () => {})
-
-              failingPool.query('SELECT 1', error => {
-                assert.ok(error, 'expected the pool connection to fail')
-                failingPool.end(() => done())
-              })
-            })
+          const { port } = probe.address()
+          const failingPool = new pg.Pool({
+            host: '127.0.0.1',
+            port,
+            user: 'postgres',
+            database: 'postgres',
+            connectionTimeoutMillis: 500,
           })
+          failingPool.on('error', () => {})
+
+          try {
+            const error = await new Promise(resolve => {
+              failingPool.query('SELECT 1', resolve)
+            })
+
+            assert.ok(error, 'expected the pool connection to fail')
+          } finally {
+            const closePromise = once(probe, 'close')
+            probe.close()
+            await Promise.all([failingPool.end(), closePromise])
+          }
         })
 
         it('creates a dedicated acquire span for an explicit promise pool.connect()', async () => {
@@ -744,43 +727,78 @@ describe('Plugin', () => {
             assert.ok(!Object.hasOwn(querySpan.metrics, 'db.pool.wait_time_ms'))
           })
 
-          await tracer.scope().activate(parent, async () => {
-            const client = await pool.connect()
-            await client.query('SELECT 5 AS five')
-            client.release()
-            parent.finish()
-          })
-
-          await tracePromise
+          await Promise.all([
+            tracePromise,
+            tracer.scope().activate(parent, async () => {
+              const client = await pool.connect()
+              await client.query('SELECT 5 AS five')
+              client.release()
+              parent.finish()
+            }),
+          ])
         })
 
-        it('creates a dedicated acquire span for an explicit callback pool.connect()', done => {
+        it('keeps the acquire wait when an async callback defers its query', async () => {
+          const blocker = await pool.connect()
           const parent = tracer.startSpan('acquire-callback-parent')
+          const nowStub = sinon.stub(performance, 'now').returns(100)
+          let blockerReleased = false
 
-          agent.assertSomeTraces(traces => {
+          const tracePromise = agent.assertSomeTraces(traces => {
             const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+            const querySpan = traces[0].find(span => span.resource === 'SELECT 14 AS deferred_probe')
 
             assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
             assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
-            assert.strictEqual(typeof acquireSpan.metrics['db.pool.wait_time_ms'], 'number')
-          })
-            .then(done)
-            .catch(done)
+            assert.strictEqual(acquireSpan.metrics['db.pool.wait_time_ms'], 50)
 
-          tracer.scope().activate(parent, () => {
-            pool.connect((error, client, release) => {
-              if (error) return done(error)
-              release()
-              parent.finish()
-            })
+            assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(querySpan.metrics, 'db.pool.wait_time_ms'))
           })
+
+          try {
+            const operation = new Promise((resolve, reject) => {
+              tracer.scope().activate(parent, () => {
+                pool.connect(async (error, client, release) => {
+                  if (error) {
+                    parent.finish()
+                    reject(error)
+                    return
+                  }
+
+                  try {
+                    await new Promise(resolve => setImmediate(resolve))
+                    await client.query('SELECT 14 AS deferred_probe')
+                    release()
+                    parent.finish()
+                    resolve()
+                  } catch (error) {
+                    release(error)
+                    parent.finish()
+                    reject(error)
+                  }
+                })
+              })
+            })
+
+            nowStub.returns(150)
+            blocker.release()
+            blockerReleased = true
+
+            await Promise.all([tracePromise, operation])
+          } finally {
+            if (!blockerReleased) {
+              blocker.release()
+            }
+            nowStub.restore()
+          }
         })
 
         it('records an error on the acquire span when an explicit connect fails', async () => {
-          const probe = net.createServer()
-          await new Promise(resolve => probe.listen(0, '127.0.0.1', resolve))
+          const probe = net.createServer(socket => socket.destroy())
+          probe.listen(0, '127.0.0.1')
+          await once(probe, 'listening')
           const { port } = probe.address()
-          await new Promise(resolve => probe.close(resolve))
 
           const failingPool = new pg.Pool({
             host: '127.0.0.1',
@@ -798,24 +816,28 @@ describe('Plugin', () => {
             assert.strictEqual(acquireSpan.error, 1)
           })
 
-          await assert.rejects(failingPool.connect())
-          await tracePromise
-          await failingPool.end()
+          try {
+            await Promise.all([
+              assert.rejects(failingPool.connect()),
+              tracePromise,
+            ])
+          } finally {
+            const closePromise = once(probe, 'close')
+            probe.close()
+            await Promise.all([failingPool.end(), closePromise])
+          }
         })
 
-        it('does not create an acquire span for pool.query', done => {
-          agent.assertSomeTraces(traces => {
-            assert.ok(
-              !traces[0].some(span => span.name === 'pg.pool.acquire'),
-              `unexpected acquire span: ${inspect(traces[0].map(span => span.name))}`
-            )
-          }, { spanResourceMatch: /^SELECT 6 AS six$/ })
-            .then(done)
-            .catch(done)
-
-          pool.query('SELECT 6 AS six', error => {
-            if (error) done(error)
-          })
+        it('does not create an acquire span for pool.query', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assert.ok(
+                !traces[0].some(span => span.name === 'pg.pool.acquire'),
+                `unexpected acquire span: ${inspect(traces[0].map(span => span.name))}`
+              )
+            }, { spanResourceMatch: /^SELECT 6 AS six$/ }),
+            pool.query('SELECT 6 AS six'),
+          ])
         })
       })
 
@@ -1385,6 +1407,48 @@ describe('Plugin', () => {
 
           await queryPromise
         })
+      })
+    })
+
+    describe('without pg plugin subscribers', () => {
+      const queryPoolStartChannel = dc.channel('datadog:pg:pool:query:start')
+      let pool
+
+      before(async () => {
+        await agent.load([])
+        const { Pool } = require('../../../versions/pg').get()
+
+        pool = new Pool({
+          host: '127.0.0.1',
+          user: 'postgres',
+          password: 'postgres',
+          database: 'postgres',
+          application_name: 'test',
+          max: 1,
+        })
+      })
+
+      after(async () => {
+        await pool.end()
+        await agent.close()
+      })
+
+      it('forwards pool queries and explicit connects', async () => {
+        await pool.query('SELECT 1')
+
+        const client = await pool.connect()
+        client.release()
+      })
+
+      it('forwards pool queries with only pool-query subscribers', async () => {
+        const observeQuery = () => {}
+        queryPoolStartChannel.subscribe(observeQuery)
+
+        try {
+          await pool.query('SELECT 1')
+        } finally {
+          queryPoolStartChannel.unsubscribe(observeQuery)
+        }
       })
     })
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -93,6 +93,8 @@ describe('Plugin', () => {
                   `Available keys: ${inspect(Object.keys(traces[0][0].metrics))}`
                 )
               }
+
+              assert.ok(!Object.hasOwn(traces[0][0].metrics, 'db.pool.wait_time_ms'))
             }, { spanResourceMatch: /^SELECT \$1::text as message$/ })
               .then(done)
               .catch(done)
@@ -459,6 +461,240 @@ describe('Plugin', () => {
           })
 
           await tracePromise
+        })
+
+        it('records the wait of an acquire that opens a new connection', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 0, `expected a positive wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 4 AS pool_wait_probe$/ }),
+            pool.query('SELECT 4 AS pool_wait_probe'),
+          ])
+        })
+
+        it('reports a zero wait time when an idle pooled client is reused', async () => {
+          await pool.query('SELECT 1')
+
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].metrics['db.pool.wait_time_ms'], 0)
+            }, { spanResourceMatch: /^SELECT 7 AS idle_probe$/ }),
+            pool.query('SELECT 7 AS idle_probe'),
+          ])
+        })
+
+        it('reports a positive wait time when a same-tick query takes the only idle client', async () => {
+          await pool.query('SELECT 1')
+
+          // The first query takes the idle client and the second queues behind it, while
+          // `idleCount` still reads 1 for both.
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 0, `expected a positive wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 9 AS queued_probe$/ }),
+            pool.query('SELECT 8 AS idle_taker'),
+            pool.query('SELECT 9 AS queued_probe'),
+          ])
+        })
+
+        it('keeps a concurrent acquire on another pool independent', async () => {
+          const otherPool = new pg.Pool({
+            host: '127.0.0.1',
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test',
+            max: 1,
+          })
+
+          let starvedWaitTime
+          let idleWaitTime
+
+          try {
+            await Promise.all([pool.query('SELECT 1'), otherPool.query('SELECT 1')])
+
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                starvedWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+              }, { spanResourceMatch: /^SELECT 5 AS starved_probe$/ }),
+              agent.assertSomeTraces(traces => {
+                idleWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+              }, { spanResourceMatch: /^SELECT 6 AS other_pool_probe$/ }),
+              pool.query('SELECT pg_sleep(0.2)'),
+              pool.query('SELECT 5 AS starved_probe'),
+              otherPool.query('SELECT 6 AS other_pool_probe'),
+            ])
+          } finally {
+            await otherPool.end()
+          }
+
+          assert.ok(starvedWaitTime > 150, `expected the starved pool to wait for its sleep, got ${starvedWaitTime}`)
+          assert.strictEqual(idleWaitTime, 0)
+        })
+
+        it('does not tag a query on an unrelated client with the pool wait', async () => {
+          const standalone = new pg.Client({
+            host: '127.0.0.1',
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test',
+          })
+
+          await standalone.connect()
+
+          try {
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                assert.ok(!Object.hasOwn(traces[0][0].metrics, 'db.pool.wait_time_ms'))
+              }, { spanResourceMatch: /^SELECT 10 AS unrelated_probe$/ }),
+              agent.assertSomeTraces(traces => {
+                const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+                assert.ok(waitTime > 0, `expected the acquired client to carry the wait, got ${waitTime}`)
+              }, { spanResourceMatch: /^SELECT 11 AS acquired_probe$/ }),
+              new Promise((resolve, reject) => {
+                pool.connect((error, client, release) => {
+                  if (error) {
+                    reject(error)
+                    return
+                  }
+
+                  standalone.query('SELECT 10 AS unrelated_probe', unrelatedError => {
+                    if (unrelatedError) {
+                      reject(unrelatedError)
+                    }
+                  })
+
+                  client.query('SELECT 11 AS acquired_probe', queryError => {
+                    release()
+
+                    if (queryError) {
+                      reject(queryError)
+                    } else {
+                      resolve()
+                    }
+                  })
+                })
+              }),
+            ])
+          } finally {
+            await standalone.end()
+          }
+        })
+
+        it('gives an acquire nested in a release its own wait', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 0, `expected the nested acquire to carry its own wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 12 AS nested_probe$/ }),
+            new Promise((resolve, reject) => {
+              pool.connect((error, client, release) => {
+                if (error) {
+                  reject(error)
+                  return
+                }
+
+                pool.connect((nestedError, nestedClient, nestedRelease) => {
+                  if (nestedError) {
+                    reject(nestedError)
+                    return
+                  }
+
+                  nestedClient.query('SELECT 12 AS nested_probe', queryError => {
+                    nestedRelease()
+
+                    if (queryError) {
+                      reject(queryError)
+                    } else {
+                      resolve()
+                    }
+                  })
+                })
+
+                // `release` pulses the pending queue synchronously, so the acquire queued above runs
+                // inside this callback while this callback's own entry is still on the stack.
+                release()
+              })
+            }),
+          ])
+        })
+
+        it('records the deepest wait when acquires nest six releases deep', async () => {
+          const deepest = 6
+          const blockMs = 50
+
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 40, `expected the deepest acquire's own ~${blockMs}ms wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 13 AS deep_probe$/ }),
+            new Promise((resolve, reject) => {
+              const acquireLevel = level => {
+                pool.connect((error, client, release) => {
+                  if (error) {
+                    reject(error)
+                    return
+                  }
+
+                  if (level === deepest) {
+                    client.query('SELECT 13 AS deep_probe', queryError => {
+                      release()
+
+                      if (queryError) {
+                        reject(queryError)
+                      } else {
+                        resolve()
+                      }
+                    })
+                    return
+                  }
+
+                  acquireLevel(level + 1)
+
+                  // Every level acquires the same `max: 1` client, so only the size of the wait tells
+                  // the entries apart. A timer instead of a block would end the nesting chain.
+                  if (level === deepest - 1) {
+                    const until = performance.now() + blockMs
+                    while (performance.now() < until) { /* block the acquire queued above */ }
+                  }
+
+                  release()
+                })
+              }
+
+              acquireLevel(1)
+            }),
+          ])
+        })
+
+        it('does not throw when the pool fails to acquire a connection', done => {
+          const probe = net.createServer().listen(0, '127.0.0.1', () => {
+            const { port } = probe.address()
+
+            probe.close(() => {
+              const failingPool = new pg.Pool({
+                host: '127.0.0.1',
+                port,
+                user: 'postgres',
+                database: 'postgres',
+                connectionTimeoutMillis: 500,
+              })
+              failingPool.on('error', () => {})
+
+              failingPool.query('SELECT 1', error => {
+                assert.ok(error, 'expected the pool connection to fail')
+                failingPool.end(() => done())
+              })
+            })
+          })
         })
       })
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -536,7 +536,7 @@ describe('Plugin', () => {
           assert.strictEqual(idleWaitTime, 0)
         })
 
-        it('does not tag a query on an unrelated client with the pool wait', async () => {
+        it('reports an explicit acquire on its own span and leaves every query span untagged', async () => {
           const standalone = new pg.Client({
             host: '127.0.0.1',
             user: 'postgres',
@@ -547,54 +547,69 @@ describe('Plugin', () => {
 
           await standalone.connect()
 
-          try {
-            await Promise.all([
-              agent.assertSomeTraces(traces => {
-                assert.ok(!Object.hasOwn(traces[0][0].metrics, 'db.pool.wait_time_ms'))
-              }, { spanResourceMatch: /^SELECT 10 AS unrelated_probe$/ }),
-              agent.assertSomeTraces(traces => {
-                const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const parent = tracer.startSpan('unrelated-client-parent')
 
-                assert.ok(waitTime > 0, `expected the acquired client to carry the wait, got ${waitTime}`)
-              }, { spanResourceMatch: /^SELECT 11 AS acquired_probe$/ }),
-              new Promise((resolve, reject) => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+            const unrelatedSpan = traces[0].find(span => span.resource === 'SELECT 10 AS unrelated_probe')
+            const acquiredSpan = traces[0].find(span => span.resource === 'SELECT 11 AS acquired_probe')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+
+            const waitTime = acquireSpan.metrics['db.pool.wait_time_ms']
+            assert.ok(waitTime > 0, `expected the acquire span to carry the wait, got ${waitTime}`)
+
+            assert.ok(unrelatedSpan, `missing unrelated span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(unrelatedSpan.metrics, 'db.pool.wait_time_ms'))
+
+            assert.ok(acquiredSpan, `missing acquired span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(acquiredSpan.metrics, 'db.pool.wait_time_ms'))
+          })
+
+          try {
+            await new Promise((resolve, reject) => {
+              tracer.scope().activate(parent, () => {
                 pool.connect((error, client, release) => {
                   if (error) {
                     reject(error)
                     return
                   }
 
-                  standalone.query('SELECT 10 AS unrelated_probe', unrelatedError => {
-                    if (unrelatedError) {
-                      reject(unrelatedError)
-                    }
-                  })
+                  const unrelated = standalone.query('SELECT 10 AS unrelated_probe')
+                  const acquired = client.query('SELECT 11 AS acquired_probe')
 
-                  client.query('SELECT 11 AS acquired_probe', queryError => {
+                  Promise.all([unrelated, acquired]).then(() => {
                     release()
-
-                    if (queryError) {
-                      reject(queryError)
-                    } else {
-                      resolve()
-                    }
-                  })
+                    parent.finish()
+                    resolve()
+                  }, reject)
                 })
-              }),
-            ])
+              })
+            })
+
+            await tracePromise
           } finally {
             await standalone.end()
           }
         })
 
         it('gives an acquire nested in a release its own wait', async () => {
-          await Promise.all([
-            agent.assertSomeTraces(traces => {
-              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const parent = tracer.startSpan('nested-acquire-parent')
 
-              assert.ok(waitTime > 0, `expected the nested acquire to carry its own wait, got ${waitTime}`)
-            }, { spanResourceMatch: /^SELECT 12 AS nested_probe$/ }),
-            new Promise((resolve, reject) => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const waits = traces[0]
+              .filter(span => span.name === 'pg.pool.acquire')
+              .map(span => span.metrics['db.pool.wait_time_ms'])
+
+            assert.strictEqual(waits.length, 2, `expected one span per acquire, got ${inspect(waits)}`)
+
+            for (const wait of waits) {
+              assert.ok(wait > 0, `expected each acquire to carry its own wait, got ${inspect(waits)}`)
+            }
+          })
+
+          await new Promise((resolve, reject) => {
+            tracer.scope().activate(parent, () => {
               pool.connect((error, client, release) => {
                 if (error) {
                   reject(error)
@@ -609,6 +624,7 @@ describe('Plugin', () => {
 
                   nestedClient.query('SELECT 12 AS nested_probe', queryError => {
                     nestedRelease()
+                    parent.finish()
 
                     if (queryError) {
                       reject(queryError)
@@ -619,24 +635,36 @@ describe('Plugin', () => {
                 })
 
                 // `release` pulses the pending queue synchronously, so the acquire queued above runs
-                // inside this callback while this callback's own entry is still on the stack.
+                // inside this callback.
                 release()
               })
-            }),
-          ])
+            })
+          })
+
+          await tracePromise
         })
 
         it('records the deepest wait when acquires nest six releases deep', async () => {
           const deepest = 6
           const blockMs = 50
 
-          await Promise.all([
-            agent.assertSomeTraces(traces => {
-              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const parent = tracer.startSpan('deep-acquire-parent')
 
-              assert.ok(waitTime > 40, `expected the deepest acquire's own ~${blockMs}ms wait, got ${waitTime}`)
-            }, { spanResourceMatch: /^SELECT 13 AS deep_probe$/ }),
-            new Promise((resolve, reject) => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const waits = traces[0]
+              .filter(span => span.name === 'pg.pool.acquire')
+              .map(span => span.metrics['db.pool.wait_time_ms'])
+
+            assert.strictEqual(waits.length, deepest, `expected one span per acquire, got ${inspect(waits)}`)
+            assert.strictEqual(
+              waits.filter(wait => wait > 40).length,
+              1,
+              `expected exactly one acquire to carry the ~${blockMs}ms block, got ${inspect(waits)}`
+            )
+          })
+
+          await new Promise((resolve, reject) => {
+            tracer.scope().activate(parent, () => {
               const acquireLevel = level => {
                 pool.connect((error, client, release) => {
                   if (error) {
@@ -647,6 +675,7 @@ describe('Plugin', () => {
                   if (level === deepest) {
                     client.query('SELECT 13 AS deep_probe', queryError => {
                       release()
+                      parent.finish()
 
                       if (queryError) {
                         reject(queryError)
@@ -660,7 +689,7 @@ describe('Plugin', () => {
                   acquireLevel(level + 1)
 
                   // Every level acquires the same `max: 1` client, so only the size of the wait tells
-                  // the entries apart. A timer instead of a block would end the nesting chain.
+                  // the acquires apart. A timer instead of a block would end the nesting chain.
                   if (level === deepest - 1) {
                     const until = performance.now() + blockMs
                     while (performance.now() < until) { /* block the acquire queued above */ }
@@ -671,8 +700,10 @@ describe('Plugin', () => {
               }
 
               acquireLevel(1)
-            }),
-          ])
+            })
+          })
+
+          await tracePromise
         })
 
         it('does not throw when the pool fails to acquire a connection', done => {
@@ -694,6 +725,96 @@ describe('Plugin', () => {
                 failingPool.end(() => done())
               })
             })
+          })
+        })
+
+        it('creates a dedicated acquire span for an explicit promise pool.connect()', async () => {
+          const parent = tracer.startSpan('acquire-promise-parent')
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+            const querySpan = traces[0].find(span => span.resource === 'SELECT 5 AS five')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
+            assert.strictEqual(typeof acquireSpan.metrics['db.pool.wait_time_ms'], 'number')
+            assert.ok(acquireSpan.metrics['db.pool.wait_time_ms'] >= 0)
+
+            assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(querySpan.metrics, 'db.pool.wait_time_ms'))
+          })
+
+          await tracer.scope().activate(parent, async () => {
+            const client = await pool.connect()
+            await client.query('SELECT 5 AS five')
+            client.release()
+            parent.finish()
+          })
+
+          await tracePromise
+        })
+
+        it('creates a dedicated acquire span for an explicit callback pool.connect()', done => {
+          const parent = tracer.startSpan('acquire-callback-parent')
+
+          agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
+            assert.strictEqual(typeof acquireSpan.metrics['db.pool.wait_time_ms'], 'number')
+          })
+            .then(done)
+            .catch(done)
+
+          tracer.scope().activate(parent, () => {
+            pool.connect((error, client, release) => {
+              if (error) return done(error)
+              release()
+              parent.finish()
+            })
+          })
+        })
+
+        it('records an error on the acquire span when an explicit connect fails', async () => {
+          const probe = net.createServer()
+          await new Promise(resolve => probe.listen(0, '127.0.0.1', resolve))
+          const { port } = probe.address()
+          await new Promise(resolve => probe.close(resolve))
+
+          const failingPool = new pg.Pool({
+            host: '127.0.0.1',
+            port,
+            user: 'postgres',
+            database: 'postgres',
+            connectionTimeoutMillis: 500,
+          })
+          failingPool.on('error', () => {})
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.error, 1)
+          })
+
+          await assert.rejects(failingPool.connect())
+          await tracePromise
+          await failingPool.end()
+        })
+
+        it('does not create an acquire span for pool.query', done => {
+          agent.assertSomeTraces(traces => {
+            assert.ok(
+              !traces[0].some(span => span.name === 'pg.pool.acquire'),
+              `unexpected acquire span: ${inspect(traces[0].map(span => span.name))}`
+            )
+          }, { spanResourceMatch: /^SELECT 6 AS six$/ })
+            .then(done)
+            .catch(done)
+
+          pool.query('SELECT 6 AS six', error => {
+            if (error) done(error)
           })
         })
       })

--- a/packages/datadog-plugin-pg/test/naming.js
+++ b/packages/datadog-plugin-pg/test/naming.js
@@ -13,6 +13,16 @@ const rawExpectedSchema = {
       serviceName: 'test',
     },
   },
+  poolAcquire: {
+    v0: {
+      opName: 'pg.pool.acquire',
+      serviceName: 'test-postgres',
+    },
+    v1: {
+      opName: 'postgresql.pool.acquire',
+      serviceName: 'test',
+    },
+  },
 }
 
 module.exports = {

--- a/packages/dd-trace/src/service-naming/schemas/v0/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/storage.js
@@ -150,7 +150,7 @@ const storage = {
       },
     },
     pg: {
-      opName: () => 'pg.query',
+      opName: ({ operation = 'query' }) => `pg.${operation}`,
       serviceName: withSuffixFunction('postgres'),
       serviceSource: ({ tracerService, pluginConfig, connectionName }) => {
         return optionServiceSource({ tracerService, pluginConfig, connectionName, integration: 'pg' })

--- a/packages/dd-trace/src/service-naming/schemas/v1/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v1/storage.js
@@ -82,7 +82,7 @@ const storage = {
       serviceSource: optionServiceSource,
     },
     pg: {
-      opName: () => 'postgresql.query',
+      opName: ({ operation = 'query' }) => `postgresql.${operation}`,
       serviceName: withFunction,
       serviceSource: optionServiceSource,
     },


### PR DESCRIPTION
## Summary

A query through pg's pool only got a span after a client had been acquired, so time spent waiting for a free or newly connected client was invisible. Pool-managed queries now carry `db.pool.wait_time_ms` on their query span. Explicit callback and promise `pool.connect()` calls get a dedicated `pg.pool.acquire` span with the same metric and connection errors.

## Why

pg hands idle clients back on a later tick. That delay is event-loop lag, not pool contention, so an idle acquisition reports zero without reading the clock. A nonzero metric means the pool itself made the caller wait; the explicit acquire span's duration still records the caller's full end-to-end delay.

`Pool.query()` reports the acquire on its query span instead of creating a duplicate span. Explicit acquires retain the standalone span when the callback defers its first query, when no query runs, and when acquisition fails.

Refs: https://github.com/DataDog/dd-trace-js/issues/1923