### PR TITLE
perf(debugger): sample probes in breakpoint conditions

### DIFF
--- a/benchmark/sirun/collect-overview.js
+++ b/benchmark/sirun/collect-overview.js
@@ -101,6 +101,7 @@ for (const name of benches) {
     try { fs.unlinkSync(SG_FILE) } catch {}
 
     const variantCfg = meta.variants?.[variant] || {}
+    const variantIters = variantCfg.iterations || configIters
     const inner = innerCount(variantCfg.env)
     let perIterMs = '-'
     let stddevPct = '-'
@@ -120,7 +121,7 @@ for (const name of benches) {
           const { mean, stddevPct: sd } = stats(times)
           perIterMs = (mean / 1000).toFixed(1)
           stddevPct = sd.toFixed(1)
-          totalS = ((mean / 1e6) * configIters).toFixed(0)
+          totalS = ((mean / 1e6) * variantIters).toFixed(0)
         }
       } catch { perIterMs = 'parse-err' }
     } else {
@@ -131,7 +132,7 @@ for (const name of benches) {
 
     fs.appendFileSync(OUT,
       `| ${name} | ${variant} | ${categoryOf(name)} | ${meaningOf(name)} | ${inner} | ` +
-      `${configIters} | ${perIterMs} | ${stddevPct} | ${totalS} | ${startupPct} |\n`)
+      `${variantIters} | ${perIterMs} | ${stddevPct} | ${totalS} | ${startupPct} |\n`)
     console.log(`${name}/${variant} ${perIterMs}ms sd=${stddevPct}% ${totalS}s start=${startupPct}%`)
   }
 

--- a/benchmark/sirun/debugger/app.js
+++ b/benchmark/sirun/debugger/app.js
@@ -1,12 +1,13 @@
 'use strict'
 
-// WARNING: the breakpoint target below is referenced by line number from
+// WARNING: the breakpoint targets below are referenced by line number from
 // meta.json (BREAKPOINT_LINE). Update the BREAKPOINT_LINE values there if you
-// move the `data.n = n` line.
+// move the `data.n = n` line or the unreachable `return n` line.
 
 const guard = require('../startup-guard')
 
 const OPERATIONS = Number(process.env.OPERATIONS)
