### PR TITLE
chore(release): label changelog entries by commit scope instead of "Other"

### DIFF
--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -22,8 +22,8 @@ const CATEGORY_BY_TYPE = {
   perf: 'Performance',
 }
 const PRODUCTS = [
-  ['AppSec', ['appsec', 'iast', 'rasp', 'waf', 'asm']],
-  ['AI Guard', ['aiguard', 'ai-guard']],
+  ['AppSec', ['appsec', 'iast', 'rasp', 'waf', 'asm', 'aap']],
+  ['AI Guard', ['aiguard', 'ai-guard', 'ai_guard']],
   ['Profiling', ['profiling', 'profiler']],
   ['CI Visibility', [
     'ci-visibility',
@@ -55,6 +55,8 @@ const PRODUCTS = [
   ]],
   ['Serverless', ['serverless', 'lambda', 'azure_metadata', 'inferred_proxy']],
   ['OpenTelemetry', ['otel', 'opentelemetry']],
+  ['Data Streams Monitoring', ['dsm', 'data-streams']],
+  ['Database Monitoring', ['dbm']],
   ['General', [
     'core',
     'tracing',
@@ -71,8 +73,22 @@ const PRODUCTS = [
     'telemetry',
     'remote-config',
     'runtime-metrics',
+    'runtime_metrics',
+    'metrics',
+    'dogstatsd',
     'stats',
     'sampler',
+    'propagation',
+    'exporters',
+    'agent',
+    'agentless',
+    'startup-log',
+    'shimmer',
+    'storage',
+    'esm',
+    'stacktrace',
+    'service-naming',
+    'tags',
     'types',
   ]],
 ]
@@ -164,9 +180,6 @@ function parseChange (entry) {
   const category = CATEGORY_BY_TYPE[parsed.type] || INTERNAL_CATEGORY
   const internal = INTERNAL_TYPES.has(parsed.type)
   const product = selectProduct(parsed.scopes)
-  const warning = !internal && product === 'Other'
-    ? `Unknown release-note product for ${entry.sha}: ${entry.subject}`
-    : undefined
 
   return {
     category,
@@ -175,7 +188,6 @@ function parseChange (entry) {
     pr: subjectWithPullRequest.pr,
     internal,
     revert: parsed.isRevert,
-    warning,
   }
 }
 
@@ -232,18 +244,22 @@ function splitScopes (scope) {
  * @param {string[]} scopes
  */
 function selectProduct (scopes) {
-  let fallback = 'General'
+  let allGeneral = true
 
   for (const scope of scopes) {
     const product = findProduct(scope)
-    if (!product) {
-      fallback = 'Other'
+    if (product === undefined) {
+      allGeneral = false
       continue
     }
     if (product !== 'General') return product
   }
 
-  return fallback
+  // No product groups these scopes. Fall back to the full scope list from the
+  // commit verbatim rather than a catch-all, unless every scope is a core one.
+  if (allGeneral) return 'General'
+
+  return scopes.join(', ')
 }
 
 /**

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -95,7 +95,7 @@ describe('release changelog', () => {
       '- <b>Profiling</b> Prevent panics in profiling encoding under out-of-memory and out-of-bounds ' +
         'conditions #3888',
       '- <b>LLMObs</b> Revert "Fan array-valued user tags out into one wire entry per element (#8689)" #8790',
-      '- <b>Other</b> Handle strange thing #9999',
+      '- <b>unknown-scope</b> Handle strange thing #9999',
       '',
       'Performance',
       '- <b>General</b> Reduce per-span format and encode overhead #8754',
@@ -111,7 +111,6 @@ describe('release changelog', () => {
       '',
     ].join('\n'))
     assert.deepStrictEqual(changelog.warnings, [
-      'Unknown release-note product for abc015: fix(unknown-scope): handle strange thing (#9999)',
       'Non-conventional release-note subject for abc016: ' +
         'Fixes APMS-19181: sets the service discovery logs to respect the log level (#8677)',
     ])
@@ -175,6 +174,56 @@ describe('release changelog', () => {
       '- <b>AppSec</b> Trim empty scope segments #1234',
       '',
     ].join('\n'))
+  })
+
+  it('labels an unmapped scope with the scope from the commit and does not warn', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'feat(aws-sdk): create SQS consumer spans (#8827)' },
+      { sha: 'abc002', subject: 'fix(redis): drop db.name placeholder (#8402)' },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Features',
+      '- <b>aws-sdk</b> Create SQS consumer spans #8827',
+      '',
+      'Fixes',
+      '- <b>redis</b> Drop db.name placeholder #8402',
+      '',
+    ].join('\n'))
+    assert.deepStrictEqual(changelog.warnings, [])
+  })
+
+  it('renders the full scope list when no scope maps to a product', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'fix(redis, iovalkey): align reconnect handling (#8001)' },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Fixes',
+      '- <b>redis, iovalkey</b> Align reconnect handling #8001',
+      '',
+    ].join('\n'))
+  })
+
+  it('maps newly recognized scopes to their products', () => {
+    const changelog = createReleaseChangelog([
+      { sha: 'abc001', subject: 'fix(aap): block on suspicious request (#9001)' },
+      { sha: 'abc002', subject: 'fix(ai_guard): tighten prompt evaluation (#9002)' },
+      { sha: 'abc003', subject: 'fix(dsm): track message lineage (#9003)' },
+      { sha: 'abc004', subject: 'fix(dbm): propagate trace context to SQL comments (#9004)' },
+      { sha: 'abc005', subject: 'fix(exporters): route agentless spans to the regional intake (#9005)' },
+    ])
+
+    assert.strictEqual(changelog.markdown, [
+      'Fixes',
+      '- <b>AppSec</b> Block on suspicious request #9001',
+      '- <b>AI Guard</b> Tighten prompt evaluation #9002',
+      '- <b>Data Streams Monitoring</b> Track message lineage #9003',
+      '- <b>Database Monitoring</b> Propagate trace context to SQL comments #9004',
+      '- <b>General</b> Route agentless spans to the regional intake #9005',
+      '',
+    ].join('\n'))
+    assert.deepStrictEqual(changelog.warnings, [])
   })
 
   it('lists unique contributors sorted case-insensitively after the change sections', () => {


### PR DESCRIPTION
## Summary

The conventional-commit changelog (#8814) labelled every entry whose scope was missing from the product map as `Other`, collapsing most integration changes (`aws-sdk`, `next`, `redis`, ...) into one opaque bucket — visible across the v5.109.0 proposal (#8934).

1. Unmapped scopes now render with the full scope list from the commit subject, so `fix(redis, iovalkey): ...` becomes `<b>redis, iovalkey</b>` instead of `Other` (or a single pick). An all-core scope set still collapses to `General`.
2. Scopes that belong to an existing area are mapped: `aap` → AppSec, `ai_guard` → AI Guard, the core tracer scopes (`propagation`, `exporters`, `dogstatsd`, `agent`, `agentless`, ...) → General, plus new `Data Streams Monitoring` and `Database Monitoring` products so those read as full names rather than abbreviations.

Genuine third-party integration scopes with no natural product home (`aws-sdk`, `next`, `electron`, `redis`, ...) keep their own name, which is more informative than a shared bucket.

The now-dead `Unknown release-note product` warning is dropped; a named scope is the intended outcome, not something to flag.

## Test plan

- `node scripts/release/changelog.spec.js` via mocha — added `renders the full scope list when no scope maps to a product` and `maps newly recognized scopes to their products`; updated the prior fallback expectation.
- `nyc` reports 100% statements/branches/functions/lines on `scripts/release/changelog.js`.