### PR TITLE
test(log-capture): add comprehensive sender test suite [3/3]

### DIFF
--- a/packages/dd-trace/test/log-capture/sender.spec.js
+++ b/packages/dd-trace/test/log-capture/sender.spec.js
@@ -1,0 +1,285 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { describe, it, beforeEach, afterEach } = require('mocha')
+const sinon = require('sinon')
+
+let sender
+
+const BASE_OPTS = {
+  host: 'localhost',
+  port: 8080,
+  path: '/logs',
+  protocol: 'http:',
+  maxBufferSize: 100,
+  flushIntervalMs: 5000,
+  timeoutMs: 5000,
+}
+
+describe('LogCaptureSender', () => {
+  let clock, httpStub, writeStub
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers()
+    writeStub = sinon.stub()
+    httpStub = sinon.stub(require('node:http'), 'request').returns({
+      once: sinon.stub().returnsThis(),
+      write: writeStub,
+      end: sinon.stub(),
+    })
+    delete require.cache[require.resolve('../../src/log-capture/sender')]
+    sender = require('../../src/log-capture/sender')
+  })
+
+  afterEach(() => {
+    clock.restore()
+    sinon.restore()
+  })
+
+  it('should buffer log records', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    assert.strictEqual(sender.bufferSize(), 1)
+  })
+
+  it('should flush and add when maxBufferSize is reached', () => {
+    sender.configure({ ...BASE_OPTS, maxBufferSize: 2 })
+    sender.add('{"level":30,"msg":"a"}')
+    sender.add('{"level":30,"msg":"b"}')
+    // buffer is now full — next add should flush then enqueue
+    sender.add('{"level":30,"msg":"c"}')
+    assert.ok(httpStub.calledOnce, 'should have flushed when buffer was full')
+    assert.strictEqual(sender.bufferSize(), 1)
+  })
+
+  it('should clear the timer on an explicit flush so the next add re-arms at the full interval', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a"}')
+
+    // Advance partway through the interval, then flush explicitly.
+    clock.tick(BASE_OPTS.flushIntervalMs / 2)
+    sender.flush()
+    assert.strictEqual(clock.countTimers(), 0, 'explicit flush should have cleared the timer')
+
+    // A new record should re-arm the timer from scratch.
+    sender.add('{"level":30,"msg":"b"}')
+    assert.strictEqual(clock.countTimers(), 1)
+
+    // The remaining half-interval should NOT trigger a flush.
+    clock.tick(BASE_OPTS.flushIntervalMs / 2)
+    assert.strictEqual(httpStub.callCount, 1, 'only the explicit flush should have fired so far')
+
+    // The full interval from the re-arm should flush the new record.
+    clock.tick(BASE_OPTS.flushIntervalMs / 2)
+    assert.strictEqual(httpStub.callCount, 2)
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should reset the flush timer after a buffer-overflow flush', () => {
+    sender.configure({ ...BASE_OPTS, maxBufferSize: 2 })
+    sender.add('{"level":30,"msg":"a"}')
+    sender.add('{"level":30,"msg":"b"}')
+    // overflow flush: timer should be cleared and re-armed when "c" is added
+    sender.add('{"level":30,"msg":"c"}')
+    assert.strictEqual(clock.countTimers(), 1, 'timer should be re-armed after overflow flush')
+    clock.tick(BASE_OPTS.flushIntervalMs)
+    assert.ok(httpStub.calledTwice, 'second flush should occur at the new timer interval')
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should flush on interval', () => {
+    sender.configure({ ...BASE_OPTS, maxBufferSize: 1000 })
+    sender.add('{"level":30,"msg":"hello"}')
+    clock.tick(5000)
+    assert.ok(httpStub.called)
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should not leak timers when configure is called multiple times', () => {
+    sender.configure(BASE_OPTS)
+    assert.strictEqual(clock.countTimers(), 0)
+
+    sender.configure({ ...BASE_OPTS, flushIntervalMs: 1000 })
+    assert.strictEqual(clock.countTimers(), 0)
+  })
+
+  it('should not arm a timer when no records are buffered', () => {
+    sender.configure(BASE_OPTS)
+    clock.tick(10000)
+    assert.ok(!httpStub.called, 'should not send when no records were added')
+    assert.strictEqual(clock.countTimers(), 0)
+  })
+
+  it('should flush records after flushIntervalMs when records are added', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    assert.strictEqual(clock.countTimers(), 1, 'timer should be armed after first add')
+    clock.tick(BASE_OPTS.flushIntervalMs)
+    assert.ok(httpStub.called, 'should have flushed after interval')
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should flush buffered records immediately when reconfigured', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+
+    sender.configure({ ...BASE_OPTS, flushIntervalMs: 1000 })
+
+    assert.ok(httpStub.calledOnce)
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should be a no-op when not configured', () => {
+    sender.add('{"level":30,"msg":"hello"}')
+    assert.strictEqual(sender.bufferSize(), 0)
+  })
+
+  it('should trim trailing newlines from records when flushing', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a"}\n')
+    sender.add('{"level":30,"msg":"b"}\n')
+    sender.flush()
+    assert.strictEqual(writeStub.firstCall.args[0], '{"level":30,"msg":"a"}\n{"level":30,"msg":"b"}')
+  })
+
+  it('should trim trailing CRLF from records when flushing', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a"}\r\n')
+    sender.flush()
+    assert.strictEqual(writeStub.firstCall.args[0], '{"level":30,"msg":"a"}')
+  })
+
+  it('should not strip trailing spaces from records when flushing', () => {
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"a with space "}\n')
+    sender.flush()
+    assert.strictEqual(writeStub.firstCall.args[0], '{"level":30,"msg":"a with space "}')
+  })
+
+  it('should drain the response body to release the socket', () => {
+    const res = { resume: sinon.stub() }
+    httpStub.callsFake((_opts, callback) => {
+      callback(res)
+      return { once: sinon.stub().returnsThis(), write: sinon.stub(), end: sinon.stub() }
+    })
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    assert.ok(res.resume.calledOnce)
+  })
+
+  it('should destroy the request on timeout', () => {
+    let timeoutHandler
+    const req = {
+      once: sinon.stub().callsFake((event, handler) => {
+        if (event === 'timeout') timeoutHandler = handler
+        return req
+      }),
+      write: sinon.stub(),
+      end: sinon.stub(),
+      destroy: sinon.stub(),
+    }
+    httpStub.returns(req)
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    timeoutHandler()
+    assert.ok(req.destroy.calledOnce)
+  })
+
+  it('should warn on request error', () => {
+    const logModule = require('../../src/log')
+    const warnStub = sinon.stub(logModule, 'warn')
+
+    let errorHandler
+    const req = {
+      once: sinon.stub().callsFake((event, handler) => {
+        if (event === 'error') errorHandler = handler
+        return req
+      }),
+      write: sinon.stub(),
+      end: sinon.stub(),
+    }
+    httpStub.returns(req)
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+
+    assert.strictEqual(typeof errorHandler, 'function', 'error handler should be registered')
+    errorHandler(new Error('ECONNREFUSED'))
+    assert.ok(warnStub.calledOnce, 'log.warn should be called on error')
+    warnStub.restore()
+  })
+
+  it('should warn and not crash when transport.request() throws synchronously', () => {
+    const logModule = require('../../src/log')
+    const warnStub = sinon.stub(logModule, 'warn')
+
+    httpStub.throws(new Error('invalid options'))
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    assert.ok(warnStub.calledOnce, 'log.warn should be called on sync throw')
+    warnStub.restore()
+  })
+
+  it('should use https when protocol is https:', () => {
+    const httpsStub = sinon.stub(require('node:https'), 'request').returns({
+      once: sinon.stub().returnsThis(),
+      write: sinon.stub(),
+      end: sinon.stub(),
+    })
+    sender.configure({ ...BASE_OPTS, port: 443, protocol: 'https:', maxBufferSize: 1000 })
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    assert.ok(httpsStub.called)
+  })
+
+  it('should be a no-op flush when never configured', () => {
+    sender.flush()
+    assert.ok(!httpStub.called, 'should not send when opts is undefined')
+  })
+
+  it('should reschedule the timer when records arrive during flush', () => {
+    httpStub.callsFake(() => ({
+      once: sinon.stub().returnsThis(),
+      write: sinon.stub().callsFake(() => {
+        sender.add('{"level":30,"msg":"added-during-flush"}')
+      }),
+      end: sinon.stub(),
+    }))
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"initial"}')
+    clock.tick(BASE_OPTS.flushIntervalMs)
+
+    assert.strictEqual(sender.bufferSize(), 1, 'mid-flush record should remain in buffer')
+    assert.strictEqual(clock.countTimers(), 1, 'exactly one timer should be active — no duplicate')
+  })
+
+  it('should warn on timeout', () => {
+    const logModule = require('../../src/log')
+    const warnStub = sinon.stub(logModule, 'warn')
+
+    let timeoutHandler
+    const req = {
+      once: sinon.stub().callsFake((event, handler) => {
+        if (event === 'timeout') timeoutHandler = handler
+        return req
+      }),
+      write: sinon.stub(),
+      end: sinon.stub(),
+      destroy: sinon.stub(),
+    }
+    httpStub.returns(req)
+
+    sender.configure(BASE_OPTS)
+    sender.add('{"level":30,"msg":"hello"}')
+    sender.flush()
+    timeoutHandler()
+    assert.ok(warnStub.calledOnce, 'log.warn should be called on timeout')
+    warnStub.restore()
+  })
+})