+const STARTUP_GUARD_MAX_SHARE = Number(process.env.STARTUP_GUARD_MAX_SHARE)
 
 if (process.env.DD_DYNAMIC_INSTRUMENTATION_ENABLED === 'true') {
   // The devtools worker and its ports are unref'd, so nothing holds the event
@@ -16,9 +17,7 @@ if (process.env.DD_DYNAMIC_INSTRUMENTATION_ENABLED === 'true') {
   const keepAlive = setInterval(() => {}, 2 ** 31 - 1)
   require('./start-devtools-client')(() => {
     clearInterval(keepAlive)
-    // The not-hit variant only measures the passive cost of installing a probe,
-    // so it exits here instead of running the guarded work loop.
-    if (process.env.INSTALL_ONLY !== 'true') runWork()
+    runWork()
   })
 } else {
   runWork()
@@ -29,12 +28,15 @@ function runWork () {
   for (let i = 0; i < OPERATIONS; i++) {
     doSomeWork(i)
   }
-  guard.done(0.35)
+  guard.done(STARTUP_GUARD_MAX_SHARE)
 }
 
 function doSomeWork (n) {
   const data = getSomeData()
-  data.n = n
+  data.n = n // BREAKPOINT HERE!
+  if (n < 0) {
+    return n // BREAKPOINT HERE!
+  }
   return data.n
 }
 

--- a/benchmark/sirun/debugger/meta.json
+++ b/benchmark/sirun/debugger/meta.json
@@ -1,7 +1,7 @@
 {
   "name": "debugger",
   "cachegrind": false,
-  "iterations": 10,
+  "iterations": 5,
   "instructions": true,
   "variants": {
     "enabled-but-breakpoint-not-hit": {
@@ -10,10 +10,11 @@
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
+        "STARTUP_GUARD_MAX_SHARE": "0.1",
+        "OPERATIONS": "220000",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
-        "INSTALL_ONLY": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "37"
+        "BREAKPOINT_LINE": "38"
       }
     },
     "line-probe-without-snapshot": {
@@ -22,10 +23,11 @@
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
       "env": {
+        "STARTUP_GUARD_MAX_SHARE": "0.1",
+        "OPERATIONS": "32000",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "37",
-        "OPERATIONS": "3500"
+        "BREAKPOINT_LINE": "36"
       }
     },
     "line-probe-with-snapshot-default": {
@@ -33,14 +35,14 @@
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
-      "iterations": 5,
       "env": {
+        "STARTUP_GUARD_MAX_SHARE": "0.1",
+        "OPERATIONS": "32000",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "37",
+        "BREAKPOINT_LINE": "36",
         "CAPTURE_SNAPSHOT": "true",
-        "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
-        "OPERATIONS": "2450"
+        "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000"
       }
     },
     "line-probe-with-snapshot-minimal": {
@@ -48,18 +50,18 @@
       "setup_with_affinity": "bash -c \"nohup taskset -c $CPU_AFFINITY node agent.js >/dev/null 2>&1 &\"",
       "run": "node app.js",
       "run_with_affinity": "bash -c \"taskset -c $CPU_AFFINITY node app.js\"",
-      "iterations": 7,
       "env": {
+        "STARTUP_GUARD_MAX_SHARE": "0.1",
+        "OPERATIONS": "32000",
         "DD_DYNAMIC_INSTRUMENTATION_ENABLED": "true",
         "BREAKPOINT_FILE": "app.js",
-        "BREAKPOINT_LINE": "37",
+        "BREAKPOINT_LINE": "36",
         "CAPTURE_SNAPSHOT": "true",
         "MAX_SNAPSHOTS_PER_SECOND_GLOBALLY": "1000000",
         "MAX_REFERENCE_DEPTH": "0",
         "MAX_COLLECTION_SIZE": "0",
         "MAX_FIELD_COUNT": "0",
-        "MAX_LENGTH": "9007199254740991",
-        "OPERATIONS": "3500"
+        "MAX_LENGTH": "9007199254740991"
       }
     }
   }

--- a/integration-tests/debugger/sampling.spec.js
+++ b/integration-tests/debugger/sampling.spec.js
@@ -28,10 +28,10 @@ describe('Dynamic Instrumentation', function () {
             const duration = timestamp - prev
             clearTimeout(timer)
 
-            // The sampling check inside the worker uses `process.hrtime.bigint()` (monotonic), but the snapshot
-            // `timestamp` is captured via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock
-            // to drift slightly relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms
-            // tolerance on both sides of the expected 1000ms gap.
+            // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
+            // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
+            // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
+            // sides of the expected 1000ms gap.
             assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
             assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
 
@@ -84,10 +84,10 @@ describe('Dynamic Instrumentation', function () {
             const duration = timestamp - _state.prev
             clearTimeout(_state.timer)
 
-            // The sampling check inside the worker uses `process.hrtime.bigint()` (monotonic), but the snapshot
-            // `timestamp` is captured via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock
-            // to drift slightly relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms
-            // tolerance on both sides of the expected 1000ms gap.
+            // The sampling check uses `process.hrtime.bigint()` (monotonic), but the snapshot `timestamp` is captured
+            // via `Date.now()` (wall clock). NTP slewing on CI runners can cause the wall clock to drift slightly
+            // relative to the monotonic clock during the >=1s sampling window, so we allow a 75ms tolerance on both
+            // sides of the expected 1000ms gap.
             assert.ok(duration >= 925, `duration (${duration}) should be >= 925`)
             assert.ok(duration < 1075, `duration (${duration}) should be < 1075`)
 

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -5,6 +5,7 @@ const { getGeneratedPosition } = require('./source-maps')
 const session = require('./session')
 const { compile, compileSegments, templateRequiresEvaluation } = require('./condition')
 const { MAX_SNAPSHOTS_PER_SECOND_PER_PROBE, MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE } = require('./defaults')
+const { compileBreakpointCondition, getInstallSamplerExpression, getRemoveProbeExpression } = require('./probe_sampler')
 const {
   DEFAULT_MAX_REFERENCE_DEPTH,
   DEFAULT_MAX_COLLECTION_SIZE,
@@ -17,6 +18,7 @@ const {
   locationToBreakpoint,
   breakpointToProbes,
   probeToLocation,
+  samplingIndexToProbe,
 } = require('./state')
 const log = require('./log')
 
@@ -26,6 +28,7 @@ const log = require('./log')
 
 let sessionStarted = false
 const probes = new Map()
+let nextSamplingIndex = 0
 let scriptLoadingStabilizedResolve
 const scriptLoadingStabilized = new Promise((resolve) => { scriptLoadingStabilizedResolve = resolve })
 
@@ -55,6 +58,8 @@ async function addBreakpoint (probe) {
   if (!sessionStarted) await start()
 
   probes.set(probe.id, probe)
+  probe.samplingIndex = nextSamplingIndex++
+  samplingIndexToProbe.set(probe.samplingIndex, probe)
 
   const file = probe.where.sourceFile
   let lineNumber = Number(probe.where.lines[0]) // Tracer doesn't support multiple-line breakpoints
@@ -75,8 +80,6 @@ async function addBreakpoint (probe) {
     ? MAX_SNAPSHOTS_PER_SECOND_PER_PROBE
     : MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE)
   probe.nsBetweenSampling = BigInt(Math.trunc(1 / snapshotsPerSecond * 1e9))
-  // Initialize to a large negative value to ensure first probe hit is always captured
-  probe.lastCaptureNs = BigInt(Number.MIN_SAFE_INTEGER)
 
   // Warning: The code below relies on undocumented behavior of the inspector!
   // It expects that `await session.post('Debugger.enable')` will wait for all loaded scripts to be emitted as
@@ -174,7 +177,7 @@ async function addBreakpoint (probe) {
     try {
       result = /** @type {SetBreakpointResponse} */ (await session.post('Debugger.setBreakpoint', {
         location,
-        condition: probe.condition,
+        condition: compileBreakpointCondition([probe]),
       }))
     } catch (err) {
       throw new Error(`Error setting breakpoint for probe ${probe.id} (version: ${probe.version})`, { cause: err })
@@ -195,11 +198,14 @@ async function removeBreakpoint ({ id }) {
   }
 
   probes.delete(id)
+  await removeProbeFromSampler(id)
 
   const locationKey = probeToLocation.get(id)
   const breakpoint = locationToBreakpoint.get(locationKey)
   const probesAtLocation = breakpointToProbes.get(breakpoint.id)
+  const probe = probesAtLocation.get(id)
 
+  samplingIndexToProbe.delete(probe.samplingIndex)
   probesAtLocation.delete(id)
   probeToLocation.delete(id)
 
@@ -229,36 +235,37 @@ async function modifyBreakpoint (probe) {
 
 async function updateBreakpointInternal (breakpoint, probe) {
   const probesAtLocation = breakpointToProbes.get(breakpoint.id)
-  const conditionBeforeNewProbe = compileCompoundCondition([...probesAtLocation.values()])
 
-  // If a probe is provided, add it to the breakpoint. If not, it's because we're removing a probe, but potentially
-  // need to update the condition of the breakpoint.
+  // If a probe is provided, add it to the breakpoint. If not, it's because we're removing a probe. In both cases the
+  // breakpoint condition must be rebuilt to match the remaining probes at the location.
   if (probe) {
     probesAtLocation.set(probe.id, probe)
     probeToLocation.set(probe.id, breakpoint.locationKey)
   }
 
-  const condition = compileCompoundCondition([...probesAtLocation.values()])
-
-  if (condition || conditionBeforeNewProbe !== condition) {
-    try {
-      await session.post('Debugger.removeBreakpoint', { breakpointId: breakpoint.id })
-    } catch (err) {
-      throw new Error(`Error removing breakpoint for probe ${probe.id}`, { cause: err })
-    }
-    breakpointToProbes.delete(breakpoint.id)
-    let result
-    try {
-      result = /** @type {SetBreakpointResponse} */ (await session.post('Debugger.setBreakpoint', {
-        location: breakpoint.location,
-        condition,
-      }))
-    } catch (err) {
-      throw new Error(`Error setting breakpoint for probe ${probe.id} (version: ${probe.version})`, { cause: err })
-    }
-    breakpoint.id = result.breakpointId
-    breakpointToProbes.set(result.breakpointId, probesAtLocation)
+  try {
+    await session.post('Debugger.removeBreakpoint', { breakpointId: breakpoint.id })
+  } catch (err) {
+    const message = probe
+      ? `Error replacing breakpoint while adding probe ${probe.id} (version: ${probe.version})`
+      : `Error replacing breakpoint after removing probe from ${breakpoint.locationKey}`
+    throw new Error(message, { cause: err })
   }
+  breakpointToProbes.delete(breakpoint.id)
+  let result
+  try {
+    result = /** @type {SetBreakpointResponse} */ (await session.post('Debugger.setBreakpoint', {
+      location: breakpoint.location,
+      condition: compileBreakpointCondition([...probesAtLocation.values()]),
+    }))
+  } catch (err) {
+    const message = probe
+      ? `Error setting breakpoint while adding probe ${probe.id} (version: ${probe.version})`
+      : `Error setting breakpoint after removing probe from ${breakpoint.locationKey}`
+    throw new Error(message, { cause: err })
+  }
+  breakpoint.id = result.breakpointId
+  breakpointToProbes.set(result.breakpointId, probesAtLocation)
 }
 
 async function reEvaluateProbe (probe) {
@@ -280,6 +287,7 @@ async function start () {
   sessionStarted = true
   log.debug('[debugger:devtools_client] Starting debugger')
   await session.post('Debugger.enable')
+  await session.post('Runtime.evaluate', { expression: getInstallSamplerExpression() })
 
   // Wait until there's a pause in script-loading to avoid accidentally adding probes to incorrect scripts. This is not
   // a guarantee, but best effort.
@@ -306,16 +314,18 @@ function lock (fn) {
   }
 }
 
-// Only if all probes have a condition can we use a compound condition.
-// Otherwise, we need to evaluate each probe individually once the breakpoint is hit.
-function compileCompoundCondition (probes) {
-  if (probes.length === 1) return probes[0].condition
-
-  return probes.every(p => p.condition)
-    ? probes
-      .map((p) => `(() => { try { return ${p.condition} } catch { return false } })()`)
-      .join(' || ')
-    : undefined
+/**
+ * Remove cached sampling state for a probe from the runtime sampler.
+ *
+ * @param {string} id - The probe id.
+ * @returns {Promise<void>}
+ */
+async function removeProbeFromSampler (id) {
+  await session.post('Runtime.evaluate', {
+    expression: getRemoveProbeExpression(id),
+  }).catch(err => {
+    log.error('[debugger:devtools_client] Error removing probe %s from sampler', id, err)
+  })
 }
 
 function generateLocationKey (scriptId, lineNumber, columnNumber) {

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -5,7 +5,7 @@ const { getGeneratedPosition } = require('./source-maps')
 const session = require('./session')
 const { compile, compileSegments, templateRequiresEvaluation } = require('./condition')
 const { MAX_SNAPSHOTS_PER_SECOND_PER_PROBE, MAX_NON_SNAPSHOTS_PER_SECOND_PER_PROBE } = require('./defaults')
-const { compileBreakpointCondition, getInstallSamplerExpression, getRemoveProbeExpression } = require('./probe_sampler')
+const { compileBreakpointCondition, getRemoveProbeExpression } = require('./probe_sampler')
 const {
   DEFAULT_MAX_REFERENCE_DEPTH,
   DEFAULT_MAX_COLLECTION_SIZE,
@@ -287,7 +287,6 @@ async function start () {
   sessionStarted = true
   log.debug('[debugger:devtools_client] Starting debugger')
   await session.post('Debugger.enable')
-  await session.post('Runtime.evaluate', { expression: getInstallSamplerExpression() })
 
   // Wait until there's a pause in script-loading to avoid accidentally adding probes to incorrect scripts. This is not
   // a guarantee, but best effort.

--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -320,11 +320,13 @@ function lock (fn) {
  * @returns {Promise<void>}
  */
 async function removeProbeFromSampler (id) {
-  await session.post('Runtime.evaluate', {
-    expression: getRemoveProbeExpression(id),
-  }).catch(err => {
+  try {
+    await session.post('Runtime.evaluate', {
+      expression: getRemoveProbeExpression(id),
+    })
+  } catch (err) {
     log.error('[debugger:devtools_client] Error removing probe %s from sampler', id, err)
-  })
+  }
 }
 
 function generateLocationKey (scriptId, lineNumber, columnNumber) {

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -8,6 +8,7 @@ const { breakpointToProbes, samplingIndexToProbe } = require('./state')
 const session = require('./session')
 const { getLocalStateForCallFrame, evaluateCaptureExpressions } = require('./snapshot')
 const {
+  MAX_SAMPLED_PROBES_PER_PAUSE,
   SAMPLED_PROBE_COUNT_INDEX,
   SAMPLED_PROBE_INDEXES_START,
   SAMPLED_PROBE_OVERFLOW_INDEX,
@@ -65,7 +66,10 @@ session.on('Debugger.paused', async ({ params }) => {
   // V8 doesn't allow setting more than one breakpoint at a specific location, however, it's possible to set two
   // breakpoints just next to each other that will "snap" to the same logical location, which in turn will be hit at the
   // same time. E.g. index.js:1:1 and index.js:1:2.
-  const numberOfSampledProbeIndexes = Atomics.exchange(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 0)
+  const numberOfSampledProbeIndexes = Math.min(
+    Atomics.exchange(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 0),
+    MAX_SAMPLED_PROBES_PER_PAUSE
+  )
   if (Atomics.exchange(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 0) === 1) {
     log.error(
       '[debugger:devtools_client] Too many probes sampled at the same breakpoint location; skipping excess probes'

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -4,15 +4,15 @@ const { randomUUID } = require('crypto')
 const { workerData: { probeSamplerBuffer } } = require('worker_threads')
 const { version } = require('../../../../../package.json')
 const processTags = require('../../process-tags')
-const { breakpointToProbes, samplingIndexToProbe } = require('./state')
-const session = require('./session')
-const { getLocalStateForCallFrame, evaluateCaptureExpressions } = require('./snapshot')
 const {
   MAX_SAMPLED_PROBES_PER_PAUSE,
   SAMPLED_PROBE_COUNT_INDEX,
   SAMPLED_PROBE_INDEXES_START,
   SAMPLED_PROBE_OVERFLOW_INDEX,
 } = require('../probe_sampler_constants')
+const { breakpointToProbes, samplingIndexToProbe } = require('./state')
+const session = require('./session')
+const { getLocalStateForCallFrame, evaluateCaptureExpressions } = require('./snapshot')
 const send = require('./send')
 const { getStackFromCallFrames } = require('./state')
 const { ackEmitting } = require('./status')

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -12,7 +12,7 @@ const {
   SAMPLED_PROBE_COUNT_INDEX,
   SAMPLED_PROBE_INDEXES_START,
   SAMPLED_PROBE_OVERFLOW_INDEX,
-} = require('./probe_sampler')
+} = require('../probe_sampler_constants')
 const send = require('./send')
 const { getStackFromCallFrames } = require('./state')
 const { ackEmitting } = require('./status')

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -120,8 +120,7 @@ session.on('Debugger.paused', async ({ params }) => {
     }
   }
 
-  // This can happen if the sampler paused only to report overflow, or if the sampled probe indexes are inconsistent
-  // with the worker state. The inconsistent cases are logged above.
+  // This can happen if sampled probe indexes are inconsistent with the worker state. Those cases are logged above.
   if (probes.length === 0) {
     return session.post('Debugger.resume')
   }

--- a/packages/dd-trace/src/debugger/devtools_client/index.js
+++ b/packages/dd-trace/src/debugger/devtools_client/index.js
@@ -1,16 +1,21 @@
 'use strict'
 
 const { randomUUID } = require('crypto')
+const { workerData: { probeSamplerBuffer } } = require('worker_threads')
 const { version } = require('../../../../../package.json')
 const processTags = require('../../process-tags')
-const { breakpointToProbes } = require('./state')
+const { breakpointToProbes, samplingIndexToProbe } = require('./state')
 const session = require('./session')
 const { getLocalStateForCallFrame, evaluateCaptureExpressions } = require('./snapshot')
+const {
+  SAMPLED_PROBE_COUNT_INDEX,
+  SAMPLED_PROBE_INDEXES_START,
+  SAMPLED_PROBE_OVERFLOW_INDEX,
+} = require('./probe_sampler')
 const send = require('./send')
 const { getStackFromCallFrames } = require('./state')
 const { ackEmitting } = require('./status')
 const config = require('./config')
-const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('./defaults')
 const log = require('./log')
 
 require('./remote_config')
@@ -37,10 +42,7 @@ const getDDTagsExpression = `(() => {
 // something that should be useful to a Node.js developer.
 const threadId = config.parentThreadId === 0 ? `pid:${process.pid}` : `pid:${process.pid};tid:${config.parentThreadId}`
 const threadName = config.parentThreadId === 0 ? 'MainThread' : `WorkerThread:${config.parentThreadId}`
-
-const oneSecondNs = 1_000_000_000n
-let globalSnapshotSamplingRateWindowStart = 0n
-let snapshotsSampledWithinTheLastSecond = 0
+const sampledProbeIndexes = new Int32Array(probeSamplerBuffer)
 
 // WARNING: The code above the line `await session.post('Debugger.resume')` is highly optimized. Please edit with care!
 session.on('Debugger.paused', async ({ params }) => {
@@ -55,7 +57,6 @@ session.on('Debugger.paused', async ({ params }) => {
   let maxCollectionSize = 0
   let maxFieldCount = 0
   let maxLength = 0
-  let sampled = false
   let numberOfProbesWithSnapshots = 0
   let probesWithCaptureExpressions = false
   const probes = []
@@ -64,7 +65,12 @@ session.on('Debugger.paused', async ({ params }) => {
   // V8 doesn't allow setting more than one breakpoint at a specific location, however, it's possible to set two
   // breakpoints just next to each other that will "snap" to the same logical location, which in turn will be hit at the
   // same time. E.g. index.js:1:1 and index.js:1:2.
-  let numberOfProbesOnBreakpoint = params.hitBreakpoints.length
+  const numberOfSampledProbeIndexes = Atomics.exchange(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 0)
+  if (Atomics.exchange(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 0) === 1) {
+    log.error(
+      '[debugger:devtools_client] Too many probes sampled at the same breakpoint location; skipping excess probes'
+    )
+  }
 
   // TODO: Investigate if it will improve performance to create a fast-path for when there's only a single breakpoint
   for (let i = 0; i < params.hitBreakpoints.length; i++) {
@@ -76,27 +82,21 @@ session.on('Debugger.paused', async ({ params }) => {
       continue
     }
 
-    if (probesAtLocation.size !== 1) {
-      numberOfProbesOnBreakpoint = numberOfProbesOnBreakpoint + probesAtLocation.size - 1
-    }
+    for (let j = 0; j < numberOfSampledProbeIndexes; j++) {
+      const samplingIndex = Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_INDEXES_START + j)
+      const probe = samplingIndexToProbe.get(samplingIndex)
 
-    for (const probe of probesAtLocation.values()) {
-      if (start - probe.lastCaptureNs < probe.nsBetweenSampling) {
+      if (probe === undefined) {
+        log.error('[debugger:devtools_client] No probe found for sampled probe index %d', samplingIndex)
+        continue
+      }
+      if (!probesAtLocation.has(probe.id)) {
+        log.error('[debugger:devtools_client] Sampled probe %s was not found at breakpoint %s',
+          probe.id, params.hitBreakpoints[i])
         continue
       }
 
       if (probe.captureSnapshot === true || probe.compiledCaptureExpressions !== undefined) {
-        // This algorithm to calculate number of sampled snapshots within the last second is not perfect, as it's not a
-        // sliding window. But it's quick and easy :)
-        if (i === 0 && start - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
-          snapshotsSampledWithinTheLastSecond = 1
-          globalSnapshotSamplingRateWindowStart = start
-        } else if (snapshotsSampledWithinTheLastSecond >= MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) {
-          continue
-        } else {
-          snapshotsSampledWithinTheLastSecond++
-        }
-
         if (probe.captureSnapshot === true) {
           numberOfProbesWithSnapshots++
           maxReferenceDepth = Math.max(probe.capture.maxReferenceDepth, maxReferenceDepth)
@@ -108,23 +108,6 @@ session.on('Debugger.paused', async ({ params }) => {
         }
       }
 
-      if (probe.condition !== undefined) {
-        // TODO: Bundle all conditions and evaluate them in a single call
-        // TODO: Handle errors
-        const { result } = /** @type {EvaluateOnCallFrameResult} */ (
-          // eslint-disable-next-line no-await-in-loop
-          await session.post('Debugger.evaluateOnCallFrame', {
-            callFrameId: params.callFrames[0].callFrameId,
-            expression: probe.condition,
-            returnByValue: true,
-          })
-        )
-        if (result.value !== true) continue
-      }
-
-      sampled = true
-      probe.lastCaptureNs = start
-
       if (probe.templateRequiresEvaluation) {
         templateExpressions += `,${probe.template}`
       }
@@ -133,7 +116,9 @@ session.on('Debugger.paused', async ({ params }) => {
     }
   }
 
-  if (sampled === false) {
+  // This can happen if the sampler paused only to report overflow, or if the sampled probe indexes are inconsistent
+  // with the worker state. The inconsistent cases are logged above.
+  if (probes.length === 0) {
     return session.post('Debugger.resume')
   }
 

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -72,7 +72,6 @@ function getInstallSamplerExpression () {
     const ddTrace = globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]
     const probeSamplerSymbol = Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})
     const probeSamplerBufferSymbol = Symbol.for(${JSON.stringify(PROBE_SAMPLER_BUFFER_SYMBOL)})
-    if (ddTrace[probeSamplerSymbol] !== undefined) return
     if (ddTrace[probeSamplerBufferSymbol] === undefined) return
 
     const lastCaptureNsByProbeId = new Map()

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -1,0 +1,185 @@
+'use strict'
+
+const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('./defaults')
+
+const DD_TRACE_SYMBOL = 'dd-trace'
+const PROBE_SAMPLER_SYMBOL = 'dd-trace.debugger.probeSampler'
+const PROBE_SAMPLER_BUFFER_SYMBOL = 'dd-trace.debugger.probeSamplerBuffer'
+
+// Shared buffer layout. These constants are used by both the main debugger bootstrap and the devtools worker.
+const MAX_SAMPLED_PROBES_PER_PAUSE = 256
+const SAMPLED_PROBE_COUNT_INDEX = 0
+const SAMPLED_PROBE_OVERFLOW_INDEX = 1
+const SAMPLED_PROBE_INDEXES_START = 2
+
+module.exports = {
+  compileBreakpointCondition,
+  createProbeSamplerBuffer,
+  getInstallSamplerExpression,
+  getRemoveProbeExpression,
+  MAX_SAMPLED_PROBES_PER_PAUSE,
+  SAMPLED_PROBE_COUNT_INDEX,
+  SAMPLED_PROBE_INDEXES_START,
+  SAMPLED_PROBE_OVERFLOW_INDEX,
+  setProbeSamplerBuffer,
+}
+
+function getSamplerExpression () {
+  return `globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]?.` +
+    `[Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})]`
+}
+
+// Main-thread setup helpers.
+
+/**
+ * Create the shared buffer used to hand sampled probe indexes from breakpoint conditions to the debugger worker. Called
+ * by the main debugger bootstrap before the worker starts.
+ *
+ * @returns {SharedArrayBuffer}
+ */
+function createProbeSamplerBuffer () {
+  return new SharedArrayBuffer(
+    (SAMPLED_PROBE_INDEXES_START + MAX_SAMPLED_PROBES_PER_PAUSE) * Int32Array.BYTES_PER_ELEMENT
+  )
+}
+
+/**
+ * Expose the shared sampler buffer to breakpoint condition expressions in the debuggee context. Called by the main
+ * debugger bootstrap.
+ *
+ * @param {SharedArrayBuffer} buffer - The shared sampler buffer.
+ */
+function setProbeSamplerBuffer (buffer) {
+  const ddTrace = /** @type {Record<symbol, SharedArrayBuffer>} */ (
+    /** @type {Record<symbol, unknown>} */ (globalThis)[Symbol.for(DD_TRACE_SYMBOL)]
+  )
+  ddTrace[Symbol.for(PROBE_SAMPLER_BUFFER_SYMBOL)] = buffer
+  const sampledProbeIndexes = new Int32Array(buffer)
+  Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 0)
+  Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 0)
+}
+
+// Worker-side generated expression helpers.
+
+/**
+ * Build the expression that installs the runtime sampler in the debuggee context. Called by the devtools worker and
+ * evaluated on the debuggee.
+ *
+ * @returns {string}
+ */
+function getInstallSamplerExpression () {
+  return `(() => {
+    const ddTrace = globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]
+    const probeSamplerSymbol = Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})
+    const probeSamplerBufferSymbol = Symbol.for(${JSON.stringify(PROBE_SAMPLER_BUFFER_SYMBOL)})
+    if (ddTrace[probeSamplerSymbol] !== undefined) return
+    if (ddTrace[probeSamplerBufferSymbol] === undefined) return
+
+    const lastCaptureNsByProbeId = new Map()
+    const sampledProbeIndexes = new Int32Array(ddTrace[probeSamplerBufferSymbol])
+    const oneSecondNs = 1000000000n
+    let globalSnapshotSamplingRateWindowStart = 0n
+    let snapshotsSampledWithinTheLastSecond = 0
+
+    ddTrace[probeSamplerSymbol] = {
+      makeSampleDecision (probeIndex, probeId, nsBetweenSampling, isSnapshotProducingProbe) {
+        const now = globalThis.process.hrtime.bigint()
+        const lastCaptureNs = lastCaptureNsByProbeId.get(probeId)
+        if (lastCaptureNs !== undefined && now - lastCaptureNs < nsBetweenSampling) return false
+
+        const sampledProbeCount = Atomics.add(sampledProbeIndexes, ${SAMPLED_PROBE_COUNT_INDEX}, 1)
+        if (sampledProbeCount >= ${MAX_SAMPLED_PROBES_PER_PAUSE}) {
+          Atomics.store(sampledProbeIndexes, ${SAMPLED_PROBE_OVERFLOW_INDEX}, 1)
+          return false
+        }
+
+        if (isSnapshotProducingProbe === true) {
+          if (now - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
+            snapshotsSampledWithinTheLastSecond = 1
+            globalSnapshotSamplingRateWindowStart = now
+          } else if (snapshotsSampledWithinTheLastSecond >= ${MAX_SNAPSHOTS_PER_SECOND_GLOBALLY}) {
+            return false
+          } else {
+            snapshotsSampledWithinTheLastSecond++
+          }
+        }
+
+        lastCaptureNsByProbeId.set(probeId, now)
+        Atomics.store(sampledProbeIndexes, ${SAMPLED_PROBE_INDEXES_START} + sampledProbeCount, probeIndex)
+        return true
+      },
+
+      remove (probeId) {
+        lastCaptureNsByProbeId.delete(probeId)
+      }
+    }
+  })()`
+}
+
+/**
+ * Build the expression that removes a probe from runtime sampler state. Called by the devtools worker and evaluated on
+ * the debuggee.
+ *
+ * @param {string} id - The probe id.
+ * @returns {string}
+ */
+function getRemoveProbeExpression (id) {
+  return `${getSamplerExpression()}?.remove(${JSON.stringify(id)})`
+}
+
+/**
+ * Build a Chrome DevTools breakpoint condition that samples all matching probes at a location. Called by the devtools
+ * worker.
+ *
+ * @param {{
+ *   id: string,
+ *   samplingIndex: number,
+ *   nsBetweenSampling: bigint,
+ *   condition?: string,
+ *   captureSnapshot?: boolean,
+ *   compiledCaptureExpressions?: object[]
+ * }[]} probes - The probes at the breakpoint location.
+ * @returns {string}
+ */
+function compileBreakpointCondition (probes) {
+  const probeConditions = []
+  for (const probe of probes) {
+    probeConditions.push(compileProbeCondition(probe))
+  }
+
+  return `(() => {
+    const $dd_sampler = ${getSamplerExpression()}
+    if ($dd_sampler === undefined) return false
+    let $dd_sampled = false
+    ${probeConditions.join('\n    ')}
+    return $dd_sampled
+  })()`
+}
+
+/**
+ * Build the condition fragment for a single probe. Called by the devtools worker while building breakpoint conditions.
+ *
+ * @param {{
+ *   id: string,
+ *   samplingIndex: number,
+ *   nsBetweenSampling: bigint,
+ *   condition?: string,
+ *   captureSnapshot?: boolean,
+ *   compiledCaptureExpressions?: object[]
+ * }} probe - The probe to sample.
+ * @returns {string}
+ */
+function compileProbeCondition (probe) {
+  const sample = `$dd_sampler.makeSampleDecision(${probe.samplingIndex}, ${JSON.stringify(probe.id)}, ` +
+    `${probe.nsBetweenSampling}n, ${probe.captureSnapshot === true || probe.compiledCaptureExpressions !== undefined})`
+
+  if (probe.condition === undefined) {
+    return `$dd_sampled = ${sample} || $dd_sampled`
+  }
+
+  return `try {
+      if ((${probe.condition}) === true) {
+        $dd_sampled = ${sample} || $dd_sampled
+      }
+    } catch {}`
+}

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -77,7 +77,7 @@ function getInstallSamplerExpression () {
 
     const lastCaptureNsByProbeId = new Map()
     const sampledProbeIndexes = new Int32Array(ddTrace[probeSamplerBufferSymbol])
-    const oneSecondNs = 1000000000n
+    const oneSecondNs = 1_000_000_000n
     let globalSnapshotSamplingRateWindowStart = 0n
     let snapshotsSampledWithinTheLastSecond = 0
 
@@ -87,6 +87,15 @@ function getInstallSamplerExpression () {
         const lastCaptureNs = lastCaptureNsByProbeId.get(probeId)
         if (lastCaptureNs !== undefined && now - lastCaptureNs < nsBetweenSampling) return false
 
+        let shouldResetGlobalSnapshotRateWindow = false
+        if (isSnapshotProducingProbe === true) {
+          if (now - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
+            shouldResetGlobalSnapshotRateWindow = true
+          } else if (snapshotsSampledWithinTheLastSecond >= ${MAX_SNAPSHOTS_PER_SECOND_GLOBALLY}) {
+            return false
+          }
+        }
+
         const sampledProbeCount = Atomics.add(sampledProbeIndexes, ${SAMPLED_PROBE_COUNT_INDEX}, 1)
         if (sampledProbeCount >= ${MAX_SAMPLED_PROBES_PER_PAUSE}) {
           Atomics.store(sampledProbeIndexes, ${SAMPLED_PROBE_OVERFLOW_INDEX}, 1)
@@ -94,11 +103,9 @@ function getInstallSamplerExpression () {
         }
 
         if (isSnapshotProducingProbe === true) {
-          if (now - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
+          if (shouldResetGlobalSnapshotRateWindow === true) {
             snapshotsSampledWithinTheLastSecond = 1
             globalSnapshotSamplingRateWindowStart = now
-          } else if (snapshotsSampledWithinTheLastSecond >= ${MAX_SNAPSHOTS_PER_SECOND_GLOBALLY}) {
-            return false
           } else {
             snapshotsSampledWithinTheLastSecond++
           }

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -38,6 +38,10 @@ function compileBreakpointCondition (probes) {
     probeConditions.push(compileProbeCondition(probe))
   }
 
+  // NOTE: $dd_sampler is read from the realm-local `globalThis` where it was installed (the main
+  // realm). A probe whose code runs in a different V8 realm (e.g. a `vm.createContext` script with a
+  // file-path filename) won't see it and will silently never fire. Known limitation: a breakpoint
+  // condition has no realm-independent handle to reach, so we degrade rather than crash.
   return `(() => {
     const $dd_sampler = ${getSamplerExpression()}
     if ($dd_sampler === undefined) return false

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -1,125 +1,10 @@
 'use strict'
 
-const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('./defaults')
-
-const DD_TRACE_SYMBOL = 'dd-trace'
-const PROBE_SAMPLER_SYMBOL = 'dd-trace.debugger.probeSampler'
-const PROBE_SAMPLER_BUFFER_SYMBOL = 'dd-trace.debugger.probeSamplerBuffer'
-
-// Shared buffer layout. These constants are used by both the main debugger bootstrap and the devtools worker.
-const MAX_SAMPLED_PROBES_PER_PAUSE = 256
-const SAMPLED_PROBE_COUNT_INDEX = 0
-const SAMPLED_PROBE_OVERFLOW_INDEX = 1
-const SAMPLED_PROBE_INDEXES_START = 2
+const { DD_TRACE_SYMBOL, PROBE_SAMPLER_SYMBOL } = require('../probe_sampler_constants')
 
 module.exports = {
   compileBreakpointCondition,
-  createProbeSamplerBuffer,
-  getInstallSamplerExpression,
   getRemoveProbeExpression,
-  MAX_SAMPLED_PROBES_PER_PAUSE,
-  SAMPLED_PROBE_COUNT_INDEX,
-  SAMPLED_PROBE_INDEXES_START,
-  SAMPLED_PROBE_OVERFLOW_INDEX,
-  setProbeSamplerBuffer,
-}
-
-function getSamplerExpression () {
-  return `globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]?.` +
-    `[Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})]`
-}
-
-// Main-thread setup helpers.
-
-/**
- * Create the shared buffer used to hand sampled probe indexes from breakpoint conditions to the debugger worker. Called
- * by the main debugger bootstrap before the worker starts.
- *
- * @returns {SharedArrayBuffer}
- */
-function createProbeSamplerBuffer () {
-  return new SharedArrayBuffer(
-    (SAMPLED_PROBE_INDEXES_START + MAX_SAMPLED_PROBES_PER_PAUSE) * Int32Array.BYTES_PER_ELEMENT
-  )
-}
-
-/**
- * Expose the shared sampler buffer to breakpoint condition expressions in the debuggee context. Called by the main
- * debugger bootstrap.
- *
- * @param {SharedArrayBuffer} buffer - The shared sampler buffer.
- */
-function setProbeSamplerBuffer (buffer) {
-  const ddTrace = /** @type {Record<symbol, SharedArrayBuffer>} */ (
-    /** @type {Record<symbol, unknown>} */ (globalThis)[Symbol.for(DD_TRACE_SYMBOL)]
-  )
-  ddTrace[Symbol.for(PROBE_SAMPLER_BUFFER_SYMBOL)] = buffer
-  const sampledProbeIndexes = new Int32Array(buffer)
-  Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 0)
-  Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 0)
-}
-
-// Worker-side generated expression helpers.
-
-/**
- * Build the expression that installs the runtime sampler in the debuggee context. Called by the devtools worker and
- * evaluated on the debuggee.
- *
- * @returns {string}
- */
-function getInstallSamplerExpression () {
-  return `(() => {
-    const ddTrace = globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]
-    const probeSamplerSymbol = Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})
-    const probeSamplerBufferSymbol = Symbol.for(${JSON.stringify(PROBE_SAMPLER_BUFFER_SYMBOL)})
-    if (ddTrace[probeSamplerBufferSymbol] === undefined) return
-
-    const lastCaptureNsByProbeId = new Map()
-    const sampledProbeIndexes = new Int32Array(ddTrace[probeSamplerBufferSymbol])
-    const oneSecondNs = 1_000_000_000n
-    let globalSnapshotSamplingRateWindowStart = 0n
-    let snapshotsSampledWithinTheLastSecond = 0
-
-    ddTrace[probeSamplerSymbol] = {
-      makeSampleDecision (probeIndex, probeId, nsBetweenSampling, isSnapshotProducingProbe) {
-        const now = globalThis.process.hrtime.bigint()
-        const lastCaptureNs = lastCaptureNsByProbeId.get(probeId)
-        if (lastCaptureNs !== undefined && now - lastCaptureNs < nsBetweenSampling) return false
-
-        let shouldResetGlobalSnapshotRateWindow = false
-        if (isSnapshotProducingProbe === true) {
-          if (now - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
-            shouldResetGlobalSnapshotRateWindow = true
-          } else if (snapshotsSampledWithinTheLastSecond >= ${MAX_SNAPSHOTS_PER_SECOND_GLOBALLY}) {
-            return false
-          }
-        }
-
-        const sampledProbeCount = Atomics.add(sampledProbeIndexes, ${SAMPLED_PROBE_COUNT_INDEX}, 1)
-        if (sampledProbeCount >= ${MAX_SAMPLED_PROBES_PER_PAUSE}) {
-          Atomics.store(sampledProbeIndexes, ${SAMPLED_PROBE_OVERFLOW_INDEX}, 1)
-          return false
-        }
-
-        if (isSnapshotProducingProbe === true) {
-          if (shouldResetGlobalSnapshotRateWindow === true) {
-            snapshotsSampledWithinTheLastSecond = 1
-            globalSnapshotSamplingRateWindowStart = now
-          } else {
-            snapshotsSampledWithinTheLastSecond++
-          }
-        }
-
-        lastCaptureNsByProbeId.set(probeId, now)
-        Atomics.store(sampledProbeIndexes, ${SAMPLED_PROBE_INDEXES_START} + sampledProbeCount, probeIndex)
-        return true
-      },
-
-      remove (probeId) {
-        lastCaptureNsByProbeId.delete(probeId)
-      }
-    }
-  })()`
 }
 
 /**
@@ -188,4 +73,9 @@ function compileProbeCondition (probe) {
         $dd_sampled = ${sample} || $dd_sampled
       }
     } catch {}`
+}
+
+function getSamplerExpression () {
+  return `globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]?.` +
+    `[Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})]`
 }

--- a/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/devtools_client/probe_sampler.js
@@ -2,6 +2,9 @@
 
 const { DD_TRACE_SYMBOL, PROBE_SAMPLER_SYMBOL } = require('../probe_sampler_constants')
 
+const SAMPLER_EXPRESSION = `globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]?.` +
+  `[Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})]`
+
 module.exports = {
   compileBreakpointCondition,
   getRemoveProbeExpression,
@@ -15,7 +18,7 @@ module.exports = {
  * @returns {string}
  */
 function getRemoveProbeExpression (id) {
-  return `${getSamplerExpression()}?.remove(${JSON.stringify(id)})`
+  return `${SAMPLER_EXPRESSION}?.remove(${JSON.stringify(id)})`
 }
 
 /**
@@ -43,7 +46,7 @@ function compileBreakpointCondition (probes) {
   // file-path filename) won't see it and will silently never fire. Known limitation: a breakpoint
   // condition has no realm-independent handle to reach, so we degrade rather than crash.
   return `(() => {
-    const $dd_sampler = ${getSamplerExpression()}
+    const $dd_sampler = ${SAMPLER_EXPRESSION}
     if ($dd_sampler === undefined) return false
     let $dd_sampled = false
     ${probeConditions.join('\n    ')}
@@ -77,9 +80,4 @@ function compileProbeCondition (probe) {
         $dd_sampled = ${sample} || $dd_sampled
       }
     } catch {}`
-}
-
-function getSamplerExpression () {
-  return `globalThis[Symbol.for(${JSON.stringify(DD_TRACE_SYMBOL)})]?.` +
-    `[Symbol.for(${JSON.stringify(PROBE_SAMPLER_SYMBOL)})]`
 }

--- a/packages/dd-trace/src/debugger/devtools_client/state.js
+++ b/packages/dd-trace/src/debugger/devtools_client/state.js
@@ -33,6 +33,7 @@ module.exports = {
   locationToBreakpoint: new Map(),
   breakpointToProbes: new Map(),
   probeToLocation: new Map(),
+  samplingIndexToProbe: new Map(),
 
   _loadedScripts: loadedScripts, // Only exposed for testing
   _scriptUrls: scriptUrls, // Only exposed for testing

--- a/packages/dd-trace/src/debugger/index.js
+++ b/packages/dd-trace/src/debugger/index.js
@@ -8,7 +8,7 @@ const log = require('../log')
 const { fetchAgentInfo } = require('../agent/info')
 const getDebuggerConfig = require('./config')
 const { DEBUGGER_DIAGNOSTICS_V1, DEBUGGER_INPUT_V2 } = require('./constants')
-const { createProbeSamplerBuffer, setProbeSamplerBuffer } = require('./devtools_client/probe_sampler')
+const { installProbeSampler, uninstallProbeSampler } = require('./probe_sampler')
 
 /**
  * @typedef {ReturnType<import('../config')>} Config
@@ -63,10 +63,10 @@ function start (config, rcInstance) {
   const probeChannel = new MessageChannel()
   const logChannel = new MessageChannel()
   configChannel = new MessageChannel()
-  const probeSamplerBuffer = createProbeSamplerBuffer()
 
   globalThis[Symbol.for('dd-trace')].utilTypes = types
-  setProbeSamplerBuffer(probeSamplerBuffer)
+
+  const probeSamplerBuffer = installProbeSampler()
 
   readProbeFile(config.dynamicInstrumentation.probeFile, (probes) => {
     const action = 'apply'
@@ -191,6 +191,7 @@ function cleanup (error) {
     worker.removeAllListeners()
     worker = null
   }
+  uninstallProbeSampler()
   configChannel = null
   inputPath = null
 

--- a/packages/dd-trace/src/debugger/index.js
+++ b/packages/dd-trace/src/debugger/index.js
@@ -8,6 +8,7 @@ const log = require('../log')
 const { fetchAgentInfo } = require('../agent/info')
 const getDebuggerConfig = require('./config')
 const { DEBUGGER_DIAGNOSTICS_V1, DEBUGGER_INPUT_V2 } = require('./constants')
+const { createProbeSamplerBuffer, setProbeSamplerBuffer } = require('./devtools_client/probe_sampler')
 
 /**
  * @typedef {ReturnType<import('../config')>} Config
@@ -62,8 +63,10 @@ function start (config, rcInstance) {
   const probeChannel = new MessageChannel()
   const logChannel = new MessageChannel()
   configChannel = new MessageChannel()
+  const probeSamplerBuffer = createProbeSamplerBuffer()
 
   globalThis[Symbol.for('dd-trace')].utilTypes = types
+  setProbeSamplerBuffer(probeSamplerBuffer)
 
   readProbeFile(config.dynamicInstrumentation.probeFile, (probes) => {
     const action = 'apply'
@@ -110,6 +113,7 @@ function start (config, rcInstance) {
           probePort: probeChannel.port1,
           logPort: logChannel.port1,
           configPort: configChannel.port1,
+          probeSamplerBuffer,
         },
         transferList: [probeChannel.port1, logChannel.port1, configChannel.port1],
       }

--- a/packages/dd-trace/src/debugger/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/probe_sampler.js
@@ -86,7 +86,7 @@ function installProbeSampler () {
      */
     remove (probeId) {
       lastCaptureNsByProbeId.delete(probeId)
-    }
+    },
   }
 
   return buffer

--- a/packages/dd-trace/src/debugger/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/probe_sampler.js
@@ -1,0 +1,124 @@
+'use strict'
+
+const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('./devtools_client/defaults')
+const {
+  DD_TRACE_SYMBOL,
+  MAX_SAMPLED_PROBES_PER_PAUSE,
+  PROBE_SAMPLER_BUFFER_SYMBOL,
+  PROBE_SAMPLER_SYMBOL,
+  SAMPLED_PROBE_COUNT_INDEX,
+  SAMPLED_PROBE_INDEXES_START,
+  SAMPLED_PROBE_OVERFLOW_INDEX,
+} = require('./probe_sampler_constants')
+
+module.exports = {
+  installProbeSampler,
+  uninstallProbeSampler,
+}
+
+/**
+ * Install the runtime sampler in the debuggee context.
+ *
+ * @returns {SharedArrayBuffer} The shared sampler buffer to pass to the debugger worker.
+ */
+function installProbeSampler () {
+  const ddTrace = getDatadogGlobal()
+  const buffer = createProbeSamplerBuffer()
+  ddTrace[Symbol.for(PROBE_SAMPLER_BUFFER_SYMBOL)] = buffer
+
+  const lastCaptureNsByProbeId = new Map()
+  const sampledProbeIndexes = new Int32Array(buffer)
+  Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 0)
+  Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 0)
+
+  const oneSecondNs = 1_000_000_000n
+  let globalSnapshotSamplingRateWindowStart = 0n
+  let snapshotsSampledWithinTheLastSecond = 0
+
+  ddTrace[Symbol.for(PROBE_SAMPLER_SYMBOL)] = {
+    /**
+     * Decide if a probe should be sampled and store sampled probe indexes for the debugger worker.
+     *
+     * @param {number} probeIndex - The worker-side probe sampling index.
+     * @param {string} probeId - The probe id.
+     * @param {bigint} nsBetweenSampling - Minimum nanoseconds between samples for this probe.
+     * @param {boolean} isSnapshotProducingProbe - Whether this probe counts toward the global snapshot sample limit.
+     * @returns {boolean} Whether this probe should make the breakpoint condition pause.
+     */
+    makeSampleDecision (probeIndex, probeId, nsBetweenSampling, isSnapshotProducingProbe) {
+      const now = process.hrtime.bigint()
+      const lastCaptureNs = lastCaptureNsByProbeId.get(probeId)
+      if (lastCaptureNs !== undefined && now - lastCaptureNs < nsBetweenSampling) return false
+
+      let shouldResetGlobalSnapshotRateWindow = false
+      if (isSnapshotProducingProbe === true) {
+        if (now - globalSnapshotSamplingRateWindowStart > oneSecondNs) {
+          shouldResetGlobalSnapshotRateWindow = true
+        } else if (snapshotsSampledWithinTheLastSecond >= MAX_SNAPSHOTS_PER_SECOND_GLOBALLY) {
+          return false
+        }
+      }
+
+      const sampledProbeCount = Atomics.add(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 1)
+      if (sampledProbeCount >= MAX_SAMPLED_PROBES_PER_PAUSE) {
+        Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 1)
+        return false
+      }
+
+      if (isSnapshotProducingProbe === true) {
+        if (shouldResetGlobalSnapshotRateWindow === true) {
+          snapshotsSampledWithinTheLastSecond = 1
+          globalSnapshotSamplingRateWindowStart = now
+        } else {
+          snapshotsSampledWithinTheLastSecond++
+        }
+      }
+
+      lastCaptureNsByProbeId.set(probeId, now)
+      Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_INDEXES_START + sampledProbeCount, probeIndex)
+      return true
+    },
+
+    /**
+     * Remove cached sampling state for a probe.
+     *
+     * @param {string} probeId - The probe id.
+     */
+    remove (probeId) {
+      lastCaptureNsByProbeId.delete(probeId)
+    }
+  }
+
+  return buffer
+}
+
+/**
+ * Remove the runtime sampler and shared buffer from the debuggee context.
+ */
+function uninstallProbeSampler () {
+  const ddTrace = getDatadogGlobal()
+  delete ddTrace[Symbol.for(PROBE_SAMPLER_SYMBOL)]
+  delete ddTrace[Symbol.for(PROBE_SAMPLER_BUFFER_SYMBOL)]
+}
+
+/**
+ * Get the Datadog global object.
+ *
+ * @returns {Record<symbol, SharedArrayBuffer | object | undefined>}
+ */
+function getDatadogGlobal () {
+  return /** @type {Record<symbol, SharedArrayBuffer | object | undefined>} */ (
+    /** @type {Record<symbol, unknown>} */ (globalThis)[Symbol.for(DD_TRACE_SYMBOL)]
+  )
+}
+
+/**
+ * Create the shared buffer used to hand sampled probe indexes from breakpoint conditions to the debugger worker.
+ *
+ * @returns {SharedArrayBuffer}
+ */
+function createProbeSamplerBuffer () {
+  return new SharedArrayBuffer(
+    (SAMPLED_PROBE_INDEXES_START + MAX_SAMPLED_PROBES_PER_PAUSE) * Int32Array.BYTES_PER_ELEMENT
+  )
+}

--- a/packages/dd-trace/src/debugger/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/probe_sampler.js
@@ -10,6 +10,10 @@ const {
   SAMPLED_PROBE_OVERFLOW_INDEX,
 } = require('./probe_sampler_constants')
 
+const ddTraceGlobal = /** @type {Record<symbol, SharedArrayBuffer | object | undefined>} */ (
+  /** @type {Record<symbol, unknown>} */ (globalThis)[Symbol.for(DD_TRACE_SYMBOL)]
+)
+
 module.exports = {
   installProbeSampler,
   uninstallProbeSampler,
@@ -21,7 +25,6 @@ module.exports = {
  * @returns {SharedArrayBuffer} The shared sampler buffer to pass to the debugger worker.
  */
 function installProbeSampler () {
-  const ddTrace = getDatadogGlobal()
   const buffer = createProbeSamplerBuffer()
 
   const lastCaptureNsByProbeId = new Map()
@@ -33,7 +36,7 @@ function installProbeSampler () {
   let globalSnapshotSamplingRateWindowStart = 0n
   let snapshotsSampledWithinTheLastSecond = 0
 
-  ddTrace[Symbol.for(PROBE_SAMPLER_SYMBOL)] = {
+  ddTraceGlobal[Symbol.for(PROBE_SAMPLER_SYMBOL)] = {
     /**
      * Decide if a probe should be sampled and store sampled probe indexes for the debugger worker.
      *
@@ -94,19 +97,7 @@ function installProbeSampler () {
  * Remove the runtime sampler from the debuggee context.
  */
 function uninstallProbeSampler () {
-  const ddTrace = getDatadogGlobal()
-  delete ddTrace[Symbol.for(PROBE_SAMPLER_SYMBOL)]
-}
-
-/**
- * Get the Datadog global object.
- *
- * @returns {Record<symbol, SharedArrayBuffer | object | undefined>}
- */
-function getDatadogGlobal () {
-  return /** @type {Record<symbol, SharedArrayBuffer | object | undefined>} */ (
-    /** @type {Record<symbol, unknown>} */ (globalThis)[Symbol.for(DD_TRACE_SYMBOL)]
-  )
+  delete ddTraceGlobal[Symbol.for(PROBE_SAMPLER_SYMBOL)]
 }
 
 /**

--- a/packages/dd-trace/src/debugger/probe_sampler.js
+++ b/packages/dd-trace/src/debugger/probe_sampler.js
@@ -4,7 +4,6 @@ const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('./devtools_client/default
 const {
   DD_TRACE_SYMBOL,
   MAX_SAMPLED_PROBES_PER_PAUSE,
-  PROBE_SAMPLER_BUFFER_SYMBOL,
   PROBE_SAMPLER_SYMBOL,
   SAMPLED_PROBE_COUNT_INDEX,
   SAMPLED_PROBE_INDEXES_START,
@@ -24,7 +23,6 @@ module.exports = {
 function installProbeSampler () {
   const ddTrace = getDatadogGlobal()
   const buffer = createProbeSamplerBuffer()
-  ddTrace[Symbol.for(PROBE_SAMPLER_BUFFER_SYMBOL)] = buffer
 
   const lastCaptureNsByProbeId = new Map()
   const sampledProbeIndexes = new Int32Array(buffer)
@@ -93,12 +91,11 @@ function installProbeSampler () {
 }
 
 /**
- * Remove the runtime sampler and shared buffer from the debuggee context.
+ * Remove the runtime sampler from the debuggee context.
  */
 function uninstallProbeSampler () {
   const ddTrace = getDatadogGlobal()
   delete ddTrace[Symbol.for(PROBE_SAMPLER_SYMBOL)]
-  delete ddTrace[Symbol.for(PROBE_SAMPLER_BUFFER_SYMBOL)]
 }
 
 /**

--- a/packages/dd-trace/src/debugger/probe_sampler_constants.js
+++ b/packages/dd-trace/src/debugger/probe_sampler_constants.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const DD_TRACE_SYMBOL = 'dd-trace'
+const PROBE_SAMPLER_SYMBOL = 'dd-trace.debugger.probeSampler'
+const PROBE_SAMPLER_BUFFER_SYMBOL = 'dd-trace.debugger.probeSamplerBuffer'
+
+// Shared sampler contract used by the main debugger bootstrap and the devtools worker.
+const MAX_SAMPLED_PROBES_PER_PAUSE = 256
+const SAMPLED_PROBE_COUNT_INDEX = 0
+const SAMPLED_PROBE_OVERFLOW_INDEX = 1
+const SAMPLED_PROBE_INDEXES_START = 2
+
+module.exports = {
+  DD_TRACE_SYMBOL,
+  MAX_SAMPLED_PROBES_PER_PAUSE,
+  PROBE_SAMPLER_BUFFER_SYMBOL,
+  PROBE_SAMPLER_SYMBOL,
+  SAMPLED_PROBE_COUNT_INDEX,
+  SAMPLED_PROBE_INDEXES_START,
+  SAMPLED_PROBE_OVERFLOW_INDEX,
+}

--- a/packages/dd-trace/src/debugger/probe_sampler_constants.js
+++ b/packages/dd-trace/src/debugger/probe_sampler_constants.js
@@ -2,7 +2,6 @@
 
 const DD_TRACE_SYMBOL = 'dd-trace'
 const PROBE_SAMPLER_SYMBOL = 'dd-trace.debugger.probeSampler'
-const PROBE_SAMPLER_BUFFER_SYMBOL = 'dd-trace.debugger.probeSamplerBuffer'
 
 // Shared sampler contract used by the main debugger bootstrap and the devtools worker.
 const MAX_SAMPLED_PROBES_PER_PAUSE = 256
@@ -13,7 +12,6 @@ const SAMPLED_PROBE_INDEXES_START = 2
 module.exports = {
   DD_TRACE_SYMBOL,
   MAX_SAMPLED_PROBES_PER_PAUSE,
-  PROBE_SAMPLER_BUFFER_SYMBOL,
   PROBE_SAMPLER_SYMBOL,
   SAMPLED_PROBE_COUNT_INDEX,
   SAMPLED_PROBE_INDEXES_START,

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -103,8 +103,7 @@ describe('breakpoints', function () {
       await addProbe()
 
       sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate')
-      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
         location: {
           scriptId: 'script-1',
           lineNumber: 9,
@@ -112,7 +111,7 @@ describe('breakpoints', function () {
         },
         condition: compileBreakpointCondition([{ id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n }]),
       })
-      sinon.assert.calledThrice(sessionMock.post)
+      sinon.assert.calledTwice(sessionMock.post)
     })
 
     it('should not enable debugger for subsequent breakpoints', async function () {
@@ -135,10 +134,9 @@ describe('breakpoints', function () {
       ])
 
       sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate')
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint')
       sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint')
-      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint')
-      sinon.assert.callCount(sessionMock.post, 4)
+      sinon.assert.calledThrice(sessionMock.post)
 
       sinon.assert.calledWith(stateMock.findScriptFromPartialPath.firstCall, 'test.js')
       sinon.assert.calledWith(stateMock.findScriptFromPartialPath.secondCall, 'test2.js')
@@ -415,11 +413,10 @@ describe('breakpoints', function () {
           addProbe({ id: 'probe-2' }),
         ])
         sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-        sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate')
-        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint')
-        sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.removeBreakpoint')
-        sinon.assert.calledWith(sessionMock.post.getCall(4), 'Debugger.setBreakpoint')
-        sinon.assert.callCount(sessionMock.post, 5)
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint')
+      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.removeBreakpoint')
+      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint')
+      sinon.assert.callCount(sessionMock.post, 4)
       })
     })
 
@@ -613,9 +610,8 @@ describe('breakpoints', function () {
       })
       sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.disable')
       sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Runtime.evaluate')
-      sinon.assert.calledWith(sessionMock.post.getCall(4), 'Debugger.setBreakpoint')
-      sinon.assert.callCount(sessionMock.post, 5)
+      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint')
+      sinon.assert.callCount(sessionMock.post, 4)
     })
 
     it('should not disable the debugger if a new probe is in the process of being added', async function () {
@@ -842,8 +838,7 @@ describe('breakpoints', function () {
       })
       sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.disable')
       sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Runtime.evaluate')
-      sinon.assert.calledWith(sessionMock.post.getCall(4), 'Debugger.setBreakpoint', {
+      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint', {
         location: {
           scriptId: 'script-1',
           lineNumber: 9,
@@ -853,7 +848,7 @@ describe('breakpoints', function () {
           { id: 'probe-1', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
         ]),
       })
-      sinon.assert.callCount(sessionMock.post, 5)
+      sinon.assert.callCount(sessionMock.post, 4)
     })
 
     it('should re-add the probe when there are other active probes', async function () {

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -25,6 +25,14 @@ describe('breakpoints', function () {
   let sessionMock
   /**
    * @type {{
+   *   debug: sinon.SinonStub;
+   *   error: sinon.SinonStub;
+   *   '@noCallThru': boolean;
+   * }}
+   */
+  let logMock
+  /**
+   * @type {{
    *   findScriptFromPartialPath: sinon.SinonStub;
    *   clearState: sinon.SinonStub;
    *   locationToBreakpoint: Map<string, {
@@ -77,6 +85,12 @@ describe('breakpoints', function () {
       '@noCallThru': true,
     }
 
+    logMock = {
+      debug: sinon.stub(),
+      error: sinon.stub(),
+      '@noCallThru': true,
+    }
+
     stateMock = {
       findScriptFromPartialPath: sinon.stub().returns({
         url: 'file:///path/to/test.js',
@@ -95,6 +109,7 @@ describe('breakpoints', function () {
     breakpoints = proxyquire('../../../src/debugger/devtools_client/breakpoints', {
       './session': sessionMock,
       './state': stateMock,
+      './log': logMock,
     })
   })
 
@@ -453,6 +468,57 @@ describe('breakpoints', function () {
         })
     })
 
+    it('should wrap errors when replacing a breakpoint while adding a probe fails', async function () {
+      await addProbe()
+      sessionMock.post.resetHistory()
+
+      const cause = new Error('inspector failure')
+      sessionMock.post.callsFake((method, { location } = {}) => {
+        if (method === 'Debugger.removeBreakpoint') {
+          return Promise.reject(cause)
+        }
+        if (method === 'Debugger.setBreakpoint') {
+          return Promise.resolve({
+            breakpointId: `bp-${location.scriptId}:${location.lineNumber}:${location.columnNumber}`,
+          })
+        }
+        return Promise.resolve({})
+      })
+
+      await assert.rejects(
+        addProbe({ id: 'probe-2' }),
+        (err) => {
+          assert(err instanceof Error)
+          assert.strictEqual(err.message, 'Error replacing breakpoint while adding probe probe-2 (version: 1)')
+          assert.strictEqual(err.cause, cause)
+          return true
+        }
+      )
+    })
+
+    it('should wrap errors when setting a replacement breakpoint while adding a probe fails', async function () {
+      await addProbe()
+      sessionMock.post.resetHistory()
+
+      const cause = new Error('inspector failure')
+      sessionMock.post.callsFake((method, { location } = {}) => {
+        if (method === 'Debugger.setBreakpoint') {
+          return Promise.reject(cause)
+        }
+        return Promise.resolve({})
+      })
+
+      await assert.rejects(
+        addProbe({ id: 'probe-2' }),
+        (err) => {
+          assert(err instanceof Error)
+          assert.strictEqual(err.message, 'Error setting breakpoint while adding probe probe-2 (version: 1)')
+          assert.strictEqual(err.cause, cause)
+          return true
+        }
+      )
+    })
+
     describe('captureExpressions', function () {
       it('should compile capture expressions', async function () {
         await addProbe({
@@ -632,6 +698,35 @@ describe('breakpoints', function () {
       sinon.assert.calledThrice(sessionMock.post)
     })
 
+    it('should log and continue if removing a probe from the runtime sampler fails', async function () {
+      await addProbe()
+      sessionMock.post.resetHistory()
+      logMock.error.resetHistory()
+
+      const cause = new Error('runtime failure')
+      sessionMock.post.callsFake((method, { location } = {}) => {
+        if (method === 'Runtime.evaluate') {
+          return Promise.reject(cause)
+        }
+        if (method === 'Debugger.setBreakpoint') {
+          return Promise.resolve({
+            breakpointId: `bp-${location.scriptId}:${location.lineNumber}:${location.columnNumber}`,
+          })
+        }
+        return Promise.resolve({})
+      })
+
+      await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+      sinon.assert.calledWith(
+        logMock.error,
+        '[debugger:devtools_client] Error removing probe %s from sampler',
+        'probe-1',
+        cause
+      )
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.disable')
+    })
+
     describe('update breakpoint when removing one of multiple probes at the same location', function () {
       it('no conditions', async function () {
         await addProbe()
@@ -791,6 +886,59 @@ describe('breakpoints', function () {
           ]),
         })
         sinon.assert.calledThrice(sessionMock.post)
+      })
+
+      it('should wrap errors when removing the existing breakpoint fails', async function () {
+        await addProbe()
+        await addProbe({ id: 'probe-2' })
+        sessionMock.post.resetHistory()
+
+        const cause = new Error('inspector failure')
+        sessionMock.post.callsFake((method, { location } = {}) => {
+          if (method === 'Debugger.removeBreakpoint') {
+            return Promise.reject(cause)
+          }
+          if (method === 'Debugger.setBreakpoint') {
+            return Promise.resolve({
+              breakpointId: `bp-${location.scriptId}:${location.lineNumber}:${location.columnNumber}`,
+            })
+          }
+          return Promise.resolve({})
+        })
+
+        await assert.rejects(
+          breakpoints.removeBreakpoint({ id: 'probe-1' }),
+          (err) => {
+            assert(err instanceof Error)
+            assert.strictEqual(err.message, 'Error replacing breakpoint after removing probe from script-1:10:0')
+            assert.strictEqual(err.cause, cause)
+            return true
+          }
+        )
+      })
+
+      it('should wrap errors when setting the replacement breakpoint fails', async function () {
+        await addProbe()
+        await addProbe({ id: 'probe-2' })
+        sessionMock.post.resetHistory()
+
+        const cause = new Error('inspector failure')
+        sessionMock.post.callsFake((method) => {
+          if (method === 'Debugger.setBreakpoint') {
+            return Promise.reject(cause)
+          }
+          return Promise.resolve({})
+        })
+
+        await assert.rejects(
+          breakpoints.removeBreakpoint({ id: 'probe-1' }),
+          (err) => {
+            assert(err instanceof Error)
+            assert.strictEqual(err.message, 'Error setting breakpoint after removing probe from script-1:10:0')
+            assert.strictEqual(err.cause, cause)
+            return true
+          }
+        )
       })
     })
 

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -413,10 +413,10 @@ describe('breakpoints', function () {
           addProbe({ id: 'probe-2' }),
         ])
         sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint')
-      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.removeBreakpoint')
-      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint')
-      sinon.assert.callCount(sessionMock.post, 4)
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint')
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.removeBreakpoint')
+        sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint')
+        sinon.assert.callCount(sessionMock.post, 4)
       })
     })
 

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -10,6 +10,8 @@ const sinon = require('sinon')
 const { assertObjectContains } = require('../../../../../integration-tests/helpers')
 require('../../setup/mocha')
 
+const { compileBreakpointCondition } = require('../../../src/debugger/devtools_client/probe_sampler')
+
 describe('breakpoints', function () {
   /** @type {typeof import('../../../src/debugger/devtools_client/breakpoints')} */
   let breakpoints
@@ -33,6 +35,7 @@ describe('breakpoints', function () {
    *   breakpointToProbes: Map<string, Map<string, {
    *     id: string;
    *     version: number;
+   *     samplingIndex: number;
    *     where: { sourceFile: string; lines: string[] };
    *     when: { json: { eq: [{ ref: string; value: unknown }]; dsl: string }; dsl: string };
    *     sampling?: { snapshotsPerSecond: number };
@@ -41,12 +44,12 @@ describe('breakpoints', function () {
    *     location: { file: string; lines: string[] };
    *     templateRequiresEvaluation: boolean;
    *     template: string;
-   *     lastCaptureNs: bigint;
    *     nsBetweenSampling: bigint;
    *     compiledCaptureExpressions?:
    *       import('../../../src/debugger/devtools_client/snapshot').CompiledCaptureExpression[];
    *   }>>;
    *   probeToLocation: Map<string, string>;
+   *   samplingIndexToProbe: Map<number, object>;
    *   '@noCallThru': boolean;
    * }}
    */
@@ -64,6 +67,10 @@ describe('breakpoints', function () {
         }
         return Promise.resolve({})
       }),
+      /**
+       * @param {string} event
+       * @param {Function} callback
+       */
       on (event, callback) {
         if (event === 'scriptLoadingStabilized') callback()
       },
@@ -81,6 +88,7 @@ describe('breakpoints', function () {
       locationToBreakpoint: new Map(),
       breakpointToProbes: new Map(),
       probeToLocation: new Map(),
+      samplingIndexToProbe: new Map(),
       '@noCallThru': true,
     }
 
@@ -95,15 +103,16 @@ describe('breakpoints', function () {
       await addProbe()
 
       sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate')
+      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
         location: {
           scriptId: 'script-1',
           lineNumber: 9,
           columnNumber: 0,
         },
-        condition: undefined,
+        condition: compileBreakpointCondition([{ id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n }]),
       })
-      sinon.assert.calledTwice(sessionMock.post)
+      sinon.assert.calledThrice(sessionMock.post)
     })
 
     it('should not enable debugger for subsequent breakpoints', async function () {
@@ -126,16 +135,17 @@ describe('breakpoints', function () {
       ])
 
       sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint')
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate')
       sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint')
-      sinon.assert.calledThrice(sessionMock.post)
+      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.setBreakpoint')
+      sinon.assert.callCount(sessionMock.post, 4)
 
       sinon.assert.calledWith(stateMock.findScriptFromPartialPath.firstCall, 'test.js')
       sinon.assert.calledWith(stateMock.findScriptFromPartialPath.secondCall, 'test2.js')
       sinon.assert.calledTwice(stateMock.findScriptFromPartialPath)
     })
 
-    it('should initialize lastCaptureNs to ensure first probe hit is always captured', async function () {
+    it('should set the probe sampling interval', async function () {
       await addProbe({ sampling: { snapshotsPerSecond: 0.5 } })
 
       // Verify the probe was stored in the breakpointToProbes map
@@ -144,10 +154,6 @@ describe('breakpoints', function () {
 
       const probe = probesAtLocation.get('probe-1')
       assert(probe, 'Probe should be stored in map')
-
-      // Verify lastCaptureNs is initialized to -(2^53 - 1) to ensure first hit is always captured
-      assert.strictEqual(probe.lastCaptureNs, BigInt(Number.MIN_SAFE_INTEGER),
-        'lastCaptureNs should be initialized to -(2^53 - 1) to ensure first probe hit is always captured')
 
       // Verify nsBetweenSampling is calculated correctly
       assert.strictEqual(
@@ -297,7 +303,19 @@ describe('breakpoints', function () {
         // Add second probe to same location
         await addProbe({ id: 'probe-2' })
 
-        sinon.assert.notCalled(sessionMock.post)
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0,
+          },
+          condition: compileBreakpointCondition([
+            { id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n },
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n },
+          ]),
+        })
+        sinon.assert.calledTwice(sessionMock.post)
       })
 
       it('mixed: 2nd probe no condition', async function () {
@@ -312,7 +330,7 @@ describe('breakpoints', function () {
         // Add second probe to same location
         await addProbe({ id: 'probe-2' })
 
-        // Should remove previous breakpoint and create a new one with both conditions
+        // Should remove previous breakpoint and create a new one with both probes in the sampler condition
         sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
         sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
           location: {
@@ -320,7 +338,10 @@ describe('breakpoints', function () {
             lineNumber: 9,
             columnNumber: 0,
           },
-          condition: undefined,
+          condition: compileBreakpointCondition([
+            { id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n },
+          ]),
         })
         sinon.assert.calledTwice(sessionMock.post)
       })
@@ -338,7 +359,19 @@ describe('breakpoints', function () {
           },
         })
 
-        sinon.assert.notCalled(sessionMock.post)
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0,
+          },
+          condition: compileBreakpointCondition([
+            { id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n },
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
+          ]),
+        })
+        sinon.assert.calledTwice(sessionMock.post)
       })
 
       it('all conditions', async function () {
@@ -359,7 +392,7 @@ describe('breakpoints', function () {
           },
         })
 
-        // Should remove previous breakpoint and create a new one with both conditions
+        // Should remove previous breakpoint and create a new one with both probes in the sampler condition
         sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
         sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
           location: {
@@ -367,9 +400,10 @@ describe('breakpoints', function () {
             lineNumber: 9,
             columnNumber: 0,
           },
-          condition:
-            '(() => { try { return (foo) === (42) } catch { return false } })() || ' +
-            '(() => { try { return (foo) === (43) } catch { return false } })()',
+          condition: compileBreakpointCondition([
+            { id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (43)' },
+          ]),
         })
         sinon.assert.calledTwice(sessionMock.post)
       })
@@ -381,8 +415,11 @@ describe('breakpoints', function () {
           addProbe({ id: 'probe-2' }),
         ])
         sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.enable')
-        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint')
-        sinon.assert.calledTwice(sessionMock.post)
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate')
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint')
+        sinon.assert.calledWith(sessionMock.post.getCall(3), 'Debugger.removeBreakpoint')
+        sinon.assert.calledWith(sessionMock.post.getCall(4), 'Debugger.setBreakpoint')
+        sinon.assert.callCount(sessionMock.post, 5)
       })
     })
 
@@ -536,7 +573,11 @@ describe('breakpoints', function () {
 
       await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-      sinon.assert.calledOnceWithExactly(sessionMock.post, 'Debugger.disable')
+      sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+        expression: removeProbeExpression('probe-1'),
+      })
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.disable')
+      sinon.assert.calledTwice(sessionMock.post)
       sinon.assert.calledOnce(stateMock.clearState)
     })
 
@@ -547,10 +588,14 @@ describe('breakpoints', function () {
 
       await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-      sinon.assert.calledOnceWithExactly(sessionMock.post,
+      sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+        expression: removeProbeExpression('probe-1'),
+      })
+      sinon.assert.calledWith(sessionMock.post.secondCall,
         'Debugger.removeBreakpoint',
         { breakpointId }
       )
+      sinon.assert.calledTwice(sessionMock.post)
       sinon.assert.notCalled(stateMock.clearState)
     })
 
@@ -563,10 +608,14 @@ describe('breakpoints', function () {
         addProbe({ id: 'probe-2', where: { sourceFile: 'test2.js', lines: ['20'] } }),
       ])
 
-      sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.disable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint')
-      sinon.assert.calledThrice(sessionMock.post)
+      sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+        expression: removeProbeExpression('probe-1'),
+      })
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.disable')
+      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.enable')
+      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Runtime.evaluate')
+      sinon.assert.calledWith(sessionMock.post.getCall(4), 'Debugger.setBreakpoint')
+      sinon.assert.callCount(sessionMock.post, 5)
     })
 
     it('should not disable the debugger if a new probe is in the process of being added', async function () {
@@ -580,8 +629,11 @@ describe('breakpoints', function () {
       ])
 
       sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.setBreakpoint')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint')
-      sinon.assert.calledTwice(sessionMock.post)
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Runtime.evaluate', {
+        expression: removeProbeExpression('probe-1'),
+      })
+      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.removeBreakpoint')
+      sinon.assert.calledThrice(sessionMock.post)
     })
 
     describe('update breakpoint when removing one of multiple probes at the same location', function () {
@@ -592,7 +644,19 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        sinon.assert.notCalled(sessionMock.post)
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+          expression: removeProbeExpression('probe-1'),
+        })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint', { breakpointId })
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0,
+          },
+          condition: compileBreakpointCondition([{ id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n }]),
+        })
+        sinon.assert.calledThrice(sessionMock.post)
       })
 
       it('mixed: removed probe with no condition', async function () {
@@ -608,16 +672,21 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
-        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+          expression: removeProbeExpression('probe-1'),
+        })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint', { breakpointId })
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
           location: {
             scriptId: 'script-1',
             lineNumber: 9,
             columnNumber: 0,
           },
