### PR TITLE
bench(startup): add ESM variant that exercises the iitm loader

### DIFF
--- a/benchmark/sirun/startup/README.md
+++ b/benchmark/sirun/startup/README.md
@@ -1,7 +1,13 @@
 Measures tracer startup overhead: how much the loader hooks add when wrapping a
 representative production dependency graph. `everything-fixture/` is a
 self-contained sub-project (own `package.json`/`package-lock.json`/`node_modules`)
-loaded via a single `require`, curated toward modules dd-trace instruments.
+curated toward modules dd-trace instruments. Both fixture entries read the same
+`dependencies`, so updating `package.json` covers both:
+
+- `index.js` loads them with CommonJS `require`, exercising require-in-the-middle.
+- `index.mjs` loads them with ESM `import`; the `with-tracer-everything-esm`
+  variant registers the iitm ESM loader via `--import ../../../register.js`, so
+  this is the variant that measures the synchronous-vs-asynchronous loader cost.
 
 ## Updating the fixture
 

--- a/benchmark/sirun/startup/everything-fixture/index.mjs
+++ b/benchmark/sirun/startup/everything-fixture/index.mjs
@@ -1,0 +1,9 @@
+import { createRequire } from 'node:module'
+
+// Bare-specifier dynamic imports resolve against this sub-project's own
+// node_modules and go through the ESM resolve/load hooks, unlike the CJS
+// `require` in index.js. This is what puts the iitm ESM loader on the measured
+// path when the startup bench registers it via `--import ../../../register.js`.
+const { dependencies } = createRequire(import.meta.url)('./package.json')
+
+await Promise.all(Object.keys(dependencies).map((name) => import(name)))

--- a/benchmark/sirun/startup/meta.json
+++ b/benchmark/sirun/startup/meta.json
@@ -16,6 +16,14 @@
         "USE_TRACER": "1",
         "EVERYTHING": "1"
       }
+    },
+    "with-tracer-everything-esm": {
+      "env": {
+        "USE_TRACER": "1",
+        "EVERYTHING": "1",
+        "ESM": "1",
+        "NODE_OPTIONS": "--import ../../../register.js"
+      }
     }
   }
 }

--- a/benchmark/sirun/startup/startup-test.js
+++ b/benchmark/sirun/startup/startup-test.js
@@ -7,10 +7,27 @@ if (Number(process.env.USE_TRACER)) {
 }
 
 if (Number(process.env.EVERYTHING)) {
-  require('./everything-fixture')
+  if (Number(process.env.ESM)) {
+    // The ESM variant registers the iitm ESM loader through
+    // NODE_OPTIONS=--import ../../../register.js, so importing the fixture routes
+    // every dependency and its transitive graph through the loader's resolve/load
+    // hooks. The CJS branch below goes through require-in-the-middle and never
+    // touches the ESM loader, so this is the only startup variant that measures
+    // the synchronous-vs-asynchronous loader cost the iitm hooks change.
+    assert.match(
+      process.env.NODE_OPTIONS ?? '',
+      /--import\b.+register\.js/,
+      'ESM startup variant must register the iitm loader via --import register.js'
+    )
+    // The floating import is the measured workload: it keeps the process alive
+    // until the graph finishes loading, and a rejection surfaces as a non-zero exit.
+    import('./everything-fixture/index.mjs')
+  } else {
+    require('./everything-fixture')
 
-  assert.ok(
-    require.cache[require.resolve('./everything-fixture/node_modules/express')],
-    'everything-fixture did not load (express not in require cache)'
-  )
+    assert.ok(
+      require.cache[require.resolve('./everything-fixture/node_modules/express')],
+      'everything-fixture did not load (express not in require cache)'
+    )
+  }
 }


### PR DESCRIPTION
## Summary

The `startup` sirun variants load `everything-fixture` through CommonJS `require`, which goes through require-in-the-middle and never registers the iitm ESM loader. That loader is what #8942 changes from an off-thread asynchronous loader (`module.register`) to an in-thread synchronous one (`module.registerHooks`), so the benchmark suite reported "performance is the same" for that PR — no variant put the loader on a measured path.

`with-tracer-everything-esm` registers the loader via `--import ../../../register.js` and imports the same fixture through ESM, so every dependency and its transitive graph flow through the loader's resolve/load hooks. On master this measures the async loader; on #8942 (sync loader on capable Node) the A/B renders the difference.

- The fixture's `index.mjs` reads the same `dependencies` as `index.js`, so the dependency list stays single-sourced in `package.json` — updating one updates both.
- Runs on the existing Node 20/24/26 matrix. Node 20 has no `registerHooks`, so #8942 keeps the async loader there (no delta); 24/26 show the sync win.

## Why

#8942's 56% Vitest startup reduction was invisible to CI because the existing startup variants are CJS-only. This closes that coverage gap and guards the ESM loader path against future regressions.

## Test plan

- [ ] CI sirun `startup / with-tracer-everything-esm` reports stable `instructions` and `wall.time` on Node 20/24/26.
- [ ] Once this lands on master, #8942 shows a reduction on this variant for Node 24/26.

Note on local validation: macOS sirun hangs on every `startup` variant (including the existing ones), so stability was checked with direct process timing — steady-state ~0.69s, ~2% spread, all three variants exit 0 on Node 20/24/26 — and the sirun numbers are left to CI's pinned isolated core, per the benchmark guidance.

Refs: https://github.com/DataDog/dd-trace-js/pull/8942