### PR TITLE
test(prisma): cleaned up prisma tests

### DIFF
--- a/packages/datadog-plugin-prisma/test/index.spec.js
+++ b/packages/datadog-plugin-prisma/test/index.spec.js
@@ -356,9 +356,6 @@ describe('Plugin', () => {
         describe(`without configuration ${config.schema}`, () => {
           before(async function () {
             this.timeout(10000)
-            clearPrismaEnv()
-            setPrismaEnv(config)
-
             await agent.load(['prisma', 'pg'])
             prisma = loadPrismaModule(config, range)
 
@@ -444,25 +441,33 @@ describe('Plugin', () => {
               }
             )
 
-            await Promise.all([
-              tracingPromise,
-            ])
+            await tracingPromise
           })
 
           it('should generate engine span from array of spans', async () => {
             const tracingPromise = agent.assertSomeTraces(traces => {
-              assert.strictEqual(traces[0].length, 2)
-              assert.strictEqual(traces[0][0].span_id, traces[0][1].parent_id)
-              assert.strictEqual(traces[0][0].name, 'prisma.engine')
-              assert.strictEqual(traces[0][0].resource, 'query')
-              assert.strictEqual(traces[0][0].meta['prisma.type'], 'engine')
-              assert.strictEqual(traces[0][0].meta['prisma.name'], 'query')
-              assert.strictEqual(traces[0][1].name, 'prisma.engine')
-              assert.strictEqual(traces[0][1].resource, 'SELECT 1')
-              assert.strictEqual(traces[0][1].type, 'sql')
-              assert.strictEqual(traces[0][1].meta['prisma.type'], 'engine')
-              assert.strictEqual(traces[0][1].meta['prisma.name'], 'db_query')
-              assert.strictEqual(traces[0][1].meta['db.type'], 'postgres')
+              assertObjectContains(traces[0], {
+                length: 2,
+                0: {
+                  name: 'prisma.engine',
+                  resource: 'query',
+                  meta: {
+                    'prisma.type': 'engine',
+                    'prisma.name': 'query',
+                  },
+                },
+                1: {
+                  parent_id: traces[0][0].span_id,
+                  name: 'prisma.engine',
+                  resource: 'SELECT 1',
+                  type: 'sql',
+                  meta: {
+                    'prisma.type': 'engine',
+                    'prisma.name': 'db_query',
+                    'db.type': 'postgres',
+                  },
+                },
+              })
             })
 
             const engineSpans = [
@@ -488,9 +493,7 @@ describe('Plugin', () => {
               },
             ]
             tracingHelper.dispatchEngineSpans(engineSpans)
-            await Promise.all([
-              tracingPromise,
-            ])
+            await tracingPromise
           })
 
           it('should include database connection attributes in db_query spans', async () => {
@@ -515,9 +518,7 @@ describe('Plugin', () => {
               ...createEngineDbQuerySpan('SELECT 1'),
             ]
             tracingHelper.dispatchEngineSpans(engineSpans)
-            await Promise.all([
-              tracingPromise,
-            ])
+            await tracingPromise
           })
 
           if (config.v7) {
@@ -574,9 +575,6 @@ describe('Plugin', () => {
         describe('without tracer initialization', () => {
           before(async function () {
             this.timeout(10000)
-            clearPrismaEnv()
-            setPrismaEnv(config)
-
             require('../../dd-trace')
 
             prisma = loadPrismaModule(config, range)
@@ -593,9 +591,6 @@ describe('Plugin', () => {
           describe('with custom service name', () => {
             before(async function () {
               this.timeout(10000)
-              clearPrismaEnv()
-              setPrismaEnv(config)
-
               const pluginConfig = {
                 service: 'custom',
               }

--- a/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
@@ -2,8 +2,10 @@
 
 const assert = require('node:assert')
 const { execSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
 
-const { describe, it, beforeEach, afterEach } = require('mocha')
+const { describe, it, before, beforeEach, afterEach } = require('mocha')
 
 const semifies = require('semifies')
 const semver = require('semver')
@@ -246,15 +248,15 @@ describe('esm', () => {
   prismaClientConfigs.forEach(config => {
     describe(config.name, () => {
       const isNodeSupported = semifies(semver.clean(process.version), '>=20.19.0')
-      const isPrismaV7 = config.configFile
-      if (config.configFile && !isNodeSupported) {
+      const isPrismaV7 = Boolean(config.configFile)
+      if (isPrismaV7 && !isNodeSupported) {
         return
       }
       if (config.skip?.()) {
         return
       }
 
-      const supportedRange = config.configFile ? '>=7.0.0' : '<7.0.0'
+      const supportedRange = isPrismaV7 ? '>=7.0.0' : '<7.0.0'
 
       withVersions('prisma', '@prisma/client', supportedRange, version => {
         if (config.ts && version === '6.1.0') return
@@ -268,7 +270,7 @@ describe('esm', () => {
           if (ext.node && !semifies(semver.clean(process.version), ext.node)) continue
           if (ext.dep === '@prisma/client') {
             deps.push(`${ext.name}@${version}`)
-          } else if (ext.dep || isPrismaV7 && ext.node) {
+          } else if (ext.dep || (isPrismaV7 && ext.node)) {
             deps.push(ext.name)
           }
         }
@@ -285,23 +287,10 @@ describe('esm', () => {
           })
         }
 
-        beforeEach(async function () {
+        before(function () {
           this.timeout(60000)
-          if (config.waitForService) {
-            await config.waitForService(true)
-          }
-          if (config.env?.DATABASE_URL?.startsWith('mongodb')) {
-            await resetMongoDb(config.env.DATABASE_URL)
-          }
-          agent = await new FakeAgent().start()
-          const commands = [
-            './node_modules/.bin/prisma db push --accept-data-loss',
-            './node_modules/.bin/prisma generate',
-          ]
-          if (!config.skipMigrateReset) {
-            commands.unshift('./node_modules/.bin/prisma migrate reset --force')
-          }
           const cwd = sandboxCwd()
+          const commands = ['./node_modules/.bin/prisma generate']
 
           if (config.ts) {
             commands.push(
@@ -326,15 +315,33 @@ describe('esm', () => {
 
           // node v18 needs the package.json to have type module to treat .js files as esm
           if (config.ts && config.name.includes('v6')) {
-            const fs = require('fs')
-            const path = require('path')
             const distPath = path.join(cwd, 'dist')
-            try {
-              fs.mkdirSync(distPath, { recursive: true })
-            } catch {}
-            const distPkgJsonPath = path.join(distPath, 'package.json')
-            fs.writeFileSync(distPkgJsonPath, JSON.stringify({ type: 'module' }, null, 2))
+            fs.mkdirSync(distPath, { recursive: true })
+            fs.writeFileSync(path.join(distPath, 'package.json'), JSON.stringify({ type: 'module' }, null, 2))
           }
+        })
+
+        beforeEach(async function () {
+          this.timeout(60000)
+          if (config.waitForService) {
+            await config.waitForService(true)
+          }
+          if (config.env?.DATABASE_URL?.startsWith('mongodb')) {
+            await resetMongoDb(config.env.DATABASE_URL)
+          }
+          agent = await new FakeAgent().start()
+          const commands = ['./node_modules/.bin/prisma db push --accept-data-loss']
+          if (!config.skipMigrateReset) {
+            commands.unshift('./node_modules/.bin/prisma migrate reset --force')
+          }
+          execSync(commands.join(' && '), {
+            cwd: sandboxCwd(),
+            stdio: 'inherit',
+            env: {
+              ...process.env,
+              ...config.env,
+            },
+          })
         })
 
         afterEach(async () => {


### PR DESCRIPTION
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- Please make sure your changes are properly tested -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

<!-- PR title must follow Conventional Commits format: type(scope): description -->
<!-- Valid types: feat, fix, docs, style, refactor, perf, test, bench, build, ci, chore, revert -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Small test-only cleanup in packages/datadog-plugin-prisma/test/. No production code or behavior changes.

Removed duplicate clearPrismaEnv() / setPrismaEnv(config) calls from the three nested before hooks. The outer before (registered once per withVersions (config, range) pair) already runs them, so the inner copies were dead work.

- Hoisted node:fs and node:path to top-level requires.
- Dropped the try/catch around fs.mkdirSync(distPath, { recursive: true })
- Renamed const isPrismaV7 = config.configFile (truthy string) to Boolean(config.configFile) and used it consistently at the supportedRange site.
- Parenthesized ext.dep || (isPrismaV7 && ext.node) so precedence reads at a glance.
- Split beforeEach work between before and beforeEach:
  - before (once per describe): prisma generate, tsc compile, and the v18 dist package.json write — all stable per config.
  - beforeEach (per test): prisma migrate reset --force && prisma db push --accept-data-loss (must run together — reset wipes DB, push re-applies schema), agent start, waitForService, resetMongoDb.
  
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->


