### PR TITLE
test: drive install script and withVersions from the shared resolver

### DIFF
--- a/packages/dd-trace/test/plugins/externals.js
+++ b/packages/dd-trace/test/plugins/externals.js
@@ -188,10 +188,6 @@ module.exports = {
       versions: ['>=4', '>=4.0.0 <4.3.0', '>=4.0.0 <5.0.0', '>=4.3.0 <5.0.0'],
     },
     {
-      name: 'mquery',
-      versions: ['>=5.0.0'],
-    },
-    {
       name: 'mongodb',
       versions: ['5', '>=6'],
     },
@@ -316,6 +312,15 @@ module.exports = {
       versions: ['^16.6.0'],
     },
   ],
+  '@apollo/server': [
+    {
+      // The shared apollo-server-* install also brings in graphql 15.x (for apollo-server v3), which yarn may
+      // hoist over the ^16.11 that @apollo/server v5 needs. Without the pin, v5 resolves 15.x, whose TypeInfo
+      // lacks the `.enter`/`.leave` methods the graphql instrumentation calls, so every traced operation throws.
+      name: 'graphql',
+      dep: true,
+    },
+  ],
   grpc: [
     {
       name: '@grpc/proto-loader',
@@ -338,6 +343,14 @@ module.exports = {
     {
       name: 'sqlite3',
       versions: ['^5.0.8'],
+    },
+    {
+      // knex 1.x is the only major whose sqlite3 dialect requires the @vscode/sqlite3 fork instead of `sqlite3`
+      // (reverted in 2.x). The instrumentation spec loads knex from `versions/knex@<ver>` and opens a sqlite3
+      // client, so the fork must be installed there. Pin an exact prerelease build so prebuilt binaries exist for
+      // the whole Node CI matrix.
+      name: '@vscode/sqlite3',
+      versions: ['5.1.12-vscode'],
     },
     {
       name: 'pg',
@@ -422,12 +435,6 @@ module.exports = {
     {
       name: 'fastify',
       versions: ['>=3'],
-    },
-  ],
-  lodash: [
-    {
-      name: 'lodash',
-      versions: ['>=4'],
     },
   ],
   mariadb: [
@@ -651,12 +658,6 @@ module.exports = {
     {
       name: 'body-parser',
       versions: ['1.20.1'],
-    },
-  ],
-  ws: [
-    {
-      name: 'ws',
-      versions: ['>=8.0.0'],
     },
   ],
 }

--- a/packages/dd-trace/test/plugins/versions.spec.js
+++ b/packages/dd-trace/test/plugins/versions.spec.js
@@ -1,0 +1,142 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+
+const { describe, it } = require('mocha')
+const { coerce, major } = require('semver')
+
+const { getVersionList, resolvePluginVersions } = require('./versions')
+
+const latests = require('./versions/package.json').dependencies
+
+const keys = (name, versions, nonConsecutive) =>
+  getVersionList(name, versions, nonConsecutive).map(({ versionKey }) => versionKey)
+
+const latestMajorKey = name => String(major(coerce(latests[name])))
+
+describe('getVersionList', () => {
+  it('collapses the wildcard to the latest major', () => {
+    assert.deepEqual(keys('mongodb', ['*']), [latestMajorKey('mongodb')])
+  })
+
+  it('collapses equivalent exact-version notations to a single key', () => {
+    assert.deepEqual(keys('mongodb', ['1.2.3', '=1.2.3', 'v1.2.3']), ['1.2.3'])
+  })
+
+  it('pins the floor and the major for a single-major range', () => {
+    // `<3` caps the range to major 2, so only the pinned floor and the latest of major 2 are keys.
+    assert.deepEqual(keys('mongodb', ['>=2 <3']), ['2.0.0', '2'])
+  })
+
+  it('covers the floor major and every major up to the range top', () => {
+    // `<5` caps the top at major 4; the floor (2.0.0) is pinned and majors 2-4 each resolve to their latest.
+    assert.deepEqual(keys('mongodb', ['>=2 <5']), ['2.0.0', '2', '3', '4'])
+  })
+
+  it('covers every major from the floor to the capped top', () => {
+    // `<6` caps the top at major 5; the floor major's latest (1) is covered too, not only the newest of the range.
+    assert.deepEqual(keys('mongodb', ['>=1 <6']), ['1.0.0', '1', '2', '3', '4', '5'])
+  })
+
+  it('de-duplicates a shared floor across multiple ranges', () => {
+    assert.deepEqual(keys('mongodb', ['>=2 <3', '^2.0.0']), ['2.0.0', '2'])
+  })
+
+  it('consolidates the floor with the top major when the floor is the pinned latest', () => {
+    // `>=<pinned latest>` floors at the newest version, so the bare top-major key resolves to that same version and is
+    // dropped; the pinned package.json is what proves the two keys identical.
+    assert.deepEqual(keys('mongodb', [`>=${latests.mongodb}`]), [latests.mongodb])
+  })
+
+  it('adds the floor, the floor major and the top major for non-consecutive packages', () => {
+    // The middle majors may be unpublished, but the floor major (1) and the top major (5) both exist and are tested.
+    assert.deepEqual(keys('mongodb', ['>=1 <6'], new Set(['mongodb'])), ['1.0.0', '1', '5'])
+  })
+
+  it('treats the built-in non-consecutive packages as floor + floor major + top major', () => {
+    // graphql jumps from 0.x to 14.x; 1.x–13.x are skipped, but the latest 0.x and the newest major are still tested.
+    assert.deepEqual(keys('graphql', ['>=0.10']), ['0.10.0', '0', latestMajorKey('graphql')])
+  })
+
+  it('throws on an unparseable range', () => {
+    assert.throws(() => getVersionList('mongodb', ['not-a-version']), /Invalid version range/)
+  })
+
+  it('throws on an empty entry', () => {
+    assert.throws(() => getVersionList('mongodb', ['', '>=2 <3']), /Empty version entry/)
+  })
+})
+
+describe('resolvePluginVersions', () => {
+  const versionKeys = result => result.versionList.map(({ versionKey }) => versionKey)
+
+  it('expands the declared versions and points the unversioned folder at the newest in-scope key', () => {
+    const result = resolvePluginVersions({ name: 'mongodb', declaredVersions: ['>=2 <5'], env: {} })
+
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
+  })
+
+  it('filters the installed keys by RANGE and follows the filtered tail', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=1 <6'],
+      env: { RANGE: '>=2.0.0 <4.0.0' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['2', '3'])
+    assert.equal(result.unversioned, '3')
+  })
+
+  it('replaces the declared versions with PACKAGE_VERSION_RANGE when the module is honoured', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <5'],
+      env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['3.0.0', '3'])
+    assert.equal(result.unversioned, '>=3 <4')
+  })
+
+  it('ignores PACKAGE_VERSION_RANGE for a sibling external that must not be sharded', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <5'],
+      honourEnvRange: false,
+      env: { PACKAGE_VERSION_RANGE: '>=3 <4' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['2.0.0', '2', '3', '4'])
+    assert.equal(result.unversioned, '4')
+  })
+
+  it('keeps the unversioned folder on the raw shard while RANGE narrows the installed keys', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=1 <6'],
+      env: { PACKAGE_VERSION_RANGE: '>=2 <5', RANGE: '>=3.0.0 <4.0.0' },
+    })
+
+    assert.deepEqual(versionKeys(result), ['3'])
+    assert.equal(result.unversioned, '>=2 <5')
+  })
+
+  it('reports nothing in scope when no version is declared', () => {
+    const result = resolvePluginVersions({ name: 'mongodb', declaredVersions: [], env: {} })
+
+    assert.deepEqual(result.versionList, [])
+    assert.equal(result.unversioned, undefined)
+  })
+
+  it('reports nothing in scope when RANGE excludes every declared key', () => {
+    const result = resolvePluginVersions({
+      name: 'mongodb',
+      declaredVersions: ['>=2 <3'],
+      env: { RANGE: '>=9.0.0 <10.0.0' },
+    })
+
+    assert.deepEqual(result.versionList, [])
+    assert.equal(result.unversioned, undefined)
+  })
+})

