### PR TITLE
feat(serverless): auto-tag HTTP spans with lambda-web-request-id on something-under-nda

### DIFF
--- a/integration-tests/something-under-nda-request-id.spec.js
+++ b/integration-tests/something-under-nda-request-id.spec.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const http = require('node:http')
+const path = require('node:path')
+
+const {
+  FakeAgent,
+  spawnProc,
+  stopProc,
+  sandboxCwd,
+  useSandbox,
+} = require('./helpers')
+
+/**
+ * @param {string} url
+ * @param {Record<string, string>} headers
+ * @returns {Promise<void>}
+ */
+function curlWithHeaders (url, headers) {
+  return new Promise((resolve, reject) => {
+    http.get(url, { headers }, res => {
+      res.resume()
+      res.once('end', resolve)
+      res.once('error', reject)
+    }).once('error', reject)
+  })
+}
+
+describe('something-under-nda request id auto-tag', () => {
+  let agent, proc, cwd, fixtureFile
+
+  useSandbox([])
+
+  before(() => {
+    cwd = sandboxCwd()
+    fixtureFile = path.join(cwd, 'something-under-nda-request-id/index.js')
+  })
+
+  beforeEach(async () => {
+    agent = await new FakeAgent().start()
+  })
+
+  afterEach(async () => {
+    await stopProc(proc)
+    await agent.stop()
+  })
+
+  it('should auto-tag span with lambda.request_id under something-under-nda', async () => {
+    proc = await spawnProc(fixtureFile, {
+      cwd,
+      env: {
+        AGENT_PORT: agent.port,
+        DD_TRACE_AGENT_PORT: agent.port,
+        SOMETHING_UNDER_NDA: 'something-under-nda',
+      },
+    })
+
+    const assertion = agent.assertMessageReceived(({ payload }) => {
+      const span = payload[0][0]
+      assert.strictEqual(span.name, 'web.request')
+      assert.strictEqual(span.meta['lambda.request_id'], 'req-abc-123')
+    })
+
+    await curlWithHeaders(proc.url, { 'lambda-web-request-id': 'req-abc-123' })
+    await assertion
+  })
+})

--- a/integration-tests/something-under-nda-request-id/index.js
+++ b/integration-tests/something-under-nda-request-id/index.js
@@ -1,0 +1,14 @@
+'use strict'
+
+require('dd-trace').init({
+  logInjection: false,
+})
+
+const http = require('http')
+
+const server = http.createServer((req, res) => {
+  res.end('ok')
+}).listen(0, () => {
+  const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
+  process.send({ port })
+})

--- a/packages/datadog-instrumentations/test/pino.spec.js
+++ b/packages/datadog-instrumentations/test/pino.spec.js
@@ -76,7 +76,7 @@ describe('pino instrumentation', () => {
         assert.ok(record.pid, 'should have pid')
         assert.ok(record.hostname, 'should have hostname')
         assert.ok(record.time, 'should have time')
-        assert.ok(record.level !== undefined, 'should have level')
+        assert.notStrictEqual(record.level, undefined, 'should have level')
         assert.strictEqual(record.msg, 'full record test')
         done()
       })

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -4,6 +4,7 @@ const uniq = require('../../../../datadog-core/src/utils/src/uniq')
 const analyticsSampler = require('../../analytics_sampler')
 const FORMAT_HTTP_HEADERS = 'http_headers'
 const log = require('../../log')
+const { isSomethingUnderNDA } = require('../../serverless')
 const tags = require('../../../../../ext/tags')
 const types = require('../../../../../ext/types')
 const kinds = require('../../../../../ext/kinds')
@@ -31,6 +32,11 @@ const HTTP_RESPONSE_HEADERS = tags.HTTP_RESPONSE_HEADERS
 const HTTP_USERAGENT = tags.HTTP_USERAGENT
 const HTTP_CLIENT_IP = tags.HTTP_CLIENT_IP
 const MANUAL_DROP = tags.MANUAL_DROP
