### PR TITLE
docs: reserve feat/fix for production code in commit convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,7 +324,10 @@ Validate basic plugin structure with:
 ### Commit Messages
 
 Conventional format: `type(scope): description`
-Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
+Types: `feat`, `fix`, `perf`, `refactor`, `test`, `bench`, `docs`, `chore`, `ci`
+Reserve `feat`/`fix`/`perf` for production code shipped in the npm package. A fix or new capability in
+tests, benchmarks, CI, or tooling uses the area type even so — a test-suite fix is `test(...)`, a benchmark
+fix `bench(...)`, a CI fix `ci(...)`; never `fix(...)`/`feat(...)`.
 Example: `feat(appsec): add new WAF rule`
 
 ### PR Requirements


### PR DESCRIPTION
## Summary

The conventional-commit type is the only signal of whether a change ships in the npm package, so a test-suite or CI fix tagged `fix(...)` misreads as a runtime bug fix in changelogs. This documents that `feat`/`fix`/`perf` are for production code; test, benchmark, CI, and tooling changes use their area type (`test`, `bench`, `ci`, `chore`, `docs`) even when they fix or add something there. Also adds `perf`/`bench` to the type list — both are already used in history but were missing.