### PR TITLE
ci(dependabot): broaden auto-merge coverage and rebalance update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
       gh-actions-packages:
         patterns:
           - "*"
+      security-non-production:
+        applies-to: security-updates
+        patterns:
+          - "*"
     labels:
       - dependabot
       - dependencies
@@ -49,6 +53,10 @@ updates:
       - semver-patch
     groups:
       docker-images:
+        patterns:
+          - "*"
+      security-non-production:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -112,6 +120,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Security fixes for shipped (production) dependencies; a human reviews majors.
+      security-production:
+        applies-to: security-updates
+        dependency-type: "production"
+        patterns:
+          - "*"
+      # Security fixes for dev-only dependencies; auto-merges fully.
+      security-non-production:
+        applies-to: security-updates
+        dependency-type: "development"
+        patterns:
+          - "*"
 
   # Vendored dependencies
   - package-ecosystem: "npm"
@@ -159,6 +179,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      # Vendored code is bundled into the shipped package, so it counts as production.
+      security-production:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   # Instrumented library support range
   - package-ecosystem: "npm"
@@ -182,7 +207,9 @@ updates:
       - dependency-name: "office-addin-mock"
         # Pinned to 2.x due to compatibility issues with newer major versions
         update-types: ["version-update:semver-major"]
-    # Cohort-based groups so a single breaking bump only blocks its own PR.
+    # Cohort-based groups so a single breaking bump only blocks its own PR. A dependency lands
+    # in the first cohort it matches; `test-versions` is the catch-all for the long tail
+    # (OpenTelemetry, OpenFeature, logging, templating, serialization, runtimes, misc).
     groups:
       ai-and-llm:
         patterns:
@@ -196,55 +223,146 @@ updates:
           - "ai"
           - "langchain"
           - "openai"
-      serverless:
+      cloud-and-messaging:
         patterns:
           - "@aws-sdk/*"
           - "@azure/*"
+          - "@confluentinc/kafka-javascript"
+          - "@google-cloud/*"
+          - "@nats-io/*"
           - "@smithy/*"
+          - "amqp10"
+          - "amqplib"
+          - "avsc"
           - "aws-sdk"
           - "azure-functions-core-tools"
+          - "bullmq"
           - "durable-functions"
-      opentelemetry:
+          - "kafkajs"
+          - "rhea"
+      databases:
         patterns:
-          - "@opentelemetry/*"
-          - "opentracing"
-      test-optimization:
+          - "@elastic/*"
+          - "@node-redis/*"
+          - "@opensearch-project/*"
+          - "@prisma/*"
+          - "@redis/*"
+          - "aerospike"
+          - "bson"
+          - "cassandra-driver"
+          - "couchbase"
+          - "elasticsearch"
+          - "generic-pool"
+          - "ioredis"
+          - "iovalkey"
+          - "knex"
+          - "mariadb"
+          - "memcached"
+          - "mongodb"
+          - "mongodb-core"
+          - "mongoose"
+          - "mquery"
+          - "mysql"
+          - "mysql2"
+          - "oracledb"
+          - "pg"
+          - "pg-cursor"
+          - "pg-native"
+          - "pg-query-stream"
+          - "prisma"
+          - "redis"
+          - "sequelize"
+          - "sharedb"
+          - "sqlite3"
+          - "tedious"
+      web-frameworks:
         patterns:
+          - "@apollo/*"
+          - "@fastify/*"
+          - "@graphql-tools/*"
+          - "@grpc/*"
+          - "@hapi/*"
+          - "@hono/*"
+          - "@koa/*"
+          - "apollo-server-core"
+          - "apollo-server-express"
+          - "apollo-server-fastify"
+          - "axios"
+          - "body-parser"
+          - "connect"
+          - "cookie"
+          - "cookie-parser"
+          - "ejs"
+          - "express"
+          - "express-mongo-sanitize"
+          - "express-session"
+          - "fastify"
+          - "find-my-way"
+          - "graphql"
+          - "graphql-tag"
+          - "graphql-tools"
+          - "graphql-yoga"
+          - "handlebars"
+          - "hapi"
+          - "hono"
+          - "koa"
+          - "koa-route"
+          - "koa-router"
+          - "koa-websocket"
+          - "ldapjs"
+          - "ldapjs-promise"
+          - "light-my-request"
+          - "loopback"
+          - "microgateway-core"
+          - "middie"
+          - "multer"
+          - "passport"
+          - "passport-http"
+          - "passport-local"
+          - "pug"
+          - "request"
+          - "restify"
+          - "router"
+          - "undici"
+          - "ws"
+      testing-and-build:
+        patterns:
+          - "@babel/*"
+          - "@cucumber/*"
+          - "@electron/*"
           - "@fast-check/jest"
           - "@happy-dom/jest-environment"
           - "@jest/*"
           - "@playwright/test"
           - "@vitest/*"
           - "babel-jest"
-          - "jest-*"
+          - "cypress"
+          - "cypress-fail-fast"
+          - "electron"
+          - "esbuild"
           - "jest"
-          - "mocha-each"
+          - "jest-*"
           - "mocha"
