### PR TITLE
perf(loader): use synchronous iitm hooks when available

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -364,6 +364,7 @@
 /packages/dd-trace/test/plugins/plugin.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/plugins/util/env.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/proxy.spec.js @DataDog/lang-platform-js
+/packages/dd-trace/test/register.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/require-package-json.spec.js @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm-tests/ @DataDog/lang-platform-js
 /packages/dd-trace/test/ritm.spec.js @DataDog/lang-platform-js

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -41,9 +41,24 @@ function load (url, context, nextLoad) {
 }
 
 function loadSync (url, context, nextLoad) {
+  if (isCommonJSRequire(context)) {
+    return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
+  }
+
   return rewriterLoader.loadSync(url, context, (url, context) => {
     return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
   })
+}
+
+function isCommonJSRequire (context) {
+  const conditions = context.conditions
+  if (!conditions) return false
+
+  for (let i = 0; i < conditions.length; i++) {
+    if (conditions[i] === 'require') return true
+  }
+
+  return false
 }
 
 function getSyncImportInTheMiddleHook () {

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -1,3 +1,9 @@
+/* eslint n/no-unsupported-features/node-builtins: ['error', { ignores: ['module.registerHooks'] }] */
+
+import * as Module from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+import { createHook, supportsSyncHooks } from 'import-in-the-middle/create-hook.mjs'
 import { initialize as origInitialize, load as origLoad, resolve } from 'import-in-the-middle/hook.mjs'
 import regexpEscapeModule from './vendor/dist/escape-string-regexp/index.js'
 import hooks from './packages/datadog-instrumentations/src/helpers/hooks.js'
@@ -8,11 +14,18 @@ import { isRelativeRequire } from './packages/datadog-instrumentations/src/helpe
 // This file must support Node.js 12.0.0 syntax
 
 const regexpEscape = regexpEscapeModule.default
+const require = Module.createRequire(import.meta.url)
+let syncImportInTheMiddleHook
 
 // For some reason `getEnvironmentVariable` is not otherwise available to ESM.
 const env = configHelper.getEnvironmentVariable
 
 function initialize (data = {}) {
+  prepareImportInTheMiddleOptions(data)
+  return origInitialize(data)
+}
+
+function prepareImportInTheMiddleOptions (data = {}) {
   if (data.include == null) data.include = []
   if (data.exclude == null) data.exclude = []
 
@@ -20,11 +33,64 @@ function initialize (data = {}) {
   addSecurityControls(data)
   addExclusions(data)
 
-  return origInitialize(data)
+  return data
 }
 
 function load (url, context, nextLoad) {
   return rewriterLoader.load(url, context, (url, context) => origLoad(url, context, nextLoad))
+}
+
+function loadSync (url, context, nextLoad) {
+  return rewriterLoader.loadSync(url, context, (url, context) => {
+    return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
+  })
+}
+
+function getSyncImportInTheMiddleHook () {
+  if (syncImportInTheMiddleHook) {
+    return syncImportInTheMiddleHook
+  }
+
+  const importInTheMiddleRegisterHooksUrl = pathToFileURL(
+    require.resolve('import-in-the-middle/register-hooks.mjs')
+  ).href
+  syncImportInTheMiddleHook = createHook({ url: importInTheMiddleRegisterHooksUrl })
+  return syncImportInTheMiddleHook
+}
+
+function registerSyncLoaderHooks (data = {}) {
+  // The synchronous loader strips the source of a require() pulled into the iitm
+  // ESM graph so Node loads it natively, but module.registerHooks rejected that
+  // nullish CommonJS source until nodejs/node#59929 (released in 22.22.3, 24.11.1,
+  // 25.1.0 and 26.0.0). On versions that ship registerHooks but predate the fix,
+  // fall back to the asynchronous loader instead of crashing mid-graph.
+  if (!supportsSyncHooks()) {
+    return false
+  }
+
+  const syncHook = getSyncImportInTheMiddleHook()
+
+  if (
+    typeof Module.registerHooks !== 'function' ||
+    typeof syncHook.applyOptions !== 'function' ||
+    typeof syncHook.loadSync !== 'function' ||
+    typeof syncHook.resolveSync !== 'function'
+  ) {
+    return false
+  }
+
+  // Node built-ins are instrumented under the synchronous loader as well: iitm
+  // reads a built-in's exports through process.getBuiltinModule(), which
+  // bypasses the registered hooks and therefore cannot re-enter them. The
+  // synchronous and asynchronous loaders share the same option preparation so
+  // that `import http from 'node:http'` is wrapped on both paths.
+  syncHook.applyOptions(prepareImportInTheMiddleOptions(data))
+  Module.registerHooks({
+    resolve: syncHook.resolveSync,
+    load: loadSync,
+  })
+
+  return true
 }
 
 function addInstrumentations (data) {
@@ -74,4 +140,4 @@ export const iitmExclusions = [
   /@anthropic-ai\/sdk\/_shims/,
 ]
 
-export { initialize, load, resolve }
+export { initialize, load, registerSyncLoaderHooks, resolve }

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -41,7 +41,7 @@ function load (url, context, nextLoad) {
 }
 
 function loadSync (url, context, nextLoad) {
-  if (isCommonJSRequire(context)) {
+  if (isCommonJSLoad(context)) {
     return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
   }
 
@@ -50,7 +50,9 @@ function loadSync (url, context, nextLoad) {
   })
 }
 
-function isCommonJSRequire (context) {
+function isCommonJSLoad (context) {
+  if (context.format === 'commonjs') return true
+
   const conditions = context.conditions
   if (!conditions) return false
 

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -51,8 +51,11 @@ function loadSync (url, context, nextLoad) {
 }
 
 function isCommonJSLoad (context) {
-  if (context.format === 'commonjs') return true
+  if (context.format) return context.format === 'commonjs'
 
+  // Sync hooks report CommonJS require() dependency loads with a `require`
+  // condition but no format. If a format is present, trust it instead: ESM
+  // loaded through require() reports `format: 'module'` and still needs rewrite.
   const conditions = context.conditions
   if (!conditions) return false
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
@@ -3,9 +3,19 @@ import { rewrite } from './index.js'
 async function load (url, context, nextLoad) {
   const result = await nextLoad(url, context)
 
+  return rewriteResult(result, url, context)
+}
+
+function loadSync (url, context, nextLoad) {
+  const result = nextLoad(url, context)
+
+  return rewriteResult(result, url, context)
+}
+
+function rewriteResult (result, url, context) {
   result.source = rewrite(result.source, url, context.format)
 
   return result
 }
 
-export { load }
+export { load, loadSync }

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
@@ -13,7 +13,13 @@ function loadSync (url, context, nextLoad) {
 }
 
 function rewriteResult (result, url, context) {
-  result.source = rewrite(result.source, url, context.format)
+  const format = result.format || context.format
+
+  // CommonJS source is rewritten by Module._compile. Rewriting it here too
+  // double-instruments CommonJS entrypoints loaded through sync hooks.
+  if (format === 'commonjs') return result
+
+  result.source = rewrite(result.source, url, format)
 
   return result
 }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { describe, it } from 'mocha'
+
+import { load, loadSync } from '../../../src/helpers/rewriter/loader.mjs'
+
+const source = 'export function getTracer () { return "tracer" }\n'
+
+describe('rewriter loader', () => {
+  it('rewrites async loader results', async () => {
+    const url = createAiModuleUrl()
+    const result = await load(url, { format: 'module' }, () => ({ format: 'module', source }))
+
+    assertRewritten(result.source)
+  })
+
+  it('rewrites sync loader results', () => {
+    const url = createAiModuleUrl()
+    const result = loadSync(url, { format: 'module' }, () => ({ format: 'module', source }))
+
+    assertRewritten(result.source)
+  })
+})
+
+function createAiModuleUrl () {
+  const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-'))
+  const packageDirectory = join(root, 'node_modules', 'ai')
+
+  mkdirSync(join(packageDirectory, 'dist'), { recursive: true })
+  writeFileSync(join(packageDirectory, 'package.json'), '{"version":"4.0.0"}')
+
+  return pathToFileURL(join(packageDirectory, 'dist', 'index.mjs')).href
+}
+
+function assertRewritten (rewrittenSource) {
+  assert.match(rewrittenSource, /from "file:\/\/.+dc-polyfill/)
+  assert.match(rewrittenSource, /tr_ch_apm_tracingChannel/)
+  assert.match(rewrittenSource, /orchestrion:ai:getTracer/)
+}

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -69,6 +69,40 @@ describe('rewriter loader', () => {
     assert.strictEqual(result.status, 0, result.stderr)
     assert.strictEqual(result.stdout.trim(), '1')
   })
+
+  it('does not rewrite CommonJS entrypoint loads in the sync loader hook', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-cjs-entrypoint-'))
+    const packageDirectory = join(root, 'node_modules', 'ai')
+
+    mkdirSync(join(packageDirectory, 'dist'), { recursive: true })
+    writeFileSync(join(packageDirectory, 'package.json'), '{"version":"4.0.0"}')
+    writeFileSync(join(packageDirectory, 'dist', 'index.js'), `
+      const { tracingChannel } = require(${JSON.stringify(join(repositoryRoot, 'node_modules', 'dc-polyfill'))})
+      const channel = tracingChannel('orchestrion:ai:getTracer')
+      let starts = 0
+
+      channel.subscribe({ start () { starts++ } })
+
+      function getTracer () { return 'tracer' }
+      getTracer()
+      console.log(starts)
+    `)
+
+    const result = spawnSync(process.execPath, [join(packageDirectory, 'dist', 'index.js')], {
+      cwd: root,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: [
+          `--import ${join(repositoryRoot, 'register.js')}`,
+          `-r ${join(repositoryRoot, 'packages', 'datadog-instrumentations', 'src', 'helpers', 'rewriter', 'loader')}`,
+        ].join(' '),
+      },
+      encoding: 'utf8',
+    })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '1')
+  })
 })
 
 function createAiModuleUrl () {

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -103,7 +103,54 @@ describe('rewriter loader', () => {
     assert.strictEqual(result.status, 0, result.stderr)
     assert.strictEqual(result.stdout.trim(), '1')
   })
+
+  it('rewrites ESM modules loaded from CommonJS in the sync loader hook', function () {
+    if (!supportsSyncLoaderHooks()) {
+      this.skip()
+    }
+
+    const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-cjs-esm-'))
+    const packageDirectory = join(root, 'node_modules', 'ai')
+
+    mkdirSync(join(packageDirectory, 'dist'), { recursive: true })
+    writeFileSync(join(packageDirectory, 'package.json'), '{"version":"4.0.0","type":"module","main":"dist/index.js"}')
+    writeFileSync(join(packageDirectory, 'dist', 'index.js'), source)
+    writeFileSync(join(root, 'main.js'), `
+      const { tracingChannel } = require(${JSON.stringify(join(repositoryRoot, 'node_modules', 'dc-polyfill'))})
+      const channel = tracingChannel('orchestrion:ai:getTracer')
+      let starts = 0
+
+      channel.subscribe({ start () { starts++ } })
+      require('ai').getTracer()
+      console.log(starts)
+    `)
+
+    const result = spawnSync(process.execPath, [join(root, 'main.js')], {
+      cwd: root,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import ${join(repositoryRoot, 'register.js')}`,
+      },
+      encoding: 'utf8',
+    })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '1')
+  })
 })
+
+function supportsSyncLoaderHooks () {
+  const version = process.versions.node.split('.')
+  const major = Number(version[0])
+  const minor = Number(version[1])
+  const patch = Number(version[2])
+
+  if (major >= 26) return true
+  if (major === 25) return minor >= 1
+  if (major === 24) return minor > 11 || (minor === 11 && patch >= 1)
+  if (major === 22) return minor > 22 || (minor === 22 && patch >= 3)
+  return false
+}
 
 function createAiModuleUrl () {
   const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-'))

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -1,14 +1,17 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { describe, it } from 'mocha'
 
 import { load, loadSync } from '../../../src/helpers/rewriter/loader.mjs'
 
 const source = 'export function getTracer () { return "tracer" }\n'
+const testDirectory = dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = resolve(testDirectory, '../../../../..')
 
 describe('rewriter loader', () => {
   it('rewrites async loader results', async () => {
@@ -23,6 +26,48 @@ describe('rewriter loader', () => {
     const result = loadSync(url, { format: 'module' }, () => ({ format: 'module', source }))
 
     assertRewritten(result.source)
+  })
+
+  it('does not rewrite CommonJS require loads in the sync loader hook', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-cjs-'))
+    const packageDirectory = join(root, 'node_modules', 'ai')
+
+    mkdirSync(join(packageDirectory, 'dist'), { recursive: true })
+    writeFileSync(join(packageDirectory, 'package.json'), '{"version":"4.0.0","main":"dist/index.js"}')
+    writeFileSync(join(packageDirectory, 'dist', 'index.js'), `
+      function getTracer () { return 'tracer' }
+      module.exports = { getTracer }
+    `)
+    writeFileSync(join(root, 'main.js'), `
+      require(${JSON.stringify(join(
+        repositoryRoot,
+        'packages',
+        'datadog-instrumentations',
+        'src',
+        'helpers',
+        'rewriter',
+        'loader'
+      ))})
+      const { tracingChannel } = require(${JSON.stringify(join(repositoryRoot, 'node_modules', 'dc-polyfill'))})
+      const channel = tracingChannel('orchestrion:ai:getTracer')
+      let starts = 0
+
+      channel.subscribe({ start () { starts++ } })
+      require('ai').getTracer()
+      console.log(starts)
+    `)
+
+    const result = spawnSync(process.execPath, [join(root, 'main.js')], {
+      cwd: root,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: `--import ${join(repositoryRoot, 'register.js')}`,
+      },
+      encoding: 'utf8',
+    })
+
+    assert.strictEqual(result.status, 0, result.stderr)
+    assert.strictEqual(result.stdout.trim(), '1')
   })
 })
 

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
+import { supportsSyncHooks } from 'import-in-the-middle/create-hook.mjs'
 import { describe, it } from 'mocha'
 
 import { load, loadSync } from '../../../src/helpers/rewriter/loader.mjs'
@@ -105,7 +106,7 @@ describe('rewriter loader', () => {
   })
 
   it('rewrites ESM modules loaded from CommonJS in the sync loader hook', function () {
-    if (!supportsSyncLoaderHooks()) {
+    if (!supportsSyncHooks()) {
       this.skip()
     }
 
@@ -138,19 +139,6 @@ describe('rewriter loader', () => {
     assert.strictEqual(result.stdout.trim(), '1')
   })
 })
-
-function supportsSyncLoaderHooks () {
-  const version = process.versions.node.split('.')
-  const major = Number(version[0])
-  const minor = Number(version[1])
-  const patch = Number(version[2])
-
-  if (major >= 26) return true
-  if (major === 25) return minor >= 1
-  if (major === 24) return minor > 11 || (minor === 11 && patch >= 1)
-  if (major === 22) return minor > 22 || (minor === 22 && patch >= 3)
-  return false
-}
 
 function createAiModuleUrl () {
   const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-'))

--- a/packages/dd-trace/test/register.spec.js
+++ b/packages/dd-trace/test/register.spec.js
@@ -1,13 +1,21 @@
 'use strict'
 
-const assert = require('node:assert/strict')
-
 const sinon = require('sinon')
 const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
 require('./setup/core')
 
 describe('register.js', () => {
+  let emitWarning
+
+  beforeEach(() => {
+    emitWarning = sinon.stub(process, 'emitWarning')
+  })
+
+  afterEach(() => {
+    emitWarning.restore()
+  })
+
   it('falls back to the async loader on unsupported Node.js versions', () => {
     const register = sinon.stub()
     const registerSyncLoaderHooks = sinon.stub().returns(true)
@@ -15,11 +23,12 @@ describe('register.js', () => {
     loadRegister({
       register,
       registerSyncLoaderHooks,
-      version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 0 },
+      supportsSyncHooks: () => false,
     })
 
     sinon.assert.notCalled(registerSyncLoaderHooks)
     sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+    sinon.assert.notCalled(emitWarning)
   })
 
   it('registers sync loader hooks on supported Node.js versions', () => {
@@ -29,44 +38,46 @@ describe('register.js', () => {
     loadRegister({
       register,
       registerSyncLoaderHooks,
-      version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+      supportsSyncHooks: () => true,
     })
 
     sinon.assert.calledOnce(registerSyncLoaderHooks)
     sinon.assert.notCalled(register)
+    sinon.assert.notCalled(emitWarning)
   })
 
-  it('throws on supported Node.js versions if sync loader registration returns false', () => {
+  it('warns and falls back if sync loader registration returns false', () => {
     const register = sinon.stub()
     const registerSyncLoaderHooks = sinon.stub().returns(false)
 
-    assert.throws(() => {
-      loadRegister({
-        register,
-        registerSyncLoaderHooks,
-        version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
-      })
-    }, /Synchronous loader hooks are supported but dd-trace could not register them\./)
+    loadRegister({
+      register,
+      registerSyncLoaderHooks,
+      supportsSyncHooks: () => true,
+    })
 
     sinon.assert.calledOnce(registerSyncLoaderHooks)
-    sinon.assert.notCalled(register)
+    sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+    sinon.assert.calledOnceWithMatch(emitWarning, /dd-trace could not register synchronous loader hooks/)
   })
 
-  it('throws sync loader registration errors on supported Node.js versions', () => {
+  it('warns and falls back if sync loader registration throws', () => {
     const error = new Error('sync hook failure')
     const register = sinon.stub()
     const registerSyncLoaderHooks = sinon.stub().throws(error)
 
-    assert.throws(() => {
-      loadRegister({
-        register,
-        registerSyncLoaderHooks,
-        version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
-      })
-    }, error)
+    loadRegister({
+      register,
+      registerSyncLoaderHooks,
+      supportsSyncHooks: () => true,
+    })
 
     sinon.assert.calledOnce(registerSyncLoaderHooks)
-    sinon.assert.notCalled(register)
+    sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+    sinon.assert.calledOnceWithMatch(
+      emitWarning,
+      /dd-trace could not register synchronous loader hooks.*sync hook failure/
+    )
   })
 
   it('falls back to the async loader if require(esm) is disabled', () => {
@@ -77,25 +88,47 @@ describe('register.js', () => {
     loadRegister({
       register,
       loaderHook: createThrowingLoaderHook(error),
-      version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+      supportsSyncHooks: () => true,
     })
 
     sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+    sinon.assert.calledOnceWithMatch(
+      emitWarning,
+      /dd-trace could not register synchronous loader hooks.*require\(esm\) is disabled/
+    )
   })
 
-  it('throws other sync loader import errors on supported Node.js versions', () => {
+  it('warns and falls back if sync loader import fails', () => {
     const register = sinon.stub()
     const error = new Error('loader import failure')
 
-    assert.throws(() => {
-      loadRegister({
-        register,
-        loaderHook: createThrowingLoaderHook(error),
-        version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
-      })
-    }, error)
+    loadRegister({
+      register,
+      loaderHook: createThrowingLoaderHook(error),
+      supportsSyncHooks: () => true,
+    })
 
-    sinon.assert.notCalled(register)
+    sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+    sinon.assert.calledOnceWithMatch(
+      emitWarning,
+      /dd-trace could not register synchronous loader hooks.*loader import failure/
+    )
+  })
+
+  it('warns and falls back if sync hook support detection fails', () => {
+    const register = sinon.stub()
+    const error = new Error('support detection failure')
+
+    loadRegister({
+      register,
+      supportsSyncHooks: () => { throw error },
+    })
+
+    sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+    sinon.assert.calledOnceWithMatch(
+      emitWarning,
+      /dd-trace could not register synchronous loader hooks.*support detection failure/
+    )
   })
 })
 
@@ -107,10 +140,10 @@ function createThrowingLoaderHook (error) {
   })
 }
 
-function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, version }) {
+function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, supportsSyncHooks }) {
   proxyquire('../../../register.js', {
     'node:module': { register },
+    'import-in-the-middle/create-hook.mjs': { supportsSyncHooks },
     './loader-hook.mjs': loaderHook || { registerSyncLoaderHooks },
-    './version': version,
   })
 }

--- a/packages/dd-trace/test/register.spec.js
+++ b/packages/dd-trace/test/register.spec.js
@@ -5,6 +5,12 @@ const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
 
 require('./setup/core')
 
+const SUPPORTED_SYNC_HOOKS_NODE_VERSION = {
+  NODE_MAJOR: 24,
+  NODE_MINOR: 11,
+  NODE_PATCH: 1,
+}
+
 describe('register.js', () => {
   let emitWarning
 
@@ -19,14 +25,21 @@ describe('register.js', () => {
   it('falls back to the async loader on unsupported Node.js versions', () => {
     const register = sinon.stub()
     const registerSyncLoaderHooks = sinon.stub().returns(true)
+    const supportsSyncHooks = sinon.stub().throws(new Error('should not be called'))
 
     loadRegister({
       register,
       registerSyncLoaderHooks,
-      supportsSyncHooks: () => false,
+      supportsSyncHooks,
+      version: {
+        NODE_MAJOR: 24,
+        NODE_MINOR: 11,
+        NODE_PATCH: 0,
+      },
     })
 
     sinon.assert.notCalled(registerSyncLoaderHooks)
+    sinon.assert.notCalled(supportsSyncHooks)
     sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
     sinon.assert.notCalled(emitWarning)
   })
@@ -140,10 +153,11 @@ function createThrowingLoaderHook (error) {
   })
 }
 
-function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, supportsSyncHooks }) {
+function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, supportsSyncHooks, version }) {
   proxyquire('../../../register.js', {
     'node:module': { register },
     'import-in-the-middle/create-hook.mjs': { supportsSyncHooks },
     './loader-hook.mjs': loaderHook || { registerSyncLoaderHooks },
+    './version': version || SUPPORTED_SYNC_HOOKS_NODE_VERSION,
   })
 }

--- a/packages/dd-trace/test/register.spec.js
+++ b/packages/dd-trace/test/register.spec.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache()
+
+require('./setup/core')
+
+describe('register.js', () => {
+  it('falls back to the async loader on unsupported Node.js versions', () => {
+    const register = sinon.stub()
+    const registerSyncLoaderHooks = sinon.stub().returns(true)
+
+    loadRegister({
+      register,
+      registerSyncLoaderHooks,
+      version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 0 },
+    })
+
+    sinon.assert.notCalled(registerSyncLoaderHooks)
+    sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+  })
+
+  it('registers sync loader hooks on supported Node.js versions', () => {
+    const register = sinon.stub()
+    const registerSyncLoaderHooks = sinon.stub().returns(true)
+
+    loadRegister({
+      register,
+      registerSyncLoaderHooks,
+      version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+    })
+
+    sinon.assert.calledOnce(registerSyncLoaderHooks)
+    sinon.assert.notCalled(register)
+  })
+
+  it('throws on supported Node.js versions if sync loader registration returns false', () => {
+    const register = sinon.stub()
+    const registerSyncLoaderHooks = sinon.stub().returns(false)
+
+    assert.throws(() => {
+      loadRegister({
+        register,
+        registerSyncLoaderHooks,
+        version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+      })
+    }, /Synchronous loader hooks are supported but dd-trace could not register them\./)
+
+    sinon.assert.calledOnce(registerSyncLoaderHooks)
+    sinon.assert.notCalled(register)
+  })
+
+  it('throws sync loader registration errors on supported Node.js versions', () => {
+    const error = new Error('sync hook failure')
+    const register = sinon.stub()
+    const registerSyncLoaderHooks = sinon.stub().throws(error)
+
+    assert.throws(() => {
+      loadRegister({
+        register,
+        registerSyncLoaderHooks,
+        version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+      })
+    }, error)
+
+    sinon.assert.calledOnce(registerSyncLoaderHooks)
+    sinon.assert.notCalled(register)
+  })
+
+  it('falls back to the async loader if require(esm) is disabled', () => {
+    const register = sinon.stub()
+    const error = new Error('require(esm) is disabled')
+    error.code = 'ERR_REQUIRE_ESM'
+
+    loadRegister({
+      register,
+      loaderHook: createThrowingLoaderHook(error),
+      version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+    })
+
+    sinon.assert.calledOnceWithExactly(register, './loader-hook.mjs', sinon.match.instanceOf(URL))
+  })
+
+  it('throws other sync loader import errors on supported Node.js versions', () => {
+    const register = sinon.stub()
+    const error = new Error('loader import failure')
+
+    assert.throws(() => {
+      loadRegister({
+        register,
+        loaderHook: createThrowingLoaderHook(error),
+        version: { NODE_MAJOR: 24, NODE_MINOR: 11, NODE_PATCH: 1 },
+      })
+    }, error)
+
+    sinon.assert.notCalled(register)
+  })
+})
+
+function createThrowingLoaderHook (error) {
+  return Object.defineProperty({}, 'registerSyncLoaderHooks', {
+    get () {
+      throw error
+    },
+  })
+}
+
+function loadRegister ({ register, registerSyncLoaderHooks, loaderHook, version }) {
+  proxyquire('../../../register.js', {
+    'node:module': { register },
+    './loader-hook.mjs': loaderHook || { registerSyncLoaderHooks },
+    './version': version,
+  })
+}

--- a/register.js
+++ b/register.js
@@ -4,6 +4,7 @@
 
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
+const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('./version')
 
 const parentURL = pathToFileURL(__filename)
 let isSyncLoaderRegistered = false
@@ -30,6 +31,10 @@ if (!isSyncLoaderRegistered) {
 }
 
 function shouldRegisterSyncLoaderHooks () {
+  if (!isSyncLoaderHookVersionSupported()) {
+    return false
+  }
+
   try {
     return require('import-in-the-middle/create-hook.mjs').supportsSyncHooks()
   } catch (error) {
@@ -38,6 +43,14 @@ function shouldRegisterSyncLoaderHooks () {
     }
   }
 
+  return false
+}
+
+function isSyncLoaderHookVersionSupported () {
+  if (NODE_MAJOR >= 26) return true
+  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
+  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
+  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
   return false
 }
 

--- a/register.js
+++ b/register.js
@@ -5,4 +5,14 @@
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
 
-register('./loader-hook.mjs', pathToFileURL(__filename))
+const parentURL = pathToFileURL(__filename)
+let isSyncLoaderRegistered = false
+
+try {
+  const { registerSyncLoaderHooks } = require('./loader-hook.mjs')
+  isSyncLoaderRegistered = registerSyncLoaderHooks()
+} catch {}
+
+if (!isSyncLoaderRegistered) {
+  register('./loader-hook.mjs', parentURL)
+}

--- a/register.js
+++ b/register.js
@@ -4,25 +4,24 @@
 
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
-const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('./version')
 
 const parentURL = pathToFileURL(__filename)
-const shouldRegisterSyncLoaderHooks = supportsSyncLoaderHooks()
 let isSyncLoaderRegistered = false
 
-if (shouldRegisterSyncLoaderHooks) {
+if (shouldRegisterSyncLoaderHooks()) {
   let registerSyncLoaderHooks
+  let syncRegistrationError
   try {
     ({ registerSyncLoaderHooks } = require('./loader-hook.mjs'))
-  } catch (e) {
-    if (e?.code !== 'ERR_REQUIRE_ESM') throw e
+    if (registerSyncLoaderHooks) {
+      isSyncLoaderRegistered = registerSyncLoaderHooks()
+    }
+  } catch (error) {
+    syncRegistrationError = error
   }
 
-  if (registerSyncLoaderHooks) {
-    isSyncLoaderRegistered = registerSyncLoaderHooks()
-    if (!isSyncLoaderRegistered) {
-      throw new Error('Synchronous loader hooks are supported but dd-trace could not register them.')
-    }
+  if (!isSyncLoaderRegistered) {
+    warnSyncLoaderFallback(syncRegistrationError)
   }
 }
 
@@ -30,10 +29,24 @@ if (!isSyncLoaderRegistered) {
   register('./loader-hook.mjs', parentURL)
 }
 
-function supportsSyncLoaderHooks () {
-  if (NODE_MAJOR >= 26) return true
-  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
-  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
-  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
+function shouldRegisterSyncLoaderHooks () {
+  try {
+    return require('import-in-the-middle/create-hook.mjs').supportsSyncHooks()
+  } catch (error) {
+    if (error?.code !== 'ERR_REQUIRE_ESM') {
+      warnSyncLoaderFallback(error)
+    }
+  }
+
   return false
+}
+
+function warnSyncLoaderFallback (error) {
+  let message = 'dd-trace could not register synchronous loader hooks. Falling back to the asynchronous loader.'
+
+  if (error?.message) {
+    message += ` ${error.message}`
+  }
+
+  process.emitWarning(message)
 }

--- a/register.js
+++ b/register.js
@@ -4,15 +4,36 @@
 
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
+const { NODE_MAJOR, NODE_MINOR, NODE_PATCH } = require('./version')
 
 const parentURL = pathToFileURL(__filename)
+const shouldRegisterSyncLoaderHooks = supportsSyncLoaderHooks()
 let isSyncLoaderRegistered = false
 
-try {
-  const { registerSyncLoaderHooks } = require('./loader-hook.mjs')
-  isSyncLoaderRegistered = registerSyncLoaderHooks()
-} catch {}
+if (shouldRegisterSyncLoaderHooks) {
+  let registerSyncLoaderHooks
+  try {
+    ({ registerSyncLoaderHooks } = require('./loader-hook.mjs'))
+  } catch (e) {
+    if (e?.code !== 'ERR_REQUIRE_ESM') throw e
+  }
+
+  if (registerSyncLoaderHooks) {
+    isSyncLoaderRegistered = registerSyncLoaderHooks()
+    if (!isSyncLoaderRegistered) {
+      throw new Error('Synchronous loader hooks are supported but dd-trace could not register them.')
+    }
+  }
+}
 
 if (!isSyncLoaderRegistered) {
   register('./loader-hook.mjs', parentURL)
+}
+
+function supportsSyncLoaderHooks () {
+  if (NODE_MAJOR >= 26) return true
+  if (NODE_MAJOR === 25) return NODE_MINOR >= 1
+  if (NODE_MAJOR === 24) return NODE_MINOR > 11 || (NODE_MINOR === 11 && NODE_PATCH >= 1)
+  if (NODE_MAJOR === 22) return NODE_MINOR > 22 || (NODE_MINOR === 22 && NODE_PATCH >= 3)
+  return false
 }


### PR DESCRIPTION
### What does this PR do?

Uses `module.registerHooks()` from `dd-trace/register.js` when the runtime supports the synchronous `import-in-the-middle` loader path. Unsupported runtimes keep the existing `module.register('./loader-hook.mjs')` async fallback.

The sync path reuses the same loader include/exclude setup as the async path, preserves the ESM rewriter path for non-`require` loads, and skips loader-level rewriting for CommonJS `require` loads so the existing `_compile` rewriter handles CJS once instead of nesting wrappers.

### Motivation

Vitest Test Optimization with `isolate: true` starts many worker processes, and each process pays loader initialization cost. On supported Node versions, the synchronous iitm loader path reduces that worker startup overhead without adding Vitest-specific loader narrowing.

### Benchmark

Benchmarked with Node 24.17.0 and Vitest 4.1.9 (`latest`) in a local demo project with 200 generated test files and 2 zero-delay tests per file, for 400 total tests. The suite used `isolate: true`, `pool: forks`, `npm test -- --reporter=dot`, and a local HTTP intake to verify Test Optimization payloads. Each row reports the median of 7 measured runs after 1 warmup.

Compared `origin/master` (`ea50dc683`) against this PR (`8030bd7b8`).

| dd-trace checkout | No-trace median | Traced median | Median overhead | Overhead reduction vs master | % overhead reduction vs master |
| --- | ---: | ---: | ---: | ---: | ---: |
| Current `master` | 4.46s | 21.75s | 17.29s | baseline | baseline |
| Current PR | 4.60s | 14.12s | 9.51s | 7.78s | 45.0% |

Local intake validation stayed correct: every traced run reported all 400 test events to the Test Optimization intake.
