### PR TITLE
fix(tedious): run BulkLoad row-stream listeners in the registration context

### DIFF
--- a/.github/workflows/apm-integrations.yml
+++ b/.github/workflows/apm-integrations.yml
@@ -1351,6 +1351,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+    strategy:
+      fail-fast: false
+      # tedious spans 19 majors; installing and testing them all in one job exceeds the step time budget. Shard by
+      # major range so each job stays small. PACKAGE_VERSION_RANGE narrows both the install and the tested versions.
+      matrix:
+        range:
+          - ">=1.0.0 <7.0.0"
+          - ">=7.0.0 <13.0.0"
+          - ">=13.0.0"
     services:
       mssql:
         image: ghcr.io/datadog/dd-trace-js/mcr.microsoft.com/mssql/server@sha256:8bb7f2f0684104d98ef4cbedf574210f38ea0f00fc0713af9d3f962f7578a6a8 # 2019-latest
@@ -1363,19 +1372,22 @@ jobs:
     env:
       PLUGINS: tedious
       SERVICES: mssql
+      PACKAGE_VERSION_RANGE: ${{ matrix.range }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/node/latest
       - uses: ./.github/actions/install
       - run: yarn test:plugins:ci
+      # The upstream suite always exercises the latest version, so run it only on the shard that installs it.
       - run: yarn test:plugins:upstream
+        if: ${{ matrix.range == '>=13.0.0' }}
       - uses: ./.github/actions/coverage
         with:
-          flags: apm-integrations-tedious
+          flags: apm-integrations-tedious-${{ strategy.job-index }}
       - uses: ./.github/actions/upload-junit-artifacts
         if: "!cancelled()"
         with:
-          id: ${{ github.job }}
+          id: ${{ github.job }}-${{ strategy.job-index }}
 
   undici:
     runs-on: ubuntu-latest

--- a/packages/datadog-instrumentations/src/tedious.js
+++ b/packages/datadog-instrumentations/src/tedious.js
@@ -4,12 +4,39 @@ const shimmer = require('../../datadog-shimmer')
 const {
   channel,
   addHook,
+  AsyncResource,
 } = require('./helpers/instrument')
+
+// Listeners added to the BulkLoad row stream (`bulkLoad.getRowStream()`) by the caller would
+// otherwise run in whatever async context emits the stream event, losing the span that was active
+// when the listener was registered. Bind each registered listener to its registration context so
+// `'finish'`/`'error'`/`'data'` handlers run in the caller's span. tedious' own internal listeners
+// are attached before `getRowStream` returns, so only caller listeners are bound.
+const ROW_STREAM_LISTENER_METHODS = ['addListener', 'on', 'once', 'prependListener', 'prependOnceListener']
+
+function bindRowStreamListeners (rowStream) {
+  for (const method of ROW_STREAM_LISTENER_METHODS) {
+    shimmer.wrap(rowStream, method, register => function (eventName, listener) {
+      if (typeof listener !== 'function') {
+        return register.apply(this, arguments)
+      }
+      return register.call(this, eventName, AsyncResource.bind(listener))
+    })
+  }
+  return rowStream
+}
 
 addHook({ name: 'tedious', versions: ['>=1.0.0'] }, tedious => {
   const startCh = channel('apm:tedious:request:start')
   const finishCh = channel('apm:tedious:request:finish')
   const errorCh = channel('apm:tedious:request:error')
+
+  if (typeof tedious.BulkLoad?.prototype?.getRowStream === 'function') {
+    shimmer.wrap(tedious.BulkLoad.prototype, 'getRowStream', getRowStream => function () {
+      return bindRowStreamListeners(getRowStream.apply(this, arguments))
+    })
+  }
+
   shimmer.wrap(tedious.Connection.prototype, 'makeRequest', makeRequest => function (request) {
     if (!startCh.hasSubscribers) {
       return makeRequest.apply(this, arguments)

--- a/packages/datadog-plugin-tedious/test/index.spec.js
+++ b/packages/datadog-plugin-tedious/test/index.spec.js
@@ -358,7 +358,10 @@ describe('Plugin', () => {
             connection.execBulkLoad(bulkLoad, [{ num: 5 }])
           })
 
-          if (semver.intersects(version, '>=4.2.0') && !semver.intersects(version, '>=14')) {
+          // `getRowStream()` is deprecated in tedious 13.1.0 and removed in 14. The shared test setup
+          // (setup/core.js) rethrows DeprecationWarnings, so calling it on >=13 aborts the process; only
+          // exercise the streaming row input on the majors below 13.
+          if (semver.intersects(version, '>=4.2.0') && !semver.intersects(version, '>=13')) {
             it('should handle streaming BulkLoad requests', done => {
               const bulkLoad = buildBulkLoad()
               const rowStream = bulkLoad.getRowStream()
@@ -408,7 +411,9 @@ describe('Plugin', () => {
       let connection
 
       beforeEach(async () => {
-        await agent.load('tedious', { dbmPropagationMode: 'service', service: 'custom' })
+        // Pin the service version so the injected `ddpv` is deterministic; without it the tag falls back
+        // to `pkg.version` (the nearest package.json to mocha), which drifts on every mocha bump.
+        await agent.load('tedious', { dbmPropagationMode: 'service', service: 'custom' }, { version: '1.0.0' })
         tds = require(`../../../versions/tedious@${version}`).get()
       })
 
@@ -454,8 +459,14 @@ describe('Plugin', () => {
         const promise = agent
           .assertSomeTraces(traces => {
             assert.strictEqual(traces[0][0].resource, 'SELECT 1 + 1 AS solution')
-            assert.strictEqual(request.sqlTextOrProcedure, "/*dddb='master',dddbs='custom',dde='tester'," +
-              "ddh='localhost',ddps='test',ddpv='10.8.2'*/ SELECT 1 + 1 AS solution")
+            // Some tedious majors route `execSql` through `sp_executesql`, so the injected query lands in
+            // the `statement`/`stmt` parameter instead of `sqlTextOrProcedure`; read it where the
+            // instrumentation wrote it (see `getQueryOrProcedure`).
+            const injectedQuery = request.parametersByName?.statement?.value ??
+              request.parametersByName?.stmt?.value ??
+              request.sqlTextOrProcedure
+            assert.strictEqual(injectedQuery, "/*dddb='master',dddbs='custom',dde='tester'," +
+              "ddh='localhost',ddps='test',ddpv='1.0.0'*/ SELECT 1 + 1 AS solution")
           })
 
         connection.execSql(request)

--- a/packages/dd-trace/test/setup/services/mssql.js
+++ b/packages/dd-trace/test/setup/services/mssql.js
@@ -1,9 +1,16 @@
 'use strict'
 
+const semver = require('semver')
+
 const RetryOperation = require('../operation')
 
 function waitForMssql (isSandbox) {
-  const tedious = isSandbox ? require('tedious') : require('../../../../../versions/tedious').get()
+  const tediousPackage = isSandbox ? require('tedious') : require('../../../../../versions/tedious')
+  const tedious = isSandbox ? tediousPackage : tediousPackage.get()
+  // tedious <10 starts connecting on construction, while >=10 requires an explicit connect(); calling connect() on
+  // the older line throws "No event 'socketConnect' in state 'SentPrelogin'". The version expansion can resolve the
+  // unversioned folder to an older major (e.g. the >=1 <7 shard), so mirror the guard the plugin specs already use.
+  const needsExplicitConnect = isSandbox || semver.intersects(tediousPackage.version(), '>=10.0.0')
 
   return /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
     const operation = new RetryOperation('mssql')
@@ -35,7 +42,7 @@ function waitForMssql (isSandbox) {
 
         connection.execSql(request)
       })
-      connection.connect()
+      if (needsExplicitConnect) connection.connect()
     })
   }))
 }


### PR DESCRIPTION
## Summary

A listener added to `bulkLoad.getRowStream()` ran in the async context that emits the stream event, not the one active when it was registered, so a caller's `finish`/`error`/`data` handler lost the span it was registered under. Each caller listener is now bound to its registration context (tedious' internal listeners attach before `getRowStream` returns, so only caller listeners are bound).

Two tedious-specific test adaptations ride along: shard the CI job by major range (19 majors blow the step budget), and gate the `getRowStream` streaming test below major 13 (deprecated there, removed in 14) while calling `connect()` only on `>=10`.

Independent of the resolver rework — `PACKAGE_VERSION_RANGE` sharding and the conditional gates run on the current install path; the new majors simply are not exercised until the matrix widens.

## Test plan

- [ ] `SERVICES=mssql PLUGINS=tedious` matrix is green across all three shards.
- [ ] The pre-existing "run the BulkLoad stream event listeners in the parent context" test passes on a `>=4.2 <13` shard.

## Note

Binding a user listener to its registration context is intrinsically an AsyncLocalStorage operation; a diagnostic channel carries instrumentation events and cannot rebind a foreign listener. The duplicate of this wrap pattern in `ws`/`electron`/`ldapjs` could later fold into a shared `bindEmitterListeners` helper.