+          - "mocha-each"
+          - "next"
+          - "nock"
           - "nyc"
-          - "playwright-core"
+          - "office-addin-mock"
           - "playwright"
+          - "playwright-core"
+          - "react"
+          - "react-dom"
+          - "selenium-webdriver"
+          - "sinon"
           - "tinypool"
+          - "typescript"
           - "vitest"
-      databases:
-        patterns:
-          - "@node-redis/client"
-          - "@prisma/*"
-          - "@redis/client"
-          - "ioredis"
-          - "mongodb-core"
-          - "mongodb"
-          - "mongoose"
-          - "mysql"
-          - "mysql2"
-          - "pg-cursor"
-          - "pg-native"
-          - "pg-query-stream"
-          - "pg"
-          - "prisma"
-          - "redis"
-          - "sqlite3"
-          - "tedious"
+          - "workerpool"
       test-versions:
+        patterns:
+          - "*"
+      security-non-production:
+        applies-to: security-updates
         patterns:
           - "*"
 
@@ -272,5 +390,9 @@ updates:
         update-types: ["version-update:semver-major"]
     groups:
       test-versions:
+        patterns:
+          - "*"
+      security-non-production:
+        applies-to: security-updates
         patterns:
           - "*"

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -8,8 +8,11 @@ on:
       - synchronize
 
 env:
-  # Add Groups here to enable auto-merge for Dependabot PRs
-  GROUPS: '["dev-minor-and-patch-dependencies", "gh-actions-packages", "test-versions"]'
+  # Add Groups here to enable auto-merge for Dependabot PRs. Production npm *version* updates
+  # (`runtime-minor-and-patch-dependencies`, `vendor-minor-and-patch-dependencies`) are
+  # intentionally absent: they ship to customers and stay on manual review. Production
+  # *security* fixes still auto-merge (see `security-production`), but only below a major.
+  GROUPS: '["dev-minor-and-patch-dependencies", "gh-actions-packages", "docker-images", "ai-and-llm", "cloud-and-messaging", "databases", "web-frameworks", "testing-and-build", "test-versions", "security-production", "security-non-production"]'
 
 jobs:
   dependabot-automation:
@@ -31,14 +34,23 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # 3.1.0
         with:
           github-token: "${{ steps.octo-sts.outputs.token }}"
+      # A major bump in `security-production` ships a breaking change to customers, so a human
+      # reviews it. Every other allowed group auto-merges regardless of semver level: test-only
+      # matrix bumps, non-production security fixes, and majors already gated by dependabot.yml.
       - name: Approve a PR
-        if: contains(fromJSON(env.GROUPS), steps.metadata.outputs.dependency-group)
+        if: >-
+          contains(fromJSON(env.GROUPS), steps.metadata.outputs.dependency-group) &&
+          (steps.metadata.outputs.dependency-group != 'security-production' ||
+          steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       - name: Enable auto-merge for Dependabot PRs
-        if: contains(fromJSON(env.GROUPS), steps.metadata.outputs.dependency-group)
+        if: >-
+          contains(fromJSON(env.GROUPS), steps.metadata.outputs.dependency-group) &&
+          (steps.metadata.outputs.dependency-group != 'security-production' ||
+          steps.metadata.outputs.update-type != 'version-update:semver-major')
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

Auto-merge covered only dev dependencies, GitHub Actions, and the catch-all test-version group. The test-only plugin-version cohorts and digest-pinned docker images were reviewed by hand despite being fully CI-gated, and security advisories matched no group at all, so a vulnerability in any manifest -- fixtures included -- lingered until a human noticed and tripped vulnerability reporting.

1. Auto-merge the test-only plugin-version cohorts and docker base images; production npm and vendored version updates stay on manual review since they ship to customers.
2. Rebalance the plugin-version cohorts so the catch-all no longer holds most libraries: drop the standalone `opentelemetry` group, fold messaging into `cloud-and-messaging`, add `web-frameworks`, and broaden `databases` and `testing-and-build`. First-match distribution over the current fixture manifest: ai-and-llm 20, cloud-and-messaging 29, databases 37, web-frameworks 53, testing-and-build 44, test-versions (catch-all) 39.
3. Group security updates per manifest and auto-merge them, split into `security-production` (ships to customers, majors held for human review) and `security-non-production` (dev, fixtures, infra; auto-merges fully).

## Why

- Production npm and vendored *version* updates stay manual: they ship to customers and a green matrix does not prove a behavioral regression will not reach them. Their *security* fixes still auto-merge below a major.
- A major bump in `security-production` ships a breaking change to customers, so it is held for human review; every other group auto-merges regardless of semver level.
- `web-frameworks` is the largest cohort on purpose -- web is the biggest instrumented domain. Splitting it further trades a group against the per-ecosystem PR limit.

## Test plan

- Confirm Dependabot accepts the config (repo Insights -> Dependency graph -> Dependabot, no parse errors).
- Verify every group name auto-merged via `GROUPS` in the workflow matches a group defined in `dependabot.yml`; a mismatch silently drops a group back to manual review.
- Confirm branch protection requires the plugin-matrix and docker suites, so `--auto` cannot land a bump those checks never ran.