### PR TITLE
feat(log-capture): core log-capture subsystem and configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,8 @@
 
 # Serverless
 /packages/dd-trace/src/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/src/log-capture/ @DataDog/serverless-aws @DataDog/debugger-nodejs
+/packages/dd-trace/test/log-capture/ @DataDog/serverless-aws @DataDog/debugger-nodejs
 /packages/dd-trace/test/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/azure_metadata.spec.js @DataDog/apm-serverless
 /packages/dd-trace/test/serverless.spec.js @DataDog/apm-serverless

--- a/index.d.ts
+++ b/index.d.ts
@@ -1347,6 +1347,71 @@ declare namespace tracer {
      */
     traceWebsocketMessagesSeparateTraces?: boolean
 
+    /**
+     * Whether to enable log capture (forwarding application logs to Datadog).
+     * Defaults to true in serverless environments, false otherwise.
+     * @default false
+     * @env DD_LOG_CAPTURE_ENABLED
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureEnabled?: boolean
+
+    /**
+     * Hostname of the log intake endpoint.
+     * @default 'localhost'
+     * @env DD_LOG_CAPTURE_HOST
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureHost?: string
+
+    /**
+     * Port of the log intake endpoint.
+     * @default 10517
+     * @env DD_LOG_CAPTURE_PORT
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCapturePort?: number
+
+    /**
+     * Protocol for the log intake endpoint ('http:' or 'https:').
+     * @default 'http:'
+     * @env DD_LOG_CAPTURE_PROTOCOL
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureProtocol?: string
+
+    /**
+     * URL path for the log intake endpoint.
+     * @default '/logs'
+     * @env DD_LOG_CAPTURE_PATH
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCapturePath?: string
+
+    /**
+     * Maximum number of log records to buffer before forcing a flush.
+     * @default 1000
+     * @env DD_LOG_CAPTURE_MAX_BUFFER_SIZE
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureMaxBufferSize?: number
+
+    /**
+     * Interval in milliseconds between periodic log flushes.
+     * @default 5000
+     * @env DD_LOG_CAPTURE_FLUSH_INTERVAL_MS
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureFlushIntervalMs?: number
+
+    /**
+     * Timeout in milliseconds for log intake HTTP requests.
+     * @default 5000
+     * @env DD_LOG_CAPTURE_TIMEOUT_MS
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureTimeoutMs?: number
+
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:debugger": "mocha \"packages/dd-trace/test/debugger/**/*.spec.js\"",
     "test:debugger:ci": "nyc --silent node init && nyc -- npm run test:debugger",
     "test:eslint-rules": "node eslint-rules/*.test.mjs",
-    "test:trace:core": "node scripts/mocha-parallel-files.js --expose-gc --timeout 30000 -- \"packages/dd-trace/test/*.spec.js\" \"packages/dd-trace/test/{agent,ci-visibility,config,crashtracking,datastreams,encode,exporters,msgpack,opentelemetry,opentracing,payload-tagging,plugins,remote_config,service-naming,standalone,telemetry,external-logger}/**/*.spec.js\"",
+    "test:trace:core": "node scripts/mocha-parallel-files.js --expose-gc --timeout 30000 -- \"packages/dd-trace/test/*.spec.js\" \"packages/dd-trace/test/{agent,ci-visibility,config,crashtracking,datastreams,encode,exporters,log-capture,msgpack,opentelemetry,opentracing,payload-tagging,plugins,remote_config,service-naming,standalone,telemetry,external-logger}/**/*.spec.js\"",
     "test:trace:core:ci": "nyc --silent node init && nyc -- npm run test:trace:core",
     "test:trace:guardrails": "mocha \"packages/dd-trace/test/guardrails/**/*.spec.js\"",
     "test:trace:guardrails:ci": "nyc --silent node init && nyc -- npm run test:trace:guardrails",

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -478,6 +478,14 @@ export interface GeneratedConfig {
     enabled: boolean;
     mlApp: string | undefined;
   };
+  logCaptureEnabled: boolean;
+  logCaptureFlushIntervalMs: number;
+  logCaptureHost: string;
+  logCaptureMaxBufferSize: number;
+  logCapturePath: string;
+  logCapturePort: number;
+  logCaptureProtocol: string;
+  logCaptureTimeoutMs: number;
   logInjection: boolean;
   logLevel: "debug" | "info" | "warn" | "error";
   middlewareTracingEnabled: boolean;

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -17,6 +17,7 @@ const {
   IS_SERVERLESS,
   getIsGCPFunction,
   getIsAzureFunction,
+  isSomethingUnderNDA,
 } = require('../serverless')
 const { ORIGIN_KEY, DATADOG_MINI_AGENT_PATH } = require('../constants')
 const { appendRules } = require('../payload-tagging/config')
@@ -320,6 +321,7 @@ class Config extends ConfigBase {
 
   // Handles values calculated from a mixture of options and env vars
   #applyCalculated () {
+    const logCaptureEnabledIsRC = trackedConfigOrigins.get('logCaptureEnabled') === 'remote_config'
     undo(this, 'calculated')
 
     if (this.url ||
@@ -553,6 +555,10 @@ class Config extends ConfigBase {
       setAndTrack(this, 'remoteConfig.enabled', false)
     }
 
+    if (!logCaptureEnabledIsRC && !trackedConfigOrigins.has('logCaptureEnabled')) {
+      setAndTrack(this, 'logCaptureEnabled', isSomethingUnderNDA())
+    }
+
     // TODO: Should this unconditionally be disabled?
     if (getEnvironmentVariable('JEST_WORKER_ID') && !trackedConfigOrigins.has('telemetry.enabled')) {
       setAndTrack(this, 'telemetry.enabled', false)
@@ -609,6 +615,26 @@ class Config extends ConfigBase {
       deactivateIfEnabledAndWarnOnWindows(this, 'DD_PROFILING_CPU_ENABLED')
       deactivateIfEnabledAndWarnOnWindows(this, 'DD_PROFILING_TIMELINE_ENABLED')
       deactivateIfEnabledAndWarnOnWindows(this, 'DD_PROFILING_ASYNC_CONTEXT_FRAME_ENABLED')
+    }
+
+    // Normalize logCaptureProtocol: strip any '://' suffix, lowercase, add trailing colon,
+    // then validate — only 'http:' and 'https:' are supported; warn and fall back to 'http:'.
+    if (this.logCaptureProtocol) {
+      const rawProtocol = this.logCaptureProtocol
+      let protocol = rawProtocol.toLowerCase().replace(/:\/\/.*$/, '')
+      if (!protocol.endsWith(':')) {
+        protocol += ':'
+      }
+      if (protocol !== 'http:' && protocol !== 'https:') {
+        log.warn('logCaptureProtocol: unsupported value %j, falling back to http:', rawProtocol)
+        protocol = 'http:'
+      }
+      const origin = trackedConfigOrigins.get('logCaptureProtocol')
+      if (origin === undefined) {
+        set(this, 'logCaptureProtocol', protocol)
+      } else {
+        setAndTrack(this, 'logCaptureProtocol', protocol, rawProtocol, /** @type {TelemetrySource} */ (origin))
+      }
     }
 
     // Single tags update is tracked as a calculated value.

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1255,6 +1255,86 @@
         "default": "false"
       }
     ],
+    "DD_LOG_CAPTURE_ENABLED": [
+      {
+        "implementation": "B",
+        "type": "boolean",
+        "configurationNames": [
+          "logCaptureEnabled"
+        ],
+        "default": "false"
+      }
+    ],
+    "DD_LOG_CAPTURE_FLUSH_INTERVAL_MS": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCaptureFlushIntervalMs"
+        ],
+        "default": "5000"
+      }
+    ],
+    "DD_LOG_CAPTURE_HOST": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "logCaptureHost"
+        ],
+        "default": "localhost"
+      }
+    ],
+    "DD_LOG_CAPTURE_MAX_BUFFER_SIZE": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCaptureMaxBufferSize"
+        ],
+        "default": "1000"
+      }
+    ],
+    "DD_LOG_CAPTURE_PATH": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "logCapturePath"
+        ],
+        "default": "/logs"
+      }
+    ],
+    "DD_LOG_CAPTURE_PORT": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCapturePort"
+        ],
+        "default": "10517"
+      }
+    ],
+    "DD_LOG_CAPTURE_PROTOCOL": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "logCaptureProtocol"
+        ],
+        "default": "http:"
+      }
+    ],
+    "DD_LOG_CAPTURE_TIMEOUT_MS": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCaptureTimeoutMs"
+        ],
+        "default": "5000"
+      }
+    ],
     "DD_TRACE_AWS_DURABLE_EXECUTION_SDK_JS_ENABLED": [
       {
         "implementation": "A",

--- a/packages/dd-trace/src/log-capture/index.js
+++ b/packages/dd-trace/src/log-capture/index.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const sender = require('./sender')
+
+/**
+ * Initialize the log-capture transport: configure the sender with the
+ * resolved options and register its flush hook in the beforeExit lifecycle.
+ * Safe to call repeatedly — re-configuration flushes any buffered records
+ * before switching, and the flush hook is registered at most once.
+ *
+ * @param {import('../config/config-base')} config
+ */
+function initializeLogCapture (config) {
+  sender.configure({
+    host: config.logCaptureHost,
+    port: config.logCapturePort,
+    path: config.logCapturePath,
+    protocol: config.logCaptureProtocol,
+    maxBufferSize: config.logCaptureMaxBufferSize,
+    flushIntervalMs: config.logCaptureFlushIntervalMs,
+    timeoutMs: config.logCaptureTimeoutMs,
+  })
+  const handlers = globalThis[Symbol.for('dd-trace')]?.beforeExitHandlers
+  if (handlers && !handlers.has(sender.flush)) {
+    handlers.add(sender.flush)
+  }
+}
+
+module.exports = { initializeLogCapture }

--- a/packages/dd-trace/src/log-capture/sender.js
+++ b/packages/dd-trace/src/log-capture/sender.js
@@ -1,0 +1,146 @@
+'use strict'
+
+const http = require('node:http')
+const https = require('node:https')
+
+const log = require('../log')
+
+/**
+ * @typedef {{ host: string, port: number, path: string, protocol: string,
+ *   maxBufferSize: number, flushIntervalMs: number, timeoutMs: number }} SenderOpts
+ */
+
+/** @type {SenderOpts | undefined} */
+let opts
+
+/** @type {string[]} */
+let buffer = []
+
+/** @type {ReturnType<typeof setTimeout> | undefined} */
+let timer
+
+/**
+ * Configure the sender. Safe to call multiple times — re-configuration flushes
+ * any buffered records under the old config before switching to the new one.
+ * @param {SenderOpts} options
+ */
+function configure (options) {
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    timer = undefined
+  }
+
+  // Flush any records buffered before this configuration (e.g. on re-configure).
+  flush()
+
+  opts = options
+}
+
+/**
+ * Add a JSON log line to the buffer.
+ * Arms a one-shot flush timer on the first record added after a flush.
+ * @param {string} jsonLine
+ */
+function add (jsonLine) {
+  if (opts === undefined) return
+  if (buffer.length >= opts.maxBufferSize) {
+    flush()
+  }
+  buffer.push(jsonLine)
+  if (timer === undefined) {
+    timer = setTimeout(flushAndReschedule, opts.flushIntervalMs)
+    timer.unref?.()
+  }
+}
+
+/**
+ * Flush buffered records and re-arm the timer if more records arrived during flush.
+ */
+function flushAndReschedule () {
+  timer = undefined
+  flush()
+  if (buffer.length > 0) {
+    // A re-entrant add() inside flush() may have already armed a timer.
+    // Cancel it so we don't leave an orphaned handle.
+    clearTimeout(timer)
+    timer = setTimeout(flushAndReschedule, opts.flushIntervalMs)
+    timer.unref?.()
+  }
+}
+
+/**
+ * Return the current number of buffered records.
+ * @returns {number}
+ */
+function bufferSize () {
+  return buffer.length
+}
+
+/**
+ * Flush buffered log records to the HTTP/HTTPS intake as NDJSON.
+ * The buffer is drained before sending so concurrent flushes do not double-send.
+ */
+function flush () {
+  if (opts === undefined || buffer.length === 0) return
+
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    timer = undefined
+  }
+
+  const records = buffer
+  buffer = []
+
+  const body = records.map(r => r.replace(/\r?\n$/, '')).join('\n')
+
+  const transport = opts.protocol === 'https:' ? https : http
+
+  const reqOpts = {
+    host: opts.host,
+    port: opts.port,
+    path: opts.path,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Content-Length': Buffer.byteLength(body),
+    },
+    timeout: opts.timeoutMs,
+  }
+
+  let req
+  try {
+    req = transport.request(reqOpts, (res) => {
+      res.resume() // drain the response body so the socket can be released
+    })
+  } catch (err) {
+    log.warn('Log capture flush error: %s', err.message)
+    return
+  }
+
+  req.once('error', (err) => {
+    log.warn('Log capture flush error: %s', err.message)
+  })
+
+  req.once('timeout', () => {
+    log.warn('Log capture flush timed out')
+    req.destroy()
+  })
+
+  req.write(body)
+  req.end()
+}
+
+/**
+ * Stop the sender: cancel any pending flush timer and reset all state.
+ * Intended for use in tests and graceful shutdown.
+ */
+function stop () {
+  if (timer !== undefined) {
+    clearTimeout(timer)
+    timer = undefined
+  }
+  buffer = []
+  opts = undefined
+}
+
+module.exports = { configure, add, bufferSize, flush, stop }

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -35,6 +35,10 @@ function getIsFlexConsumptionAzureFunction () {
   return getIsAzureFunction() && getEnvironmentVariable('WEBSITE_SKU') === 'FlexConsumption'
 }
 
