### PR TITLE
fix(debugger): keep breakpoint id in sync after update

### DIFF
--- a/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
+++ b/packages/dd-trace/src/debugger/devtools_client/breakpoints.js
@@ -256,6 +256,7 @@ async function updateBreakpointInternal (breakpoint, probe) {
     } catch (err) {
       throw new Error(`Error setting breakpoint for probe ${probe.id} (version: ${probe.version})`, { cause: err })
     }
+    breakpoint.id = result.breakpointId
     breakpointToProbes.set(result.breakpointId, probesAtLocation)
   }
 }

--- a/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
+++ b/packages/dd-trace/test/debugger/devtools_client/breakpoints.spec.js
@@ -664,6 +664,47 @@ describe('breakpoints', function () {
         })
         sinon.assert.calledTwice(sessionMock.post)
       })
+
+      it('should use the new breakpoint id after updating conditions', async function () {
+        let nextBreakpointId = 0
+        sessionMock.post.callsFake((method, { location } = {}) => {
+          if (method === 'Debugger.setBreakpoint') {
+            nextBreakpointId += 1
+            return Promise.resolve({
+              breakpointId: `bp-${nextBreakpointId}`,
+            })
+          }
+          return Promise.resolve({})
+        })
+
+        await addProbe({
+          when: {
+            json: { eq: [{ ref: 'foo' }, 42] },
+            dsl: 'foo = 42',
+          },
+        })
+        await addProbe({
+          id: 'probe-2',
+          when: {
+            json: { eq: [{ ref: 'foo' }, 43] },
+            dsl: 'foo = 43',
+          },
+        })
+        sessionMock.post.resetHistory()
+
+        await breakpoints.removeBreakpoint({ id: 'probe-1' })
+
+        sinon.assert.calledWith(sessionMock.post.firstCall, 'Debugger.removeBreakpoint', { breakpointId: 'bp-2' })
+        sinon.assert.calledWith(sessionMock.post.secondCall, 'Debugger.setBreakpoint', {
+          location: {
+            scriptId: 'script-1',
+            lineNumber: 9,
+            columnNumber: 0,
+          },
+          condition: '(foo) === (43)',
+        })
+        sinon.assert.calledTwice(sessionMock.post)
+      })
     })
 
     it('should throw error if debugger not started', async function () {


### PR DESCRIPTION
### What does this PR do?

Keeps the debugger devtools client's stored breakpoint id in sync when a breakpoint is removed and recreated to update its condition.

Adds a regression test that makes `Debugger.setBreakpoint` return a new id for each replacement, then verifies later updates remove the active breakpoint id instead of the stale one.

### Motivation

When multiple probes share a location and their combined condition changes, the client replaces the inspector breakpoint. V8 can return a different breakpoint id for the replacement. We already moved the probe map to the new id, but the location map still held the old id, so later removals or updates could target stale state.