--- a/packages/dd-trace/test/plugins/versions/index.js
+++ b/packages/dd-trace/test/plugins/versions/index.js
@@ -1,9 +1,19 @@
 'use strict'
 
-const { subset } = require('semver')
+const { clean, coerce, intersects, subset } = require('semver')
+
 const latests = require('./package.json').dependencies
 
 const exactVersionExp = /^=?\d+\.\d+\.\d+/
+
+// Packages whose published majors are not contiguous. `getVersionList()` must not auto-fill their in-between majors:
+// the missing majors were never published, so installing them fails. A failing install of a multi-major range is the
+// signal to add a package here (the install script's error points back to this list). New entries must explain the gap
+// so the next reader does not "fix" it by removing the entry.
+const nonConsecutiveMajorPackages = new Set([
+  'graphql', // jumps from 0.x straight to 14.x (no 1.x–13.x); 14.x–17.x are covered via the apollo externals entries
+  '@redis/client', // jumps from 2.x to 5.x (no 3.x–4.x)
+])
 
 /**
  * @param {string} name
@@ -40,6 +50,150 @@ function capSubrange (name, subrange) {
   return `${subrange} <=${latests[name]}`
 }
 
+/**
+ * Expand a module's declared version entries into the de-duplicated set of version keys to install and test. Each key
+ * maps to a `versions/<name>@<key>` workspace folder; the install script and `withVersions()` share this so the set of
+ * installed folders and the set of tested folders never drift apart.
+ *
+ * Per declared range this yields the lowest supported version (pinned exactly) and the newest version of every major
+ * the range spans, keyed by the bare major so the key resolves to that major's latest. Covering each major explicitly
+ * (rather than emitting the raw range, which resolves only to the newest version of the whole range) makes sure the
+ * floor major's latest is tested too. The top major is derived from the pinned latest in `package.json` rather than a
+ * registry lookup, so a major that was never published makes the install fail loudly — the signal to add the package
+ * to `nonConsecutiveMajorPackages`.
+ *
+ * Notations that resolve to the same exact version (`1.2.3`, `=1.2.3`, `v1.2.3`) collapse to a single key, and `*`
+ * collapses to the latest major (the same version an open-ended range resolves to), so a version is never installed
+ * twice under different spellings. A floor that equals the pinned latest also drops the redundant top-major key,
+ * since the pinned `package.json` proves they resolve to the same version.
+ *
+ * @param {string} name The module name, e.g. `mongodb`.
+ * @param {string[]} versions The declared version entries, e.g. `['>=3.3 <5', '5', '>=6']`.
+ * @param {Set<string>} [nonConsecutiveMajors] Module names whose majors are not contiguous; injectable for testing.
+ * @returns {Array<{ versionKey: string, range: string }>} Ordered, de-duplicated entries. `versionKey` is the folder
+ *   suffix; `range` is the declaring entry it came from.
+ */
+function getVersionList (name, versions, nonConsecutiveMajors = nonConsecutiveMajorPackages) {
+  /** @type {Map<string, { versionKey: string, range: string }>} */
+  const entries = new Map()
+
+  const add = (versionKey, range) => {
+    if (!entries.has(versionKey)) entries.set(versionKey, { versionKey, range })
+  }
+
+  for (const range of versions) {
+    // An empty entry is a setup mistake (a stray comma or an undefined slot); fail loudly rather than skip silently.
+    if (!range) {
+      throw new Error(`Empty version entry declared for '${name}'. Each declared version must be a non-empty range.`)
+    }
+
+    if (range === '*') {
+      add(latestMajor(name), range)
+      continue
+    }
+
+    // Exact-version notations collapse to one key so the same version is never installed twice.
+    const exact = clean(range)
+    if (exact) {
+      add(exact, range)
+      continue
+    }
+
+    const floor = coerce(range)
+    if (!floor) throw new Error(`Invalid version range for '${name}': ${range}`)
+
+    add(floor.version, range)
+
+    const topMajor = highestMajor(name, range, floor.major)
+    if (nonConsecutiveMajors.has(name)) {
+      // Only the in-between majors were never published. The floor major and the top major both exist, so add the
+      // latest of each (skipping the uncertain middle, which is what would make the install fail).
+      add(String(floor.major), range)
+      if (topMajor > floor.major) add(String(topMajor), range)
+    } else {
+      for (let major = floor.major; major <= topMajor; major++) {
+        if (intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) add(String(major), range)
+      }
+    }
+  }
+
+  // The bare-major key for the pinned latest's major resolves to the pin itself, so when a declared floor already pins
+  // that exact version the major key would install the same thing. Drop it. This is the only such redundancy the
+  // pinned upper bound lets us prove; for lower majors the newest published version is unknown without the registry.
+  const pinned = coerce(latests[name])
+  if (pinned && entries.has(pinned.version)) entries.delete(String(pinned.major))
+
+  return [...entries.values()]
+}
+
+/**
+ * The latest major of `name` as a bare-major version key. `*` resolves here so it de-duplicates against an open-ended
+ * range whose top resolves to the same newest version.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function latestMajor (name) {
+  const latest = coerce(latests[name])
+  if (!latest) {
+    throw new Error(
+      `Latest version for '${name}' needs to be defined in 'packages/dd-trace/test/plugins/versions/package.json'.`
+    )
+  }
+  return String(latest.major)
+}
+
+/**
+ * Highest major still spanned by `range`, capped at the pinned latest. Iterates down from the latest so the first
+ * intersecting major is the top; nothing above the pinned latest is installed.
+ *
+ * @param {string} name
+ * @param {string} range
+ * @param {number} floorMajor
+ * @returns {number}
+ */
+function highestMajor (name, range, floorMajor) {
+  const latest = coerce(latests[name])
+  if (!latest) return floorMajor
+  for (let major = latest.major; major > floorMajor; major--) {
+    if (intersects(`>=${major}.0.0 <${major + 1}.0.0`, range)) return major
+  }
+  return floorMajor
+}
+
+/**
+ * Resolve which version keys to install and test for a module, plus which key the unversioned
+ * `versions/<name>` folder points at. `scripts/install_plugin_modules.js` and `withVersions()` both call this so the
+ * installed folder set and the tested folder set are derived from one place and cannot drift.
+ *
+ * @param {object} options
+ * @param {string} options.name The module name, e.g. `fastify`.
+ * @param {string[]} options.declaredVersions The declared version entries to expand.
+ * @param {boolean} [options.honourEnvRange] Whether `PACKAGE_VERSION_RANGE` applies to this module. False for sibling
+ *   externals that must stay on their declared versions while the matrix shards a different package.
+ * @param {NodeJS.ProcessEnv} [options.env] Injectable for testing.
+ * @returns {{ versionList: Array<{ versionKey: string, range: string }>, unversioned: string|undefined }} The ordered,
+ *   `RANGE`-filtered key set, and the key the default `versions/<name>` folder resolves to (the newest in-scope entry,
+ *   or `undefined` when nothing is in scope).
+ */
+function resolvePluginVersions ({ name, declaredVersions, honourEnvRange = true, env = process.env }) {
+  const useEnvRange = Boolean(env.PACKAGE_VERSION_RANGE) && honourEnvRange
+  const versions = useEnvRange ? [env.PACKAGE_VERSION_RANGE] : declaredVersions
+
+  let versionList = getVersionList(name, versions)
+  if (env.RANGE) {
+    versionList = versionList.filter(({ versionKey }) => subset(versionKey, env.RANGE))
+  }
+
+  // With `PACKAGE_VERSION_RANGE` the shard itself is the target, so the unversioned folder keeps the raw range even
+  // when `RANGE` narrows the installed keys; otherwise it follows the newest in-scope key.
+  const unversioned = useEnvRange ? env.PACKAGE_VERSION_RANGE : versionList.at(-1)?.versionKey
+
+  return { versionList, unversioned }
+}
+
 module.exports = {
-  getCappedRange
+  getCappedRange,
+  getVersionList,
+  resolvePluginVersions,
 }

