### PR TITLE
fix(esbuild): support import-in-the-middle 3.1 exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   ],
   "dependencies": {
     "dc-polyfill": "^0.1.11",
-    "import-in-the-middle": "^3.0.1",
+    "import-in-the-middle": "^3.1.0",
     "opentracing": ">=0.14.7"
   },
   "optionalDependencies": {

--- a/packages/datadog-esbuild/src/utils.js
+++ b/packages/datadog-esbuild/src/utils.js
@@ -6,6 +6,9 @@ const fs = require('node:fs')
 const path = require('node:path')
 const { NODE_MAJOR, NODE_MINOR } = require('../../../version.js')
 
+const LOAD_OPERATION = 0
+const RESOLVE_OPERATION = 1
+
 const getExportsImporting = (url) => import(url).then(Object.keys)
 let getExportsModulePromise
 
@@ -19,7 +22,11 @@ const loadGetExportsModule = () => {
 const getExports = NODE_MAJOR >= 20 || (NODE_MAJOR === 18 && NODE_MINOR >= 19)
   ? async (srcUrl, context, getSource) => {
     const mod = await loadGetExportsModule()
-    return mod.getExports(srcUrl, context, getSource)
+    const exportNames = mod.getExports(srcUrl, context, getSource)
+    if (exportNames?.next) {
+      return driveGetExportsGenerator(exportNames, getSource)
+    }
+    return exportNames
   }
   : getExportsImporting
 
@@ -76,6 +83,42 @@ function getSource (url, { format }) {
     source: fs.readFileSync(fileURLToPath(url), 'utf8'),
     format,
   }
+}
+
+/**
+ * Drives the generator returned by import-in-the-middle >=3.1.0 export discovery.
+ *
+ * @param {Generator<Array, Set<string>>} exportsGenerator Generator returned by getExports
+ * @param {(url: URL, context: object) => { source: string, format: string }} getSource
+ * Function that loads module source
+ * @returns {Set<string>}
+ */
+function driveGetExportsGenerator (exportsGenerator, getSource) {
+  let next = exportsGenerator.next()
+  while (next.done === false) {
+    let result
+    let error
+    let threw = false
+
+    try {
+      const operation = next.value
+      const operationType = operation[0]
+
+      if (operationType === LOAD_OPERATION) {
+        result = getSource(operation[1], operation[2])
+      } else if (operationType === RESOLVE_OPERATION) {
+        result = resolve(operation[1], operation[2])
+      } else {
+        throw new Error(`Unsupported import-in-the-middle getExports operation: ${operationType}`)
+      }
+    } catch (err) {
+      threw = true
+      error = err
+    }
+
+    next = threw ? exportsGenerator.throw(error) : exportsGenerator.next(result)
+  }
+  return next.value
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-import-in-the-middle@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz#8a0a1230c9b865c0e12698171646ae1e3fff691d"
-  integrity sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==
+import-in-the-middle@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz#0d0e88c93c276599bd4bf81835946d723656efab"
+  integrity sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==
   dependencies:
     acorn "^8.15.0"
     acorn-import-attributes "^1.9.5"


### PR DESCRIPTION
## What does this PR do?

Updates the esbuild bundler helper to support `import-in-the-middle@3.1.0` export discovery. `import-in-the-middle` changed its internal `lib/get-exports.mjs#getExports` helper from an async function returning export names into a generator that yields loader I/O operations. The esbuild helper now detects that generator shape and drives its `LOAD` and `RESOLVE` operations locally before continuing to build ESM proxy setters.

This also bumps the dependency range to `^3.1.0` and refreshes `yarn.lock`.

## Motivation

CI started failing in esbuild jobs with `TypeError: n.replaceAll is not a function` after `import-in-the-middle@3.1.0` was published. The dd-trace esbuild integration deep-imports `import-in-the-middle/lib/get-exports.mjs`, so it was still expecting the old `Promise<Set<string>>` shape and accidentally iterated the new generator's yielded `[LOAD, url, context]` operation arrays as export names.

## Testing

- `./node_modules/.bin/eslint packages/datadog-esbuild/src/utils.js --max-warnings 0`
- `./node_modules/.bin/mocha packages/datadog-esbuild/test/utils.spec.js`
- `npm run test:esbuild:ci`
- `npm exec --yes --package node@24.16.0 -- node build-and-test-koa.mjs` from `integration-tests/esbuild`