### PR TITLE
fix(appsec): skip mongodb >=7 NoSQL tests on Node.js < 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.11",
-    "import-in-the-middle": "^3.0.1",
+    "import-in-the-middle": "3.0.1",
     "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -20,6 +20,7 @@ describe('nosql injection detection in mongodb - whole feature', () => {
     withVersions('express-mongo-sanitize', 'mongodb', mongodbVersion => {
       const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
 
+      // TODO: remove once Node.js 18 is no longer supported
       if (satisfies(mongodb.version(), '>=7') && NODE_MAJOR < 20) {
         describe.skip(
           `Skipping the tests as mongodb@${mongodb.version()} requires Node.js >= 20 (current: ${NODE_MAJOR})`

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -18,12 +18,13 @@ describe('nosql injection detection in mongodb - whole feature', () => {
   // https://github.com/fiznool/express-mongo-sanitize/issues/200
   withVersions('express-mongo-sanitize', 'express', '>4.18.0 <5.0.0', expressVersion => {
     withVersions('express-mongo-sanitize', 'mongodb', mongodbVersion => {
-      if (satisfies(mongodbVersion, '>=7') && NODE_MAJOR < 20) {
+      const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
+
+      if (satisfies(mongodb.version(), '>=7') && NODE_MAJOR < 20) {
         // eslint-disable-next-line mocha/no-pending-tests
-        describe.skip(`refusing to run tests as mongodb@${mongodbVersion} requires Node.js >= 20 (current: ${NODE_MAJOR})`)
+        describe.skip(`Skipping the tests as mongodb@${mongodb.version()} requires Node.js >= 20 (current: ${NODE_MAJOR})`)
         return
       }
-      const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
 
       const vulnerableMethodFilename = 'mongodb-vulnerable-method.js'
       let collection, tmpFilePath

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -21,8 +21,9 @@ describe('nosql injection detection in mongodb - whole feature', () => {
       const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
 
       if (satisfies(mongodb.version(), '>=7') && NODE_MAJOR < 20) {
-        // eslint-disable-next-line mocha/no-pending-tests
-        describe.skip(`Skipping the tests as mongodb@${mongodb.version()} requires Node.js >= 20 (current: ${NODE_MAJOR})`)
+        describe.skip(
+          `Skipping the tests as mongodb@${mongodb.version()} requires Node.js >= 20 (current: ${NODE_MAJOR})`
+        )
         return
       }
 

--- a/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/analyzers/nosql-injection-mongodb-analyzer.express-mongo-sanitize.plugin.spec.js
@@ -12,11 +12,17 @@ const satisfies = require('semifies')
 const agent = require('../../../plugins/agent')
 const { withVersions } = require('../../../setup/mocha')
 const { prepareTestServerForIastInExpress } = require('../utils')
+const { NODE_MAJOR } = require('../../../../../../version')
 
 describe('nosql injection detection in mongodb - whole feature', () => {
   // https://github.com/fiznool/express-mongo-sanitize/issues/200
   withVersions('express-mongo-sanitize', 'express', '>4.18.0 <5.0.0', expressVersion => {
     withVersions('express-mongo-sanitize', 'mongodb', mongodbVersion => {
+      if (satisfies(mongodbVersion, '>=7') && NODE_MAJOR < 20) {
+        // eslint-disable-next-line mocha/no-pending-tests
+        describe.skip(`refusing to run tests as mongodb@${mongodbVersion} requires Node.js >= 20 (current: ${NODE_MAJOR})`)
+        return
+      }
       const mongodb = require(`../../../../../../versions/mongodb@${mongodbVersion}`)
 
       const vulnerableMethodFilename = 'mongodb-vulnerable-method.js'

--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -157,7 +157,7 @@ module.exports = {
   'express-mongo-sanitize': [
     {
       name: 'mongodb',
-      versions: ['>=3.3 <5', '5', '>=6'],
+      versions: ['>=3.3 <5', '5', '6', '>=7'],
     },
     {
       name: 'mongodb-core',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,7 +2598,7 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^3.0.1:
+import-in-the-middle@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
   integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==


### PR DESCRIPTION
### What does this PR do?
Skips NoSQL MongoDB IAST tests for `mongodb >= 7` when running on `Node.js < 20`.

### Motivation
`bson@7.3.0` was published on June 17th with `"engines": { "node": ">=20.19.0" }`. Since `mongodb@7.x` depends on `bson` with an open range (`^7.0.0`), fresh installs of `mongodb@7.x` now pull `bson@7.3.0`, which crashes on Node.js 18 with a `TypeError: undefined is not a function` in a static class initializer.

### Additional Notes
`mongodb@7.x` support on `Node.js 20+` is not affected.