--- a/packages/dd-trace/test/plugins/versions/package.json
+++ b/packages/dd-trace/test/plugins/versions/package.json
@@ -89,6 +89,7 @@
     "@vitest/coverage-istanbul": "4.1.9",
     "@vitest/coverage-v8": "4.1.9",
     "@vitest/runner": "4.1.9",
+    "@vscode/sqlite3": "5.1.12-vscode",
     "aerospike": "6.7.0",
     "ai": "6.0.204",
     "amqp10": "3.6.0",

--- a/packages/dd-trace/test/setup/mocha.js
+++ b/packages/dd-trace/test/setup/mocha.js
@@ -14,6 +14,7 @@ const sinon = require('sinon')
 require('./core')
 
 const externals = require('../plugins/externals')
+const { resolvePluginVersions } = require('../plugins/versions')
 const runtimeMetrics = require('../../src/runtime_metrics')
 const Nomenclature = require('../../src/service-naming')
 const { SVC_SRC_KEY } = require('../../src/constants')
@@ -283,20 +284,17 @@ function withVersions (plugin, modules, range, cb) {
 
       // Some entries coming from `externals.js` are dependency-only (e.g. `dep: true`) and don't have `versions`.
       // Treat those as "not a test target" instead of crashing.
-      const versions = process.env.PACKAGE_VERSION_RANGE
-        ? [process.env.PACKAGE_VERSION_RANGE]
-        : normalizeVersions(instrumentation.versions)
+      // Share the install script's resolution so the tested folders exactly match the installed ones (lowest supported
+      // version, the latest of every major in between, and the newest supported version), de-duplicated by version.
+      const { versionList } = resolvePluginVersions({
+        name: moduleName,
+        declaredVersions: normalizeVersions(instrumentation.versions),
+      })
 
-      for (const version of versions) {
-        if (process.env.RANGE && !semver.subset(version, process.env.RANGE)) continue
-        if (version !== '*') {
-          const min = semver.coerce(version)?.version
-          if (!min) throw new Error(`Invalid version: ${version}`)
-          testVersions.set(min, { versionRange: version, versionKey: min, resolvedVersion: min })
-        }
-
-        const max = require(getModulePath(moduleName, version)).version()
-        testVersions.set(max, { versionRange: version, versionKey: version, resolvedVersion: max })
+      for (const { versionKey, range: declaredRange } of versionList) {
+        // Exact keys resolve to themselves; range keys (`*`, `>=2`, `>=3.0.0 <4.0.0`) resolve to what was installed.
+        const resolvedVersion = semver.valid(versionKey) ?? require(getModulePath(moduleName, versionKey)).version()
+        testVersions.set(resolvedVersion, { versionRange: declaredRange, versionKey, resolvedVersion })
       }
     }
 

--- a/scripts/install_plugin_modules.js
+++ b/scripts/install_plugin_modules.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { createHash } = require('crypto')
-const { lstat, mkdir, readdir, writeFile } = require('fs/promises')
+const { lstat, mkdir, readdir, readFile, writeFile } = require('fs/promises')
 const { createRequire } = require('module')
 const { arch } = require('os')
 const { join } = require('path')
@@ -11,12 +11,17 @@ const semver = require('semver')
 
 const externals = require('../packages/dd-trace/test/plugins/externals')
 const { getInstrumentation } = require('../packages/dd-trace/test/setup/helpers/load-inst')
-const { getCappedRange } = require('../packages/dd-trace/test/plugins/versions')
+const { getCappedRange, resolvePluginVersions } = require('../packages/dd-trace/test/plugins/versions')
 const latests = require('../packages/dd-trace/test/plugins/versions/package.json').dependencies
 const { isRelativeRequire } = require('../packages/datadog-instrumentations/src/helpers/shared-utils')
 const exec = require('./helpers/exec')
+const mapWithConcurrency = require('./helpers/concurrency')
 const requirePackageJsonPath = require.resolve('../packages/dd-trace/src/require-package-json')
 const requirePackageJson = require(requirePackageJsonPath)
+
+// Generating the whole versions/ tree is thousands of mkdir/writeFile calls; bound them so we never exhaust file
+// descriptors (EMFILE). yarn install itself dominates the wall-clock, so a moderate cap costs nothing.
+const FS_CONCURRENCY = 50
 
 // Can remove aerospike after removing support for aerospike < 5.2.0 (for Node.js 22, v5.12.1 is required)
 // Can remove couchbase after removing support for couchbase < 3.2.2
@@ -42,8 +47,10 @@ run()
 async function run () {
   await assertPrerequisites()
   install()
-  await assertPeerDependencies(join(__dirname, '..', 'versions'))
-  install()
+  const changed = await assertPeerDependencies(join(__dirname, '..', 'versions'))
+  // The second install only does something when peer-dependency patching actually changed a manifest. Targeted
+  // installs for plugins without external peer dependencies (the common CI matrix case) skip it entirely.
+  if (changed) install()
 }
 
 async function assertPrerequisites () {
@@ -54,68 +61,73 @@ async function assertPrerequisites () {
     .map(file => file.slice(0, -3))
     .filter(file => !filter || filter.includes(file))
 
-  const internals = moduleNames.reduce((/** @type {object[]} */ internals, moduleName) => {
-    internals.push(...getInstrumentation(moduleName))
-    return internals
-  }, [])
+  const packages = collectPackages(moduleNames)
 
-  for (const inst of internals) {
-    // eslint-disable-next-line no-await-in-loop
-    await assertInstrumentation(inst, false)
-  }
-
-  const externalNames = Object.keys(externals).filter(name => moduleNames.includes(name))
-
-  for (const name of externalNames) {
-    for (const inst of externals[name]) {
-      // eslint-disable-next-line no-await-in-loop
-      await assertInstrumentation(inst, true, name)
-    }
-  }
+  await mapWithConcurrency(packages, FS_CONCURRENCY, ({ name, version, range, external }) =>
+    assertPackage(name, version, range, external))
 
   await assertWorkspaces()
 }
 
 /**
- * @param {object} instrumentation
- * @param {boolean} external
- * @param {string} [pluginName] The plugin key the external entry belongs to. Same-name externals (e.g. the aerospike
- *   externals entry that mirrors the addHook versions) honour `PACKAGE_VERSION_RANGE` so per-major CI matrices do not
- *   force every major to install on every job.
+ * Build the ordered, de-duplicated set of workspace folders to generate. A version that is referenced under several
+ * notations (or by both an internal and an external entry) is generated once; internal entries are processed first so
+ * the nohoisted (isolated) variant wins for any shared folder.
+ *
+ * @param {string[]} moduleNames
+ * @returns {Array<{ name: string, version: string|null, range: string, external: boolean }>}
  */
-async function assertInstrumentation (instrumentation, external, pluginName) {
-  const honourEnvRange = !external || instrumentation.name === pluginName
-  const versions = process.env.PACKAGE_VERSION_RANGE && honourEnvRange
-    ? [process.env.PACKAGE_VERSION_RANGE]
-    : (instrumentation.versions || [])
+function collectPackages (moduleNames) {
+  const seen = new Set()
+  /** @type {Array<{ name: string, version: string|null, range: string, external: boolean }>} */
+  const packages = []
 
-  for (const version of versions) {
-    if (!version) continue
-
-    if (version !== '*') {
-      const result = semver.coerce(version)
-      if (!result) throw new Error(`Invalid version: ${version}`)
-      // eslint-disable-next-line no-await-in-loop
-      await assertModules(instrumentation.name, result.version, external)
-    }
-
-    // eslint-disable-next-line no-await-in-loop
-    await assertModules(instrumentation.name, version, external)
+  const addFolder = (name, version, range, external) => {
+    // File-path requires are resolved from disk; their non-path counterparts already cover them.
+    if (isRelativeRequire(name)) return
+    const key = basename(name, version)
+    if (seen.has(key)) return
+    seen.add(key)
+    packages.push({ name, version, range, external })
   }
-}
 
-/**
- * @param {string} name
- * @param {string} version
- * @param {boolean} external
- */
-async function assertModules (name, version, external) {
-  const range = process.env.RANGE
-  if (range && !semver.subset(version, range)) return
-  await Promise.all([
-    assertPackage(name, null, version, external),
-    assertPackage(name, version, version, external),
-  ])
+  /**
+   * @param {{ name: string, versions?: string[] }} instrumentation
+   * @param {boolean} external
+   * @param {string} [pluginName] The plugin key an external entry belongs to. Same-name externals (e.g. the aerospike
+   *   entry mirroring the addHook versions) honour `PACKAGE_VERSION_RANGE` so per-major CI matrices do not force every
+   *   major to install on every job.
+   */
+  const addInstrumentation = (instrumentation, external, pluginName) => {
+    const { versionList, unversioned } = resolvePluginVersions({
+      name: instrumentation.name,
+      declaredVersions: instrumentation.versions || [],
+      honourEnvRange: !external || instrumentation.name === pluginName,
+    })
+
+    // The unversioned `versions/<name>` folder is the default `require('versions/<name>')` target used by service
+    // setup and several plugin specs.
+    if (unversioned) addFolder(instrumentation.name, null, unversioned, external)
+
+    for (const { versionKey } of versionList) {
+      addFolder(instrumentation.name, versionKey, versionKey, external)
+    }
+  }
+
+  for (const moduleName of moduleNames) {
+    for (const instrumentation of getInstrumentation(moduleName)) {
+      addInstrumentation(instrumentation, false)
+    }
+  }
+
+  for (const name of Object.keys(externals)) {
+    if (!moduleNames.includes(name)) continue
+    for (const instrumentation of externals[name]) {
+      addInstrumentation(instrumentation, true, name)
+    }
+  }
+
+  return packages
 }
 
 /**
@@ -133,8 +145,6 @@ async function assertFolder (name, version) {
  * @param {boolean} external
  */
 async function assertPackage (name, version, dependencyVersionRange, external) {
-  // Early return to prevent filePaths from being installed, their non path counterparts should suffice
-  if (isRelativeRequire(name)) return
   const dependencies = {
     [name]: getCappedRange(name, dependencyVersionRange),
   }
@@ -165,68 +175,96 @@ async function assertPackage (name, version, dependencyVersionRange, external) {
 }
 
 /**
- * @param {object} rootFolder
- * @param {string} parent
+ * Patch generated workspace manifests with the peer/dev dependency versions resolved from the installed packages, so a
+ * second install pulls compatible peers.
+ *
+ * @param {string} rootFolder
+ * @returns {Promise<boolean>} Whether any manifest changed (and therefore a second install is required).
  */
-async function assertPeerDependencies (rootFolder, parent = '') {
+async function assertPeerDependencies (rootFolder) {
+  const folders = await collectPeerDependencyFolders(rootFolder)
+  const changes = await mapWithConcurrency(folders, FS_CONCURRENCY, patchPeerDependencies)
+  return changes.some(Boolean)
+}
+
+/**
+ * Walk the generated tree and return the leaf workspace folders that have external peer dependencies to patch.
+ *
+ * @param {string} rootFolder
+ * @param {string} [parent]
+ * @returns {Promise<Array<{ folder: string, externalName: string }>>}
+ */
+async function collectPeerDependencyFolders (rootFolder, parent = '') {
   const entries = await readdir(rootFolder)
+  const folders = []
 
   for (const entry of entries) {
-    const folder = join(rootFolder, entry)
+    const current = join(rootFolder, entry)
 
     // eslint-disable-next-line no-await-in-loop
-    const folderStat = await lstat(folder)
+    const folderStat = await lstat(current)
     if (!folderStat.isDirectory()) continue
     if (entry === 'node_modules') continue
     if (!isGeneratedWorkspace(entry, parent)) continue
     if (entry.startsWith('@')) {
       // eslint-disable-next-line no-await-in-loop
-      await assertPeerDependencies(folder, parent ? join(parent, entry) : entry)
+      folders.push(...await collectPeerDependencyFolders(current, parent ? join(parent, entry) : entry))
       continue
     }
 
     const externalName = join(parent, entry.split('@')[0])
+    if (externalDeps.has(externalName)) folders.push({ folder: current, externalName })
+  }
 
-    if (!externalDeps.has(externalName)) continue
+  return folders
+}
 
-    const versionPkgJsonPath = join(folder, 'package.json')
-    const versionPkgJson = require(versionPkgJsonPath)
+/**
+ * @param {{ folder: string, externalName: string }} entry
+ * @returns {Promise<boolean>} Whether the manifest changed on disk.
+ */
+async function patchPeerDependencies ({ folder, externalName }) {
+  const versionPkgJsonPath = join(folder, 'package.json')
+  const before = await readFile(versionPkgJsonPath, 'utf8')
+  const versionPkgJson = JSON.parse(before)
 
-    let pkgJson
+  let pkgJson
 
-    for (const { dep, name, node, forced } of externalDeps.get(externalName)) {
-      if (node && !semver.satisfies(process.versions.node, node)) {
-        continue
-      }
-      if (!pkgJson) {
-        const requireFromWorkspace = createRequire(join(folder, 'package.json'))
-        const nodeModulesPaths = requireFromWorkspace.resolve.paths(externalName)
-        pkgJson = requirePackageJson(externalName, { paths: nodeModulesPaths })
-      }
+  for (const { dep, name, node, forced } of externalDeps.get(externalName)) {
+    if (node && !semver.satisfies(process.versions.node, node)) {
+      continue
+    }
+    if (!pkgJson) {
+      const requireFromWorkspace = createRequire(join(folder, 'package.json'))
+      const nodeModulesPaths = requireFromWorkspace.resolve.paths(externalName)
+      pkgJson = requirePackageJson(externalName, { paths: nodeModulesPaths })
+    }
 
-      for (const section of ['devDependencies', 'peerDependencies']) {
-        if (pkgJson[section]?.[name]) {
-          if (dep === externalName) {
-            versionPkgJson.dependencies[name] = pkgJson.version
-          } else {
-            versionPkgJson.dependencies[name] = pkgJson[section][name].includes('||')
-              // Use the first version in the list (as npm does by default)
-              ? pkgJson[section][name].split('||')[0].trim()
-              // Only one version available so use that.
-              : pkgJson[section][name]
-          }
-          break
+    for (const section of ['devDependencies', 'peerDependencies']) {
+      if (pkgJson[section]?.[name]) {
+        if (dep === externalName) {
+          versionPkgJson.dependencies[name] = pkgJson.version
+        } else {
+          versionPkgJson.dependencies[name] = pkgJson[section][name].includes('||')
+            // Use the first version in the list (as npm does by default)
+            ? pkgJson[section][name].split('||')[0].trim()
+            // Only one version available so use that.
+            : pkgJson[section][name]
         }
-      }
-
-      if (!versionPkgJson.dependencies[name] && forced) {
-        versionPkgJson.dependencies[name] = latests[name]
+        break
       }
     }
 
-    // eslint-disable-next-line no-await-in-loop
-    await writeFile(versionPkgJsonPath, JSON.stringify(versionPkgJson, null, 2))
+    if (!versionPkgJson.dependencies[name] && forced) {
+      versionPkgJson.dependencies[name] = latests[name]
+    }
   }
+
+  const after = JSON.stringify(versionPkgJson, null, 2) + '\n'
+  if (after === before) return false
+
+  await writeFile(versionPkgJsonPath, after)
+  return true
 }
 
 /**
@@ -313,9 +351,21 @@ async function assertWorkspaces () {
 function install (retry = true) {
   try {
     exec('yarn --ignore-engines', { cwd: folder() })
-  } catch (err) {
-    if (!retry) throw err
-    install(false) // retry in case of server error from registry
+  } catch (error) {
+    if (retry) {
+      install(false) // retry in case of server error from registry
+      return
+    }
+    // A non-transient failure is most often an unresolvable version: a declared range spans a major version that was
+    // never published. Point at the fix instead of leaving a bare yarn error.
+    throw new Error(
+      'yarn failed to install the generated versions/ workspaces. If a plugin declares a version range that spans a ' +
+      'major version that was never published (non-consecutive majors), add that package to ' +
+      '`nonConsecutiveMajorPackages` in packages/dd-trace/test/plugins/versions/index.js (or split the range) so its ' +
+      'in-between majors are not installed.\n' +
+      `Original error: ${error.message}`,
+      { cause: error }
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

The install script and `withVersions()` now both expand versions through `resolvePluginVersions`, so the generated `versions/` folders and the folders the suite iterates derive from one place and cannot drift. The generator bounds its `mkdir`/`writeFile` fan-out with the concurrency helper to avoid `EMFILE`.

Because the resolver fills every in-between major automatically, the `lodash`, `ws`, and `mquery` same-name externals that only re-stated their `addHook` ranges are dropped. Two peer-dependency anchors replace them: `@apollo/server` pins `graphql` so v5 does not resolve the 15.x that apollo-server v3 drags in, and `knex` installs the `@vscode/sqlite3` fork its 1.x dialect needs.

## Test plan

- [ ] `PLUGINS="mongodb" node scripts/install_plugin_modules.js` and confirm the generated `versions/mongodb@*` folders match the majors `withVersions('mongodb', …)` iterates.
- [ ] A targeted plugin run (`PLUGINS="fastify" npm run test:plugins`) to confirm the matrix still resolves.

Stacked on #9021 (resolver) → #9019 (concurrency).

## Follow-up

Per self-review: remove the remaining same-name externals (`aerospike` and the other version-only self-references) so `externals.js` stops declaring the test matrix, and simplify the `honourEnvRange`/`pluginName` branch once none remain.