### PR TITLE
chore(release): sort changelog entries and bold every section heading

### DIFF
--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const INTERNAL_CATEGORY = '<b>Internal</b> (CI, Testing, Benchmarking)'
+const INTERNAL_CATEGORY = 'Internal'
 const CATEGORY_ORDER = [
   'Features',
   'Fixes',
@@ -290,15 +290,15 @@ function renderMarkdown (sections, contributors) {
     const changes = sections.get(category)
     if (!changes?.length) continue
 
-    lines.push(category)
-    for (const change of changes) {
+    lines.push(renderHeading(category))
+    for (const change of changes.sort(compareChanges)) {
       lines.push(renderChange(change))
     }
     lines.push('')
   }
 
   if (contributors.size > 0) {
-    lines.push('Contributors')
+    lines.push('<b>Contributors</b>')
     for (const contributor of [...contributors].sort(compareContributors)) {
       lines.push(`- ${contributor}`)
     }
@@ -306,6 +306,33 @@ function renderMarkdown (sections, contributors) {
   }
 
   return lines.join('\n')
+}
+
+/**
+ * @param {string} category
+ */
+function renderHeading (category) {
+  if (category === INTERNAL_CATEGORY) {
+    return `<b>${category}</b> (CI, Testing, Benchmarking)`
+  }
+
+  return `<b>${category}</b>`
+}
+
+/**
+ * Groups same-product entries together; the internal section carries no product,
+ * so it falls through to a plain subject sort.
+ *
+ * @param {Change} a
+ * @param {Change} b
+ */
+function compareChanges (a, b) {
+  if (!a.internal) {
+    const byProduct = a.product.toLowerCase().localeCompare(b.product.toLowerCase())
+    if (byProduct !== 0) return byProduct
+  }
+
+  return a.subject.toLowerCase().localeCompare(b.subject.toLowerCase())
 }
 
 /**

--- a/scripts/release/changelog.spec.js
+++ b/scripts/release/changelog.spec.js
@@ -80,33 +80,33 @@ describe('release changelog', () => {
 
     assert.strictEqual(changelog.isMinor, true)
     assert.strictEqual(changelog.markdown, [
-      'Features',
+      '<b>Features</b>',
       '- <b>AppSec</b> Add AppSec integrations to Laminas Framework ' +
         '(http.route, endpoint collection, login events) #3716',
-      '- <b>OpenTelemetry</b> Add support for OTLP Runtime Metrics #8357',
-      '- <b>LLMObs</b> Support Bedrock Converse and ConverseStream #8079',
       '- <b>General</b> Add Node.js 26 support #8429',
+      '- <b>LLMObs</b> Support Bedrock Converse and ConverseStream #8079',
+      '- <b>OpenTelemetry</b> Add support for OTLP Runtime Metrics #8357',
       '',
-      'Fixes',
-      '- <b>AppSec</b> Treat cleared shared memory as no-config rather than an error in AppSec helper #3876',
+      '<b>Fixes</b>',
       '- <b>AppSec</b> Avoid the possibility of sensitive data going to the telemetry logs backend ' +
         'via WAF strings #3884',
+      '- <b>AppSec</b> Treat cleared shared memory as no-config rather than an error in AppSec helper #3876',
       '- <b>General</b> Encoder JSON number type fix #38799',
+      '- <b>LLMObs</b> Revert "Fan array-valued user tags out into one wire entry per element (#8689)" #8790',
       '- <b>Profiling</b> Prevent panics in profiling encoding under out-of-memory and out-of-bounds ' +
         'conditions #3888',
-      '- <b>LLMObs</b> Revert "Fan array-valued user tags out into one wire entry per element (#8689)" #8790',
       '- <b>unknown-scope</b> Handle strange thing #9999',
       '',
-      'Performance',
+      '<b>Performance</b>',
       '- <b>General</b> Reduce per-span format and encode overhead #8754',
       '',
-      'Documentation',
+      '<b>Documentation</b>',
       '- <b>General</b> Note that startSpan does not activate the returned span #8771',
       '',
       '<b>Internal</b> (CI, Testing, Benchmarking)',
+      '- Add the startup guard to the writer encode loop #8755',
       '- Bump the serverless group across 1 directory with 8 updates #8782',
       '- Cap proposal at 100 commits and notify guild at 50 #8711',
-      '- Add the startup guard to the writer encode loop #8755',
       '- Fixes APMS-19181: sets the service discovery logs to respect the log level #8677',
       '',
     ].join('\n'))
@@ -130,10 +130,10 @@ describe('release changelog', () => {
 
     assert.strictEqual(changelog.isMinor, false)
     assert.strictEqual(changelog.markdown, [
-      'Features',
+      '<b>Features</b>',
       '- <b>AppSec</b> Revert "Add experimental detection (#8689)" #8790',
       '',
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>Profiling</b> Correct sample counts #8791',
       '',
     ].join('\n'))
@@ -152,10 +152,10 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Features',
+      '<b>Features</b>',
       '- <b>OpenTelemetry</b> Add breaking OpenTelemetry behavior',
       '',
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>General</b> Keep request tagging stable',
       '',
     ].join('\n'))
@@ -170,7 +170,7 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>AppSec</b> Trim empty scope segments #1234',
       '',
     ].join('\n'))
@@ -183,10 +183,10 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Features',
+      '<b>Features</b>',
       '- <b>aws-sdk</b> Create SQS consumer spans #8827',
       '',
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>redis</b> Drop db.name placeholder #8402',
       '',
     ].join('\n'))
@@ -199,7 +199,7 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>redis, iovalkey</b> Align reconnect handling #8001',
       '',
     ].join('\n'))
@@ -215,9 +215,9 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Fixes',
-      '- <b>AppSec</b> Block on suspicious request #9001',
+      '<b>Fixes</b>',
       '- <b>AI Guard</b> Tighten prompt evaluation #9002',
+      '- <b>AppSec</b> Block on suspicious request #9001',
       '- <b>Data Streams Monitoring</b> Track message lineage #9003',
       '- <b>Database Monitoring</b> Propagate trace context to SQL comments #9004',
       '- <b>General</b> Route agentless spans to the regional intake #9005',
@@ -234,16 +234,16 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Features',
+      '<b>Features</b>',
       '- <b>AppSec</b> Add thing #1',
       '',
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>Profiling</b> Fix thing #2',
       '',
       '<b>Internal</b> (CI, Testing, Benchmarking)',
       '- Tweak the workflow #3',
       '',
-      'Contributors',
+      '<b>Contributors</b>',
       '- @alice',
       '- @Zoe',
       '',
@@ -256,7 +256,7 @@ describe('release changelog', () => {
     ])
 
     assert.strictEqual(changelog.markdown, [
-      'Fixes',
+      '<b>Fixes</b>',
       '- <b>AppSec</b> Handle thing #1',
       '',
     ].join('\n'))


### PR DESCRIPTION
## Summary

Builds on #8941. Two readability tweaks to the generated release notes:

1. Each section sorts its entries by product label, then subject, so every `AppSec`, `LLMObs`, ... entry groups together instead of appearing in commit order. The Internal section carries no product label, so it sorts by subject and lines the dependency bumps up.
2. Every section heading is bold (`<b>Features</b>`, `<b>Fixes</b>`, `<b>Performance</b>`, `<b>Documentation</b>`, `<b>Contributors</b>`) to match the existing `<b>Internal</b>` heading.

## Test plan

- `scripts/release/changelog.spec.js` via mocha — updated all expectations for the bold headings and sorted order.
- `nyc` reports 100% statements/branches/functions/lines on `scripts/release/changelog.js`.