+
+// Auto-appended to config.headers by getHeadersToRecord when running under something-under-nda,
+// so the generated `something-under-nda-request-id` header is tagged on each HTTP span —
+// bridging platform logs to Datadog traces via the `something_under_nda.request_id` tag.
+const SOMETHING_UNDER_NDA_DEFAULT_HEADER = ['lambda-web-request-id', 'lambda.request_id']
 
 const contexts = new WeakMap()
 
@@ -498,9 +504,10 @@ function addResponseHeaders (context) {
 }
 
 function getHeadersToRecord (config) {
+  let userHeaders = []
   if (Array.isArray(config.headers)) {
     try {
-      return config.headers
+      userHeaders = config.headers
         .map(h => h.split(':'))
         .map(([key, tag]) => [key.toLowerCase(), tag])
     } catch (err) {
@@ -509,7 +516,13 @@ function getHeadersToRecord (config) {
   } else if (config.hasOwnProperty('headers')) {
     log.error('Expected `headers` to be an array of strings.')
   }
-  return []
+
+  if (isSomethingUnderNDA() &&
+      !userHeaders.some(([key]) => key === SOMETHING_UNDER_NDA_DEFAULT_HEADER[0])) {
+    userHeaders.push(SOMETHING_UNDER_NDA_DEFAULT_HEADER)
+  }
+
+  return userHeaders
 }
 
 function isNot500ErrorCode (code) {

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict')
 
-const { describe, it, beforeEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 const sinon = require('sinon')
 
 require('../../setup/core')
@@ -81,6 +81,84 @@ describe('plugins/util/web', () => {
       assert.strictEqual(config.validateStatus(200), false)
       assert.ok(Object.hasOwn(config, 'hooks'))
       assert.strictEqual(config.hooks.request(), 'test')
+    })
+
+    it('should return no header mappings when a headers entry cannot be parsed', () => {
+      const config = web.normalizeConfig({
+        headers: [null],
+      })
+
+      assert.deepStrictEqual(config.headers, [])
+    })
+
+    it('should return no header mappings when headers is not an array', () => {
+      const config = web.normalizeConfig({
+        headers: 'x-foo:tag',
+      })
+
+      assert.deepStrictEqual(config.headers, [])
+    })
+
+    describe('something-under-nda request id auto-tag', () => {
+      const SOMETHING_UNDER_NDA_ENV = 'SOMETHING_UNDER_NDA'
+      let priorSomethingUnderNDA
+
+      beforeEach(() => {
+        priorSomethingUnderNDA = process.env[SOMETHING_UNDER_NDA_ENV]
+        delete process.env[SOMETHING_UNDER_NDA_ENV]
+      })
+
+      afterEach(() => {
+        if (priorSomethingUnderNDA === undefined) delete process.env[SOMETHING_UNDER_NDA_ENV]
+        else process.env[SOMETHING_UNDER_NDA_ENV] = priorSomethingUnderNDA
+      })
+
+      it('should not auto-tag when not under something-under-nda', () => {
+        const config = web.normalizeConfig({})
+
+        assert.deepStrictEqual(config.headers, [])
+      })
+
+      it('should auto-tag under something-under-nda', () => {
+        process.env[SOMETHING_UNDER_NDA_ENV] = 'something-under-nda'
+
+        const config = web.normalizeConfig({})
+
+        assert.deepStrictEqual(config.headers, [['lambda-web-request-id', 'lambda.request_id']])
+      })
+
+      it('should auto-tag alongside user-provided headers', () => {
+        process.env[SOMETHING_UNDER_NDA_ENV] = 'something-under-nda'
+
+        const config = web.normalizeConfig({
+          headers: ['x-my-header:my.tag'],
+        })
+
+        assert.deepStrictEqual(config.headers, [
+          ['x-my-header', 'my.tag'],
+          ['lambda-web-request-id', 'lambda.request_id'],
+        ])
+      })
+
+      it('should defer to user override of the header tag name', () => {
+        process.env[SOMETHING_UNDER_NDA_ENV] = 'something-under-nda'
+
+        const config = web.normalizeConfig({
+          headers: ['lambda-web-request-id:custom.request_id'],
+        })
+
+        assert.deepStrictEqual(config.headers, [['lambda-web-request-id', 'custom.request_id']])
+      })
+
+      it('should match user override case-insensitively', () => {
+        process.env[SOMETHING_UNDER_NDA_ENV] = 'something-under-nda'
+
+        const config = web.normalizeConfig({
+          headers: ['Lambda-Web-Request-Id:custom.request_id'],
+        })
+
+        assert.deepStrictEqual(config.headers, [['lambda-web-request-id', 'custom.request_id']])
+      })
     })
 
     describe('queryStringObfuscation', () => {

--- a/packages/dd-trace/test/serverless.spec.js
+++ b/packages/dd-trace/test/serverless.spec.js
@@ -2,11 +2,11 @@
 
 const assert = require('node:assert/strict')
 
-const { describe, it, afterEach } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
 
 require('./setup/core')
 
-const { enableGCPPubSubPushSubscription } = require('../src/serverless')
+const { enableGCPPubSubPushSubscription, isSomethingUnderNDA } = require('../src/serverless')
 
 describe('enableGCPPubSubPushSubscription', () => {
   const originalKService = process.env.K_SERVICE
@@ -34,5 +34,32 @@ describe('enableGCPPubSubPushSubscription', () => {
     process.env.K_SERVICE = 'svc'
     process.env.DD_TRACE_GCP_PUBSUB_PUSH_ENABLED = 'false'
     assert.strictEqual(enableGCPPubSubPushSubscription(), false)
+  })
+})
+
+describe('serverless', () => {
+  describe('isSomethingUnderNDA', () => {
+    const SOMETHING_UNDER_NDA_ENV = 'SOMETHING_UNDER_NDA'
+    let priorSomethingUnderNDA
+
+    beforeEach(() => {
+      priorSomethingUnderNDA = process.env[SOMETHING_UNDER_NDA_ENV]
+      delete process.env[SOMETHING_UNDER_NDA_ENV]
+    })
+
+    afterEach(() => {
+      if (priorSomethingUnderNDA === undefined) delete process.env[SOMETHING_UNDER_NDA_ENV]
+      else process.env[SOMETHING_UNDER_NDA_ENV] = priorSomethingUnderNDA
+    })
+
+    it('should return false when not under something-under-nda', () => {
+      assert.strictEqual(isSomethingUnderNDA(), false)
+    })
+
+    it('should return true when under something-under-nda', () => {
+      process.env[SOMETHING_UNDER_NDA_ENV] = 'something-under-nda'
+
+      assert.strictEqual(isSomethingUnderNDA(), true)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Stacks on #8987.

On something-under-nda, every HTTP request carries a \`lambda-web-request-id\` header that uniquely identifies the invocation. Without this, that ID never appears in the trace — correlating a Datadog span to platform logs requires users to manually configure header capture, a step that's invisible by default and easy to miss.

This PR makes `lambda-web-request-id` → `lambda.request_id` automatic: when the tracer detects it is running under something-under-nda, it appends the header mapping to every HTTP span with no configuration required. User-supplied mappings for that header take precedence; the auto-entry is skipped if one is already present.

## Architecture

```
HTTP request arrives with lambda-web-request-id header
  → getHeadersToRecord() appends ['lambda-web-request-id', 'lambda.request_id'] when isSomethingUnderNDA()
  → addRequestHeaders() tags span with lambda.request_id = <header value>
  → span carries lambda.request_id, correlating Datadog traces to platform logs
```

## Test plan

- [ ] Unit tests: `./node_modules/.bin/mocha packages/dd-trace/test/serverless.spec.js packages/dd-trace/test/plugins/util/web.spec.js`
- [ ] Integration test: `./node_modules/.bin/mocha --timeout 60000 integration-tests/something-under-nda-request-id.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)