### PR TITLE
fix(ci): apply Vitest ATR retries to project configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -141,6 +141,7 @@
 /integration-tests/playwright/ @DataDog/ci-app-libraries
 /integration-tests/vitest/ @DataDog/ci-app-libraries
 /integration-tests/vitest.config.mjs @DataDog/ci-app-libraries
+/integration-tests/vitest.second-project.config.mjs @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.js @DataDog/ci-app-libraries
 /integration-tests/ci-visibility-intake.spec.js @DataDog/ci-app-libraries
 /integration-tests/CODEOWNERS @DataDog/ci-app-libraries

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -31,7 +31,8 @@ if (process.env.CUSTOM_SEQUENCER) {
 }
 
 if (process.env.PROJECT_POOL_CONFIG) {
-  const projectConfig = {
+  const projectConfigs = []
+  const firstProjectConfig = {
     include: [
       process.env.TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
     ],
@@ -39,14 +40,25 @@ if (process.env.PROJECT_POOL_CONFIG) {
     pool: process.env.PROJECT_POOL_CONFIG,
   }
   if (process.env.PROJECT_RETRY_CONFIG) {
-    projectConfig.retry = Number(process.env.PROJECT_RETRY_CONFIG)
+    firstProjectConfig.retry = Number(process.env.PROJECT_RETRY_CONFIG)
+  }
+  projectConfigs.push({ test: firstProjectConfig })
+
+  if (process.env.SECOND_PROJECT_POOL_CONFIG) {
+    const secondProjectConfig = {
+      include: [
+        process.env.SECOND_PROJECT_TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
+      ],
+      name: 'second-project-pool',
+      pool: process.env.SECOND_PROJECT_POOL_CONFIG,
+    }
+    if (process.env.SECOND_PROJECT_RETRY_CONFIG) {
+      secondProjectConfig.retry = Number(process.env.SECOND_PROJECT_RETRY_CONFIG)
+    }
+    projectConfigs.push({ test: secondProjectConfig })
   }
 
-  config.test.projects = [
-    {
-      test: projectConfig,
-    },
-  ]
+  config.test.projects = projectConfigs
 }
 
 if (process.env.COVERAGE_PROVIDER) {

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -36,7 +36,9 @@ if (process.env.PROJECT_POOL_CONFIG) {
     include: [
       process.env.TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
     ],
-    name: 'project-pool',
+    name: process.env.PROJECT_NAME_COLOR
+      ? { label: 'project-pool', color: process.env.PROJECT_NAME_COLOR }
+      : 'project-pool',
     pool: process.env.PROJECT_POOL_CONFIG,
   }
   if (process.env.PROJECT_RETRY_CONFIG) {
@@ -49,7 +51,9 @@ if (process.env.PROJECT_POOL_CONFIG) {
       include: [
         process.env.SECOND_PROJECT_TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
       ],
-      name: 'second-project-pool',
+      name: process.env.SECOND_PROJECT_NAME_COLOR
+        ? { label: 'second-project-pool', color: process.env.SECOND_PROJECT_NAME_COLOR }
+        : 'second-project-pool',
       pool: process.env.SECOND_PROJECT_POOL_CONFIG,
     }
     if (process.env.SECOND_PROJECT_RETRY_CONFIG) {

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -46,7 +46,9 @@ if (process.env.PROJECT_POOL_CONFIG) {
   }
   projectConfigs.push({ test: firstProjectConfig })
 
-  if (process.env.SECOND_PROJECT_POOL_CONFIG) {
+  if (process.env.SECOND_PROJECT_CONFIG_FILE) {
+    projectConfigs.push('vitest.second-project.config.mjs')
+  } else if (process.env.SECOND_PROJECT_POOL_CONFIG) {
     const secondProjectConfig = {
       include: [
         process.env.SECOND_PROJECT_TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
@@ -58,6 +60,9 @@ if (process.env.PROJECT_POOL_CONFIG) {
     }
     if (process.env.SECOND_PROJECT_RETRY_CONFIG) {
       secondProjectConfig.retry = Number(process.env.SECOND_PROJECT_RETRY_CONFIG)
+    }
+    if (process.env.SECOND_PROJECT_UNNAMED) {
+      delete secondProjectConfig.name
     }
     projectConfigs.push({ test: secondProjectConfig })
   }

--- a/integration-tests/vitest.config.mjs
+++ b/integration-tests/vitest.config.mjs
@@ -31,15 +31,20 @@ if (process.env.CUSTOM_SEQUENCER) {
 }
 
 if (process.env.PROJECT_POOL_CONFIG) {
+  const projectConfig = {
+    include: [
+      process.env.TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
+    ],
+    name: 'project-pool',
+    pool: process.env.PROJECT_POOL_CONFIG,
+  }
+  if (process.env.PROJECT_RETRY_CONFIG) {
+    projectConfig.retry = Number(process.env.PROJECT_RETRY_CONFIG)
+  }
+
   config.test.projects = [
     {
-      test: {
-        include: [
-          process.env.TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
-        ],
-        name: 'project-pool',
-        pool: process.env.PROJECT_POOL_CONFIG,
-      },
+      test: projectConfig,
     },
   ]
 }

--- a/integration-tests/vitest.second-project.config.mjs
+++ b/integration-tests/vitest.second-project.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite'
+
+const config = {
+  test: {
+    include: [
+      process.env.SECOND_PROJECT_TEST_DIR || 'ci-visibility/vitest-tests/test-visibility*',
+    ],
+    name: process.env.SECOND_PROJECT_NAME_COLOR
+      ? { label: 'second-project-pool', color: process.env.SECOND_PROJECT_NAME_COLOR }
+      : 'second-project-pool',
+    pool: process.env.SECOND_PROJECT_POOL_CONFIG || 'forks',
+  },
+}
+
+if (process.env.SECOND_PROJECT_RETRY_CONFIG) {
+  config.test.retry = Number(process.env.SECOND_PROJECT_RETRY_CONFIG)
+}
+
+export default defineConfig(config)

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -67,11 +67,11 @@ versions.forEach((version) => {
     })
 
     beforeEach(async function () {
+      testOutput = ''
       receiver = await new FakeCiVisIntake().start()
     })
 
     afterEach(async () => {
-      testOutput = ''
       childProcess.kill()
       await receiver.stop()
     })
@@ -705,8 +705,9 @@ versions.forEach((version) => {
                   test.meta[TEST_NAME] === 'flaky test retries with hooks can retry tests that eventually pass'
                 )
                 .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+              const receivedTestNames = inspect(tests.map(test => test.meta[TEST_NAME]))
 
-              assert.strictEqual(projectWithExistingRetry.length, 2)
+              assert.strictEqual(projectWithExistingRetry.length, 2, `${receivedTestNames}\n${testOutput}`)
               assert.ok(!(TEST_IS_RETRY in projectWithExistingRetry[0].meta), inspect(projectWithExistingRetry[0].meta))
               assert.ok(
                 !(TEST_RETRY_REASON in projectWithExistingRetry[0].meta),
@@ -726,6 +727,80 @@ versions.forEach((version) => {
             })
 
           childProcess = exec(
+            './node_modules/.bin/vitest run --project project-pool --project second-project-pool',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '3',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+                PROJECT_POOL_CONFIG: 'forks',
+                PROJECT_RETRY_CONFIG: '1',
+                SECOND_PROJECT_CONFIG_FILE: 'true',
+                SECOND_PROJECT_POOL_CONFIG: 'forks',
+                SECOND_PROJECT_NAME_COLOR: 'blue',
+                SECOND_PROJECT_TEST_DIR: 'ci-visibility/vitest-tests/hooks-flaky-test-retries.mjs',
+                TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries.mjs',
+              },
+            }
+          )
+          childProcess.stdout?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+
+          await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        })
+
+      vitestProjectsIt('marks unnamed project retries as ATR in mixed project runs',
+        async () => {
+          receiver.setSettings({
+            itr_enabled: false,
+            code_coverage: false,
+            tests_skipping: false,
+            flaky_test_retries_enabled: true,
+            early_flake_detection: { enabled: false },
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const projectWithExistingRetry = tests
+                .filter(test => test.meta[TEST_NAME] === 'flaky test retries can retry tests that eventually pass')
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+              const unnamedProjectWithAtrRetry = tests
+                .filter(test =>
+                  test.meta[TEST_NAME] === 'flaky test retries with hooks can retry tests that eventually pass'
+                )
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+              const receivedTestNames = inspect(tests.map(test => test.meta[TEST_NAME]))
+
+              assert.strictEqual(projectWithExistingRetry.length, 2, `${receivedTestNames}\n${testOutput}`)
+              assert.ok(!(TEST_IS_RETRY in projectWithExistingRetry[0].meta), inspect(projectWithExistingRetry[0].meta))
+              assert.ok(
+                !(TEST_RETRY_REASON in projectWithExistingRetry[0].meta),
+                inspect(projectWithExistingRetry[0].meta)
+              )
+              assert.strictEqual(projectWithExistingRetry[1].meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(projectWithExistingRetry[1].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.ext)
+              assert.strictEqual(projectWithExistingRetry[1].meta[TEST_FINAL_STATUS], 'fail')
+
+              assert.strictEqual(unnamedProjectWithAtrRetry.length, 4, `${receivedTestNames}\n${testOutput}`)
+              assert.ok(
+                !(TEST_IS_RETRY in unnamedProjectWithAtrRetry[0].meta),
+                inspect(unnamedProjectWithAtrRetry[0].meta)
+              )
+              for (const test of unnamedProjectWithAtrRetry.slice(1)) {
+                assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+                assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+              }
+              assert.strictEqual(unnamedProjectWithAtrRetry[3].meta[TEST_FINAL_STATUS], 'pass')
+            })
+
+          childProcess = exec(
             './node_modules/.bin/vitest run',
             {
               cwd,
@@ -736,12 +811,18 @@ versions.forEach((version) => {
                 PROJECT_POOL_CONFIG: 'forks',
                 PROJECT_RETRY_CONFIG: '1',
                 SECOND_PROJECT_POOL_CONFIG: 'forks',
-                SECOND_PROJECT_NAME_COLOR: 'blue',
                 SECOND_PROJECT_TEST_DIR: 'ci-visibility/vitest-tests/hooks-flaky-test-retries.mjs',
+                SECOND_PROJECT_UNNAMED: 'true',
                 TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries.mjs',
               },
             }
           )
+          childProcess.stdout?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
+          childProcess.stderr?.on('data', (chunk) => {
+            testOutput += chunk.toString()
+          })
 
           await Promise.all([once(childProcess, 'exit'), eventsPromise])
         })

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -736,6 +736,7 @@ versions.forEach((version) => {
                 PROJECT_POOL_CONFIG: 'forks',
                 PROJECT_RETRY_CONFIG: '1',
                 SECOND_PROJECT_POOL_CONFIG: 'forks',
+                SECOND_PROJECT_NAME_COLOR: 'blue',
                 SECOND_PROJECT_TEST_DIR: 'ci-visibility/vitest-tests/hooks-flaky-test-retries.mjs',
                 TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries.mjs',
               },

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -638,6 +638,51 @@ versions.forEach((version) => {
           await Promise.all([once(childProcess, 'exit'), eventsPromise])
         })
 
+      vitestProjectsIt('does not enable ATR metadata from a non-runnable root project config',
+        async () => {
+          receiver.setSettings({
+            itr_enabled: false,
+            code_coverage: false,
+            tests_skipping: false,
+            flaky_test_retries_enabled: true,
+            early_flake_detection: { enabled: false },
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const retriedTestName = 'flaky test retries can retry tests that eventually pass'
+              const retriedTests = tests
+                .filter(test => test.meta[TEST_NAME] === retriedTestName)
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              assert.strictEqual(retriedTests.length, 2)
+              assert.ok(!(TEST_IS_RETRY in retriedTests[0].meta), inspect(retriedTests[0].meta))
+              assert.ok(!(TEST_RETRY_REASON in retriedTests[0].meta), inspect(retriedTests[0].meta))
+              assert.strictEqual(retriedTests[1].meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(retriedTests[1].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.ext)
+              assert.strictEqual(retriedTests[1].meta[TEST_FINAL_STATUS], 'fail')
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/vitest run --project project-pool',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '3',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+                PROJECT_POOL_CONFIG: 'forks',
+                PROJECT_RETRY_CONFIG: '1',
+                TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries.mjs',
+              },
+            }
+          )
+
+          await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        })
+
       it('sets final_status tag to test status reported to test framework on last retry (EFD active only)',
         async () => {
           receiver.setKnownTests({

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -603,24 +603,6 @@ versions.forEach((version) => {
             early_flake_detection: { enabled: false },
           })
 
-          const projectConfigPath = path.join(cwd, 'vitest-projects.config.mjs')
-          fs.writeFileSync(projectConfigPath, `
-            import { defineConfig } from 'vitest/config'
-
-            export default defineConfig({
-              test: {
-                projects: [
-                  {
-                    test: {
-                      name: 'unit',
-                      include: ['ci-visibility/vitest-tests/flaky-test-retries.mjs'],
-                    },
-                  },
-                ],
-              },
-            })
-          `)
-
           const eventsPromise = receiver
             .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
               const events = payloads.flatMap(({ payload }) => payload.events)
@@ -640,29 +622,18 @@ versions.forEach((version) => {
             })
 
           childProcess = exec(
-            './node_modules/.bin/vitest run --config vitest-projects.config.mjs --project unit',
+            './node_modules/.bin/vitest run --project project-pool',
             {
               cwd,
               env: {
                 ...getCiVisAgentlessConfig(receiver.port),
                 DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '3',
                 NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+                PROJECT_POOL_CONFIG: 'forks',
+                TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries.mjs',
               },
             }
           )
-
-          childProcess.on('exit', () => {
-            if (childProcess.exitCode !== 0) {
-              // eslint-disable-next-line no-console
-              console.log(testOutput)
-            }
-          })
-          childProcess.stderr.on('data', (data) => {
-            testOutput += data.toString()
-          })
-          childProcess.stdout.on('data', (data) => {
-            testOutput += data.toString()
-          })
 
           await Promise.all([once(childProcess, 'exit'), eventsPromise])
         })

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -53,6 +53,7 @@ const versions = NODE_MAJOR <= 18 ? ['1.6.0', '3.2.6'] : ['1.6.0', 'latest']
 versions.forEach((version) => {
   describe(`vitest@${version}`, () => {
     let cwd, receiver, childProcess, testOutput
+    const vitestProjectsIt = version === 'latest' && NODE_MAJOR >= 20 ? it : it.skip
 
     useSandbox([
       `vitest@${version}`,
@@ -588,6 +589,80 @@ versions.forEach((version) => {
               },
             }
           )
+
+          await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        })
+
+      vitestProjectsIt('applies ATR retry configuration to Vitest projects',
+        async () => {
+          receiver.setSettings({
+            itr_enabled: false,
+            code_coverage: false,
+            tests_skipping: false,
+            flaky_test_retries_enabled: true,
+            early_flake_detection: { enabled: false },
+          })
+
+          const projectConfigPath = path.join(cwd, 'vitest-projects.config.mjs')
+          fs.writeFileSync(projectConfigPath, `
+            import { defineConfig } from 'vitest/config'
+
+            export default defineConfig({
+              test: {
+                projects: [
+                  {
+                    test: {
+                      name: 'unit',
+                      include: ['ci-visibility/vitest-tests/flaky-test-retries.mjs'],
+                    },
+                  },
+                ],
+              },
+            })
+          `)
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const retriedTestName = 'flaky test retries can retry tests that eventually pass'
+              const retriedTests = tests
+                .filter(test => test.meta[TEST_NAME] === retriedTestName)
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              assert.strictEqual(retriedTests.length, 4)
+              assert.ok(!(TEST_IS_RETRY in retriedTests[0].meta))
+              for (const test of retriedTests.slice(1)) {
+                assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+                assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+              }
+              assert.strictEqual(retriedTests[3].meta[TEST_FINAL_STATUS], 'pass')
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/vitest run --config vitest-projects.config.mjs --project unit',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '3',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+              },
+            }
+          )
+
+          childProcess.on('exit', () => {
+            if (childProcess.exitCode !== 0) {
+              // eslint-disable-next-line no-console
+              console.log(testOutput)
+            }
+          })
+          childProcess.stderr.on('data', (data) => {
+            testOutput += data.toString()
+          })
+          childProcess.stdout.on('data', (data) => {
+            testOutput += data.toString()
+          })
 
           await Promise.all([once(childProcess, 'exit'), eventsPromise])
         })

--- a/integration-tests/vitest/vitest.advanced.spec.js
+++ b/integration-tests/vitest/vitest.advanced.spec.js
@@ -683,6 +683,68 @@ versions.forEach((version) => {
           await Promise.all([once(childProcess, 'exit'), eventsPromise])
         })
 
+      vitestProjectsIt('does not mark user-configured retries as ATR in mixed project runs',
+        async () => {
+          receiver.setSettings({
+            itr_enabled: false,
+            code_coverage: false,
+            tests_skipping: false,
+            flaky_test_retries_enabled: true,
+            early_flake_detection: { enabled: false },
+          })
+
+          const eventsPromise = receiver
+            .gatherPayloadsMaxTimeout(({ url }) => url.endsWith('/api/v2/citestcycle'), (payloads) => {
+              const events = payloads.flatMap(({ payload }) => payload.events)
+              const tests = events.filter(event => event.type === 'test').map(event => event.content)
+              const projectWithExistingRetry = tests
+                .filter(test => test.meta[TEST_NAME] === 'flaky test retries can retry tests that eventually pass')
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+              const projectWithAtrRetry = tests
+                .filter(test =>
+                  test.meta[TEST_NAME] === 'flaky test retries with hooks can retry tests that eventually pass'
+                )
+                .sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0))
+
+              assert.strictEqual(projectWithExistingRetry.length, 2)
+              assert.ok(!(TEST_IS_RETRY in projectWithExistingRetry[0].meta), inspect(projectWithExistingRetry[0].meta))
+              assert.ok(
+                !(TEST_RETRY_REASON in projectWithExistingRetry[0].meta),
+                inspect(projectWithExistingRetry[0].meta)
+              )
+              assert.strictEqual(projectWithExistingRetry[1].meta[TEST_IS_RETRY], 'true')
+              assert.strictEqual(projectWithExistingRetry[1].meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.ext)
+              assert.strictEqual(projectWithExistingRetry[1].meta[TEST_FINAL_STATUS], 'fail')
+
+              assert.strictEqual(projectWithAtrRetry.length, 4)
+              assert.ok(!(TEST_IS_RETRY in projectWithAtrRetry[0].meta), inspect(projectWithAtrRetry[0].meta))
+              for (const test of projectWithAtrRetry.slice(1)) {
+                assert.strictEqual(test.meta[TEST_IS_RETRY], 'true')
+                assert.strictEqual(test.meta[TEST_RETRY_REASON], TEST_RETRY_REASON_TYPES.atr)
+              }
+              assert.strictEqual(projectWithAtrRetry[3].meta[TEST_FINAL_STATUS], 'pass')
+            })
+
+          childProcess = exec(
+            './node_modules/.bin/vitest run',
+            {
+              cwd,
+              env: {
+                ...getCiVisAgentlessConfig(receiver.port),
+                DD_CIVISIBILITY_FLAKY_RETRY_COUNT: '3',
+                NODE_OPTIONS: '--import dd-trace/register.js -r dd-trace/ci/init',
+                PROJECT_POOL_CONFIG: 'forks',
+                PROJECT_RETRY_CONFIG: '1',
+                SECOND_PROJECT_POOL_CONFIG: 'forks',
+                SECOND_PROJECT_TEST_DIR: 'ci-visibility/vitest-tests/hooks-flaky-test-retries.mjs',
+                TEST_DIR: 'ci-visibility/vitest-tests/flaky-test-retries.mjs',
+              },
+            }
+          )
+
+          await Promise.all([once(childProcess, 'exit'), eventsPromise])
+        })
+
       it('sets final_status tag to test status reported to test framework on last retry (EFD active only)',
         async () => {
           receiver.setKnownTests({

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -138,6 +138,7 @@ function getProvidedContext () {
       _ddTestManagementTests: testManagementTests,
       _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
+      _ddFlakyTestRetriesProjectNames: flakyTestRetriesProjectNames,
       _ddIsImpactedTestsEnabled: isImpactedTestsEnabled,
       _ddModifiedFiles: modifiedFiles,
       _ddTestSessionId: testSessionId,
@@ -159,6 +160,7 @@ function getProvidedContext () {
       testManagementTests,
       isFlakyTestRetriesEnabled,
       flakyTestRetriesCount: flakyTestRetriesCount ?? 0,
+      flakyTestRetriesProjectNames,
       isImpactedTestsEnabled,
       modifiedFiles,
       testSessionId,
@@ -181,6 +183,7 @@ function getProvidedContext () {
       testManagementTests: {},
       isFlakyTestRetriesEnabled: false,
       flakyTestRetriesCount: 0,
+      flakyTestRetriesProjectNames: undefined,
       isImpactedTestsEnabled: false,
       modifiedFiles: {},
       testSessionId: undefined,
@@ -501,10 +504,12 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
     getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
   })
 
-  if (configureFlakyTestRetries(ctx, testSpecifications)) {
+  const flakyTestRetriesConfiguration = configureFlakyTestRetries(ctx, testSpecifications)
+  if (flakyTestRetriesConfiguration) {
     setProvidedContext(ctx, {
       _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
+      _ddFlakyTestRetriesProjectNames: flakyTestRetriesConfiguration.projectNames,
     }, 'Could not send library configuration to workers.')
   }
 
@@ -595,20 +600,32 @@ function ensureMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
  *
  * @param {object} ctx
  * @param {unknown[]|undefined} testSpecifications
- * @returns {boolean}
+ * @returns {{ projectNames?: string[] }|undefined}
  */
 function configureFlakyTestRetries (ctx, testSpecifications) {
-  if (!isFlakyTestRetriesEnabled || flakyTestRetriesCount <= 0) return false
+  if (!isFlakyTestRetriesEnabled || flakyTestRetriesCount <= 0) return
 
   let configured = false
-  for (const config of getVitestProjectConfigs(ctx, testSpecifications)) {
+  let hasNamedProject = false
+  const projectNames = []
+  for (const { config, projectName } of getVitestProjectConfigs(ctx, testSpecifications)) {
+    if (projectName) {
+      hasNamedProject = true
+    }
     if (!config.retry) {
       config.retry = flakyTestRetriesCount
       configured = true
+      if (projectName) {
+        projectNames.push(projectName)
+      }
     }
   }
 
-  return configured
+  if (!configured) return
+
+  return {
+    projectNames: hasNamedProject ? projectNames : undefined,
+  }
 }
 
 /**
@@ -616,64 +633,65 @@ function configureFlakyTestRetries (ctx, testSpecifications) {
  *
  * @param {object} ctx
  * @param {unknown[]|undefined} testSpecifications
- * @returns {object[]}
+ * @returns {{ config: object, projectName?: string }[]}
  */
 function getVitestProjectConfigs (ctx, testSpecifications) {
-  const configs = []
+  const entries = []
 
-  addTestSpecificationConfigs(configs, testSpecifications)
-  if (configs.length > 0) {
-    return configs
+  addTestSpecificationConfigs(entries, testSpecifications)
+  if (entries.length > 0) {
+    return entries
   }
 
-  addSelectedInlineProjectConfigs(configs, safeConfig(ctx))
-  if (configs.length > 0) {
-    return configs
+  addSelectedInlineProjectConfigs(entries, safeConfig(ctx))
+  if (entries.length > 0) {
+    return entries
   }
 
   if (Array.isArray(ctx?.projects)) {
     for (const project of ctx.projects) {
-      addConfig(configs, safeConfig(project))
+      addConfig(entries, safeConfig(project), getProjectName(project))
     }
-    if (configs.length > 0) {
-      return configs
+    if (entries.length > 0) {
+      return entries
     }
   }
 
-  addConfig(configs, safeConfig(ctx))
-  addConfig(configs, safeConfig(safeWorkspaceProject(ctx)))
+  addConfig(entries, safeConfig(ctx))
+  addConfig(entries, safeConfig(safeWorkspaceProject(ctx)))
 
-  return configs
+  return entries
 }
 
 /**
  * Add configs from runnable test specifications once.
  *
- * @param {object[]} configs
+ * @param {{ config: object, projectName?: string }[]} entries
  * @param {unknown[]|undefined} testSpecifications
  */
-function addTestSpecificationConfigs (configs, testSpecifications) {
+function addTestSpecificationConfigs (entries, testSpecifications) {
   if (!Array.isArray(testSpecifications)) return
 
   for (const testSpecification of testSpecifications) {
-    addConfig(configs, safeConfig(getTestSpecificationProject(testSpecification)))
+    const project = getTestSpecificationProject(testSpecification)
+    addConfig(entries, safeConfig(project), getProjectName(project))
   }
 }
 
 /**
  * Add selected inline project configs from the root Vitest config once.
  *
- * @param {object[]} configs
+ * @param {{ config: object, projectName?: string }[]} entries
  * @param {object|undefined} rootConfig
  */
-function addSelectedInlineProjectConfigs (configs, rootConfig) {
+function addSelectedInlineProjectConfigs (entries, rootConfig) {
   const selectedProjectNames = getSelectedProjectNames()
   if (selectedProjectNames.length === 0 || !Array.isArray(rootConfig?.projects)) return
 
   for (const project of rootConfig.projects) {
     const config = getInlineProjectConfig(project)
     if (selectedProjectNames.includes(config?.name)) {
-      addConfig(configs, config)
+      addConfig(entries, config, getProjectName(project))
     }
   }
 }
@@ -708,14 +726,25 @@ function getInlineProjectConfig (project) {
 }
 
 /**
+ * Return a Vitest project name from runtime or inline project objects.
+ *
+ * @param {unknown} project
+ * @returns {string|undefined}
+ */
+function getProjectName (project) {
+  return project?.name || project?.config?.name || project?.test?.name
+}
+
+/**
  * Add a config object once.
  *
- * @param {object[]} configs
+ * @param {{ config: object, projectName?: string }[]} entries
  * @param {object|undefined} config
+ * @param {string|undefined} projectName
  */
-function addConfig (configs, config) {
-  if (config && !configs.includes(config)) {
-    configs.push(config)
+function addConfig (entries, config, projectName) {
+  if (config && !entries.some(entry => entry.config === config)) {
+    entries.push({ config, projectName })
   }
 }
 
@@ -745,6 +774,22 @@ function safeWorkspaceProject (ctx) {
     project = getWorkspaceProject(ctx)
   } catch {}
   return project
+}
+
+/**
+ * Return whether Datadog configured ATR retries for a task.
+ *
+ * @param {object} providedContext
+ * @param {object} task
+ * @returns {boolean}
+ */
+function isFlakyTestRetriesEnabledForTask (providedContext, task) {
+  if (!providedContext.isFlakyTestRetriesEnabled) return false
+
+  const { flakyTestRetriesProjectNames } = providedContext
+  if (!Array.isArray(flakyTestRetriesProjectNames)) return true
+
+  return flakyTestRetriesProjectNames.includes(task.file?.projectName)
 }
 
 function getSortWrapper (sort, frameworkVersion) {
@@ -1164,15 +1209,15 @@ function wrapVitestTestRunner (VitestTestRunner) {
     let isNew = false
     let isQuarantined = false
 
+    const providedContext = getProvidedContext()
     const {
       isKnownTestsEnabled,
       isEarlyFlakeDetectionEnabled,
       isDiEnabled,
       isTestManagementTestsEnabled,
       testManagementTests,
-      isFlakyTestRetriesEnabled,
       slowTestRetries,
-    } = getProvidedContext()
+    } = providedContext
 
     if (isKnownTestsEnabled) {
       isNew = newTasks.has(task)
@@ -1302,7 +1347,7 @@ function wrapVitestTestRunner (VitestTestRunner) {
     }
 
     const isRetryReasonAtr = numAttempt > 0 &&
-      isFlakyTestRetriesEnabled &&
+      isFlakyTestRetriesEnabledForTask(providedContext, task) &&
       !isRetryReasonAttemptToFix &&
       !isRetryReasonEfd
 
@@ -1693,7 +1738,7 @@ addHook({
           }
 
           // ATR: set hasFailedAllRetries when all auto test retries were exhausted and every attempt failed
-          const isAtrRetry = providedContext.isFlakyTestRetriesEnabled && !attemptToFixTasks.has(task) &&
+          const isAtrRetry = isFlakyTestRetriesEnabledForTask(providedContext, task) && !attemptToFixTasks.has(task) &&
             !newTasks.has(task) && !modifiedTasks.has(task)
           if (isAtrRetry) {
             const maxRetries = providedContext.flakyTestRetriesCount ?? 0

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -501,7 +501,7 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
     getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
   })
 
-  if (configureFlakyTestRetries(ctx)) {
+  if (configureFlakyTestRetries(ctx, testSpecifications)) {
     setProvidedContext(ctx, {
       _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
@@ -594,13 +594,14 @@ function ensureMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
  * Configure Vitest retries for the root project and resolved workspace projects.
  *
  * @param {object} ctx
+ * @param {unknown[]|undefined} testSpecifications
  * @returns {boolean}
  */
-function configureFlakyTestRetries (ctx) {
+function configureFlakyTestRetries (ctx, testSpecifications) {
   if (!isFlakyTestRetriesEnabled || flakyTestRetriesCount <= 0) return false
 
   let configured = false
-  for (const config of getVitestProjectConfigs(ctx)) {
+  for (const config of getVitestProjectConfigs(ctx, testSpecifications)) {
     if (!config.retry) {
       config.retry = flakyTestRetriesCount
       configured = true
@@ -614,21 +615,96 @@ function configureFlakyTestRetries (ctx) {
  * Return unique Vitest configs that can be used to run tests.
  *
  * @param {object} ctx
+ * @param {unknown[]|undefined} testSpecifications
  * @returns {object[]}
  */
-function getVitestProjectConfigs (ctx) {
+function getVitestProjectConfigs (ctx, testSpecifications) {
   const configs = []
 
-  addConfig(configs, safeConfig(ctx))
-  addConfig(configs, safeConfig(safeWorkspaceProject(ctx)))
+  addTestSpecificationConfigs(configs, testSpecifications)
+  if (configs.length > 0) {
+    return configs
+  }
+
+  addSelectedInlineProjectConfigs(configs, safeConfig(ctx))
+  if (configs.length > 0) {
+    return configs
+  }
 
   if (Array.isArray(ctx?.projects)) {
     for (const project of ctx.projects) {
       addConfig(configs, safeConfig(project))
     }
+    if (configs.length > 0) {
+      return configs
+    }
   }
 
+  addConfig(configs, safeConfig(ctx))
+  addConfig(configs, safeConfig(safeWorkspaceProject(ctx)))
+
   return configs
+}
+
+/**
+ * Add configs from runnable test specifications once.
+ *
+ * @param {object[]} configs
+ * @param {unknown[]|undefined} testSpecifications
+ */
+function addTestSpecificationConfigs (configs, testSpecifications) {
+  if (!Array.isArray(testSpecifications)) return
+
+  for (const testSpecification of testSpecifications) {
+    addConfig(configs, safeConfig(getTestSpecificationProject(testSpecification)))
+  }
+}
+
+/**
+ * Add selected inline project configs from the root Vitest config once.
+ *
+ * @param {object[]} configs
+ * @param {object|undefined} rootConfig
+ */
+function addSelectedInlineProjectConfigs (configs, rootConfig) {
+  const selectedProjectNames = getSelectedProjectNames()
+  if (selectedProjectNames.length === 0 || !Array.isArray(rootConfig?.projects)) return
+
+  for (const project of rootConfig.projects) {
+    const config = getInlineProjectConfig(project)
+    if (selectedProjectNames.includes(config?.name)) {
+      addConfig(configs, config)
+    }
+  }
+}
+
+/**
+ * Return selected project names from the Vitest CLI arguments.
+ *
+ * @returns {string[]}
+ */
+function getSelectedProjectNames () {
+  const names = []
+  for (let index = 0; index < process.argv.length; index++) {
+    const argument = process.argv[index]
+    if (argument === '--project' && process.argv[index + 1]) {
+      names.push(process.argv[index + 1])
+      index++
+    } else if (argument.startsWith('--project=')) {
+      names.push(argument.slice('--project='.length))
+    }
+  }
+  return names
+}
+
+/**
+ * Return the test config from an inline Vitest project entry.
+ *
+ * @param {unknown} project
+ * @returns {object|undefined}
+ */
+function getInlineProjectConfig (project) {
+  return project?.test || project
 }
 
 /**
@@ -749,8 +825,21 @@ function isThreadPool (pool) {
   return pool === 'threads' || pool === 'vmThreads'
 }
 
+/**
+ * Return the project object attached to a Vitest test specification.
+ *
+ * @param {unknown} testSpecification
+ * @returns {object|undefined}
+ */
+function getTestSpecificationProject (testSpecification) {
+  if (Array.isArray(testSpecification)) {
+    return testSpecification[0]
+  }
+  return testSpecification?.project
+}
+
 function getTestSpecificationPool (testSpecification) {
-  const project = Array.isArray(testSpecification) ? testSpecification[0] : testSpecification?.project
+  const project = getTestSpecificationProject(testSpecification)
   return project?.config?.pool || project?.serializedConfig?.pool || project?.pool || testSpecification?.pool
 }
 

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -501,8 +501,7 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
     getTestManagementTests: () => getChannelPromise(testManagementTestsCh),
   })
 
-  if (isFlakyTestRetriesEnabled && !ctx.config.retry && flakyTestRetriesCount > 0) {
-    ctx.config.retry = flakyTestRetriesCount
+  if (configureFlakyTestRetries(ctx)) {
     setProvidedContext(ctx, {
       _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
@@ -589,6 +588,87 @@ function ensureMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
     mainProcessSetupPromises.set(ctx, setupPromise)
   }
   return setupPromise
+}
+
+/**
+ * Configure Vitest retries for the root project and resolved workspace projects.
+ *
+ * @param {object} ctx
+ * @returns {boolean}
+ */
+function configureFlakyTestRetries (ctx) {
+  if (!isFlakyTestRetriesEnabled || flakyTestRetriesCount <= 0) return false
+
+  let configured = false
+  for (const config of getVitestProjectConfigs(ctx)) {
+    if (!config.retry) {
+      config.retry = flakyTestRetriesCount
+      configured = true
+    }
+  }
+
+  return configured
+}
+
+/**
+ * Return unique Vitest configs that can be used to run tests.
+ *
+ * @param {object} ctx
+ * @returns {object[]}
+ */
+function getVitestProjectConfigs (ctx) {
+  const configs = []
+
+  addConfig(configs, safeConfig(ctx))
+  addConfig(configs, safeConfig(safeWorkspaceProject(ctx)))
+
+  if (Array.isArray(ctx?.projects)) {
+    for (const project of ctx.projects) {
+      addConfig(configs, safeConfig(project))
+    }
+  }
+
+  return configs
+}
+
+/**
+ * Add a config object once.
+ *
+ * @param {object[]} configs
+ * @param {object|undefined} config
+ */
+function addConfig (configs, config) {
+  if (config && !configs.includes(config)) {
+    configs.push(config)
+  }
+}
+
+/**
+ * Read a Vitest config object without assuming the project is initialized.
+ *
+ * @param {object|undefined} project
+ * @returns {object|undefined}
+ */
+function safeConfig (project) {
+  try {
+    return project?.config
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Read the workspace project without assuming the root server is initialized.
+ *
+ * @param {object} ctx
+ * @returns {object|undefined}
+ */
+function safeWorkspaceProject (ctx) {
+  try {
+    return getWorkspaceProject(ctx)
+  } catch {
+    return undefined
+  }
 }
 
 function getSortWrapper (sort, frameworkVersion) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -138,6 +138,7 @@ function getProvidedContext () {
       _ddTestManagementTests: testManagementTests,
       _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
+      _ddFlakyTestRetriesIncludesUnnamedProject: flakyTestRetriesIncludesUnnamedProject,
       _ddFlakyTestRetriesProjectNames: flakyTestRetriesProjectNames,
       _ddIsImpactedTestsEnabled: isImpactedTestsEnabled,
       _ddModifiedFiles: modifiedFiles,
@@ -160,6 +161,7 @@ function getProvidedContext () {
       testManagementTests,
       isFlakyTestRetriesEnabled,
       flakyTestRetriesCount: flakyTestRetriesCount ?? 0,
+      flakyTestRetriesIncludesUnnamedProject,
       flakyTestRetriesProjectNames,
       isImpactedTestsEnabled,
       modifiedFiles,
@@ -183,6 +185,7 @@ function getProvidedContext () {
       testManagementTests: {},
       isFlakyTestRetriesEnabled: false,
       flakyTestRetriesCount: 0,
+      flakyTestRetriesIncludesUnnamedProject: false,
       flakyTestRetriesProjectNames: undefined,
       isImpactedTestsEnabled: false,
       modifiedFiles: {},
@@ -509,6 +512,7 @@ async function runMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
     setProvidedContext(ctx, {
       _ddIsFlakyTestRetriesEnabled: isFlakyTestRetriesEnabled,
       _ddFlakyTestRetriesCount: flakyTestRetriesCount,
+      _ddFlakyTestRetriesIncludesUnnamedProject: flakyTestRetriesConfiguration.includesUnnamedProject,
       _ddFlakyTestRetriesProjectNames: flakyTestRetriesConfiguration.projectNames,
     }, 'Could not send library configuration to workers.')
   }
@@ -600,23 +604,22 @@ function ensureMainProcessSetup (ctx, frameworkVersion, testSpecifications) {
  *
  * @param {object} ctx
  * @param {unknown[]|undefined} testSpecifications
- * @returns {{ projectNames?: string[] }|undefined}
+ * @returns {{ projectNames: string[], includesUnnamedProject: boolean }|undefined}
  */
 function configureFlakyTestRetries (ctx, testSpecifications) {
   if (!isFlakyTestRetriesEnabled || flakyTestRetriesCount <= 0) return
 
   let configured = false
-  let hasNamedProject = false
+  let includesUnnamedProject = false
   const projectNames = []
   for (const { config, projectName } of getVitestProjectConfigs(ctx, testSpecifications)) {
-    if (projectName) {
-      hasNamedProject = true
-    }
     if (!config.retry) {
       config.retry = flakyTestRetriesCount
       configured = true
       if (projectName) {
         projectNames.push(projectName)
+      } else {
+        includesUnnamedProject = true
       }
     }
   }
@@ -624,7 +627,8 @@ function configureFlakyTestRetries (ctx, testSpecifications) {
   if (!configured) return
 
   return {
-    projectNames: hasNamedProject ? projectNames : undefined,
+    includesUnnamedProject,
+    projectNames,
   }
 }
 
@@ -643,7 +647,9 @@ function getVitestProjectConfigs (ctx, testSpecifications) {
     return entries
   }
 
-  addSelectedInlineProjectConfigs(entries, safeConfig(ctx))
+  const selectedProjectNames = getSelectedProjectNames()
+  addSelectedInlineProjectConfigs(entries, safeConfig(ctx), selectedProjectNames)
+  addSelectedRuntimeProjectConfigs(entries, ctx?.projects, selectedProjectNames)
   if (entries.length > 0) {
     return entries
   }
@@ -683,9 +689,9 @@ function addTestSpecificationConfigs (entries, testSpecifications) {
  *
  * @param {{ config: object, projectName?: string }[]} entries
  * @param {object|undefined} rootConfig
+ * @param {string[]} selectedProjectNames
  */
-function addSelectedInlineProjectConfigs (entries, rootConfig) {
-  const selectedProjectNames = getSelectedProjectNames()
+function addSelectedInlineProjectConfigs (entries, rootConfig, selectedProjectNames) {
   if (selectedProjectNames.length === 0 || !Array.isArray(rootConfig?.projects)) return
 
   for (const project of rootConfig.projects) {
@@ -693,6 +699,24 @@ function addSelectedInlineProjectConfigs (entries, rootConfig) {
     const projectName = getProjectName(project)
     if (selectedProjectNames.includes(projectName)) {
       addConfig(entries, config, projectName)
+    }
+  }
+}
+
+/**
+ * Add selected resolved project configs once.
+ *
+ * @param {{ config: object, projectName?: string }[]} entries
+ * @param {unknown[]|undefined} projects
+ * @param {string[]} selectedProjectNames
+ */
+function addSelectedRuntimeProjectConfigs (entries, projects, selectedProjectNames) {
+  if (selectedProjectNames.length === 0 || !Array.isArray(projects)) return
+
+  for (const project of projects) {
+    const projectName = getProjectName(project)
+    if (selectedProjectNames.includes(projectName)) {
+      addConfig(entries, safeConfig(project), projectName)
     }
   }
 }
@@ -757,7 +781,7 @@ function normalizeProjectName (name) {
  * @param {string|undefined} projectName
  */
 function addConfig (entries, config, projectName) {
-  if (config && !entries.some(entry => entry.config === config)) {
+  if (config && !entries.some(entry => entry.config === config || (projectName && entry.projectName === projectName))) {
     entries.push({ config, projectName })
   }
 }
@@ -803,7 +827,12 @@ function isFlakyTestRetriesEnabledForTask (providedContext, task) {
   const { flakyTestRetriesProjectNames } = providedContext
   if (!Array.isArray(flakyTestRetriesProjectNames)) return true
 
-  return flakyTestRetriesProjectNames.includes(task.file?.projectName)
+  const projectName = task.file?.projectName
+  if (!projectName) {
+    return providedContext.flakyTestRetriesIncludesUnnamedProject === true
+  }
+
+  return flakyTestRetriesProjectNames.includes(projectName)
 }
 
 function getSortWrapper (sort, frameworkVersion) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -650,11 +650,11 @@ function addConfig (configs, config) {
  * @returns {object|undefined}
  */
 function safeConfig (project) {
+  let config
   try {
-    return project?.config
-  } catch {
-    return undefined
-  }
+    config = project?.config
+  } catch {}
+  return config
 }
 
 /**
@@ -664,11 +664,11 @@ function safeConfig (project) {
  * @returns {object|undefined}
  */
 function safeWorkspaceProject (ctx) {
+  let project
   try {
-    return getWorkspaceProject(ctx)
-  } catch {
-    return undefined
-  }
+    project = getWorkspaceProject(ctx)
+  } catch {}
+  return project
 }
 
 function getSortWrapper (sort, frameworkVersion) {

--- a/packages/datadog-instrumentations/src/vitest.js
+++ b/packages/datadog-instrumentations/src/vitest.js
@@ -690,8 +690,9 @@ function addSelectedInlineProjectConfigs (entries, rootConfig) {
 
   for (const project of rootConfig.projects) {
     const config = getInlineProjectConfig(project)
-    if (selectedProjectNames.includes(config?.name)) {
-      addConfig(entries, config, getProjectName(project))
+    const projectName = getProjectName(project)
+    if (selectedProjectNames.includes(projectName)) {
+      addConfig(entries, config, projectName)
     }
   }
 }
@@ -732,7 +733,20 @@ function getInlineProjectConfig (project) {
  * @returns {string|undefined}
  */
 function getProjectName (project) {
-  return project?.name || project?.config?.name || project?.test?.name
+  return normalizeProjectName(project?.name || project?.config?.name || project?.test?.name)
+}
+
+/**
+ * Return a normalized Vitest project name.
+ *
+ * @param {unknown} name
+ * @returns {string|undefined}
+ */
+function normalizeProjectName (name) {
+  if (typeof name === 'string') return name
+
+  const label = name?.label
+  return typeof label === 'string' ? label : undefined
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

- Applies Auto Test Retries retry configuration to Vitest project configs, not only the root context config.
- Adds a Vitest regression that runs with `test.projects` and `--project` to verify ATR retries are reported correctly.
- Reuses the existing Vitest integration-test config fixture for the project regression.

### Motivation

Vitest 4 creates runnable test tasks from the selected project config. When a repository uses `test.projects`, setting only `ctx.config.retry` leaves the selected project config retry count at `0`, so Auto Test Retries can be enabled but never retry that project test run.

### Additional Notes

The Vitest 1.6.0 matrix entry is skipped for this regression; the project-config case is validated on latest Vitest with Node.js 20+.