### PR TITLE
perf(loader): use synchronous iitm hooks when available

### DIFF
--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -47,7 +47,7 @@ jobs:
               && yarn set version stable
               && yarn config set nodeLinker node-modules
               && yarn config set enableScripts true
-              && yarn config set --json npmPreapprovedPackages '["@datadog/*"]'
+              && yarn config set --json npmPreapprovedPackages '["@datadog/*","import-in-the-middle"]'
               && yarn add
           - name: bun
             install: bun add --linker=hoisted

--- a/loader-hook.mjs
+++ b/loader-hook.mjs
@@ -1,3 +1,9 @@
+/* eslint n/no-unsupported-features/node-builtins: ['error', { ignores: ['module.registerHooks'] }] */
+
+import * as Module from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+import { createHook, supportsSyncHooks } from 'import-in-the-middle/create-hook.mjs'
 import { initialize as origInitialize, load as origLoad, resolve } from 'import-in-the-middle/hook.mjs'
 import regexpEscapeModule from './vendor/dist/escape-string-regexp/index.js'
 import hooks from './packages/datadog-instrumentations/src/helpers/hooks.js'
@@ -8,11 +14,18 @@ import { isRelativeRequire } from './packages/datadog-instrumentations/src/helpe
 // This file must support Node.js 12.0.0 syntax
 
 const regexpEscape = regexpEscapeModule.default
