### PR TITLE
test(prisma): skip lib checks for generated client builds

### DIFF
--- a/packages/datadog-plugin-prisma/test/index.spec.js
+++ b/packages/datadog-plugin-prisma/test/index.spec.js
@@ -35,6 +35,7 @@ function execPrismaGenerate (config, cwd) {
         '--target esnext',
         '--module commonjs',
         '--allowJs true',
+        '--skipLibCheck true',
         '--moduleResolution node',
       ].join(' '),
     ].join(' && '), {

--- a/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
+++ b/packages/datadog-plugin-prisma/test/integration-test/client.spec.js
@@ -300,6 +300,7 @@ describe('esm', () => {
               ' --module ESNext' +
               ' --strict true' +
               ' --moduleResolution bundler' +
+              ' --skipLibCheck true' +
               ' --esModuleInterop true'
             )
           }


### PR DESCRIPTION
### What does this PR do?

Adds `--skipLibCheck true` to the Prisma generated TypeScript client compile steps used by the Prisma plugin unit and integration test harnesses.

### Motivation

Fresh Prisma test dependency installs now resolve transitive `@types/node` ranges from packages such as `tedious` to `@types/node@26.0.0`, which was published on 2026-06-19. Those declarations require newer TypeScript iterator types than the Prisma v6 sandbox's `typescript@5.4.5` compiler provides, causing master to fail before any Prisma tracing assertions run.

These compile steps only need to emit generated test clients. Skipping lib checks keeps that signal while avoiding type-check failures from third-party declaration files outside the generated client.
