### PR TITLE
feat(rethinkdb): add rethinkdb integration [CLAUDE]

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1266,6 +1266,22 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/plugins/test
 
+  rethinkdb:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    services:
+      rethinkdb:
+        image: rethinkdb@sha256:30e0235da35e645025ca755c50d9ba617765f7f186fd1b0879fe00177e14de6a # 2.4.3
+        ports:
+          - 28015:28015
+    env:
+      PLUGINS: rethinkdb
+      SERVICES: rethinkdb
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/plugins/test
+
   # Restify isn't compatible with Node.js v24 so we don't run against latest Node.js
   # see: https://github.com/restify/node-restify/issues/1984
   restify:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,10 @@ services:
     image: cassandra@sha256:61cbfa672b254e8fc82ece6bfd434ef7a2000e39e32f8f03c9ee4700cd9973a5 # 3-focal
     ports:
       - "127.0.0.1:9042:9042"
+  rethinkdb:
+    image: rethinkdb@sha256:30e0235da35e645025ca755c50d9ba617765f7f186fd1b0879fe00177e14de6a # 2.4.3
+    ports:
+      - "127.0.0.1:28015:28015"
   limitd:
     image: ghcr.io/rochdev/limitd@sha256:3315deb2a9fba6d9753b26363947992c2c7b1465aba7352b4595c76a197aaeff # latest
     environment:

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,6 +93,7 @@ tracer.use('pg', {
 <h5 id="prisma"></h5>
 <h5 id="protobufjs"></h5>
 <h5 id="redis"></h5>
+<h5 id="rethinkdb"></h5>
 <h5 id="restify"></h5>
 <h5 id="rhea"></h5>
 <h5 id="router"></h5>
@@ -176,6 +177,7 @@ tracer.use('pg', {
 * [prisma](./interfaces/export_.plugins.prisma.html)
 * [protobufjs](./interfaces/export_.plugins.protobufjs.html)
 * [redis](./interfaces/export_.plugins.redis.html)
+* [rethinkdb](./interfaces/export_.plugins.rethinkdb.html)
 * [restify](./interfaces/export_.plugins.restify.html)
 * [rhea](./interfaces/export_.plugins.rhea.html)
 * [router](./interfaces/export_.plugins.router.html)

--- a/docs/test.ts
+++ b/docs/test.ts
@@ -398,6 +398,7 @@ tracer.use('prisma');
 tracer.use('protobufjs');
 tracer.use('redis');
 tracer.use('redis', redisOptions);
+tracer.use('rethinkdb');
 tracer.use('restify');
 tracer.use('restify', httpServerOptions);
 tracer.use('rhea');

--- a/index.d.ts
+++ b/index.d.ts
@@ -298,6 +298,7 @@ interface Plugins {
   "prisma": tracer.plugins.prisma;
   "protobufjs": tracer.plugins.protobufjs;
   "redis": tracer.plugins.redis;
+  "rethinkdb": tracer.plugins.rethinkdb;
   "restify": tracer.plugins.restify;
   "rhea": tracer.plugins.rhea;
   "router": tracer.plugins.router;
@@ -3012,6 +3013,12 @@ declare namespace tracer {
        */
       splitByInstance?: boolean;
     }
+
+    /**
+     * This plugin automatically instruments the
+     * [rethinkdb](https://github.com/rethinkdb/rethinkdb-javascript) module.
+     */
+    interface rethinkdb extends Instrumentation {}
 
     /**
      * This plugin automatically instruments the

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -300,6 +300,7 @@ interface Plugins {
   "prisma": tracer.plugins.prisma;
   "protobufjs": tracer.plugins.protobufjs;
   "redis": tracer.plugins.redis;
+  "rethinkdb": tracer.plugins.rethinkdb;
   "restify": tracer.plugins.restify;
   "rhea": tracer.plugins.rhea;
   "router": tracer.plugins.router;
@@ -3200,6 +3201,12 @@ declare namespace tracer {
        */
       splitByInstance?: boolean;
     }
+
+    /**
+     * This plugin automatically instruments the
+     * [rethinkdb](https://github.com/rethinkdb/rethinkdb-javascript) module.
+     */
+    interface rethinkdb extends Instrumentation {}
 
     /**
      * This plugin automatically instruments the

--- a/packages/datadog-instrumentations/src/helpers/hooks.js
+++ b/packages/datadog-instrumentations/src/helpers/hooks.js
@@ -136,6 +136,7 @@ module.exports = {
   pug: () => require('../pug'),
   q: () => require('../q'),
   redis: () => require('../redis'),
+  rethinkdb: () => require('../rethinkdb'),
   restify: () => require('../restify'),
   rhea: () => require('../rhea'),
   router: () => require('../router'),

--- a/packages/datadog-instrumentations/src/rethinkdb.js
+++ b/packages/datadog-instrumentations/src/rethinkdb.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const shimmer = require('../../datadog-shimmer')
+const {
+  channel,
+  addHook,
+} = require('./helpers/instrument')
+
+const startCh = channel('apm:rethinkdb:query:start')
+const finishCh = channel('apm:rethinkdb:query:finish')
+const errorCh = channel('apm:rethinkdb:query:error')
+
+// Shimmer is required because we must wrap the `cb` argument to intercept
+// query completion. Orchestrion's static AST rewriting cannot modify
+// dynamically-passed callback arguments at call sites.
+addHook({ name: 'rethinkdb', versions: ['>=2.3.2'], file: 'net.js' }, net => {
+  shimmer.wrap(net.Connection.prototype, '_start', _start => function (term, cb, opts) {
+    if (!startCh.hasSubscribers) {
+      return _start.apply(this, arguments)
+    }
+
+    const ctx = {
+      db: (opts && opts.db) || this.db,
+      host: this.host,
+      port: this.port,
+      query: term.toString().replace(/^undefined\./, 'r.'),
+    }
+
+    return startCh.runStores(ctx, () => {
+      if (typeof cb === 'function') {
+        arguments[1] = shimmer.wrapCallback(cb, cb => function (err, result) {
+          if (err) {
+            ctx.error = err
+            errorCh.publish(ctx)
+          }
+          ctx.result = result
+          return finishCh.runStores(ctx, cb, this, err, result)
+        })
+      }
+
+      try {
+        return _start.apply(this, arguments)
+      } catch (e) {
+        ctx.error = e
+        errorCh.publish(ctx)
+        throw e
+      }
+    })
+  })
+  return net
+})

--- a/packages/datadog-plugin-rethinkdb/src/index.js
+++ b/packages/datadog-plugin-rethinkdb/src/index.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { CLIENT_PORT_KEY } = require('../../dd-trace/src/constants')
+const DatabasePlugin = require('../../dd-trace/src/plugins/database')
+
+class RethinkDBPlugin extends DatabasePlugin {
+  static id = 'rethinkdb'
+  static system = 'rethinkdb'
+
+  bindStart (ctx) {
+    const { db, host, port, query } = ctx
+
+    this.startSpan(this.operationName(), {
+      service: this.serviceName({ pluginConfig: this.config }),
+      resource: this.maybeTruncate(query),
+      type: 'rethinkdb',
+      kind: 'client',
+      meta: {
+        'db.type': 'rethinkdb',
+        'db.name': db,
+        'out.host': host,
+        [CLIENT_PORT_KEY]: port,
+      },
+    }, ctx)
+
+    return ctx.currentStore
+  }
+}
+
+module.exports = RethinkDBPlugin

--- a/packages/datadog-plugin-rethinkdb/test/index.spec.js
+++ b/packages/datadog-plugin-rethinkdb/test/index.spec.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+
+const { ERROR_TYPE, ERROR_MESSAGE, ERROR_STACK } = require('../../dd-trace/src/constants')
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withNamingSchema, withPeerService, withVersions } = require('../../dd-trace/test/setup/mocha')
+const { expectedSchema, rawExpectedSchema } = require('./naming')
+
+describe('Plugin', () => {
+  let r
+  let tracer
+
+  describe('rethinkdb', () => {
+    withVersions('rethinkdb', 'rethinkdb', version => {
+      beforeEach(() => {
+        tracer = require('../../dd-trace')
+        r = require(`../../../versions/rethinkdb@${version}`).get()
+      })
+
+      describe('without configuration', () => {
+        let connection
+
+        before(() => agent.load('rethinkdb'))
+        after(() => agent.close({ ritmReset: false }))
+
+        beforeEach(done => {
+          r.connect({ host: '127.0.0.1', port: 28015 }, (err, conn) => {
+            if (err) return done(err)
+            connection = conn
+            done()
+          })
+        })
+
+        afterEach(done => {
+          connection.close(done)
+        })
+
+        withPeerService(
+          () => tracer,
+          'rethinkdb',
+          () => r.tableList().run(connection),
+          '127.0.0.1',
+          'out.host'
+        )
+
+        withNamingSchema(
+          done => r.tableList().run(connection, err => err && done(err)),
+          rawExpectedSchema.outbound
+        )
+
+        it('should do automatic instrumentation', done => {
+          agent
+            .assertFirstTraceSpan({
+              name: expectedSchema.outbound.opName,
+              service: expectedSchema.outbound.serviceName,
+              resource: 'r.tableList()',
+              type: 'rethinkdb',
+              meta: {
+                'db.type': 'rethinkdb',
+                'out.host': '127.0.0.1',
+                'span.kind': 'client',
+                component: 'rethinkdb',
+              },
+            })
+            .then(done)
+            .catch(done)
+
+          r.tableList().run(connection, err => err && done(err))
+        })
+
+        it('should set the database name tag', done => {
+          agent
+            .assertFirstTraceSpan({
+              meta: {
+                'db.name': 'test',
+              },
+            })
+            .then(done)
+            .catch(done)
+
+          r.tableList().run(connection, { db: 'test' }, err => err && done(err))
+        })
+
+        it('should handle errors', done => {
+          let error
+
+          agent
+            .assertFirstTraceSpan(trace => {
+              assert.strictEqual(trace.error, 1)
+              assert.ok(trace.meta[ERROR_TYPE])
+              assert.ok(trace.meta[ERROR_MESSAGE])
+              assert.ok(trace.meta[ERROR_STACK])
+            })
+            .then(done)
+            .catch(done)
+
+          r.table('nonexistent_table_that_does_not_exist').get('id').run(connection, err => {
+            error = err
+            if (!error) done(new Error('Expected an error'))
+          })
+        })
+
+        it('should run the callback in the parent context', done => {
+          const scope = tracer.scope()
+          const parent = tracer.startSpan('test')
+
+          scope.activate(parent, () => {
+            r.tableList().run(connection, () => {
+              assert.strictEqual(tracer.scope().active(), parent)
+              parent.finish()
+              done()
+            })
+          })
+        })
+      })
+
+      describe('with configuration', () => {
+        let connection
+
+        before(() => agent.load('rethinkdb', { service: 'custom' }))
+        after(() => agent.close({ ritmReset: false }))
+
+        beforeEach(done => {
+          r.connect({ host: '127.0.0.1', port: 28015 }, (err, conn) => {
+            if (err) return done(err)
+            connection = conn
+            done()
+          })
+        })
+
+        afterEach(done => {
+          connection.close(done)
+        })
+
+        withNamingSchema(
+          done => r.tableList().run(connection, err => err && done(err)),
+          {
+            v0: {
+              opName: 'rethinkdb.query',
+              serviceName: 'custom',
+            },
+            v1: {
+              opName: 'rethinkdb.query',
+              serviceName: 'custom',
+            },
+          },
+          {
+            hooks: (versionName, defaultToGlobalService) => {
+              it('should use the custom service name', done => {
+                agent
+                  .assertFirstTraceSpan({
+                    service: 'custom',
+                  })
+                  .then(done)
+                  .catch(done)
+
+                r.tableList().run(connection, err => err && done(err))
+              })
+            },
+          }
+        )
+      })
+    })
+  })
+})

--- a/packages/datadog-plugin-rethinkdb/test/naming.js
+++ b/packages/datadog-plugin-rethinkdb/test/naming.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const { resolveNaming } = require('../../dd-trace/test/plugins/helpers')
+
+const rawExpectedSchema = {
+  outbound: {
+    v0: {
+      opName: 'rethinkdb.query',
+      serviceName: 'test-rethinkdb',
+    },
+    v1: {
+      opName: 'rethinkdb.query',
+      serviceName: 'test',
+    },
+  },
+}
+
+module.exports = {
+  rawExpectedSchema,
+  expectedSchema: resolveNaming(rawExpectedSchema),
+}

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -3591,6 +3591,13 @@
         "default": "true"
       }
     ],
+    "DD_TRACE_RETHINKDB_ENABLED": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "true"
+      }
+    ],
     "DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED": [
       {
         "implementation": "A",

--- a/packages/dd-trace/src/plugins/index.js
+++ b/packages/dd-trace/src/plugins/index.js
@@ -113,6 +113,7 @@ const plugins = {
   get playwright () { return require('../../../datadog-plugin-playwright/src') },
   get protobufjs () { return require('../../../datadog-plugin-protobufjs/src') },
   get redis () { return require('../../../datadog-plugin-redis/src') },
+  get rethinkdb () { return require('../../../datadog-plugin-rethinkdb/src') },
   get restify () { return require('../../../datadog-plugin-restify/src') },
   get rhea () { return require('../../../datadog-plugin-rhea/src') },
   get router () { return require('../../../datadog-plugin-router/src') },

--- a/packages/dd-trace/src/service-naming/schemas/v0/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v0/storage.js
@@ -164,6 +164,14 @@ const storage = {
       },
     },
     redis: redisConfig,
+    rethinkdb: {
+      opName: () => 'rethinkdb.query',
+      serviceName: ({ tracerService, pluginConfig, system }) =>
+        pluginConfig.service || fromSystem(tracerService, system),
+      serviceSource: ({ tracerService, pluginConfig, connectionName }) => {
+        return optionServiceSource({ tracerService, pluginConfig, connectionName, integration: 'rethinkdb' })
+      },
+    },
     tedious: {
       opName: () => 'tedious.request',
       serviceName: ({ tracerService, pluginConfig, system }) =>

--- a/packages/dd-trace/src/service-naming/schemas/v1/storage.js
+++ b/packages/dd-trace/src/service-naming/schemas/v1/storage.js
@@ -92,6 +92,11 @@ const storage = {
       serviceSource: optionServiceSource,
     },
     redis: redisNaming,
+    rethinkdb: {
+      opName: () => 'rethinkdb.query',
+      serviceName: configWithFallback,
+      serviceSource: optionServiceSource,
+    },
     tedious: {
       opName: () => 'mssql.query',
       serviceName: configWithFallback,

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -206,6 +206,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "redis": "5.12.1",
+    "rethinkdb": "2.4.2",
     "request": "2.88.2",
     "restify": "11.1.0",
     "rhea": "3.0.5",

--- a/packages/dd-trace/test/setup/services/rethinkdb.js
+++ b/packages/dd-trace/test/setup/services/rethinkdb.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const RetryOperation = require('../operation')
+const r = require('../../../../../versions/rethinkdb').get()
+
+function waitForRethinkDB () {
+  return new Promise((resolve, reject) => {
+    const operation = new RetryOperation('rethinkdb')
+
+    operation.attempt(currentAttempt => {
+      r.connect({ host: '127.0.0.1', port: 28015 }, (err, connection) => {
+        if (operation.retry(err)) return
+        if (err) return reject(err)
+
+        connection.close(closeErr => closeErr ? reject(closeErr) : resolve())
+      })
+    })
+  })
+}
+
+module.exports = waitForRethinkDB


### PR DESCRIPTION
> _This is a demo to compare LLM quality. I do not believe we would ever merge this since nobody has ever asked for it. Compare it with #8962._
> Generated by **Claude Code**.

## Summary

- Adds automatic APM instrumentation for the `rethinkdb` npm package (versions >=2.3.2)
- Uses shimmer to wrap `Connection.prototype._start` in `net.js`, the central dispatch point for all queries
- Creates spans with `db.type`, `db.name`, `out.host`, and `network.destination.port` tags; sanitizes `term.toString()` output to replace the `undefined.` prefix with `r.`

## Test plan

- [x] Plugin tests pass for rethinkdb 2.3.2 and 2.4.2 (28 tests)
- [x] Plugin structure tests pass (169 tests)
- [x] Automatic instrumentation, db.name tag, error handling, parent context, peer service, and naming schema all verified

## Notes

Shimmer is required (instead of Orchestrion) because the instrumentation must wrap the `cb` argument passed to `_start()` to intercept query completion. Orchestrion's static AST rewriting cannot modify dynamically-passed callback arguments.

Version range starts at 2.3.2 because 2.3.0 and 2.3.1 do not export `Connection` from `net.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)