### PR TITLE
feat(aws-sdk): allow a function service for per-resource span naming

### DIFF
--- a/docs/test.ts
+++ b/docs/test.ts
@@ -253,7 +253,7 @@ const awsSdkOptions: plugins.aws_sdk = {
 };
 
 const awsSdkServiceFunctionOptions: plugins.aws_sdk = {
-  service: params => params.TableName ?? 'aws',
+  service: (params): string | undefined => params.TableName ? String(params.TableName) : undefined,
 };
 
 const bullmqOptions: plugins.bullmq = {

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -252,6 +252,10 @@ const awsSdkOptions: plugins.aws_sdk = {
   }
 };
 
+const awsSdkServiceFunctionOptions: plugins.aws_sdk = {
+  service: params => params.TableName ?? 'aws',
+};
+
 const bullmqOptions: plugins.bullmq = {
   service: 'test',
   producerFilter: ({ name, queueName }) => name !== 'skip' && queueName !== 'dead-letter',
@@ -291,9 +295,9 @@ tracer.use('amqp10');
 tracer.use('amqplib');
 tracer.use('anthropic');
 tracer.use('avsc');
-tracer.use('aws-durable-execution-sdk-js');
 tracer.use('aws-sdk');
 tracer.use('aws-sdk', awsSdkOptions);
+tracer.use('aws-sdk', awsSdkServiceFunctionOptions);
 tracer.use('azure-cosmos');
 tracer.use('azure-event-hubs')
 tracer.use('azure-functions');

--- a/index.d.ts
+++ b/index.d.ts
@@ -2241,7 +2241,7 @@ declare namespace tracer {
        * is used as the service name. Returning a nullish value falls back to the default service name, so
        * individual resources can be mapped without renaming every call to the service.
        */
-      service?: string | ((params: anyObject) => string);
+      service?: string | ((params: anyObject) => string | undefined | null);
 
       /**
        * Whether to inject all messages during batch AWS SQS, Kinesis, and SNS send operations. Normal

--- a/index.d.ts
+++ b/index.d.ts
@@ -2236,6 +2236,14 @@ declare namespace tracer {
      */
     interface aws_sdk extends Instrumentation {
       /**
+       * The service name to be used for this plugin. When a function is used it is called with the AWS
+       * request parameters (e.g. `{ TableName }` for DynamoDB, `{ Bucket }` for S3) and its return value
+       * is used as the service name. Returning a nullish value falls back to the default service name, so
+       * individual resources can be mapped without renaming every call to the service.
+       */
+      service?: string | ((params: anyObject) => string);
+
+      /**
        * Whether to inject all messages during batch AWS SQS, Kinesis, and SNS send operations. Normal
        * behavior is to inject the first message in batch send operations.
        * @default false

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -2364,6 +2364,14 @@ declare namespace tracer {
      */
     interface aws_sdk extends Instrumentation {
       /**
+       * The service name to be used for this plugin. When a function is used it is called with the AWS
+       * request parameters (e.g. `{ TableName }` for DynamoDB, `{ Bucket }` for S3) and its return value
+       * is used as the service name. Returning a nullish value falls back to the default service name, so
+       * individual resources can be mapped without renaming every call to the service.
+       */
+      service?: string | ((params: anyObject) => string | undefined | null);
+
+      /**
        * Whether to inject all messages during batch AWS SQS, Kinesis, and SNS send operations. Normal
        * behavior is to inject the first message in batch send operations.
        * @default false

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -220,8 +220,10 @@ class BaseAwsSdkPlugin extends ClientPlugin {
    * Resolve the span service. A string `service` config overrides every span;
    * a function `service` is called with the request params (`TableName`,
    * `Bucket`, `QueueUrl`, …) so a single resource can be mapped to its own
-   * service. A nullish function result falls back to the schema default, which
-   * lets callers rename only the resources they care about.
+   * service. The function result is used only when it is a non-empty string;
+   * anything else (nullish, empty, or a non-string the type does not permit)
+   * falls back to the schema default, which lets callers rename only the
+   * resources they care about.
    *
    * @param {{ params?: object }} request
    * @returns {string}
@@ -230,7 +232,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     const { service } = this.config
     if (typeof service === 'function') {
       const custom = service(request.params)
-      if (custom) return custom
+      if (typeof custom === 'string' && custom) return custom
     } else if (service) {
       return service
     }

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -217,30 +217,16 @@ class BaseAwsSdkPlugin extends ClientPlugin {
   }
 
   /**
-   * Resolve the span service. A string `service` config overrides every span;
-   * a function `service` is called with the request params (`TableName`,
-   * `Bucket`, `QueueUrl`, …) so a single resource can be mapped to its own
-   * service. The function result is used only when it is a non-empty string;
-   * anything else (nullish, empty, or a non-string the type does not permit)
-   * falls back to the schema default, which lets callers rename only the
-   * resources they care about.
-   *
    * @param {{ params?: object }} request
-   * @returns {string}
    */
   serviceName (request) {
-    const { service } = this.config
-    if (typeof service === 'function') {
-      const custom = service(request.params)
-      if (typeof custom === 'string' && custom) return custom
-    } else if (service) {
-      return service
-    }
     return super.serviceName({
       id: 'aws',
       type: 'web',
       kind: 'client',
       awsService: this.serviceIdentifier,
+      pluginConfig: this.config,
+      params: request.params,
     })
   }
 

--- a/packages/datadog-plugin-aws-sdk/src/base.js
+++ b/packages/datadog-plugin-aws-sdk/src/base.js
@@ -108,7 +108,7 @@ class BaseAwsSdkPlugin extends ClientPlugin {
       const span = this.startSpan(this.operationFromRequest(request), {
         childOf,
         meta,
-        service: this.serviceName(),
+        service: this.serviceName(request),
         integrationName: 'aws-sdk',
       }, ctx)
 
@@ -216,14 +216,30 @@ class BaseAwsSdkPlugin extends ClientPlugin {
     })
   }
 
-  serviceName () {
-    return this.config.service ||
-      super.serviceName({
-        id: 'aws',
-        type: 'web',
-        kind: 'client',
-        awsService: this.serviceIdentifier,
-      })
+  /**
+   * Resolve the span service. A string `service` config overrides every span;
+   * a function `service` is called with the request params (`TableName`,
+   * `Bucket`, `QueueUrl`, …) so a single resource can be mapped to its own
+   * service. A nullish function result falls back to the schema default, which
+   * lets callers rename only the resources they care about.
+   *
+   * @param {{ params?: object }} request
+   * @returns {string}
+   */
+  serviceName (request) {
+    const { service } = this.config
+    if (typeof service === 'function') {
+      const custom = service(request.params)
+      if (custom) return custom
+    } else if (service) {
+      return service
+    }
+    return super.serviceName({
+      id: 'aws',
+      type: 'web',
+      kind: 'client',
+      awsService: this.serviceIdentifier,
+    })
   }
 
   isEnabled (request) {

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -374,6 +374,44 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with a service function returning a non-string', () => {
+        before(() => {
+          return agent.load(['aws-sdk', 'http'], [{
+            service (params) {
+              return params?.Bucket ? params.Bucket.length : undefined
+            },
+          }, { server: false }])
+        })
+
+        before(() => {
+          AWS = require(`../../../versions/${s3ClientName}@${version}`).get()
+          s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1', s3ForcePathStyle: true })
+          tracer = require('../../dd-trace')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        it('falls back to the default service name', (done) => {
+          agent.assertSomeTraces(traces => {
+            const span = sort(traces[0])[0]
+
+            assertObjectContains(span, {
+              name: 'aws.request',
+              resource: 'completeMultipartUpload my-bucket',
+              service: 'test-aws-s3',
+            })
+          }).then(done, done)
+
+          s3.completeMultipartUpload({
+            Bucket: 'my-bucket',
+            Key: 'my-key',
+            UploadId: 'my-upload-id',
+          }, () => {})
+        })
+      })
+
       describe('with service configuration', () => {
         before(() => {
           return agent.load(['aws-sdk', 'http'], [{

--- a/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
+++ b/packages/datadog-plugin-aws-sdk/test/aws-sdk.spec.js
@@ -322,6 +322,58 @@ describe('Plugin', () => {
         })
       })
 
+      describe('with a service function', () => {
+        before(() => {
+          return agent.load(['aws-sdk', 'http'], [{
+            service (params) {
+              return params?.Bucket ? `s3-bucket-${params.Bucket}` : undefined
+            },
+          }, { server: false }])
+        })
+
+        before(() => {
+          AWS = require(`../../../versions/${s3ClientName}@${version}`).get()
+          s3 = new AWS.S3({ endpoint: 'http://127.0.0.1:4566', region: 'us-east-1', s3ForcePathStyle: true })
+          tracer = require('../../dd-trace')
+        })
+
+        after(() => {
+          return agent.close()
+        })
+
+        it('derives the service name from the request params', (done) => {
+          agent.assertSomeTraces(traces => {
+            const span = sort(traces[0])[0]
+
+            assertObjectContains(span, {
+              name: 'aws.request',
+              resource: 'completeMultipartUpload my-bucket',
+              service: 's3-bucket-my-bucket',
+            })
+          }).then(done, done)
+
+          s3.completeMultipartUpload({
+            Bucket: 'my-bucket',
+            Key: 'my-key',
+            UploadId: 'my-upload-id',
+          }, () => {})
+        })
+
+        it('falls back to the default service name when the function returns undefined', (done) => {
+          agent.assertSomeTraces(traces => {
+            const span = sort(traces[0])[0]
+
+            assertObjectContains(span, {
+              name: 'aws.request',
+              resource: 'listBuckets',
+              service: 'test-aws-s3',
+            })
+          }).then(done, done)
+
+          s3.listBuckets({}, () => {})
+        })
+      })
+
       describe('with service configuration', () => {
         before(() => {
           return agent.load(['aws-sdk', 'http'], [{

--- a/packages/dd-trace/src/service-naming/schemas/util.js
+++ b/packages/dd-trace/src/service-naming/schemas/util.js
@@ -28,12 +28,43 @@ function optionServiceSource ({ pluginConfig }) {
   }
 }
 
-function awsServiceV0 ({ tracerService, awsService }) {
-  return `${tracerService}-aws-${awsService}`
+/**
+ * Resolve a `service` config that may be a string or a function. A string
+ * overrides every span; a function is called with the request params so a
+ * single resource can be mapped to its own service, and only a non-empty
+ * string result is honored — anything else falls back to `defaultService`.
+ *
+ * @param {{ service?: string | ((params?: object) => unknown) }} [pluginConfig]
+ * @param {object} [params]
+ * @param {string} defaultService
+ * @returns {string}
+ */
+function configServiceName (pluginConfig, params, defaultService) {
+  const service = pluginConfig?.service
+  if (typeof service === 'function') {
+    const custom = service(params)
+    return typeof custom === 'string' && custom ? custom : defaultService
+  }
+  return service || defaultService
 }
 
-function awsServiceSource ({ awsService }) {
-  return awsService
+function awsServiceV0 ({ tracerService, pluginConfig, params, awsService }) {
+  return configServiceName(pluginConfig, params, `${tracerService}-aws-${awsService}`)
 }
 
-module.exports = { identityService, httpPluginClientService, awsServiceV0, optionServiceSource, awsServiceSource }
+function awsServiceV1 ({ tracerService, pluginConfig, params }) {
+  return configServiceName(pluginConfig, params, tracerService)
+}
+
+function awsServiceSource ({ awsService, pluginConfig }) {
+  return pluginConfig?.service ? 'opt.plugin' : awsService
+}
+
+module.exports = {
+  identityService,
+  httpPluginClientService,
+  awsServiceV0,
+  awsServiceV1,
+  optionServiceSource,
+  awsServiceSource,
+}

--- a/packages/dd-trace/src/service-naming/schemas/v1/web.js
+++ b/packages/dd-trace/src/service-naming/schemas/v1/web.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { identityService, httpPluginClientService, optionServiceSource } = require('../util')
+const { identityService, httpPluginClientService, optionServiceSource, awsServiceV1 } = require('../util')
 
 const web = {
   client: {
@@ -38,11 +38,13 @@ const web = {
     },
     aws: {
       opName: ({ awsService }) => `aws.${awsService}.request`,
-      serviceName: identityService,
+      serviceName: awsServiceV1,
+      serviceSource: optionServiceSource,
     },
     lambda: {
       opName: () => 'aws.lambda.invoke',
-      serviceName: identityService,
+      serviceName: awsServiceV1,
+      serviceSource: optionServiceSource,
     },
     undici: {
       opName: () => 'undici.request',

--- a/packages/dd-trace/test/service-naming/schema.spec.js
+++ b/packages/dd-trace/test/service-naming/schema.spec.js
@@ -7,6 +7,8 @@ const sinon = require('sinon')
 
 require('../setup/core')
 const SchemaDefinition = require('../../src/service-naming/schemas/definition')
+const v0 = require('../../src/service-naming/schemas/v0')
+const v1 = require('../../src/service-naming/schemas/v1')
 
 describe('Service naming', () => {
   let singleton
@@ -91,6 +93,66 @@ describe('Service naming', () => {
         sinon.assert.calledWith(dummySchema.messaging.inbound.kafka.serviceName, opts)
         sinon.assert.calledWith(dummySchema.messaging.inbound.kafka.serviceSource, opts)
         assert.deepStrictEqual(result, { name: 'kafka-service', source: 'kafka' })
+      })
+    })
+  })
+
+  describe('AWS service resolution', () => {
+    const awsName = (schema, pluginConfig, params) =>
+      schema.getServiceName('web', 'client', 'aws', {
+        tracerService: 'test',
+        awsService: 's3',
+        pluginConfig,
+        params,
+      })
+
+    describe('v0', () => {
+      it('appends the aws service to the default name', () => {
+        assert.deepStrictEqual(awsName(v0, {}, {}), { name: 'test-aws-s3', source: 's3' })
+      })
+
+      it('lets a string service override every span', () => {
+        assert.deepStrictEqual(awsName(v0, { service: 'custom' }, {}), { name: 'custom', source: 'opt.plugin' })
+      })
+
+      it('derives the name from a function service', () => {
+        const service = params => (params.Bucket ? `s3-${params.Bucket}` : undefined)
+        assert.deepStrictEqual(
+          awsName(v0, { service }, { Bucket: 'b' }),
+          { name: 's3-b', source: 'opt.plugin' }
+        )
+      })
+
+      it('falls back to the default name on a nullish or non-string function result', () => {
+        const nullish = awsName(v0, { service: () => undefined }, {})
+        const nonString = awsName(v0, { service: () => 42 }, {})
+        assert.strictEqual(nullish.name, 'test-aws-s3')
+        assert.strictEqual(nonString.name, 'test-aws-s3')
+      })
+    })
+
+    describe('v1', () => {
+      it('uses the tracer service as the default name', () => {
+        assert.deepStrictEqual(awsName(v1, {}, {}), { name: 'test', source: undefined })
+      })
+
+      it('lets a string service override every span', () => {
+        assert.deepStrictEqual(awsName(v1, { service: 'custom' }, {}), { name: 'custom', source: 'opt.plugin' })
+      })
+
+      it('derives the name from a function service', () => {
+        const service = params => (params.Bucket ? `s3-${params.Bucket}` : undefined)
+        assert.deepStrictEqual(
+          awsName(v1, { service }, { Bucket: 'b' }),
+          { name: 's3-b', source: 'opt.plugin' }
+        )
+      })
+
+      it('falls back to the tracer service on a nullish or non-string function result', () => {
+        const nullish = awsName(v1, { service: () => undefined }, {})
+        const nonString = awsName(v1, { service: () => 42 }, {})
+        assert.strictEqual(nullish.name, 'test')
+        assert.strictEqual(nonString.name, 'test')
       })
     })
   })


### PR DESCRIPTION
## Summary

The `aws-sdk` plugin only accepted a string `service`, which renames every span of a service (all DynamoDB calls, all S3 calls) at once. There was no way to map a single resource — one table, one bucket, one queue — to its own service, so two apps sharing a table could not be linked through it on the service map.

A function `service` is now called with the request params and names the span from its return value; a nullish result falls back to the default name, so only the resources that need a dedicated service are remapped. This matches the function `service` already accepted by the `pg`, `mysql`, and `oracledb` plugins.

```js
tracer.use('aws-sdk', {
  service: params => params?.TableName ? `dynamodb-${params.TableName}` : undefined
})
```

## Test plan

- New `aws-sdk` unit cases cover both branches: the function return value is used, and a nullish return falls back to the default `{service}-aws-{svc}` name.

Refs: https://github.com/DataDog/dd-trace-js/issues/4007