### PR TITLE
feat(log-capture): add DD_LOG_CAPTURE_* configuration options [1/3]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,8 @@
 
 # Serverless
 /packages/dd-trace/src/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
+/packages/dd-trace/src/log-capture/ @DataDog/serverless-aws @DataDog/debugger-nodejs
+/packages/dd-trace/test/log-capture/ @DataDog/serverless-aws @DataDog/debugger-nodejs
 /packages/dd-trace/test/lambda/ @DataDog/serverless-aws @DataDog/apm-serverless
 /packages/dd-trace/test/azure_metadata.spec.js @DataDog/apm-serverless
 /packages/dd-trace/test/serverless.spec.js @DataDog/apm-serverless

--- a/index.d.ts
+++ b/index.d.ts
@@ -1347,6 +1347,71 @@ declare namespace tracer {
      */
     traceWebsocketMessagesSeparateTraces?: boolean
 
+    /**
+     * Whether to enable log capture (forwarding application logs to Datadog).
+     * Defaults to true in serverless environments, false otherwise.
+     * @default false
+     * @env DD_LOG_CAPTURE_ENABLED
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureEnabled?: boolean
+
+    /**
+     * Hostname of the log intake endpoint.
+     * @default 'localhost'
+     * @env DD_LOG_CAPTURE_HOST
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureHost?: string
+
+    /**
+     * Port of the log intake endpoint.
+     * @default 10517
+     * @env DD_LOG_CAPTURE_PORT
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCapturePort?: number
+
+    /**
+     * Protocol for the log intake endpoint ('http:' or 'https:').
+     * @default 'http:'
+     * @env DD_LOG_CAPTURE_PROTOCOL
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureProtocol?: string
+
+    /**
+     * URL path for the log intake endpoint.
+     * @default '/logs'
+     * @env DD_LOG_CAPTURE_PATH
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCapturePath?: string
+
+    /**
+     * Maximum number of log records to buffer before forcing a flush.
+     * @default 1000
+     * @env DD_LOG_CAPTURE_MAX_BUFFER_SIZE
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureMaxBufferSize?: number
+
+    /**
+     * Interval in milliseconds between periodic log flushes.
+     * @default 5000
+     * @env DD_LOG_CAPTURE_FLUSH_INTERVAL_MS
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureFlushIntervalMs?: number
+
+    /**
+     * Timeout in milliseconds for log intake HTTP requests.
+     * @default 5000
+     * @env DD_LOG_CAPTURE_TIMEOUT_MS
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureTimeoutMs?: number
+
   }
 
   /**

--- a/index.d.v5.ts
+++ b/index.d.v5.ts
@@ -1459,6 +1459,71 @@ declare namespace tracer {
      */
     traceWebsocketMessagesSeparateTraces?: boolean
 
+    /**
+     * Whether to enable log capture (forwarding application logs to Datadog).
+     * Defaults to true in serverless environments, false otherwise.
+     * @default false
+     * @env DD_LOG_CAPTURE_ENABLED
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureEnabled?: boolean
+
+    /**
+     * Hostname of the log intake endpoint.
+     * @default 'localhost'
+     * @env DD_LOG_CAPTURE_HOST
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureHost?: string
+
+    /**
+     * Port of the log intake endpoint.
+     * @default 10517
+     * @env DD_LOG_CAPTURE_PORT
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCapturePort?: number
+
+    /**
+     * Protocol for the log intake endpoint ('http:' or 'https:').
+     * @default 'http:'
+     * @env DD_LOG_CAPTURE_PROTOCOL
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureProtocol?: string
+
+    /**
+     * URL path for the log intake endpoint.
+     * @default '/logs'
+     * @env DD_LOG_CAPTURE_PATH
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCapturePath?: string
+
+    /**
+     * Maximum number of log records to buffer before forcing a flush.
+     * @default 1000
+     * @env DD_LOG_CAPTURE_MAX_BUFFER_SIZE
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureMaxBufferSize?: number
+
+    /**
+     * Interval in milliseconds between periodic log flushes.
+     * @default 5000
+     * @env DD_LOG_CAPTURE_FLUSH_INTERVAL_MS
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureFlushIntervalMs?: number
+
+    /**
+     * Timeout in milliseconds for log intake HTTP requests.
+     * @default 5000
+     * @env DD_LOG_CAPTURE_TIMEOUT_MS
+     * Programmatic configuration takes precedence over the environment variables listed above.
+     */
+    logCaptureTimeoutMs?: number
+
   }
 
   /**

--- a/packages/dd-trace/src/config/generated-config-types.d.ts
+++ b/packages/dd-trace/src/config/generated-config-types.d.ts
@@ -478,6 +478,14 @@ export interface GeneratedConfig {
     enabled: boolean;
     mlApp: string | undefined;
   };
+  logCaptureEnabled: boolean;
+  logCaptureFlushIntervalMs: number;
+  logCaptureHost: string;
+  logCaptureMaxBufferSize: number;
+  logCapturePath: string;
+  logCapturePort: number;
+  logCaptureProtocol: string;
+  logCaptureTimeoutMs: number;
   logInjection: boolean;
   logLevel: "debug" | "info" | "warn" | "error";
   middlewareTracingEnabled: boolean;

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -87,6 +87,9 @@ const changeTracker = {
  */
 function undo (config, source) {
   for (const name of changeTracker[source]) {
+    // A calculated value that RC has since overridden must not be reset here —
+    // the RC value takes precedence and will survive until RC itself is rolled back.
+    if (source === 'calculated' && trackedConfigOrigins.get(name) === 'remote_config') continue
     const entry = changeTracker.baseValuesByPath[name] ?? { source: 'default', value: defaults[name] }
     setAndTrack(config, name, entry.value, undefined, entry.source)
   }
@@ -619,22 +622,20 @@ class Config extends ConfigBase {
 
     // Normalize logCaptureProtocol: strip any '://' suffix, lowercase, add trailing colon,
     // then validate — only 'http:' and 'https:' are supported; warn and fall back to 'http:'.
-    if (this.logCaptureProtocol) {
-      const rawProtocol = this.logCaptureProtocol
-      let protocol = rawProtocol.toLowerCase().replace(/:\/\/.*$/, '')
-      if (!protocol.endsWith(':')) {
-        protocol += ':'
-      }
-      if (protocol !== 'http:' && protocol !== 'https:') {
-        log.warn('logCaptureProtocol: unsupported value %j, falling back to http:', rawProtocol)
-        protocol = 'http:'
-      }
-      const origin = trackedConfigOrigins.get('logCaptureProtocol')
-      if (origin === undefined) {
-        set(this, 'logCaptureProtocol', protocol)
-      } else {
-        setAndTrack(this, 'logCaptureProtocol', protocol, rawProtocol, /** @type {TelemetrySource} */ (origin))
-      }
+    const rawProtocol = this.logCaptureProtocol
+    let protocol = String(rawProtocol).toLowerCase().replace(/:\/\/.*$/, '')
+    if (!protocol.endsWith(':')) {
+      protocol += ':'
+    }
+    if (protocol !== 'http:' && protocol !== 'https:') {
+      log.warn('logCaptureProtocol: unsupported value %j, falling back to http:', rawProtocol)
+      protocol = 'http:'
+    }
+    const origin = trackedConfigOrigins.get('logCaptureProtocol')
+    if (origin === undefined) {
+      set(this, 'logCaptureProtocol', protocol)
+    } else {
+      setAndTrack(this, 'logCaptureProtocol', protocol, rawProtocol, /** @type {TelemetrySource} */ (origin))
     }
 
     // Single tags update is tracked as a calculated value.

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -628,7 +628,7 @@ class Config extends ConfigBase {
       protocol += ':'
     }
     if (protocol !== 'http:' && protocol !== 'https:') {
-      log.warn('logCaptureProtocol: unsupported value %j, falling back to http:', rawProtocol)
+      log.warn('logCaptureProtocol: unsupported value %o, falling back to http:', rawProtocol)
       protocol = 'http:'
     }
     const origin = trackedConfigOrigins.get('logCaptureProtocol')

--- a/packages/dd-trace/src/config/index.js
+++ b/packages/dd-trace/src/config/index.js
@@ -17,6 +17,7 @@ const {
   IS_SERVERLESS,
   getIsGCPFunction,
   getIsAzureFunction,
+  isSomethingUnderNDA,
 } = require('../serverless')
 const { ORIGIN_KEY, DATADOG_MINI_AGENT_PATH } = require('../constants')
 const { appendRules } = require('../payload-tagging/config')
@@ -320,6 +321,7 @@ class Config extends ConfigBase {
 
   // Handles values calculated from a mixture of options and env vars
   #applyCalculated () {
+    const logCaptureEnabledIsRC = trackedConfigOrigins.get('logCaptureEnabled') === 'remote_config'
     undo(this, 'calculated')
 
     if (this.url ||
@@ -553,6 +555,10 @@ class Config extends ConfigBase {
       setAndTrack(this, 'remoteConfig.enabled', false)
     }
 
+    if (!logCaptureEnabledIsRC && !trackedConfigOrigins.has('logCaptureEnabled')) {
+      setAndTrack(this, 'logCaptureEnabled', isSomethingUnderNDA())
+    }
+
     // TODO: Should this unconditionally be disabled?
     if (getEnvironmentVariable('JEST_WORKER_ID') && !trackedConfigOrigins.has('telemetry.enabled')) {
       setAndTrack(this, 'telemetry.enabled', false)
@@ -609,6 +615,26 @@ class Config extends ConfigBase {
       deactivateIfEnabledAndWarnOnWindows(this, 'DD_PROFILING_CPU_ENABLED')
       deactivateIfEnabledAndWarnOnWindows(this, 'DD_PROFILING_TIMELINE_ENABLED')
       deactivateIfEnabledAndWarnOnWindows(this, 'DD_PROFILING_ASYNC_CONTEXT_FRAME_ENABLED')
+    }
+
+    // Normalize logCaptureProtocol: strip any '://' suffix, lowercase, add trailing colon,
+    // then validate — only 'http:' and 'https:' are supported; warn and fall back to 'http:'.
+    if (this.logCaptureProtocol) {
+      const rawProtocol = this.logCaptureProtocol
+      let protocol = rawProtocol.toLowerCase().replace(/:\/\/.*$/, '')
+      if (!protocol.endsWith(':')) {
+        protocol += ':'
+      }
+      if (protocol !== 'http:' && protocol !== 'https:') {
+        log.warn('logCaptureProtocol: unsupported value %j, falling back to http:', rawProtocol)
+        protocol = 'http:'
+      }
+      const origin = trackedConfigOrigins.get('logCaptureProtocol')
+      if (origin === undefined) {
+        set(this, 'logCaptureProtocol', protocol)
+      } else {
+        setAndTrack(this, 'logCaptureProtocol', protocol, rawProtocol, /** @type {TelemetrySource} */ (origin))
+      }
     }
 
     // Single tags update is tracked as a calculated value.

--- a/packages/dd-trace/src/config/supported-configurations.json
+++ b/packages/dd-trace/src/config/supported-configurations.json
@@ -1255,6 +1255,86 @@
         "default": "false"
       }
     ],
+    "DD_LOG_CAPTURE_ENABLED": [
+      {
+        "implementation": "B",
+        "type": "boolean",
+        "configurationNames": [
+          "logCaptureEnabled"
+        ],
+        "default": "false"
+      }
+    ],
+    "DD_LOG_CAPTURE_FLUSH_INTERVAL_MS": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCaptureFlushIntervalMs"
+        ],
+        "default": "5000"
+      }
+    ],
+    "DD_LOG_CAPTURE_HOST": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "logCaptureHost"
+        ],
+        "default": "localhost"
+      }
+    ],
+    "DD_LOG_CAPTURE_MAX_BUFFER_SIZE": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCaptureMaxBufferSize"
+        ],
+        "default": "1000"
+      }
+    ],
+    "DD_LOG_CAPTURE_PATH": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "logCapturePath"
+        ],
+        "default": "/logs"
+      }
+    ],
+    "DD_LOG_CAPTURE_PORT": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCapturePort"
+        ],
+        "default": "10517"
+      }
+    ],
+    "DD_LOG_CAPTURE_PROTOCOL": [
+      {
+        "implementation": "B",
+        "type": "string",
+        "configurationNames": [
+          "logCaptureProtocol"
+        ],
+        "default": "http:"
+      }
+    ],
+    "DD_LOG_CAPTURE_TIMEOUT_MS": [
+      {
+        "implementation": "B",
+        "type": "int",
+        "configurationNames": [
+          "logCaptureTimeoutMs"
+        ],
+        "default": "5000"
+      }
+    ],
     "DD_TRACE_AWS_DURABLE_EXECUTION_SDK_JS_ENABLED": [
       {
         "implementation": "A",

--- a/packages/dd-trace/src/serverless.js
+++ b/packages/dd-trace/src/serverless.js
@@ -35,6 +35,10 @@ function getIsFlexConsumptionAzureFunction () {
   return getIsAzureFunction() && getEnvironmentVariable('WEBSITE_SKU') === 'FlexConsumption'
 }
 
+function isSomethingUnderNDA () {
+  return getEnvironmentVariable('SOMETHING_UNDER_NDA') === 'something-under-nda'
+}
+
 function isInServerlessEnvironment () {
   const inAWSLambda = getEnvironmentVariable('AWS_LAMBDA_FUNCTION_NAME') !== undefined
   const isGCPFunction = getIsGCPFunction()
@@ -48,5 +52,6 @@ module.exports = {
   getIsAzureFunction,
   enableGCPPubSubPushSubscription,
   getIsFlexConsumptionAzureFunction,
+  isSomethingUnderNDA,
   IS_SERVERLESS: isInServerlessEnvironment(),
 }

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1714,6 +1714,18 @@ describe('Config', () => {
     delete process.env.SOMETHING_UNDER_NDA
   })
 
+  it('should preserve RC logCaptureEnabled when it matches the computed serverless default', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+
+    config.setRemoteConfig({ logCaptureEnabled: true })
+    assert.strictEqual(config.logCaptureEnabled, true)
+    assert.strictEqual(config.getOrigin('logCaptureEnabled'), 'remote_config')
+
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
   it('should respect DD_LOG_CAPTURE_ENABLED=false even in serverless environment', () => {
     process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
     process.env.DD_LOG_CAPTURE_ENABLED = 'false'
@@ -1775,7 +1787,7 @@ describe('Config', () => {
     delete process.env.DD_LOG_CAPTURE_PROTOCOL
   })
 
-  it('should normalize DD_LOG_CAPTURE_PROTOCOL uppercase without colon', () => {
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL uppercase with colon', () => {
     process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS:'
     const config = getConfig()
     assert.strictEqual(config.logCaptureProtocol, 'https:')
@@ -1836,6 +1848,11 @@ describe('Config', () => {
     const config = getConfig()
     assert.strictEqual(config.logCaptureProtocol, 'http:')
     delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should fall back to http: for a non-string logCaptureProtocol option without crashing', () => {
+    const config = getConfig({ logCaptureProtocol: 123 })
+    assert.strictEqual(config.logCaptureProtocol, 'http:')
   })
 
   it('should not track logCaptureProtocol origin when using the default value', () => {

--- a/packages/dd-trace/test/config/index.spec.js
+++ b/packages/dd-trace/test/config/index.spec.js
@@ -1670,6 +1670,180 @@ describe('Config', () => {
     assert.strictEqual(config.appsec.eventTracking.mode, 'anonymous')
   })
 
+  it('should read DD_LOG_CAPTURE_ENABLED', () => {
+    process.env.DD_LOG_CAPTURE_ENABLED = 'true'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+    delete process.env.DD_LOG_CAPTURE_ENABLED
+  })
+
+  it('should default logCaptureEnabled to true when SOMETHING_UNDER_NDA is something-under-nda', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should not override DD_LOG_CAPTURE_ENABLED=false when SOMETHING_UNDER_NDA is something-under-nda', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    process.env.DD_LOG_CAPTURE_ENABLED = 'false'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, false)
+    delete process.env.SOMETHING_UNDER_NDA
+    delete process.env.DD_LOG_CAPTURE_ENABLED
+  })
+
+  it('should not default logCaptureEnabled to true when SOMETHING_UNDER_NDA is not something-under-nda', () => {
+    process.env.SOMETHING_UNDER_NDA = 'on-demand'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, false)
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should restore logCaptureEnabled to SOMETHING_UNDER_NDA default after remote config rollback', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, true)
+
+    config.setRemoteConfig({ logCaptureEnabled: false })
+    assert.strictEqual(config.logCaptureEnabled, false)
+
+    config.setRemoteConfig(null)
+    assert.strictEqual(config.logCaptureEnabled, true)
+
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should respect DD_LOG_CAPTURE_ENABLED=false even in serverless environment', () => {
+    process.env.SOMETHING_UNDER_NDA = 'something-under-nda'
+    process.env.DD_LOG_CAPTURE_ENABLED = 'false'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureEnabled, false)
+    delete process.env.DD_LOG_CAPTURE_ENABLED
+    delete process.env.SOMETHING_UNDER_NDA
+  })
+
+  it('should default logCaptureHost to localhost', () => {
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureHost, 'localhost')
+  })
+
+  it('should default logCapturePort to 10517', () => {
+    const config = getConfig()
+    assert.strictEqual(config.logCapturePort, 10517)
+  })
+
+  it('should read DD_LOG_CAPTURE_HOST', () => {
+    process.env.DD_LOG_CAPTURE_HOST = 'my-intake.internal'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureHost, 'my-intake.internal')
+    delete process.env.DD_LOG_CAPTURE_HOST
+  })
+
+  it('should read DD_LOG_CAPTURE_PORT', () => {
+    process.env.DD_LOG_CAPTURE_PORT = '8080'
+    const config = getConfig()
+    assert.strictEqual(config.logCapturePort, 8080)
+    delete process.env.DD_LOG_CAPTURE_PORT
+  })
+
+  it('should read DD_LOG_CAPTURE_PATH', () => {
+    process.env.DD_LOG_CAPTURE_PATH = '/custom-logs'
+    const config = getConfig()
+    assert.strictEqual(config.logCapturePath, '/custom-logs')
+    delete process.env.DD_LOG_CAPTURE_PATH
+  })
+
+  it('should read DD_LOG_CAPTURE_PROTOCOL', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'https:'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL without trailing colon', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'https'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL to lowercase', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize DD_LOG_CAPTURE_PROTOCOL uppercase without colon', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS:'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should read DD_LOG_CAPTURE_MAX_BUFFER_SIZE', () => {
+    process.env.DD_LOG_CAPTURE_MAX_BUFFER_SIZE = '500'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureMaxBufferSize, 500)
+    delete process.env.DD_LOG_CAPTURE_MAX_BUFFER_SIZE
+  })
+
+  it('should read DD_LOG_CAPTURE_FLUSH_INTERVAL_MS', () => {
+    process.env.DD_LOG_CAPTURE_FLUSH_INTERVAL_MS = '2000'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureFlushIntervalMs, 2000)
+    delete process.env.DD_LOG_CAPTURE_FLUSH_INTERVAL_MS
+  })
+
+  it('should read DD_LOG_CAPTURE_TIMEOUT_MS', () => {
+    process.env.DD_LOG_CAPTURE_TIMEOUT_MS = '3000'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureTimeoutMs, 3000)
+    delete process.env.DD_LOG_CAPTURE_TIMEOUT_MS
+  })
+
+  it('should normalize logCaptureProtocol option to lowercase with colon', () => {
+    const config = getConfig({ logCaptureProtocol: 'HTTPS:' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should preserve the origin of logCaptureProtocol after normalization', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'HTTPS'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+    assert.strictEqual(config.getOrigin('logCaptureProtocol'), 'env_var')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should normalize logCaptureProtocol option without trailing colon', () => {
+    const config = getConfig({ logCaptureProtocol: 'HTTPS' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should normalize logCaptureProtocol option lowercase without colon', () => {
+    const config = getConfig({ logCaptureProtocol: 'https' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should normalize logCaptureProtocol stripping :// suffix', () => {
+    const config = getConfig({ logCaptureProtocol: 'https://' })
+    assert.strictEqual(config.logCaptureProtocol, 'https:')
+  })
+
+  it('should fall back to http: and warn for unsupported logCaptureProtocol', () => {
+    process.env.DD_LOG_CAPTURE_PROTOCOL = 'ftp'
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'http:')
+    delete process.env.DD_LOG_CAPTURE_PROTOCOL
+  })
+
+  it('should not track logCaptureProtocol origin when using the default value', () => {
+    const config = getConfig()
+    assert.strictEqual(config.logCaptureProtocol, 'http:')
+    assert.strictEqual(config.getOrigin('logCaptureProtocol'), 'default')
+  })
+
   it('should initialize from the options', () => {
     const logger = {
       warn: sinon.spy(),

--- a/packages/dd-trace/test/plugins/agent.js
+++ b/packages/dd-trace/test/plugins/agent.js
@@ -82,6 +82,8 @@ const TRACKED_NON_PREFIX_ENV_NAMES = new Set([
   // GitHub Actions CI plugin metadata
   'GITHUB_EVENT_PATH',
   'RUNNER_TEMP',
+  // serverless feature-flag (isSomethingUnderNDA detection)
+  'SOMETHING_UNDER_NDA',
   // misc CI provider / build tooling reads
   'HOME',
   'LAGE_PACKAGE_NAME',


### PR DESCRIPTION
### What does this PR do?

Introduces the configuration surface for the log-capture subsystem: 8 new \`DD_LOG_CAPTURE_*\` environment variables plus the supporting config infrastructure.

### Motivation

In serverless and agentless deployments (e.g. AWS Lambda, Google Cloud Run), the application and the Datadog Agent don't share a host, so logs written to stdout/stderr never reach Datadog automatically. The only reliable path is for the tracer itself to forward them directly to the log intake over HTTP/HTTPS.

Before any forwarding can happen, we need to know *where* to send logs and *how* to behave. This PR establishes that surface. Everything is opt-in via \`DD_LOG_CAPTURE_ENABLED\`, which defaults to \`true\` automatically in environments detected as serverless (via \`isSomethingUnderNDA()\`), so operators in standard deployments are unaffected.

\`logCaptureProtocol\` gets extra care: it normalises case and strips \`://\` suffixes (a common user mistake), validates strictly to \`http:\`/\`https:\`, and preserves the raw source value so \`getOrigin()\` and telemetry see the real input rather than the normalised result.

### Additional Notes

This is **PR 1 of 3** in a split of the original #8964 (kept under 300 lines each):
1. **[this PR]** Configuration surface
2. #8983 — Sender implementation and orchestration layer
3. #8984 — Comprehensive sender test suite

**Implementation notes:**

The computed default for \`logCaptureEnabled\` lives in \`#applyCalculated()\` rather than \`defaults.js\` so that Remote Config overrides and \`undo()\` round-trips work correctly — the serverless-detection call runs after RC is applied, not at class construction time.

\`undo(this, 'calculated')\` now skips fields that RC currently owns. Without this, \`setRemoteConfig({ logCaptureEnabled: true })\` in a serverless environment (where the computed default is also \`true\`) would have its value silently wiped on the next recalculation: the field was still in \`changeTracker['calculated']\` from the initial construction pass, so \`undo\` would reset it to the default \`false\` — leaving log capture disabled despite an active RC override.

The \`if (this.logCaptureProtocol)\` guard was dropped because \`logCaptureProtocol\` always has a default of \`'http:'\` (from \`supported-configurations.json\`), making the false branch structurally unreachable.

## Test plan

- [x] \`./node_modules/.bin/mocha packages/dd-trace/test/config/index.spec.js --grep "logCapture"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)