-          condition: '(foo) === (42)',
+          condition: compileBreakpointCondition([
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
+          ]),
         })
-        sinon.assert.calledTwice(sessionMock.post)
+        sinon.assert.calledThrice(sessionMock.post)
       })
 
       it('mixed: removed probe with condition', async function () {
@@ -632,7 +701,19 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        sinon.assert.notCalled(sessionMock.post)
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+          expression: removeProbeExpression('probe-1'),
+        })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint', { breakpointId })
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0,
+          },
+          condition: compileBreakpointCondition([{ id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n }]),
+        })
+        sinon.assert.calledThrice(sessionMock.post)
       })
 
       it('all conditions', async function () {
@@ -653,16 +734,21 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
-        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+          expression: removeProbeExpression('probe-1'),
+        })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint', { breakpointId })
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
           location: {
             scriptId: 'script-1',
             lineNumber: 9,
             columnNumber: 0,
           },
-          condition: '(foo) === (43)',
+          condition: compileBreakpointCondition([
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (43)' },
+          ]),
         })
-        sinon.assert.calledTwice(sessionMock.post)
+        sinon.assert.calledThrice(sessionMock.post)
       })
 
       it('should use the new breakpoint id after updating conditions', async function () {
@@ -694,16 +780,21 @@ describe('breakpoints', function () {
 
         await breakpoints.removeBreakpoint({ id: 'probe-1' })
 
-        sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId: 'bp-2' })
-        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+          expression: removeProbeExpression('probe-1'),
+        })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint', { breakpointId: 'bp-2' })
+        sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
           location: {
             scriptId: 'script-1',
             lineNumber: 9,
             columnNumber: 0,
           },
