### PR TITLE
feat(log-capture): pino integration and public API

### DIFF
--- a/.github/workflows/instrumentation.yml
+++ b/.github/workflows/instrumentation.yml
@@ -464,6 +464,16 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/instrumentations/test
 
+  instrumentation-pino:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      PLUGINS: pino
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: ./.github/actions/instrumentations/test
+
   instrumentation-promise-js:
     runs-on: ubuntu-latest
     permissions:

--- a/docs/API.md
+++ b/docs/API.md
@@ -535,6 +535,38 @@ const tracer = require('dd-trace').init({
 })
 ```
 
+<h4 id="log-capture">Automatic log capture</h4>
+
+dd-trace can forward JSON log records written by Pino directly to a custom HTTP(S) intake without adding transports to each logger. The forwarding hook publishes full log entries (including Datadog trace metadata when log injection is enabled) through an internal buffer that flushes on a timer and before process exit.
+
+**Default behavior:** Log capture is enabled automatically in certain environments. For all other environments, enable it with `logCaptureEnabled: true` (or `DD_LOG_CAPTURE_ENABLED=true`). By default the sender targets `localhost:10517`; override with `logCaptureHost`/`DD_LOG_CAPTURE_HOST` and `logCapturePort`/`DD_LOG_CAPTURE_PORT` when needed.
+
+Optional tuning knobs map 1:1 with the configuration API:
+
+* `logCaptureHost` (`DD_LOG_CAPTURE_HOST`, default `localhost`)
+* `logCapturePort` (`DD_LOG_CAPTURE_PORT`, default `10517`)
+* `logCapturePath` (`DD_LOG_CAPTURE_PATH`, default `/logs`)
+* `logCaptureProtocol` (`DD_LOG_CAPTURE_PROTOCOL`, default `http:`)
+* `logCaptureMaxBufferSize` (`DD_LOG_CAPTURE_MAX_BUFFER_SIZE`, default `1000` records)
+* `logCaptureFlushIntervalMs` (`DD_LOG_CAPTURE_FLUSH_INTERVAL_MS`, default `5000`)
+* `logCaptureTimeoutMs` (`DD_LOG_CAPTURE_TIMEOUT_MS`, default `5000`)
+
+Example:
+
+```javascript
+require('dd-trace').init({
+  logInjection: true,
+  logCaptureEnabled: true,
+  // host and port default to localhost:10517; override if needed:
+  logCaptureHost: 'logs.my-intake.internal',
+  logCapturePort: 8080,
+  logCaptureProtocol: 'https:',
+})
+```
+
+No additional transports or stream shims are required in user code.
+
+
 <h3 id="span-hooks">Span Hooks</h3>
 
 In some cases, it's necessary to update the metadata of a span created by one of the built-in integrations. This is possible using span hooks registered by integration. Each hook provides the span as the first argument and other contextual objects as additional arguments.

--- a/packages/datadog-instrumentations/src/pino.js
+++ b/packages/datadog-instrumentations/src/pino.js
@@ -35,12 +35,12 @@ function wrapAsJson (asJson) {
   return function asJsonWithTrace (obj, msg, num, time) {
     obj = arguments[0] = obj || {}
 
-    // Caller-provided `dd` wins -- skip the splice so a bespoke `dd` survives.
-    if (!jsonCh.hasSubscribers || Object.hasOwn(obj, 'dd')) {
+    if (!jsonCh.hasSubscribers) {
       return asJson.apply(this, arguments)
     }
 
-    const payload = { line: asJson.apply(this, arguments) }
+    // Pass hasUserDd so the plugin can skip injection while still capturing.
+    const payload = { line: asJson.apply(this, arguments), hasUserDd: Object.hasOwn(obj, 'dd') }
     jsonCh.publish(payload)
     return payload.line
   }

--- a/packages/datadog-instrumentations/test/pino.spec.js
+++ b/packages/datadog-instrumentations/test/pino.spec.js
@@ -1,0 +1,139 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { Writable } = require('node:stream')
+
+const { channel } = require('dc-polyfill')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+const agent = require('../../dd-trace/test/plugins/agent')
+const { withVersions } = require('../../dd-trace/test/setup/mocha')
+
+// In the current architecture, pino exposes the fully-serialized JSON line via
+// apm:pino:log:json. This channel is used for both log injection and log capture.
+const jsonCh = channel('apm:pino:log:json')
+
+describe('pino instrumentation', () => {
+  withVersions('pino', 'pino', version => {
+    let logger
+    let stream
+    let captured
+    let captureSub
+
+    beforeEach(() => {
+      return agent.load('pino')
+    })
+
+    afterEach(() => {
+      if (captureSub) {
+        jsonCh.unsubscribe(captureSub)
+        captureSub = null
+      }
+      return agent.close({ ritmReset: false })
+    })
+
+    beforeEach(function () {
+      const pino = require(`../../../versions/pino@${version}`).get()
+
+      if (!pino) {
+        this.skip()
+        return
+      }
+
+      stream = new Writable()
+      stream._write = (chunk, enc, cb) => cb()
+      sinon.spy(stream, 'write')
+
+      logger = pino({}, stream)
+
+      captured = null
+      captureSub = (payload) => { captured = payload }
+      jsonCh.subscribe(captureSub)
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should emit to apm:pino:log:json channel on logger.info', (done) => {
+      logger.info('capture test')
+
+      setImmediate(() => {
+        assert.ok(captured, 'json channel should have fired')
+        const record = JSON.parse(captured.line)
+        assert.strictEqual(record.msg, 'capture test')
+        done()
+      })
+    })
+
+    it('should include complete record fields (pid, hostname, time, level) in capture', (done) => {
+      logger.info('full record test')
+
+      setImmediate(() => {
+        assert.ok(captured, 'json channel should have fired')
+        const record = JSON.parse(captured.line)
+        assert.ok(record.pid, 'should have pid')
+        assert.ok(record.hostname, 'should have hostname')
+        assert.ok(record.time, 'should have time')
+        assert.ok(record.level !== undefined, 'should have level')
+        assert.strictEqual(record.msg, 'full record test')
+        done()
+      })
+    })
+
+    it('should include extra fields in the captured record', (done) => {
+      logger.info({ extra: 'field' }, 'with extra field')
+
+      setImmediate(() => {
+        assert.ok(captured, 'json channel should have fired')
+        const record = JSON.parse(captured.line)
+        assert.strictEqual(record.msg, 'with extra field')
+        assert.strictEqual(record.extra, 'field')
+        done()
+      })
+    })
+  })
+
+  // Separate describe for the hasSubscribers guard: loaded with logInjection disabled
+  // so PinoPlugin does not subscribe to apm:pino:log:json, making the guard testable.
+  withVersions('pino', 'pino', version => {
+    let logger
+    let stream
+
+    beforeEach(() => {
+      return agent.load('pino', { logInjection: false, logCaptureEnabled: false })
+    })
+
+    afterEach(() => {
+      return agent.close({ ritmReset: false })
+    })
+
+    beforeEach(function () {
+      const pino = require(`../../../versions/pino@${version}`).get()
+
+      if (!pino) {
+        this.skip()
+        return
+      }
+
+      stream = new Writable()
+      stream._write = (chunk, enc, cb) => cb()
+      sinon.spy(stream, 'write')
+
+      logger = pino({}, stream)
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should not emit to json channel when there are no subscribers', () => {
+      // PinoPlugin is disabled (logInjection=false, logCaptureEnabled=false), so the only
+      // way hasSubscribers can be true is if external code subscribed — there is none here.
+      assert.strictEqual(jsonCh.hasSubscribers, false)
+
+      logger.info('no subscriber test')
+    })
+  })
+})

--- a/packages/datadog-plugin-pino/src/index.js
+++ b/packages/datadog-plugin-pino/src/index.js
@@ -13,23 +13,62 @@ class PinoPlugin extends LogPlugin {
   }
 
   /**
-   * Splice `,"dd":<json>` into the JSON line pino has already produced.
+   * Disable the generic apm:${id}:log capture path for pino.
+   *
+   * Pino's apm:pino:log:json channel provides the fully-serialized JSON line
+   * and is used for both injection and capture in handleJsonLine.
+   * This prevents double-capture from the LogPlugin base class subscriber.
+   *
+   * @returns {false}
+   */
+  get _captureEnabled () {
+    return false
+  }
+
+  /**
+   * Splice `,"dd":<json>` into the JSON line pino has already produced,
+   * and optionally capture the complete record for log forwarding.
    * The caller-owned message object is never observed -- user Proxies and
    * custom serialisers see nothing because there is no mutation to see.
    *
    * @param {{ line: string }} payload
    */
   handleJsonLine (payload) {
+    if (typeof payload?.line !== 'string') return
+
+    // hasUserDd: caller already has a dd field — preserve it; skip injection but still capture.
+    const shouldInject = this.config.logInjection && !payload.hasUserDd
+    const shouldCapture = this.config.logCaptureEnabled
+
+    if (!shouldInject && !shouldCapture) return
+
     const logHolder = buildLogHolder(this.tracer)
-    if (!logHolder) return
 
-    const line = payload.line
-    const lastClose = line.lastIndexOf('}')
-    if (lastClose < 1) return
+    if (shouldInject && logHolder) {
+      const line = payload.line
+      const lastClose = line.lastIndexOf('}')
+      if (lastClose >= 1) {
+        const ddJson = JSON.stringify(logHolder.dd)
+        const sep = line.charCodeAt(lastClose - 1) === 0x7B ? '' : ','
+        payload.line = line.slice(0, lastClose) + sep + '"dd":' + ddJson + line.slice(lastClose)
+      }
+    }
 
-    const ddJson = JSON.stringify(logHolder.dd)
-    const sep = line.charCodeAt(lastClose - 1) === 0x7B ? '' : ','
-    payload.line = line.slice(0, lastClose) + sep + '"dd":' + ddJson + line.slice(lastClose)
+    if (shouldCapture) {
+      if (!shouldInject && logHolder) {
+        // Enrich the captured record with dd context without modifying the actual log line.
+        const line = payload.line
+        const lastClose = line.lastIndexOf('}')
+        if (lastClose >= 1) {
+          const ddJson = JSON.stringify(logHolder.dd)
+          const sep = line.charCodeAt(lastClose - 1) === 0x7B ? '' : ','
+          this.capture(line.slice(0, lastClose) + sep + '"dd":' + ddJson + line.slice(lastClose))
+          return
+        }
+      }
+      // If injection already happened, payload.line includes dd; otherwise capture raw.
+      this.capture(payload.line)
+    }
   }
 
   /**
@@ -41,6 +80,8 @@ class PinoPlugin extends LogPlugin {
    * @param {{ message: object }} arg
    */
   handlePrettyMessage (arg) {
+    if (!this.config.logInjection) return
+
     const logHolder = buildLogHolder(this.tracer)
     if (!logHolder) return
 

--- a/packages/datadog-plugin-pino/test/index.spec.js
+++ b/packages/datadog-plugin-pino/test/index.spec.js
@@ -47,6 +47,16 @@ describe('Plugin', () => {
             const pretty = require('../../../versions/pino-pretty@8.0.0').get()
 
             stream = pretty().pipe(stream)
+          } else if (semver.intersects(version, '>=5 <8') && options.prettyPrint) {
+            // pino 5-7 supports prettyPrint internally by calling require('pino-pretty').
+            // In this test environment, that resolves to pino-pretty@8 which exports an
+            // abstractTransport-based Transform stream — incompatible with pino 5-7's
+            // expectation of a sync factory function. pino-pretty@8 also creates a
+            // SonicBoom (writing to stdout) that registers with on-exit-leak-free,
+            // leaving async resources that prevent mocha from exiting after the test.
+            // Provide pino-pretty@3 via the `prettifier` option so pino uses its
+            // synchronous factory interface and avoids the leaked resources.
+            options.prettifier = require('../../../versions/pino-pretty@3.0.0').get()
           }
 
           logger = pino(options, stream)
@@ -246,6 +256,41 @@ describe('Plugin', () => {
               })
             })
           }
+        })
+
+        describe('log capture channel (apm:pino:log:json)', () => {
+          beforeEach(() => {
+            return agent.load('pino')
+          })
+
+          beforeEach(function () {
+            setupTest()
+
+            if (!logger) {
+              this.skip()
+            }
+          })
+
+          it('should emit a complete JSON record including pid, hostname, level, time, msg', (done) => {
+            const { channel } = require('dc-polyfill')
+            const captureCh = channel('apm:pino:log:json')
+            let captured
+            const sub = (payload) => { captured = payload }
+            captureCh.subscribe(sub)
+
+            logger.info('hello capture')
+
+            setImmediate(() => {
+              captureCh.unsubscribe(sub)
+              assert.ok(captured, 'json channel should have fired')
+              const record = JSON.parse(captured.line)
+              assert.ok(record.pid, 'should have pid')
+              assert.ok(record.hostname, 'should have hostname')
+              assert.ok(record.time, 'should have time')
+              assert.strictEqual(record.msg, 'hello capture')
+              done()
+            })
+          })
         })
       })
     })

--- a/packages/datadog-plugin-pino/test/log_capture.spec.js
+++ b/packages/datadog-plugin-pino/test/log_capture.spec.js
@@ -1,0 +1,137 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const { channel } = require('dc-polyfill')
+
+require('../../dd-trace/test/setup/core')
+const PinoPlugin = require('../src/index')
+const Tracer = require('../../dd-trace/src/tracer')
+const getConfig = require('../../dd-trace/src/config')
+
+// In the current architecture, pino publishes the complete serialized JSON line
+// to apm:pino:log:json with payload { line: string }.
+const pinoJsonChannel = channel('apm:pino:log:json')
+
+const config = {
+  env: 'my-env',
+  service: 'my-service',
+  version: '1.2.3',
+}
+
+const tracer = new Tracer(getConfig({
+  logInjection: true,
+  enabled: true,
+  ...config,
+}))
+
+describe('PinoPlugin', () => {
+  describe('log capture (apm:pino:log:json channel)', () => {
+    let captureSender
+    let pinoPlugin
+
+    beforeEach(() => {
+      // Do NOT clear the require cache — log_plugin.js holds a top-level reference to the
+      // same sender module, so we must configure the same instance.
+      captureSender = require('../../dd-trace/src/log-capture/sender')
+      captureSender.stop() // reset any prior state
+      captureSender.configure({
+        host: 'localhost',
+        port: 9999,
+        path: '/logs',
+        protocol: 'http:',
+        maxBufferSize: 1000,
+        flushIntervalMs: 5000,
+        timeoutMs: 5000,
+      })
+      pinoPlugin = new PinoPlugin({ _tracer: tracer })
+    })
+
+    afterEach(() => {
+      pinoPlugin.configure({ enabled: false })
+      captureSender.stop()
+    })
+
+    it('forwards pino json capture records when logCaptureEnabled is true', () => {
+      pinoPlugin.configure({
+        logInjection: true,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+      const rawJson = '{"level":30,"msg":"pino log"}'
+      pinoJsonChannel.publish({ line: rawJson })
+      assert.strictEqual(captureSender.bufferSize(), 1)
+    })
+
+    it('does not forward pino json capture records when logCaptureEnabled is false', () => {
+      pinoPlugin.configure({
+        logInjection: true,
+        logCaptureEnabled: false,
+        enabled: true,
+      })
+      pinoJsonChannel.publish({ line: '{"level":30,"msg":"pino log"}' })
+      assert.strictEqual(captureSender.bufferSize(), 0)
+    })
+
+    it('adds raw json directly when logInjection is on', () => {
+      pinoPlugin.configure({
+        logInjection: true,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+
+      const addedLines = []
+      const origAdd = captureSender.add
+      captureSender.add = (json) => addedLines.push(json)
+      try {
+        // When logInjection is on, handleJsonLine splices dd into the line first.
+        // Simulate a line that already has dd (as pino would produce after injection).
+        const rawJson = '{"level":30,"msg":"raw pino","dd":{"trace_id":"abc"}}'
+        pinoJsonChannel.publish({ line: rawJson })
+      } finally {
+        captureSender.add = origAdd
+      }
+
+      assert.strictEqual(addedLines.length, 1, 'should have forwarded one record')
+    })
+
+    it('enriches capture records with dd trace context when logInjection is off', () => {
+      pinoPlugin.configure({
+        logInjection: false,
+        logCaptureEnabled: true,
+        enabled: true,
+      })
+
+      const addedLines = []
+      const origAdd = captureSender.add
+      captureSender.add = (json) => addedLines.push(json)
+      try {
+        pinoJsonChannel.publish({ line: '{"level":30,"msg":"pino log"}' })
+      } finally {
+        captureSender.add = origAdd
+      }
+
+      assert.strictEqual(addedLines.length, 1, 'capture sender should have received one enriched record')
+      const parsed = JSON.parse(addedLines[0])
+      // dd should be present with at least service/env/version even without an active span
+      assert.ok('dd' in parsed, 'captured pino record should have dd even when logInjection is off')
+      assert.strictEqual(parsed.dd.service, config.service)
+      assert.strictEqual(parsed.dd.env, config.env)
+      assert.strictEqual(parsed.dd.version, config.version)
+    })
+
+    it('does not forward pino records when logCaptureEnabled is false (no-op check)', () => {
+      pinoPlugin.configure({
+        logInjection: false,
+        logCaptureEnabled: false,
+        enabled: true,
+      })
+
+      // apm:pino:log:json should NOT trigger capture when both injection and capture are off
+      pinoJsonChannel.publish({ line: '{"level":30,"msg":"pino log"}' })
+
+      assert.strictEqual(captureSender.bufferSize(), 0)
+    })
+  })
+})

--- a/packages/datadog-plugin-pino/test/unit.spec.js
+++ b/packages/datadog-plugin-pino/test/unit.spec.js
@@ -132,5 +132,18 @@ describe('PinoPlugin', () => {
         tracer.inject = originalInject
       }
     })
+
+    it('leaves the message untouched when logInjection is disabled (capture-only mode)', () => {
+      plugin.configure({ logInjection: false, logCaptureEnabled: true, enabled: true })
+      try {
+        const original = { msg: 'hello', level: 30 }
+        const data = { message: original }
+        messageCh.publish(data)
+        assert.strictEqual(data.message, original, 'message should not be wrapped in capture-only mode')
+        assert.ok(!('dd' in data.message), 'dd should not be injected when logInjection is false')
+      } finally {
+        plugin.configure({ logInjection: true, enabled: true })
+      }
+    })
   })
 })


### PR DESCRIPTION
## Why

Pino is the most widely used structured logger in the Node.js ecosystem. Without a pino-specific integration, log capture would work generically through the base `LogPlugin` channel — but pino's architecture makes that suboptimal. Pino serializes each record to a JSON string internally before the log plugin sees it; the base channel operates on the JS object before serialization. This means generic capture would require re-serializing the object, potentially producing a subtly different JSON representation than what pino itself emits.

This PR adds a pino-specific integration that hooks into pino's `apm:pino:log:json` channel — which fires *after* pino has produced the final JSON line — to both inject trace correlation and capture the exact bytes pino would write to disk. Pino-pretty (the human-readable formatter) is handled separately via `apm:pino:log`, which exposes the original JS object; injection there uses a Proxy so pino-pretty sees a virtual `dd` field without any actual mutation.

A bug is also fixed: `handlePrettyMessage()` was unconditionally applying the `dd` proxy regardless of the `logInjection` setting. Since the plugin is now enabled by `logCaptureEnabled` alone, this caused `dd` to be injected into pino-pretty output in capture-only configurations. The method now short-circuits when `logInjection` is disabled.

## What

- `datadog-plugin-pino/src/index.js`:
  - Overrides `_captureEnabled` to `false` — pino uses its own `apm:pino:log:json` channel for capture, preventing double-capture from the base class subscriber
  - `handleJsonLine`: handles both injection (splicing `,"dd":{...}` into the JSON line) and capture (forwarding the exact JSON line, enriching with `dd` when injection is off)
  - `handlePrettyMessage`: now guarded by `logInjection` to avoid injecting `dd` in capture-only mode
- `datadog-instrumentations`: adds pino instrumentation hook for the `apm:pino:log:json` channel
- `index.d.ts`: adds all `logCapture*` options to `TracerOptions`
- `docs/API.md`: documents all `DD_LOG_CAPTURE_*` options
- CI: adds `instrumentation-pino` job to `instrumentation.yml`

## Stack

This is **PR 3 of 3** in a stacked series:
1. #8964 — Core log-capture subsystem and configuration
2. #8965 — Wire log-capture into plugin system
3. **[this PR]** Pino integration and public API

The full change is in #8957.

## Test plan

- [x] `unset OTEL_TRACES_EXPORTER OTEL_LOGS_EXPORTER OTEL_METRICS_EXPORTER && PLUGINS="pino" npm run test:plugins`
- [x] `./node_modules/.bin/mocha packages/datadog-plugin-pino/test/log_capture.spec.js`
- [x] `./node_modules/.bin/mocha packages/datadog-plugin-pino/test/unit.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)