### PR TITLE
fix(web): let late routes supersede endpoint fallback

### DIFF
--- a/packages/datadog-plugin-http/test/http_endpoint.spec.js
+++ b/packages/datadog-plugin-http/test/http_endpoint.spec.js
@@ -6,6 +6,7 @@ const axios = require('axios')
 const { describe, it, beforeEach, afterEach, before } = require('mocha')
 
 const agent = require('../../dd-trace/test/plugins/agent')
+const web = require('../../dd-trace/src/plugins/util/web')
 
 describe('Plugin', () => {
   let http
@@ -105,6 +106,27 @@ describe('Plugin', () => {
             .catch(done)
 
           axios.get(`http://localhost:${port}/resources/abc-123`).catch(done)
+        })
+
+        it('keeps http.route when a framework resolves the route at finish time', done => {
+          // Model a framework that resolves the route once the response is
+          // ending: the beforeEnd callback runs after AppSec's pre-finish hook
+          // has already stamped http.endpoint, the same ordering that dropped
+          // http.route on the root span with API Security enabled.
+          app = req => {
+            web.beforeEnd(req, () => web.setRoute(req, '/users/:id'))
+          }
+
+          agent
+            .assertSomeTraces(traces => {
+              assert.strictEqual(traces[0][0].name, 'web.request')
+              assert.strictEqual(traces[0][0].meta['http.route'], '/users/:id')
+              assert.strictEqual(traces[0][0].resource, 'GET /users/:id')
+            })
+            .then(done)
+            .catch(done)
+
+          axios.get(`http://localhost:${port}/users/123`).catch(done)
         })
       })
     })

--- a/packages/dd-trace/src/plugins/util/web.js
+++ b/packages/dd-trace/src/plugins/util/web.js
@@ -433,26 +433,25 @@ function applyRouteOrEndpointTag (context) {
   if (!span) return
   const spanContext = span.context()
 
-  // AppSec calls `web.setRouteOrEndpointTag` from a pre-finish hook so the
-  // route/endpoint tags are available for API Security sampling, and the
-  // normal finish-time path runs this again. Either tag being present
-  // means the work has already been done; paths are stable between the
-  // two calls, so the second pass has nothing to add.
-  if (spanContext.hasTag(HTTP_ROUTE) || spanContext.hasTag(HTTP_ENDPOINT)) return
+  // AppSec runs this from a pre-finish hook and the finish path runs it
+  // again. http.route is terminal once set; nothing supersedes it.
+  if (spanContext.hasTag(HTTP_ROUTE)) return
 
   // Skip the `Array.prototype.join` builtin in the empty / single-segment
   // cases; `paths[0]` covers both (`undefined` is falsy for the empty case).
   const route = paths.length > 1 ? paths.join('') : paths[0]
 
   if (route) {
-    // Use http.route from trusted framework instrumentation.
+    // A framework route supersedes any http.endpoint fallback a pre-finish
+    // call stamped before the route resolved; it must not be gated on
+    // HTTP_ENDPOINT.
     span.setTag(HTTP_ROUTE, route)
     return
   }
 
-  if (!config.resourceRenamingEnabled) return
+  // Route unavailable. Compute the http.endpoint fallback once across both calls.
+  if (!config.resourceRenamingEnabled || spanContext.hasTag(HTTP_ENDPOINT)) return
 
-  // Route is unavailable, compute http.endpoint once.
   const url = spanContext.getTag(HTTP_URL)
   const endpoint = url ? calculateHttpEndpoint(url) : '/'
   span.setTag(HTTP_ENDPOINT, endpoint)

--- a/packages/dd-trace/test/plugins/util/web.spec.js
+++ b/packages/dd-trace/test/plugins/util/web.spec.js
@@ -537,6 +537,61 @@ describe('plugins/util/web', () => {
     })
   })
 
+  describe('route resolved after the AppSec pre-finish endpoint fallback', () => {
+    let context
+
+    beforeEach(() => {
+      config = web.normalizeConfig({ resourceRenamingEnabled: true })
+      req.method = 'GET'
+      req.url = '/users/123'
+
+      span = web.startSpan(tracer, config, req, res, 'test.request')
+      tags = span.context().getTags()
+      context = web.getContext(req)
+    })
+
+    it('keeps http.route when the framework resolves the route after http.endpoint was stamped', () => {
+      // AppSec's incomingHttpRequestEnd hook stamps http.endpoint while the
+      // framework route is still unresolved.
+      web.setRouteOrEndpointTag(req)
+      assert.ok(Object.hasOwn(tags, HTTP_ENDPOINT))
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE))
+
+      // The framework resolves the route between the pre-finish hook and finish.
+      web.setRoute(req, '/users/:id')
+
+      web.finishAll(context)
+
+      assert.strictEqual(tags[HTTP_ROUTE], '/users/:id')
+      assert.strictEqual(tags[RESOURCE_NAME], 'GET /users/:id')
+    })
+
+    it('uses http.route alone when the route resolves before the pre-finish hook', () => {
+      web.setRoute(req, '/users/:id')
+
+      web.setRouteOrEndpointTag(req)
+      assert.ok(!Object.hasOwn(tags, HTTP_ENDPOINT))
+
+      web.finishAll(context)
+
+      assert.strictEqual(tags[HTTP_ROUTE], '/users/:id')
+      assert.ok(!Object.hasOwn(tags, HTTP_ENDPOINT))
+      assert.strictEqual(tags[RESOURCE_NAME], 'GET /users/:id')
+    })
+
+    it('keeps the http.endpoint fallback when no route ever resolves', () => {
+      web.setRouteOrEndpointTag(req)
+      const endpoint = tags[HTTP_ENDPOINT]
+      assert.ok(endpoint)
+
+      web.finishAll(context)
+
+      assert.strictEqual(tags[HTTP_ENDPOINT], endpoint)
+      assert.ok(!Object.hasOwn(tags, HTTP_ROUTE))
+      assert.strictEqual(tags[RESOURCE_NAME], 'GET')
+    })
+  })
+
   describe('configured header tagging across the request lifecycle', () => {
     const USER_AGENT_TAG = `${HTTP_REQUEST_HEADERS}.user-agent`
     const SERVER_TAG = `${HTTP_RESPONSE_HEADERS}.server`


### PR DESCRIPTION
## Summary

When API Security samples before span finish, it can stamp `http.endpoint` before a framework has resolved the route. This keeps `http.route` authoritative when the route appears before the finish-time pass, so the root HTTP span keeps the framework resource name instead of falling back to the bare method.

## Test plan

- `npx mocha packages/dd-trace/test/plugins/util/web.spec.js packages/datadog-plugin-http/test/http_endpoint.spec.js`
- `./node_modules/.bin/eslint packages/datadog-plugin-http/test/http_endpoint.spec.js packages/dd-trace/src/plugins/util/web.js packages/dd-trace/test/plugins/util/web.spec.js`
- `npm run lint`

Refs: https://github.com/DataDog/dd-trace-js/pull/8492