### PR TITLE
feat(log-capture): wire log-capture into plugin system

### DIFF
--- a/packages/datadog-plugin-bunyan/src/index.js
+++ b/packages/datadog-plugin-bunyan/src/index.js
@@ -23,6 +23,7 @@ class BunyanPlugin extends LogPlugin {
    * @param {{ message: object }} arg
    */
   handleLog (arg) {
+    if (!this.config.logInjection) return
     const rec = arg.message
     if (rec === null || typeof rec !== 'object' || Object.hasOwn(rec, 'dd')) return
 

--- a/packages/datadog-plugin-winston/src/index.js
+++ b/packages/datadog-plugin-winston/src/index.js
@@ -21,6 +21,7 @@ class WinstonPlugin extends LogPlugin {
    * @param {{ message: unknown }} arg
    */
   handleLog (arg) {
+    if (!this.config.logInjection) return
     const info = arg.message
     if (info === null || typeof info !== 'object' || Object.hasOwn(info, 'dd')) return
 

--- a/packages/dd-trace/src/plugin_manager.js
+++ b/packages/dd-trace/src/plugin_manager.js
@@ -153,6 +153,14 @@ module.exports = class PluginManager {
   #getSharedConfig (name) {
     const {
       logInjection,
+      logCaptureEnabled,
+      logCaptureHost,
+      logCapturePort,
+      logCaptureProtocol,
+      logCapturePath,
+      logCaptureFlushIntervalMs,
+      logCaptureMaxBufferSize,
+      logCaptureTimeoutMs,
       serviceMapping,
       queryStringObfuscation,
       site,
@@ -194,6 +202,14 @@ module.exports = class PluginManager {
       traceWebsocketMessagesSeparateTraces,
       experimental,
       resourceRenamingEnabled,
+      logCaptureEnabled,
+      logCaptureHost,
+      logCapturePort,
+      logCaptureProtocol,
+      logCapturePath,
+      logCaptureFlushIntervalMs,
+      logCaptureMaxBufferSize,
+      logCaptureTimeoutMs,
     }
 
     if (logInjection !== undefined) {

--- a/packages/dd-trace/src/plugins/log_plugin.js
+++ b/packages/dd-trace/src/plugins/log_plugin.js
@@ -1,14 +1,68 @@
 'use strict'
 
+const log = require('../log')
+const captureSender = require('../log-capture/sender')
+const { buildLogHolder, messageProxy } = require('./log_injection')
 const Plugin = require('./plugin')
 
-class LogPlugin extends Plugin {
-  configure (config) {
-    return super.configure({
-      ...config,
-      enabled: config.enabled && (config.logInjection || config.DD_AGENTLESS_LOG_SUBMISSION_ENABLED),
+module.exports = class LogPlugin extends Plugin {
+  constructor (...args) {
+    super(...args)
+
+    this.addSub(`apm:${this.constructor.id}:log`, (arg) => {
+      // Injection is handled by each subclass directly (direct mutation for
+      // bunyan/winston, JSON splice + proxy for pino). Only handle capture here.
+      // Subclasses may override _captureEnabled to suppress this path and
+      // handle capture via their own channel instead (e.g. pino uses
+      // apm:pino:log:json so it overrides _captureEnabled to false).
+      if (!this._captureEnabled) return
+
+      try {
+        const logHolder = buildLogHolder(this.tracer)
+        // Enrich the captured record with dd trace context via a temporary
+        // proxy that never mutates arg.message.
+        const msg = logHolder ? messageProxy(arg.message, logHolder) : arg.message
+        this.capture(JSON.stringify(msg))
+      } catch (err) {
+        log.debug('Log capture serialization error: %s', err.message)
+      }
     })
   }
-}
 
-module.exports = LogPlugin
+  /**
+   * Whether log capture is enabled for this plugin instance.
+   * Subclasses may override this to return false and handle capture themselves
+   * via a dedicated channel instead.
+   *
+   * @returns {boolean}
+   */
+  get _captureEnabled () {
+    return !!this.config.logCaptureEnabled
+  }
+
+  /**
+   * Forward a pre-serialized JSON log record to the capture sender.
+   *
+   * @param {string} jsonStr Serialized JSON log record.
+   * @returns {void}
+   */
+  capture (jsonStr) {
+    captureSender.add(jsonStr)
+  }
+
+  configure (config) {
+    if (typeof config === 'boolean') {
+      return super.configure(config)
+    }
+
+    super.configure({
+      ...config,
+      enabled: config.enabled && (
+        config.logInjection ||
+        config.DD_AGENTLESS_LOG_SUBMISSION_ENABLED ||
+        config.logCaptureEnabled
+      ),
+    })
+
+  }
+}

--- a/packages/dd-trace/src/proxy.js
+++ b/packages/dd-trace/src/proxy.js
@@ -208,6 +208,11 @@ class Tracer extends NoopProxy {
         initializeOpenTelemetryMetrics(config)
       }
 
+      if (config.logCaptureEnabled) {
+        const { initializeLogCapture } = require('./log-capture')
+        initializeLogCapture(config)
+      }
+
       if (config.runtimeMetrics.enabled) {
         runtimeMetrics.start(config)
       }

--- a/packages/dd-trace/test/plugin_manager.spec.js
+++ b/packages/dd-trace/test/plugin_manager.spec.js
@@ -371,6 +371,30 @@ describe('Plugin Manager', () => {
         clientIpEnabled: true,
       })
     })
+
+    it('forwards logCapture* options to plugins', () => {
+      pm.configure(makeTracerConfig({
+        logCaptureEnabled: true,
+        logCaptureHost: 'intake.example.com',
+        logCapturePort: 8443,
+        logCaptureProtocol: 'https:',
+        logCapturePath: '/custom-logs',
+        logCaptureFlushIntervalMs: 3000,
+        logCaptureMaxBufferSize: 500,
+        logCaptureTimeoutMs: 2000,
+      }))
+      loadChannel.publish({ name: 'two' })
+      sinon.assert.calledWithMatch(Two.prototype.configure, {
+        logCaptureEnabled: true,
+        logCaptureHost: 'intake.example.com',
+        logCapturePort: 8443,
+        logCaptureProtocol: 'https:',
+        logCapturePath: '/custom-logs',
+        logCaptureFlushIntervalMs: 3000,
+        logCaptureMaxBufferSize: 500,
+        logCaptureTimeoutMs: 2000,
+      })
+    })
   })
 
   describe('destroy', () => {

--- a/packages/dd-trace/test/plugins/log_plugin.spec.js
+++ b/packages/dd-trace/test/plugins/log_plugin.spec.js
@@ -3,7 +3,8 @@
 const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
 
-const { describe, it } = require('mocha')
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
 const { channel } = require('dc-polyfill')
 const { storage } = require('../../../datadog-core')
 
@@ -21,7 +22,10 @@ class TestLog extends LogPlugin {
 
   constructor (...args) {
     super(...args)
+    // Real logger subclasses gate injection on logInjection config.
+    // The base class no longer injects — that is each subclass's responsibility.
     this.addSub('apm:test:log', (arg) => {
+      if (!this.config.logInjection) return
       const logHolder = buildLogHolder(this.tracer)
       if (!logHolder) return
       arg.message = messageProxy(arg.message, logHolder)
@@ -115,5 +119,156 @@ describe('LogPlugin', () => {
 
     assert.strictEqual(data.message.dd, override)
     assert.ok(Object.hasOwn(data.message, 'dd'), `Available keys: ${inspect(Object.keys(data.message))}`)
+  })
+
+  it('does not modify arg.message — injection is a subclass responsibility', () => {
+    // A bare LogPlugin subclass with no injection subscriber must leave
+    // arg.message untouched, even when logInjection is on.
+    class BaseOnly extends LogPlugin {
+      static id = 'test-base-only'
+    }
+    const baseOnlyPlugin = new BaseOnly({ _tracer: tracer })
+    baseOnlyPlugin.configure({ logInjection: true, enabled: true })
+    const baseOnlyCh = channel('apm:test-base-only:log')
+
+    const original = { level: 'info', msg: 'hello' }
+    const data = { message: original }
+    baseOnlyCh.publish(data)
+
+    assert.strictEqual(data.message, original, 'base class must not replace arg.message with a proxy')
+    assert.ok(!Object.hasOwn(data.message, 'dd'), 'base class must not add dd to the message object')
+  })
+
+  it('does not add duplicate dd key when message already has a dd property', () => {
+    const existingDd = { trace_id: 'existing-trace' }
+    const data = { message: { level: 'info', dd: existingDd } }
+    testLogChannel.publish(data)
+    // Trigger the ownKeys trap — dd should appear exactly once
+    const keys = Object.keys(data.message)
+    assert.strictEqual(keys.filter(k => k === 'dd').length, 1)
+    assert.strictEqual(data.message.dd, existingDd)
+  })
+
+  describe('log capture forwarding', () => {
+    let captureSender
+
+    beforeEach(() => {
+      // Sender configuration is the responsibility of PluginManager, not LogPlugin.
+      // Configure it directly here to keep these tests self-contained.
+      // Do NOT clear the require cache — log_plugin.js holds a top-level reference to
+      // the same sender module, so we must configure the same instance.
+      captureSender = require('../../src/log-capture/sender')
+      captureSender.stop() // reset any prior state
+      captureSender.configure({
+        host: 'localhost',
+        port: 9999,
+        path: '/logs',
+        protocol: 'http:',
+        maxBufferSize: 1000,
+        flushIntervalMs: 5000,
+        timeoutMs: 5000,
+      })
+    })
+
+    afterEach(() => {
+      captureSender.stop()
+      plugin.configure({ logInjection: true, logCaptureEnabled: false, enabled: true })
+    })
+
+    it('forwards log records when capture is enabled', () => {
+      plugin.configure({
+        logInjection: false,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+      const data = { message: { level: 'info', msg: 'hello', time: Date.now() } }
+      testLogChannel.publish(data)
+      assert.strictEqual(captureSender.bufferSize(), 1)
+    })
+
+    it('does not forward when logCaptureEnabled is false', () => {
+      plugin.configure({ logInjection: true, logCaptureEnabled: false, enabled: true })
+      const data = { message: { level: 'info', msg: 'hello' } }
+      testLogChannel.publish(data)
+      assert.strictEqual(captureSender.bufferSize(), 0)
+    })
+
+    it('does not throw when log message cannot be serialized', () => {
+      plugin.configure({
+        logInjection: false,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+      const circular = {}
+      circular.self = circular
+      const data = { message: circular }
+      testLogChannel.publish(data)
+      assert.strictEqual(captureSender.bufferSize(), 0)
+    })
+
+    it('does not inject dd into actual message when logInjection is false', () => {
+      plugin.configure({
+        logInjection: false,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+      const data = { message: { level: 'info', msg: 'hello' } }
+      testLogChannel.publish(data)
+      assert.ok(!Object.hasOwn(data.message, 'dd'), 'actual message should not have dd when logInjection is false')
+      assert.strictEqual(captureSender.bufferSize(), 1)
+    })
+
+    it('forwards captured record with dd proxy when logInjection and capture are both enabled', () => {
+      plugin.configure({
+        logInjection: true,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+      const data = { message: { level: 'info', msg: 'hello', time: Date.now() } }
+      testLogChannel.publish(data)
+      assert.strictEqual(captureSender.bufferSize(), 1)
+    })
+
+    it('captures raw message when no trace context is available (no active span)', () => {
+      const logInjection = require('../../src/plugins/log_injection')
+      const stub = sinon.stub(logInjection, 'buildLogHolder').returns(undefined)
+
+      plugin.configure({
+        logInjection: false,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+      const data = { message: { level: 'info', msg: 'no-span' } }
+      testLogChannel.publish(data)
+
+      assert.strictEqual(captureSender.bufferSize(), 1, 'should capture even without a log holder')
+      stub.restore()
+    })
+
+    it('does not call buildLogHolder when neither injection nor capture is enabled', () => {
+      const logInjection = require('../../src/plugins/log_injection')
+      const stub = sinon.stub(logInjection, 'buildLogHolder').returns(undefined)
+
+      plugin.configure({
+        logInjection: false,
+        logCaptureEnabled: false,
+        enabled: true,
+      })
+      const data = { message: { level: 'info', msg: 'hello' } }
+      testLogChannel.publish(data)
+
+      assert.ok(stub.notCalled, 'buildLogHolder should not be called when both are disabled')
+      stub.restore()
+    })
+  })
+
+  describe('configure(false)', () => {
+    it('delegates to super without spreading, leaving config as { enabled: false }', () => {
+      const fresh = new (class extends LogPlugin { static id = 'test2' })({
+        _tracer: tracer,
+      })
+      fresh.configure(false)
+      assert.deepStrictEqual(fresh.config, { enabled: false })
+    })
   })
 })

--- a/packages/dd-trace/test/proxy.spec.js
+++ b/packages/dd-trace/test/proxy.spec.js
@@ -45,6 +45,7 @@ describe('TracerProxy', () => {
   let NoopDogStatsDClient
   let OpenFeatureProvider
   let openfeatureProvider
+  let logCapture
 
   beforeEach(() => {
     process.env.DD_TRACE_MOCHA_ENABLED = 'false'
@@ -204,6 +205,10 @@ describe('TracerProxy', () => {
 
     OpenFeatureProvider = sinon.stub().returns(openfeatureProvider)
 
+    logCapture = {
+      initializeLogCapture: sinon.spy(),
+    }
+
     flare = {
       enable: sinon.spy(),
       disable: sinon.spy(),
@@ -255,6 +260,7 @@ describe('TracerProxy', () => {
       './flare': flare,
       './openfeature': openfeature,
       './openfeature/flagging_provider': OpenFeatureProvider,
+      './log-capture': logCapture,
     })
 
     proxy = new ProxyClass()
@@ -611,6 +617,22 @@ describe('TracerProxy', () => {
 
         const config = AppsecSdk.firstCall.args[1]
         sinon.assert.calledOnceWithExactly(standalone.configure, config)
+      })
+
+      it('should initialize log capture when logCaptureEnabled is true', () => {
+        config.logCaptureEnabled = true
+
+        proxy.init()
+
+        sinon.assert.calledOnceWithExactly(logCapture.initializeLogCapture, config)
+      })
+
+      it('should not initialize log capture when logCaptureEnabled is false', () => {
+        config.logCaptureEnabled = false
+
+        proxy.init()
+
+        sinon.assert.notCalled(logCapture.initializeLogCapture)
       })
     })
 


### PR DESCRIPTION
## Why

The core log-capture transport (#8964) can buffer and flush log records, but nothing in the tracer yet produces those records. Log plugins — the layer that sits between a logging framework and the tracer — are the natural integration point: they already subscribe to framework-specific diagnostic channels and handle log injection. This PR wires log capture into that existing layer so that any logger with a \`LogPlugin\` gets forwarding for free, without requiring per-framework plumbing.

Two correctness issues are also fixed here:
- Log records were silently dropped when there was no active span (the capture path was gated on a trace-context holder that only exists during a span). Capture now falls back to the raw message so logs are never lost.
- \`buildLogHolder()\` (which calls \`tracer.inject()\`) was called on every log line even when both injection and capture were disabled. It is now gated so the inject cost is only paid when needed.

## What

- \`log_plugin.js\`: base \`LogPlugin\` gains a \`capture()\` method and \`_captureEnabled\` getter; the \`apm:${id}:log\` subscriber forwards serialized records to the capture sender when \`logCaptureEnabled\` is set; \`buildLogHolder()\` is only called when injection or capture is active; capture falls back to the raw message when no trace context is available; \`configure(false)\` is short-circuited to \`super\` to preserve correct \`this.config\` state; plugin activation now also triggers on \`logCaptureEnabled\` (alongside \`logInjection\`)
- \`plugin_manager.js\`: forwards all \`logCapture*\` config fields in the shared plugin config object
- \`proxy.js\`: calls \`initializeLogCapture()\` on tracer init when \`logCaptureEnabled\` is set

## Stack

This is **PR 2 of 3** in a stacked series:
1. #8964 — Core log-capture subsystem and configuration
2. **[this PR]** Wire log-capture into plugin system
3. #8966 — Pino integration and public API

The full change is in #8957.

## Test plan

- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/plugins/log_plugin.spec.js\`
- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/plugin_manager.spec.js\`
- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/proxy.spec.js\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)