### PR TITLE
test: fix independent plugin and config spec reliability

### DIFF
--- a/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
+++ b/packages/datadog-plugin-google-cloud-pubsub/test/index.spec.js
@@ -2,9 +2,10 @@
 
 const assert = require('node:assert/strict')
 const { inspect } = require('node:util')
-const sinon = require('sinon')
 
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
+const semver = require('semver')
+const sinon = require('sinon')
 
 const { ERROR_MESSAGE, ERROR_TYPE, ERROR_STACK } = require('../../dd-trace/src/constants')
 const id = require('../../dd-trace/src/id')
@@ -56,6 +57,12 @@ describe('Plugin', () => {
       let v1
       let gax
 
+      // pubsub 2.x bundles its own @grpc/grpc-js, so the internal v1 client rejects credentials minted by the
+      // test-pinned google-gax@3.5.7 ("Channel credentials must be a ChannelCredentials object"). 1.x and 3.x+
+      // stay compatible, so gate only the low-level v1 tests on 2.x; the public-API tests still cover that major.
+      const pkgVersion = require(`../../../versions/@google-cloud/pubsub@${version}`).version()
+      const itInternalApi = semver.satisfies(pkgVersion, '2.x') ? it.skip : it
+
       describe('without configuration', () => {
         beforeEach(() => {
           return agent.load('google-cloud-pubsub', { dsmEnabled: false }, { flushMinSpans: 1 })
@@ -92,7 +99,7 @@ describe('Plugin', () => {
             return expectedSpanPromise
           })
 
-          it('should be instrumented when using the internal API', async () => {
+          itInternalApi('should be instrumented when using the internal API', async () => {
             const publisher = new v1.PublisherClient({
               grpc: gax.grpc,
               projectId: project,
@@ -117,7 +124,7 @@ describe('Plugin', () => {
             return expectedSpanPromise
           })
 
-          it('should be instrumented w/ error', async () => {
+          itInternalApi('should be instrumented w/ error', async () => {
             const expectedSpanPromise = expectSpanWithDefaults({
               name: expectedSchema.controlPlane.opName,
               service: expectedSchema.controlPlane.serviceName,

--- a/packages/dd-trace/test/appsec/attacker-fingerprinting.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/attacker-fingerprinting.fastify.plugin.spec.js
@@ -13,7 +13,7 @@ const { withVersions } = require('../setup/mocha')
 
 withVersions('fastify', 'fastify', fastifyVersion => {
   describe('Attacker fingerprinting', () => {
-    let server, axios
+    let app, server, axios
 
     before(() => {
       return agent.load(['fastify', 'http'], { client: false })
@@ -22,23 +22,23 @@ withVersions('fastify', 'fastify', fastifyVersion => {
     before((done) => {
       const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
 
-      const app = fastify()
+      app = fastify()
 
       app.post('/', (request, reply) => {
         reply.send('DONE')
       })
 
-      app.listen({ port: 0 }, () => {
+      app.listen({ host: '127.0.0.1', port: 0 }, () => {
         const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-        axios = Axios.create({ baseURL: `http://localhost:${port}` })
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
         done()
       })
       server = app.server
     })
 
-    after(() => {
-      server.close()
-      return agent.close()
+    after(async () => {
+      await app.close()
+      await agent.close()
     })
 
     beforeEach(() => {

--- a/packages/dd-trace/test/appsec/extended-data-collection.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/extended-data-collection.fastify.plugin.spec.js
@@ -58,7 +58,11 @@ describe('extended data collection', () => {
         reply.send('DONE')
       })
 
-      app.listen(port, (err, address) => {
+      // Fastify 1.x already accepts the options-object form, while the variadic `listen(port, cb)` signature is a
+      // throwing deprecation in 4.x and removed in 5.x. Use the object form so every tested major starts cleanly.
+      // Bind to the loopback IP rather than `localhost`: a hostname makes fastify resolve every address it maps to
+      // (`dns.lookup(..., { all: true })`) and bind a server per address, which is slow and races teardown.
+      app.listen({ host: '127.0.0.1', port: 0 }, (err) => {
         if (err) {
           throw err
         }
@@ -95,7 +99,7 @@ describe('extended data collection', () => {
         },
       }
       await axios.post(
-        `http://localhost:${port}/`,
+        `http://127.0.0.1:${port}/`,
         requestBody,
         {
           headers: {
@@ -126,7 +130,7 @@ describe('extended data collection', () => {
         bodyParam: 'collect-standard',
       }
       await axios.post(
-        `http://localhost:${port}/redacted-headers`,
+        `http://127.0.0.1:${port}/redacted-headers`,
         requestBody,
         {
           headers: {
@@ -175,7 +179,7 @@ describe('extended data collection', () => {
         },
       }
       await axios.post(
-        `http://localhost:${port}/`,
+        `http://127.0.0.1:${port}/`,
         requestBody,
         {
           headers: {
@@ -230,7 +234,7 @@ describe('extended data collection', () => {
         bodyParam: 'collect-standard',
         deepObject: expectedDeepTruncatedObject,
       }
-      await axios.post(`http://localhost:${port}/`, requestBody)
+      await axios.post(`http://127.0.0.1:${port}/`, requestBody)
 
       await agent.assertSomeTraces((traces) => {
         const span = traces[0][0]
@@ -251,7 +255,7 @@ describe('extended data collection', () => {
         bodyParam: 'collect-standard',
         longValue: Array(4096).fill('A').join(''),
       }
-      await axios.post(`http://localhost:${port}/`, requestBody)
+      await axios.post(`http://127.0.0.1:${port}/`, requestBody)
 
       await agent.assertSomeTraces((traces) => {
         const span = traces[0][0]
@@ -273,7 +277,7 @@ describe('extended data collection', () => {
         bodyParam: 'collect-standard',
         children: children.slice(0, 256),
       }
-      await axios.post(`http://localhost:${port}/`, requestBody)
+      await axios.post(`http://127.0.0.1:${port}/`, requestBody)
 
       await agent.assertSomeTraces((traces) => {
         const span = traces[0][0]

--- a/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/iast/taint-tracking/sources/taint-tracking.fastify.plugin.spec.js
@@ -62,12 +62,12 @@ describe('URI sourcing with fastify', () => {
         reply.code(200).send()
       })
 
-      await appInstance.listen({ port: 0 })
+      await appInstance.listen({ host: '127.0.0.1', port: 0 })
 
       const port = appInstance.server.address().port
 
       const response = await axios
-        .get(`http://localhost:${port}/path/vulnerable`)
+        .get(`http://127.0.0.1:${port}/path/vulnerable`)
       assert.strictEqual(response.status, 200)
     })
   })
@@ -123,12 +123,12 @@ describe('Path params sourcing with fastify', () => {
         reply.code(200).send()
       })
 
-      await appInstance.listen({ port: 0 })
+      await appInstance.listen({ host: '127.0.0.1', port: 0 })
 
       const port = appInstance.server.address().port
 
       const response = await axios
-        .get(`http://localhost:${port}/tainted1/tainted2`)
+        .get(`http://127.0.0.1:${port}/tainted1/tainted2`)
       assert.strictEqual(response.status, 200)
     })
   })

--- a/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/index.fastify.plugin.spec.js
@@ -17,9 +17,17 @@ const { withVersions } = require('../setup/mocha')
 const { getConfigFresh } = require('../helpers/config')
 const { blockedTemplateJson: json, setTestBlockingTemplates } = require('./utils')
 
+// The version matrices below necessarily pair plugin majors with fastify majors they reject. fastify core
+// reports that while booting (during `listen`) as FST_ERR_PLUGIN_VERSION_MISMATCH; older fastify-plugin
+// builds throw a plain Error carrying the same "expected '<range>' fastify version" text instead. Either
+// means "skip this unsupported combo", not a real failure.
+function isFastifyPluginVersionMismatch (error) {
+  return error.code === 'FST_ERR_PLUGIN_VERSION_MISMATCH' || /expected '.+?' fastify version/.test(error.message)
+}
+
 withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersion) => {
   describe('Suspicious request blocking - query', () => {
-    let server, requestBody, axios
+    let app, server, requestBody, axios
 
     before(() => {
       return agent.load(['fastify', 'http'], { client: false })
@@ -28,24 +36,24 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
     before((done) => {
       const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
 
-      const app = fastify()
+      app = fastify()
 
       app.get('/', (request, reply) => {
         requestBody()
         reply.send('DONE')
       })
 
-      app.listen({ port: 0 }, () => {
+      app.listen({ host: '127.0.0.1', port: 0 }, () => {
         const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-        axios = Axios.create({ baseURL: `http://localhost:${port}` })
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
         done()
       })
       server = app.server
     })
 
-    after(() => {
-      server.close()
-      return agent.close()
+    after(async () => {
+      await app.close()
+      await agent.close()
     })
 
     beforeEach(async () => {
@@ -85,7 +93,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
   })
 
   describe('Suspicious request blocking - body', () => {
-    let server, requestBody, axios
+    let app, server, requestBody, axios
 
     before(() => {
       return agent.load(['fastify', 'http'], { client: false })
@@ -94,24 +102,24 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
     before((done) => {
       const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
 
-      const app = fastify()
+      app = fastify()
 
       app.post('/', (request, reply) => {
         requestBody()
         reply.send('DONE')
       })
 
-      app.listen({ port: 0 }, () => {
+      app.listen({ host: '127.0.0.1', port: 0 }, () => {
         const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-        axios = Axios.create({ baseURL: `http://localhost:${port}` })
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
         done()
       })
       server = app.server
     })
 
-    after(() => {
-      server.close()
-      return agent.close()
+    after(async () => {
+      await app.close()
+      await agent.close()
     })
 
     beforeEach(async () => {
@@ -186,7 +194,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
   })
 
   describe('Appsec blocking with schema validation', () => {
-    let server, axios
+    let app, server, axios
 
     before(() => {
       return agent.load(['fastify', 'http'], { client: false })
@@ -195,7 +203,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
     before((done) => {
       const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
 
-      const app = fastify()
+      app = fastify()
 
       app.post('/schema-validated', {
         schema: {
@@ -211,17 +219,17 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
         reply.send('DONE')
       })
 
-      app.listen({ port: 0 }, () => {
+      app.listen({ host: '127.0.0.1', port: 0 }, () => {
         const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-        axios = Axios.create({ baseURL: `http://localhost:${port}` })
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
         done()
       })
       server = app.server
     })
 
-    after(() => {
-      server.close()
-      return agent.close()
+    after(async () => {
+      await app.close()
+      await agent.close()
     })
 
     beforeEach(async () => {
@@ -262,7 +270,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
   })
 
   describe('Suspicious request blocking - path parameters', () => {
-    let server, preHandlerHookSpy, preValidationHookSpy, axios
+    let app, server, preHandlerHookSpy, preValidationHookSpy, axios
 
     before(() => {
       return agent.load(['fastify', 'http'], { client: false })
@@ -271,7 +279,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
     before((done) => {
       const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
 
-      const app = fastify()
+      app = fastify()
       app.get('/multiple-path-params/:parameter1/:parameter2', (request, reply) => {
         reply.send('DONE')
       })
@@ -301,17 +309,17 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
         reply.send('DONE')
       })
 
-      app.listen({ port: 0 }, () => {
+      app.listen({ host: '127.0.0.1', port: 0 }, () => {
         const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-        axios = Axios.create({ baseURL: `http://localhost:${port}` })
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
         done()
       })
       server = app.server
     })
 
-    after(() => {
-      server.close()
-      return agent.close()
+    after(async () => {
+      await app.close()
+      await agent.close()
     })
 
     beforeEach(async () => {
@@ -465,7 +473,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
             return agent.load(['fastify', '@fastify/cookie', 'http'], { client: false })
           })
 
-          before((done) => {
+          before(async function () {
             const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
             const fastifyCookie = require(`../../../../versions/@fastify/cookie@${cookieVersion}`).get()
 
@@ -484,12 +492,18 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
               reply.send('DONE')
             })
 
-            app.listen({ port: 0 }, () => {
-              const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-              axios = Axios.create({ baseURL: `http://localhost:${port}` })
-              done()
-            })
+            try {
+              await app.listen({ host: '127.0.0.1', port: 0 })
+            } catch (error) {
+              if (isFastifyPluginVersionMismatch(error)) {
+                return this.skip()
+              }
+              throw error
+            }
+
             server = app.server
+            const { port } = /** @type {import('net').AddressInfo} */ (server.address())
+            axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
           })
 
           beforeEach(async () => {
@@ -570,7 +584,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
         return agent.load(['fastify', '@fastify/multipart', 'http'], { client: false })
       })
 
-      before((done) => {
+      before(async function () {
         const fastify = require(`../../../../versions/fastify@${fastifyVersion}`).get()
         const fastifyMultipart = require(`../../../../versions/@fastify/multipart@${multipartVersion}`).get()
 
@@ -583,12 +597,18 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
           reply.send('DONE')
         })
 
-        app.listen({ port: 0 }, () => {
-          const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-          axios = Axios.create({ baseURL: `http://localhost:${port}` })
-          done()
-        })
+        try {
+          await app.listen({ host: '127.0.0.1', port: 0 })
+        } catch (error) {
+          if (isFastifyPluginVersionMismatch(error)) {
+            return this.skip()
+          }
+          throw error
+        }
+
         server = app.server
+        const { port } = /** @type {import('net').AddressInfo} */ (server.address())
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
       })
 
       beforeEach(() => {
@@ -640,7 +660,7 @@ withVersions('fastify', 'fastify', '>=2', (fastifyVersion, _, fastifyLoadedVersi
 
 describe('Api Security - Fastify', () => {
   withVersions('fastify', 'fastify', version => {
-    let config, server, axios
+    let config, app, server, axios
 
     before(() => {
       return agent.load(['fastify', 'http'], { client: false })
@@ -649,7 +669,7 @@ describe('Api Security - Fastify', () => {
     before((done) => {
       const fastify = require(`../../../../versions/fastify@${version}`).get()
 
-      const app = fastify()
+      app = fastify()
 
       app.post('/send', (request, reply) => {
         reply.send({ sendResKey: 'sendResValue' })
@@ -677,17 +697,17 @@ describe('Api Security - Fastify', () => {
         reply.send(new Uint16Array(10))
       })
 
-      app.listen({ port: 0 }, () => {
+      app.listen({ host: '127.0.0.1', port: 0 }, () => {
         const port = (/** @type {import('net').AddressInfo} */ (server.address())).port
-        axios = Axios.create({ baseURL: `http://localhost:${port}` })
+        axios = Axios.create({ baseURL: `http://127.0.0.1:${port}` })
         done()
       })
       server = app.server
     })
 
-    after(() => {
-      server.close()
-      return agent.close()
+    after(async () => {
+      await app.close()
+      await agent.close()
     })
 
     beforeEach(() => {

--- a/packages/dd-trace/test/appsec/rasp/rasp_blocking.fastify.plugin.spec.js
+++ b/packages/dd-trace/test/appsec/rasp/rasp_blocking.fastify.plugin.spec.js
@@ -17,7 +17,7 @@ const { checkRaspExecutedAndNotThreat, checkRaspExecutedAndHasThreat } = require
 
 describe('RASP - fastify blocking', () => {
   withVersions('fastify', 'fastify', '>=2', (version) => {
-    let app, hooks, axios
+    let app, hooks, axios, pool
 
     before(async () => {
       await agent.load(['http', 'fastify'], { client: false })
@@ -48,7 +48,7 @@ describe('RASP - fastify blocking', () => {
       const childProcess = require('child_process')
       const fs = require('fs')
       const pg = require('../../../../../versions/pg@8.7.3').get()
-      const pool = new pg.Pool({
+      pool = new pg.Pool({
         host: '127.0.0.1',
         user: 'postgres',
         password: 'postgres',
@@ -85,10 +85,10 @@ describe('RASP - fastify blocking', () => {
         })
       })
 
-      await app.listen()
+      await app.listen({ host: '127.0.0.1', port: 0 })
 
       axios = Axios.create({
-        baseURL: `http://localhost:${app.server.address().port}`,
+        baseURL: `http://127.0.0.1:${app.server.address().port}`,
         validateStatus: () => true,
         responseType: 'text',
       })
@@ -99,7 +99,10 @@ describe('RASP - fastify blocking', () => {
     })
 
     after(async () => {
-      await app.server.close()
+      // The pg.Pool keeps connections and a reaper timer alive; leaking one per fastify version starves the
+      // event loop until later `before` hooks (server startup) time out.
+      await app.close()
+      await pool?.end()
       appsec.disable()
       await agent.close()
     })

--- a/packages/dd-trace/test/helpers/config.js
+++ b/packages/dd-trace/test/helpers/config.js
@@ -3,12 +3,19 @@
 const proxyquire = require('proxyquire')
 
 function getConfigFresh (options) {
+  const childCountBefore = module.children.length
   const helper = proxyquire.noPreserveCache()('../../src/config/helper.js', {})
   const defaults = proxyquire.noPreserveCache()('../../src/config/defaults.js', {})
-  return proxyquire.noPreserveCache()('../../src/config', {
+  const config = proxyquire.noPreserveCache()('../../src/config', {
     './defaults': defaults,
     './helper': helper,
   })(options)
+  // proxyquire links every freshly loaded module into this module's `children`;
+  // `noPreserveCache` clears `require.cache` but not that array, so each
+  // re-instrumented config graph stays pinned for the process lifetime. Detaching
+  // them lets the fresh graph collect once the returned config is dropped.
+  module.children.length = childCountBefore
+  return config
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

Three independent test-suite fixes, none dependent on the version-matrix rework:

1. `appsec`: the @fastify/cookie and @fastify/multipart matrices pair plugin majors with fastify-core majors they reject (`FST_ERR_PLUGIN_VERSION_MISMATCH`, or a plain "expected '<range>' fastify version" Error on older fastify-plugin). Skip that combo instead of failing, bind to 127.0.0.1, and await `app.close()`.
2. `google-cloud-pubsub`: pubsub 2.x bundles its own `@grpc/grpc-js`, whose v1 client rejects the test-pinned `google-gax@3.5.7` credentials. Gate only the v1 internal-API tests on 2.x; the public-API tests still cover it.
3. `config`: `getConfigFresh` leaked every re-instrumented config graph through proxyquire's `module.children`, growing the appsec suite heap until it OOMed under coverage. Detach the freshly loaded children after each call.