+const require = Module.createRequire(import.meta.url)
+let syncImportInTheMiddleHook
 
 // For some reason `getEnvironmentVariable` is not otherwise available to ESM.
 const env = configHelper.getEnvironmentVariable
 
 function initialize (data = {}) {
+  prepareImportInTheMiddleOptions(data)
+  return origInitialize(data)
+}
+
+function prepareImportInTheMiddleOptions (data = {}) {
   if (data.include == null) data.include = []
   if (data.exclude == null) data.exclude = []
 
@@ -20,11 +33,64 @@ function initialize (data = {}) {
   addSecurityControls(data)
   addExclusions(data)
 
-  return origInitialize(data)
+  return data
 }
 
 function load (url, context, nextLoad) {
   return rewriterLoader.load(url, context, (url, context) => origLoad(url, context, nextLoad))
+}
+
+function loadSync (url, context, nextLoad) {
+  return rewriterLoader.loadSync(url, context, (url, context) => {
+    return getSyncImportInTheMiddleHook().loadSync(url, context, nextLoad)
+  })
+}
+
+function getSyncImportInTheMiddleHook () {
+  if (syncImportInTheMiddleHook) {
+    return syncImportInTheMiddleHook
+  }
+
+  const importInTheMiddleRegisterHooksUrl = pathToFileURL(
+    require.resolve('import-in-the-middle/register-hooks.mjs')
+  ).href
+  syncImportInTheMiddleHook = createHook({ url: importInTheMiddleRegisterHooksUrl })
+  return syncImportInTheMiddleHook
+}
+
+function registerSyncLoaderHooks (data = {}) {
+  // The synchronous loader strips the source of a require() pulled into the iitm
+  // ESM graph so Node loads it natively, but module.registerHooks rejected that
+  // nullish CommonJS source until nodejs/node#59929 (released in 22.22.3, 24.11.1,
+  // 25.1.0 and 26.0.0). On versions that ship registerHooks but predate the fix,
+  // fall back to the asynchronous loader instead of crashing mid-graph.
+  if (!supportsSyncHooks()) {
+    return false
+  }
+
+  const syncHook = getSyncImportInTheMiddleHook()
+
+  if (
+    typeof Module.registerHooks !== 'function' ||
+    typeof syncHook.applyOptions !== 'function' ||
+    typeof syncHook.loadSync !== 'function' ||
+    typeof syncHook.resolveSync !== 'function'
+  ) {
+    return false
+  }
+
+  // Node built-ins are instrumented under the synchronous loader as well: iitm
+  // reads a built-in's exports through process.getBuiltinModule(), which
+  // bypasses the registered hooks and therefore cannot re-enter them. The
+  // synchronous and asynchronous loaders share the same option preparation so
+  // that `import http from 'node:http'` is wrapped on both paths.
+  syncHook.applyOptions(prepareImportInTheMiddleOptions(data))
+  Module.registerHooks({
+    resolve: syncHook.resolveSync,
+    load: loadSync,
+  })
+
+  return true
 }
 
 function addInstrumentations (data) {
@@ -74,4 +140,4 @@ export const iitmExclusions = [
   /@anthropic-ai\/sdk\/_shims/,
 ]
 
-export { initialize, load, resolve }
+export { initialize, load, registerSyncLoaderHooks, resolve }

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.11",
-    "import-in-the-middle": "^3.0.1",
+    "import-in-the-middle": "^3.1.0",
     "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {

--- a/packages/datadog-esbuild/src/utils.js
+++ b/packages/datadog-esbuild/src/utils.js
@@ -7,19 +7,24 @@ const path = require('node:path')
 const { NODE_MAJOR, NODE_MINOR } = require('../../../version.js')
 
 const getExportsImporting = (url) => import(url).then(Object.keys)
-let getExportsModulePromise
+let getExportsModulesPromise
 
-const loadGetExportsModule = () => {
-  if (!getExportsModulePromise) {
-    getExportsModulePromise = import('import-in-the-middle/lib/get-exports.mjs')
+const loadGetExportsModules = () => {
+  if (!getExportsModulesPromise) {
+    getExportsModulesPromise = Promise.all([
+      import('import-in-the-middle/lib/get-exports.mjs'),
+      import('import-in-the-middle/lib/io.mjs'),
+    ])
   }
-  return getExportsModulePromise
+  return getExportsModulesPromise
 }
 
 const getExports = NODE_MAJOR >= 20 || (NODE_MAJOR === 18 && NODE_MINOR >= 19)
   ? async (srcUrl, context, getSource) => {
-    const mod = await loadGetExportsModule()
-    return mod.getExports(srcUrl, context, getSource)
+    const [{ getExports: collectExports }, { driveAsync }] = await loadGetExportsModules()
+    // import-in-the-middle's getExports is a sans-io generator; driveAsync fulfils
+    // its `[LOAD, ...]` operations with the on-disk source reader (lib/io.mjs).
+    return driveAsync(collectExports(srcUrl, context), { load: getSource })
   }
   : getExportsImporting
 

--- a/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
+++ b/packages/datadog-instrumentations/src/helpers/rewriter/loader.mjs
@@ -3,9 +3,19 @@ import { rewrite } from './index.js'
 async function load (url, context, nextLoad) {
   const result = await nextLoad(url, context)
 
+  return rewriteResult(result, url, context)
+}
+
+function loadSync (url, context, nextLoad) {
+  const result = nextLoad(url, context)
+
+  return rewriteResult(result, url, context)
+}
+
+function rewriteResult (result, url, context) {
   result.source = rewrite(result.source, url, context.format)
 
   return result
 }
 
-export { load }
+export { load, loadSync }

--- a/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
+++ b/packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { describe, it } from 'mocha'
+
+import { load, loadSync } from '../../../src/helpers/rewriter/loader.mjs'
+
+const source = 'export function getTracer () { return "tracer" }\n'
+
+describe('rewriter loader', () => {
+  it('rewrites async loader results', async () => {
+    const url = createAiModuleUrl()
+    const result = await load(url, { format: 'module' }, () => ({ format: 'module', source }))
+
+    assertRewritten(result.source)
+  })
+
+  it('rewrites sync loader results', () => {
+    const url = createAiModuleUrl()
+    const result = loadSync(url, { format: 'module' }, () => ({ format: 'module', source }))
+
+    assertRewritten(result.source)
+  })
+})
+
+function createAiModuleUrl () {
+  const root = mkdtempSync(join(tmpdir(), 'dd-rewriter-loader-'))
+  const packageDirectory = join(root, 'node_modules', 'ai')
+
+  mkdirSync(join(packageDirectory, 'dist'), { recursive: true })
+  writeFileSync(join(packageDirectory, 'package.json'), '{"version":"4.0.0"}')
+
+  return pathToFileURL(join(packageDirectory, 'dist', 'index.mjs')).href
+}
+
+function assertRewritten (rewrittenSource) {
+  assert.match(rewrittenSource, /from "file:\/\/.+dc-polyfill/)
+  assert.match(rewrittenSource, /tr_ch_apm_tracingChannel/)
+  assert.match(rewrittenSource, /orchestrion:ai:getTracer/)
+}

--- a/register.js
+++ b/register.js
@@ -5,4 +5,14 @@
 const { register } = require('node:module')
 const { pathToFileURL } = require('node:url')
 
-register('./loader-hook.mjs', pathToFileURL(__filename))
+const parentURL = pathToFileURL(__filename)
+let isSyncLoaderRegistered = false
+
+try {
+  const { registerSyncLoaderHooks } = require('./loader-hook.mjs')
+  isSyncLoaderRegistered = registerSyncLoaderHooks()
+} catch {}
+
+if (!isSyncLoaderRegistered) {
+  register('./loader-hook.mjs', parentURL)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
-  integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==
+import-in-the-middle@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz#0d0e88c93c276599bd4bf81835946d723656efab"
+  integrity sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==
   dependencies:
     acorn "^8.15.0"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
### What does this PR do?
Uses `import-in-the-middle` synchronous loader hooks from `dd-trace/register.js` when the runtime and iitm support them, while keeping the existing async loader fallback for unsupported runtimes.

The sync path shares the same iitm option preparation as the async path, preserves the rewriter step for ESM orchestrion instrumentation, and updates the esbuild helper to drive iitm's sans-io export collector.

### Motivation
Vitest isolated workers pay the loader initialization cost once per worker. On supported Node versions, the synchronous hook path avoids the broader async loader overhead while keeping the existing loader behavior as the fallback.

### Additional Notes
Stacked on #8972. No benchmark rerun was done for this split. Quick local checks passed: touched-file ESLint and `packages/datadog-instrumentations/test/helpers/rewriter/loader.spec.mjs`.