-          condition: '(foo) === (43)',
+          condition: compileBreakpointCondition([
+            { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (43)' },
+          ]),
         })
-        sinon.assert.calledTwice(sessionMock.post)
+        sinon.assert.calledThrice(sessionMock.post)
       })
     })
 
@@ -746,17 +837,23 @@ describe('breakpoints', function () {
       })
       await breakpoints.modifyBreakpoint(probe)
 
-      sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.disable')
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.enable')
-      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
+      sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+        expression: removeProbeExpression('probe-1'),
+      })
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.disable')
+      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.enable')
+      sinon.assert.calledWith(sessionMock.post.getCall(3), 'Runtime.evaluate')
+      sinon.assert.calledWith(sessionMock.post.getCall(4), 'Debugger.setBreakpoint', {
         location: {
           scriptId: 'script-1',
           lineNumber: 9,
           columnNumber: 0,
         },
-        condition: '(foo) === (42)',
+        condition: compileBreakpointCondition([
+          { id: 'probe-1', samplingIndex: 1, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
+        ]),
       })
-      sinon.assert.calledThrice(sessionMock.post)
+      sinon.assert.callCount(sessionMock.post, 5)
     })
 
     it('should re-add the probe when there are other active probes', async function () {
@@ -774,19 +871,29 @@ describe('breakpoints', function () {
       })
       await breakpoints.modifyBreakpoint(probe)
 
-      sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId })
-      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+      sinon.assert.calledWith(sessionMock.post.firstCall, 'Runtime.evaluate', {
+        expression: removeProbeExpression('probe-1'),
+      })
+      sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.removeBreakpoint', { breakpointId })
+      sinon.assert.calledWith(sessionMock.post.thirdCall, 'Debugger.setBreakpoint', {
         location: {
           scriptId: 'script-1',
           lineNumber: 9,
           columnNumber: 0,
         },
-        condition: '(foo) === (42)',
+        condition: compileBreakpointCondition([
+          { id: 'probe-1', samplingIndex: 2, nsBetweenSampling: 200000n, condition: '(foo) === (42)' },
+        ]),
       })
