### PR TITLE
perf(test-optimization): reuse vitest git metadata in workers

### DIFF
--- a/integration-tests/ci-visibility/vitest-tests/vitest-worker-env.mjs
+++ b/integration-tests/ci-visibility/vitest-tests/vitest-worker-env.mjs
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest'
+
+describe('vitest worker env', () => {
+  it('sets DD_VITEST_WORKER', () => {
+    expect(process.env.DD_VITEST_WORKER).toBe('1')
+  })
+})

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -30,6 +30,20 @@ if (process.env.CUSTOM_SEQUENCER) {
   }
 }
 
+if (process.env.PROJECT_POOL_CONFIG) {
+  config.test.projects = [
+    {
+      test: {
+        include: [
+          process.env.TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
+        ],
+        name: 'project-pool',
+        pool: process.env.PROJECT_POOL_CONFIG,
+      },
+    },
+  ]
+}
+
 if (process.env.COVERAGE_PROVIDER) {
   config.test.coverage = {
     provider: process.env.COVERAGE_PROVIDER || 'v8',

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -289,6 +289,40 @@ versions.forEach((version) => {
       assert.strictEqual(code, 0)
     })
 
+    newerVitestIt('sets DD_VITEST_WORKER in workers when a fork project has a threads root pool', async () => {
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const test = events.find(event => event.type === 'test').content
+
+          assert.ok(test)
+          assert.strictEqual(test.meta[TEST_NAME], 'vitest worker env sets DD_VITEST_WORKER')
+          assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            TEST_DIR: 'ci-visibility/vitest-tests/vitest-worker-env.mjs',
+            POOL_CONFIG: 'threads',
+            PROJECT_POOL_CONFIG: 'forks',
+            DD_SERVICE: undefined,
+          },
+        }
+      )
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 0)
+    })
+
     it('propagates test span context to HTTP requests and hooks during test execution', async () => {
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {

--- a/integration-tests/vitest/vitest.core.spec.js
+++ b/integration-tests/vitest/vitest.core.spec.js
@@ -256,6 +256,39 @@ versions.forEach((version) => {
       })
     })
 
+    newerVitestIt('sets DD_VITEST_WORKER in workers with pool=forks', async () => {
+      const eventsPromise = receiver
+        .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {
+          const events = payloads.flatMap(({ payload }) => payload.events)
+          const test = events.find(event => event.type === 'test').content
+
+          assert.ok(test)
+          assert.strictEqual(test.meta[TEST_NAME], 'vitest worker env sets DD_VITEST_WORKER')
+          assert.strictEqual(test.meta[TEST_STATUS], 'pass')
+        }, 25000)
+
+      childProcess = exec(
+        './node_modules/.bin/vitest run',
+        {
+          cwd,
+          env: {
+            ...getCiVisAgentlessConfig(receiver.port),
+            NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+            TEST_DIR: 'ci-visibility/vitest-tests/vitest-worker-env.mjs',
+            POOL_CONFIG: 'forks',
+            DD_SERVICE: undefined,
+          },
+        }
+      )
+
+      const [[code]] = await Promise.all([
+        once(childProcess, 'exit'),
+        eventsPromise,
+      ])
+
+      assert.strictEqual(code, 0)
+    })
+
     it('propagates test span context to HTTP requests and hooks during test execution', async () => {
       const eventsPromise = receiver
         .gatherPayloadsMaxTimeout(({ url }) => url === '/api/v2/citestcycle', (payloads) => {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -143,6 +143,8 @@ function getProvidedContext () {
       _ddTestSessionId: testSessionId,
       _ddTestModuleId: testModuleId,
       _ddTestCommand: testCommand,
+      _ddRepositoryRoot: repositoryRoot,
+      _ddCodeOwnersEntries: codeOwnersEntries,
     } = globalThis.__vitest_worker__.providedContext
 
     return {
@@ -162,6 +164,8 @@ function getProvidedContext () {
       testSessionId,
       testModuleId,
       testCommand,
+      repositoryRoot,
+      codeOwnersEntries,
     }
   } catch {
     log.error('Vitest workers could not parse provided context, so some features will not work.')
@@ -182,6 +186,8 @@ function getProvidedContext () {
       testSessionId: undefined,
       testModuleId: undefined,
       testCommand: undefined,
+      repositoryRoot: undefined,
+      codeOwnersEntries: undefined,
     }
   }
 }
@@ -472,7 +478,7 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
   }
 
   if (testSessionConfigurationCh.hasSubscribers) {
-    const { testSessionId, testModuleId, testCommand } = await getChannelPromise(
+    const { testSessionId, testModuleId, testCommand, repositoryRoot, codeOwnersEntries } = await getChannelPromise(
       testSessionConfigurationCh,
       frameworkVersion
     )
@@ -480,6 +486,8 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
       _ddTestSessionId: testSessionId,
       _ddTestModuleId: testModuleId,
       _ddTestCommand: testCommand,
+      _ddRepositoryRoot: repositoryRoot,
+      _ddCodeOwnersEntries: codeOwnersEntries,
     }, 'Could not send test session configuration to workers.')
   }
 
@@ -653,15 +661,32 @@ function getCliOrStartVitestWrapper (frameworkVersion) {
   }
 }
 