+function isSomethingUnderNDA () {
+  return getEnvironmentVariable('SOMETHING_UNDER_NDA') === 'something-under-nda'
+}
+
 function isInServerlessEnvironment () {
   const inAWSLambda = getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME') !== undefined
   const isGCPFunction = getIsGCPFunction()
@@ -48,5 +52,6 @@ module.exports = {
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  isSomethingUnderNDA,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1670,6 +1670,180 @@ describe('Config', () => {
     assert.strictEqual(config.appsec.eventTracking.mode, 'anonymous')
   })
 
+  it('should read DD_LOG_CAPTURE_ENABLED', () => {
+    process.env.DD_LOG_CAPTURE_ENABLED = 'true'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+    delete process.env.DD_LOG_CAPTURE_ENABLED
+  })
+
+  it('should default logCaptureEnabled to true when SOMETHING_UNDER_NDA is something-under-nda', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should not override DD_LOG_CAPTURE_ENABLED=false when SOMETHING_UNDER_NDA is something-under-nda', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    process.env.DD_LOG_CAPTURE_ENABLED = 'false'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, false)
+    delete process.env.SOMETHING_UNDER_NDA
+    delete process.env.DD_LOG_CAPTURE_ENABLED
+  })
+
+  it('should not default logCaptureEnabled to true when SOMETHING_UNDER_NDA is not something-under-nda', () => {
+    process.env.SOMETHING_UNDER_NDA = 'on-demand'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, false)
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should restore logCaptureEnabled to SOMETHING_UNDER_NDA default after remote config rollback', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+
+    config.setRemoteConfig({ logCaptureEnabled: false })
+    assert.strictEqual(config.logCaptureEnabled, false)
+
+    config.setRemoteConfig(null)
+    assert.strictEqual(config.logCaptureEnabled, true)
+
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should respect DD_LOG_CAPTURE_ENABLED=false even in serverless environment', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    process.env.DD_LOG_CAPTURE_ENABLED = 'false'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, false)
+    delete process.env.DD_LOG_CAPTURE_ENABLED
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should default logCaptureHost to localhost', () => {
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureHost, 'localhost')
+  })
+
+  it('should default logCapturePort to 10517', () => {
+    const config = getConfig()
+    assert.strictEqual(config.logCapturePort, 10517)
+  })
+
+  it('should read DD_LOG_CAPTURE_HOST', () => {
+    process.env.DD_LOG_CAPTURE_HOST = 'my-intake.internal'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureHost, 'my-intake.internal')
+    delete process.env.DD_LOG_CAPTURE_HOST
+  })
+
+  it('should read DD_LOG_CAPTURE_PORT', () => {
+    process.env.DD_LOG_CAPTURE_PORT = '8080'
+    const config = getConfig()
+    assert.strictEqual(config.logCapturePort, 8080)
+    delete process.env.DD_LOG_CAPTURE_PORT
+  })
+
+  it('should read DD_LOG_CAPTURE_PATH', () => {
+    process.env.DD_LOG_CAPTURE_PATH = '/custom-logs'
+    const config = getConfig()
+    assert.strictEqual(config.logCapturePath, '/custom-logs')
+    delete process.env.DD_LOG_CAPTURE_PATH
+  })
+
+  it('should read DD_LOG_CAPTURE_PROTOCOL', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'https:'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL without trailing colon', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'https'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL to lowercase', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL uppercase without colon', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS:'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should read DD_LOG_CAPTURE_MAX_BUFFER_SIZE', () => {
+    process.env.DD_LOG_CAPTURE_MAX_BUFFER_SIZE = '500'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureMaxBufferSize, 500)
+    delete process.env.DD_LOG_CAPTURE_MAX_BUFFER_SIZE
+  })
+
+  it('should read DD_LOG_CAPTURE_FLUSH_INTERVAL_MS', () => {
+    process.env.DD_LOG_CAPTURE_FLUSH_INTERVAL_MS = '2000'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureFlushIntervalMs, 2000)
+    delete process.env.DD_LOG_CAPTURE_FLUSH_INTERVAL_MS
+  })
+
+  it('should read DD_LOG_CAPTURE_TIMEOUT_MS', () => {
+    process.env.DD_LOG_CAPTURE_TIMEOUT_MS = '3000'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureTimeoutMs, 3000)
+    delete process.env.DD_LOG_CAPTURE_TIMEOUT_MS
+  })
+
+  it('should normalize logCaptureProtocol option to lowercase with colon', () => {
+    const config = getConfig({ logCaptureProtocol: 'HTTPS:' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should preserve the origin of logCaptureProtocol after normalization', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    assert.strictEqual(config.getOrigin('logCaptureProtocol'), 'env_var')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize logCaptureProtocol option without trailing colon', () => {
+    const config = getConfig({ logCaptureProtocol: 'HTTPS' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should normalize logCaptureProtocol option lowercase without colon', () => {
+    const config = getConfig({ logCaptureProtocol: 'https' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should normalize logCaptureProtocol stripping :// suffix', () => {
+    const config = getConfig({ logCaptureProtocol: 'https://' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should fall back to http: and warn for unsupported logCaptureProtocol', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'ftp'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'http:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should not track logCaptureProtocol origin when using the default value', () => {
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'http:')
+    assert.strictEqual(config.getOrigin('logCaptureProtocol'), 'default')
+  })
+
   it('should initialize from the options', () => {
     const logger = {
       warn: sinon.spy(),

--- a/packages/dd-trace/test/log-capture/index.spec.js
+++ b/packages/dd-trace/test/log-capture/index.spec.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+
+require('../setup/core')
+
+const sender = require('../../src/log-capture/sender')
+const { initializeLogCapture } = require('../../src/log-capture')
+
+const baseConfig = {
+  logCaptureHost: 'localhost',
+  logCapturePort: 9999,
+  logCaptureProtocol: 'http:',
+  logCapturePath: '/logs',
+  logCaptureFlushIntervalMs: 5000,
+  logCaptureMaxBufferSize: 1000,
+  logCaptureTimeoutMs: 5000,
+}
+
+describe('initializeLogCapture', () => {
+  beforeEach(() => {
+    sender.stop()
+  })
+
+  afterEach(() => {
+    globalThis[Symbol.for('dd-trace')]?.beforeExitHandlers?.delete(sender.flush)
+    sender.stop()
+  })
+
+  it('configures the sender so subsequent records are buffered', () => {
+    initializeLogCapture(baseConfig)
+
+    sender.add('{"level":30,"msg":"test"}')
+    assert.strictEqual(sender.bufferSize(), 1)
+  })
+
+  it('registers flush in beforeExitHandlers', () => {
+    initializeLogCapture(baseConfig)
+
+    assert.ok(
+      globalThis[Symbol.for('dd-trace')].beforeExitHandlers.has(sender.flush),
+      'flush should be registered in beforeExitHandlers'
+    )
+  })
+
+  it('does not register flush twice on repeated calls', () => {
+    initializeLogCapture(baseConfig)
+    initializeLogCapture(baseConfig)
+
+    const handlers = globalThis[Symbol.for('dd-trace')].beforeExitHandlers
+    assert.ok(handlers.has(sender.flush))
+    assert.strictEqual([...handlers].filter(h => h === sender.flush).length, 1)
+  })
+})

--- a/packages/dd-trace/test/log-capture/sender.spec.js
+++ b/packages/dd-trace/test/log-capture/sender.spec.js
@@ -1,0 +1,285 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+let sender
+
+const BASE_OPTS = {
+  host: 'localhost',
+  port: 8080,
+  path: '/logs',
+  protocol: 'http:',
+  maxBufferSize: 100,
+  flushIntervalMs: 5000,
+  timeoutMs: 5000,
+}
+
+describe('LogCaptureSender', () => {
+  let clock, httpStub, writeStub
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+    writeStub = sinon.stub()
+    httpStub = sinon.stub(require('node:http'), 'request').returns({
+      once: sinon.stub().returnsThis(),
+      write: writeStub,
+      end: sinon.stub(),
+    })
+    delete require.cache[require.resolve('../../src/log-capture/sender')]
+    sender = require('../../src/log-capture/sender')
+  })
+
+  afterEach(() => {
+    clock.restore()
+    sinon.restore()
+  })
+
+  it('should buffer log records', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    assert.strictEqual(sender.bufferSize(), 1)
+  })
+
+  it('should flush and add when maxBufferSize is reached', () => {
+    sender.configure({ ...BASE_OPTS, maxBufferSize: 2 })
+    sender.add('{"level":30,"msg":"a"}')
+    sender.add('{"level":30,"msg":"b"}')
+    // buffer is now full — next add should flush then enqueue
+    sender.add('{"level":30,"msg":"c"}')
+    assert.ok(httpStub.calledOnce, 'should have flushed when buffer was full')
+    assert.strictEqual(sender.bufferSize(), 1)
+  })
+
+  it('should clear the timer on an explicit flush so the next add re-arms at the full interval', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a"}')
+
+    // Advance partway through the interval, then flush explicitly.
+    clock.tick(BASE_OPTS.flushIntervalMs / 2)
+    sender.flush()
+    assert.strictEqual(clock.countTimers(), 0, 'explicit flush should have cleared the timer')
+
+    // A new record should re-arm the timer from scratch.
+    sender.add('{"level":30,"msg":"b"}')
+    assert.strictEqual(clock.countTimers(), 1)
+
+    // The remaining half-interval should NOT trigger a flush.
+    clock.tick(BASE_OPTS.flushIntervalMs / 2)
+    assert.strictEqual(httpStub.callCount, 1, 'only the explicit flush should have fired so far')
+
+    // The full interval from the re-arm should flush the new record.
+    clock.tick(BASE_OPTS.flushIntervalMs / 2)
+    assert.strictEqual(httpStub.callCount, 2)
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should reset the flush timer after a buffer-overflow flush', () => {
+    sender.configure({ ...BASE_OPTS, maxBufferSize: 2 })
+    sender.add('{"level":30,"msg":"a"}')
+    sender.add('{"level":30,"msg":"b"}')
+    // overflow flush: timer should be cleared and re-armed when "c" is added
+    sender.add('{"level":30,"msg":"c"}')
+    assert.strictEqual(clock.countTimers(), 1, 'timer should be re-armed after overflow flush')
+    clock.tick(BASE_OPTS.flushIntervalMs)
+    assert.ok(httpStub.calledTwice, 'second flush should occur at the new timer interval')
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should flush on interval', () => {
+    sender.configure({ ...BASE_OPTS, maxBufferSize: 1000 })
+    sender.add('{"level":30,"msg":"hello"}')
+    clock.tick(5000)
+    assert.ok(httpStub.called)
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should not leak timers when configure is called multiple times', () => {
+    sender.configure(BASE_OPTS)
+    assert.strictEqual(clock.countTimers(), 0)
+
+    sender.configure({ ...BASE_OPTS, flushIntervalMs: 1000 })
+    assert.strictEqual(clock.countTimers(), 0)
+  })
+
+  it('should not arm a timer when no records are buffered', () => {
+    sender.configure(BASE_OPTS)
+    clock.tick(10000)
+    assert.ok(!httpStub.called, 'should not send when no records were added')
+    assert.strictEqual(clock.countTimers(), 0)
+  })
+
+  it('should flush records after flushIntervalMs when records are added', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    assert.strictEqual(clock.countTimers(), 1, 'timer should be armed after first add')
+    clock.tick(BASE_OPTS.flushIntervalMs)
+    assert.ok(httpStub.called, 'should have flushed after interval')
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should flush buffered records immediately when reconfigured', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+
+    sender.configure({ ...BASE_OPTS, flushIntervalMs: 1000 })
+
+    assert.ok(httpStub.calledOnce)
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should be a no-op when not configured', () => {
+    sender.add('{"level":30,"msg":"hello"}')
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should trim trailing newlines from records when flushing', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a"}\n')
+    sender.add('{"level":30,"msg":"b"}\n')
+    sender.flush()
+    assert.strictEqual(writeStub.firstCall.args[0], '{"level":30,"msg":"a"}\n{"level":30,"msg":"b"}')
+  })
+
+  it('should trim trailing CRLF from records when flushing', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a"}\r\n')
+    sender.flush()
+    assert.strictEqual(writeStub.firstCall.args[0], '{"level":30,"msg":"a"}')
+  })
+
+  it('should not strip trailing spaces from records when flushing', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a with space "}\n')
+    sender.flush()
+    assert.strictEqual(writeStub.firstCall.args[0], '{"level":30,"msg":"a with space "}')
+  })
+
+  it('should drain the response body to release the socket', () => {
+    const res = { resume: sinon.stub() }
+    httpStub.callsFake((_opts, callback) => {
+      callback(res)
+      return { once: sinon.stub().returnsThis(), write: sinon.stub(), end: sinon.stub() }
+    })
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    assert.ok(res.resume.calledOnce)
+  })
+
+  it('should destroy the request on timeout', () => {
+    let timeoutHandler
+    const req = {
+      once: sinon.stub().callsFake((event, handler) => {
+        if (event === 'timeout') timeoutHandler = handler
+        return req
+      }),
+      write: sinon.stub(),
+      end: sinon.stub(),
+      destroy: sinon.stub(),
+    }
+    httpStub.returns(req)
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    timeoutHandler()
+    assert.ok(req.destroy.calledOnce)
+  })
+
+  it('should warn on request error', () => {
+    const logModule = require('../../src/log')
+    const warnStub = sinon.stub(logModule, 'warn')
+
+    let errorHandler
+    const req = {
+      once: sinon.stub().callsFake((event, handler) => {
+        if (event === 'error') errorHandler = handler
+        return req
+      }),
+      write: sinon.stub(),
+      end: sinon.stub(),
+    }
+    httpStub.returns(req)
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+
+    assert.strictEqual(typeof errorHandler, 'function', 'error handler should be registered')
+    errorHandler(new Error('ECONNREFUSED'))
+    assert.ok(warnStub.calledOnce, 'log.warn should be called on error')
+    warnStub.restore()
+  })
+
+  it('should warn and not crash when transport.request() throws synchronously', () => {
+    const logModule = require('../../src/log')
+    const warnStub = sinon.stub(logModule, 'warn')
+
+    httpStub.throws(new Error('invalid options'))
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    assert.ok(warnStub.calledOnce, 'log.warn should be called on sync throw')
+    warnStub.restore()
+  })
+
+  it('should use https when protocol is https:', () => {
+    const httpsStub = sinon.stub(require('node:https'), 'request').returns({
+      once: sinon.stub().returnsThis(),
+      write: sinon.stub(),
+      end: sinon.stub(),
+    })
+    sender.configure({ ...BASE_OPTS, port: 443, protocol: 'https:', maxBufferSize: 1000 })
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    assert.ok(httpsStub.called)
+  })
+
+  it('should be a no-op flush when never configured', () => {
+    sender.flush()
+    assert.ok(!httpStub.called, 'should not send when opts is undefined')
+  })
+
+  it('should reschedule the timer when records arrive during flush', () => {
+    httpStub.callsFake(() => ({
+      once: sinon.stub().returnsThis(),
+      write: sinon.stub().callsFake(() => {
+        sender.add('{"level":30,"msg":"added-during-flush"}')
+      }),
+      end: sinon.stub(),
+    }))
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"initial"}')
+    clock.tick(BASE_OPTS.flushIntervalMs)
+
+    assert.strictEqual(sender.bufferSize(), 1, 'mid-flush record should remain in buffer')
+    assert.strictEqual(clock.countTimers(), 1, 'exactly one timer should be active — no duplicate')
+  })
+
+  it('should warn on timeout', () => {
+    const logModule = require('../../src/log')
+    const warnStub = sinon.stub(logModule, 'warn')
+
+    let timeoutHandler
+    const req = {
+      once: sinon.stub().callsFake((event, handler) => {
+        if (event === 'timeout') timeoutHandler = handler
+        return req
+      }),
+      write: sinon.stub(),
+      end: sinon.stub(),
+      destroy: sinon.stub(),
+    }
+    httpStub.returns(req)
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    timeoutHandler()
+    assert.ok(warnStub.calledOnce, 'log.warn should be called on timeout')
+    warnStub.restore()
+  })
+})

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -82,6 +82,8 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   // GitHub Actions CI plugin metadata
   'GITHUB_EVENT_PATH',
   'RUNNER_TEMP',
+  // serverless feature-flag (isSomethingUnderNDA detection)
+  'SOMETHING_UNDER_NDA',
   // misc CI provider / build tooling reads
   'HOME',
   'LAGE_PACKAGE_NAME',


### PR DESCRIPTION
## Why

When the Datadog Agent is not co-located with the application (e.g. in certain serverless environments), logs written by the application don't automatically reach Datadog — they can only be collected if the runtime itself forwards them. This PR introduces the core infrastructure for **log capture**: the tracer buffers structured log records in-process and flushes them directly to the Datadog log intake over HTTP/HTTPS, without requiring a sidecar agent.

Log capture is opt-in via \`DD_LOG_CAPTURE_ENABLED\` and defaults to \`true\` in environments where direct forwarding is needed (detected via \`isSomethingUnderNDA()\`).

## What

- Adds \`packages/dd-trace/src/log-capture/sender.js\`: buffered NDJSON sender with configurable flush interval, max buffer size, and HTTP/HTTPS transport
  - \`flush()\` clears the pending timer before draining so any subsequent \`add()\` re-arms at the full interval (no stale timers on explicit/overflow flushes)
  - \`flushAndReschedule()\` cancels any timer armed re-entrantly during \`flush()\` before scheduling its own, preventing duplicate timers
  - Trailing newline stripping uses \`replace(/\r?\n\$/,'') \` rather than \`trimEnd()\` so trailing spaces in JSON values are preserved
  - \`transport.request()\` is wrapped in try/catch so a synchronous throw (e.g. invalid options) logs a warning rather than crashing the app
- Adds \`packages/dd-trace/src/log-capture/index.js\`: configures the sender from tracer config and registers a \`beforeExit\` flush hook
- Config: 8 new \`DD_LOG_CAPTURE_*\` env vars in \`config/index.js\`, \`supported-configurations.json\`, and \`generated-config-types.d.ts\`
  - \`logCaptureEnabled\` computed default moved to \`#applyCalculated()\` to keep \`defaults\` immutable and respect RC overrides correctly
  - \`logCaptureProtocol\` normalization strips any \`://\` suffix, validates strictly to \`http:\`/\`https:\`, and warns + falls back to \`http:\` on invalid input; preserves the original source and raw value for correct \`getOrigin()\` and telemetry
- \`index.d.ts\`: TypeScript declarations for all 8 \`logCapture*\` options
- \`serverless.js\`: exports \`isSomethingUnderNDA()\` feature-flag helper
- \`package.json\`: adds \`log-capture\` to the \`test:trace:core\` glob

## Stack

This is **PR 1 of 3** in a stacked series:
1. **[this PR]** Core log-capture subsystem and configuration
2. #8965 — Wire log-capture into plugin system
3. #8966 — Pino integration and public API

The full change is in #8957.

## Test plan

- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/log-capture/sender.spec.js\`
- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/log-capture/index.spec.js\`
- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/config/index.spec.js --grep "logCapture"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)