### PR DESCRIPTION
### What does this PR do?

Adds a 285-line test suite for `LogCaptureSender` — the HTTP transport module introduced in PR #8983.

### Motivation

The sender is the most stateful and timing-sensitive piece of the log-capture subsystem: it manages a live buffer, a self-rescheduling timer, two distinct flush paths (interval and overflow), and an HTTP connection that can time out or fail. Each of those moving parts has subtle invariants — e.g. that an explicit flush clears the timer so the *next* record re-arms at the full interval, or that a record added *during* a flush doesn't produce a duplicate timer — that are easy to break in a refactor.

sinon's fake timers make these timing properties testable without `sleep()` and without making the suite slow or flaky. The `require.cache` bust in `beforeEach` ensures each test gets a fresh module with clean state, so tests are fully independent regardless of run order.

The suite is intentionally exhaustive for a module of this complexity: boundary conditions (empty buffer, unconfigured sender, reconfigure-while-buffered), error paths (request error, synchronous throw, timeout), HTTP details (newline stripping, CRLF stripping, space preservation, response draining, HTTPS selection), and re-entrant edge cases.

### Additional Notes

This is **PR 3 of 3** in a split of the original #8964:
1. #8982 — Configuration surface
2. #8983 — Sender implementation and orchestration layer
3. **[this PR]** Comprehensive sender test suite

Stacks on #8983. No production code changes — this PR is purely tests.

## Test plan

- [x] `./node_modules/.bin/mocha packages/dd-trace/test/log-capture/sender.spec.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)