### PR TITLE
fix(llmobs): emit a single llm span for langchain + anthropic

### DIFF
--- a/packages/dd-trace/src/llmobs/plugins/langchain/index.js
+++ b/packages/dd-trace/src/llmobs/plugins/langchain/index.js
@@ -9,7 +9,11 @@ const ANTHROPIC_PROVIDER_NAME = 'anthropic'
 const BEDROCK_PROVIDER_NAME = 'amazon_bedrock'
 const OPENAI_PROVIDER_NAME = 'openai'
 
-const SUPPORTED_INTEGRATIONS = new Set(['openai'])
+// Providers that ship their own LLMObs integration. When one of these is also
+// enabled, the LangChain model span is demoted to `workflow` so the provider
+// integration emits the single `llm` span — avoiding two llm spans (and
+// double-counted tokens/cost) for one underlying call.
+const SUPPORTED_INTEGRATIONS = new Set(['openai', 'anthropic'])
 const LLM_SPAN_TYPES = new Set(['llm', 'chat_model', 'embedding'])
 const LLM = 'llm'
 const WORKFLOW = 'workflow'

--- a/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
+++ b/packages/dd-trace/test/llmobs/plugins/langchain/index.spec.js
@@ -75,6 +75,52 @@ describe('integrations', () => {
     throw new Error(`Invalid type: ${type}`)
   }
 
+  // When a provider's own integration is enabled alongside LangChain, the
+  // LangChain model span is demoted to a `workflow` wrapper and the provider
+  // emits the single `llm` span. This avoids two llm spans (and double-counted
+  // tokens/cost) for one underlying call, while keeping the provider's
+  // cache-aware token accounting.
+  describe('langchain with a provider integration also enabled', () => {
+    const { getEvents } = useLlmObs({ plugin: ['langchain', 'anthropic'] })
+
+    withVersions('langchain', ['@langchain/core'], (version) => {
+      beforeEach(() => {
+        langchainAnthropic = require(`../../../../../../versions/@langchain/anthropic@${version}`).get()
+        langchainAnthropicVersion = require(`../../../../../../versions/@langchain/anthropic@${version}`).version()
+      })
+
+      it('emits one llm span from the provider and demotes the langchain span to workflow', async () => {
+        const usingNewerAnthropic = semifies(langchainAnthropicVersion, '>=1.3.22')
+        const modelName = usingNewerAnthropic ? 'claude-haiku-4-5-20251001' : 'claude-3-5-sonnet-20241022'
+
+        const chatModel = getLangChainAnthropicClient('chat', { modelName })
+        await chatModel.invoke('Hello!')
+
+        const { llmobsSpans } = await getEvents(2)
+
+        const workflowSpan = llmobsSpans.find(span => span.name === 'langchain.chat_models.anthropic.ChatAnthropic')
+        const llmSpan = llmobsSpans.find(span => span.name === 'anthropic.request')
+
+        assert.ok(workflowSpan, 'expected a langchain ChatAnthropic span')
+        assert.ok(llmSpan, 'expected an anthropic.request span')
+
+        // exactly one llm-kind span for the single underlying call
+        const llmSpans = llmobsSpans.filter(span => span.meta['span.kind'] === 'llm')
+        assert.equal(llmSpans.length, 1, 'expected exactly one llm span')
+
+        // the langchain span is demoted to a workflow wrapper...
+        assert.equal(workflowSpan.meta['span.kind'], 'workflow')
+        assert.ok(workflowSpan.tags.includes('integration:langchain'))
+
+        // ...and the provider emits the single llm span, nested under it
+        assert.equal(llmSpan.meta['span.kind'], 'llm')
+        assert.equal(llmSpan.meta.model_provider, 'anthropic')
+        assert.ok(llmSpan.tags.includes('integration:anthropic'))
+        assert.equal(llmSpan.parent_id, workflowSpan.span_id)
+      })
+    })
+  })
+
   describe('langchain', () => {
     const { getEvents } = useLlmObs({ plugin: 'langchain' })
 


### PR DESCRIPTION
### What

Add `anthropic` to `SUPPORTED_INTEGRATIONS` in the LangChain LLMObs plugin so a LangChain → Anthropic call produces **one** `llm` span instead of two.

Closes #8936

### Why

With `DD_LLMOBS_ENABLED` and both the `langchain` and `anthropic` integrations active, a single model call emitted two `llm`-kind spans, nested:

```
langchain.chat_models.anthropic.ChatAnthropic   (integration: langchain)
  └─ anthropic.request                            (integration: anthropic)   ← same call
```

Both carry the same token metrics, so the session/trace cost rollup sums both layers and overcounts spend (~2.2× in the reporting app). The two layers also disagree on cost — the LangChain span is cache-blind (`cache_read_input_tokens = 0`) while `anthropic.request` accounts for prompt-cache reads.

### How

The dedup mechanism already exists: in `getKind`, when a provider in `SUPPORTED_INTEGRATIONS` has its own LLMObs integration enabled (`isLLMIntegrationEnabled`), the LangChain model span is demoted to a `workflow` wrapper and the provider integration emits the single `llm` span. `getIntegrationName` already maps the Anthropic chat-model provider to `'anthropic'`, but `'anthropic'` was missing from `SUPPORTED_INTEGRATIONS`, so only `openai` benefited.

This one-line change makes the surviving `llm` span the **anthropic** one, which preserves cache-aware token accounting (`cache_read`/`cache_write`) — so it both removes the duplicate *and* keeps cost correct.

### Scope / safety

- **No effect when the anthropic integration isn't enabled** (e.g. langchain-only setups): `isLLMIntegrationEnabled('anthropic')` is then false and the LangChain span stays `llm`. Existing langchain-only tests are unchanged.
- Scoped to `anthropic` to match the issue. `bedrock` / `google-genai` have the same shape and could follow once their plugin-name resolution in `isLLMIntegrationEnabled` is confirmed — happy to do that in a follow-up.

### Test

Adds a case under `test/llmobs/plugins/langchain/index.spec.js` that loads **both** integrations (`useLlmObs({ plugin: ['langchain', 'anthropic'] })`) and asserts: exactly one `llm` span, the LangChain span demoted to `workflow`, and the `anthropic.request` span nested under it. This also adds the first coverage of the demotion path (previously untested even for openai).

> Note: I wasn't able to run the full VCR plugin suite locally (it needs `yarn services` + the test-agent on `:9126`), so I validated the source change and test by inspection and syntax-check and am relying on CI to exercise the cassettes. Both changed files pass `node --check`. Happy to adjust assertions if the cassette shapes differ.

### Checklist

- semver: patch (bugfix) — deferring to the team to confirm the label.
- CLA: will sign via the bot.