+function markVitestWorkerEnv (ctx) {
+  const config = ctx?.config
+  if (!config || config.pool === 'threads' || config.pool === 'vmThreads') {
+    return
+  }
+  config.env = config.env || {}
+  config.env.DD_VITEST_WORKER = '1'
+}
+
 function wrapVitestRunFiles (Vitest, frameworkVersion) {
   if (!Vitest?.prototype?.runFiles) {
     return
   }
 
   shimmer.wrap(Vitest.prototype, 'runFiles', runFiles => async function (testSpecifications) {
+    markVitestWorkerEnv(this)
     await ensureMainProcessSetup(this, frameworkVersion, testSpecifications)
     return runFiles.apply(this, arguments)
   })
+
+  if (Vitest.prototype.collectTests) {
+    shimmer.wrap(Vitest.prototype, 'collectTests', collectTests => function () {
+      markVitestWorkerEnv(this)
+      return collectTests.apply(this, arguments)
+    })
+  }
 }
 
 function getCreateCliWrapper (vitestPackage, frameworkVersion) {
@@ -1393,6 +1418,8 @@ addHook({
       testSessionId: providedContext.testSessionId,
       testModuleId: providedContext.testModuleId,
       testCommand: providedContext.testCommand,
+      repositoryRoot: providedContext.repositoryRoot,
+      codeOwnersEntries: providedContext.codeOwnersEntries,
     }
     testSuiteStartCh.runStores(testSuiteCtx, () => {})
     const startTestsResponse = await startTests.apply(this, arguments)

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -661,9 +661,41 @@ function getCliOrStartVitestWrapper (frameworkVersion) {
   }
 }
 
-function markVitestWorkerEnv (ctx) {
+function isForkPool (pool) {
+  return pool === 'forks' || pool === 'vmForks'
+}
+
+function isThreadPool (pool) {
+  return pool === 'threads' || pool === 'vmThreads'
+}
+
+function getTestSpecificationPool (testSpecification) {
+  const project = Array.isArray(testSpecification) ? testSpecification[0] : testSpecification?.project
+  return project?.config?.pool || project?.serializedConfig?.pool || project?.pool || testSpecification?.pool
+}
+
+function hasForkPoolTestSpecification (testSpecifications) {
+  if (!Array.isArray(testSpecifications)) {
+    return false
+  }
+
+  for (const testSpecification of testSpecifications) {
+    if (isForkPool(getTestSpecificationPool(testSpecification))) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function shouldMarkVitestWorkerEnv (pool, testSpecifications) {
+  return isForkPool(pool) || hasForkPoolTestSpecification(testSpecifications) ||
+    (!testSpecifications && !isThreadPool(pool))
+}
+
+function markVitestWorkerEnv (ctx, testSpecifications) {
   const config = ctx?.config
-  if (!config || config.pool === 'threads' || config.pool === 'vmThreads') {
+  if (!config || !shouldMarkVitestWorkerEnv(config.pool, testSpecifications)) {
     return
   }
   config.env = config.env || {}
@@ -676,7 +708,7 @@ function wrapVitestRunFiles (Vitest, frameworkVersion) {
   }
 
   shimmer.wrap(Vitest.prototype, 'runFiles', runFiles => async function (testSpecifications) {
-    markVitestWorkerEnv(this)
+    markVitestWorkerEnv(this, testSpecifications)
     await ensureMainProcessSetup(this, frameworkVersion, testSpecifications)
     return runFiles.apply(this, arguments)
   })

--- a/packages/datadog-plugin-vitest/src/index.js
+++ b/packages/datadog-plugin-vitest/src/index.js
@@ -63,6 +63,8 @@ class VitestPlugin extends CiPlugin {
         testSessionId: testSessionSpanContext?.toTraceId(),
         testModuleId: testModuleSpanContext?.toSpanId(),
         testCommand: this.command,
+        repositoryRoot: this.repositoryRoot,
+        codeOwnersEntries: this.codeOwnersEntries,
       })
     })
 
@@ -307,10 +309,11 @@ class VitestPlugin extends CiPlugin {
     })
 
     this.addBind('ci:vitest:test-suite:start', (ctx) => {
-      const { testSuiteAbsolutePath, frameworkVersion } = ctx
+      const { codeOwnersEntries, repositoryRoot, testSuiteAbsolutePath, frameworkVersion } = ctx
 
       const testCommand = ctx.testCommand || 'vitest run'
       const { testSessionId, testModuleId } = ctx
+      this._setRepositoryRoot(repositoryRoot, codeOwnersEntries)
       this.command = testCommand
       this.frameworkVersion = frameworkVersion
       const testSessionSpanContext = testSessionId && testModuleId

--- a/packages/dd-trace/src/plugins/ci_plugin.js
+++ b/packages/dd-trace/src/plugins/ci_plugin.js
@@ -443,6 +443,28 @@ module.exports = class CiPlugin extends Plugin {
   }
 
   /**
+   * Updates repository-root-dependent state when a worker receives the root from
+   * the coordinator process after plugin configuration.
+   *
+   * @param {string|undefined} repositoryRoot - Repository root discovered by the coordinator process.
+   * @param {Array<{ pattern: string, owners: string[] }>|null|undefined} codeOwnersEntries
+   * Parsed CODEOWNERS entries discovered by the coordinator process.
+   * @returns {void}
+   */
+  _setRepositoryRoot (repositoryRoot, codeOwnersEntries) {
+    if (codeOwnersEntries !== undefined) {
+      this.codeOwnersEntries = codeOwnersEntries
+    }
+
+    if (!repositoryRoot || repositoryRoot === this.repositoryRoot) return
+
+    this.repositoryRoot = repositoryRoot
+    if (codeOwnersEntries === undefined) {
+      this.codeOwnersEntries = getCodeOwnersFileEntries(this.repositoryRoot)
+    }
+  }
+
+  /**
    * Returns request error tags from the test session span for propagation to module, suite and test spans.
    * @returns {Record<string, string>}
    */
@@ -610,6 +632,8 @@ module.exports = class CiPlugin extends Plugin {
     const workerTestFramework = WORKER_EXPORTER_TO_TEST_FRAMEWORK[exporter]
     this.shouldSkipGitMetadataExtraction = workerTestFramework &&
       TEST_FRAMEWORKS_TO_SKIP_GIT_METADATA_EXTRACTION.has(workerTestFramework)
+    const shouldDeferCodeOwnersEntries = workerTestFramework === 'vitest'
+    const shouldDeferRepositoryRoot = workerTestFramework === 'vitest'
 
     this.testEnvironmentMetadata = getTestEnvironmentMetadata(
       this.constructor.id,
@@ -635,9 +659,10 @@ module.exports = class CiPlugin extends Plugin {
       [GIT_COMMIT_HEAD_MESSAGE]: commitHeadMessage,
     } = this.testEnvironmentMetadata
 
-    this.repositoryRoot = repositoryRoot || getRepositoryRoot() || process.cwd()
+    this.repositoryRoot = repositoryRoot ||
+      (shouldDeferRepositoryRoot ? process.cwd() : getRepositoryRoot() || process.cwd())
 
-    this.codeOwnersEntries = getCodeOwnersFileEntries(this.repositoryRoot)
+    this.codeOwnersEntries = shouldDeferCodeOwnersEntries ? null : getCodeOwnersFileEntries(this.repositoryRoot)
 
     this.ciProviderName = ciProviderName
 

--- a/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
+++ b/packages/dd-trace/test/ci-visibility/ci-plugin.spec.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+
+require('../setup/core')
+
+const {
+  OS_ARCHITECTURE,
+  OS_PLATFORM,
+  OS_VERSION,
+  RUNTIME_NAME,
+  RUNTIME_VERSION,
+} = require('../../src/plugins/util/env')
+const {
+  CI_PROVIDER_NAME,
+  CI_WORKSPACE_PATH,
+  GIT_BRANCH,
+  GIT_COMMIT_HEAD_MESSAGE,
+  GIT_COMMIT_HEAD_SHA,
+  GIT_COMMIT_MESSAGE,
+  GIT_COMMIT_SHA,
+  GIT_PULL_REQUEST_BASE_BRANCH_SHA,
+  GIT_REPOSITORY_URL,
+  GIT_TAG,
+} = require('../../src/plugins/util/tags')
+
+describe('CiPlugin', () => {
+  let CiPlugin
+  let getCodeOwnersFileEntries
+  let getRepositoryRoot
+  let getTestEnvironmentMetadata
+
+  beforeEach(() => {
+    getCodeOwnersFileEntries = sinon.stub()
+    getRepositoryRoot = sinon.stub()
+    getTestEnvironmentMetadata = sinon.stub().returns(getTestEnvironmentMetadataPayload())
+
+    CiPlugin = proxyquire('../../src/plugins/ci_plugin', {
+      './util/git': {
+        getRepositoryRoot,
+      },
+      './util/test': {
+        ...require('../../src/plugins/util/test'),
+        getCodeOwnersFileEntries,
+        getTestEnvironmentMetadata,
+      },
+    })
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('defers repository root and CODEOWNERS discovery in Vitest workers', () => {
+    const cwd = sinon.stub(process, 'cwd').returns('/worker-cwd')
+    const plugin = createPlugin('vitest_worker')
+
+    assert.strictEqual(plugin.repositoryRoot, '/worker-cwd')
+    assert.strictEqual(plugin.codeOwnersEntries, null)
+    assert.strictEqual(plugin.shouldSkipGitMetadataExtraction, true)
+    sinon.assert.calledWith(getTestEnvironmentMetadata, 'vitest', sinon.match.object, true)
+    sinon.assert.notCalled(getRepositoryRoot)
+    sinon.assert.notCalled(getCodeOwnersFileEntries)
+    sinon.assert.called(cwd)
+  })
+
+  it('reuses repository root and CODEOWNERS entries received from the Vitest coordinator', () => {
+    const codeOwnersEntries = [{ pattern: '*.js', owners: ['@datadog-dd-trace-js'] }]
+    const plugin = createPlugin('vitest_worker')
+
+    plugin._setRepositoryRoot('/repo-root', codeOwnersEntries)
+
+    assert.strictEqual(plugin.repositoryRoot, '/repo-root')
+    assert.strictEqual(plugin.codeOwnersEntries, codeOwnersEntries)
+    sinon.assert.notCalled(getRepositoryRoot)
+    sinon.assert.notCalled(getCodeOwnersFileEntries)
+  })
+
+  it('keeps repository root discovery for non-Vitest workers', () => {
+    const codeOwnersEntries = [{ pattern: '*.js', owners: ['@datadog-dd-trace-js'] }]
+    getRepositoryRoot.returns('/repo-root')
+    getCodeOwnersFileEntries.returns(codeOwnersEntries)
+
+    const plugin = createPlugin('jest_worker')
+
+    assert.strictEqual(plugin.repositoryRoot, '/repo-root')
+    assert.strictEqual(plugin.codeOwnersEntries, codeOwnersEntries)
+    assert.strictEqual(plugin.shouldSkipGitMetadataExtraction, true)
+    sinon.assert.calledOnce(getRepositoryRoot)
+    sinon.assert.calledOnceWithExactly(getCodeOwnersFileEntries, '/repo-root')
+  })
+
+  function createPlugin (exporter) {
+    class TestPlugin extends CiPlugin {
+      static id = 'vitest'
+    }
+
+    const plugin = new TestPlugin({ _exporter: {} })
+    plugin.configure({
+      enabled: false,
+      experimental: {
+        exporter,
+      },
+    })
+    return plugin
+  }
+})
+
+function getTestEnvironmentMetadataPayload () {
+  return {
+    [GIT_REPOSITORY_URL]: 'git@github.com:DataDog/dd-trace-js.git',
+    [GIT_COMMIT_SHA]: 'abc123',
+    [OS_VERSION]: 'test-os-version',
+    [OS_PLATFORM]: 'test-os-platform',
+    [OS_ARCHITECTURE]: 'test-os-architecture',
+    [RUNTIME_NAME]: 'node',
+    [RUNTIME_VERSION]: process.version,
+    [GIT_BRANCH]: 'test-branch',
+    [CI_PROVIDER_NAME]: 'github',
+    [CI_WORKSPACE_PATH]: undefined,
+    [GIT_COMMIT_MESSAGE]: 'test commit',
+    [GIT_TAG]: undefined,
+    [GIT_PULL_REQUEST_BASE_BRANCH_SHA]: undefined,
+    [GIT_COMMIT_HEAD_SHA]: undefined,
+    [GIT_COMMIT_HEAD_MESSAGE]: undefined,
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Extracted from https://github.com/DataDog/dd-trace-js/pull/8869

This PR propagates the Vitest coordinator process repository root and parsed CODEOWNERS entries to Vitest workers.

Workers apply that coordinator data when test suites start, so they do not need to rediscover the repository root or reparse CODEOWNERS independently in each isolated worker process.

It also sets `DD_VITEST_WORKER=1` for newer Vitest fork workers so they are identified through the dedicated worker environment flag.

### Motivation

Vitest runs test files in isolated workers by default. With Test Optimization enabled, each worker initializes dd-trace and was paying for repository-root discovery plus CODEOWNERS parsing independently. Reusing the coordinator process data avoids that repeated worker startup work while preserving the same repository-root and CODEOWNERS reporting behavior.

### Benchmark

Benchmark setup: Vitest `3.2.6`, `isolate:true`, 200 suites, 2 zero-delay tests per suite, 5 runs.

| Scenario | Median | Overhead vs no trace | Overhead cut |
|---|---:|---:|---:|
| No trace | `6.697s` | n/a | n/a |
| Traced master `f39f25f32` | `38.923s` | `32.226s` | baseline |
| Traced this PR | `30.990s` | `24.293s` | `24.6%` |