-      sinon.assert.calledTwice(sessionMock.post)
+      sinon.assert.calledThrice(sessionMock.post)
     })
   })
 
+  /**
+   * Add a generated probe.
+   *
+   * @param {object} [probe] - Probe config overrides.
+   */
   async function addProbe (probe) {
     await breakpoints.addBreakpoint(genProbeConfig(probe))
   }
@@ -801,14 +908,27 @@ describe('breakpoints', function () {
  * @param {object} [config.where] The location information. Defaults to a test file on line 10.
  * @param {object} [config.when] The condition for the probe.
  *   { json: { eq: [{ ref: 'foo' }, 42] }, dsl: 'foo = 42' } by default.
- * @returns {{ id: string; version: number; where: object; when: object; }}
+ * @returns {{ id: string; version: number; where: object; when?: object; }}
  */
 function genProbeConfig ({ id, version, where, when, ...rest } = {}) {
-  return {
+  /** @type {{ id: string; version: number; where: object; when?: object; [key: string]: unknown }} */
+  const probe = {
     id: id || 'probe-1',
     version: version || 1,
     where: where || { sourceFile: 'test.js', lines: ['10'] },
-    when,
     ...rest,
   }
+  if (when !== undefined) probe.when = when
+  return probe
+}
+
+/**
+ * Build the runtime sampler cleanup expression.
+ *
+ * @param {string} id - The probe id.
+ * @returns {string}
+ */
+function removeProbeExpression (id) {
+  return 'globalThis[Symbol.for("dd-trace")]?.[Symbol.for("dd-trace.debugger.probeSampler")]' +
+    `?.remove(${JSON.stringify(id)})`
 }

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -9,11 +9,8 @@ const sinon = require('sinon')
 
 require('../../setup/mocha')
 
-const {
-  getInstallSamplerExpression,
-  MAX_SAMPLED_PROBES_PER_PAUSE,
-  setProbeSamplerBuffer,
-} = require('../../../src/debugger/devtools_client/probe_sampler')
+const { installProbeSampler } = require('../../../src/debugger/probe_sampler')
+const { MAX_SAMPLED_PROBES_PER_PAUSE } = require('../../../src/debugger/probe_sampler_constants')
 
 const breakpoint = { file: 'file.js', line: 1 }
 const breakpointId = 'breakpoint-id'
@@ -97,7 +94,7 @@ describe('onPause', function () {
 
     send = sinon.spy()
     send['@noCallThru'] = true
-    sampledProbeIndexes = new Int32Array(new SharedArrayBuffer(258 * Int32Array.BYTES_PER_ELEMENT))
+    sampledProbeIndexes = new Int32Array(installProbeSampler())
 
     state = proxyquire('../../../src/debugger/devtools_client/state', { './session': session })
     proxyquire.noCallThru()('../../../src/debugger/devtools_client/status', { './config': config })
@@ -197,7 +194,7 @@ describe('onPause', function () {
 
   it('should not read past the sampled probe buffer when more probes are sampled than it can hold', async function () {
     const probesAtLocation = new Map()
-    const sampler = installSampler(/** @type {SharedArrayBuffer} */ (sampledProbeIndexes.buffer))
+    const sampler = getSampler()
     for (let i = 0; i <= MAX_SAMPLED_PROBES_PER_PAUSE; i++) {
       const probe = genProcessedProbe(`probe-${i}`)
       probesAtLocation.set(probe.id, probe)
@@ -250,14 +247,6 @@ describe('onPause', function () {
  * Generate a processed probe fixture for pause-handler tests.
  *
  * @param {string} id - The probe id.
- * @returns {{
- *   id: string,
- *   version: number,
- *   location: { file: string, lines: string[] },
- *   templateRequiresEvaluation: boolean,
- *   template: string,
- *   captureSnapshot: boolean
- * }}
  */
 function genProcessedProbe (id) {
   return {
@@ -271,15 +260,9 @@ function genProcessedProbe (id) {
 }
 
 /**
- * Install the runtime probe sampler for tests.
- *
- * @param {SharedArrayBuffer} buffer - The shared sampler buffer.
- * @returns {{ makeSampleDecision: Function }}
+ * Get the installed runtime probe sampler for tests.
  */
-function installSampler (buffer) {
-  setProbeSamplerBuffer(buffer)
-  // eslint-disable-next-line no-new-func
-  new Function(getInstallSamplerExpression())()
+function getSampler () {
   return /** @type {{ makeSampleDecision: Function }} */ (
     globalThis[Symbol.for('dd-trace')][Symbol.for('dd-trace.debugger.probeSampler')]
   )

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -9,6 +9,12 @@ const sinon = require('sinon')
 
 require('../../setup/mocha')
 
+const {
+  getInstallSamplerExpression,
+  MAX_SAMPLED_PROBES_PER_PAUSE,
+  setProbeSamplerBuffer,
+} = require('../../../src/debugger/devtools_client/probe_sampler')
+
 const breakpoint = { file: 'file.js', line: 1 }
 const breakpointId = 'breakpoint-id'
 const scriptId = 'script-id'
@@ -189,6 +195,26 @@ describe('onPause', function () {
     sinon.assert.notCalled(send)
   })
 
+  it('should not read past the sampled probe buffer when more probes are sampled than it can hold', async function () {
+    const probesAtLocation = new Map()
+    const sampler = installSampler(/** @type {SharedArrayBuffer} */ (sampledProbeIndexes.buffer))
+    for (let i = 0; i <= MAX_SAMPLED_PROBES_PER_PAUSE; i++) {
+      const probe = genProcessedProbe(`probe-${i}`)
+      probesAtLocation.set(probe.id, probe)
+      state.samplingIndexToProbe.set(i, probe)
+      sampler.makeSampleDecision(i, probe.id, 0n, false)
+    }
+    state.breakpointToProbes.set(breakpointId, probesAtLocation)
+
+    await onPaused(event)
+
+    sinon.assert.calledWith(log.error,
+      '[debugger:devtools_client] Too many probes sampled at the same breakpoint location; skipping excess probes')
+    sinon.assert.calledWith(session.post.secondCall, 'Debugger.resume')
+    sinon.assert.callCount(ackEmitting, MAX_SAMPLED_PROBES_PER_PAUSE)
+    sinon.assert.callCount(send, MAX_SAMPLED_PROBES_PER_PAUSE)
+  })
+
   it('should log if a sampled probe index is unknown', async function () {
     state.breakpointToProbes.set(breakpointId, new Map())
     Atomics.store(sampledProbeIndexes, 0, 1)
@@ -242,4 +268,19 @@ function genProcessedProbe (id) {
     template: id.replace('-', ' '),
     captureSnapshot: false,
   }
+}
+
+/**
+ * Install the runtime probe sampler for tests.
+ *
+ * @param {SharedArrayBuffer} buffer - The shared sampler buffer.
+ * @returns {{ makeSampleDecision: Function }}
+ */
+function installSampler (buffer) {
+  setProbeSamplerBuffer(buffer)
+  // eslint-disable-next-line no-new-func
+  new Function(getInstallSamplerExpression())()
+  return /** @type {{ makeSampleDecision: Function }} */ (
+    globalThis[Symbol.for('dd-trace')][Symbol.for('dd-trace.debugger.probeSampler')]
+  )
 }

--- a/packages/dd-trace/test/debugger/devtools_client/index.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert/strict')
+const workerThreads = require('node:worker_threads')
 
 const { beforeEach, describe, it } = require('mocha')
 const proxyquire = require('proxyquire')
@@ -19,7 +20,11 @@ const event = {
   params: {
     reason: 'other',
     hitBreakpoints: [breakpointId],
-    callFrames: [{ functionName, location: { scriptId, lineNumber: breakpoint.line - 1, columnNumber: 0 } }],
+    callFrames: [{
+      callFrameId: 'call-frame-id',
+      functionName,
+      location: { scriptId, lineNumber: breakpoint.line - 1, columnNumber: 0 },
+    }],
   },
 }
 
@@ -39,12 +44,16 @@ describe('onPause', function () {
   /** @type {Function} */
   let onPaused
   /** @type {sinon.SinonSpy} */
-  let ackReceived
+  let ackEmitting
+  /** @type {import('../../../src/debugger/devtools_client/state')} */
+  let state
+  /** @type {Int32Array} */
+  let sampledProbeIndexes
   /** @type {unknown} */
   let log
 
   beforeEach(async function () {
-    ackReceived = sinon.spy()
+    ackEmitting = sinon.spy()
     log = {
       error: sinon.spy(),
       debug: sinon.spy(),
@@ -57,7 +66,12 @@ describe('onPause', function () {
           listener({ params: { scriptId, url } })
         }
       }),
-      post: sinon.spy(),
+      post: sinon.stub().callsFake((method, params) => {
+        if (method === 'Debugger.evaluateOnCallFrame') {
+          return Promise.resolve({ result: { value: [{}] } })
+        }
+        return Promise.resolve({})
+      }),
       emit: sinon.spy(),
       '@noCallThru': true,
     }
@@ -71,13 +85,15 @@ describe('onPause', function () {
         redactedIdentifiers: [],
         redactionExcludedIdentifiers: [],
       },
+      propagateProcessTags: { enabled: false },
       '@noCallThru': true,
     }
 
     send = sinon.spy()
     send['@noCallThru'] = true
+    sampledProbeIndexes = new Int32Array(new SharedArrayBuffer(258 * Int32Array.BYTES_PER_ELEMENT))
 
-    const state = proxyquire('../../../src/debugger/devtools_client/state', { './session': session })
+    state = proxyquire('../../../src/debugger/devtools_client/state', { './session': session })
     proxyquire.noCallThru()('../../../src/debugger/devtools_client/status', { './config': config })
     const collector = proxyquire('../../../src/debugger/devtools_client/snapshot/collector', { '../session': session })
     const redaction = proxyquire('../../../src/debugger/devtools_client/snapshot/redaction', { '../config': config })
@@ -90,13 +106,17 @@ describe('onPause', function () {
       './processor': processor,
     })
     proxyquire('../../../src/debugger/devtools_client', {
+      worker_threads: {
+        ...workerThreads,
+        workerData: { probeSamplerBuffer: sampledProbeIndexes.buffer },
+      },
       './config': config,
       './session': session,
       './state': state,
       './snapshot': snapshot,
       './log': log,
       './send': send,
-      './status': { ackReceived },
+      './status': { ackEmitting },
       './remote_config': { '@noCallThru': true },
     })
 
@@ -108,7 +128,7 @@ describe('onPause', function () {
   it('should not fail if there is no probe for at the breakpoint', async function () {
     await onPaused(event)
     sinon.assert.calledOnceWithExactly(session.post, 'Debugger.resume')
-    sinon.assert.notCalled(ackReceived)
+    sinon.assert.notCalled(ackEmitting)
     sinon.assert.notCalled(send)
   })
 
@@ -131,7 +151,95 @@ describe('onPause', function () {
     assert(thrown instanceof Error)
     assert.strictEqual(thrown.message, 'Unexpected Debugger.paused reason: OOM')
     sinon.assert.notCalled(session.post)
-    sinon.assert.notCalled(ackReceived)
+    sinon.assert.notCalled(ackEmitting)
+    sinon.assert.notCalled(send)
+  })
+
+  it('should process only sampled probes for a breakpoint', async function () {
+    const probe1 = genProcessedProbe('probe-1')
+    const probe2 = genProcessedProbe('probe-2')
+
+    state.breakpointToProbes.set(breakpointId, new Map([
+      [probe1.id, probe1],
+      [probe2.id, probe2],
+    ]))
+    state.samplingIndexToProbe.set(1, probe2)
+    Atomics.store(sampledProbeIndexes, 0, 1)
+    Atomics.store(sampledProbeIndexes, 2, 1)
+
+    await onPaused(event)
+
+    sinon.assert.calledWith(session.post.secondCall, 'Debugger.resume')
+    sinon.assert.calledOnceWithExactly(ackEmitting, probe2)
+    sinon.assert.calledOnce(send)
+    assert.strictEqual(send.firstCall.args[0], 'probe 2')
+    assert.strictEqual(send.firstCall.args[2], undefined)
+  })
+
+  it('should log sampler overflow', async function () {
+    state.breakpointToProbes.set(breakpointId, new Map())
+    Atomics.store(sampledProbeIndexes, 1, 1)
+
+    await onPaused(event)
+
+    sinon.assert.calledWith(log.error,
+      '[debugger:devtools_client] Too many probes sampled at the same breakpoint location; skipping excess probes')
+    sinon.assert.calledOnceWithExactly(session.post, 'Debugger.resume')
+    sinon.assert.notCalled(ackEmitting)
+    sinon.assert.notCalled(send)
+  })
+
+  it('should log if a sampled probe index is unknown', async function () {
+    state.breakpointToProbes.set(breakpointId, new Map())
+    Atomics.store(sampledProbeIndexes, 0, 1)
+    Atomics.store(sampledProbeIndexes, 2, 42)
+
+    await onPaused(event)
+
+    sinon.assert.calledWith(log.error, '[debugger:devtools_client] No probe found for sampled probe index %d', 42)
+    sinon.assert.calledOnceWithExactly(session.post, 'Debugger.resume')
+    sinon.assert.notCalled(ackEmitting)
+    sinon.assert.notCalled(send)
+  })
+
+  it('should log if a sampled probe is not attached to the hit breakpoint', async function () {
+    const probe = genProcessedProbe('probe-1')
+
+    state.breakpointToProbes.set(breakpointId, new Map())
+    state.samplingIndexToProbe.set(1, probe)
+    Atomics.store(sampledProbeIndexes, 0, 1)
+    Atomics.store(sampledProbeIndexes, 2, 1)
+
+    await onPaused(event)
+
+    sinon.assert.calledWith(log.error,
+      '[debugger:devtools_client] Sampled probe %s was not found at breakpoint %s', 'probe-1', breakpointId)
+    sinon.assert.calledOnceWithExactly(session.post, 'Debugger.resume')
+    sinon.assert.notCalled(ackEmitting)
     sinon.assert.notCalled(send)
   })
 })
+
+/**
+ * Generate a processed probe fixture for pause-handler tests.
+ *
+ * @param {string} id - The probe id.
+ * @returns {{
+ *   id: string,
+ *   version: number,
+ *   location: { file: string, lines: string[] },
+ *   templateRequiresEvaluation: boolean,
+ *   template: string,
+ *   captureSnapshot: boolean
+ * }}
+ */
+function genProcessedProbe (id) {
+  return {
+    id,
+    version: 1,
+    location: { file: path, lines: ['1'] },
+    templateRequiresEvaluation: false,
+    template: id.replace('-', ' '),
+    captureSnapshot: false,
+  }
+}

--- a/packages/dd-trace/test/debugger/devtools_client/probe_sampler.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/probe_sampler.spec.js
@@ -1,0 +1,237 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { beforeEach, describe, it } = require('mocha')
+require('../../setup/mocha')
+
+const {
+  compileBreakpointCondition,
+  createProbeSamplerBuffer,
+  getInstallSamplerExpression,
+  getRemoveProbeExpression,
+  MAX_SAMPLED_PROBES_PER_PAUSE,
+  SAMPLED_PROBE_COUNT_INDEX,
+  SAMPLED_PROBE_INDEXES_START,
+  SAMPLED_PROBE_OVERFLOW_INDEX,
+  setProbeSamplerBuffer,
+} = require('../../../src/debugger/devtools_client/probe_sampler')
+const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('../../../src/debugger/devtools_client/defaults')
+
+const ddTraceSymbol = Symbol.for('dd-trace')
+const samplerSymbol = Symbol.for('dd-trace.debugger.probeSampler')
+const samplerBufferSymbol = Symbol.for('dd-trace.debugger.probeSamplerBuffer')
+
+describe('probe sampler', function () {
+  /** @type {typeof process.hrtime.bigint} */
+  let originalHrtimeBigint
+  /** @type {bigint} */
+  let now
+
+  beforeEach(function () {
+    delete getDatadogGlobal()[samplerSymbol]
+    delete getDatadogGlobal()[samplerBufferSymbol]
+    originalHrtimeBigint = process.hrtime.bigint
+    now = 1_000_000_000n
+    process.hrtime.bigint = () => now
+  })
+
+  afterEach(function () {
+    process.hrtime.bigint = originalHrtimeBigint
+    delete getDatadogGlobal()[samplerSymbol]
+    delete getDatadogGlobal()[samplerBufferSymbol]
+  })
+
+  describe('shared buffer', function () {
+    it('should create a shared buffer with the expected layout', function () {
+      const buffer = createProbeSamplerBuffer()
+      const sampledProbeIndexes = new Int32Array(buffer)
+
+      assert(buffer instanceof SharedArrayBuffer)
+      assert.strictEqual(sampledProbeIndexes.length, SAMPLED_PROBE_INDEXES_START + MAX_SAMPLED_PROBES_PER_PAUSE)
+    })
+
+    it('should expose and initialize the shared buffer', function () {
+      const buffer = createProbeSamplerBuffer()
+      const sampledProbeIndexes = new Int32Array(buffer)
+      Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 42)
+      Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 1)
+
+      setProbeSamplerBuffer(buffer)
+
+      assert.strictEqual(getDatadogGlobal()[samplerBufferSymbol], buffer)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX), 0)
+    })
+  })
+
+  describe('generated expressions', function () {
+    it('should compile a breakpoint condition for probes without conditions', function () {
+      assert.strictEqual(compileBreakpointCondition([
+        { id: 'probe-1', samplingIndex: 0, nsBetweenSampling: 200000n },
+        { id: 'probe-2', samplingIndex: 1, nsBetweenSampling: 200000n },
+      ]), `(() => {
+    const $dd_sampler = globalThis[Symbol.for("dd-trace")]?.[Symbol.for("dd-trace.debugger.probeSampler")]
+    if ($dd_sampler === undefined) return false
+    let $dd_sampled = false
+    $dd_sampled = $dd_sampler.makeSampleDecision(0, "probe-1", 200000n, false) || $dd_sampled
+    $dd_sampled = $dd_sampler.makeSampleDecision(1, "probe-2", 200000n, false) || $dd_sampled
+    return $dd_sampled
+  })()`)
+    })
+
+    it('should compile a breakpoint condition for probes with conditions and snapshot capture', function () {
+      assert.strictEqual(compileBreakpointCondition([
+        {
+          id: 'probe-1',
+          samplingIndex: 0,
+          nsBetweenSampling: 200000n,
+          condition: '(foo) === (42)',
+          captureSnapshot: true,
+        },
+      ]), `(() => {
+    const $dd_sampler = globalThis[Symbol.for("dd-trace")]?.[Symbol.for("dd-trace.debugger.probeSampler")]
+    if ($dd_sampler === undefined) return false
+    let $dd_sampled = false
+    try {
+      if (((foo) === (42)) === true) {
+        $dd_sampled = $dd_sampler.makeSampleDecision(0, "probe-1", 200000n, true) || $dd_sampled
+      }
+    } catch {}
+    return $dd_sampled
+  })()`)
+    })
+
+    it('should compile an expression that removes probe sampler state', function () {
+      assert.strictEqual(getRemoveProbeExpression('probe-1'),
+        'globalThis[Symbol.for("dd-trace")]?.[Symbol.for("dd-trace.debugger.probeSampler")]?.remove("probe-1")')
+    })
+  })
+
+  describe('runtime sampler', function () {
+    it('should install the runtime sampler when the buffer is present', function () {
+      installSampler()
+
+      assert.strictEqual(typeof getSampler().makeSampleDecision, 'function')
+      assert.strictEqual(typeof getSampler().remove, 'function')
+    })
+
+    it('should skip installation when the buffer is missing', function () {
+      // eslint-disable-next-line no-new-func
+      new Function(getInstallSamplerExpression())()
+
+      assert.strictEqual(getDatadogGlobal()[samplerSymbol], undefined)
+    })
+
+    it('should sample a probe and write its index to the shared buffer', function () {
+      const sampledProbeIndexes = installSampler()
+
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_INDEXES_START), 0)
+
+      const sampled = getSampler().makeSampleDecision(7, 'probe-1', 200000n, false)
+
+      assert.strictEqual(sampled, true)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 1)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_INDEXES_START), 7)
+    })
+
+    it('should skip repeated hits within the sampling interval', function () {
+      const sampledProbeIndexes = installSampler()
+      const sampler = getSampler()
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+
+      assert.strictEqual(sampler.makeSampleDecision(7, 'probe-1', 200000n, false), true)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 1)
+
+      now += 100000n
+
+      assert.strictEqual(sampler.makeSampleDecision(7, 'probe-1', 200000n, false), false)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 1)
+    })
+
+    it('should allow a removed probe to sample again immediately', function () {
+      const sampledProbeIndexes = installSampler()
+      const sampler = getSampler()
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+
+      assert.strictEqual(sampler.makeSampleDecision(7, 'probe-1', 200000n, false), true)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 1)
+
+      sampler.remove('probe-1')
+
+      assert.strictEqual(sampler.makeSampleDecision(7, 'probe-1', 200000n, false), true)
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 2)
+    })
+
+    it('should apply the global snapshot sample rate only to snapshot-producing probes', function () {
+      const sampledProbeIndexes = installSampler()
+      const sampler = getSampler()
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+
+      for (let i = 0; i < MAX_SNAPSHOTS_PER_SECOND_GLOBALLY; i++) {
+        assert.strictEqual(sampler.makeSampleDecision(i, `snapshot-${i}`, 0n, true), true)
+      }
+
+      assert.strictEqual(sampler.makeSampleDecision(99, 'snapshot-over-limit', 0n, true), false)
+      assert.strictEqual(sampler.makeSampleDecision(100, 'non-snapshot', 0n, false), true)
+      assert.strictEqual(
+        Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX),
+        MAX_SNAPSHOTS_PER_SECOND_GLOBALLY + 2
+      )
+    })
+
+    it('should reset the global snapshot sample rate after one second', function () {
+      installSampler()
+      const sampler = getSampler()
+
+      for (let i = 0; i < MAX_SNAPSHOTS_PER_SECOND_GLOBALLY; i++) {
+        assert.strictEqual(sampler.makeSampleDecision(i, `snapshot-${i}`, 0n, true), true)
+      }
+
+      now += 1_000_000_001n
+      assert.strictEqual(sampler.makeSampleDecision(99, 'snapshot-next-window', 0n, true), true)
+    })
+
+    it('should set overflow and skip probes when the shared buffer is full', function () {
+      const sampledProbeIndexes = installSampler()
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX), 0)
+
+      Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, MAX_SAMPLED_PROBES_PER_PAUSE)
+
+      assert.strictEqual(
+        getSampler().makeSampleDecision(7, 'probe-1', 200000n, false),
+        false
+      )
+      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX), 1)
+    })
+  })
+})
+
+function installSampler () {
+  const buffer = createProbeSamplerBuffer()
+  setProbeSamplerBuffer(buffer)
+  // eslint-disable-next-line no-new-func
+  new Function(getInstallSamplerExpression())()
+  return new Int32Array(buffer)
+}
+
+/**
+ * Get the Datadog global test object.
+ *
+ * @returns {Record<symbol, unknown>}
+ */
+function getDatadogGlobal () {
+  return /** @type {Record<symbol, unknown>} */ (
+    /** @type {Record<symbol, unknown>} */ (globalThis)[ddTraceSymbol]
+  )
+}
+
+/**
+ * Get the installed runtime sampler.
+ *
+ * @returns {{ makeSampleDecision: Function, remove: Function }}
+ */
+function getSampler () {
+  return /** @type {{ makeSampleDecision: Function, remove: Function }} */ (getDatadogGlobal()[samplerSymbol])
+}

--- a/packages/dd-trace/test/debugger/devtools_client/probe_sampler.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/probe_sampler.spec.js
@@ -116,6 +116,19 @@ describe('probe sampler', function () {
       assert.strictEqual(typeof getSampler().remove, 'function')
     })
 
+    it('should reinstall the runtime sampler with the latest shared buffer', function () {
+      const firstBuffer = createProbeSamplerBuffer()
+      const firstSampledProbeIndexes = installSampler(firstBuffer)
+
+      const secondBuffer = createProbeSamplerBuffer()
+      const secondSampledProbeIndexes = installSampler(secondBuffer)
+
+      assert.strictEqual(getSampler().makeSampleDecision(7, 'probe-1', 200000n, false), true)
+      assert.strictEqual(Atomics.load(firstSampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+      assert.strictEqual(Atomics.load(secondSampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 1)
+      assert.strictEqual(Atomics.load(secondSampledProbeIndexes, SAMPLED_PROBE_INDEXES_START), 7)
+    })
+
     it('should skip installation when the buffer is missing', function () {
       // eslint-disable-next-line no-new-func
       new Function(getInstallSamplerExpression())()
@@ -227,8 +240,13 @@ describe('probe sampler', function () {
   })
 })
 
-function installSampler () {
-  const buffer = createProbeSamplerBuffer()
+/**
+ * Install the runtime sampler expression for tests.
+ *
+ * @param {SharedArrayBuffer} [buffer] - The shared sampler buffer.
+ * @returns {Int32Array}
+ */
+function installSampler (buffer = createProbeSamplerBuffer()) {
   setProbeSamplerBuffer(buffer)
   // eslint-disable-next-line no-new-func
   new Function(getInstallSamplerExpression())()

--- a/packages/dd-trace/test/debugger/devtools_client/probe_sampler.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/probe_sampler.spec.js
@@ -177,7 +177,26 @@ describe('probe sampler', function () {
       assert.strictEqual(sampler.makeSampleDecision(100, 'non-snapshot', 0n, false), true)
       assert.strictEqual(
         Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX),
-        MAX_SNAPSHOTS_PER_SECOND_GLOBALLY + 2
+        MAX_SNAPSHOTS_PER_SECOND_GLOBALLY + 1
+      )
+    })
+
+    it('should not advance the sampled probe count when global snapshot rate rejects a probe', function () {
+      const sampledProbeIndexes = installSampler()
+      const sampler = getSampler()
+
+      for (let i = 0; i < MAX_SNAPSHOTS_PER_SECOND_GLOBALLY; i++) {
+        assert.strictEqual(sampler.makeSampleDecision(i, `snapshot-${i}`, 0n, true), true)
+      }
+      assert.strictEqual(
+        Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX),
+        MAX_SNAPSHOTS_PER_SECOND_GLOBALLY
+      )
+
+      assert.strictEqual(sampler.makeSampleDecision(99, 'snapshot-over-limit', 0n, true), false)
+      assert.strictEqual(
+        Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX),
+        MAX_SNAPSHOTS_PER_SECOND_GLOBALLY
       )
     })
 

--- a/packages/dd-trace/test/debugger/probe_sampler.spec.js
+++ b/packages/dd-trace/test/debugger/probe_sampler.spec.js
@@ -3,20 +3,20 @@
 const assert = require('node:assert/strict')
 
 const { beforeEach, describe, it } = require('mocha')
-require('../../setup/mocha')
+require('../setup/mocha')
 
 const {
-  compileBreakpointCondition,
-  createProbeSamplerBuffer,
-  getInstallSamplerExpression,
-  getRemoveProbeExpression,
   MAX_SAMPLED_PROBES_PER_PAUSE,
   SAMPLED_PROBE_COUNT_INDEX,
   SAMPLED_PROBE_INDEXES_START,
   SAMPLED_PROBE_OVERFLOW_INDEX,
-  setProbeSamplerBuffer,
-} = require('../../../src/debugger/devtools_client/probe_sampler')
-const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('../../../src/debugger/devtools_client/defaults')
+} = require('../../src/debugger/probe_sampler_constants')
+const { installProbeSampler, uninstallProbeSampler } = require('../../src/debugger/probe_sampler')
+const {
+  compileBreakpointCondition,
+  getRemoveProbeExpression,
+} = require('../../src/debugger/devtools_client/probe_sampler')
+const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('../../src/debugger/devtools_client/defaults')
 
 const ddTraceSymbol = Symbol.for('dd-trace')
 const samplerSymbol = Symbol.for('dd-trace.debugger.probeSampler')
@@ -44,7 +44,7 @@ describe('probe sampler', function () {
 
   describe('shared buffer', function () {
     it('should create a shared buffer with the expected layout', function () {
-      const buffer = createProbeSamplerBuffer()
+      const buffer = installProbeSampler()
       const sampledProbeIndexes = new Int32Array(buffer)
 
       assert(buffer instanceof SharedArrayBuffer)
@@ -52,16 +52,20 @@ describe('probe sampler', function () {
     })
 
     it('should expose and initialize the shared buffer', function () {
-      const buffer = createProbeSamplerBuffer()
-      const sampledProbeIndexes = new Int32Array(buffer)
-      Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX, 42)
-      Atomics.store(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX, 1)
+      const installedBuffer = installProbeSampler()
+      const installedSampledProbeIndexes = new Int32Array(installedBuffer)
 
-      setProbeSamplerBuffer(buffer)
+      assert.strictEqual(getDatadogGlobal()[samplerBufferSymbol], installedBuffer)
+      assert.strictEqual(Atomics.load(installedSampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
+      assert.strictEqual(Atomics.load(installedSampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX), 0)
+    })
 
-      assert.strictEqual(getDatadogGlobal()[samplerBufferSymbol], buffer)
-      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
-      assert.strictEqual(Atomics.load(sampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX), 0)
+    it('should remove the shared buffer and runtime sampler', function () {
+      installSampler()
+      uninstallProbeSampler()
+
+      assert.strictEqual(getDatadogGlobal()[samplerSymbol], undefined)
+      assert.strictEqual(getDatadogGlobal()[samplerBufferSymbol], undefined)
     })
   })
 
@@ -117,23 +121,14 @@ describe('probe sampler', function () {
     })
 
     it('should reinstall the runtime sampler with the latest shared buffer', function () {
-      const firstBuffer = createProbeSamplerBuffer()
-      const firstSampledProbeIndexes = installSampler(firstBuffer)
+      const firstSampledProbeIndexes = installSampler()
 
-      const secondBuffer = createProbeSamplerBuffer()
-      const secondSampledProbeIndexes = installSampler(secondBuffer)
+      const secondSampledProbeIndexes = installSampler()
 
       assert.strictEqual(getSampler().makeSampleDecision(7, 'probe-1', 200000n, false), true)
       assert.strictEqual(Atomics.load(firstSampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
       assert.strictEqual(Atomics.load(secondSampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 1)
       assert.strictEqual(Atomics.load(secondSampledProbeIndexes, SAMPLED_PROBE_INDEXES_START), 7)
-    })
-
-    it('should skip installation when the buffer is missing', function () {
-      // eslint-disable-next-line no-new-func
-      new Function(getInstallSamplerExpression())()
-
-      assert.strictEqual(getDatadogGlobal()[samplerSymbol], undefined)
     })
 
     it('should sample a probe and write its index to the shared buffer', function () {
@@ -241,22 +236,14 @@ describe('probe sampler', function () {
 })
 
 /**
- * Install the runtime sampler expression for tests.
- *
- * @param {SharedArrayBuffer} [buffer] - The shared sampler buffer.
- * @returns {Int32Array}
+ * Install the runtime sampler for tests.
  */
-function installSampler (buffer = createProbeSamplerBuffer()) {
-  setProbeSamplerBuffer(buffer)
-  // eslint-disable-next-line no-new-func
-  new Function(getInstallSamplerExpression())()
-  return new Int32Array(buffer)
+function installSampler () {
+  return new Int32Array(installProbeSampler())
 }
 
 /**
  * Get the Datadog global test object.
- *
- * @returns {Record<symbol, unknown>}
  */
 function getDatadogGlobal () {
   return /** @type {Record<symbol, unknown>} */ (
@@ -266,8 +253,6 @@ function getDatadogGlobal () {
 
 /**
  * Get the installed runtime sampler.
- *
- * @returns {{ makeSampleDecision: Function, remove: Function }}
  */
 function getSampler () {
   return /** @type {{ makeSampleDecision: Function, remove: Function }} */ (getDatadogGlobal()[samplerSymbol])

--- a/packages/dd-trace/test/debugger/probe_sampler.spec.js
+++ b/packages/dd-trace/test/debugger/probe_sampler.spec.js
@@ -20,7 +20,6 @@ const { MAX_SNAPSHOTS_PER_SECOND_GLOBALLY } = require('../../src/debugger/devtoo
 
 const ddTraceSymbol = Symbol.for('dd-trace')
 const samplerSymbol = Symbol.for('dd-trace.debugger.probeSampler')
-const samplerBufferSymbol = Symbol.for('dd-trace.debugger.probeSamplerBuffer')
 
 describe('probe sampler', function () {
   /** @type {typeof process.hrtime.bigint} */
@@ -30,7 +29,6 @@ describe('probe sampler', function () {
 
   beforeEach(function () {
     delete getDatadogGlobal()[samplerSymbol]
-    delete getDatadogGlobal()[samplerBufferSymbol]
     originalHrtimeBigint = process.hrtime.bigint
     now = 1_000_000_000n
     process.hrtime.bigint = () => now
@@ -39,7 +37,6 @@ describe('probe sampler', function () {
   afterEach(function () {
     process.hrtime.bigint = originalHrtimeBigint
     delete getDatadogGlobal()[samplerSymbol]
-    delete getDatadogGlobal()[samplerBufferSymbol]
   })
 
   describe('shared buffer', function () {
@@ -51,21 +48,19 @@ describe('probe sampler', function () {
       assert.strictEqual(sampledProbeIndexes.length, SAMPLED_PROBE_INDEXES_START + MAX_SAMPLED_PROBES_PER_PAUSE)
     })
 
-    it('should expose and initialize the shared buffer', function () {
+    it('should initialize the shared buffer', function () {
       const installedBuffer = installProbeSampler()
       const installedSampledProbeIndexes = new Int32Array(installedBuffer)
 
-      assert.strictEqual(getDatadogGlobal()[samplerBufferSymbol], installedBuffer)
       assert.strictEqual(Atomics.load(installedSampledProbeIndexes, SAMPLED_PROBE_COUNT_INDEX), 0)
       assert.strictEqual(Atomics.load(installedSampledProbeIndexes, SAMPLED_PROBE_OVERFLOW_INDEX), 0)
     })
 
-    it('should remove the shared buffer and runtime sampler', function () {
+    it('should remove the runtime sampler', function () {
       installSampler()
       uninstallProbeSampler()
 
       assert.strictEqual(getDatadogGlobal()[samplerSymbol], undefined)
-      assert.strictEqual(getDatadogGlobal()[samplerBufferSymbol], undefined)
     })
   })
 


### PR DESCRIPTION
### What does this PR do?

Moves Node.js debugger probe sampling into generated breakpoint conditions so unsampled probe hits can avoid pausing the debuggee process. The debugger bootstrap installs a runtime sampler in the debuggee process and shares a buffer with the devtools worker. Breakpoint conditions make the sampling decision inline and record sampled probe indexes into that buffer; the worker then only processes the probes the condition path sampled.

### Motivation

Probe sampling was previously decided after V8 had already paused the application and control had moved to the devtools worker. That meant probes dropped by per-probe sampling or the global snapshot sampling limit could still add pause overhead. Moving the decision into the breakpoint condition makes the common unsampled case cheaper.

### Additional Notes

Added focused tests for `probe_sampler`, breakpoint condition rebuilding, sampler state cleanup on probe removal, pause handling with sampled probe indexes, overflow handling, and stale/inconsistent sampled probe state.

### Known limitations

Breakpoint conditions read the sampler from the realm-local `globalThis`, so a probe whose code runs in a separate V8 realm (e.g. a `vm.runInContext` script) can't reach it and silently won't fire, rather than crash.

In practice the only affected user is one who runs application code in a vm context with an absolute-path filename *and* places a probe on a line inside it:

```js
const vm = require('node:vm')

const context = vm.createContext({})
vm.runInContext(
  'function handler () { /* a probe on this line no longer fires */ }',
  context,
  { filename: '/app/handler.js' } // absolute path, otherwise the probe never matched at all
)
```

This only narrows an already-degraded, undocumented path for Dynamic Instrumentation: even before this change such probes produced correlation-less snapshots, because `global.require` doesn't exist in the vm realm. Test Optimization's failing-test replay is unaffected, as it runs in a separate worker that sets unconditional breakpoints.