### PR TITLE
feat(pg): trace explicit pool.connect() acquires with a dedicated span

### DIFF
--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { errorMonitor } = require('node:events')
+const { performance } = require('node:perf_hooks')
 
 const shimmer = require('../../datadog-shimmer')
 const {
@@ -22,6 +23,13 @@ const poolConnectFinishCh = channel('apm:pg:pool:connect:finish')
 // the un-injected `text` so the wrap doesn't capture a previous DBM injection as the new original.
 const originalTextCache = new WeakMap()
 
+// pg dispatches the pooled query synchronously from the connect callback, so the acquire wait
+// reaches `wrapQuery` through this stack: `_release` pulses the pending queue synchronously, which
+// nests acquires, and the client pins each wait to the connection that actually waited for it.
+// Each entry is popped by the frame that pushed it, so no client outlives its callback.
+const poolWaitClients = []
+const poolWaitTimes = []
+
 addHook({ name: 'pg', versions: ['>=8.0.3'], file: 'lib/native/client.js' }, Client => {
   shimmer.wrap(Client.prototype, 'query', query => wrapQuery(query))
   return Client
@@ -41,8 +49,23 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
     }
 
     const ctx = {}
+    // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
+    // outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
+    const start = this.idleCount > this.waitingCount ? 0 : performance.now()
     arguments[0] = function (...args) {
-      return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+      const client = args[1]
+      if (client !== undefined) {
+        poolWaitClients.push(client)
+        poolWaitTimes.push(start === 0 ? 0 : performance.now() - start)
+      }
+      try {
+        return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+      } finally {
+        if (client !== undefined) {
+          poolWaitClients.pop()
+          poolWaitTimes.pop()
+        }
+      }
     }
 
     poolConnectStartCh.publish(ctx)
@@ -83,6 +106,17 @@ function wrapQuery (query) {
       abortController,
       stream,
     }
+
+    if (poolWaitClients.length !== 0) {
+      for (let i = poolWaitClients.length - 1; i >= 0; i--) {
+        if (poolWaitClients[i] === this) {
+          ctx.poolWaitTime = poolWaitTimes[i]
+          poolWaitClients[i] = undefined
+          break
+        }
+      }
+    }
+
     const finish = (error, res) => {
       if (error) {
         ctx.error = error

--- a/packages/datadog-instrumentations/src/pg.js
+++ b/packages/datadog-instrumentations/src/pg.js
@@ -19,6 +19,9 @@ const finishPoolQueryCh = channel('datadog:pg:pool:query:finish')
 const poolConnectStartCh = channel('apm:pg:pool:connect:start')
 const poolConnectFinishCh = channel('apm:pg:pool:connect:finish')
 
+const poolAcquireStartCh = channel('apm:pg:pool:acquire:start')
+const poolAcquireFinishCh = channel('apm:pg:pool:acquire:finish')
+
 // Drivers like pg-promise reuse the same prepared-statement query object across executions; cache
 // the un-injected `text` so the wrap doesn't capture a previous DBM injection as the new original.
 const originalTextCache = new WeakMap()
@@ -29,6 +32,12 @@ const originalTextCache = new WeakMap()
 // Each entry is popped by the frame that pushed it, so no client outlives its callback.
 const poolWaitClients = []
 const poolWaitTimes = []
+
+// `Pool.prototype.query` acquires a client internally via `connect`. That acquire is reported as a
+// tag on the resulting query span, so the connect wrap must not also open a standalone acquire span
+// for it; an explicit user `pool.connect()` gets the standalone span instead. `connect` is invoked
+// synchronously from within `query`, so a module flag set around the call reliably distinguishes them.
+let acquiringForPoolQuery = false
 
 addHook({ name: 'pg', versions: ['>=8.0.3'], file: 'lib/native/client.js' }, Client => {
   shimmer.wrap(Client.prototype, 'query', query => wrapQuery(query))
@@ -44,27 +53,59 @@ addHook({ name: 'pg', versions: ['>=8.0.3'] }, pg => {
   // pg defers a busy pool's connect callback and runs it in the releasing query's async context;
   // capture the caller's context and restore it around the callback so spans attach to the caller.
   shimmer.wrap(pg.Pool.prototype, 'connect', connect => function (cb) {
-    if (typeof cb !== 'function' || !poolConnectStartCh.hasSubscribers) {
+    // `await pool.connect()`: no callback, so the caller's async context is preserved by the await
+    // itself and only the standalone acquire span is needed. `Pool.query` always acquires with a
+    // callback, so a missing callback is always an explicit caller-initiated acquire.
+    if (typeof cb !== 'function') {
+      if (!poolAcquireStartCh.hasSubscribers) {
+        return connect.apply(this, arguments)
+      }
+
+      const start = acquireStart(this)
+      const acquireCtx = { poolOptions: this.options }
+      poolAcquireStartCh.publish(acquireCtx)
+
+      return connect.apply(this, arguments).then(client => {
+        finishAcquire(acquireCtx, start)
+        return client
+      }, error => {
+        acquireCtx.error = error
+        finishAcquire(acquireCtx, start)
+        throw error
+      })
+    }
+
+    if (!poolConnectStartCh.hasSubscribers) {
       return connect.apply(this, arguments)
     }
 
     const ctx = {}
-    // pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
-    // outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
-    const start = this.idleCount > this.waitingCount ? 0 : performance.now()
-    arguments[0] = function (...args) {
-      const client = args[1]
-      if (client !== undefined) {
-        poolWaitClients.push(client)
-        poolWaitTimes.push(start === 0 ? 0 : performance.now() - start)
-      }
-      try {
-        return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
-      } finally {
+    const start = acquireStart(this)
+
+    if (acquiringForPoolQuery) {
+      arguments[0] = function (...args) {
+        const client = args[1]
         if (client !== undefined) {
-          poolWaitClients.pop()
-          poolWaitTimes.pop()
+          poolWaitClients.push(client)
+          poolWaitTimes.push(acquireWait(start))
         }
+        try {
+          return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
+        } finally {
+          if (client !== undefined) {
+            poolWaitClients.pop()
+            poolWaitTimes.pop()
+          }
+        }
+      }
+    } else {
+      const acquireCtx = { poolOptions: this.options }
+      poolAcquireStartCh.publish(acquireCtx)
+
+      arguments[0] = function (...args) {
+        acquireCtx.error = args[0]
+        finishAcquire(acquireCtx, start)
+        return poolConnectFinishCh.runStores(ctx, cb, this, ...args)
       }
     }
 
@@ -219,10 +260,30 @@ function wrapQuery (query) {
 const finish = (ctx) => {
   finishPoolQueryCh.publish(ctx)
 }
+// pg drains its pending queue FIFO on the next tick, so an idle client is only ours when it
+// outnumbers the requests already queued ahead of us. That handoff is not a wait on the pool.
+function acquireStart (pool) {
+  return pool.idleCount > pool.waitingCount ? 0 : performance.now()
+}
+function acquireWait (start) {
+  return start === 0 ? 0 : performance.now() - start
+}
+function finishAcquire (ctx, start) {
+  ctx.poolWaitTime = acquireWait(start)
+  poolAcquireFinishCh.publish(ctx)
+}
+function acquireForPoolQuery (query, pool, args) {
+  acquiringForPoolQuery = true
+  try {
+    return query.apply(pool, args)
+  } finally {
+    acquiringForPoolQuery = false
+  }
+}
 function wrapPoolQuery (query) {
   return function (...args) {
     if (!startPoolQueryCh.hasSubscribers) {
-      return query.apply(this, args)
+      return acquireForPoolQuery(query, this, args)
     }
 
     const pgQuery = args[0] !== null && typeof args[0] === 'object' ? args[0] : { text: args[0] }
@@ -252,7 +313,7 @@ function wrapPoolQuery (query) {
         })
       }
 
-      const retval = query.apply(this, args)
+      const retval = acquireForPoolQuery(query, this, args)
 
       if (retval?.then) {
         retval.then(() => {

--- a/packages/datadog-instrumentations/test/pg.spec.js
+++ b/packages/datadog-instrumentations/test/pg.spec.js
@@ -26,6 +26,8 @@ describe('pg instrumentation', () => {
       abortController.abort(error)
     }
 
+    function observeQuery () {}
+
     before(() => {
       return agent.load(['pg'])
     })
@@ -197,11 +199,20 @@ describe('pg instrumentation', () => {
         afterEach(() => {
           if (queryPoolStartChannel.hasSubscribers) {
             queryPoolStartChannel.unsubscribe(abortQuery)
+            queryPoolStartChannel.unsubscribe(observeQuery)
           }
         })
 
         describe('using callback', () => {
           it('Should not fail if it is not aborted', (done) => {
+            pool.query('SELECT 1', (err) => {
+              done(err)
+            })
+          })
+
+          it('Should run the query when a subscriber does not abort it', (done) => {
+            queryPoolStartChannel.subscribe(observeQuery)
+
             pool.query('SELECT 1', (err) => {
               done(err)
             })

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -16,6 +16,33 @@ class PGPlugin extends DatabasePlugin {
       ctx.parentStore = storage('legacy').getStore()
     })
     this.addBind('apm:pg:pool:connect:finish', ctx => ctx.parentStore)
+
+    this.addSub('apm:pg:pool:acquire:start', ctx => {
+      const params = ctx.poolOptions
+
+      ctx.acquireSpan = this.startSpan('pg.pool.acquire', {
+        service: this.serviceName({ pluginConfig: this.config, params }),
+        resource: 'pg.pool.acquire',
+        type: 'sql',
+        kind: 'client',
+        meta: {
+          'db.type': 'postgres',
+          'db.name': params.database,
+          'db.user': params.user,
+          'out.host': params.host,
+          [CLIENT_PORT_KEY]: params.port,
+        },
+      }, false)
+    })
+    this.addSub('apm:pg:pool:acquire:finish', ctx => {
+      const span = ctx.acquireSpan
+
+      if (ctx.error) {
+        this.addError(ctx.error, span)
+      }
+      span.setTag('db.pool.wait_time_ms', ctx.poolWaitTime)
+      span.finish()
+    })
   }
 
   bindStart (ctx) {

--- a/packages/datadog-plugin-pg/src/index.js
+++ b/packages/datadog-plugin-pg/src/index.js
@@ -42,6 +42,10 @@ class PGPlugin extends DatabasePlugin {
       span.setTag('db.stream', 1)
     }
 
+    if (ctx.poolWaitTime !== undefined) {
+      span.setTag('db.pool.wait_time_ms', ctx.poolWaitTime)
+    }
+
     ctx.injected = this.injectDbmQuery(span, originalText, service.name, !!query.name)
 
     return ctx.currentStore

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -93,6 +93,8 @@ describe('Plugin', () => {
                   `Available keys: ${inspect(Object.keys(traces[0][0].metrics))}`
                 )
               }
+
+              assert.ok(!Object.hasOwn(traces[0][0].metrics, 'db.pool.wait_time_ms'))
             }, { spanResourceMatch: /^SELECT \$1::text as message$/ })
               .then(done)
               .catch(done)
@@ -459,6 +461,240 @@ describe('Plugin', () => {
           })
 
           await tracePromise
+        })
+
+        it('records the wait of an acquire that opens a new connection', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 0, `expected a positive wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 4 AS pool_wait_probe$/ }),
+            pool.query('SELECT 4 AS pool_wait_probe'),
+          ])
+        })
+
+        it('reports a zero wait time when an idle pooled client is reused', async () => {
+          await pool.query('SELECT 1')
+
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].metrics['db.pool.wait_time_ms'], 0)
+            }, { spanResourceMatch: /^SELECT 7 AS idle_probe$/ }),
+            pool.query('SELECT 7 AS idle_probe'),
+          ])
+        })
+
+        it('reports a positive wait time when a same-tick query takes the only idle client', async () => {
+          await pool.query('SELECT 1')
+
+          // The first query takes the idle client and the second queues behind it, while
+          // `idleCount` still reads 1 for both.
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 0, `expected a positive wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 9 AS queued_probe$/ }),
+            pool.query('SELECT 8 AS idle_taker'),
+            pool.query('SELECT 9 AS queued_probe'),
+          ])
+        })
+
+        it('keeps a concurrent acquire on another pool independent', async () => {
+          const otherPool = new pg.Pool({
+            host: '127.0.0.1',
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test',
+            max: 1,
+          })
+
+          let starvedWaitTime
+          let idleWaitTime
+
+          try {
+            await Promise.all([pool.query('SELECT 1'), otherPool.query('SELECT 1')])
+
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                starvedWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+              }, { spanResourceMatch: /^SELECT 5 AS starved_probe$/ }),
+              agent.assertSomeTraces(traces => {
+                idleWaitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+              }, { spanResourceMatch: /^SELECT 6 AS other_pool_probe$/ }),
+              pool.query('SELECT pg_sleep(0.2)'),
+              pool.query('SELECT 5 AS starved_probe'),
+              otherPool.query('SELECT 6 AS other_pool_probe'),
+            ])
+          } finally {
+            await otherPool.end()
+          }
+
+          assert.ok(starvedWaitTime > 150, `expected the starved pool to wait for its sleep, got ${starvedWaitTime}`)
+          assert.strictEqual(idleWaitTime, 0)
+        })
+
+        it('does not tag a query on an unrelated client with the pool wait', async () => {
+          const standalone = new pg.Client({
+            host: '127.0.0.1',
+            user: 'postgres',
+            password: 'postgres',
+            database: 'postgres',
+            application_name: 'test',
+          })
+
+          await standalone.connect()
+
+          try {
+            await Promise.all([
+              agent.assertSomeTraces(traces => {
+                assert.ok(!Object.hasOwn(traces[0][0].metrics, 'db.pool.wait_time_ms'))
+              }, { spanResourceMatch: /^SELECT 10 AS unrelated_probe$/ }),
+              agent.assertSomeTraces(traces => {
+                const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+                assert.ok(waitTime > 0, `expected the acquired client to carry the wait, got ${waitTime}`)
+              }, { spanResourceMatch: /^SELECT 11 AS acquired_probe$/ }),
+              new Promise((resolve, reject) => {
+                pool.connect((error, client, release) => {
+                  if (error) {
+                    reject(error)
+                    return
+                  }
+
+                  standalone.query('SELECT 10 AS unrelated_probe', unrelatedError => {
+                    if (unrelatedError) {
+                      reject(unrelatedError)
+                    }
+                  })
+
+                  client.query('SELECT 11 AS acquired_probe', queryError => {
+                    release()
+
+                    if (queryError) {
+                      reject(queryError)
+                    } else {
+                      resolve()
+                    }
+                  })
+                })
+              }),
+            ])
+          } finally {
+            await standalone.end()
+          }
+        })
+
+        it('gives an acquire nested in a release its own wait', async () => {
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 0, `expected the nested acquire to carry its own wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 12 AS nested_probe$/ }),
+            new Promise((resolve, reject) => {
+              pool.connect((error, client, release) => {
+                if (error) {
+                  reject(error)
+                  return
+                }
+
+                pool.connect((nestedError, nestedClient, nestedRelease) => {
+                  if (nestedError) {
+                    reject(nestedError)
+                    return
+                  }
+
+                  nestedClient.query('SELECT 12 AS nested_probe', queryError => {
+                    nestedRelease()
+
+                    if (queryError) {
+                      reject(queryError)
+                    } else {
+                      resolve()
+                    }
+                  })
+                })
+
+                // `release` pulses the pending queue synchronously, so the acquire queued above runs
+                // inside this callback while this callback's own entry is still on the stack.
+                release()
+              })
+            }),
+          ])
+        })
+
+        it('records the deepest wait when acquires nest six releases deep', async () => {
+          const deepest = 6
+          const blockMs = 50
+
+          await Promise.all([
+            agent.assertSomeTraces(traces => {
+              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+
+              assert.ok(waitTime > 40, `expected the deepest acquire's own ~${blockMs}ms wait, got ${waitTime}`)
+            }, { spanResourceMatch: /^SELECT 13 AS deep_probe$/ }),
+            new Promise((resolve, reject) => {
+              const acquireLevel = level => {
+                pool.connect((error, client, release) => {
+                  if (error) {
+                    reject(error)
+                    return
+                  }
+
+                  if (level === deepest) {
+                    client.query('SELECT 13 AS deep_probe', queryError => {
+                      release()
+
+                      if (queryError) {
+                        reject(queryError)
+                      } else {
+                        resolve()
+                      }
+                    })
+                    return
+                  }
+
+                  acquireLevel(level + 1)
+
+                  // Every level acquires the same `max: 1` client, so only the size of the wait tells
+                  // the entries apart. A timer instead of a block would end the nesting chain.
+                  if (level === deepest - 1) {
+                    const until = performance.now() + blockMs
+                    while (performance.now() < until) { /* block the acquire queued above */ }
+                  }
+
+                  release()
+                })
+              }
+
+              acquireLevel(1)
+            }),
+          ])
+        })
+
+        it('does not throw when the pool fails to acquire a connection', done => {
+          const probe = net.createServer().listen(0, '127.0.0.1', () => {
+            const { port } = probe.address()
+
+            probe.close(() => {
+              const failingPool = new pg.Pool({
+                host: '127.0.0.1',
+                port,
+                user: 'postgres',
+                database: 'postgres',
+                connectionTimeoutMillis: 500,
+              })
+              failingPool.on('error', () => {})
+
+              failingPool.query('SELECT 1', error => {
+                assert.ok(error, 'expected the pool connection to fail')
+                failingPool.end(() => done())
+              })
+            })
+          })
         })
       })
 

--- a/packages/datadog-plugin-pg/test/index.spec.js
+++ b/packages/datadog-plugin-pg/test/index.spec.js
@@ -536,7 +536,7 @@ describe('Plugin', () => {
           assert.strictEqual(idleWaitTime, 0)
         })
 
-        it('does not tag a query on an unrelated client with the pool wait', async () => {
+        it('reports an explicit acquire on its own span and leaves every query span untagged', async () => {
           const standalone = new pg.Client({
             host: '127.0.0.1',
             user: 'postgres',
@@ -547,54 +547,69 @@ describe('Plugin', () => {
 
           await standalone.connect()
 
-          try {
-            await Promise.all([
-              agent.assertSomeTraces(traces => {
-                assert.ok(!Object.hasOwn(traces[0][0].metrics, 'db.pool.wait_time_ms'))
-              }, { spanResourceMatch: /^SELECT 10 AS unrelated_probe$/ }),
-              agent.assertSomeTraces(traces => {
-                const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const parent = tracer.startSpan('unrelated-client-parent')
 
-                assert.ok(waitTime > 0, `expected the acquired client to carry the wait, got ${waitTime}`)
-              }, { spanResourceMatch: /^SELECT 11 AS acquired_probe$/ }),
-              new Promise((resolve, reject) => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+            const unrelatedSpan = traces[0].find(span => span.resource === 'SELECT 10 AS unrelated_probe')
+            const acquiredSpan = traces[0].find(span => span.resource === 'SELECT 11 AS acquired_probe')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+
+            const waitTime = acquireSpan.metrics['db.pool.wait_time_ms']
+            assert.ok(waitTime > 0, `expected the acquire span to carry the wait, got ${waitTime}`)
+
+            assert.ok(unrelatedSpan, `missing unrelated span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(unrelatedSpan.metrics, 'db.pool.wait_time_ms'))
+
+            assert.ok(acquiredSpan, `missing acquired span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(acquiredSpan.metrics, 'db.pool.wait_time_ms'))
+          })
+
+          try {
+            await new Promise((resolve, reject) => {
+              tracer.scope().activate(parent, () => {
                 pool.connect((error, client, release) => {
                   if (error) {
                     reject(error)
                     return
                   }
 
-                  standalone.query('SELECT 10 AS unrelated_probe', unrelatedError => {
-                    if (unrelatedError) {
-                      reject(unrelatedError)
-                    }
-                  })
+                  const unrelated = standalone.query('SELECT 10 AS unrelated_probe')
+                  const acquired = client.query('SELECT 11 AS acquired_probe')
 
-                  client.query('SELECT 11 AS acquired_probe', queryError => {
+                  Promise.all([unrelated, acquired]).then(() => {
                     release()
-
-                    if (queryError) {
-                      reject(queryError)
-                    } else {
-                      resolve()
-                    }
-                  })
+                    parent.finish()
+                    resolve()
+                  }, reject)
                 })
-              }),
-            ])
+              })
+            })
+
+            await tracePromise
           } finally {
             await standalone.end()
           }
         })
 
         it('gives an acquire nested in a release its own wait', async () => {
-          await Promise.all([
-            agent.assertSomeTraces(traces => {
-              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const parent = tracer.startSpan('nested-acquire-parent')
 
-              assert.ok(waitTime > 0, `expected the nested acquire to carry its own wait, got ${waitTime}`)
-            }, { spanResourceMatch: /^SELECT 12 AS nested_probe$/ }),
-            new Promise((resolve, reject) => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const waits = traces[0]
+              .filter(span => span.name === 'pg.pool.acquire')
+              .map(span => span.metrics['db.pool.wait_time_ms'])
+
+            assert.strictEqual(waits.length, 2, `expected one span per acquire, got ${inspect(waits)}`)
+
+            for (const wait of waits) {
+              assert.ok(wait > 0, `expected each acquire to carry its own wait, got ${inspect(waits)}`)
+            }
+          })
+
+          await new Promise((resolve, reject) => {
+            tracer.scope().activate(parent, () => {
               pool.connect((error, client, release) => {
                 if (error) {
                   reject(error)
@@ -609,6 +624,7 @@ describe('Plugin', () => {
 
                   nestedClient.query('SELECT 12 AS nested_probe', queryError => {
                     nestedRelease()
+                    parent.finish()
 
                     if (queryError) {
                       reject(queryError)
@@ -619,24 +635,36 @@ describe('Plugin', () => {
                 })
 
                 // `release` pulses the pending queue synchronously, so the acquire queued above runs
-                // inside this callback while this callback's own entry is still on the stack.
+                // inside this callback.
                 release()
               })
-            }),
-          ])
+            })
+          })
+
+          await tracePromise
         })
 
         it('records the deepest wait when acquires nest six releases deep', async () => {
           const deepest = 6
           const blockMs = 50
 
-          await Promise.all([
-            agent.assertSomeTraces(traces => {
-              const waitTime = traces[0][0].metrics['db.pool.wait_time_ms']
+          const parent = tracer.startSpan('deep-acquire-parent')
 
-              assert.ok(waitTime > 40, `expected the deepest acquire's own ~${blockMs}ms wait, got ${waitTime}`)
-            }, { spanResourceMatch: /^SELECT 13 AS deep_probe$/ }),
-            new Promise((resolve, reject) => {
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const waits = traces[0]
+              .filter(span => span.name === 'pg.pool.acquire')
+              .map(span => span.metrics['db.pool.wait_time_ms'])
+
+            assert.strictEqual(waits.length, deepest, `expected one span per acquire, got ${inspect(waits)}`)
+            assert.strictEqual(
+              waits.filter(wait => wait > 40).length,
+              1,
+              `expected exactly one acquire to carry the ~${blockMs}ms block, got ${inspect(waits)}`
+            )
+          })
+
+          await new Promise((resolve, reject) => {
+            tracer.scope().activate(parent, () => {
               const acquireLevel = level => {
                 pool.connect((error, client, release) => {
                   if (error) {
@@ -647,6 +675,7 @@ describe('Plugin', () => {
                   if (level === deepest) {
                     client.query('SELECT 13 AS deep_probe', queryError => {
                       release()
+                      parent.finish()
 
                       if (queryError) {
                         reject(queryError)
@@ -660,7 +689,7 @@ describe('Plugin', () => {
                   acquireLevel(level + 1)
 
                   // Every level acquires the same `max: 1` client, so only the size of the wait tells
-                  // the entries apart. A timer instead of a block would end the nesting chain.
+                  // the acquires apart. A timer instead of a block would end the nesting chain.
                   if (level === deepest - 1) {
                     const until = performance.now() + blockMs
                     while (performance.now() < until) { /* block the acquire queued above */ }
@@ -671,8 +700,10 @@ describe('Plugin', () => {
               }
 
               acquireLevel(1)
-            }),
-          ])
+            })
+          })
+
+          await tracePromise
         })
 
         it('does not throw when the pool fails to acquire a connection', done => {
@@ -694,6 +725,96 @@ describe('Plugin', () => {
                 failingPool.end(() => done())
               })
             })
+          })
+        })
+
+        it('creates a dedicated acquire span for an explicit promise pool.connect()', async () => {
+          const parent = tracer.startSpan('acquire-promise-parent')
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+            const querySpan = traces[0].find(span => span.resource === 'SELECT 5 AS five')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
+            assert.strictEqual(typeof acquireSpan.metrics['db.pool.wait_time_ms'], 'number')
+            assert.ok(acquireSpan.metrics['db.pool.wait_time_ms'] >= 0)
+
+            assert.ok(querySpan, `missing query span: ${inspect(traces[0].map(span => span.resource))}`)
+            assert.ok(!Object.hasOwn(querySpan.metrics, 'db.pool.wait_time_ms'))
+          })
+
+          await tracer.scope().activate(parent, async () => {
+            const client = await pool.connect()
+            await client.query('SELECT 5 AS five')
+            client.release()
+            parent.finish()
+          })
+
+          await tracePromise
+        })
+
+        it('creates a dedicated acquire span for an explicit callback pool.connect()', done => {
+          const parent = tracer.startSpan('acquire-callback-parent')
+
+          agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.parent_id.toString(), parent.context().toSpanId())
+            assert.strictEqual(typeof acquireSpan.metrics['db.pool.wait_time_ms'], 'number')
+          })
+            .then(done)
+            .catch(done)
+
+          tracer.scope().activate(parent, () => {
+            pool.connect((error, client, release) => {
+              if (error) return done(error)
+              release()
+              parent.finish()
+            })
+          })
+        })
+
+        it('records an error on the acquire span when an explicit connect fails', async () => {
+          const probe = net.createServer()
+          await new Promise(resolve => probe.listen(0, '127.0.0.1', resolve))
+          const { port } = probe.address()
+          await new Promise(resolve => probe.close(resolve))
+
+          const failingPool = new pg.Pool({
+            host: '127.0.0.1',
+            port,
+            user: 'postgres',
+            database: 'postgres',
+            connectionTimeoutMillis: 500,
+          })
+          failingPool.on('error', () => {})
+
+          const tracePromise = agent.assertSomeTraces(traces => {
+            const acquireSpan = traces[0].find(span => span.name === 'pg.pool.acquire')
+
+            assert.ok(acquireSpan, `missing acquire span: ${inspect(traces[0].map(span => span.name))}`)
+            assert.strictEqual(acquireSpan.error, 1)
+          })
+
+          await assert.rejects(failingPool.connect())
+          await tracePromise
+          await failingPool.end()
+        })
+
+        it('does not create an acquire span for pool.query', done => {
+          agent.assertSomeTraces(traces => {
+            assert.ok(
+              !traces[0].some(span => span.name === 'pg.pool.acquire'),
+              `unexpected acquire span: ${inspect(traces[0].map(span => span.name))}`
+            )
+          }, { spanResourceMatch: /^SELECT 6 AS six$/ })
+            .then(done)
+            .catch(done)
+
+          pool.query('SELECT 6 AS six', error => {
+            if (error) done(error)
           })
         })
       })


### PR DESCRIPTION
Depends on #8914 (stacked; review that first).

## Summary

An explicit `pool.connect()` had no span for the acquire and the promise form was not instrumented at all, so a client checked out for a transaction hid the time spent waiting for the pool, and a failed checkout was invisible. Each explicit acquire now opens a `pg.pool.acquire` span as a child of the caller, carrying `db.pool.wait_time_ms` and recording connection errors.

## Why

The metric is not a restatement of the span's duration. pg hands an idle client back on a later tick, so an acquire opened while the event loop is busy spans that lag — 100 ms against a blocked loop, where the pool made the caller wait for none of it. The duration says how long the caller waited, the metric how much of that the pool caused.

The acquire `Pool.query` runs internally keeps reporting its wait as a tag on the query span, so a given acquire is counted once. Explicit acquires no longer feed that handoff, so the first query on a `pool.connect(cb)` client reports no wait of its own.

Refs: https://github.com/DataDog/dd-trace-js/issues/1923