### PR TITLE
fix(sampling): materialize the priority decision when reading the W3C sampled flag

### DIFF
--- a/packages/dd-trace/src/opentelemetry/span_context.js
+++ b/packages/dd-trace/src/opentelemetry/span_context.js
@@ -32,6 +32,7 @@ class SpanContext {
   }
 
   get traceFlags () {
+    this._ddContext._ensureSamplingPriority()
     return this._ddContext._sampling.priority >= AUTO_KEEP ? 1 : 0
   }
 

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -63,11 +63,25 @@ class DatadogSpanContext {
   }
 
   toTraceparent () {
+    this._ensureSamplingPriority()
     const flags = this._sampling.priority >= AUTO_KEEP ? '01' : '00'
     const traceId = this.toTraceId(true)
     const spanId = this.toSpanId(true)
     const version = (this._traceparent && this._traceparent.version) || '00'
     return `${version}-${traceId}-${spanId}-${flags}`
+  }
+
+  /**
+   * Materialize the lazy priority-sampling decision for this trace, the same
+   * way {@link DatadogTracer#inject} does before propagation. The auto priority
+   * is otherwise computed at flush time, so the W3C sampled flag reads "drop"
+   * for a freshly started, not-yet-flushed span — see
+   * https://github.com/DataDog/dd-trace-js/issues/2547.
+   */
+  _ensureSamplingPriority () {
+    if (this._sampling.priority !== undefined) return
+    const root = this._trace.started[0]
+    root?._prioritySampler?.sample(root)
   }
 
   /**

--- a/packages/dd-trace/src/opentracing/span_context.js
+++ b/packages/dd-trace/src/opentracing/span_context.js
@@ -77,11 +77,14 @@ class DatadogSpanContext {
    * is otherwise computed at flush time, so the W3C sampled flag reads "drop"
    * for a freshly started, not-yet-flushed span — see
    * https://github.com/DataDog/dd-trace-js/issues/2547.
+   *
+   * The root span is only used to reach the priority sampler; `this` is passed
+   * to `sample()` so a manual sampling tag set directly on this context is
+   * honored, matching what `inject(this)` would decide.
    */
   _ensureSamplingPriority () {
     if (this._sampling.priority !== undefined) return
-    const root = this._trace.started[0]
-    root?._prioritySampler?.sample(root)
+    this._trace.started[0]?._prioritySampler?.sample(this)
   }
 
   /**

--- a/packages/dd-trace/test/opentelemetry/tracer.spec.js
+++ b/packages/dd-trace/test/opentelemetry/tracer.spec.js
@@ -240,6 +240,17 @@ describe('OTel Tracer', () => {
     })
   })
 
+  it('reflects the sampling decision in traceFlags before the span ends', () => {
+    const otelTracer = new Tracer({}, {}, new TracerProvider())
+
+    const span = otelTracer.startSpan('name')
+    try {
+      assert.strictEqual(span.spanContext().traceFlags, 1)
+    } finally {
+      span.end()
+    }
+  })
+
   describe('_convertOtelContextToDatadog (traceparent/tracestate extraction)', () => {
     const TRACE_ID = '0123456789abcdef0123456789abcdef'
     const SPAN_ID = '0123456789abcdef'

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -6,6 +6,7 @@ const { describe, it, beforeEach } = require('mocha')
 
 require('../setup/core')
 const id = require('../../src/id')
+const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../ext/priority')
 
 describe('SpanContext', () => {
   let SpanContext
@@ -165,6 +166,50 @@ describe('SpanContext', () => {
 
       assert.strictEqual(spanContext.toTraceparent(), '00-00000000000007890000000000000123-0000000000000456-00')
     })
+
+    it('materializes the lazy sampling decision so the sampled flag is set before finish', () => {
+      const spanContext = withRootSampler(AUTO_KEEP)
+
+      assert.match(spanContext.toTraceparent(), /-01$/)
+    })
+
+    it('reflects a drop decision rather than defaulting the flag to keep', () => {
+      const spanContext = withRootSampler(AUTO_REJECT)
+
+      assert.match(spanContext.toTraceparent(), /-00$/)
+      assert.strictEqual(spanContext._sampling.priority, AUTO_REJECT)
+    })
+
+    it('does not re-sample once a priority is already decided', () => {
+      const spanContext = new SpanContext({ traceId: id('123', 16), spanId: id('456', 16) })
+      spanContext._sampling.priority = USER_KEEP
+      spanContext._trace.started.push({
+        context: () => spanContext,
+        _prioritySampler: { sample () { throw new Error('should not re-sample a decided trace') } },
+      })
+
+      assert.match(spanContext.toTraceparent(), /-01$/)
+    })
+
+    /**
+     * Builds a context whose root span carries a priority sampler that records
+     * the given decision, mirroring the lazy auto-sampling path.
+     *
+     * @param {import('../../src/priority_sampler').SamplingPriority} priority
+     * @returns {SpanContext}
+     */
+    function withRootSampler (priority) {
+      const spanContext = new SpanContext({ traceId: id('123', 16), spanId: id('456', 16) })
+      spanContext._trace.started.push({
+        context: () => spanContext,
+        _prioritySampler: {
+          sample (span) {
+            span.context()._sampling.priority = priority
+          },
+        },
+      })
+      return spanContext
+    }
   })
 
   describe('tag accessor API', () => {

--- a/packages/dd-trace/test/opentracing/span_context.spec.js
+++ b/packages/dd-trace/test/opentracing/span_context.spec.js
@@ -5,8 +5,11 @@ const assert = require('node:assert/strict')
 const { describe, it, beforeEach } = require('mocha')
 
 require('../setup/core')
+const getConfig = require('../../src/config')
 const id = require('../../src/id')
-const { AUTO_KEEP, AUTO_REJECT, USER_KEEP } = require('../../../../ext/priority')
+const Span = require('../../src/opentracing/span')
+const PrioritySampler = require('../../src/priority_sampler')
+const { MANUAL_KEEP, SAMPLING_PRIORITY } = require('../../../../ext/tags')
 
 describe('SpanContext', () => {
   let SpanContext
@@ -167,48 +170,47 @@ describe('SpanContext', () => {
       assert.strictEqual(spanContext.toTraceparent(), '00-00000000000007890000000000000123-0000000000000456-00')
     })
 
-    it('materializes the lazy sampling decision so the sampled flag is set before finish', () => {
-      const spanContext = withRootSampler(AUTO_KEEP)
+    it('materializes the lazy auto-keep decision so the sampled flag is set before finish', () => {
+      const span = startSpan(new PrioritySampler())
 
-      assert.match(spanContext.toTraceparent(), /-01$/)
+      assert.match(span.context().toTraceparent(), /-01$/)
     })
 
-    it('reflects a drop decision rather than defaulting the flag to keep', () => {
-      const spanContext = withRootSampler(AUTO_REJECT)
+    it('reflects an auto-drop decision rather than defaulting the flag to keep', () => {
+      const span = startSpan(new PrioritySampler(undefined, { sampleRate: 0 }))
 
-      assert.match(spanContext.toTraceparent(), /-00$/)
-      assert.strictEqual(spanContext._sampling.priority, AUTO_REJECT)
+      assert.match(span.context().toTraceparent(), /-00$/)
     })
 
-    it('does not re-sample once a priority is already decided', () => {
-      const spanContext = new SpanContext({ traceId: id('123', 16), spanId: id('456', 16) })
-      spanContext._sampling.priority = USER_KEEP
-      spanContext._trace.started.push({
-        context: () => spanContext,
-        _prioritySampler: { sample () { throw new Error('should not re-sample a decided trace') } },
-      })
+    it('honors a manual drop tag set directly on a non-root context', () => {
+      const prioritySampler = new PrioritySampler()
+      const root = startSpan(prioritySampler)
+      const child = startSpan(prioritySampler, root)
+      child.context().setTag(SAMPLING_PRIORITY, 0)
 
-      assert.match(spanContext.toTraceparent(), /-01$/)
+      assert.match(child.context().toTraceparent(), /-00$/)
+    })
+
+    it('does not override a priority that was already decided', () => {
+      const span = startSpan(new PrioritySampler(undefined, { sampleRate: 0 }))
+      span.setTag(MANUAL_KEEP, true)
+
+      assert.match(span.context().toTraceparent(), /-01$/)
     })
 
     /**
-     * Builds a context whose root span carries a priority sampler that records
-     * the given decision, mirroring the lazy auto-sampling path.
+     * Starts a real span backed by a real priority sampler — the collaborator
+     * toTraceparent() reaches through _ensureSamplingPriority() to settle the
+     * lazy decision.
      *
-     * @param {import('../../src/priority_sampler').SamplingPriority} priority
-     * @returns {SpanContext}
+     * @param {PrioritySampler} prioritySampler
+     * @param {Span} [parent] Root span to descend from; omit for a root span.
+     * @returns {Span}
      */
-    function withRootSampler (priority) {
-      const spanContext = new SpanContext({ traceId: id('123', 16), spanId: id('456', 16) })
-      spanContext._trace.started.push({
-        context: () => spanContext,
-        _prioritySampler: {
-          sample (span) {
-            span.context()._sampling.priority = priority
-          },
-        },
-      })
-      return spanContext
+    function startSpan (prioritySampler, parent) {
+      const tracer = { _config: getConfig() }
+      const processor = { process () {} }
+      return new Span(tracer, processor, prioritySampler, { operationName: 'test', parent: parent?.context() })
     }
   })
 


### PR DESCRIPTION
## Summary

The auto priority-sampling decision is computed lazily, at flush/inject time. Reading the W3C sampled flag before that — `span.context().toTraceparent()` or the OpenTelemetry `span.spanContext().traceFlags` right after `startSpan()` — therefore reported "drop" (`00` / `0`) even for a trace that is kept once it flushes. This is the observable symptom of #2547 and is more visible now that the OTel bridge is a supported surface (the OTel `Sampler.shouldSample` hook is still an unused stub, so OTel users get dd-trace's lazy model rather than head-based sampling).

Both readers now materialize the decision the same way `inject()` already does, via a shared `_ensureSamplingPriority()` helper on the Datadog span context. Distributed propagation was already correct (inject forces the decision); this only fixes the local programmatic read.

## Why

The decision is trace-level and made once (the `_sampling` object is shared by reference across the trace), so a single root computation settles the whole local trace and an early read locks it in using the service tag present at read time — the same trade-off `inject()` already makes. This is the surgical fix for the symptom; making sampling fully head-based at span start (wiring `opentelemetry/sampler.js` and computing the root decision in `startSpan`) is a larger, separate change with its own behavior/perf implications.

## Test plan

- `packages/dd-trace/test/opentracing/span_context.spec.js` — `toTraceparent()` reflects keep/drop before finish, and does not re-sample an already-decided trace.
- `packages/dd-trace/test/opentelemetry/tracer.spec.js` — OTel `traceFlags` reflects the decision before `span.end()`.
- Both new assertions fail on master (read `00`/`0`) and pass with the fix.

Refs: https://github.com/DataDog/dd-trace-js/issues/2547