### PR TITLE
fix(metrics): use UNIX-epoch nanoseconds for OTLP metric timestamps

### DIFF
--- a/packages/dd-trace/src/opentelemetry/metrics/instruments.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/instruments.js
@@ -2,6 +2,7 @@
 
 const { sanitizeAttributes } = require('../../../../../vendor/dist/@opentelemetry/core')
 const { METRIC_TYPES } = require('./constants')
+const { nowUnixNano } = require('./time')
 
 /**
  * @typedef {import('@opentelemetry/api').Attributes} Attributes
@@ -62,7 +63,7 @@ class Instrument {
       type,
       value,
       attributes: sanitizeAttributes(attributes),
-      timestamp: Number(process.hrtime.bigint()),
+      timestamp: nowUnixNano(),
     }
   }
 }

--- a/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/periodic_metric_reader.js
@@ -6,6 +6,7 @@ const {
   METRIC_TYPES, TEMPORALITY, DEFAULT_HISTOGRAM_BUCKETS, DEFAULT_MAX_MEASUREMENT_QUEUE_SIZE,
 } = require('./constants')
 const { ObservableInstrument } = require('./instruments')
+const { nowUnixNano } = require('./time')
 
 /**
  * @typedef {import('@opentelemetry/api').Attributes} Attributes
@@ -309,7 +310,7 @@ class PeriodicMetricReader {
  *
  */
 class MetricAggregator {
-  #startTime = Number(process.hrtime.bigint())
+  #startTime = nowUnixNano()
   #temporalityPreference
   #maxBatchedQueueSize
 

--- a/packages/dd-trace/src/opentelemetry/metrics/time.js
+++ b/packages/dd-trace/src/opentelemetry/metrics/time.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { timeOrigin } = performance
+
+/**
+ * Current wall-clock time as UNIX epoch nanoseconds, the unit OTLP requires for
+ * `timeUnixNano` / `startTimeUnixNano`. `process.hrtime.bigint()` is a monotonic
+ * clock with an arbitrary origin, so its values decode as 1970 timestamps that
+ * the Datadog Agent silently drops. Anchoring on `performance.timeOrigin` puts
+ * the value on the epoch while `performance.now()` keeps it monotonic, so a
+ * backward wall-clock jump can't make `timeUnixNano` precede `startTimeUnixNano`.
+ *
+ * @returns {number} Nanoseconds since the UNIX epoch
+ */
+function nowUnixNano () {
+  return Math.round((timeOrigin + performance.now()) * 1e6)
+}
+
+module.exports = { nowUnixNano }

--- a/packages/dd-trace/test/opentelemetry/metrics.spec.js
+++ b/packages/dd-trace/test/opentelemetry/metrics.spec.js
@@ -315,6 +315,36 @@ describe('OpenTelemetry Meter Provider', () => {
       setTimeout(() => { validator(); done() }, 150)
     })
 
+    it('timestamps data points with UNIX-epoch nanoseconds, not the monotonic clock', (done) => {
+      // The delta counter pins the per-measurement timestamp; the UpDownCounter
+      // is always CUMULATIVE, so it pins the aggregator's start time too.
+      const lowerBoundNano = Date.now() * 1e6
+      const validator = mockOtlpExport((decoded) => {
+        const upperBoundNano = (Date.now() + 1000) * 1e6
+        const assertEpochNano = (label, value) => {
+          assert(
+            value >= lowerBoundNano && value <= upperBoundNano,
+            `${label} ${value} should be epoch nanoseconds within [${lowerBoundNano}, ${upperBoundNano}]`
+          )
+        }
+
+        const metricsList = decoded.resourceMetrics[0].scopeMetrics[0].metrics
+        const counter = metricsList.find(m => m.name === 'counter').sum.dataPoints[0]
+        assertEpochNano('counter.timeUnixNano', counter.timeUnixNano)
+
+        const updown = metricsList.find(m => m.name === 'updown').sum.dataPoints[0]
+        assertEpochNano('updown.timeUnixNano', updown.timeUnixNano)
+        assertEpochNano('updown.startTimeUnixNano', updown.startTimeUnixNano)
+      })
+
+      setupMetrics()
+      const meter = metrics.getMeter('app')
+      meter.createCounter('counter').add(5)
+      meter.createUpDownCounter('updown').add(3)
+
+      setTimeout(() => { validator(); done() }, 150)
+    })
+
     it('uses JSON with string timestamps when configured', (done) => {
       const validator = mockOtlpExport((decoded, headers) => {
         assert.strictEqual(headers['Content-Type'], 'application/json')


### PR DESCRIPTION
## Summary

When `DD_METRICS_OTEL_ENABLED=true`, the custom OTLP metrics exporter set `timeUnixNano` / `startTimeUnixNano` from `process.hrtime.bigint()`, a monotonic clock with an arbitrary origin rather than UNIX-epoch nanoseconds. The Datadog Agent OTLP receiver accepted the payloads but decoded the timestamps as 1970 and silently dropped the metrics during intake, so nothing showed up in Metrics Explorer (including the OpenFeature `feature_flag.evaluations` counter).

Both timestamp sources now derive from `performance.timeOrigin` (anchors the value on the epoch) plus `performance.now()` (keeps it monotonic, so `timeUnixNano` can't precede `startTimeUnixNano`). The shared `nowUnixNano()` helper keeps the two call sites — per-measurement timestamps in `instruments.js` and the cumulative aggregator start time in `periodic_metric_reader.js` — from drifting, and matches the epoch-anchoring already used by the OTel bridge spans in the same directory.

## Test plan

- [x] New regression test in `metrics.spec.js` records a delta counter and an always-cumulative UpDownCounter, asserting all timestamps land in an epoch-nanosecond window around `Date.now()`. Fails on master (~1970), passes with the fix.
- [x] Full `metrics.spec.js` suite green (58 tests); `nyc` shows the touched lines covered.

Fixes: https://github.com/DataDog/dd-trace-js/issues/8958