### PR TITLE
fix(deps): bump import-in-the-middle to 3.1.0

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -47,7 +47,7 @@ jobs:
               && yarn set version stable
               && yarn config set nodeLinker node-modules
               && yarn config set enableScripts true
-              && yarn config set --json npmPreapprovedPackages '["@datadog/*"]'
+              && yarn config set --json npmPreapprovedPackages '["@datadog/*","import-in-the-middle"]'
               && yarn add
           - name: bun
             install: bun add --linker=hoisted

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.11",
-    "import-in-the-middle": "3.0.1",
+    "import-in-the-middle": "^3.1.0",
     "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {

--- a/packages/datadog-esbuild/src/utils.js
+++ b/packages/datadog-esbuild/src/utils.js
@@ -6,6 +6,9 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { NODE_MAJOR, NODE_MINOR } = require('../../../version.js')
 
+const LOAD_OPERATION = 0
+const RESOLVE_OPERATION = 1
+
 const getExportsImporting = (url) => import(url).then(Object.keys)
 let getExportsModulePromise
 
@@ -19,7 +22,11 @@ const loadGetExportsModule = () => {
 const getExports = NODE_MAJOR >= 20 || (NODE_MAJOR === 18 && NODE_MINOR >= 19)
   ? async (srcUrl, context, getSource) => {
     const mod = await loadGetExportsModule()
-    return mod.getExports(srcUrl, context, getSource)
+    const exportNames = mod.getExports(srcUrl, context, getSource)
+    if (exportNames?.next) {
+      return driveGetExportsGenerator(exportNames, getSource)
+    }
+    return exportNames
   }
   : getExportsImporting
 
@@ -76,6 +83,42 @@ function getSource (url, { format }) {
     source: fs.readFileSync(fileURLToPath(url), 'utf8'),
     format,
   }
+}
+
+/**
+ * Drives the generator returned by import-in-the-middle >=3.1.0 export discovery.
+ *
+ * @param {Generator<Array, Set<string>>} exportsGenerator Generator returned by getExports
+ * @param {(url: URL, context: object) => { source: string, format: string }} getSource
+ * Function that loads module source
+ * @returns {Set<string>}
+ */
+function driveGetExportsGenerator (exportsGenerator, getSource) {
+  let next = exportsGenerator.next()
+  while (next.done === false) {
+    let result
+    let error
+    let threw = false
+
+    try {
+      const operation = next.value
+      const operationType = operation[0]
+
+      if (operationType === LOAD_OPERATION) {
+        result = getSource(operation[1], operation[2])
+      } else if (operationType === RESOLVE_OPERATION) {
+        result = resolve(operation[1], operation[2])
+      } else {
+        throw new Error(`Unsupported import-in-the-middle getExports operation: ${operationType}`)
+      }
+    } catch (err) {
+      threw = true
+      error = err
+    }
+
+    next = threw ? exportsGenerator.throw(error) : exportsGenerator.next(result)
+  }
+  return next.value
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
-  integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==
+import-in-the-middle@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz#0d0e88c93c276599bd4bf81835946d723656efab"
+  integrity sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==
   dependencies:
     acorn "^8.15.0"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
### What does this PR do?
Bumps `import-in-the-middle` from master's temporary `3.0.1` pin to `^3.1.0` and refreshes the matching `yarn.lock` entry.

It also updates `packages/datadog-esbuild` for the `import-in-the-middle` 3.1 export-collection API and preapproves `import-in-the-middle` in the Yarn Berry package-manager smoke test so the packed `dd-trace` install can pass Yarn's quarantine gate.

### Motivation
`import-in-the-middle` 3.1.0 contains the loader support needed by the follow-up Test Optimization startup improvement for Vitest workers. Master is pinned to `3.0.1` only as a temporary stopgap while these compatibility fixes land.

### Root Cause
`dd-trace` deep-imports `import-in-the-middle/lib/get-exports.mjs` from `packages/datadog-esbuild`. In `import-in-the-middle@3.0.1`, `getExports(url, context, parentLoad)` was an async function that returned export names, so our esbuild code could `await getExports(...)` and iterate strings such as `default` or `exportMethod`.

In `import-in-the-middle@3.1.0`, `getExports(url, context)` became a generator-based API. It yields loader operations such as `[LOAD, url, context]` and expects callers to drive the generator with `driveAsync()` or `driveSync()` from `import-in-the-middle/lib/io.mjs`. Our old caller still treated the return value as export names, so the first yielded operation array reached the export-name loop and crashed at `n.replaceAll(...)` because `n` was an array, not a string.

This PR updates the esbuild adapter to drive the new generator with `driveAsync(collectExports(srcUrl, context), { load: getSource })`.

### Evidence
With `import-in-the-middle@3.0.1`, `packages/datadog-esbuild/test/utils.spec.js` passes with 12 tests passing.

After forcing only `import-in-the-middle@3.1.0` on master, the same test reproduces the CI failure with 9 passing, 3 failing, and `TypeError: n.replaceAll is not a function`.

Under Node 24.16.0, `integration-tests/esbuild/build-and-test-koa.mjs` also reproduces the matrix failure.

### Additional Notes
The sync-loader implementation is split into a stacked follow-up PR.